### PR TITLE
non blocking axis moves on lcd menu

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -615,7 +615,7 @@ static void lcd_move_axis(int current_axis){
             break;
     }
     
-    
+    //updates future position for axis
     if (encoderPosition != 0)
     {
     
@@ -624,13 +624,13 @@ static void lcd_move_axis(int current_axis){
         lcdDrawUpdate = 1;
     }
     
+    //move current axis if axis has not matched up to future distance yet, move axis by current move_menu_scale
     if(current_position[current_axis]!=future_position[current_axis])
     {
-        //if(current_axis != E_AXIS) // The extruder doesn't  have  a min and a max
-        //{
+        if(current_axis != E_AXIS) // The extruder doesn't  have  a min and a max
+        {
             refresh_cmd_timeout(); //this is not used for E, I don't know why
-        //}
-        if(current_axis == E_AXIS) move_menu_scale = 10.0;
+        }
         if (future_position[current_axis] > current_position[current_axis])
             current_position[current_axis]+=move_menu_scale;
         else


### PR DESCRIPTION
If I move too far whenever I am moving an axis with the LCD I have to wait for the move to complete before I can change the move. Worse if I move the dial while one move is  going on it will queue other moves. This is just a bad user experience.

These changes make it so that moves are done incrementally to reach a future value that can change any time. While this does make for slightly bumpier movement on the .1 mm setting it does have advantages. For example if you see that you are about to crash into something you can immediately dial back the knob and it will reverse direction.

This is my first pull request, let me know if I've made glaring mistakes. I will try to fix them.
