### PR TITLE
reversed sorting order of sd files when displayed

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -563,12 +563,11 @@ void lcd_sdcard_menu()
     }else{
         MENU_ITEM(function, LCD_STR_FOLDER "..", lcd_sd_updir);
     }
-    
     for(uint16_t i=0;i<fileCnt;i++)
     {
         if (_menuItemNr == _lineNr)
         {
-            card.getfilename(i);
+            card.getfilename((fileCnt-1)-i);
             if (card.filenameIsDir)
             {
                 MENU_ITEM(sddirectory, MSG_CARD_MENU, card.filename, card.longFilename);


### PR DESCRIPTION
the last saved file is most often the one someone wants to print. this saves a lot of knob turning.

This is meant to quicker find the file someone wants to print from the sd card. Especially when there are a lot of files on the card it is quite annoying to scroll to the last file.

It simply changes the order of files displayed.
