### PR TITLE
Fix Makefile

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -61,7 +61,7 @@ SRC =  $(ARDUINO)/pins_arduino.c $(ARDUINO)/wiring.c \
 	$(ARDUINO)/wiring_pulse.c \
 	$(ARDUINO)/wiring_shift.c $(ARDUINO)/WInterrupts.c
 CXXSRC = $(ARDUINO)/WMath.cpp $(ARDUINO)/WString.cpp\
-	$(ARDUINO)/Print.cpp Marlin.cpp MarlinSerial.cpp Sd2Card.cpp SdBaseFile.cpp SdFatUtil.cpp SdFile.cpp SdVolume.cpp motion_control.cpp planner.cpp stepper.cpp temperature.cpp cardreader.cpp
+	$(ARDUINO)/Print.cpp applet/Marlin.cpp MarlinSerial.cpp Sd2Card.cpp SdBaseFile.cpp SdFatUtil.cpp SdFile.cpp SdVolume.cpp motion_control.cpp planner.cpp stepper.cpp temperature.cpp cardreader.cpp
 FORMAT = ihex
 
 


### PR DESCRIPTION
Could you pull this change which fixes the Makefile for me (and still works for others such as Triffid_Hunter) ? It simply explicitely points to the applet/Marlin.cpp from produced from the pde instead of just pointing to a Marlin.cpp, which all toolchains might not find.
