### PR TITLE
Fix build for non-sled bed auto levelling

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1268,7 +1268,7 @@ void refresh_cmd_timeout(void)
   } //retract
 #endif //FWRETRACT
 
-#ifdef ENABLE_AUTO_BED_LEVELING
+#ifdef Z_PROBE_SLED
 //
 // Method to dock/undock a sled designed by Charles Bell.
 //


### PR DESCRIPTION
This function should only be used with sled, not all bed auto levelling.

Looks like Charles missed just one ifdef in commit d2fcb3ee
