### PR TITLE
LCD: Added Deadzone at 100% Feedrate

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -76,7 +76,6 @@ static void menu_action_setting_edit_callback_float51(const char* pstr, float* p
 static void menu_action_setting_edit_callback_float52(const char* pstr, float* ptr, float minValue, float maxValue, menuFunc_t callbackFunc);
 static void menu_action_setting_edit_callback_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue, menuFunc_t callbackFunc);
 
-#define ENCODER_STEPS_PER_MENU_ITEM 5
 #define ENCODER_FEEDRATE_DEADZONE 10
 
 #if !defined(LCD_I2C_VIKI)


### PR DESCRIPTION
This adds a deadzone at 100% Feedrate when changing it at the status
screen/main menu. Prevents from unwanted feedrate-changing when
navigating back to the main menu and makes it easier to return to 100%.

UPDATE: changed indentation to soft tabs, merged conflict
