### PR TITLE
added support for the reprapworld keypad

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -338,10 +338,10 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 
-// The RepRapWorld Keypad v1.1
+// The RepRapWorld REPRAPWORLD_KEYPAD v1.1
 // http://reprapworld.com/?products_details&products_id=202&cPath=1591_1626
-//#define KEYPAD
-//#define KEYPAD_MOVE_STEP 10.0 // how much should be moved when a key is pressed, eg 10.0 means 10mm per click
+//#define REPRAPWORLD_KEYPAD
+//#define REPRAPWORLD_KEYPAD_MOVE_STEP 10.0 // how much should be moved when a key is pressed, eg 10.0 means 10mm per click
 
 //automatic expansion
 #if defined (REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
@@ -355,7 +355,7 @@ const bool Z_ENDSTOPS_INVERTING = true; // set to true to invert the logic of th
  #define NEWPANEL
 #endif 
 
-#if defined(KEYPAD)
+#if defined(REPRAPWORLD_KEYPAD)
   #define NEWPANEL
   #define ULTIPANEL
 #endif

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -416,7 +416,7 @@
       #define BEEPER 33	 // Beeper on AUX-4
 
       //buttons are directly attached using AUX-2
-      #ifdef KEYPAD
+      #ifdef REPRAPWORLD_KEYPAD
         #define BTN_EN1 64 // encoder
         #define BTN_EN2 59 // encoder
         #define BTN_ENC 63 // enter button
@@ -424,14 +424,14 @@
         #define SHIFT_CLK 44 // shift register
         #define SHIFT_LD 42 // shift register
         // define register bit values, don't change it
