### PR TITLE
Changed #ifcheck on ULTIMAKERCONTROLLER check for encoder wheel. 

### DIFF
--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -128,7 +128,7 @@ extern volatile uint16_t buttons;  //an extended version of the last checked but
 // These values are independent of which pins are used for EN_A and EN_B indications
 // The rotary encoder part is also independent to the chipset used for the LCD
 #if defined(EN_A) && defined(EN_B)
-  #ifndef ULTIMAKERCONTROLLER
+  #ifndef ULTIMAKERCONTROLLER_DEV
     #define encrot0 0
     #define encrot1 2
     #define encrot2 3


### PR DESCRIPTION
As it was, the encoder was backwards. This was the behaviour on the dev UltiMaker ulticontroller, but release versions use the standard.

If you have an old style ulticontroller (-dev release) then define  ULTIMAKERCONTROLLER_DEV in the Configuration.h
