### PR TITLE
regenerated thermistor table 7

### DIFF
--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -310,7 +310,7 @@ const short temptable_7[][2] PROGMEM = {
    {955*OVERSAMPLENR, 35},
    {973*OVERSAMPLENR, 27},
    {991*OVERSAMPLENR, 17},
-   {1009*OVERSAMPLENR, 1}
+   {1009*OVERSAMPLENR, 1},
    {1023*OVERSAMPLENR, 0}  //to allow internal 0 degrees C
 };
 #endif


### PR DESCRIPTION
Generated with createTemperatureLookup.py. The old table crapped out at
270C, which was a problem for polycarbonate.

This is my first pull request, so be gentle with me.
