### PR TITLE
PS_ON configurable boot state

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -79,6 +79,9 @@
 
 #define POWER_SUPPLY 1
 
+// Define this to have the electronics keep the powersupply off on startup. If you don't know what this is leave it.
+// #define PS_DEFAULT_OFF
+
 //===========================================================================
 //=============================Thermal Settings  ============================
 //===========================================================================

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -366,7 +366,11 @@ void setup_powerhold()
   #endif
   #if defined(PS_ON_PIN) && PS_ON_PIN > -1
     SET_OUTPUT(PS_ON_PIN);
-    WRITE(PS_ON_PIN, PS_ON_AWAKE);
+	#if defined(PS_DEFAULT_OFF)
+	  WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+    #else
+	  WRITE(PS_ON_PIN, PS_ON_AWAKE);
+	#endif
   #endif
 }
 


### PR DESCRIPTION
Allows the user to select wheter or not the PSU should be turned on or
kept in standby when marlin boots
