### PR TITLE
Separate PID_MAX from BANG_MAX

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -117,7 +117,8 @@
 // PID settings:
 // Comment the following line to disable PID and enable bang-bang.
 #define PIDTEMP
-#define PID_MAX 256 // limits current to nozzle; 256=full current
+#define BANG_MAX 256 // limits current to nozzle while in bang-bang mode; 256=full current
+#define PID_MAX 256 // limits current to nozzle while PID is active (see PID_FUNCTIONAL_RANGE below); 256=full current
 #ifdef PIDTEMP
   //#define PID_DEBUG // Sends debug data to the serial port. 
   //#define PID_OPENLOOP 1 // Puts PID in open loop. M104/M140 sets the output power from 0 to PID_MAX

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -325,10 +325,10 @@ void manage_heater()
     #ifndef PID_OPENLOOP
         pid_error[e] = target_temperature[e] - pid_input;
         if(pid_error[e] > PID_FUNCTIONAL_RANGE) {
-          pid_output = PID_MAX;
+          pid_output = BANG_MAX;
           pid_reset[e] = true;
         }
-        else if(pid_error[e] < -PID_FUNCTIONAL_RANGE) {
+        else if(pid_error[e] < -PID_FUNCTIONAL_RANGE || target_temperature[e] == 0) {
           pid_output = 0;
           pid_reset[e] = true;
         }


### PR DESCRIPTION
This allows PID_FUNCTIONAL_RANGE to use a maximum duty cycle higher
than PID_MAX. This is useful for powerful heaters to heat quickly in
bang-bang mode, but use a lower duty cycle that is easier to stabilize
in PID mode.
