### PR TITLE
Fix for Viki LCD issues printing from SD card

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -675,6 +675,8 @@ static void lcd_sd_updir()
 
 void lcd_sdcard_menu()
 {
+    if (lcdDrawUpdate == 0 && LCD_CLICKED == 0) 
+        return;	// nothing to do (so don't thrash the SD card)
     uint16_t fileCnt = card.getnrfilenames();
     START_MENU();
     MENU_ITEM(back, MSG_MAIN, lcd_main_menu);


### PR DESCRIPTION
There has been some discussion about problems printing directly from the SD card using the Viki LCD (https://groups.google.com/forum/?fromgroups#!topic/makergear/G23y21KWTmI).

This appears to be due to the SD menu refreshing so slowly that the button interrupt clears the state of `LCD_CLICKED` before file menu items get rendered and actioned.  The first attached commit saves `LCD_CLICKED` when the menu refresh starts and then uses that saved value later which seems to resolve the issue (from testing on my Makergear M2).

The second commit attached adds a check at the top of the SD menu function and bails out if no drawing updates are required and a button has not been clicked.  This is to save the menu from re-reading the SD card contents every 100ms to refresh itself.

Sorry for combining two commits in the same pull request (I'm still learning how to use Github).
