### PR TITLE
Add support for the Sanguinololu Wireless Adapter (SWA).

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -331,6 +331,9 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 // http://reprap.org/wiki/RAMPS_1.3/1.4_GADGETS3D_Shield_with_Panel
 //#define G3D_PANEL
 
+// The ODDepot.com Sanguinololu Wireless Adapter
+//#define SWASUPPORT // Enable Sanguinololu Wireless Adapter
+
 //automatic expansion
 #if defined(ULTIMAKERCONTROLLER) || defined(REPRAP_DISCOUNT_SMART_CONTROLLER) || defined(G3D_PANEL)
  #define ULTIPANEL
@@ -368,6 +371,13 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 		#define LCD_HEIGHT 2
 	#endif    
   #endif
+#endif
+
+#ifdef SWASUPPORT
+  #define MOTHERBOARD 62
+  #define SERIAL_PORT 1
+  #define BAUDRATE 115200
+  #define SDSUPPORT
 #endif
 
 // Increase the FAN pwm frequency. Removes the PWM noise but increases heating in the FET/Arduino

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -39,6 +39,7 @@
 #include "ConfigurationStore.h"
 #include "language.h"
 #include "pins_arduino.h"
+#include "SWAConfig.h"
 
 #if DIGIPOTSS_PIN > -1
 #include <SPI.h>
@@ -328,6 +329,9 @@ void setup()
   setup_killpin(); 
   setup_powerhold();
   MYSERIAL.begin(BAUDRATE);
+  #ifdef SWASUPPORT
+    setup_SWA(MYSERIAL);
+  #endif
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START;
 

--- a/Marlin/SWAConfig.cpp
+++ b/Marlin/SWAConfig.cpp
@@ -1,0 +1,68 @@
+/*
+ Code to configure and handle the Sanguinololu Wireless Adapter.
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Created on 28 Feb 2013 by ODDepot.com
+*/
+
+
+#include "Marlin.h"
+#include "SWAConfig.h"
+
+
+void setup_SWA(MarlinSerial MYSERIAL) {
+  /*
+    The WT41 (the bluetooth module on the Sanguinololu Wireless Adapter) enters command mode on
+    startup and REMAINS there until a bluetooth connection is established. If any data is sent
+    by Marlin, iWRAP (the firmware on the WT41) will assume it's a command and issue a
+    'SYNTAX ERROR' if it doesn't recognize it.  If this occurs too many times in a second it will
+    overburden the WT41 and the WT41 will not have enough resources to make a proper bluetooth 
+    connection. This code is necessary to throttle communication on the serial port and give the
+    WT41 the resources it needs to make a connection and enter data mode.
+  */
+
+  // Tell the WT41 to turn on the LED, this is a test to make sure the WT41 is responding
+  delay(1000);  // The WT41 needs some extra time to process commands
+  MYSERIAL.write("PIO SETDIR FF FF\r\n");  // Set PIO direction
+  delay(1000);
+  MYSERIAL.write("PIO SET FF 00\r\n");  // Set PIO output (turn LED on)
+
+  // Other configurations or commands should be done here, see the WT41 datasheet for details
+  // delay(1000);
+  // MYSERIAL.write("\r\n")
+
+  // Wait here until a bluetooth connection is established
+  while(1){
+    MYSERIAL.flush();  // Make sure there's nothing in the receive buffer
+
+    // Send string to the WT41 and wait for a reply (if there is one)
+    MYSERIAL.write("WT41 intialized\r\n");
+    delay(1000);
+
+    // If the WT41 has entered data mode (it will once a bluetooth connection is established) there
+    // won't be a reply and the string just sent should be passed on to the host software
+    if(!MYSERIAL.available()){
+      break; // Done here, break the loop and exit the function
+    }
+  }
+
+  // This is suppose to be the preferred method of entering data mode but it doesn't work, maybe
+  // it's a bug in iWRAP?
+  /*delay(1000);
+  MYSERIAL.write("+++");  // Switch from command mode to data mode
+  delay(1000);
+  MYSERIAL.write("WT41 intialized\r\n");*/
+
+}

--- a/Marlin/SWAConfig.h
+++ b/Marlin/SWAConfig.h
@@ -1,0 +1,24 @@
+/*
+ Code to configure and handle the Sanguinololu Wireless Adapter.
+ 
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ Created on 28 Feb 2013 by ODDepot.com
+*/
+
+
+#include "Marlin.h"
+
+
+void setup_SWA(MarlinSerial MYSERIAL);


### PR DESCRIPTION
Extra code is needed beyond setting 'Serial 1' in Configuration.h,
this is provided by SWAConfig.h and SWAConfig.cpp. Appropriate
settings are added to Configuration.h and minimal code is added to
Marlin_main.cpp to bind everything together.