-        #define BLEN_KEYPAD_F3 0
-        #define BLEN_KEYPAD_F2 1
-        #define BLEN_KEYPAD_F1 2
-        #define BLEN_KEYPAD_UP 3
-        #define BLEN_KEYPAD_RIGHT 4
-        #define BLEN_KEYPAD_MIDDLE 5
-        #define BLEN_KEYPAD_DOWN 6
-        #define BLEN_KEYPAD_LEFT 7
+        #define BLEN_REPRAPWORLD_KEYPAD_F3 0
+        #define BLEN_REPRAPWORLD_KEYPAD_F2 1
+        #define BLEN_REPRAPWORLD_KEYPAD_F1 2
+        #define BLEN_REPRAPWORLD_KEYPAD_UP 3
+        #define BLEN_REPRAPWORLD_KEYPAD_RIGHT 4
+        #define BLEN_REPRAPWORLD_KEYPAD_MIDDLE 5
+        #define BLEN_REPRAPWORLD_KEYPAD_DOWN 6
+        #define BLEN_REPRAPWORLD_KEYPAD_LEFT 7
 	  #else
         #define BTN_EN1 37
         #define BTN_EN2 35

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -113,7 +113,7 @@ static void menu_action_setting_edit_callback_long5(const char* pstr, unsigned l
 
 /** Used variables to keep track of the menu */
 volatile uint8_t buttons;//Contains the bits of the currently pressed buttons.
-volatile uint8_t buttons_keypad; // to store the keypad shiftregister values
+volatile uint8_t buttons_reprapworld_keypad; // to store the reprapworld_keypad shiftregister values
 
 uint8_t currentMenuViewOffset;              /* scroll offset in the current menu */
 uint32_t blocking_enc;
@@ -688,19 +688,18 @@ menu_edit_type(float, float51, ftostr51, 10)
 menu_edit_type(float, float52, ftostr52, 100)
 menu_edit_type(unsigned long, long5, ftostr5, 0.01)
 
-#ifdef KEYPAD
-	static void keypad_move_y_down() {
-	SERIAL_ECHO("keypad_move_y_down");
+#ifdef REPRAPWORLD_KEYPAD
+	static void reprapworld_keypad_move_y_down() {
         encoderPosition = 1;
-        move_menu_scale = KEYPAD_MOVE_STEP;
+        move_menu_scale = REPRAPWORLD_KEYPAD_MOVE_STEP;
 		lcd_move_y();
 	}
-	static void keypad_move_y_up() {
+	static void reprapworld_keypad_move_y_up() {
 		encoderPosition = -1;
-		move_menu_scale = KEYPAD_MOVE_STEP;
+		move_menu_scale = REPRAPWORLD_KEYPAD_MOVE_STEP;
     	lcd_move_y();
 	}
-	static void keypad_move_home() {
+	static void reprapworld_keypad_move_home() {
 		//enquecommand_P((PSTR("G28"))); // move all axis home
 		// TODO gregor: move all axis home, i have currently only one axis on my prusa i3
 		enquecommand_P((PSTR("G28 Y")));
@@ -770,7 +769,7 @@ void lcd_init()
     WRITE(BTN_EN1,HIGH);
     WRITE(BTN_EN2,HIGH);
     WRITE(BTN_ENC,HIGH);
-    #ifdef KEYPAD
+    #ifdef REPRAPWORLD_KEYPAD
       pinMode(SHIFT_CLK,OUTPUT);
       pinMode(SHIFT_LD,OUTPUT);
       pinMode(SHIFT_OUT,INPUT);
@@ -823,15 +822,15 @@ void lcd_update()
     if (lcd_next_update_millis < millis())
     {
 #ifdef ULTIPANEL
-		#ifdef KEYPAD
-        	if (KEYPAD_MOVE_Y_DOWN) {
-        		keypad_move_y_down();
+		#ifdef REPRAPWORLD_KEYPAD
+        	if (REPRAPWORLD_KEYPAD_MOVE_Y_DOWN) {
+        		reprapworld_keypad_move_y_down();
         	}
-        	if (KEYPAD_MOVE_Y_UP) {
-        		keypad_move_y_up();
+        	if (REPRAPWORLD_KEYPAD_MOVE_Y_UP) {
+        		reprapworld_keypad_move_y_up();
         	}
-        	if (KEYPAD_MOVE_HOME) {
-        		keypad_move_home();
+        	if (REPRAPWORLD_KEYPAD_MOVE_HOME) {
+        		reprapworld_keypad_move_home();
         	}
 		#endif
         if (encoderDiff)
@@ -914,18 +913,20 @@ void lcd_buttons_update()
     if((blocking_enc<millis()) && (READ(BTN_ENC)==0))
         newbutton |= EN_C;
     buttons = newbutton;
-    // for the keypad
-    uint8_t newbutton_keypad=0;
-    WRITE(SHIFT_LD,LOW);
-    WRITE(SHIFT_LD,HIGH);
-    for(int8_t i=0;i<8;i++) {
-        newbutton_keypad = newbutton_keypad>>1;
-        if(READ(SHIFT_OUT))
-            newbutton_keypad|=(1<<7);
-        WRITE(SHIFT_CLK,HIGH);
-        WRITE(SHIFT_CLK,LOW);
-    }
-    buttons_keypad=~newbutton_keypad; //invert it, because a pressed switch produces a logical 0
+    #ifdef REPRAPWORLD_KEYPAD
+      // for the reprapworld_keypad
+      uint8_t newbutton_reprapworld_keypad=0;
+      WRITE(SHIFT_LD,LOW);
+      WRITE(SHIFT_LD,HIGH);
+      for(int8_t i=0;i<8;i++) {
+          newbutton_reprapworld_keypad = newbutton_reprapworld_keypad>>1;
+          if(READ(SHIFT_OUT))
+              newbutton_reprapworld_keypad|=(1<<7);
+          WRITE(SHIFT_CLK,HIGH);
+          WRITE(SHIFT_CLK,LOW);
+      }
+      buttons_reprapworld_keypad=~newbutton_reprapworld_keypad; //invert it, because a pressed switch produces a logical 0
+	#endif
 #else   //read it from the shift register
     uint8_t newbutton=0;
     WRITE(SHIFT_LD,LOW);

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -23,8 +23,8 @@
   #ifdef ULTIPANEL
   void lcd_buttons_update();
   extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
-  #ifdef KEYPAD
-    extern volatile uint8_t buttons_keypad; // to store the keypad shiftregister values
+  #ifdef REPRAPWORLD_KEYPAD
+    extern volatile uint8_t buttons_reprapworld_keypad; // to store the keypad shiftregister values
   #endif
   #else
   FORCE_INLINE void lcd_buttons_update() {}
@@ -44,21 +44,21 @@
     #define EN_A (1<<BLEN_A)
 
     #define LCD_CLICKED (buttons&EN_C)
-    #ifdef KEYPAD
-  	  #define EN_KEYPAD_F3 (1<<BLEN_KEYPAD_F3)
-  	  #define EN_KEYPAD_F2 (1<<BLEN_KEYPAD_F2)
-  	  #define EN_KEYPAD_F1 (1<<BLEN_KEYPAD_F1)
-  	  #define EN_KEYPAD_UP (1<<BLEN_KEYPAD_UP)
-  	  #define EN_KEYPAD_RIGHT (1<<BLEN_KEYPAD_RIGHT)
-  	  #define EN_KEYPAD_MIDDLE (1<<BLEN_KEYPAD_MIDDLE)
-  	  #define EN_KEYPAD_DOWN (1<<BLEN_KEYPAD_DOWN)
-  	  #define EN_KEYPAD_LEFT (1<<BLEN_KEYPAD_LEFT)
+    #ifdef REPRAPWORLD_KEYPAD
+  	  #define EN_REPRAPWORLD_KEYPAD_F3 (1<<BLEN_REPRAPWORLD_KEYPAD_F3)
+  	  #define EN_REPRAPWORLD_KEYPAD_F2 (1<<BLEN_REPRAPWORLD_KEYPAD_F2)
+  	  #define EN_REPRAPWORLD_KEYPAD_F1 (1<<BLEN_REPRAPWORLD_KEYPAD_F1)
+  	  #define EN_REPRAPWORLD_KEYPAD_UP (1<<BLEN_REPRAPWORLD_KEYPAD_UP)
+  	  #define EN_REPRAPWORLD_KEYPAD_RIGHT (1<<BLEN_REPRAPWORLD_KEYPAD_RIGHT)
+  	  #define EN_REPRAPWORLD_KEYPAD_MIDDLE (1<<BLEN_REPRAPWORLD_KEYPAD_MIDDLE)
+  	  #define EN_REPRAPWORLD_KEYPAD_DOWN (1<<BLEN_REPRAPWORLD_KEYPAD_DOWN)
+  	  #define EN_REPRAPWORLD_KEYPAD_LEFT (1<<BLEN_REPRAPWORLD_KEYPAD_LEFT)
 
-  	  #define LCD_CLICKED ((buttons&EN_C) || (buttons_keypad&EN_KEYPAD_F1))
-  	  #define KEYPAD_MOVE_Y_DOWN (buttons_keypad&EN_KEYPAD_DOWN)
-  	  #define KEYPAD_MOVE_Y_UP (buttons_keypad&EN_KEYPAD_UP)
-  	  #define KEYPAD_MOVE_HOME (buttons_keypad&EN_KEYPAD_MIDDLE)
-    #endif //KEYPAD
+  	  #define LCD_CLICKED ((buttons&EN_C) || (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_F1))
+  	  #define REPRAPWORLD_KEYPAD_MOVE_Y_DOWN (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_DOWN)
+  	  #define REPRAPWORLD_KEYPAD_MOVE_Y_UP (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_UP)
+  	  #define REPRAPWORLD_KEYPAD_MOVE_HOME (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_MIDDLE)
+    #endif //REPRAPWORLD_KEYPAD
   #else
     //atomatic, do not change
     #define B_LE (1<<BL_LE)


### PR DESCRIPTION
hi,

i have spend some hours to learn how to handle shift registers and then to add some functionality  to the keypad buttons they were not supported in any way since it was released. currently not all buttons work because i haven't finished yet my prusa i3 yet because of some missing parts from reprapworld :-) and therefore i have only the y axis which i can play with.
what work:
- button f1 open the menu
- button down move the bed down
- button up move the bed up
- button middle move the y axis to home
  what did not work:
- all other buttons but i will add the functionality when i get the missing parts

hopefully this piece of code will find a place in the marlin firmware.

king regards
gregor
