### PR TITLE
Make Gen7 1.4+ heater temp sensort pins match silkscreen.

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -181,10 +181,10 @@
 #define E0_DIR_PIN 18
 #define E0_ENABLE_PIN 25
 
-#define TEMP_0_PIN 0
+#define TEMP_0_PIN 1
 #define TEMP_1_PIN -1
 #define TEMP_2_PIN -1
-#define TEMP_BED_PIN 1
+#define TEMP_BED_PIN 0
 
 #define HEATER_0_PIN 4
 #define HEATER_1_PIN -1


### PR DESCRIPTION
Re: Issue #284.

The heater temperature sensor pins currently do not match the Gen7 design. I like it when correctness is considered a priority.

Compiled and tested on my Gen7 1.4 wires as designed; hot end supply and sensor plugs closest to the stepper drivers, bed plugs farthest from stepper drivers.
