### PR TITLE
Fix issues with inconsistent order of includes across source files

### DIFF
--- a/Marlin/EEPROMwrite.h
+++ b/Marlin/EEPROMwrite.h
@@ -1,10 +1,11 @@
 #ifndef __EEPROMH
 #define __EEPROMH
 
+#include <EEPROM.h>
+
 #include "Marlin.h"
 #include "planner.h"
 #include "temperature.h"
-#include <EEPROM.h>
 
 template <class T> int EEPROM_writeAnything(int &ee, const T& value)
 {

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -4,9 +4,11 @@
 // Tonokip RepRap firmware rewrite based off of Hydra-mmm firmware.
 // Licence: GPL
 #include <WProgram.h>
-#include "fastio.h"
 #include <avr/pgmspace.h>
+
+#include "fastio.h"
 #include "Configuration.h"
+#include "pins.h"
 
 //#define SERIAL_ECHO(x) Serial << "echo: " << x;
 //#define SERIAL_ECHOLN(x) Serial << "echo: "<<x<<endl;

--- a/Marlin/Marlin.pde
+++ b/Marlin/Marlin.pde
@@ -27,15 +27,15 @@
 
 #include <EEPROM.h>
 
-#include "EEPROMwrite.h"
 #include "fastio.h"
 #include "Configuration.h"
 #include "pins.h"
 #include "Marlin.h"
-#include "ultralcd.h"
 #include "planner.h"
 #include "stepper.h"
 #include "temperature.h"
+#include "EEPROMwrite.h"
+#include "ultralcd.h"
 #include "motion_control.h"
 #include "cardreader.h"
 #include "watchdog.h"

--- a/Marlin/motion_control.cpp
+++ b/Marlin/motion_control.cpp
@@ -21,8 +21,8 @@
 
 #include "Configuration.h"
 #include "Marlin.h"
-#include "stepper.h"
 #include "planner.h"
+#include "stepper.h"
 
 // The arc is approximated by generating a huge number of tiny, linear segments. The length of each 
 // segment is configured in settings.mm_per_arc_segment.  

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -56,10 +56,10 @@
 //#include <math.h>       
 //#include <stdlib.h>
 
-#include "Marlin.h"
+#include "fastio.h"
 #include "Configuration.h"
 #include "pins.h"
-#include "fastio.h"
+#include "Marlin.h"
 #include "planner.h"
 #include "stepper.h"
 #include "temperature.h"

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -21,12 +21,12 @@
 /* The timer calculations of this module informed by the 'RepRap cartesian firmware' by Zack Smith
    and Philipp Tiefenbacher. */
 
-#include "stepper.h"
+#include "fastio.h"
 #include "Configuration.h"
+#include "pins.h"
 #include "Marlin.h"
 #include "planner.h"
-#include "pins.h"
-#include "fastio.h"
+#include "stepper.h"
 #include "temperature.h"
 #include "ultralcd.h"
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -21,8 +21,8 @@
 #ifndef temperature_h
 #define temperature_h 
 
-#include "Marlin.h"
 #include "fastio.h"
+#include "Marlin.h"
 #ifdef PID_ADD_EXTRUSION_RATE
   #include "stepper.h"
 #endif


### PR DESCRIPTION
Marlin.h always needs pins.h to be included before it, this was only
done in some files and not others. Marlin.h now explicitly includes
what it needs. Also, include order was different for each source
file, this has been cleaned up.
Should fix issues with certain pin options not working properly or even
compiling, such as the motor enable pins.
