### PR TITLE
Improvements and bugfixes to PID heater controller code

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -183,7 +183,7 @@
   //#define PID_OPENLOOP 1 // Puts PID in open loop. M104/M140 sets the output power from 0 to PID_MAX
   #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
                                   // is more then PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
-  #define PID_INTEGRAL_DRIVE_MAX 255  //limit for the integral term
+  #define PID_INTEGRAL_DRIVE_MAX PID_MAX  //limit for the integral term
   #define K1 0.95 //smoothing factor within the PID
   #define PID_dT ((OVERSAMPLENR * 8.0)/(F_CPU / 64.0 / 256.0)) //sampling period of the temperature routine
 
@@ -229,6 +229,8 @@
 #define MAX_BED_POWER 255 // limits duty cycle to bed; 255=full current
 
 #ifdef PIDTEMPBED
+  #define PID_INTEGRAL_DRIVE_MAX_BED MAX_BED_POWER  //limit for the integral term
+
 //120v 250W silicone heater into 4mm borosilicate (MendelMax 1.5+)
 //from FOPDT model - kp=.39 Tp=405 Tdead=66, Tc set to 79.2, aggressive factor of .15 (vs .1, 1, 10)
     #define  DEFAULT_bedKp 10.00

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -725,7 +725,7 @@ void tp_init()
 #endif //PIDTEMP
 #ifdef PIDTEMPBED
     temp_iState_min_bed = 0.0;
-    temp_iState_max_bed = PID_INTEGRAL_DRIVE_MAX / bedKi;
+    temp_iState_max_bed = PID_INTEGRAL_DRIVE_MAX_BED / bedKi;
 #endif //PIDTEMPBED
   }
 


### PR DESCRIPTION
A set of improvements and bugfixes for a fast-response low thermal capacity extruder to work:
- PID_autotune() (M303) could set heater power higher than PID_MAX when PID_MAX<20 -- fixed by 1. properly checking power range and 2. removing the lower limit of 20 for _bias_ value.
- PID controlled heater could get stuck at target temperature minus PID_FUNCTIONAL_RANGE if heater response is fast enough because of a drop in heating power at PID turn on temperature -- fixed by initializing I term so that power changes continuously at PID turn on.
- PID_autotune() (M303) failed with "Temperature too high!" error if heater is faster than ~20 C/5 sec. Fixed by allowing to heat/cool for less than 5 sec in case it hits target temperature + 15 C.
- Change default PID_INTEGRAL_DRIVE_MAX from 255 to PID_MAX for extruders and to BED_MAX_POWER for bed to lower heating overshoot due to I term windup. Introduce a separate PID_INTEGRAL_DRIVE_MAX_BED for bed.
- Allow setting asymmetric PID_FUNCTIONAL_RANGE in Configuration.h. This allows to extend the low limit of PID range to slow down heating in advance without extending the high limit.
