### PR TITLE
Bugfix Autolevel/Z-Probe-Sled

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1268,7 +1268,7 @@ void refresh_cmd_timeout(void)
   } //retract
 #endif //FWRETRACT
 
-#ifdef ENABLE_AUTO_BED_LEVELING
+#ifdef Z_PROBE_SLED
 //
 // Method to dock/undock a sled designed by Charles Bell.
 //
@@ -1286,7 +1286,11 @@ static void dock_sled(bool dock, int offset=0) {
  }
 
  if (dock) {
+   #ifdef SLED_DOCKING_OFFSET
    do_blocking_move_to(X_MAX_POS + SLED_DOCKING_OFFSET + offset,
+   #else
+   do_blocking_move_to(X_MAX_POS + offset,
+   #endif
                        current_position[Y_AXIS],
                        current_position[Z_AXIS]);
    // turn off magnet
@@ -1296,13 +1300,18 @@ static void dock_sled(bool dock, int offset=0) {
      z_loc = Z_RAISE_BEFORE_PROBING;
    else
      z_loc = current_position[Z_AXIS];
+
+   #ifdef SLED_DOCKING_OFFSET
    do_blocking_move_to(X_MAX_POS + SLED_DOCKING_OFFSET + offset,
+   #else
+   do_blocking_move_to(X_MAX_POS + offset,
+   #endif
                        Y_PROBE_OFFSET_FROM_EXTRUDER, z_loc);
    // turn on magnet
    digitalWrite(SERVO0_PIN, HIGH);
  }
 }
-#endif
+#endif //Z_PROBE_SLED
 
 void process_commands()
 {
@@ -1549,7 +1558,7 @@ void process_commands()
             current_position[Z_AXIS] = 0;
 
             plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-            plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feedrate, active_extruder);
+            plan_buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feedrate/60, active_extruder);
             st_synchronize();
             current_position[X_AXIS] = destination[X_AXIS];
             current_position[Y_AXIS] = destination[Y_AXIS];


### PR DESCRIPTION
When moving to probe point the feedrate (in mm/min) is not converted to
mm/sec resulting in very rapid movement.

If autoleveling is enabled, dock_sled function is being generated but
requires SLED_DOCKING_OFFSET to be defined.
Bugfix: If SLED_DOCKING_OFFSET is not defined, assume a value of 0 and
drop it completely.
Improvement: Generate dock_sled function only if Z_PROBE_SLED is
defined.
