### PR TITLE
Update temperature.cpp

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -306,7 +306,7 @@ void PID_autotune(float temp, int extruder, int ncycles)
       return;
     }
     if(cycles > ncycles) {
-      SERIAL_PROTOCOLLNPGM("PID Autotune finished! Put the Kp, Ki and Kd constants into Configuration.h");
+      SERIAL_PROTOCOLLNPGM("PID Autotune finished! Put the Kp, Ki and Kd constants into Configuration.h (it may take a minute for the values to be calculated)");
       return;
     }
     lcd_update();


### PR DESCRIPTION
Tell the user they may have to wait a minute before the ki,kd,kp values are returned when M303 auto tune PID is run. Would have saved me a bit of confusion if this was in here earlier.
