### PR TITLE
Expanded M302 to allow setting the temp

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -119,7 +119,7 @@
 // M240 - Trigger a camera to take a photograph
 // M300 - Play beepsound S<frequency Hz> P<duration ms>
 // M301 - Set PID parameters P I and D
-// M302 - Allow cold extrudes
+// M302 - Allow cold extrudes, or set the minimum extrude S<temperature>.
 // M303 - PID relay autotune S<temperature> sets the target temperature. (default target temperature = 150C)
 // M304 - Set bed PID parameters P I and D
 // M400 - Finish all moves
@@ -1530,12 +1530,15 @@ void process_commands()
       #endif
      }
     break;
-      
-    case 302: // allow cold extrudes
+    #ifdef PREVENT_DANGEROUS_EXTRUDE
+    case 302: // allow cold extrudes, or set the minimum extrude temperature
     {
-      allow_cold_extrudes(true);
+	  float temp = .0;
+	  if (code_seen('S')) temp=code_value();
+      set_extrude_min_temp(temp);
     }
     break;
+	#endif
     case 303: // M303 PID autotune
     {
       float temp = 150.0;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -98,7 +98,7 @@ volatile unsigned char block_buffer_tail;           // Index of the block to pro
 //=============================private variables ============================
 //===========================================================================
 #ifdef PREVENT_DANGEROUS_EXTRUDE
-bool allow_cold_extrude=false;
+float extrude_min_temp=EXTRUDE_MINTEMP;
 #endif
 #ifdef XY_FREQUENCY_LIMIT
 #define MAX_FREQ_TIME (1000000.0/XY_FREQUENCY_LIMIT)
@@ -519,7 +519,7 @@ void plan_buffer_line(const float &x, const float &y, const float &z, const floa
   #ifdef PREVENT_DANGEROUS_EXTRUDE
   if(target[E_AXIS]!=position[E_AXIS])
   {
-    if(degHotend(active_extruder)<EXTRUDE_MINTEMP && !allow_cold_extrude)
+    if(degHotend(active_extruder)<extrude_min_temp)
     {
       position[E_AXIS]=target[E_AXIS]; //behave as if the move really took place, but ignore E part
       SERIAL_ECHO_START;
@@ -896,12 +896,12 @@ uint8_t movesplanned()
   return (block_buffer_head-block_buffer_tail + BLOCK_BUFFER_SIZE) & (BLOCK_BUFFER_SIZE - 1);
 }
 
-void allow_cold_extrudes(bool allow)
-{
 #ifdef PREVENT_DANGEROUS_EXTRUDE
-  allow_cold_extrude=allow;
-#endif
+void set_extrude_min_temp(float temp)
+{
+  extrude_min_temp=temp;
 }
+#endif
 
 // Calculate the steps/s^2 acceleration rates, based on the mm/s^s
 void reset_acceleration_rates()

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -135,7 +135,9 @@ FORCE_INLINE bool blocks_queued()
     return true;
 }
 
-void allow_cold_extrudes(bool allow);
+#ifdef PREVENT_DANGEROUS_EXTRUDE
+void set_extrude_min_temp(float temp);
+#endif
 
 void reset_acceleration_rates();
 #endif


### PR DESCRIPTION
Cold extrusion prevention can be very useful, but the temperature limit differs quite a lot between ABS and PLA, and sometimes even between colours.

M302 is updated so it allows you to change the temperature. M302 S170 will set the cold extrusion temperature limit to 170C instead of disabling it.

M302 without the S-parameter will set the limit to 0C, effectively disabling cold extrusion prevention, making it backwards compatible with old G-Code.
