### PR TITLE
Move initialization of errormagic[] and echomagic[] to Marlin_main.cpp

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -66,8 +66,9 @@
 #define SERIAL_PROTOCOLLNPGM(x) (serialprintPGM(PSTR(x)),MYSERIAL.write('\n'))
 
 
-const char errormagic[] PROGMEM ="Error:";
-const char echomagic[] PROGMEM ="echo:";
+extern const char errormagic[] PROGMEM;
+extern const char echomagic[] PROGMEM;
+
 #define SERIAL_ERROR_START (serialprintPGM(errormagic))
 #define SERIAL_ERROR(x) SERIAL_PROTOCOL(x)
 #define SERIAL_ERRORPGM(x) SERIAL_PROTOCOLPGM(x)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -329,6 +329,9 @@ bool cancel_heatup = false ;
   int meas_delay_cm = MEASUREMENT_DELAY_CM;  //distance delay setting
 #endif
 
+const char errormagic[] PROGMEM = "Error:";
+const char echomagic[] PROGMEM = "echo:";
+
 //===========================================================================
 //=============================Private Variables=============================
 //===========================================================================


### PR DESCRIPTION
Trivial change to omit warnings.

Tested on Prusa i3 with arduino/ramps, compiled by arduino 1.0.6
