### PR TITLE
Fixed stop print LCD function on M104

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1946,14 +1946,14 @@ void process_commands()
       /* See if we are heating up or cooling down */
       target_direction = isHeatingHotend(tmp_extruder); // true if heating, false if cooling
       
-      forced_heating_stop = false;
+      cancel_heatup = false;
 
       #ifdef TEMP_RESIDENCY_TIME
         long residencyStart;
         residencyStart = -1;
         /* continue to loop until we have reached the target temp
           _and_ until TEMP_RESIDENCY_TIME hasn't passed since we reached it */
-        while((forced_heating_stop == false)&&((residencyStart == -1) ||
+        while((!cancel_heatup)&&((residencyStart == -1) ||
               (residencyStart >= 0 && (((unsigned int) (millis() - residencyStart)) < (TEMP_RESIDENCY_TIME * 1000UL)))) ) {
       #else
         while ( target_direction ? (isHeatingHotend(tmp_extruder)) : (isCoolingHotend(tmp_extruder)&&(CooldownNoWait==false)) ) {
@@ -2010,10 +2010,11 @@ void process_commands()
           CooldownNoWait = false;
         }
         codenum = millis();
-
+        
+        cancel_heatup = false;
         target_direction = isHeatingBed(); // true if heating, false if cooling
 
-        while ( target_direction ? (isHeatingBed()) : (isCoolingBed()&&(CooldownNoWait==false)) )
+        while ( (target_direction)&&(!cancel_heatup) ? (isHeatingBed()) : (isCoolingBed()&&(CooldownNoWait==false)) )
         {
           if(( millis() - codenum) > 1000 ) //Print Temp Reading every 1 second while heating up.
           {

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -19,7 +19,7 @@ int absPreheatHotendTemp;
 int absPreheatHPBTemp;
 int absPreheatFanSpeed;
 
-boolean forced_heating_stop = false ;
+bool cancel_heatup = false ;
 
 #ifdef ULTIPANEL
 static float manual_feedrate[] = MANUAL_FEEDRATE;
@@ -258,7 +258,7 @@ static void lcd_sdcard_stop()
     }
     autotempShutdown();
     
-    forced_heating_stop = true;
+    cancel_heatup = true;
 }
 
 /* Menu implementation */

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -43,7 +43,7 @@
   extern int absPreheatHPBTemp;
   extern int absPreheatFanSpeed;
   
-  extern boolean forced_heating_stop;
+  extern bool cancel_heatup;
     
   void lcd_buzz(long duration,uint16_t freq);
   bool lcd_clicked();


### PR DESCRIPTION
When you print from sd card one file, but you want to stop print before finishing the heating process (on M104 loop), marlin can't target any new gcode file.
