### PR TITLE
multiple FWretract fixes

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1114,7 +1114,9 @@ void process_commands()
         destination[Y_AXIS]=current_position[Y_AXIS];
         destination[Z_AXIS]=current_position[Z_AXIS];
         current_position[Z_AXIS]-=retract_zlift;
-        destination[E_AXIS]=current_position[E_AXIS]-retract_length/volumetric_multiplier[active_extruder];
+        destination[E_AXIS]=current_position[E_AXIS];
+        current_position[E_AXIS]+=retract_length/volumetric_multiplier[active_extruder];
+        plan_set_e_position(current_position[E_AXIS]);
         float oldFeedrate = feedrate;
         feedrate=retract_feedrate;
         retracted=true;
@@ -1130,7 +1132,9 @@ void process_commands()
         destination[Y_AXIS]=current_position[Y_AXIS];
         destination[Z_AXIS]=current_position[Z_AXIS];
         current_position[Z_AXIS]+=retract_zlift;
-        destination[E_AXIS]=current_position[E_AXIS]+(retract_length+retract_recover_length)/volumetric_multiplier[active_extruder]; 
+        destination[E_AXIS]=current_position[E_AXIS];
+        current_position[E_AXIS]-=(retract_length+retract_recover_length)/volumetric_multiplier[active_extruder]; 
+        plan_set_e_position(current_position[E_AXIS]);
         float oldFeedrate = feedrate;
         feedrate=retract_recover_feedrate;
         retracted=false;


### PR DESCRIPTION
Keeps Keep FWRETRACT values in terms of millimeters when using M200 for volumetric E units (thanks @daid)
correct feedrate units in comments for M207/M208
Fix bug causing G10/G11 to be broken by using G92 E0 between retract and recover (Slic3r's G10/G11 implementation always does this).

This has been tested and is working using volumetric E units (faked by setting filament diameter in Slic3r to 1.12837916709551) with M200 in start code and Slic3r's "Use firmware retraction" setting.
