### PR TITLE
createTemperatureLookupMarlin.py: Add resolution comments and format for...

### DIFF
--- a/Marlin/createTemperatureLookupMarlin.py
+++ b/Marlin/createTemperatureLookupMarlin.py
@@ -134,7 +134,7 @@ def main(argv):
     temps = range(max_temp, min_temp + tmp, tmp);
 
     print "// Thermistor lookup table for Marlin"
-    print "// ./createTemperatureLookup.py --rp=%s --t1=%s:%s --t2=%s:%s --t3=%s:%s --num-temps=%s" % (rp, t1, r1, t2, r2, t3, r3, num_temps)
+    print "// ./createTemperatureLookupMarlin.py --rp=%s --t1=%s:%s --t2=%s:%s --t3=%s:%s --num-temps=%s" % (rp, t1, r1, t2, r2, t3, r3, num_temps)
     print "// Steinhart-Hart Coefficients: %.15g, %.15g,  %.15g " % (t.c1, t.c2, t.c3)
     print "//#define NUMTEMPS %s" % (len(temps))
     print "const short temptable[NUMTEMPS][2] PROGMEM = {"


### PR DESCRIPTION
createTemperatureLookupMarlin.py: Add resolution comments and format for Marlin.

This formats the output more like the existing thermistortables.h output, replacing the hard-coded *16 oversampling with *OVERSAMPLENR.  This might make it easier to calibrate some table to your actual pullup resistor, thermistor, and measured temperatures.

Note that the output casts the value to a short after multiplication by OVERSAMPLENR in order to not discard resolution.

The Steinhart-Hart coefficients (http://en.wikipedia.org/wiki/Steinhart%E2%80%93Hart_equation) used the calculation of the values are also printed in the comments.

It also adds per-line comments detailing the resistance, voltage, and resolution of the thermistor in degreeC/count.  The resolution data might help those that might want to tune the pullup resistor to tradeoff resolution for accuracy in a region of interest.

https://github.com/ErikZalm/Marlin/issues/105 is related.
