### PR TITLE
Missing #else in temperature.cpp prevented reading bed temp when TEMP_BE...

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -885,6 +885,8 @@ ISR(TIMER0_COMPB_vect)
       #if (TEMP_BED_PIN > -1)
         #if TEMP_BED_PIN > 7
           ADCSRB = 1<<MUX5;
+        #else
+          ADCSRB = 0;
         #endif
         ADMUX = ((1 << REFS0) | (TEMP_BED_PIN & 0x07));
         ADCSRA |= 1<<ADSC; // Start conversion


### PR DESCRIPTION
Missing #else in temperature.cpp prevented reading bed temp when TEMP_BED_PIN <7.

Thanks to Leland Wallace for helping me track this down via "Sesame Street" coding (what is not like the other)
