### PR TITLE
Fix compile error on boards without a bed heater

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -725,7 +725,9 @@ void min_temp_error(uint8_t e) {
 }
 
 void bed_max_temp_error(void) {
+#if HEATER_BED_PIN > -1
   WRITE(HEATER_BED_PIN, 0);
+#endif
   if(IsStopped() == false) {
     SERIAL_ERROR_START;
     SERIAL_ERRORLNPGM("Temperature heated bed switched off. MAXTEMP triggered !!");


### PR DESCRIPTION
Hello, 

I noticed the latest code does not compile if no bed heater is specified. I wrapped the offending line of code in a #if as is done in other functions. 
