### PR TITLE
Create an explicit rule for building applet/Marlin.cpp.

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -277,7 +277,7 @@ applet/%.o: %.c Configuration.h Configuration_adv.h $(MAKEFILE)
 	$(Pecho) "  CC    $@"
 	$P $(CC) -MMD -c $(ALL_CFLAGS) $< -o $@
 
-applet/Marlin.o: applet/Marlin.cpp Configuration.h Configuration_adv.h $(MAKEFILE)
+applet/%.o: applet/%.cpp Configuration.h Configuration_adv.h $(MAKEFILE)
 	$(Pecho) "  CXX   $@"
 	$P $(CXX) -MMD -c $(ALL_CXXFLAGS) $< -o $@
 


### PR DESCRIPTION
Fixes some of the behaviour in bug #269.

It would seem that the pattern matches do not work when the source
file is created when make is running. The result of this is that it is
necessary to run "make" twice to build the firmware.

This adds an explicit rule without a pattern match for building
applet/Marlin.cpp. It corrects the make behaviour at the cost of adding
a little redundancy in the Makefile.
