### PR TITLE
M30 response is missing linefeed, "ok" therefore not on own line

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -437,7 +437,7 @@ void CardReader::removeFile(char* name)
     if (file.remove(curDir, fname)) 
     {
       SERIAL_PROTOCOLPGM("File deleted:");
-      SERIAL_PROTOCOL(fname);
+      SERIAL_PROTOCOLLN(fname);
       sdpos = 0;
     }
     else


### PR DESCRIPTION
This leads to the command not being acknowledged properly, leading to consecutive issues in host software waiting for an acknowledgement.

Without patch:

```
Send: M30 test.g
Recv: File deleted:test.gok
```

With patch:

```
Send: M30 test.g
Recv: File deleted:test.g
Recv: ok
```
