### PR TITLE
Added support for dual Z axis stepper drivers

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -78,6 +78,18 @@
 
 //#define Z_LATE_ENABLE // Enable Z the last moment. Needed if your Z driver overheats.
 
+// A single Z stepper driver is usually used to drive 2 stepper motors.
+// Uncomment this define to utilize a separate stepper driver for each Z axis motor.
+// Only a few motherboards support this, like RAMPS, which have dual extruder support (the 2nd, often unused, extruder driver is used
+// to control the 2nd Z axis stepper motor). The pins are currently only defined for a RAMPS motherboards.
+// On a RAMPS (or other 5 driver) motherboard, using this feature will limit you to using 1 extruder.
+//#define Z_DUAL_STEPPER_DRIVERS
+
+#ifdef Z_DUAL_STEPPER_DRIVERS
+  #undef EXTRUDERS
+  #define EXTRUDERS 1
+#endif
+
 //homing hits the endstop, then retracts by this distance, before it tries to slowly bump again:
 #define X_HOME_RETRACT_MM 5 
 #define Y_HOME_RETRACT_MM 5 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -122,8 +122,13 @@ void manage_inactivity(byte debug);
 #endif
 
 #if Z_ENABLE_PIN > -1
-  #define  enable_z() WRITE(Z_ENABLE_PIN, Z_ENABLE_ON)
-  #define disable_z() WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON)
+  #ifdef Z_DUAL_STEPPER_DRIVERS
+    #define  enable_z() { WRITE(Z_ENABLE_PIN, Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON); }
+    #define disable_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN,!Z_ENABLE_ON); }
+  #else
+    #define  enable_z() WRITE(Z_ENABLE_PIN, Z_ENABLE_ON)
+    #define disable_z() WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON)
+  #endif
 #else
   #define enable_z() ;
   #define disable_z() ;

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -267,6 +267,10 @@
 #define Z_MIN_PIN          18
 #define Z_MAX_PIN          19
 
+#define Z2_STEP_PIN        36
+#define Z2_DIR_PIN         34
+#define Z2_ENABLE_PIN      30
+
 #define E0_STEP_PIN        26
 #define E0_DIR_PIN         28
 #define E0_ENABLE_PIN      24

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -421,6 +421,11 @@ ISR(TIMER1_COMPA_vect)
     
     if ((out_bits & (1<<Z_AXIS)) != 0) {   // -direction
       WRITE(Z_DIR_PIN,INVERT_Z_DIR);
+      
+	  #ifdef Z_DUAL_STEPPER_DRIVERS
+        WRITE(Z2_DIR_PIN,INVERT_Z_DIR);
+      #endif
+      
       count_direction[Z_AXIS]=-1;
       CHECK_ENDSTOPS
       {
@@ -437,6 +442,11 @@ ISR(TIMER1_COMPA_vect)
     }
     else { // +direction
       WRITE(Z_DIR_PIN,!INVERT_Z_DIR);
+
+	  #ifdef Z_DUAL_STEPPER_DRIVERS
+        WRITE(Z2_DIR_PIN,!INVERT_Z_DIR);
+      #endif
+
       count_direction[Z_AXIS]=1;
       CHECK_ENDSTOPS
       {
@@ -552,9 +562,18 @@ ISR(TIMER1_COMPA_vect)
       counter_z += current_block->steps_z;
       if (counter_z > 0) {
         WRITE(Z_STEP_PIN, !INVERT_Z_STEP_PIN);
+        
+		#ifdef Z_DUAL_STEPPER_DRIVERS
+          WRITE(Z2_STEP_PIN, !INVERT_Z_STEP_PIN);
+        #endif
+        
         counter_z -= current_block->step_event_count;
         count_position[Z_AXIS]+=count_direction[Z_AXIS];
         WRITE(Z_STEP_PIN, INVERT_Z_STEP_PIN);
+        
+		#ifdef Z_DUAL_STEPPER_DRIVERS
+          WRITE(Z2_STEP_PIN, INVERT_Z_STEP_PIN);
+        #endif
       }
 
       #ifndef ADVANCE
@@ -704,6 +723,10 @@ void st_init()
   #endif
   #if Z_DIR_PIN > -1 
     SET_OUTPUT(Z_DIR_PIN);
+
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && (Z2_DIR_PIN > -1)
+      SET_OUTPUT(Z2_DIR_PIN);
+    #endif
   #endif
   #if E0_DIR_PIN > -1 
     SET_OUTPUT(E0_DIR_PIN);
@@ -728,6 +751,11 @@ void st_init()
   #if (Z_ENABLE_PIN > -1)
     SET_OUTPUT(Z_ENABLE_PIN);
     if(!Z_ENABLE_ON) WRITE(Z_ENABLE_PIN,HIGH);
+    
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && (Z2_ENABLE_PIN > -1)
+      SET_OUTPUT(Z2_ENABLE_PIN);
+      if(!Z_ENABLE_ON) WRITE(Z2_ENABLE_PIN,HIGH);
+    #endif
   #endif
   #if (E0_ENABLE_PIN > -1)
     SET_OUTPUT(E0_ENABLE_PIN);
@@ -802,6 +830,12 @@ void st_init()
     SET_OUTPUT(Z_STEP_PIN);
     WRITE(Z_STEP_PIN,INVERT_Z_STEP_PIN);
     if(!Z_ENABLE_ON) WRITE(Z_ENABLE_PIN,HIGH);
+    
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && (Z2_STEP_PIN > -1)
+      SET_OUTPUT(Z2_STEP_PIN);
+      WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
+      if(!Z_ENABLE_ON) WRITE(Z2_ENABLE_PIN,HIGH);
+    #endif
   #endif  
   #if (E0_STEP_PIN > -1) 
     SET_OUTPUT(E0_STEP_PIN);


### PR DESCRIPTION
I've added support for dual Z axis stepper drivers (using 1 stepper driver for each Z axis stepper motor).  

On my Prusa Mendel, running both my Z axis steppers off a single driver was causing the driver (even with a heatsink + fan) to run very very hot (I have rather beefy Z steppers).  So I added another stepper driver (I'm using a RAMPS motherboard and it had a spare driver slot) and can now run each motor individually. My stepper drivers run nice and cool now.

I've been using this update for several weeks w/o any issues, and my Z axis motors stay in sync more reliably than when run off 1 driver.
