### PR TITLE
Fix "add_homeing" to "add_homing" to match changes

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -311,7 +311,7 @@ void lcd_set_home_offsets()
 {
     for(int8_t i=0; i < NUM_AXIS; i++) {
       if (i != E_AXIS) {
-        add_homeing[i] -= current_position[i];
+        add_homing[i] -= current_position[i];
         current_position[i] = 0.0;
       }
     }


### PR DESCRIPTION
The variable was changed in Marlin.h but was not fixed in UltraLCD.cpp. This broke compile.
