### PR TITLE
fixed  (#328) pwm generation at pin D12 and D13

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -709,6 +709,9 @@
 #define LED_PIN            -1
 
 #define FAN_PIN            -1 
+#if FAN_PIN == 12 || FAN_PIN ==13
+#define FAN_SOFT_PWM
+#endif
 
 #ifdef MELZI
 #define LED_PIN            28

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -460,10 +460,12 @@ void check_axes_activity()
   else
   {
     #if FAN_PIN > -1
+    #ifndef FAN_SOFT_PWM
     if (fanSpeed != 0){
       analogWrite(FAN_PIN,fanSpeed); // If buffer is empty use current fan speed
     }
     #endif
+	#endif
   }
   if((DISABLE_X) && (x_active == 0)) disable_x();
   if((DISABLE_Y) && (y_active == 0)) disable_y();
@@ -475,6 +477,7 @@ void check_axes_activity()
     disable_e2(); 
   }
 #if FAN_PIN > -1
+  #ifndef FAN_SOFT_PWM
   if((fanSpeed == 0) && (fan_speed ==0))
   {
     analogWrite(FAN_PIN, 0);
@@ -484,6 +487,7 @@ void check_axes_activity()
   {
     analogWrite(FAN_PIN,tail_fan_speed);
   }
+  #endif
 #endif
 #ifdef AUTOTEMP
   getHighESpeed();

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -96,6 +96,11 @@ static volatile bool temp_meas_ready = false;
 #endif //PIDTEMPBED
   static unsigned char soft_pwm[EXTRUDERS];
   static unsigned char soft_pwm_bed;
+#ifdef FAN_SOFT_PWM
+  static unsigned char soft_pwm_fan;
+#endif
+
+
   
 #if EXTRUDERS > 3
 # error Unsupported number of extruders
@@ -597,6 +602,9 @@ void tp_init()
     #ifdef FAST_PWM_FAN
     setPwmFrequency(FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
     #endif
+    #ifdef FAN_SOFT_PWM
+	soft_pwm_fan=(unsigned char)fanSpeed;
+	#endif
   #endif  
 
   #ifdef HEATER_0_USES_MAX6675
@@ -929,6 +937,10 @@ ISR(TIMER0_COMPB_vect)
     soft_pwm_b = soft_pwm_bed;
     if(soft_pwm_b > 0) WRITE(HEATER_BED_PIN,1);
     #endif
+    #ifdef FAN_SOFT_PWM
+    soft_pwm_fan =(unsigned char) fanSpeed;
+    if(soft_pwm_fan > 0) WRITE(FAN_PIN,1);
+    #endif
   }
   if(soft_pwm_0 <= pwm_count) WRITE(HEATER_0_PIN,0);
   #if EXTRUDERS > 1
@@ -939,6 +951,9 @@ ISR(TIMER0_COMPB_vect)
   #endif
   #if HEATER_BED_PIN > -1
   if(soft_pwm_b <= pwm_count) WRITE(HEATER_BED_PIN,0);
+  #endif
+  #ifdef FAN_SOFT_PWM
+  if(soft_pwm_fan <= pwm_count) WRITE(FAN_PIN,0);
   #endif
   
   pwm_count++;


### PR DESCRIPTION
fixes pwm generation at pin D12 and D13 when one of them is used as FAN_PIN on Sanguino, added soft pwm entry for FAN_PIN in temperature.cpp
