### PR TITLE
compile fix: quickStop() needs stepper.h

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -5,6 +5,7 @@
 #include "language.h"
 #include "cardreader.h"
 #include "temperature.h"
+#include "stepper.h"
 #include "ConfigurationStore.h"
 
 /* Configuration settings */


### PR DESCRIPTION
Some configurations don't get the stepper.h implicitly included from temperature.h
