### PR TITLE
Add command for memory position and move to x y z in memory

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -218,6 +218,7 @@ void recalc_delta_settings(float radius, float diagonal_rod);
 extern float min_pos[3];
 extern float max_pos[3];
 extern bool axis_known_position[3];
+extern float lastpos[4];
 extern float zprobe_zoffset;
 extern int fanSpeed;
 #ifdef BARICUDA


### PR DESCRIPTION
I use it when I change the filament automatically with the g-code change tools in Slic3r.
I have 4 extruders but a single nozzle, when I change the wire, move the nozzle out of the plane to make bleeding the nozzle. So before I memorize the position, I move to purge, and then resume from the last position.
