### PR TITLE
Fix Makefile-based build when avr-gcc has been compiled with --enable-cxa_atexit

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -283,6 +283,7 @@ ifneq ($(HARDWARE_MOTHERBOARD),)
 CTUNING += -DMOTHERBOARD=${HARDWARE_MOTHERBOARD}
 endif
 #CEXTRA = -Wa,-adhlns=$(<:.c=.lst)
+CEXTRA = -fno-use-cxa-atexit
 
 CFLAGS := $(CDEBUG) $(CDEFS) $(CINCS) -O$(OPT) $(CWARN) $(CEXTRA) $(CTUNING)
 CXXFLAGS :=         $(CDEFS) $(CINCS) -O$(OPT) -Wall    $(CEXTRA) $(CTUNING)


### PR DESCRIPTION
On avr-gcc with --enable-__cxa_atexit compile flag, Marlin compilation fails when SDSUPPORT is enabled because of missing references and symbols (see below). This seems to come from the SdFatLibrary which enables some cxa features which then lead to avr-gcc being unhappy. The fix is simply to tell the compiler to not use the cxa_atexit infrastructure by enabling the appropriate compile flag.
This fix has been tested for weeks on my RAMPS 1.3 and should not impact other setups (but please test it with a compiler which does not have this flag enabled (look at avr-gcc -v)).

```
LANG=C make HARDWARE_MOTHERBOARD=7 V=1
avr-gcc -mmcu=atmega2560 -DF_CPU=16000000  -I . -I applet -I ../../arduino-0023/hardware/arduino/cores/arduino -I ../../arduino-0023/libraries/LiquidCrystal -I ../../arduino-0023/libraries/SPI -I ../../arduino-0023/hardware/arduino/variants/mega -Os -Wall     -funsigned-char -funsigned-bitfields -fpack-struct -fshort-enums -w -ffunction-sections -fdata-sections -DARDUINO=23 -DMOTHERBOARD=7 -Wl,--gc-sections -o applet/Marlin.elf -L.  applet/wiring.o  applet/wiring_analog.o  applet/wiring_digital.o  applet/wiring_pulse.o  applet/wiring_shift.o  applet/WInterrupts.o  applet/pins_arduino.o  applet/main.o  applet/WMath.o  applet/WString.o  applet/Print.o  applet/Marlin_main.o  applet/MarlinSerial.o  applet/Sd2Card.o  applet/SdBaseFile.o  applet/SdFatUtil.o  applet/SdFile.o  applet/SdVolume.o  applet/motion_control.o  applet/planner.o  applet/stepper.o  applet/temperature.o  applet/cardreader.o  applet/ConfigurationStore.o  applet/watchdog.o  applet/LiquidCrystal.o  applet/ultralcd.o  applet/SPI.o  applet/Servo.o  applet/Tone.o  -lm
applet/Marlin_main.o: In function `_GLOBAL__sub_I_card':
Marlin_main.cpp:(.text.startup._GLOBAL__sub_I_card+0x8): undefined reference to `__dso_handle'
Marlin_main.cpp:(.text.startup._GLOBAL__sub_I_card+0xa): undefined reference to `__dso_handle'
Marlin_main.cpp:(.text.startup._GLOBAL__sub_I_card+0x14): undefined reference to `__cxa_atexit'
/usr/bin/avr-ld: applet/Marlin.elf: hidden symbol `__dso_handle' isn't defined
/usr/bin/avr-ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
make: *** [applet/Marlin.elf] Error 1
```
