### PR TITLE
Updated to allow RAMPS boards to use ultimaker style pannels

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -179,6 +179,13 @@ const bool Z_ENDSTOPS_INVERTING = false; // set to true to invert the logic of t
 //#define ULTRA_LCD  //general lcd support, also 16x2
 #define SDSUPPORT // Enable SD Card Support in Hardware Console
 
+// Invert the SD card Detect Pin.  
+// If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
+// You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT 
+// in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
+// be commented out otherwise
+#define SDCARDDETECTINVERTED 
+
 #define ULTIPANEL
 #ifdef ULTIPANEL
   #define NEWPANEL  //enable this if you have a click-encoder panel

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -281,8 +281,8 @@
 #ifdef ULTRA_LCD
 
   #ifdef NEWPANEL
-  //arduino pin witch triggers an piezzo beeper
-    #define BEEPER -1			// No Beeper added
+  //arduino pin which triggers an piezzo beeper
+    #define BEEPER 33			// Beeper on AUX-4
 
     #define LCD_PINS_RS 16 
     #define LCD_PINS_ENABLE 17
@@ -300,7 +300,7 @@
     #define BLEN_B 1
     #define BLEN_A 0
     
-    #define SDCARDDETECT -1		// Ramps does not use this port
+    #define SDCARDDETECT 31		// Ramps does not use this port
     
       //encoder rotation values
     #define encrot0 0
@@ -310,7 +310,7 @@
 
   #else //old style panel with shift register
     //arduino pin witch triggers an piezzo beeper
-    #define BEEPER -1		No Beeper added
+    #define BEEPER 33		No Beeper added
 
     //buttons are attached to a shift register
 	// Not wired this yet

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -27,8 +27,15 @@
     
     #define CLICKED (buttons&EN_C)
     #define BLOCK {blocking=millis()+blocktime;}
-    #define CARDINSERTED (READ(SDCARDDETECT)==0)
-    
+
+	#ifdef SDCARDDETECTINVERTED 
+		#define CARDINSERTED (READ(SDCARDDETECT)!=0)
+
+	#else
+		#define CARDINSERTED (READ(SDCARDDETECT)==0)
+
+	#endif  //SDCARDTETECTINVERTED
+
   #else
 
     //atomatic, do not change


### PR DESCRIPTION
I updated the pins.h, configuration.h file and ultraLCD.h file to allow RAMPS 1.3 (and probably 1.4) boards to use an LCD (connected to AUX-4) and rotary encoder (connected to AUX-2).  Optionally a momentary switch can be used to simulate SD card removal and reinsertion (Pin 31 AUX-4) by pulling the pin to ground.

I have this tested and working on my own Ramps board.  I hit one problem which is that the SdRamps module does not have a card detect pin.  This leaves a couple of choices. 
1.  Option out the card detect by changing ultraLCD.h to believe that the card is always inserted. 

I tried this first and it works OK.  it's a nuisance though if you are preheating your printer while the g-code compiles on your computer.  To insert a new card and have it detected, you must restart the Arduino (changing the temps back to zero)
1.  Wire an open/close switch to the front panel to simulate the SDCARDDETECT pin being pulled low or left high.

This is OK in my book.  I just didn't have any suitable switches 
1.  Add a momentary closed switch to pull the SDCARDDETECT pin low for a second or two and then invert the logic in the code
2.  Disable the SDCARDDETECT completely and alter the menu to allow a manual refresh when a card is inserted.

I can see that for those whose hardware supports it, card detect is a useful feature.  But I will look into doing it this way as it looks more elegant for the ramps users

I opted for the third, though it feels a bit cludgy, it offers the best convenience in the short term
