### PR TITLE
Also skip .files and _files with long filenames

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -90,6 +90,8 @@ void  CardReader::lsDive(const char *prepend,SdFile parent)
     {
       if (p.name[0] == DIR_NAME_FREE) break;
       if (p.name[0] == DIR_NAME_DELETED || p.name[0] == '.'|| p.name[0] == '_') continue;
+      if (longFilename[0] != '\0' &&
+          (longFilename[0] == '.' || longFilename[0] == '_')) continue;
       if ( p.name[0] == '.')
       {
         if ( p.name[1] != '.')


### PR DESCRIPTION
.\* and _\* files and directories with long filename wasn't skipped since the short versions of these filenames don't contain the leading dot or underscore.
This typically happens when certain OS'es write things like ".Spotlight-V100/" to the card.
