### PR TITLE
Code for slow down the frequency of PWM (to circa 0.125Hz) and minimum state times useful for heater drived by relay

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -148,6 +148,7 @@
 #ifdef PIDTEMP
   //#define PID_DEBUG // Sends debug data to the serial port.
   //#define PID_OPENLOOP 1 // Puts PID in open loop. M104/M140 sets the output power from 0 to PID_MAX
+  //#define SLOW_PWM_HEATERS // PWM with very low frequency (circa 0.125Hz=8s) and miminum state time of circa 1s usefoul for heater drived by relay
   #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
                                   // is more then PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
   #define PID_INTEGRAL_DRIVE_MAX PID_MAX  //limit for the integral term

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Current Status: Bug Fixing
 ===================
 
-What bugs are we working on: https://github.com/MarlinFirmware/Development/milestones/Bug%20Fixing%20Round%201
+What bugs are we working on: https://github.com/MarlinFirmware/Marlin/milestones/Bug%20Fixing%20Round%201
 
 IRC channel on freenode: #marlin-firmware
 
@@ -10,11 +10,13 @@ IRC channel on freenode: #marlin-firmware
 Developer Notes
 ===================
 
-- We are doing a kind of cleanup in the list of Issues and Pull Requests, the aim is to get to a state where we can certify the code as stable. To get the code tested as widely as possible we require several volunteers with a wide variety of hardware configurations willing to test the firmware and help us to certify it as stable. If you want to help out testing go to this issue and let us know: https://github.com/MarlinFirmware/Development/issues/1209
+- There are now 2 branches: The __development__ branch is where new features and code changes will be sorted out. This branch may have untested code in it, so please let us know if you find any bugs. When the __development__ branch has reached a state where it is stable, it will be moved to the __stable__ branch.
+
+- We are doing a kind of cleanup in the list of Issues and Pull Requests, the aim is to get to a state where we can certify the code as stable. To get the code tested as widely as possible we require several volunteers with a wide variety of hardware configurations willing to test the firmware and help us to certify it as stable. If you want to help out testing go to this issue and let us know: https://github.com/MarlinFirmware/Marlin/issues/1209
 
 - Before you submit any pull request, we ask that you _PLEASE_ test your code before submission, even if the change seems innocuous. When creating the pull request, please include the hardware you used for testing and a short synopsis of your testing procedure. Untested pull requests are less likely to be merged, as even slight changes create the risk of breaking the main branch.
 
-- If you have a fix don't open an issue telling about it, but test the code and submit a pull request.
+- If you have a fix don't open an issue telling about it, but test the code and submit a pull request. Use the __development__ branch when you submit.
 
 ==========================
 Marlin 3D Printer Firmware


### PR DESCRIPTION
Dear,
I have added some code in the "temperature.cpp" for have the possibility of control the time of the states with the heater drived by relays, with this feature now it is possible use PID function in conjunction with relay to control the temperature. I have made some tests and the temperature stay always in the range of +-1°C from the setted temp.
There is the possibility of turn on this features adding "#define SLOW_PWM_HEATERS" in Configuration.h 