### PR TITLE
Allow LCD movement of z-axis in 10mm increments

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -746,9 +746,9 @@ static void lcd_move_menu_axis()
     MENU_ITEM(back, MSG_MOVE_AXIS, lcd_move_menu);
     MENU_ITEM(submenu, MSG_MOVE_X, lcd_move_x);
     MENU_ITEM(submenu, MSG_MOVE_Y, lcd_move_y);
+    MENU_ITEM(submenu, MSG_MOVE_Z, lcd_move_z);
     if (move_menu_scale < 10.0)
     {
-        MENU_ITEM(submenu, MSG_MOVE_Z, lcd_move_z);
         MENU_ITEM(submenu, MSG_MOVE_E, lcd_move_e);
     }
     END_MENU();


### PR DESCRIPTION
Modified ultralcd.cpp to allow the user to move the z-axis in 10mm increments from the LCD (previously the max for the z-axis was 1mm). I don't know if there was previously a reason for limiting the z-axis to be able to only move in 1mm increments from the LCD, but for a simple task like raising (or lowering even) the z-axis to the opposite side of the endstop, having to increment 1mm at a time on the LCD is a bit of a pain especially with bigger machines that have build volumes in the 100mm's or 200mm's in the z, so this modification removes that restriction on the z-axis and allows the user to more quickly set a long travel distance from the LCD just like with the x and y. Tested and confirmed to work on a MakerFarm 10" Prusa i3v using RAMPS 1.4 and the RepRapDiscount Smart Controller.
