### PR TITLE
repair Bootsplash

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -24,11 +24,11 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
-#define STRING_VERSION "v1.0.2"
+#define STRING_VERSION "1.0.2"
 #define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
-#define STRING_SPLASH STRING_VERSION " - " STRING_URL // will be shown during bootup
+#define STRING_SPLASH "v" STRING_VERSION " - " STRING_URL // will be shown during bootup
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -61,8 +61,6 @@
 #include <SPI.h>
 #endif
 
-#define VERSION_STRING  "1.0.0"
-
 // look here for descriptions of G-codes: http://linuxcnc.org/handbook/gcode/g-code.html
 // http://objects.reprap.org/wiki/Mendel_User_Manual:_RepRapGCodes
 
@@ -587,7 +585,7 @@ void setup()
   MCUSR=0;
 
   SERIAL_ECHOPGM(MSG_MARLIN);
-  SERIAL_ECHOLNPGM(VERSION_STRING);
+  SERIAL_ECHOLNPGM(STRING_VERSION);
   #ifdef STRING_VERSION_CONFIG_H
     #ifdef STRING_CONFIG_H_AUTHOR
       SERIAL_ECHO_START;

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -117,18 +117,13 @@ static void lcd_implementation_init()
 	} while(u8g.nextPage());
 
   // Show splashscreen
-  int off = (u8g.getWidth() - START_BMPWIDTH) / 2;
+  int offx = (u8g.getWidth() - START_BMPWIDTH) / 2;
+  int offy = (u8g.getHeight() - 18 - START_BMPHEIGHT) / 2;
   int txtX = (u8g.getWidth() - (sizeof(STRING_SPLASH) - 1)*5) / 2; // 5 is fontwidth in pixel
   int txtY = u8g.getHeight() - 10;
 	u8g.firstPage();
 	do {
-    #ifdef START_BMPHIGH
-		  u8g.drawBitmapP(off, off, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-    #else
-      u8g.setScale2x2();
-		  u8g.drawBitmapP(off, off, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-      u8g.undoScale();
-    #endif
+	  u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
 			
     u8g.setFont(u8g_font_5x8);
 		u8g.drawStr(txtX, txtY, STRING_SPLASH);

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -118,7 +118,7 @@ static void lcd_implementation_init()
 
   // Show splashscreen
   int off = (u8g.getWidth() - START_BMPWIDTH) / 2;
-  int txtX = (u8g.getWidth() - sizeof(STRING_SPLASH) - 1) / 2;
+  int txtX = (u8g.getWidth() - (sizeof(STRING_SPLASH) - 1)*5) / 2; // 5 is fontwidth in pixel
   int txtY = u8g.getHeight() - 10;
 	u8g.firstPage();
 	do {

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -28,7 +28,7 @@
 #define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #define STRING_CONFIG_H_AUTHOR "(K8200, CONSULitAS)" // Who made the changes.
-#define STRING_SPLASH STRING_VERSION " - " STRING_URL // will be shown during bootup
+#define STRING_SPLASH "v" STRING_VERSION " - " STRING_URL // will be shown during bootup
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -42,8 +42,11 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
+#define STRING_VERSION "1.0.2"
+#define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_SPLASH "v" STRING_VERSION " - " STRING_URL // will be shown during bootup
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.

--- a/Marlin/example_configurations/delta/Configuration.h
+++ b/Marlin/example_configurations/delta/Configuration.h
@@ -17,8 +17,11 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
+#define STRING_VERSION "1.0.2"
+#define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_SPLASH "v" STRING_VERSION " - " STRING_URL // will be shown during bootup
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -24,8 +24,11 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
+#define STRING_VERSION "1.0.2"
+#define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_SPLASH "v" STRING_VERSION " - " STRING_URL // will be shown during bootup
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -24,8 +24,11 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
+#define STRING_VERSION "1.0.2"
+#define STRING_URL "reprap.org"
 #define STRING_VERSION_CONFIG_H __DATE__ " " __TIME__ // build date and time
 #define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_SPLASH "v" STRING_VERSION " - " STRING_URL // will be shown during bootup
 
 // SERIAL_PORT selects which serial port should be used for communication with the host.
 // This allows the connection of wireless adapters (for instance) to non-default port pins.


### PR DESCRIPTION
The #defines:
# define VERSION_STRING  "1.0.0"    in  Marlin_main.cpp and
# define STRING_VERSION "v1.0.2" in Configuration.h are close to redundant. On the other hand a definition in a .cpp-file is not a really good idea.

So replaced VERSION_STRING by a modified  STRING_VERSION and added the 'v' where needed.

Repaird the centering of the bootspash-sting.
Repaird the centering of the bootsplash-logo.

Removed the use of u8g.setScale2x2(); in dogm_lcd_implementation.h because the introduction of this used more space than the reduction of the size of the logo provided. 
With '#define START_BMPHIGH' in Configuration.h you can now decide to have a bigger (400 Bytes) logo, but the small one is good enough for me.

By the way. in 'dogm_lcd_implementation.h' we can find a lot of code - not really nice in a .h-file.
