### PR TITLE
Updated gen3+ board pins names to current convention

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -1781,8 +1781,8 @@
 #define Z_DIR_PIN          28
 #define Z_STOP_PIN         30
 
-#define E_STEP_PIN         17
-#define E_DIR_PIN          21
+#define E0_STEP_PIN         17
+#define E0_DIR_PIN          21
 
 #define LED_PIN            -1
 
@@ -1793,15 +1793,16 @@
 
 #define HEATER_0_PIN       12 // (extruder)
 
-#define HEATER_1_PIN       16 // (bed)
+#define HEATER_BED_PIN     16 // (bed)
 #define X_ENABLE_PIN       19
 #define Y_ENABLE_PIN       24
 #define Z_ENABLE_PIN       29
-#define E_ENABLE_PIN       13
+#define E0_ENABLE_PIN      13
 
 #define TEMP_0_PIN          0   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 33 extruder)
-#define TEMP_1_PIN          5   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
+#define TEMP_1_PIN         -1   
 #define TEMP_2_PIN         -1
+#define TEMP_BED_PIN        5   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)  
 #define SDPOWER            -1
 #define SDSS               4
 #define HEATER_2_PIN       -1


### PR DESCRIPTION
Gen3+ pin names where not the current standard, so would not compile.
Renamed to current conventions 
