### PR TITLE
fix strange surface normal problem with 3-point autoleveling

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -913,7 +913,7 @@ static void set_bed_level_equation_3pts(float z_at_pt_1, float z_at_pt_2, float 
     vector_3 from_2_to_1 = (pt1 - pt2).get_normal();
     vector_3 from_2_to_3 = (pt3 - pt2).get_normal();
     vector_3 planeNormal = vector_3::cross(from_2_to_1, from_2_to_3).get_normal();
-    planeNormal = vector_3(planeNormal.x, planeNormal.y, abs(planeNormal.z));
+    planeNormal = vector_3(-planeNormal.x, -planeNormal.y, 1);
 
     plan_bed_level_matrix = matrix_3x3::create_look_at(planeNormal);
 


### PR DESCRIPTION
the plane normal vector that was set in set_bed_level_equation_3pts was looking very wrong to me--after doing a 3-point bed probe, the z-axis seemed to move in the opposite direction that it should to compensate for bed height.

i just made the vector3 constructor call in set_bed_level_equation_3pts look like the call from the (presumably functional) set_bed_level_equation_lsq. things seem to be working for me.

i suspect that this solves Marlin issue #910 and maybe issue #1002 and some other less descriptive bug reports.
