### PR TITLE
Fixes typo for lcd backlighting on I2C PCF8575

### DIFF
--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -297,7 +297,7 @@ static void lcd_implementation_init()
         B00000
     }; //thanks Sonny Mounicou
 
-#if defined(LCDI2C_TYPE_PCF8575)
+#if defined(LCD_I2C_TYPE_PCF8575)
     lcd.begin(LCD_WIDTH, LCD_HEIGHT);
   #ifdef LCD_I2C_PIN_BL
     lcd.setBacklightPin(LCD_I2C_PIN_BL,POSITIVE);


### PR DESCRIPTION
When using LCD_I2C_TYPE_PCF8575T (like Sainsmart I2C), the backlight
won't come on; the incorrect ifdef blocks the evocation of the backlight
functions.
