### PR TITLE
Wing fix float delta

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -319,6 +319,7 @@ bool cancel_heatup = false ;
 const char axis_codes[NUM_AXIS] = {'X', 'Y', 'Z', 'E'};
 static float destination[NUM_AXIS] = {  0.0, 0.0, 0.0, 0.0};
 
+#ifndef DELTA
 static float delta[3] = {0.0, 0.0, 0.0};
 #endif
 


### PR DESCRIPTION
Creating pull request to address issue:  "float delta error when DELTA is defined #1072"

Wraps the: `static float delta[3]` inside of an #ifndef statement so that the two "float delta[]" will not collide if DELTA is defined for delta printer configuration.
