### PR TITLE
Add (as an option) slower SD transfer mode

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -319,6 +319,7 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 //#define ULTRA_LCD  //general lcd support, also 16x2
 //#define DOGLCD	// Support for SPI LCD 128x64 (Controller ST7565R graphic Display Family)
 //#define SDSUPPORT // Enable SD Card Support in Hardware Console
+//#define SDSLOW // Use slower SD transfer mode (not normally needed - uncomment if you're getting volume init error)
 
 //#define ULTIMAKERCONTROLLER //as available from the ultimaker online store.
 //#define ULTIPANEL  //the ultipanel as on thingiverse

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -146,7 +146,11 @@ void CardReader::initsd()
   cardOK = false;
   if(root.isOpen())
     root.close();
+#ifdef SDSLOW
+  if (!card.init(SPI_HALF_SPEED,SDSS))
+#else
   if (!card.init(SPI_FULL_SPEED,SDSS))
+#endif
   {
     //if (!card.init(SPI_HALF_SPEED,SDSS))
     SERIAL_ECHO_START;


### PR DESCRIPTION
When using slow 5V -> 3.3V buffer and/or slow SD card(?) you'll get volume init error. Limiting SPI speed solves the problem.
I've found that it isn't only my problem so I added an option #SDSLOW.
