### PR TITLE
Add Travis CI config to build Marlin firmware.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+---
+language: c
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq gcc-avr binutils-avr avr-libc gcc-4.8 g++-4.8 arduino
+  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 90
+  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 90
+  - gcc --version
+  - g++ --version
+
+script: "cd Marlin && make HARDWARE_MOTHERBOARD=70 ARDUINO_INSTALL_DIR=/usr/share/arduino"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Marlin 3D Printer Firmware
 ==========================
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224)
+[![Travis Build Status](https://travis-ci.org/ErikZalm/Marlin.svg)](https://travis-ci.org/ErikZalm/Marlin)
 
 Marlin has a GPL license because I believe in open development.
 Please do not use this code in products (3D printers, CNC etc) that are closed source or are crippled by a patent.


### PR DESCRIPTION
This CL adds a [Travis CI](https://travis-ci.org/) config to allow automatic builds on every commit and send an email, if the build is failed. It also adds a build status banner, like below:

[![Build Status](https://travis-ci.org/krasin/Marlin.svg)](https://travis-ci.org/krasin/Marlin)

The only difference is that the banner above points to my fork, and the banner proposed by this CL points to the not-yet-existing profile for ErikZalm.

This CL also opens a door for running automated tests on each commit.

To enable Travis CI on github.com/ErikZalm/Marlin, the following quick setup is needed:
1. Go to https://travis-ci.org/ and click "Sign in with GitHub" button in the upper right corner.
2. Grant the requested permissions (it will not ask for code access, just commit hooks/list emails/access project activity)
3. Go to https://travis-ci.org/profile and enable builds on ErikZalm/Marlin repository
4. Merge this CL and enjoy the reduced risk to break the build and not to get noticed.

Please, let me know, if this CL needs more clarification. I would be happy to address any concerns.
