### PR TITLE
Format Z like XY on LCD

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1444,7 +1444,7 @@ char *ftostr12ns(const float &x)
 }
 
 //  convert float to space-padded string with -_23.4_ format
-char *ftostr32np(const float &x) {
+char *ftostr32sp(const float &x) {
   long xx = abs(x * 100);
   uint8_t dig;
 

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -119,7 +119,7 @@ char *ftostr31ns(const float &x); // float to string without sign character
 char *ftostr31(const float &x);
 char *ftostr32(const float &x);
 char *ftostr12ns(const float &x); 
-char *ftostr32np(const float &x); // remove zero-padding from ftostr32
+char *ftostr32sp(const float &x); // remove zero-padding from ftostr32
 char *ftostr5(const float &x);
 char *ftostr51(const float &x);
 char *ftostr52(const float &x);

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -475,7 +475,7 @@ static void lcd_implementation_status_screen()
 # endif//LCD_WIDTH > 19
     lcd.setCursor(LCD_WIDTH - 8, 1);
     lcd.print('Z');
-    lcd.print(ftostr32np(current_position[Z_AXIS] + 0.00001));
+    lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
 #endif//LCD_HEIGHT > 2
 
 #if LCD_HEIGHT > 3


### PR DESCRIPTION
This change displays the Z coordinate space-padded on the LCD so that it matches the style of X and Y, adding a function called ftostr32sp for the purpose.
