### PR TITLE
Split do_blocking_move() to XY and Z sections

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1057,11 +1057,16 @@ static void run_z_probe() {
 static void do_blocking_move_to(float x, float y, float z) {
     float oldFeedRate = feedrate;
 
+    feedrate = homing_feedrate[Z_AXIS];
+
+    current_position[Z_AXIS] = z;
+    plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], feedrate/60, active_extruder);
+    st_synchronize();
+
     feedrate = XY_TRAVEL_SPEED;
 
     current_position[X_AXIS] = x;
     current_position[Y_AXIS] = y;
-    current_position[Z_AXIS] = z;
     plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], feedrate/60, active_extruder);
     st_synchronize();
 


### PR DESCRIPTION
do_blocking_move() function might have exceeded the Z homing speed if the distance between two probes is sufficiently small. For some printer constructions (i.e., the ones with tiny beds), this will cause the Z axis to try to move faster than it can, leading to bad things.

This commit splits the Z and XY movement, and uses the Z homing speed for Z movement, while XY_TRAVEL_SPEED is used after the probe is lifted from the bed.
