### PR TITLE
Revert previous change pin check change

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -96,7 +96,7 @@ void process_commands();
 
 void manage_inactivity();
 
-#if X_ENABLE_PIN > -1
+#if defined(X_ENABLE_PIN) && X_ENABLE_PIN > -1
   #define  enable_x() WRITE(X_ENABLE_PIN, X_ENABLE_ON)
   #define disable_x() WRITE(X_ENABLE_PIN,!X_ENABLE_ON)
 #else
@@ -104,7 +104,7 @@ void manage_inactivity();
   #define disable_x() ;
 #endif
 
-#if Y_ENABLE_PIN > -1
+#if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
   #define  enable_y() WRITE(Y_ENABLE_PIN, Y_ENABLE_ON)
   #define disable_y() WRITE(Y_ENABLE_PIN,!Y_ENABLE_ON)
 #else
@@ -112,7 +112,7 @@ void manage_inactivity();
   #define disable_y() ;
 #endif
 
-#if Z_ENABLE_PIN > -1
+#if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
   #ifdef Z_DUAL_STEPPER_DRIVERS
     #define  enable_z() { WRITE(Z_ENABLE_PIN, Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN, Z_ENABLE_ON); }
     #define disable_z() { WRITE(Z_ENABLE_PIN,!Z_ENABLE_ON); WRITE(Z2_ENABLE_PIN,!Z_ENABLE_ON); }

--- a/Marlin/Marlin.pde
+++ b/Marlin/Marlin.pde
@@ -47,6 +47,6 @@
   #endif
 #endif
 
-#if DIGIPOTSS_PIN > -1
+#if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
 #include <SPI.h>
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -44,7 +44,7 @@
 #include "Servo.h"
 #endif
 
-#if DIGIPOTSS_PIN > 0
+#if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
 #include <SPI.h>
 #endif
 
