### PR TITLE
Add feature 'switch unused feeder(s) off'

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -305,7 +305,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define DISABLE_Y false
 #define DISABLE_Z false
 #define DISABLE_E false // For all extruders
-#define DISABLE_UNSELECTED_E true //disable only not selected extruders and keep selected extruder active
+#define DISABLE_INACTIVE_EXTRUDER true //disable only inactive extruders and keep active extruder enabled
 
 #define INVERT_X_DIR true    // for Mendel set to false, for Orca set to true
 #define INVERT_Y_DIR false    // for Mendel set to true, for Orca set to false

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -660,7 +660,7 @@ block->steps_y = labs((target[X_AXIS]-position[X_AXIS]) - (target[Y_AXIS]-positi
   // Enable extruder(s)
   if(block->steps_e != 0)
   {
-    if (DISABLE_UNSELECTED_E) //enable only selected extruder
+    if (DISABLE_INACTIVE_EXTRUDER) //enable only selected extruder
     {
       switch(extruder)
       {


### PR DESCRIPTION
Having the non-active feeder motors powered on all the time is not
necessary. A feature to deactivate the unused feeder motors has been
implemented. The feature is enabled on default but can be switched off
in the configuration.
It has been tested on my dual extruder Ultimaker Original.
