### PR TITLE
Fixed "Cooldown" Selection not reseting bed temp

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -252,6 +252,7 @@ void lcd_preheat_pla()
     setTargetBed(plaPreheatHPBTemp);
     fanSpeed = plaPreheatFanSpeed;
     lcd_return_to_status();
+	setWatch();	// heater sanity check timer
 }
 
 void lcd_preheat_abs()
@@ -262,6 +263,16 @@ void lcd_preheat_abs()
     setTargetBed(absPreheatHPBTemp);
     fanSpeed = absPreheatFanSpeed;
     lcd_return_to_status();
+	setWatch();	// heater sanity check timer
+}
+
+static void lcd_cooldown()
+{
+	setTargetHotend0(0);
+	setTargetHotend1(0);
+	setTargetHotend2(0);
+	setTargetBed(0);
+	lcd_return_to_status();
 }
 
 static void lcd_tune_menu()
@@ -299,7 +310,7 @@ static void lcd_prepare_menu()
     //MENU_ITEM(gcode, MSG_SET_ORIGIN, PSTR("G92 X0 Y0 Z0"));
     MENU_ITEM(function, MSG_PREHEAT_PLA, lcd_preheat_pla);
     MENU_ITEM(function, MSG_PREHEAT_ABS, lcd_preheat_abs);
-    MENU_ITEM(gcode, MSG_COOLDOWN, PSTR("M104 S0\nM140 S0"));
+    MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
     MENU_ITEM(submenu, MSG_MOVE_AXIS, lcd_move_menu);
     END_MENU();
 }


### PR DESCRIPTION
- enquecommand with multiple lines "\n" doesn't work -> M140 S0 didn't
  get processed. So I wrote a new func for the cooldown which uses
  setTargetHotend. In addition this does return to status page after
  selection.
  - Added setWatch() to preheat-functions (Temperatur sanity check
    would never have worked when preheating from the lcd panel)
