### PR TITLE
Change diameter code to 'D'

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -130,7 +130,7 @@
 // M150 - Set BlinkM Colour Output R: Red<0-255> U(!): Green<0-255> B: Blue<0-255> over i2c, G for green does not work.
 // M190 - Sxxx Wait for bed current temp to reach target temp. Waits only when heating
 //        Rxxx Wait for bed current temp to reach target temp. Waits when heating and cooling
-// M200 - Set filament diameter
+// M200 D<millimeters>- set filament diameter and set E axis units to cubic millimeters (use S0 to set back to millimeters).
 // M201 - Set max acceleration in units/s^2 for print moves (M201 X1000 Y1000)
 // M202 - Set max acceleration in units/s^2 for travel moves (M202 X1000 Y1000) Unused in Marlin!!
 // M203 - Set maximum feedrate that your machine can sustain (M203 X200 Y200 Z300 E10000) in mm/sec
@@ -2198,11 +2198,12 @@ void process_commands()
       }
       break;
     #endif //BLINKM
-    case 200: // M200 S<millimeters> set filament diameter and set E axis units to cubic millimeters (use S0 to set back to millimeters).
+    case 200: // M200 D<millimeters> set filament diameter and set E axis units to cubic millimeters (use S0 to set back to millimeters).
       {
-        float area;
-        if(code_seen('S')) {
-          float radius = code_value() / 2;
+        float area = .0;
+        float radius = .0;
+        if(code_seen('D')) {
+          radius = (float)code_value() * .5;
           if(radius == 0) {
             area = 1;
           } else {


### PR DESCRIPTION
For some reason that I can’t figure out, the decimal is dropped when
using ’S’ for the code.

Also some minor code improvements to M200.
