### PR TITLE
MAX6675 Slave Select pin 

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -904,9 +904,9 @@
   #define SCK_PIN          52
   #define MISO_PIN         50
   #define MOSI_PIN         51
-  #define MAX6675_SS       53
+  #define MAX6675_SS       66// Do not use pin 53 if there is even the remote possibility of using Dsplay/SD card
 #else
-  #define MAX6675_SS       49
+  #define MAX6675_SS       66// Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
 #endif
 
 #endif // RAMPS_OLD || RAMPS_13_EFB || RAMPS_13_EEB || RAMPS_13_EFF || 3DRAG


### PR DESCRIPTION
Somehow the pin definitions for the MAX6675 Slave Select/Chip Select got changed back to the hardware SPI SS/CS.  
Pin 49 cannot be used as that is used by the SD card socket to detect if a SD card is present.
Pin 53 is the Hardware SPI SS, which is dedicated, nicely, to the SD card SS and therefore cannot be used as the MAX6675 SS
Pin 66 is in the Aux2 port adjacent to the Hardware SPI interface port on RAMPS 1.4, and is currently not used for anything and is ideal to use as the Slave Select pin for the MAX6675.
