### PR TITLE
Adjust the Z display to hide float rounding errors

### DIFF
--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -467,7 +467,7 @@ static void lcd_implementation_status_screen()
 # endif//LCD_WIDTH > 19
     lcd.setCursor(LCD_WIDTH - 8, 1);
     lcd.print('Z');
-    lcd.print(ftostr32(current_position[Z_AXIS]));
+    lcd.print(ftostr32(current_position[Z_AXIS] + 0.00001));
 #endif//LCD_HEIGHT > 2
 
 #if LCD_HEIGHT > 3


### PR DESCRIPTION
Due to floating point's natural rounding issues Z coordinates such as 0.4 may be displayed as 0.39. This patch simply adds 0.0001 to the displayed Z coordinate to prevent this from happening. (We might also add to the XY coordinates, but nobody really cares about their accuracy as much as Z.)
