### PR TITLE
Use the right pins for Gen7 1.4

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -187,6 +187,7 @@
 #define HEATER_2_PIN -1
 #define HEATER_BED_PIN 3
 
+#define KILL_PIN -1
 
 #define SDPOWER -1
 #define SDSS -1 // SCL pin of I2C header


### PR DESCRIPTION
Gen7 1.4 made a lot of changes to the pins, enough that it makes sense to split it out.
