### PR TITLE
Arduino preprocessor cannot handle SPI include.

### DIFF
--- a/Marlin/Marlin.pde
+++ b/Marlin/Marlin.pde
@@ -47,6 +47,3 @@
   #endif
 #endif
 
-#if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
-#include <SPI.h>
-#endif


### PR DESCRIPTION
When trying to compile with a Gen6 board it fails, since it include the
SPI headers which are not properly defined on the board. The include is
supposed to be ignored, how-ever the arduino pre-processor is too
limited to handle this case.

It also seems rather useless (at first) glance to include the SPI.h at
this location, since the header entries are not used over here, so
removing seems a save alternative.

Some background:
    http://softsolder.com/2009/10/06/arduino-be-careful-with-the-preprocessor/
