### PR TITLE
EEPROM data not aligned

### DIFF
--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -98,12 +98,14 @@ void Config_StoreSettings()
 		dummy = 0.0f;
         EEPROM_WRITE_VAR(i,dummy);
         EEPROM_WRITE_VAR(i,dummy);
+        EEPROM_WRITE_VAR(i,dummy);
 	  }
 	}
   #else//PIDTEMP
 		float dummy = 3000.0f;
     EEPROM_WRITE_VAR(i,dummy);
 		dummy = 0.0f;
+    EEPROM_WRITE_VAR(i,dummy);
     EEPROM_WRITE_VAR(i,dummy);
     EEPROM_WRITE_VAR(i,dummy);
   #endif//PIDTEMP

--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -271,6 +271,7 @@ SERIAL_ECHOLNPGM("Scaling factors:");
     SERIAL_ECHOPAIR("   Swap rec. addl. length (mm): ", retract_recover_length_swap);
     SERIAL_ECHOLN("");
 #endif//EXTRUDERS > 1
+#endif//FWRETRACT
     SERIAL_ECHO_START;
     if (volumetric_enabled) {
         SERIAL_ECHOLNPGM("Filament settings:");
@@ -295,7 +296,6 @@ SERIAL_ECHOLNPGM("Scaling factors:");
     } else {
         SERIAL_ECHOLNPGM("Filament settings: Disabled");
     }
-#endif//FWRETRACT
 #ifdef CUSTOM_M_CODES
   SERIAL_ECHO_START;
   SERIAL_ECHOLNPGM("Z-Probe Offset (mm):");


### PR DESCRIPTION
In a recent PR, PIDTEMP data was added to the EEPROM with an alignment error. This PR is meant to correct that. There was also a #endif misplaced in the EEPROM print settings.
