### PR TITLE
pins.h: Define Z_MAX_PIN for Gen7 board

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -81,7 +81,7 @@
 #define Z_DIR_PIN 25
 #define Z_ENABLE_PIN 24
 #define Z_MIN_PIN 1
-#define Z_MAX_PIN 
+#define Z_MAX_PIN 0
 
 //extruder pins
 #define E0_STEP_PIN 28


### PR DESCRIPTION
The Z_MAX_PIN value was defined as no-value, but this causes
the compile to fail.  Fix this by setting the Z_MAX_PIN to the
correct value (which happens to be 0 for pin PB0/DIO0/0).
