### PR TITLE
Added: hardware pwm functionality

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -36,6 +36,13 @@
 
 #include "Sd2PinMap.h"
 
+//#define Hardware_pwm 1 
+
+// uncomment the above to allow for the usage of 
+//hardware pwm on heaters connected to hardware pwm capable pins
+// the frequancy is somwhere around 3kHz as opposed to 4Hz in software pwm mode
+// this is mainly for use with powersupplies that cannot handle the 4Hz pwm 
+// 
 
 //===========================================================================
 //=============================public variables============================
@@ -1205,27 +1212,110 @@ ISR(TIMER0_COMPB_vect)
    static unsigned long raw_filwidth_value = 0;  //added for filament width sensor
   #endif
   
-  if(pwm_count == 0){
+    if(pwm_count == 0){
     soft_pwm_0 = soft_pwm[0];
-    if(soft_pwm_0 > 0) { 
-      WRITE(HEATER_0_PIN,1);
+    if(soft_pwm_0 > 0) {
+      
+      #ifndef Hardware_pwm
+      WRITE(HEATER_0_PIN,1); 
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_0_PIN,soft_pwm_0);
+      #endif
+      
       #ifdef HEATERS_PARALLEL
+      #ifndef Hardware_pwm
       WRITE(HEATER_1_PIN,1);
       #endif
-    } else WRITE(HEATER_0_PIN,0);
-	
+      #ifdef Hardware_pwm
+      analogWrite(HEATER_1_PIN,soft_pwm_0);
+      #endif
+      
+      
+      #endif
+    } else {
+ 
+      #ifndef Hardware_pwm
+       WRITE(HEATER_0_PIN,0);
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_0_PIN,0);
+      #endif	
+}
     #if EXTRUDERS > 1
     soft_pwm_1 = soft_pwm[1];
-    if(soft_pwm_1 > 0) WRITE(HEATER_1_PIN,1); else WRITE(HEATER_1_PIN,0);
+    if(soft_pwm_1 > 0) 
+    {
+       
+      #ifndef Hardware_pwm
+      WRITE(HEATER_1_PIN,1);
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_1_PIN,soft_pwm_1);
+      #endif
+       
+    }
+    else
+   { 
+      #ifndef Hardware_pwm
+      WRITE(HEATER_1_PIN,1);
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_1_PIN,0);
+      #endif
+   }
     #endif
     #if EXTRUDERS > 2
     soft_pwm_2 = soft_pwm[2];
-    if(soft_pwm_2 > 0) WRITE(HEATER_2_PIN,1); else WRITE(HEATER_2_PIN,0);
+    if(soft_pwm_2 > 0)
+    {
+      
+      #ifndef Hardware_pwm
+      WRITE(HEATER_2_PIN,1);
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_2_PIN,soft_pwm_2);
+      #endif
+    }
+    else
+   {
+      #ifndef Hardware_pwm
+      WRITE(HEATER_2_PIN,0);
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_2_PIN,0);
+      #endif
+   }
     #endif
+    
+    
     #if defined(HEATER_BED_PIN) && HEATER_BED_PIN > -1
     soft_pwm_b = soft_pwm_bed;
-    if(soft_pwm_b > 0) WRITE(HEATER_BED_PIN,1); else WRITE(HEATER_BED_PIN,0);
+    if(soft_pwm_b > 0){
+      #ifndef Hardware_pwm
+      WRITE(HEATER_BED_PIN,1); 
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_BED_PIN,soft_pwm_b);
+      #endif
+      
+    } 
+    else
+    {
+      #ifndef Hardware_pwm
+      WRITE(HEATER_BED_PIN,0);
+      #endif
+      #ifdef Hardware_pwm 
+      analogWrite(HEATER_BED_PIN,0);
+      #endif
+      
+
+    }    
+    
+    
     #endif
+       
+    
     #ifdef FAN_SOFT_PWM
     soft_pwm_fan = fanSpeedSoftPwm / 2;
     if(soft_pwm_fan > 0) WRITE(FAN_PIN,1); else WRITE(FAN_PIN,0);


### PR DESCRIPTION
These are the changes I've made to temperature.cpp to allow the usage of hardware pwm.
it's totally optional and doesn't take effect unless you uncomment the #define Hardware_pwm

This is required for those who are trying to run those 19v power bricks (laptop power supplies) 
