### PR TITLE
Fix autoretract bug

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1344,7 +1344,7 @@ void process_commands()
                   current_position[E_AXIS] = destination[E_AXIS]; //hide the slicer-generated retract/recover from calculations
                   plan_set_e_position(current_position[E_AXIS]); //AND from the planner
                   retract(!retracted[active_extruder]);
-                  return;
+                  break;
               }
             }
           #endif //FWRETRACT


### PR DESCRIPTION
After some commits (https://github.com/ErikZalm/Marlin/commit/3c927901a4dcc4fb4bbfd6bf914a35f8277165db ; https://github.com/ErikZalm/Marlin/commit/9db9842aeabe76f78bfda67fac89b75a531bb0b7) the firmware retraction was broken. This pull request fixes it
