### PR TITLE
Fix bugs in Extruder Runout Prevention, including DAMAGING HEAD CRASH

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3304,6 +3304,7 @@ void manage_inactivity()
      current_position[E_AXIS]=oldepos;
      destination[E_AXIS]=oldedes;
      plan_set_e_position(oldepos);
+     previous_millis_cmd=millis();
      st_synchronize();
      WRITE(E0_ENABLE_PIN,oldstatus);
     }


### PR DESCRIPTION
This fixes a bug in Extruder Runout Prevention which has damaged several of our machines by causing the Z axis to attempt to move past its maximum.
