### PR TITLE
Corrected retract() call for use of auto probe without sled enabled.

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1138,8 +1138,8 @@ static void homeaxis(int axis) {
 #if defined (ENABLE_AUTO_BED_LEVELING) && (PROBE_SERVO_DEACTIVATION_DELAY > 0)
   #ifndef Z_PROBE_SLED
     if (axis==Z_AXIS) retract_z_probe();
-  #endif#
-endif
+  #endif
+#endif
 
   }
 }
@@ -1193,7 +1193,7 @@ void refresh_cmd_timeout(void)
   } //retract
 #endif //FWRETRACT
 
-#ifdef ENABLE_AUTO_BED_LEVELING
+#ifdef Z_PROBE_SLED
 //
 // Method to dock/undock a sled designed by Charles Bell.
 //


### PR DESCRIPTION
Hi. This patch fixes a bug I introduced whereby compiling with auto bed leveling without the z probe leaves out the retract() call. As you will see, I accidentally commented out the call during testing and forgot to correct it. Also changes the #ifdef for the sled code only to include in compile only when the sled is activated. Another oversight. Sorry. My apologies. All is well now. ;)
