### PR TITLE
Report temperatures for all extruders in reply to M105

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1210,7 +1210,6 @@ void process_commands()
           SERIAL_PROTOCOLPGM(" /");
           SERIAL_PROTOCOL_F(degTargetBed(),1);
         #endif //TEMP_BED_PIN
-      #else
         for (int8_t cur_extruder = 0; cur_extruder < EXTRUDERS; ++cur_extruder) {
           SERIAL_PROTOCOLPGM(" T");
           SERIAL_PROTOCOL(cur_extruder);
@@ -1219,6 +1218,7 @@ void process_commands()
           SERIAL_PROTOCOLPGM(" /");
           SERIAL_PROTOCOL_F(degTargetHotend(cur_extruder),1); 
         }
+      #else
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM(MSG_ERR_NO_THERMISTORS);
       #endif


### PR DESCRIPTION
This change modifies the output of M105 to additionally report the temperatures of all extruders as Tx:temp/setpoint.
This should be backwards compatible enough with all hosts and firmwares, but if it looks too dangerous we could only enable it, for instance by asking for the temperature of extruder -1 or something like this.
