### PR TITLE
fix avrdude upload in makefile

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -36,11 +36,12 @@
 # Note that all settings are set with ?=, this means you can override them
 # from the commandline with "make HARDWARE_MOTHERBOARD=71" for example
 
-# This defined the board you are compiling for (see Configuration.h for the options)
+# This defined the board you are compiling for (see boards.h for the options)
 HARDWARE_MOTHERBOARD ?= 11
 
 # Arduino source install directory, and version number
-ARDUINO_INSTALL_DIR  ?= /Applications/Arduino.app/Contents/Resources/Java
+# On most linuxes this will be /usr/share/arduino
+ARDUINO_INSTALL_DIR  ?= /usr/share/arduino
 ARDUINO_VERSION      ?= 105
 
 # You can optionally set a path to the avr-gcc tools. Requires a trailing slash. (ex: /usr/local/avr-gcc/bin)
@@ -49,9 +50,11 @@ AVR_TOOLS_PATH ?=
 #Programmer configuration
 UPLOAD_RATE        ?= 115200
 AVRDUDE_PROGRAMMER ?= arduino
+# on most linuxes this will be /dev/ttyACM0 or /dev/ttyACM1 
 UPLOAD_PORT        ?= /dev/arduino
 
-#Directory used to build files in, contains all the build files, from object files to the final hex file.
+#Directory used to build files in, contains all the build files, from object files to the final hex file
+#on linux it is best to put an absolute path like /home/username/tmp .
 BUILD_DIR          ?= applet
 
 # This defines whether Liquid_TWI2 support will be built
@@ -351,15 +354,15 @@ LDFLAGS = -lm
 
 # Programming support using avrdude. Settings and variables.
 AVRDUDE_PORT = $(UPLOAD_PORT)
-AVRDUDE_WRITE_FLASH = -U flash:w:$(BUILD_DIR)/$(TARGET).hex:i
+AVRDUDE_WRITE_FLASH = -Uflash:w:$(BUILD_DIR)/$(TARGET).hex:i
 ifeq ($(shell uname -s), Linux)
 AVRDUDE_CONF = $(ARDUINO_INSTALL_DIR)/hardware/tools/avrdude.conf
 else
 AVRDUDE_CONF = $(ARDUINO_INSTALL_DIR)/hardware/tools/avr/etc/avrdude.conf
 endif
-AVRDUDE_FLAGS = -D -C $(AVRDUDE_CONF) \
-	-p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER) \
-	-b $(UPLOAD_RATE)
+AVRDUDE_FLAGS = -q -q -D -C$(AVRDUDE_CONF) \
+	-p$(MCU) -P$(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER) -cwiring\
+	-b$(UPLOAD_RATE)
 
 # Define all object files.
 OBJ = ${patsubst %.c, $(BUILD_DIR)/%.o, ${SRC}}


### PR DESCRIPTION
Makefile does not seem to drive avrdude properly when using "make upload" ,  reverse engineered by capturing avrdude command line used by ArduinoIDE and altering Makefile to match. Now for basic operations 

make
make upload 

now work.

There is a known problem with it picking up the U8glib when compiling in a graphic display. I will deal with this seperatly

Tested on Ubuntu 14.10 and Fedora 20. 

thawkins@thawkins-N550JK:~/Public/Firmware/Marlin/Marlin$ make upload
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_analog.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_digital.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_pulse.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_shift.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/WInterrupts.c
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/WMath.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/WString.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/Print.cpp
  CXX   Marlin_main.cpp
  CXX   MarlinSerial.cpp
  CXX   Sd2Card.cpp
  CXX   SdBaseFile.cpp
  CXX   SdFatUtil.cpp
  CXX   SdFile.cpp
  CXX   SdVolume.cpp
  CXX   motion_control.cpp
  CXX   planner.cpp
  CXX   stepper.cpp
  CXX   temperature.cpp
  CXX   cardreader.cpp
  CXX   ConfigurationStore.cpp
  CXX   watchdog.cpp
  CXX   /usr/share/arduino/libraries/SPI/SPI.cpp
  CXX   Servo.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/Tone.cpp
  CXX   ultralcd.cpp
  CXX   digipot_mcp4451.cpp
  CXX   vector_3.cpp
  CXX   qr_solve.cpp
  CXX   /usr/share/arduino/libraries/LiquidCrystal/LiquidCrystal.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/main.cpp
  CXX   /home/thawkins/tmp/Marlin.elf
  COPY  /home/thawkins/tmp/Marlin.hex
