### PR TITLE
make DELTA_DIAGONAL_ROD_2 more efficient (use sq instead of pow)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -108,7 +108,7 @@
 #define DELTA_TOWER3_Y DELTA_RADIUS
 
 // Diagonal rod squared
-#define DELTA_DIAGONAL_ROD_2 pow(DELTA_DIAGONAL_ROD,2)
+#define DELTA_DIAGONAL_ROD_2 sq(DELTA_DIAGONAL_ROD)
 
 //===========================================================================
 //=============================Thermal Settings  ============================


### PR DESCRIPTION
sq is a macro sq(a) = a*a which evaluates at compile time if 'a' is a constant, so it is much faster than pow

--HG--
extra : source : 789b1da12ee0823d8036e4df13e5eff391e1f0c6
