### PR TITLE
Fixes SD card use on Melzi

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -719,7 +719,7 @@
 #define SDPOWER            -1
 #define SDSS               31
 
-//#ifdef MELZI
+//#ifdef MELZI						// Not needed and setting SDSS to pin 24 corrupts hotend temp readout
 //#define SDSS               24
 //#endif
 


### PR DESCRIPTION
In the current state Marlin defines pin 24 to SDSS for Melzi boards, wich leads to a corrupt hotend temperature readout. SDSS should be set to pin 31 like the original code does. Commented out the sections that sets SDSS to 24 for melzi.
Also see http://forums.reprap.org/read.php?147,141416,141416