stty hup < /dev/ttyACM1; true
avrdude -q -q -D -C/usr/share/arduino/hardware/tools/avrdude.conf -patmega2560 -P/dev/ttyACM1 -c arduino -cwiring -b115200 -Uflash:w:/home/thawkins/tmp/Marlin.hex:i
stty -hup < /dev/ttyACM1; true
# Display size of file.

Prior to these changes I would get 

thawkins@thawkins-N550JK:~/Public/Firmware/Marlin/Marlin$ make upload
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_analog.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_digital.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_pulse.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/wiring_shift.c
  CC    /usr/share/arduino/hardware/arduino/cores/arduino/WInterrupts.c
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/WMath.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/WString.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/Print.cpp
  CXX   Marlin_main.cpp
  CXX   MarlinSerial.cpp
  CXX   Sd2Card.cpp
  CXX   SdBaseFile.cpp
  CXX   SdFatUtil.cpp
  CXX   SdFile.cpp
  CXX   SdVolume.cpp
  CXX   motion_control.cpp
  CXX   planner.cpp
  CXX   stepper.cpp
  CXX   temperature.cpp
  CXX   cardreader.cpp
  CXX   ConfigurationStore.cpp
  CXX   watchdog.cpp
  CXX   /usr/share/arduino/libraries/SPI/SPI.cpp
  CXX   Servo.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/Tone.cpp
  CXX   ultralcd.cpp
  CXX   digipot_mcp4451.cpp
  CXX   vector_3.cpp
  CXX   qr_solve.cpp
  CXX   /usr/share/arduino/libraries/LiquidCrystal/LiquidCrystal.cpp
  CXX   /usr/share/arduino/hardware/arduino/cores/arduino/main.cpp
  CXX   /home/thawkins/tmp/Marlin.elf
  COPY  /home/thawkins/tmp/Marlin.hex
stty hup < /dev/ttyACM0; true
avrdude -D -C /usr/share/arduino/hardware/tools/avrdude.conf -p atmega2560 -P /dev/ttyACM0 -c arduino -b 115200 -U flash:w:/home/thawkins/tmp/Marlin.hex:i
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 1 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 2 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 3 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 4 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 5 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 6 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 7 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 8 of 10: not in sync: resp=0x00
^CMakefile:406: recipe for target 'upload' failed
make: **\* [upload] Interrupt

thawkins@thawkins-N550JK:~/Public/Firmware/Marlin/Marlin$ make upload
stty hup < /dev/ttyACM0; true
avrdude -D -C /usr/share/arduino/hardware/tools/avrdude.conf -p atmega2560 -P /dev/ttyACM0 -c arduino -b 115200 -U flash:w:/home/thawkins/tmp/Marlin.hex:i
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 1 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 2 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 3 of 10: not in sync: resp=0x00
avrdude: stk500_recv(): programmer is not responding
avrdude: stk500_getsync() attempt 4 of 10: not in sync: resp=0x00
avrdude: stk500_getsync() attempt 5 of 10: not in sync: resp=0x6e
avrdude: stk500_getsync() attempt 6 of 10: not in sync: resp=0x6e
avrdude: stk500_getsync() attempt 7 of 10: not in sync: resp=0xa8
avrdude: stk500_getsync() attempt 8 of 10: not in sync: resp=0x0c
avrdude: stk500_getsync() attempt 9 of 10: not in sync: resp=0x4d
avrdude: stk500_getsync() attempt 10 of 10: not in sync: resp=0x5e

avrdude done.  Thank you.

Makefile:406: recipe for target 'upload' failed
make: **\* [upload] Error 1
