### PR TITLE
Currently Arduino 1.0 doesn’t work with most of the modern reprap firmwa...

### DIFF
--- a/README
+++ b/README
@@ -31,7 +31,7 @@ The default baudrate is 115200.
 Configuring and compilation
 
 
-Install the latest arduino software IDE/toolset (currently 0022)
+Install the latest arduino software IDE/toolset (currently 0022) ¡ARDUINO 1.0 DOES NOT WORK!
    http://www.arduino.cc/en/Main/Software
 
 Install Ultimaker's RepG 25 build


### PR DESCRIPTION
Currently Arduino 1.0 doesn’t work with most of the modern reprap firmwares.  I believe it has to do with all the SD card library changes...but really I don't know.  The stop gap solution is to use any arduino version <1.0 (which is confusing since that is 23 or something...)
