### PR TITLE
Fix reseting CHDK pin to LOW

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3516,10 +3516,9 @@ void manage_inactivity()
   }
   
   #ifdef CHDK //Check if pin should be set to LOW after M240 set it to HIGH
-    if (chdkActive)
+    if (chdkActive && (millis() - chdkHigh > CHDK_DELAY))
     {
       chdkActive = false;
-      if (millis()-chdkHigh < CHDK_DELAY) return;
       WRITE(CHDK, LOW);
     }
   #endif


### PR DESCRIPTION
chdkActive was set to false regardless of (millis() - chdkHigh) being bigger than the CHDK_DELAY or not. So if (millis() - chdkHigh) wasn't bigger than the delay the first time, the CHDK would never be set back to LOW.

Also, don't return from the function, as there might be other stuff to do, after the CHDK check.
