### PR TITLE
extruder heater meltdown prevention

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -12,11 +12,13 @@
 
 //// Heating sanity check:
 // This waits for the watchperiod in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero. 
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+// it checks first and second order differences of stored temp readings while the extruder is on
+// then averages second order differences.  if 2nd-order-avg < 0 the therm is disconnected
+// to use with PID make sure the PID parameters are already calibrated.  To auto-calibrate with M303 you may
+// need to disable WATCH_TEMP_PERIOD by commenting out the next line.
+// NOTE: commenting out the next line will disable thermistor protection check
+#define WATCH_TEMP_PERIOD 50  // milliseconds
+//#define WATCH_TEMP_PERIOD_DEBUG
 
 // Wait for Cooldown
 // This defines if the M109 call should not block if it is cooling down.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1112,7 +1112,6 @@ void process_commands()
         break;
       }
       if (code_seen('S')) setTargetHotend(code_value(), tmp_extruder);
-      setWatch();
       break;
     case 140: // M140 set bed temp
       if (code_seen('S')) setTargetBed(code_value());
@@ -1166,7 +1165,6 @@ void process_commands()
         }
       #endif
 
-      setWatch();
       codenum = millis();
 
       /* See if we are heating up or cooling down */

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -128,7 +128,7 @@ FORCE_INLINE bool isCoolingBed() {
 
 int getHeaterPower(int heater);
 void disable_heater();
-void setWatch();
+//void setWatch();
 void updatePID();
 
 FORCE_INLINE void autotempShutdown(){


### PR DESCRIPTION
The temperature protection in Marlin still allows the hotend to exceed MAXTEMP if the thermal sensor (thermistor or probe) becomes physically dislodged from the hotend.  The WATCH_TEMP_PERIOD check works now in some cases, whereas about 12 months ago it was logically broken and didn't work at all.  This patch reduces the response time for a detached thermistor event from 40 seconds to approximately 7 (using bang-bang in my testing).

Goal:  to detect the thermistor becoming physically dislodged from the hotend in ~10 seconds or less.

Background:
Reproducing one edge case of hotend catastrophe in Marlin is rather easy:  simply dislodge the thermistor while printing ABS, or after the nozzle is pre-heated to ABS temp.  The current algorithm will wait 40 seconds (by default) until it triggers heater shutdown.  In this scenario a (non-metal) hotend is likely to melt.

To solve this problem in hardware one can attach a second thermistor and measure room temperature, and if the extruder sensor ever has the same measurement while heating, we know something is wrong.  Marlin has support for a redundant thermistor to handle this.

In software we may be able to analyze the trends of temperature measurements to detect a thermistor dislodged event.  First, we know that when the target temperature is reached, the heater will shutdown, and analysis is not needed.

I've attached some screenshots that illustrate what types of temperature graphs we should expect both in "works as expected" situations, and when the thermistor is disloged.  These are hand-drawn, which works OK because the reading are noisy.  These graphs have no legends but are meant to reflect coarse-grained data.  That is - noise is a factor in sensor readings so as we zoom in on the data noise becomes more influential.

Fig 1, 2, 3 show normal/working behavior.  Fig 4, 5, 6 show scenarios in which the thermistor is dislodged.

Fig_1:  
![temp_graph_0](https://f.cloud.github.com/assets/260223/658535/04d309fe-d5ed-11e2-8b90-984d0f630691.png) - normal heating

Fig_2:
![temp_graph_1](https://f.cloud.github.com/assets/260223/658538/24abf34e-d5ed-11e2-8809-28255ab5ef14.png) - target temperature reached, normal overshoot and undershoot

Fig_3:
![temp_graph_2](https://f.cloud.github.com/assets/260223/658541/3695d386-d5ed-11e2-96af-23218d2f40b5.png) - magnified view of temperature curve during undershoot

Fig_4:
![temp_graph_3](https://f.cloud.github.com/assets/260223/658542/45e57ff8-d5ed-11e2-9bb0-81d785f782ee.png) - thermistor detached _when_ we turned the heater on

Fig_5:
![temp_graph_4](https://f.cloud.github.com/assets/260223/658543/50d129c6-d5ed-11e2-910f-8fe3dc0b42e6.png) - target was reached, then thermistor became detached

Fig_6:
![temp_graph_5](https://f.cloud.github.com/assets/260223/658544/669ab646-d5ed-11e2-88c3-4a6fa777fbf2.png) - while reaching target, thermistor became detached

Analysis:
Figures 1-3 above show that when the heater is working as expected, the 2nd order temperature differences should always be >= 0.  "2nd order temperature differences" means:  the difference of the differences of temperature, sampled at a constant rate.

Fig. 3 shows that in the case of undershoot, the heater turns on to correct the temperature, and the 2nd order temperature differences are >= 0.

Fig. 4 shows a scenario of detachment with no deviation from the previous trend of readings.  The 1st and 2nd order differences are rather constant if we smooth for noise.

Fig. 5 shows a scenario of detachment with a sudden deviation from the previous trend.  The 1st and 2nd order temp. differences also show a drastic change which greatly exceeds noise levels.

Fig. 6 shows a scenario of detachment with a sudden deviation from previous trend.  The 1st and 2nd order temp. differences also show a drastic change which greatly exceeds noise levels.

Solution:
We can measure the 2nd-order differences in analog readings, smooth for noise, and shutdown the heaters if the 2nd-order average is < 0.  In other words, whenever heat is applied the rate-of-change of temperature-change should always be positive.  This can be described as "the nozzle is warming".  If the heater is on yet the sensor doesn't indicate the "nozzle is warming", then we know failure has occurred.

UPDATE:  This assertion only holds true in some cases, as the graphs illustrate.  In fact, during normal heating, an ideal graph of 1st order differences is a straight line, so the 2nd order difference is 0.

Implementation:
The theory breaks down in the real world due to thermistor error and system noise, which are significant factors.  If the power applied to the hotend is small, then the level of noise can effectively prevent accurate analysis.  To handle this the algorithm averages a set of _analog themistor_ readings.  Then it stores the latest average in a circular buffer, called the first-order array.  As the 1st order array fills with averaged values, the 2nd order array is filled with the difference between the two latest 1st order values.  Then, as the 2nd order array is filled, a 3rd order array is also filled with differences in the latest two 2nd order values.  When the 3rd order array is full, an average is taken.  If the average is increasing, then we trigger a "THERMISTOR DETACHED" message and shut down the heaters.

Testing:
I've tested this on our j-heads with 3% and a 1% thermistor I'm using.  Initial testing took some time but I've been able to set target temps from 50C - 200C, not see false-positives, and adjust the temp up or down without false positives.  I've found that this works best with bang-bang.  In order to work properly with PID the firmware needs _actually calibrated_ PID values, and I didn't have those for this session.  This seems to makes sense - if the PID values are too low then not enough power goes to the nozzle, and differences in analog readings are on the same order as noise, thus a false positive is rather likely.
