### PR TITLE
ultralcd.cpp compile errors when !defined(PIDTEMP)

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -505,9 +505,11 @@ static void lcd_control_menu()
 
 static void lcd_control_temperature_menu()
 {
+#ifdef PIDTEMP
     // set up temp variables - undo the default scaling
     raw_Ki = unscalePID_i(Ki);
     raw_Kd = unscalePID_d(Kd);
+#endif
 
     START_MENU();
     MENU_ITEM(back, MSG_CONTROL, lcd_control_menu);


### PR DESCRIPTION
There were some compile errors with ultralcd.cpp when PIDTEMP is not defined. The fixes in this branch make sure that no PID functions are called when not using PIDTEMP.
