### PR TITLE
Fix compilation error when PIDTEMP is undefined and ULTIPANEL is defined...

### DIFF
--- a/Marlin/ultralcd.pde
+++ b/Marlin/ultralcd.pde
@@ -1181,6 +1181,7 @@ void MainMenu::showControlTemp()
         }
         
       }break;
+      	#ifdef PIDTEMP
       case ItemCT_PID_P: 
       {
       if(force_lcd_update)
@@ -1323,6 +1324,7 @@ void MainMenu::showControlTemp()
         }
         
       }
+      	#endif
       #endif
       break;
     default:   


### PR DESCRIPTION
asking for Ki, PID_dT etc.. when PIDTEMP is undefined.
