### PR TITLE
Allow step rates less than 32 steps/sec (fix issue #986)

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -57,6 +57,7 @@
 #include "temperature.h"
 #include "ultralcd.h"
 #include "language.h"
+#include <limits.h>
 
 //===========================================================================
 //=============================public variables ============================
@@ -177,11 +178,11 @@ void calculate_trapezoid_for_block(block_t *block, float entry_factor, float exi
   unsigned long final_rate = ceil(block->nominal_rate*exit_factor); // (step/min)
 
   // Limit minimal step rate (Otherwise the timer will overflow.)
-  if(initial_rate <120) {
-    initial_rate=120; 
+  if(initial_rate < 120) {
+    initial_rate=120;
   }
   if(final_rate < 120) {
-    final_rate=120;  
+    final_rate=120;
   }
 
   long acceleration = block->acceleration_st;
@@ -736,6 +737,11 @@ block->steps_y = labs((target[X_AXIS]-position[X_AXIS]) - (target[Y_AXIS]-positi
 
   block->nominal_speed = block->millimeters * inverse_second; // (mm/sec) Always > 0
   block->nominal_rate = ceil(block->step_event_count * inverse_second); // (step/sec) Always > 0
+
+  while(block->nominal_rate < STEPPER_MIN_TICK_RATE && block->step_event_count < ULONG_MAX/2+1) {
+    block->step_event_count <<= 1;
+    block->nominal_rate = ceil(block->step_event_count * inverse_second);
+  }
 
   // Calculate and limit speed in mm/sec for each axis
   float current_speed[4];

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -260,6 +260,7 @@ FORCE_INLINE unsigned short calc_timer(unsigned short step_rate) {
     step_loops = 1;
   }
 
+  // Note: update STEPPER_MIN_TICK_RATE if you replace F_CPU/500000 with something else
   if(step_rate < (F_CPU/500000)) step_rate = (F_CPU/500000);
   step_rate -= (F_CPU/500000); // Correct for minimal speed
   if(step_rate >= (8*256)){ // higher step rate

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -48,6 +48,9 @@
 extern bool abort_on_endstop_hit;
 #endif
 
+// This tells planner.cpp the minimum timer tick rate stepper.cpp supports. Twice more to be sure.
+#define STEPPER_MIN_TICK_RATE (F_CPU / 500000 * 2)
+
 // Initialize and start the stepper motor subsystem
 void st_init();
 


### PR DESCRIPTION
Change block initialization in planner.cpp to allow motion rates less
than 32 steps/sec.

Old behavior: planner.cpp set stepper interrupt rate to the highest step
rate among steppers. In case that rate turned out to be too slow,
stepper.cpp increased stepper interrupt rate to the minimum supported
rate, that increased motion rate.

New behavior: introduce a new macros STEPPER_MIN_TICK_RATE in stepper.h.
In case nominal_rate is too low, increase both step_event_count and
nominal_rate proportionally.

This fixes issue https://github.com/ErikZalm/Marlin/issues/986
