### PR TITLE
Marlin v1, alignment of the Italian language

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -1050,6 +1050,8 @@
 	#define MSG_AUTORETRACT          "AutoArretramento"
 	#define MSG_SERIAL_ERROR_MENU_STRUCTURE "Qualcosa non va in MenuStructure."
 	#define MSG_FILAMENTCHANGE       "Cambia filamento"
+	#define MSG_INIT_SDCARD          "Iniz. SD-Card"
+	#define MSG_CNG_SDCARD           "Cambia SD-Card"
 
 	// Serial Console Messages
 


### PR DESCRIPTION
Remove space and some fix in the italian messages, add SD-Card change and SD-Card init definition.
