### PR TITLE
Updated option on M600 change filament gcode to charge filament until user press the button.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -425,6 +425,7 @@ const unsigned int dropsegments=5; //everything with less than this number of st
     #define FILAMENTCHANGE_ZADD 10
     #define FILAMENTCHANGE_FIRSTRETRACT -2
     #define FILAMENTCHANGE_FINALRETRACT -100
+    #define AUTO_FILAMENT_CHANGE
   #endif
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2861,28 +2861,39 @@ void process_commands()
         LCD_ALERTMESSAGEPGM(MSG_FILAMENTCHANGE);
         uint8_t cnt=0;
         while(!lcd_clicked()){
-          cnt++;
-          manage_heater();
-          manage_inactivity();
-          lcd_update();
-          if(cnt==0)
-          {
-          #if BEEPER > 0
-            SET_OUTPUT(BEEPER);
+          #ifndef AUTO_FILAMENT_CHANGE
+			  cnt++;
+			  manage_heater();
+			  manage_inactivity();
+			  lcd_update();
+			  if(cnt==0)
+			  {
+			#if BEEPER > 0
+				SET_OUTPUT(BEEPER);
 
-            WRITE(BEEPER,HIGH);
-            delay(3);
-            WRITE(BEEPER,LOW);
-            delay(3);
-          #else
-			#if !defined(LCD_FEEDBACK_FREQUENCY_HZ) || !defined(LCD_FEEDBACK_FREQUENCY_DURATION_MS)
-              lcd_buzz(1000/6,100);
+				WRITE(BEEPER,HIGH);
+				delay(3);
+				WRITE(BEEPER,LOW);
+				delay(3);
 			#else
-			  lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS,LCD_FEEDBACK_FREQUENCY_HZ);
+					#if !defined(LCD_FEEDBACK_FREQUENCY_HZ) || !defined(LCD_FEEDBACK_FREQUENCY_DURATION_MS)
+				lcd_buzz(1000/6,100);
+					#else
+				lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS,LCD_FEEDBACK_FREQUENCY_HZ);
+					#endif
 			#endif
-          #endif
           }
+          #else
+          current_position[E_AXIS]+=0.04;
+          plan_buffer_line(target[X_AXIS], target[Y_AXIS], target[Z_AXIS],current_position[E_AXIS], 300/60, active_extruder);
+          st_synchronize();
+          #endif
         }
+
+		#ifdef AUTO_FILAMENT_CHANGE
+          current_position[E_AXIS]=0;
+          st_synchronize();
+		#endif
 
         //return to normal
         if(code_seen('L'))


### PR DESCRIPTION
Sending the M600, marlin does:
1. FILAMENTCHANGE_FIRSTRETRACT
2. FILAMENTCHANGE_ZADD
3. Goes to ILAMENTCHANGE_XPOS and FILAMENTCHANGE_YPOS
4. FILAMENTCHANGE_FINALRETRACT
5. Extrude until user click the button on LCD panel ->implemented here
6. Goes to the last position to continue printing
7. Add FILAMENTCHANGE_FIRSTRETRACT
