### PR TITLE
Removed GIT fragments from language.h

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -1463,10 +1463,5 @@
 	#define MSG_ERR_COLD_EXTRUDE_STOP " kylmana pursotus estetty"
 	#define MSG_ERR_LONG_EXTRUDE_STOP " liian pitka pursotus estetty"
 
-#endif
-<<<<<<< HEAD
 #endif // ifndef LANGUAGE_H
 
-=======
-#endif // ifndef LANGUAGE_H
->>>>>>> origin/Marlin_v1


### PR DESCRIPTION
Seems that there was something wrong while merging the files.
This pull request removes the wrong strings at the end of the file.
The file does now compile.
