### PR TITLE
MACHINE NAME and FIRMWARE_URL in configuration.h

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -75,8 +75,11 @@
 #define MOTHERBOARD 7
 #endif
 
-// Define this to set a custom name for your generic Mendel,
-// #define CUSTOM_MENDEL_NAME "This Mendel"
+// Define this to set a custom name for your printer,
+// #define MACHINE_NAME "This Mendel"
+
+// Define this to set a custom location to look for firmware for your printer,
+// #define FIRMWARE_URL "https://github.com/ErikZalm/Marlin/"
 
 // Define this to set a unique identifier for this printer, (Used by some programs to differentiate between machines)
 // You can use an online service to generate a random UUID. (eg http://www.uuidgenerator.net/version4)

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -34,14 +34,14 @@
 #elif MOTHERBOARD == 77
 	#define MACHINE_NAME "3Drag"
 	#define FIRMWARE_URL "http://3dprint.elettronicain.it/"
-#else
-	#ifdef CUSTOM_MENDEL_NAME
-		#define MACHINE_NAME CUSTOM_MENDEL_NAME
-	#else
-		#define MACHINE_NAME "Mendel"
-	#endif
+#endif
 
-// Default firmware set to Mendel
+//Use default values for MACHINE_NAME and FIRMWARE_URL if they have not been set above or in Configuration.h
+#ifndef MACHINE_NAME // Default name set to Mendel
+        #define MACHINE_NAME "Mendel"
+#endif
+
+#ifndef FIRMWARE_URL // Default firmware set to Mendel
 	#define FIRMWARE_URL "https://github.com/ErikZalm/Marlin/"
 #endif
 


### PR DESCRIPTION
This allows MACHINE_NAME and FIRMWARE_URL to be optionally set from
Configuration.h rather than modifying language.h. This is mostly useful
for manufacturers to set MACHINE_NAME and point FIRMWARE_URL to their
own fork, without making the list unwieldy and hard to parse in
language.h due to every manufacturer adding themselves in the upstream
repo or creating merge conflicts because they don’t.
