### PR TITLE
Fixes commands not being acknowledged in the same order they are received in

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -721,14 +721,7 @@ void get_command()
           case 1:
           case 2:
           case 3:
-            if(Stopped == false) { // If printer is stopped by an error the G[0-3] codes are ignored.
-          #ifdef SDSUPPORT
-              if(card.saving)
-                break;
-          #endif //SDSUPPORT
-              SERIAL_PROTOCOLLNPGM(MSG_OK);
-            }
-            else {
+            if (Stopped == true) {
               SERIAL_ERRORLNPGM(MSG_ERR_STOPPED);
               LCD_MESSAGEPGM(MSG_STOPPED);
             }
@@ -1357,7 +1350,6 @@ void process_commands()
           #endif //FWRETRACT
         prepare_move();
         //ClearToSend();
-        return;
       }
       break;
 #ifndef SCARA //disable arc support
@@ -1365,14 +1357,12 @@ void process_commands()
       if(Stopped == false) {
         get_arc_coordinates();
         prepare_arc_move(true);
-        return;
       }
       break;
     case 3: // G3  - CCW ARC
       if(Stopped == false) {
         get_arc_coordinates();
         prepare_arc_move(false);
-        return;
       }
       break;
 #endif


### PR DESCRIPTION
(See the discussion at ErikZalm/Marlin#1147)

`G0` to `G3` were previously acknowledged in the get_command method, causing
them to be possibly acknowledged before commands coming after them that
were acknowledged in process_commands.

This patch fixes this, moving the acknowledgement of `G0` to `G3` to the
`process_commands` method as well. These commands are therefore no
longer acknowledged when the enter the `cmd_buffer` but instead only
acknowledged when the enter the `plan_buffer`.

Guaranteeing that commands are acknowledged in the same order in which
they were received by the firmware allows host software to be able to
track the life cycle of commands and such a better management of the
firmware's serial buffers as well as better internal command processing
and response parsing without having to depend on throwing an epic
amount of regular expressions against each line received back from the
firmware.