@@ -300,7 +300,7 @@ void enquecommand_P(const char *cmd)
 
 void setup_killpin()
 {
-  #if( KILL_PIN>-1 )
+  #if defined(KILL_PIN) && KILL_PIN > -1
     pinMode(KILL_PIN,INPUT);
     WRITE(KILL_PIN,HIGH);
   #endif
@@ -308,50 +308,44 @@ void setup_killpin()
 
 void setup_photpin()
 {
-  #ifdef PHOTOGRAPH_PIN
-    #if (PHOTOGRAPH_PIN > 0)
+  #if defined(PHOTOGRAPH_PIN) && PHOTOGRAPH_PIN > -1
     SET_OUTPUT(PHOTOGRAPH_PIN);
     WRITE(PHOTOGRAPH_PIN, LOW);
-    #endif
   #endif
 }
 
 void setup_powerhold()
 {
- #ifdef SUICIDE_PIN
-   #if (SUICIDE_PIN> 0)
-      SET_OUTPUT(SUICIDE_PIN);
-      WRITE(SUICIDE_PIN, HIGH);
-   #endif
- #endif
- #if (PS_ON_PIN > 0)
-   SET_OUTPUT(PS_ON_PIN);
-   WRITE(PS_ON_PIN, PS_ON_AWAKE);
- #endif
+  #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
+    SET_OUTPUT(SUICIDE_PIN);
+    WRITE(SUICIDE_PIN, HIGH);
+  #endif
+  #if defined(PS_ON_PIN) && PS_ON_PIN > -1
+    SET_OUTPUT(PS_ON_PIN);
+    WRITE(PS_ON_PIN, PS_ON_AWAKE);
+  #endif
 }
 
 void suicide()
 {
- #ifdef SUICIDE_PIN
-    #if (SUICIDE_PIN > 0)
-      SET_OUTPUT(SUICIDE_PIN);
-      WRITE(SUICIDE_PIN, LOW);
-    #endif
+  #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
+    SET_OUTPUT(SUICIDE_PIN);
+    WRITE(SUICIDE_PIN, LOW);
   #endif
 }
 
 void servo_init()
 {
-  #if (NUM_SERVOS >= 1) && (SERVO0_PIN > 0)
+  #if (NUM_SERVOS >= 1) && defined(SERVO0_PIN) && (SERVO0_PIN > -1)
     servos[0].attach(SERVO0_PIN);
   #endif
-  #if (NUM_SERVOS >= 2) && (SERVO1_PIN > 0)
+  #if (NUM_SERVOS >= 2) && defined(SERVO1_PIN) && (SERVO1_PIN > -1)
     servos[1].attach(SERVO1_PIN);
   #endif
-  #if (NUM_SERVOS >= 3) && (SERVO2_PIN > 0)
+  #if (NUM_SERVOS >= 3) && defined(SERVO2_PIN) && (SERVO2_PIN > -1)
     servos[2].attach(SERVO2_PIN);
   #endif
-  #if (NUM_SERVOS >= 4) && (SERVO3_PIN > 0)
+  #if (NUM_SERVOS >= 4) && defined(SERVO3_PIN) && (SERVO3_PIN > -1)
     servos[3].attach(SERVO3_PIN);
   #endif
   #if (NUM_SERVOS >= 5)
@@ -411,7 +405,7 @@ void setup()
 
   lcd_init();
   
-  #if CONTROLLERFAN_PIN > 0
+  #if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
     SET_OUTPUT(CONTROLLERFAN_PIN); //Set pin used for driver cooling fan
   #endif 
 }
@@ -669,7 +663,7 @@ static void axis_is_at_home(int axis) {
 
 static void homeaxis(int axis) {
 #define HOMEAXIS_DO(LETTER) \
-  ((LETTER##_MIN_PIN > 0 && LETTER##_HOME_DIR==-1) || (LETTER##_MAX_PIN > 0 && LETTER##_HOME_DIR==1))
+  ((LETTER##_MIN_PIN > -1 && LETTER##_HOME_DIR==-1) || (LETTER##_MAX_PIN > -1 && LETTER##_HOME_DIR==1))
 
   if (axis==X_AXIS ? HOMEAXIS_DO(X) :
       axis==Y_AXIS ? HOMEAXIS_DO(Y) :
@@ -1036,7 +1030,7 @@ void process_commands()
             break;
           }
         }
-      #if FAN_PIN > 0
+      #if defined(FAN_PIN) && FAN_PIN > -1
         if (pin_number == FAN_PIN)
           fanSpeed = pin_status;
       #endif
@@ -1062,12 +1056,12 @@ void process_commands()
       if(setTargetedHotend(105)){
         break;
       }
-      #if (TEMP_0_PIN > 0)
+      #if defined(TEMP_0_PIN) && TEMP_0_PIN > -1
         SERIAL_PROTOCOLPGM("ok T:");
         SERIAL_PROTOCOL_F(degHotend(tmp_extruder),1);
         SERIAL_PROTOCOLPGM(" /");
         SERIAL_PROTOCOL_F(degTargetHotend(tmp_extruder),1);
-        #if TEMP_BED_PIN > 0
+        #if defined(TEMP_BED_PIN) && TEMP_BED_PIN > -1
           SERIAL_PROTOCOLPGM(" B:");
           SERIAL_PROTOCOL_F(degBed(),1);
           SERIAL_PROTOCOLPGM(" /");
@@ -1165,7 +1159,7 @@ void process_commands()
       }
       break;
     case 190: // M190 - Wait for bed heater to reach target.
-    #if TEMP_BED_PIN > 0
+    #if defined(TEMP_BED_PIN) && TEMP_BED_PIN > -1
         LCD_MESSAGEPGM(MSG_BED_HEATING);
         if (code_seen('S')) setTargetBed(code_value());
         codenum = millis();
@@ -1192,7 +1186,7 @@ void process_commands()
     #endif
         break;
 
-    #if FAN_PIN > 0
+    #if defined(FAN_PIN) && FAN_PIN > -1
       case 106: //M106 Fan On
         if (code_seen('S')){
            fanSpeed=constrain(code_value(),0,255);
@@ -1207,7 +1201,7 @@ void process_commands()
     #endif //FAN_PIN
     #ifdef BARICUDA
       // PWM for HEATER_1_PIN
-      #if HEATER_1_PIN > 0
+      #if defined(HEATER_1_PIN) && HEATER_1_PIN > -1
         case 126: //M126 valve open
           if (code_seen('S')){
              ValvePressure=constrain(code_value(),0,255);
@@ -1222,7 +1216,7 @@ void process_commands()
       #endif //HEATER_1_PIN
 
       // PWM for HEATER_2_PIN
-      #if HEATER_2_PIN > 0
+      #if defined(HEATER_2_PIN) && HEATER_2_PIN > -1
         case 128: //M128 valve open
           if (code_seen('S')){
              EtoPPressure=constrain(code_value(),0,255);
@@ -1237,7 +1231,7 @@ void process_commands()
       #endif //HEATER_2_PIN
     #endif
 
-    #if (PS_ON_PIN > 0)
+    #if defined(PS_ON_PIN) && PS_ON_PIN > -1
       case 80: // M80 - ATX Power On
         SET_OUTPUT(PS_ON_PIN); //GND
         WRITE(PS_ON_PIN, PS_ON_AWAKE);
@@ -1246,10 +1240,10 @@ void process_commands()
 
       case 81: // M81 - ATX Power Off
 
-      #if defined SUICIDE_PIN && SUICIDE_PIN > 0
+      #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
         st_synchronize();
         suicide();
-      #elif (PS_ON_PIN > 0)
+      #elif defined(PS_ON_PIN) && PS_ON_PIN > -1
         SET_OUTPUT(PS_ON_PIN);
         WRITE(PS_ON_PIN, PS_ON_ASLEEP);
       #endif
@@ -1354,27 +1348,27 @@ void process_commands()
       break;
     case 119: // M119
     SERIAL_PROTOCOLLN(MSG_M119_REPORT);
-      #if (X_MIN_PIN > 0)
+      #if defined(X_MIN_PIN) && X_MIN_PIN > -1
         SERIAL_PROTOCOLPGM(MSG_X_MIN);
         SERIAL_PROTOCOLLN(((READ(X_MIN_PIN)^X_ENDSTOPS_INVERTING)?MSG_ENDSTOP_HIT:MSG_ENDSTOP_OPEN));
       #endif
-      #if (X_MAX_PIN > 0)
+      #if defined(X_MAX_PIN) && X_MAX_PIN > -1
         SERIAL_PROTOCOLPGM(MSG_X_MAX);
         SERIAL_PROTOCOLLN(((READ(X_MAX_PIN)^X_ENDSTOPS_INVERTING)?MSG_ENDSTOP_HIT:MSG_ENDSTOP_OPEN));
       #endif
-      #if (Y_MIN_PIN > 0)
+      #if defined(Y_MIN_PIN) && Y_MIN_PIN > -1
         SERIAL_PROTOCOLPGM(MSG_Y_MIN);
         SERIAL_PROTOCOLLN(((READ(Y_MIN_PIN)^Y_ENDSTOPS_INVERTING)?MSG_ENDSTOP_HIT:MSG_ENDSTOP_OPEN));
       #endif
-      #if (Y_MAX_PIN > 0)
+      #if defined(Y_MAX_PIN) && Y_MAX_PIN > -1
         SERIAL_PROTOCOLPGM(MSG_Y_MAX);
         SERIAL_PROTOCOLLN(((READ(Y_MAX_PIN)^Y_ENDSTOPS_INVERTING)?MSG_ENDSTOP_HIT:MSG_ENDSTOP_OPEN));
       #endif
-      #if (Z_MIN_PIN > 0)
+      #if defined(Z_MIN_PIN) && Z_MIN_PIN > -1
         SERIAL_PROTOCOLPGM(MSG_Z_MIN);
         SERIAL_PROTOCOLLN(((READ(Z_MIN_PIN)^Z_ENDSTOPS_INVERTING)?MSG_ENDSTOP_HIT:MSG_ENDSTOP_OPEN));
       #endif
-      #if (Z_MAX_PIN > 0)
+      #if defined(Z_MAX_PIN) && Z_MAX_PIN > -1
         SERIAL_PROTOCOLPGM(MSG_Z_MAX);
         SERIAL_PROTOCOLLN(((READ(Z_MAX_PIN)^Z_ENDSTOPS_INVERTING)?MSG_ENDSTOP_HIT:MSG_ENDSTOP_OPEN));
       #endif
@@ -1612,8 +1606,7 @@ void process_commands()
     #endif //PIDTEMP
     case 240: // M240  Triggers a camera by emulating a Canon RC-1 : http://www.doc-diy.net/photo/rc-1_hacked/
      {
-      #ifdef PHOTOGRAPH_PIN
-        #if (PHOTOGRAPH_PIN > 0)
+      #if defined(PHOTOGRAPH_PIN) && PHOTOGRAPH_PIN > -1
         const uint8_t NUM_PULSES=16;
         const float PULSE_LENGTH=0.01524;
         for(int i=0; i < NUM_PULSES; i++) {
@@ -1629,7 +1622,6 @@ void process_commands()
           WRITE(PHOTOGRAPH_PIN, LOW);
           _delay_ms(PULSE_LENGTH);
         }
-        #endif
       #endif
      }
     break;
@@ -1811,7 +1803,7 @@ void process_commands()
     #endif //FILAMENTCHANGEENABLE
     case 907: // M907 Set digital trimpot motor current using axis codes.
     {
-      #if DIGIPOTSS_PIN > 0
+      #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
         for(int i=0;i<NUM_AXIS;i++) if(code_seen(axis_codes[i])) digipot_current(i,code_value());
         if(code_seen('B')) digipot_current(4,code_value());
         if(code_seen('S')) for(int i=0;i<=4;i++) digipot_current(i,code_value());
@@ -1820,7 +1812,7 @@ void process_commands()
     break;
     case 908: // M908 Control digital trimpot directly.
     {
-      #if DIGIPOTSS_PIN > 0
+      #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
         uint8_t channel,current;
         if(code_seen('P')) channel=code_value();
         if(code_seen('S')) current=code_value();
@@ -1830,7 +1822,7 @@ void process_commands()
     break;
     case 350: // M350 Set microstepping mode. Warning: Steps per unit remains unchanged. S code sets stepping mode for all drivers.
     {
-      #if X_MS1_PIN > 0
+      #if defined(X_MS1_PIN) && X_MS1_PIN > -1
         if(code_seen('S')) for(int i=0;i<=4;i++) microstep_mode(i,code_value());
         for(int i=0;i<NUM_AXIS;i++) if(code_seen(axis_codes[i])) microstep_mode(i,(uint8_t)code_value());
         if(code_seen('B')) microstep_mode(4,code_value());
@@ -1840,7 +1832,7 @@ void process_commands()
     break;
     case 351: // M351 Toggle MS1 MS2 pins directly, S# determines MS1 or MS2, X# sets the pin high/low.
     {
-      #if X_MS1_PIN > 0
+      #if defined(X_MS1_PIN) && X_MS1_PIN > -1
       if(code_seen('S')) switch((int)code_value())
       {
         case 1:
@@ -2064,11 +2056,13 @@ void prepare_arc_move(char isclockwise) {
   previous_millis_cmd = millis();
 }
 
-#if CONTROLLERFAN_PIN > 0
+#if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
 
-#if CONTROLLERFAN_PIN == FAN_PIN 
-   #error "You cannot set CONTROLLERFAN_PIN equal to FAN_PIN"
-#endif
+#if defined(FAN_PIN)
+  #if CONTROLLERFAN_PIN == FAN_PIN 
+    #error "You cannot set CONTROLLERFAN_PIN equal to FAN_PIN"
+  #endif
+#endif  
 
 unsigned long lastMotor = 0; //Save the time for when a motor was turned on last
 unsigned long lastMotorCheck = 0;
@@ -2124,11 +2118,11 @@ void manage_inactivity()
       }
     }
   }
-  #if KILL_PIN > 0
+  #if defined(KILL_PIN) && KILL_PIN > -1
     if( 0 == READ(KILL_PIN) )
       kill();
   #endif
-  #if CONTROLLERFAN_PIN > 0
+  #if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
     controllerFan(); //Check if fan should be turned on to cool stepper drivers down
   #endif
   #ifdef EXTRUDER_RUNOUT_PREVENT
@@ -2165,7 +2159,9 @@ void kill()
   disable_e1();
   disable_e2();
 
-  if(PS_ON_PIN > 0) pinMode(PS_ON_PIN,INPUT);
+#if defined(PS_ON_PIN) && PS_ON_PIN > -1
+  pinMode(PS_ON_PIN,INPUT);
+#endif  
   SERIAL_ERROR_START;
   SERIAL_ERRORLNPGM(MSG_ERR_KILLED);
   LCD_ALERTMESSAGEPGM(MSG_KILLED);

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -279,7 +279,7 @@ static void lcd_implementation_status_screen()
  // Fan
  u8g.setFont(FONT_STATUSMENU);
  u8g.setPrintPos(104,27);
- #if FAN_PIN > 0
+ #if defined(FAN_PIN) && FAN_PIN > -1
  u8g.print(itostr3(int((fanSpeed*100)/256 + 1)));
  u8g.print("%");
  #else

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -472,7 +472,7 @@ void check_axes_activity()
     disable_e1();
     disable_e2(); 
   }
-#if FAN_PIN > -1
+#if defined(FAN_PIN) && FAN_PIN > -1
   #ifndef FAN_SOFT_PWM
     #ifdef FAN_KICKSTART_TIME
       static unsigned long fan_kick_end;
@@ -496,11 +496,11 @@ void check_axes_activity()
 #endif
 
 #ifdef BARICUDA
-  #if HEATER_1_PIN > -1
+  #if defined(HEATER_1_PIN) && HEATER_1_PIN > -1
       analogWrite(HEATER_1_PIN,tail_valve_pressure);
   #endif
 
-  #if HEATER_2_PIN > -1
+  #if defined(HEATER_2_PIN) && HEATER_2_PIN > -1
       analogWrite(HEATER_2_PIN,tail_e_to_p_pressure);
   #endif
 #endif

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -29,7 +29,7 @@
 #include "language.h"
 #include "cardreader.h"
 #include "speed_lookuptable.h"
-#if DIGIPOTSS_PIN > -1
+#if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
 #include <SPI.h>
 #endif
 
@@ -353,7 +353,7 @@ ISR(TIMER1_COMPA_vect)
       count_direction[X_AXIS]=-1;
       CHECK_ENDSTOPS
       {
-        #if X_MIN_PIN > -1
+        #if defined(X_MIN_PIN) && X_MIN_PIN > -1
           bool x_min_endstop=(READ(X_MIN_PIN) != X_ENDSTOPS_INVERTING);
           if(x_min_endstop && old_x_min_endstop && (current_block->steps_x > 0)) {
             endstops_trigsteps[X_AXIS] = count_position[X_AXIS];
@@ -372,7 +372,7 @@ ISR(TIMER1_COMPA_vect)
       count_direction[X_AXIS]=1;
       CHECK_ENDSTOPS 
       {
-        #if X_MAX_PIN > -1
+        #if defined(X_MAX_PIN) && X_MAX_PIN > -1
           bool x_max_endstop=(READ(X_MAX_PIN) != X_ENDSTOPS_INVERTING);
           if(x_max_endstop && old_x_max_endstop && (current_block->steps_x > 0)){
             endstops_trigsteps[X_AXIS] = count_position[X_AXIS];
@@ -391,7 +391,7 @@ ISR(TIMER1_COMPA_vect)
       count_direction[Y_AXIS]=-1;
       CHECK_ENDSTOPS
       {
-        #if Y_MIN_PIN > -1
+        #if defined(Y_MIN_PIN) && Y_MIN_PIN > -1
           bool y_min_endstop=(READ(Y_MIN_PIN) != Y_ENDSTOPS_INVERTING);
           if(y_min_endstop && old_y_min_endstop && (current_block->steps_y > 0)) {
             endstops_trigsteps[Y_AXIS] = count_position[Y_AXIS];
@@ -409,7 +409,7 @@ ISR(TIMER1_COMPA_vect)
       count_direction[Y_AXIS]=1;
       CHECK_ENDSTOPS
       {
-        #if Y_MAX_PIN > -1
+        #if defined(Y_MAX_PIN) && Y_MAX_PIN > -1
           bool y_max_endstop=(READ(Y_MAX_PIN) != Y_ENDSTOPS_INVERTING);
           if(y_max_endstop && old_y_max_endstop && (current_block->steps_y > 0)){
             endstops_trigsteps[Y_AXIS] = count_position[Y_AXIS];
@@ -452,7 +452,7 @@ ISR(TIMER1_COMPA_vect)
       count_direction[Z_AXIS]=-1;
       CHECK_ENDSTOPS
       {
-        #if Z_MIN_PIN > -1
+        #if defined(Z_MIN_PIN) && Z_MIN_PIN > -1
           bool z_min_endstop=(READ(Z_MIN_PIN) != Z_ENDSTOPS_INVERTING);
           if(z_min_endstop && old_z_min_endstop && (current_block->steps_z > 0)) {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
@@ -473,7 +473,7 @@ ISR(TIMER1_COMPA_vect)
       count_direction[Z_AXIS]=1;
       CHECK_ENDSTOPS
       {
-        #if Z_MAX_PIN > -1
+        #if defined(Z_MAX_PIN) && Z_MAX_PIN > -1
           bool z_max_endstop=(READ(Z_MAX_PIN) != Z_ENDSTOPS_INVERTING);
           if(z_max_endstop && old_z_max_endstop && (current_block->steps_z > 0)) {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
@@ -743,20 +743,20 @@ void st_init()
   microstep_init(); //Initialize Microstepping Pins
   
   //Initialize Dir Pins
-  #if X_DIR_PIN > -1
+  #if defined(X_DIR_PIN) && X_DIR_PIN > -1
     SET_OUTPUT(X_DIR_PIN);
   #endif
-  #if Y_DIR_PIN > -1 
+  #if defined(Y_DIR_PIN) && Y_DIR_PIN > -1 
     SET_OUTPUT(Y_DIR_PIN);
   #endif
-  #if Z_DIR_PIN > -1 
+  #if defined(Z_DIR_PIN) && Z_DIR_PIN > -1 
     SET_OUTPUT(Z_DIR_PIN);
 
-    #if defined(Z_DUAL_STEPPER_DRIVERS) && (Z2_DIR_PIN > -1)
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_DIR_PIN) && (Z2_DIR_PIN > -1)
       SET_OUTPUT(Z2_DIR_PIN);
     #endif
   #endif
-  #if E0_DIR_PIN > -1 
+  #if defined(E0_DIR_PIN) && E0_DIR_PIN > -1 
     SET_OUTPUT(E0_DIR_PIN);
   #endif
   #if defined(E1_DIR_PIN) && (E1_DIR_PIN > -1)
@@ -768,24 +768,24 @@ void st_init()
 
   //Initialize Enable Pins - steppers default to disabled.
 
-  #if (X_ENABLE_PIN > -1)
+  #if defined(X_ENABLE_PIN) && X_ENABLE_PIN > -1
     SET_OUTPUT(X_ENABLE_PIN);
     if(!X_ENABLE_ON) WRITE(X_ENABLE_PIN,HIGH);
   #endif
-  #if (Y_ENABLE_PIN > -1)
+  #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
     SET_OUTPUT(Y_ENABLE_PIN);
     if(!Y_ENABLE_ON) WRITE(Y_ENABLE_PIN,HIGH);
   #endif
-  #if (Z_ENABLE_PIN > -1)
+  #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
     SET_OUTPUT(Z_ENABLE_PIN);
     if(!Z_ENABLE_ON) WRITE(Z_ENABLE_PIN,HIGH);
     
-    #if defined(Z_DUAL_STEPPER_DRIVERS) && (Z2_ENABLE_PIN > -1)
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_ENABLE_PIN) && (Z2_ENABLE_PIN > -1)
       SET_OUTPUT(Z2_ENABLE_PIN);
       if(!Z_ENABLE_ON) WRITE(Z2_ENABLE_PIN,HIGH);
     #endif
   #endif
-  #if (E0_ENABLE_PIN > -1)
+  #if defined(E0_ENABLE_PIN) && (E0_ENABLE_PIN > -1)
     SET_OUTPUT(E0_ENABLE_PIN);
     if(!E_ENABLE_ON) WRITE(E0_ENABLE_PIN,HIGH);
   #endif
@@ -800,42 +800,42 @@ void st_init()
 
   //endstops and pullups
   
-  #if X_MIN_PIN > -1
+  #if defined(X_MIN_PIN) && X_MIN_PIN > -1
     SET_INPUT(X_MIN_PIN); 
     #ifdef ENDSTOPPULLUP_XMIN
       WRITE(X_MIN_PIN,HIGH);
     #endif
   #endif
       
-  #if Y_MIN_PIN > -1
+  #if defined(Y_MIN_PIN) && Y_MIN_PIN > -1
     SET_INPUT(Y_MIN_PIN); 
     #ifdef ENDSTOPPULLUP_YMIN
       WRITE(Y_MIN_PIN,HIGH);
     #endif
   #endif
   
-  #if Z_MIN_PIN > -1
+  #if defined(Z_MIN_PIN) && Z_MIN_PIN > -1
     SET_INPUT(Z_MIN_PIN); 
     #ifdef ENDSTOPPULLUP_ZMIN
       WRITE(Z_MIN_PIN,HIGH);
     #endif
   #endif
       
-  #if X_MAX_PIN > -1
+  #if defined(X_MAX_PIN) && X_MAX_PIN > -1
     SET_INPUT(X_MAX_PIN); 
     #ifdef ENDSTOPPULLUP_XMAX
       WRITE(X_MAX_PIN,HIGH);
     #endif
   #endif
       
-  #if Y_MAX_PIN > -1
+  #if defined(Y_MAX_PIN) && Y_MAX_PIN > -1
     SET_INPUT(Y_MAX_PIN); 
     #ifdef ENDSTOPPULLUP_YMAX
       WRITE(Y_MAX_PIN,HIGH);
     #endif
   #endif
   
-  #if Z_MAX_PIN > -1
+  #if defined(Z_MAX_PIN) && Z_MAX_PIN > -1
     SET_INPUT(Z_MAX_PIN); 
     #ifdef ENDSTOPPULLUP_ZMAX
       WRITE(Z_MAX_PIN,HIGH);
@@ -844,26 +844,26 @@ void st_init()
  
 
   //Initialize Step Pins
-  #if (X_STEP_PIN > -1) 
+  #if defined(X_STEP_PIN) && (X_STEP_PIN > -1) 
     SET_OUTPUT(X_STEP_PIN);
     WRITE(X_STEP_PIN,INVERT_X_STEP_PIN);
     disable_x();
   #endif  
-  #if (Y_STEP_PIN > -1) 
+  #if defined(Y_STEP_PIN) && (Y_STEP_PIN > -1) 
     SET_OUTPUT(Y_STEP_PIN);
     WRITE(Y_STEP_PIN,INVERT_Y_STEP_PIN);
     disable_y();
   #endif  
-  #if (Z_STEP_PIN > -1) 
+  #if defined(Z_STEP_PIN) && (Z_STEP_PIN > -1) 
     SET_OUTPUT(Z_STEP_PIN);
     WRITE(Z_STEP_PIN,INVERT_Z_STEP_PIN);
-    #if defined(Z_DUAL_STEPPER_DRIVERS) && (Z2_STEP_PIN > -1)
+    #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_STEP_PIN) && (Z2_STEP_PIN > -1)
       SET_OUTPUT(Z2_STEP_PIN);
       WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
     #endif
     disable_z();
   #endif  
-  #if (E0_STEP_PIN > -1) 
+  #if defined(E0_STEP_PIN) && (E0_STEP_PIN > -1) 
     SET_OUTPUT(E0_STEP_PIN);
     WRITE(E0_STEP_PIN,INVERT_E_STEP_PIN);
     disable_e0();
@@ -974,7 +974,7 @@ void quickStop()
 
 void digitalPotWrite(int address, int value) // From Arduino DigitalPotControl example
 {
-  #if DIGIPOTSS_PIN > -1
+  #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
     digitalWrite(DIGIPOTSS_PIN,LOW); // take the SS pin low to select the chip
     SPI.transfer(address); //  send in the address and value via SPI:
     SPI.transfer(value);
@@ -985,7 +985,7 @@ void digitalPotWrite(int address, int value) // From Arduino DigitalPotControl e
 
 void digipot_init() //Initialize Digipot Motor Current
 {
-  #if DIGIPOTSS_PIN > -1
+  #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
     const uint8_t digipot_motor_current[] = DIGIPOT_MOTOR_CURRENT;
     
     SPI.begin(); 
@@ -998,7 +998,7 @@ void digipot_init() //Initialize Digipot Motor Current
 
 void digipot_current(uint8_t driver, int current)
 {
-  #if DIGIPOTSS_PIN > -1
+  #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
     const uint8_t digipot_ch[] = DIGIPOT_CHANNELS;
     digitalPotWrite(digipot_ch[driver], current);
   #endif
@@ -1006,7 +1006,7 @@ void digipot_current(uint8_t driver, int current)
 
 void microstep_init()
 {
-  #if X_MS1_PIN > -1
+  #if defined(X_MS1_PIN) && X_MS1_PIN > -1
   const uint8_t microstep_modes[] = MICROSTEP_MODES;
   pinMode(X_MS2_PIN,OUTPUT);
   pinMode(Y_MS2_PIN,OUTPUT);

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -99,7 +99,9 @@ static volatile bool temp_meas_ready = false;
 #ifdef FAN_SOFT_PWM
   static unsigned char soft_pwm_fan;
 #endif
-#if EXTRUDER_0_AUTO_FAN_PIN > 0 || EXTRUDER_1_AUTO_FAN_PIN > 0 || EXTRUDER_2_AUTO_FAN_PIN > 0
+#if (defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1) || \
+    (defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1) || \
+    (defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1)
   static unsigned long extruder_autofan_last_check;
 #endif  
   
@@ -307,9 +309,11 @@ int getHeaterPower(int heater) {
   return soft_pwm[heater];
 }
 
-#if EXTRUDER_0_AUTO_FAN_PIN > 0 || EXTRUDER_1_AUTO_FAN_PIN > 0 || EXTRUDER_2_AUTO_FAN_PIN > 0
+#if (defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1) || \
+    (defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1) || \
+    (defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1)
 
-  #if FAN_PIN > 0
+  #if defined(FAN_PIN) && FAN_PIN > -1
     #if EXTRUDER_0_AUTO_FAN_PIN == FAN_PIN 
        #error "You cannot set EXTRUDER_0_AUTO_FAN_PIN equal to FAN_PIN"
     #endif
@@ -335,11 +339,11 @@ void checkExtruderAutoFans()
   uint8_t fanState = 0;
 
   // which fan pins need to be turned on?      
-  #if EXTRUDER_0_AUTO_FAN_PIN > 0
+  #if defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1
     if (current_temperature[0] > EXTRUDER_AUTO_FAN_TEMPERATURE) 
       fanState |= 1;
   #endif
-  #if EXTRUDER_1_AUTO_FAN_PIN > 0
+  #if defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1
     if (current_temperature[1] > EXTRUDER_AUTO_FAN_TEMPERATURE) 
     {
       if (EXTRUDER_1_AUTO_FAN_PIN == EXTRUDER_0_AUTO_FAN_PIN) 
@@ -348,7 +352,7 @@ void checkExtruderAutoFans()
         fanState |= 2;
     }
   #endif
-  #if EXTRUDER_2_AUTO_FAN_PIN > 0
+  #if defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1
     if (current_temperature[2] > EXTRUDER_AUTO_FAN_TEMPERATURE) 
     {
       if (EXTRUDER_2_AUTO_FAN_PIN == EXTRUDER_0_AUTO_FAN_PIN) 
@@ -361,14 +365,14 @@ void checkExtruderAutoFans()
   #endif
   
   // update extruder auto fan states
-  #if EXTRUDER_0_AUTO_FAN_PIN > 0
+  #if defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1
     setExtruderAutoFanState(EXTRUDER_0_AUTO_FAN_PIN, (fanState & 1) != 0);
   #endif 
-  #if EXTRUDER_1_AUTO_FAN_PIN > 0
+  #if defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1
     if (EXTRUDER_1_AUTO_FAN_PIN != EXTRUDER_0_AUTO_FAN_PIN) 
       setExtruderAutoFanState(EXTRUDER_1_AUTO_FAN_PIN, (fanState & 2) != 0);
   #endif 
-  #if EXTRUDER_2_AUTO_FAN_PIN > 0
+  #if defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1
     if (EXTRUDER_2_AUTO_FAN_PIN != EXTRUDER_0_AUTO_FAN_PIN 
         && EXTRUDER_2_AUTO_FAN_PIN != EXTRUDER_1_AUTO_FAN_PIN)
       setExtruderAutoFanState(EXTRUDER_2_AUTO_FAN_PIN, (fanState & 4) != 0);
@@ -470,7 +474,9 @@ void manage_heater()
 
   } // End extruder for loop
 
-  #if EXTRUDER_0_AUTO_FAN_PIN > 0 || EXTRUDER_1_AUTO_FAN_PIN > 0 || EXTRUDER_2_AUTO_FAN_PIN > 0
+  #if (defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1) || \
+      (defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1) || \
+      (defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1)
   if(millis() - extruder_autofan_last_check > 2500)  // only need to check fan state very infrequently
   {
     checkExtruderAutoFans();
@@ -669,19 +675,19 @@ void tp_init()
 #endif //PIDTEMPBED
   }
 
-  #if (HEATER_0_PIN > -1) 
+  #if defined(HEATER_0_PIN) && (HEATER_0_PIN > -1) 
     SET_OUTPUT(HEATER_0_PIN);
   #endif  
-  #if (HEATER_1_PIN > -1) 
+  #if defined(HEATER_1_PIN) && (HEATER_1_PIN > -1) 
     SET_OUTPUT(HEATER_1_PIN);
   #endif  
-  #if (HEATER_2_PIN > -1) 
+  #if defined(HEATER_2_PIN) && (HEATER_2_PIN > -1) 
     SET_OUTPUT(HEATER_2_PIN);
   #endif  
-  #if (HEATER_BED_PIN > -1) 
+  #if defined(HEATER_BED_PIN) && (HEATER_BED_PIN > -1) 
     SET_OUTPUT(HEATER_BED_PIN);
   #endif  
-  #if (FAN_PIN > -1) 
+  #if defined(FAN_PIN) && (FAN_PIN > -1) 
     SET_OUTPUT(FAN_PIN);
     #ifdef FAST_PWM_FAN
     setPwmFrequency(FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
@@ -713,28 +719,28 @@ void tp_init()
   #ifdef DIDR2
     DIDR2 = 0;
   #endif
-  #if (TEMP_0_PIN > -1)
+  #if defined(TEMP_0_PIN) && (TEMP_0_PIN > -1)
     #if TEMP_0_PIN < 8
        DIDR0 |= 1 << TEMP_0_PIN; 
     #else
        DIDR2 |= 1<<(TEMP_0_PIN - 8); 
     #endif
   #endif
-  #if (TEMP_1_PIN > -1)
+  #if defined(TEMP_1_PIN) && (TEMP_1_PIN > -1)
     #if TEMP_1_PIN < 8
        DIDR0 |= 1<<TEMP_1_PIN; 
     #else
        DIDR2 |= 1<<(TEMP_1_PIN - 8); 
     #endif
   #endif
-  #if (TEMP_2_PIN > -1)
+  #if defined(TEMP_2_PIN) && (TEMP_2_PIN > -1)
     #if TEMP_2_PIN < 8
        DIDR0 |= 1 << TEMP_2_PIN; 
     #else
        DIDR2 |= 1<<(TEMP_2_PIN - 8); 
     #endif
   #endif
-  #if (TEMP_BED_PIN > -1)
+  #if defined(TEMP_BED_PIN) && (TEMP_BED_PIN > -1)
     #if TEMP_BED_PIN < 8
        DIDR0 |= 1<<TEMP_BED_PIN; 
     #else
@@ -855,34 +861,34 @@ void disable_heater()
   for(int i=0;i<EXTRUDERS;i++)
     setTargetHotend(0,i);
   setTargetBed(0);
-  #if TEMP_0_PIN > -1
+  #if defined(TEMP_0_PIN) && TEMP_0_PIN > -1
   target_temperature[0]=0;
   soft_pwm[0]=0;
-   #if HEATER_0_PIN > -1  
+   #if defined(HEATER_0_PIN) && HEATER_0_PIN > -1  
      WRITE(HEATER_0_PIN,LOW);
    #endif
   #endif
      
-  #if TEMP_1_PIN > -1
+  #if defined(TEMP_1_PIN) && TEMP_1_PIN > -1
     target_temperature[1]=0;
     soft_pwm[1]=0;
-    #if HEATER_1_PIN > -1 
+    #if defined(HEATER_1_PIN) && HEATER_1_PIN > -1 
       WRITE(HEATER_1_PIN,LOW);
     #endif
   #endif
       
-  #if TEMP_2_PIN > -1
+  #if defined(TEMP_2_PIN) && TEMP_2_PIN > -1
     target_temperature[2]=0;
     soft_pwm[2]=0;
-    #if HEATER_2_PIN > -1  
+    #if defined(HEATER_2_PIN) && HEATER_2_PIN > -1  
       WRITE(HEATER_2_PIN,LOW);
     #endif
   #endif 
 
-  #if TEMP_BED_PIN > -1
+  #if defined(TEMP_BED_PIN) && TEMP_BED_PIN > -1
     target_temperature_bed=0;
     soft_pwm_bed=0;
-    #if HEATER_BED_PIN > -1  
+    #if defined(HEATER_BED_PIN) && HEATER_BED_PIN > -1  
       WRITE(HEATER_BED_PIN,LOW);
     #endif
   #endif 
@@ -1018,7 +1024,7 @@ ISR(TIMER0_COMPB_vect)
     soft_pwm_2 = soft_pwm[2];
     if(soft_pwm_2 > 0) WRITE(HEATER_2_PIN,1);
     #endif
-    #if HEATER_BED_PIN > -1
+    #if defined(HEATER_BED_PIN) && HEATER_BED_PIN > -1
     soft_pwm_b = soft_pwm_bed;
     if(soft_pwm_b > 0) WRITE(HEATER_BED_PIN,1);
     #endif
@@ -1034,7 +1040,7 @@ ISR(TIMER0_COMPB_vect)
   #if EXTRUDERS > 2
   if(soft_pwm_2 <= pwm_count) WRITE(HEATER_2_PIN,0);
   #endif
-  #if HEATER_BED_PIN > -1
+  #if defined(HEATER_BED_PIN) && HEATER_BED_PIN > -1
   if(soft_pwm_b <= pwm_count) WRITE(HEATER_BED_PIN,0);
   #endif
   #ifdef FAN_SOFT_PWM
@@ -1046,7 +1052,7 @@ ISR(TIMER0_COMPB_vect)
   
   switch(temp_state) {
     case 0: // Prepare TEMP_0
-      #if (TEMP_0_PIN > -1)
+      #if defined(TEMP_0_PIN) && (TEMP_0_PIN > -1)
         #if TEMP_0_PIN > 7
           ADCSRB = 1<<MUX5;
         #else
@@ -1059,7 +1065,7 @@ ISR(TIMER0_COMPB_vect)
       temp_state = 1;
       break;
     case 1: // Measure TEMP_0
-      #if (TEMP_0_PIN > -1)
+      #if defined(TEMP_0_PIN) && (TEMP_0_PIN > -1)
         raw_temp_0_value += ADC;
       #endif
       #ifdef HEATER_0_USES_MAX6675 // TODO remove the blocking
@@ -1068,7 +1074,7 @@ ISR(TIMER0_COMPB_vect)
       temp_state = 2;
       break;
     case 2: // Prepare TEMP_BED
-      #if (TEMP_BED_PIN > -1)
+      #if defined(TEMP_BED_PIN) && (TEMP_BED_PIN > -1)
         #if TEMP_BED_PIN > 7
           ADCSRB = 1<<MUX5;
         #else
@@ -1081,13 +1087,13 @@ ISR(TIMER0_COMPB_vect)
       temp_state = 3;
       break;
     case 3: // Measure TEMP_BED
-      #if (TEMP_BED_PIN > -1)
+      #if defined(TEMP_BED_PIN) && (TEMP_BED_PIN > -1)
         raw_temp_bed_value += ADC;
       #endif
       temp_state = 4;
       break;
     case 4: // Prepare TEMP_1
-      #if (TEMP_1_PIN > -1)
+      #if defined(TEMP_1_PIN) && (TEMP_1_PIN > -1)
         #if TEMP_1_PIN > 7
           ADCSRB = 1<<MUX5;
         #else
@@ -1100,13 +1106,13 @@ ISR(TIMER0_COMPB_vect)
       temp_state = 5;
       break;
     case 5: // Measure TEMP_1
-      #if (TEMP_1_PIN > -1)
+      #if defined(TEMP_1_PIN) && (TEMP_1_PIN > -1)
         raw_temp_1_value += ADC;
       #endif
       temp_state = 6;
       break;
     case 6: // Prepare TEMP_2
-      #if (TEMP_2_PIN > -1)
+      #if defined(TEMP_2_PIN) && (TEMP_2_PIN > -1)
         #if TEMP_2_PIN > 7
           ADCSRB = 1<<MUX5;
         #else
@@ -1119,7 +1125,7 @@ ISR(TIMER0_COMPB_vect)
       temp_state = 7;
       break;
     case 7: // Measure TEMP_2
-      #if (TEMP_2_PIN > -1)
+      #if defined(TEMP_2_PIN) && (TEMP_2_PIN > -1)
         raw_temp_2_value += ADC;
       #endif
       temp_state = 0;


### PR DESCRIPTION
Reviert previous change of #if BLAH_PIN > 0 to #if defined(BLAH_PIN) &&
BLAH_PIN > -1. Unfortunately some times pin 0 is used. For my sins I've
gone through and replaced all unsafe checks of #if BLAH_PIN > -1 with
the safe version. (From #407)
