### PR TITLE
Fix compile error

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1080,7 +1080,7 @@ static void homeaxis(int axis) {
   }
 }
 #define HOMEAXIS(LETTER) homeaxis(LETTER##_AXIS)
-+void refresh_cmd_timeout(void)
+void refresh_cmd_timeout(void)
 {
   previous_millis_cmd = millis();
 }


### PR DESCRIPTION
Small typo that causes compilation to fail.   Introduced in 477b6fa1d
