### PR TITLE
Z and Y dual stepper drivers error

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -161,7 +161,7 @@
   #define EXTRUDERS 1
 #endif
 
-#ifdef Z_DUAL_STEPPER_DRIVERS && Y_DUAL_STEPPER_DRIVERS
+#if defined (Z_DUAL_STEPPER_DRIVERS) && defined (Y_DUAL_STEPPER_DRIVERS)
   #error "You cannot have dual drivers for both Y and Z"
 #endif
 


### PR DESCRIPTION
if you try to enable Z_DUAL_STEPPER_DRIVERS the error "You cannot have dual drivers for both Y and Z" shows even if you don't have defined Y_DUAL_STEPPER_DRIVERS and don't let you compile the firmware

to solve this problem i change this line:
# ifdef Z_DUAL_STEPPER_DRIVERS && Y_DUAL_STEPPER_DRIVERS

to:
# if defined (Z_DUAL_STEPPER_DRIVERS) && defined (Y_DUAL_STEPPER_DRIVERS)

now the error only show if you define both Z_DUAL_STEPPER_DRIVERS and Y_DUAL_STEPPER_DRIVERS
