### PR TITLE
Update Marlin/stepper.cpp

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -453,7 +453,6 @@ ISR(TIMER1_COMPA_vect)
       if (counter_x > 0) {
         WRITE(X_STEP_PIN, HIGH);
         counter_x -= current_block->step_event_count;
-        WRITE(X_STEP_PIN, LOW);
         count_position[X_AXIS]+=count_direction[X_AXIS];   
       }
 
@@ -461,7 +460,6 @@ ISR(TIMER1_COMPA_vect)
       if (counter_y > 0) {
         WRITE(Y_STEP_PIN, HIGH);
         counter_y -= current_block->step_event_count;
-        WRITE(Y_STEP_PIN, LOW);
         count_position[Y_AXIS]+=count_direction[Y_AXIS];
       }
 
@@ -469,7 +467,6 @@ ISR(TIMER1_COMPA_vect)
       if (counter_z > 0) {
         WRITE(Z_STEP_PIN, HIGH);
         counter_z -= current_block->step_event_count;
-        WRITE(Z_STEP_PIN, LOW);
         count_position[Z_AXIS]+=count_direction[Z_AXIS];
       }
 
@@ -483,6 +480,19 @@ ISR(TIMER1_COMPA_vect)
         }
       #endif //!ADVANCE
       step_events_completed += 1;  
+      
+      /*
+        Turn off all steps (even if only one is active).
+        This will lengthen out the step pulse width.
+        Additional delay can be compiled in using EXTEND_STEP_PULSE_USEC.
+      */  
+      #if defined(EXTEND_STEP_PULSE_USEC)
+        delayMicroseconds(EXTEND_STEP_PULSE_USEC);
+      #endif
+      WRITE(X_STEP_PIN, LOW);
+      WRITE(Y_STEP_PIN, LOW);
+      WRITE(Z_STEP_PIN, LOW);
+
       if(step_events_completed >= current_block->step_event_count) break;
     }
     // Calculare new timer value


### PR DESCRIPTION
  The original Marlin firmware sends out a step pulse by toggling the _STEP_PIN high then immediately low resulting in a 1.4usec pulse.
  A Pololu A4988 with a 1usec pulse width requirement which works fine.
  However, other stepper drivers use a TB6560AHQ with a 30usec requirement. (No wonder it won't work at <1.4usec.) 

  By comparison, Teacup firmware has a step pulse width of 60usec.
  The Marlin firmware stepper.c file has been modified to set the _STEP_PINs low a little later in the code.
  This alone extends the step pulse to approx 10usec.
  Define the EXTEND_STEP_PULSE_USEC macro to extend the step pulses. (This is only applied to the XYZ steppers.)
  Stepper interrupt gives a step pulse period = 10 usec plus this value to the XYZ steppers.  
