### PR TITLE
Use C++ initialization list

### DIFF
--- a/Marlin/vector_3.cpp
+++ b/Marlin/vector_3.cpp
@@ -22,19 +22,9 @@
 #ifdef ENABLE_AUTO_BED_LEVELING
 #include "vector_3.h"
 
-vector_3::vector_3()
-{
-  this->x = 0;
-  this->y = 0;
-  this->z = 0;
-}
+vector_3::vector_3() : x(0), y(0), z(0) { }
 
-vector_3::vector_3(float x, float y, float z)
-{
-	this->x = x;
-	this->y = y;
-	this->z = z;
-}
+vector_3::vector_3(float x_, float y_, float z_) : x(x_), y(y_), z(z_) { }
 
 vector_3 vector_3::cross(vector_3 left, vector_3 right)
 {
@@ -62,7 +52,7 @@ vector_3 vector_3::get_normal()
 
 float vector_3::get_length() 
 {
-        float length = sqrt((x * x) + (y * y) + (z * z));
+	float length = sqrt((x * x) + (y * y) + (z * z));
 	return length;
 }
  


### PR DESCRIPTION
This is the recommended approach for object initialization. The change
doesn't affect binary size (although in theory it could make it smaller).
