### PR TITLE
Add feedback from the M207/M208 commands

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2355,6 +2355,14 @@ void process_commands()
       {
         retract_zlift = code_value() ;
       }
+    SERIAL_PROTOCOL(MSG_OK);
+    SERIAL_PROTOCOL(" S:");
+    SERIAL_PROTOCOL(retract_length);
+    SERIAL_PROTOCOL(" F:");
+    SERIAL_PROTOCOL(retract_feedrate);
+    SERIAL_PROTOCOL(" Z:");
+    SERIAL_PROTOCOL(retract_zlift);
+    SERIAL_PROTOCOLLN("");
     }break;
     case 208: // M208 - set retract recover length S[positive mm surplus to the M207 S*] F[feedrate mm/sec]
     {
@@ -2366,6 +2374,12 @@ void process_commands()
       {
         retract_recover_feedrate = code_value() ;
       }
+    SERIAL_PROTOCOL(MSG_OK);
+    SERIAL_PROTOCOL(" S:");
+    SERIAL_PROTOCOL(retract_recover_length);
+    SERIAL_PROTOCOL(" F:");
+    SERIAL_PROTOCOL(retract_recover_feedrate);
+    SERIAL_PROTOCOLLN("");
     }break;
     case 209: // M209 - S<1=true/0=false> enable automatic retract detect if the slicer did not support G10/11: every normal extrude-only move will be classified as retract depending on the direction.
     {


### PR DESCRIPTION
Quick n dirty change to echo back the fw retract settings when using M207/208.  Not sure it's really the best way to handle this, I'd actually rather store in EEPROM (if enabled) and retrieve via M503.  If that's viable I can ditch this patch and get that working instead.
