### PR TITLE
Fix servo control for Melzi v2.0

### DIFF
--- a/Marlin/Servo.h
+++ b/Marlin/Servo.h
@@ -77,7 +77,7 @@ typedef enum { _timer3, _Nbr_16timers } timer16_Sequence_t ;
 //typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;
 typedef enum { _timer3, _Nbr_16timers } timer16_Sequence_t ;
 
-#elif defined(__AVR_ATmega128__) ||defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+#elif defined(__AVR_ATmega128__) ||defined(__AVR_ATmega1281__) || defined(__AVR_ATmega1284P__) ||defined(__AVR_ATmega2561__)
 #define _useTimer3
 //#define _useTimer1
 //typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;


### PR DESCRIPTION
This allows using servos on the spare IO pins that the Melzi board has.
