### PR TITLE
Fixed bug that makes ulticontroller knob backwards introduced Feb 28 201...

### DIFF
--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -128,17 +128,10 @@ extern volatile uint16_t buttons;  //an extended version of the last checked but
 // These values are independent of which pins are used for EN_A and EN_B indications
 // The rotary encoder part is also independent to the chipset used for the LCD
 #if defined(EN_A) && defined(EN_B)
-  #ifndef ULTIMAKERCONTROLLER
     #define encrot0 0
     #define encrot1 2
     #define encrot2 3
     #define encrot3 1
-  #else
-    #define encrot0 0
-    #define encrot1 1
-    #define encrot2 3
-    #define encrot3 2
-  #endif
 #endif 
 
 #endif //ULTIPANEL


### PR DESCRIPTION
Erik - I'm new to github but not to git and not to embedded programming.  Barry Carter built a Marlin builder here
http://marlinbuilder.robotfuzz.com/
which replaces Daid's marlin builder which died (the hardware died).  People are starting to use it and because Barry is using a recent version of Marlin and because Daid forked last year some time, Daid hasn't hit this bug yet.  Barry asked me to track it down (people were complaining) and fix it and so here is the bug fix.  For now Barry did his own fix similar to mine but not as well researched.

I tested this fix on my ultimaker and it fixes the knob nicely.  I didn't actually print anything yet but this code change only affects the ulticontroller knob (aka the encoder).
# \- George Roberts

Fixed bug that makes ulticontroller knob backwards introduced Feb 28 2013 by Robert.

Bug introduced in version 6beb42cdf65971aeca93868305ed93ae6ed732eb.
Robert did a good job of simplifying but messed up this chunk of code.

Looking at working version: 839bef6d5d436055c6cef051b6b32a84bd18d05a
it seems there is no case where encrot3 should be defined as 2
because if ULTICONTROLLER is defined then NEWPANEL is also defined.
