### PR TITLE
Add fwretract settings to M503 output (updated)

### DIFF
--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -204,14 +204,14 @@ SERIAL_ECHOLNPGM("Scaling factors:");
     SERIAL_ECHOLNPGM("Retract: S=Length (mm) F:Speed (mm/m) Z: ZLift (mm)");
     SERIAL_ECHO_START;
     SERIAL_ECHOPAIR("   M207 S",retract_length); 
-    SERIAL_ECHOPAIR(" F" ,retract_feedrate); 
+    SERIAL_ECHOPAIR(" F" ,retract_feedrate*60); 
     SERIAL_ECHOPAIR(" Z" ,retract_zlift);
     SERIAL_ECHOLN(""); 
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPGM("Recover: S=Extra length (mm) F:Speed (mm/m)");
     SERIAL_ECHO_START;
     SERIAL_ECHOPAIR("   M208 S",retract_recover_length); 
-    SERIAL_ECHOPAIR(" F" ,retract_recover_feedrate); 
+    SERIAL_ECHOPAIR(" F" ,retract_recover_feedrate*60); 
     SERIAL_ECHOLN(""); 
 #endif
 } 


### PR DESCRIPTION
This is a cleaner pull for #844 for the Development branch.  I've been running this patch on my Mendel90 running the usual Melzi for quite some time now, testing is as simple as running 'M503' and looking for the new output.
