### PR TITLE
Make EEPROM storage consistent

### DIFF
--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -72,7 +72,7 @@ void _EEPROM_writeData(int &pos, uint8_t* value, uint8_t size) {
   uint8_t c;
   while(size--) {
     eeprom_write_byte((unsigned char*)pos, *value);
-    eeprom_read_byte((unsigned char*)pos, *c);
+    *c = eeprom_read_byte((unsigned char*)pos);
     if (*c != *value) {
       SERIAL_ECHO_START;
       SERIAL_ECHOLNPGM(MSG_ERR_EEPROM_WRITE);

--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -1,33 +1,92 @@
+/**
+ * ConfigurationStore.cpp
+ *
+ * Configuration and EEPROM storage
+ *
+ * V15 EEPROM Layout:
+ *
+ *  ver
+ *  axis_steps_per_unit (x4)
+ *  max_feedrate (x4)
+ *  max_acceleration_units_per_sq_second (x4)
+ *  acceleration
+ *  retract_acceleration
+ *  minimumfeedrate
+ *  mintravelfeedrate
+ *  minsegmenttime
+ *  max_xy_jerk
+ *  max_z_jerk
+ *  max_e_jerk
+ *  add_homing (x3)
+ *
+ * DELTA:
+ *  endstop_adj (x3)
+ *  delta_radius
+ *  delta_diagonal_rod
+ *  delta_segments_per_second
+ *
+ * ULTIPANEL:
+ *  plaPreheatHotendTemp
+ *  plaPreheatHPBTemp
+ *  plaPreheatFanSpeed
+ *  absPreheatHotendTemp
+ *  absPreheatHPBTemp
+ *  absPreheatFanSpeed
+ *  zprobe_zoffset
+ *
+ * PIDTEMP:
+ *  Kp[0], Ki[0], Kd[0], Kc[0]
+ *  Kp[1], Ki[1], Kd[1], Kc[1]
+ *  Kp[2], Ki[2], Kd[2], Kc[2]
+ *  Kp[3], Ki[3], Kd[3], Kc[3]
+ *
+ * DOGLCD:
+ *  lcd_contrast
+ *
+ * SCARA:
+ *  axis_scaling (x3)
+ *
+ * FWRETRACT:
+ *  autoretract_enabled
+ *  retract_length
+ *  retract_length_swap
+ *  retract_feedrate
+ *  retract_zlift
+ *  retract_recover_length
+ *  retract_recover_length_swap
+ *  retract_recover_feedrate
+ *
+ *  volumetric_enabled
+ *
+ *  filament_size (x4)
+ *
+ */
 #include "Marlin.h"
 #include "planner.h"
 #include "temperature.h"
 #include "ultralcd.h"
 #include "ConfigurationStore.h"
 
-void _EEPROM_writeData(int &pos, uint8_t* value, uint8_t size)
-{
-    do
-    {
-        eeprom_write_byte((unsigned char*)pos, *value);
-        pos++;
-        value++;
-    }while(--size);
+void _EEPROM_writeData(int &pos, uint8_t* value, uint8_t size) {
+  do {
+    eeprom_write_byte((unsigned char*)pos, *value);
+    pos++;
+    value++;
+  } while (--size);
+}
+void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size) {
+  do {
+    *value = eeprom_read_byte((unsigned char*)pos);
+    pos++;
+    value++;
+  } while (--size);
 }
 #define EEPROM_WRITE_VAR(pos, value) _EEPROM_writeData(pos, (uint8_t*)&value, sizeof(value))
-void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size)
-{
-    do
-    {
-        *value = eeprom_read_byte((unsigned char*)pos);
-        pos++;
-        value++;
-    }while(--size);
-}
 #define EEPROM_READ_VAR(pos, value) _EEPROM_readData(pos, (uint8_t*)&value, sizeof(value))
+
 //======================================================================================
 
-
-
+#define DUMMY_PID_VALUE 3000.0f
 
 #define EEPROM_OFFSET 100
 
@@ -38,506 +97,562 @@ void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size)
 // wrong data being written to the variables.
 // ALSO:  always make sure the variables in the Store and retrieve sections are in the same order.
 
-#define EEPROM_VERSION "V14"
+#define EEPROM_VERSION "V15"
 
 #ifdef EEPROM_SETTINGS
-void Config_StoreSettings() 
-{
-  char ver[4]= "000";
-  int i=EEPROM_OFFSET;
-  EEPROM_WRITE_VAR(i,ver); // invalidate data first 
-  EEPROM_WRITE_VAR(i,axis_steps_per_unit);
-  EEPROM_WRITE_VAR(i,max_feedrate);  
-  EEPROM_WRITE_VAR(i,max_acceleration_units_per_sq_second);
-  EEPROM_WRITE_VAR(i,acceleration);
-  EEPROM_WRITE_VAR(i,retract_acceleration);
-  EEPROM_WRITE_VAR(i,minimumfeedrate);
-  EEPROM_WRITE_VAR(i,mintravelfeedrate);
-  EEPROM_WRITE_VAR(i,minsegmenttime);
-  EEPROM_WRITE_VAR(i,max_xy_jerk);
-  EEPROM_WRITE_VAR(i,max_z_jerk);
-  EEPROM_WRITE_VAR(i,max_e_jerk);
-  EEPROM_WRITE_VAR(i,add_homing);
+
+void Config_StoreSettings()  {
+  float dummy = 0.0f;
+  char ver[4] = "000";
+  int i = EEPROM_OFFSET;
+  EEPROM_WRITE_VAR(i, ver); // invalidate data first
+  EEPROM_WRITE_VAR(i, axis_steps_per_unit);
+  EEPROM_WRITE_VAR(i, max_feedrate);
+  EEPROM_WRITE_VAR(i, max_acceleration_units_per_sq_second);
+  EEPROM_WRITE_VAR(i, acceleration);
+  EEPROM_WRITE_VAR(i, retract_acceleration);
+  EEPROM_WRITE_VAR(i, minimumfeedrate);
+  EEPROM_WRITE_VAR(i, mintravelfeedrate);
+  EEPROM_WRITE_VAR(i, minsegmenttime);
+  EEPROM_WRITE_VAR(i, max_xy_jerk);
+  EEPROM_WRITE_VAR(i, max_z_jerk);
+  EEPROM_WRITE_VAR(i, max_e_jerk);
+  EEPROM_WRITE_VAR(i, add_homing);
+
   #ifdef DELTA
-  EEPROM_WRITE_VAR(i,endstop_adj);
-  EEPROM_WRITE_VAR(i,delta_radius);
-  EEPROM_WRITE_VAR(i,delta_diagonal_rod);
-  EEPROM_WRITE_VAR(i,delta_segments_per_second);
-  #endif//DELTA
+    EEPROM_WRITE_VAR(i, endstop_adj);               // 3 floats
+    EEPROM_WRITE_VAR(i, delta_radius);              // 1 float
+    EEPROM_WRITE_VAR(i, delta_diagonal_rod);        // 1 float
+    EEPROM_WRITE_VAR(i, delta_segments_per_second); // 1 float
+  #else
+    dummy = 0.0f;
+    for (int q=6; q--;) EEPROM_WRITE_VAR(i, dummy);
+  #endif
+
   #ifndef ULTIPANEL
-  int plaPreheatHotendTemp = PLA_PREHEAT_HOTEND_TEMP, plaPreheatHPBTemp = PLA_PREHEAT_HPB_TEMP, plaPreheatFanSpeed = PLA_PREHEAT_FAN_SPEED;
-  int absPreheatHotendTemp = ABS_PREHEAT_HOTEND_TEMP, absPreheatHPBTemp = ABS_PREHEAT_HPB_TEMP, absPreheatFanSpeed = ABS_PREHEAT_FAN_SPEED;
-  #endif//ULTIPANEL
-  EEPROM_WRITE_VAR(i,plaPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,plaPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,plaPreheatFanSpeed);
-  EEPROM_WRITE_VAR(i,absPreheatHotendTemp);
-  EEPROM_WRITE_VAR(i,absPreheatHPBTemp);
-  EEPROM_WRITE_VAR(i,absPreheatFanSpeed);
-  EEPROM_WRITE_VAR(i,zprobe_zoffset);
-  #ifdef PIDTEMP
-    float dummy = 0.0f;
-    for (int e = 0; e < 4; e++)
-	{
-	  if (e < EXTRUDERS)
-	  {
-        EEPROM_WRITE_VAR(i,PID_PARAM(Kp,e));
-        EEPROM_WRITE_VAR(i,PID_PARAM(Ki,e));
-        EEPROM_WRITE_VAR(i,PID_PARAM(Kd,e));
+    int plaPreheatHotendTemp = PLA_PREHEAT_HOTEND_TEMP, plaPreheatHPBTemp = PLA_PREHEAT_HPB_TEMP, plaPreheatFanSpeed = PLA_PREHEAT_FAN_SPEED,
+        absPreheatHotendTemp = ABS_PREHEAT_HOTEND_TEMP, absPreheatHPBTemp = ABS_PREHEAT_HPB_TEMP, absPreheatFanSpeed = ABS_PREHEAT_FAN_SPEED;
+  #endif // !ULTIPANEL
+
+  EEPROM_WRITE_VAR(i, plaPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, plaPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, plaPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, absPreheatHotendTemp);
+  EEPROM_WRITE_VAR(i, absPreheatHPBTemp);
+  EEPROM_WRITE_VAR(i, absPreheatFanSpeed);
+  EEPROM_WRITE_VAR(i, zprobe_zoffset);
+
+  for (int e = 0; e < 4; e++) {
+
+    #ifdef PIDTEMP
+      if (e < EXTRUDERS) {
+        EEPROM_WRITE_VAR(i, PID_PARAM(Kp, e));
+        EEPROM_WRITE_VAR(i, PID_PARAM(Ki, e));
+        EEPROM_WRITE_VAR(i, PID_PARAM(Kd, e));
         #ifdef PID_ADD_EXTRUSION_RATE
-        EEPROM_WRITE_VAR(i,PID_PARAM(Kc,e));
-        #else//PID_ADD_EXTRUSION_RATE
-		dummy = 1.0f; // 1.0 = default kc
-	    EEPROM_WRITE_VAR(dummmy);
-        #endif//PID_ADD_EXTRUSION_RATE
-	  }
-	  else
-	  {
-		dummy = 3000.0f;
-	    EEPROM_WRITE_VAR(i, dummy);
-		dummy = 0.0f;
-        EEPROM_WRITE_VAR(i,dummy);
-        EEPROM_WRITE_VAR(i,dummy);
-        EEPROM_WRITE_VAR(i,dummy);
-	  }
-	}
-  #else//PIDTEMP
-		float dummy = 3000.0f;
-    EEPROM_WRITE_VAR(i,dummy);
-		dummy = 0.0f;
-    EEPROM_WRITE_VAR(i,dummy);
-    EEPROM_WRITE_VAR(i,dummy);
-    EEPROM_WRITE_VAR(i,dummy);
-  #endif//PIDTEMP
+          EEPROM_WRITE_VAR(i, PID_PARAM(Kc, e));
+        #else
+          dummy = 1.0f; // 1.0 = default kc
+          EEPROM_WRITE_VAR(dummmy);
+        #endif
+      }
+      else {
+    #else // !PIDTEMP
+      {
+    #endif // !PIDTEMP
+
+      dummy = DUMMY_PID_VALUE;
+      EEPROM_WRITE_VAR(i, dummy);
+      dummy = 0.0f;
+      for (int q = 3; q--;) EEPROM_WRITE_VAR(i, dummy);
+    }
+  } // Extruders Loop
+
   #ifndef DOGLCD
     int lcd_contrast = 32;
-  #endif//DOGLCD
-  EEPROM_WRITE_VAR(i,lcd_contrast);
+  #endif
+  EEPROM_WRITE_VAR(i, lcd_contrast);
+
   #ifdef SCARA
-  EEPROM_WRITE_VAR(i,axis_scaling);        // Add scaling for SCARA
-  #endif//SCARA
+    EEPROM_WRITE_VAR(i, axis_scaling); // 3 floats
+  #else
+    dummy = 1.0f;
+    EEPROM_WRITE_VAR(i, dummy);
+  #endif
+
   #ifdef FWRETRACT
-  EEPROM_WRITE_VAR(i,autoretract_enabled);
-  EEPROM_WRITE_VAR(i,retract_length);
-  #if EXTRUDERS > 1
-  EEPROM_WRITE_VAR(i,retract_length_swap);
-  #endif//EXTRUDERS > 1
-  EEPROM_WRITE_VAR(i,retract_feedrate);
-  EEPROM_WRITE_VAR(i,retract_zlift);
-  EEPROM_WRITE_VAR(i,retract_recover_length);
-  #if EXTRUDERS > 1
-  EEPROM_WRITE_VAR(i,retract_recover_length_swap);
-  #endif//EXTRUDERS > 1
-  EEPROM_WRITE_VAR(i,retract_recover_feedrate);
-  #endif//FWRETRACT
+    EEPROM_WRITE_VAR(i, autoretract_enabled);
+    EEPROM_WRITE_VAR(i, retract_length);
+    #if EXTRUDERS > 1
+      EEPROM_WRITE_VAR(i, retract_length_swap);
+    #else
+      dummy = 0.0f;
+      EEPROM_WRITE_VAR(i, dummy);
+    #endif
+    EEPROM_WRITE_VAR(i, retract_feedrate);
+    EEPROM_WRITE_VAR(i, retract_zlift);
+    EEPROM_WRITE_VAR(i, retract_recover_length);
+    #if EXTRUDERS > 1
+      EEPROM_WRITE_VAR(i, retract_recover_length_swap);
+    #else
+      dummy = 0.0f;
+      EEPROM_WRITE_VAR(i, dummy);
+    #endif
+    EEPROM_WRITE_VAR(i, retract_recover_feedrate);
+  #endif // FWRETRACT
+
+  EEPROM_WRITE_VAR(i, volumetric_enabled);
 
   // Save filament sizes
-  EEPROM_WRITE_VAR(i, volumetric_enabled);
-  EEPROM_WRITE_VAR(i, filament_size[0]);
-#if EXTRUDERS > 1
-  EEPROM_WRITE_VAR(i, filament_size[1]);
-#if EXTRUDERS > 2
-  EEPROM_WRITE_VAR(i, filament_size[2]);
-#if EXTRUDERS > 3
-  EEPROM_WRITE_VAR(i, filament_size[3]);
-#endif //EXTRUDERS > 3
-#endif //EXTRUDERS > 2
-#endif //EXTRUDERS > 1
-  
-  char ver2[4]=EEPROM_VERSION;
-  i=EEPROM_OFFSET;
-  EEPROM_WRITE_VAR(i,ver2); // validate data
+  for (int q = 0; q < 4; q++) {
+    if (q < EXTRUDERS) dummy = filament_size[q];
+    EEPROM_WRITE_VAR(i, dummy);
+  }
+
+  int storageSize = i;
+
+  char ver2[4] = EEPROM_VERSION;
+  int j = EEPROM_OFFSET;
+  EEPROM_WRITE_VAR(j, ver2); // validate data
+
+  // Report storage size
   SERIAL_ECHO_START;
-  SERIAL_ECHOLNPGM("Settings Stored");
+  SERIAL_ECHOPAIR("Settings Stored (", (unsigned long)i);
+  SERIAL_ECHOLNPGM(" bytes)");
 }
-#endif //EEPROM_SETTINGS
 
+void Config_RetrieveSettings() {
 
-#ifndef DISABLE_M503
-void Config_PrintSettings()
-{  // Always have this function, even with EEPROM_SETTINGS disabled, the current values will be shown
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Steps per unit:");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M92 X",axis_steps_per_unit[X_AXIS]);
-    SERIAL_ECHOPAIR(" Y",axis_steps_per_unit[Y_AXIS]);
-    SERIAL_ECHOPAIR(" Z",axis_steps_per_unit[Z_AXIS]);
-    SERIAL_ECHOPAIR(" E",axis_steps_per_unit[E_AXIS]);
-    SERIAL_ECHOLN("");
-      
-    SERIAL_ECHO_START;
-#ifdef SCARA
-SERIAL_ECHOLNPGM("Scaling factors:");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M365 X",axis_scaling[X_AXIS]);
-    SERIAL_ECHOPAIR(" Y",axis_scaling[Y_AXIS]);
-    SERIAL_ECHOPAIR(" Z",axis_scaling[Z_AXIS]);
-    SERIAL_ECHOLN("");
-      
-    SERIAL_ECHO_START;
-#endif//SCARA
-    SERIAL_ECHOLNPGM("Maximum feedrates (mm/s):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M203 X", max_feedrate[X_AXIS]);
-    SERIAL_ECHOPAIR(" Y", max_feedrate[Y_AXIS]); 
-    SERIAL_ECHOPAIR(" Z", max_feedrate[Z_AXIS]); 
-    SERIAL_ECHOPAIR(" E", max_feedrate[E_AXIS]);
-    SERIAL_ECHOLN("");
+  int i = EEPROM_OFFSET;
+  char stored_ver[4];
+  char ver[4] = EEPROM_VERSION;
+  EEPROM_READ_VAR(i, stored_ver); //read stored version
+  //  SERIAL_ECHOLN("Version: [" << ver << "] Stored version: [" << stored_ver << "]");
 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Maximum Acceleration (mm/s2):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M201 X" ,max_acceleration_units_per_sq_second[X_AXIS] ); 
-    SERIAL_ECHOPAIR(" Y" , max_acceleration_units_per_sq_second[Y_AXIS] ); 
-    SERIAL_ECHOPAIR(" Z" ,max_acceleration_units_per_sq_second[Z_AXIS] );
-    SERIAL_ECHOPAIR(" E" ,max_acceleration_units_per_sq_second[E_AXIS]);
-    SERIAL_ECHOLN("");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Acceleration: S=acceleration, T=retract acceleration");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M204 S",acceleration ); 
-    SERIAL_ECHOPAIR(" T" ,retract_acceleration);
-    SERIAL_ECHOLN("");
+  if (strncmp(ver, stored_ver, 3) != 0) {
+    Config_ResetDefault();
+  }
+  else {
+    float dummy = 0;
 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Advanced variables: S=Min feedrate (mm/s), T=Min travel feedrate (mm/s), B=minimum segment time (ms), X=maximum XY jerk (mm/s),  Z=maximum Z jerk (mm/s),  E=maximum E jerk (mm/s)");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M205 S",minimumfeedrate ); 
-    SERIAL_ECHOPAIR(" T" ,mintravelfeedrate ); 
-    SERIAL_ECHOPAIR(" B" ,minsegmenttime ); 
-    SERIAL_ECHOPAIR(" X" ,max_xy_jerk ); 
-    SERIAL_ECHOPAIR(" Z" ,max_z_jerk);
-    SERIAL_ECHOPAIR(" E" ,max_e_jerk);
-    SERIAL_ECHOLN(""); 
+    // version number match
+    EEPROM_READ_VAR(i, axis_steps_per_unit);
+    EEPROM_READ_VAR(i, max_feedrate);
+    EEPROM_READ_VAR(i, max_acceleration_units_per_sq_second);
 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Home offset (mm):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M206 X",add_homing[X_AXIS] );
-    SERIAL_ECHOPAIR(" Y" ,add_homing[Y_AXIS] );
-    SERIAL_ECHOPAIR(" Z" ,add_homing[Z_AXIS] );
-    SERIAL_ECHOLN("");
-#ifdef DELTA
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Endstop adjustement (mm):");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("  M666 X",endstop_adj[X_AXIS] );
-    SERIAL_ECHOPAIR(" Y" ,endstop_adj[Y_AXIS] );
-    SERIAL_ECHOPAIR(" Z" ,endstop_adj[Z_AXIS] );
-	SERIAL_ECHOLN("");
-	SERIAL_ECHO_START;
-	SERIAL_ECHOLNPGM("Delta settings: L=delta_diagonal_rod, R=delta_radius, S=delta_segments_per_second");
-	SERIAL_ECHO_START;
-	SERIAL_ECHOPAIR("  M665 L",delta_diagonal_rod );
-	SERIAL_ECHOPAIR(" R" ,delta_radius );
-	SERIAL_ECHOPAIR(" S" ,delta_segments_per_second );
-	SERIAL_ECHOLN("");
-#endif//DELTA
-#ifdef PIDTEMP
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("PID settings:");
-	SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   M301 P", PID_PARAM(Kp,0)); // for compatibility with hosts, only echos values for E0
-	SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, 0)));
-	SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, 0)));
-    SERIAL_ECHOLN(""); 
-#endif//PIDTEMP
-#ifdef FWRETRACT
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Retract: S=Length (mm) F:Speed (mm/m) Z: ZLift (mm)");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   M207 S",retract_length); 
-    SERIAL_ECHOPAIR(" F" ,retract_feedrate*60); 
-    SERIAL_ECHOPAIR(" Z" ,retract_zlift);
-    SERIAL_ECHOLN(""); 
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Recover: S=Extra length (mm) F:Speed (mm/m)");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   M208 S",retract_recover_length);
-    SERIAL_ECHOPAIR(" F", retract_recover_feedrate*60);
-	SERIAL_ECHOLN("");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Auto-Retract: S=0 to disable, 1 to interpret extrude-only moves as retracts or recoveries");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   M209 S", (unsigned long)(autoretract_enabled ? 1 : 0));
-    SERIAL_ECHOLN("");
-#if EXTRUDERS > 1
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM("Multi-extruder settings:");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   Swap retract length (mm):    ", retract_length_swap);
-    SERIAL_ECHOLN("");
-    SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("   Swap rec. addl. length (mm): ", retract_recover_length_swap);
-    SERIAL_ECHOLN("");
-#endif//EXTRUDERS > 1
-#endif//FWRETRACT
-    SERIAL_ECHO_START;
-    if (volumetric_enabled) {
-        SERIAL_ECHOLNPGM("Filament settings:");
-        SERIAL_ECHO_START;
-        SERIAL_ECHOPAIR("   M200 D", filament_size[0]);
-        SERIAL_ECHOLN(""); 
-#if EXTRUDERS > 1
-		SERIAL_ECHO_START;
-        SERIAL_ECHOPAIR("   M200 T1 D", filament_size[1]);
-        SERIAL_ECHOLN(""); 
-#if EXTRUDERS > 2
-		SERIAL_ECHO_START;
-        SERIAL_ECHOPAIR("   M200 T2 D", filament_size[2]);
-		SERIAL_ECHOLN("");
-#if EXTRUDERS > 3
-        SERIAL_ECHO_START;
-        SERIAL_ECHOPAIR("   M200 T3 D", filament_size[3]);
-        SERIAL_ECHOLN("");
-#endif //EXTRUDERS > 3
-#endif //EXTRUDERS > 2
-#endif //EXTRUDERS > 1
-    } else {
-        SERIAL_ECHOLNPGM("Filament settings: Disabled");
-    }
-#ifdef CUSTOM_M_CODES
-  SERIAL_ECHO_START;
-  SERIAL_ECHOLNPGM("Z-Probe Offset (mm):");
-  SERIAL_ECHO_START;
-  SERIAL_ECHO("   M");
-  SERIAL_ECHO(CUSTOM_M_CODE_SET_Z_PROBE_OFFSET);
-  SERIAL_ECHOPAIR(" Z",-zprobe_zoffset);
-  SERIAL_ECHOLN("");
-#endif
-}
-#endif//DISABLE_M503
-
-
-#ifdef EEPROM_SETTINGS
-void Config_RetrieveSettings()
-{
-    int i=EEPROM_OFFSET;
-    char stored_ver[4];
-    char ver[4]=EEPROM_VERSION;
-    EEPROM_READ_VAR(i,stored_ver); //read stored version
-    //  SERIAL_ECHOLN("Version: [" << ver << "] Stored version: [" << stored_ver << "]");
-    if (strncmp(ver,stored_ver,3) == 0)
-    {
-        // version number match
-        EEPROM_READ_VAR(i,axis_steps_per_unit);
-        EEPROM_READ_VAR(i,max_feedrate);  
-        EEPROM_READ_VAR(i,max_acceleration_units_per_sq_second);
-        
         // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
-		reset_acceleration_rates();
-        
-        EEPROM_READ_VAR(i,acceleration);
-        EEPROM_READ_VAR(i,retract_acceleration);
-        EEPROM_READ_VAR(i,minimumfeedrate);
-        EEPROM_READ_VAR(i,mintravelfeedrate);
-        EEPROM_READ_VAR(i,minsegmenttime);
-        EEPROM_READ_VAR(i,max_xy_jerk);
-        EEPROM_READ_VAR(i,max_z_jerk);
-        EEPROM_READ_VAR(i,max_e_jerk);
-        EEPROM_READ_VAR(i,add_homing);
-        #ifdef DELTA
-		EEPROM_READ_VAR(i,endstop_adj);
-		EEPROM_READ_VAR(i,delta_radius);
-		EEPROM_READ_VAR(i,delta_diagonal_rod);
-		EEPROM_READ_VAR(i,delta_segments_per_second);
-        #endif//DELTA
-        #ifndef ULTIPANEL
-        int plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed;
-        int absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed;
-        #endif//ULTIPANEL
-        EEPROM_READ_VAR(i,plaPreheatHotendTemp);
-        EEPROM_READ_VAR(i,plaPreheatHPBTemp);
-        EEPROM_READ_VAR(i,plaPreheatFanSpeed);
-        EEPROM_READ_VAR(i,absPreheatHotendTemp);
-        EEPROM_READ_VAR(i,absPreheatHPBTemp);
-        EEPROM_READ_VAR(i,absPreheatFanSpeed);
-        EEPROM_READ_VAR(i,zprobe_zoffset);
-        #ifdef PIDTEMP
-		float dummy = 0.0f;
-		for (int e = 0; e < 4; e++) // 4 = max extruders supported by marlin
-		{
-		  if (e < EXTRUDERS)
-		  {
-		    // do not need to scale PID values as the values in EEPROM are already scaled			  
-            EEPROM_READ_VAR(i,PID_PARAM(Kp,e));
-            EEPROM_READ_VAR(i,PID_PARAM(Ki,e));
-		    EEPROM_READ_VAR(i,PID_PARAM(Kd,e));
-#ifdef PID_ADD_EXTRUSION_RATE
-            EEPROM_READ_VAR(i,PID_PARAM(Kc,e));
-#else//PID_ADD_EXTRUSION_RATE
-	        EEPROM_READ_VAR(i,dummy);
-#endif//PID_ADD_EXTRUSION_RATE
-		  }
-		  else
-		  {
-			EEPROM_READ_VAR(i,dummy);
-			EEPROM_READ_VAR(i,dummy);
-			EEPROM_READ_VAR(i,dummy);
-			EEPROM_READ_VAR(i,dummy);
-		  }
-		}
-		#else//PIDTEMP
-		// 4 x 3 = 12 slots for PID parameters
-		float dummy = 0.0f;
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);
-		EEPROM_READ_VAR(i,dummy);			
-		#endif//PIDTEMP
-        #ifndef DOGLCD
-        int lcd_contrast;
-        #endif//DOGLCD
-        EEPROM_READ_VAR(i,lcd_contrast);
-		#ifdef SCARA
-		EEPROM_READ_VAR(i,axis_scaling);
-		#endif//SCARA
-
-		#ifdef FWRETRACT
-		EEPROM_READ_VAR(i,autoretract_enabled);
-		EEPROM_READ_VAR(i,retract_length);
-		#if EXTRUDERS > 1
-		EEPROM_READ_VAR(i,retract_length_swap);
-		#endif//EXTRUDERS > 1
-		EEPROM_READ_VAR(i,retract_feedrate);
-		EEPROM_READ_VAR(i,retract_zlift);
-		EEPROM_READ_VAR(i,retract_recover_length);
-		#if EXTRUDERS > 1
-		EEPROM_READ_VAR(i,retract_recover_length_swap);
-		#endif//EXTRUDERS > 1
-		EEPROM_READ_VAR(i,retract_recover_feedrate);
-		#endif//FWRETRACT
-
-		EEPROM_READ_VAR(i, volumetric_enabled);
-		EEPROM_READ_VAR(i, filament_size[0]);
-#if EXTRUDERS > 1
-		EEPROM_READ_VAR(i, filament_size[1]);
-#if EXTRUDERS > 2
-		EEPROM_READ_VAR(i, filament_size[2]);
-#if EXTRUDERS > 3
-    EEPROM_READ_VAR(i, filament_size[3]);
-#endif //EXTRUDERS > 3
-#endif //EXTRUDERS > 2
-#endif //EXTRUDERS > 1
-		calculate_volumetric_multipliers();
-		// Call updatePID (similar to when we have processed M301)
-		updatePID();
-        SERIAL_ECHO_START;
-        SERIAL_ECHOLNPGM("Stored settings retrieved");
-    }
-    else
-    {
-        Config_ResetDefault();
-    }
-    #ifdef EEPROM_CHITCHAT
-      Config_PrintSettings();
-    #endif//EEPROM_CHITCHAT
-}
-#endif//EEPROM_SETTINGS
-
-void Config_ResetDefault()
-{
-    float tmp1[]=DEFAULT_AXIS_STEPS_PER_UNIT;
-    float tmp2[]=DEFAULT_MAX_FEEDRATE;
-    long tmp3[]=DEFAULT_MAX_ACCELERATION;
-    for (short i=0;i<4;i++) 
-    {
-        axis_steps_per_unit[i]=tmp1[i];  
-        max_feedrate[i]=tmp2[i];  
-        max_acceleration_units_per_sq_second[i]=tmp3[i];
-		#ifdef SCARA
-		axis_scaling[i]=1;
-		#endif//SCARA
-    }
-    
-    // steps per sq second need to be updated to agree with the units per sq second
     reset_acceleration_rates();
-    
-    acceleration=DEFAULT_ACCELERATION;
-    retract_acceleration=DEFAULT_RETRACT_ACCELERATION;
-    minimumfeedrate=DEFAULT_MINIMUMFEEDRATE;
-    minsegmenttime=DEFAULT_MINSEGMENTTIME;       
-    mintravelfeedrate=DEFAULT_MINTRAVELFEEDRATE;
-    max_xy_jerk=DEFAULT_XYJERK;
-    max_z_jerk=DEFAULT_ZJERK;
-    max_e_jerk=DEFAULT_EJERK;
-    add_homing[X_AXIS] = add_homing[Y_AXIS] = add_homing[Z_AXIS] = 0;
-#ifdef DELTA
-	endstop_adj[X_AXIS] = endstop_adj[Y_AXIS] = endstop_adj[Z_AXIS] = 0;
-	delta_radius= DELTA_RADIUS;
-	delta_diagonal_rod= DELTA_DIAGONAL_ROD;
-	delta_segments_per_second= DELTA_SEGMENTS_PER_SECOND;
-	recalc_delta_settings(delta_radius, delta_diagonal_rod);
-#endif//DELTA
-#ifdef ULTIPANEL
+
+    EEPROM_READ_VAR(i, acceleration);
+    EEPROM_READ_VAR(i, retract_acceleration);
+    EEPROM_READ_VAR(i, minimumfeedrate);
+    EEPROM_READ_VAR(i, mintravelfeedrate);
+    EEPROM_READ_VAR(i, minsegmenttime);
+    EEPROM_READ_VAR(i, max_xy_jerk);
+    EEPROM_READ_VAR(i, max_z_jerk);
+    EEPROM_READ_VAR(i, max_e_jerk);
+    EEPROM_READ_VAR(i, add_homing);
+
+    #ifdef DELTA
+      EEPROM_READ_VAR(i, endstop_adj);                // 3 floats
+      EEPROM_READ_VAR(i, delta_radius);               // 1 float
+      EEPROM_READ_VAR(i, delta_diagonal_rod);         // 1 float
+      EEPROM_READ_VAR(i, delta_segments_per_second);  // 1 float
+    #else
+      for (int q=6; q--;) EEPROM_READ_VAR(i, dummy);
+    #endif
+
+    #ifndef ULTIPANEL
+      int plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed,
+          absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed;
+    #endif
+
+    EEPROM_READ_VAR(i, plaPreheatHotendTemp);
+    EEPROM_READ_VAR(i, plaPreheatHPBTemp);
+    EEPROM_READ_VAR(i, plaPreheatFanSpeed);
+    EEPROM_READ_VAR(i, absPreheatHotendTemp);
+    EEPROM_READ_VAR(i, absPreheatHPBTemp);
+    EEPROM_READ_VAR(i, absPreheatFanSpeed);
+    EEPROM_READ_VAR(i, zprobe_zoffset);
+
+    #ifdef PIDTEMP
+      for (int e = 0; e < 4; e++) { // 4 = max extruders currently supported by Marlin
+        EEPROM_READ_VAR(i, dummy);
+        if (e < EXTRUDERS && dummy != DUMMY_PID_VALUE) {
+          // do not need to scale PID values as the values in EEPROM are already scaled
+          PID_PARAM(Kp, e) = dummy;
+          EEPROM_READ_VAR(i, PID_PARAM(Ki, e));
+          EEPROM_READ_VAR(i, PID_PARAM(Kd, e));
+          #ifdef PID_ADD_EXTRUSION_RATE
+            EEPROM_READ_VAR(i, PID_PARAM(Kc, e));
+          #else
+            EEPROM_READ_VAR(i, dummy);
+          #endif
+        }
+        else {
+          for (int q=3; q--;) EEPROM_READ_VAR(i, dummy);
+        }
+      }
+    #else // !PIDTEMP
+      // 4 x 3 = 12 slots for PID parameters
+      for (int q=12; q--;) EEPROM_READ_VAR(i, dummy);
+    #endif // !PIDTEMP
+
+    #ifndef DOGLCD
+      int lcd_contrast;
+    #endif
+    EEPROM_READ_VAR(i, lcd_contrast);
+
+    #ifdef SCARA
+      EEPROM_READ_VAR(i, axis_scaling);  // 3 floats
+    #else
+      EEPROM_READ_VAR(i, dummy);
+    #endif
+
+    #ifdef FWRETRACT
+      EEPROM_READ_VAR(i, autoretract_enabled);
+      EEPROM_READ_VAR(i, retract_length);
+      #if EXTRUDERS > 1
+        EEPROM_READ_VAR(i, retract_length_swap);
+      #else
+        EEPROM_READ_VAR(i, dummy);
+      #endif
+      EEPROM_READ_VAR(i, retract_feedrate);
+      EEPROM_READ_VAR(i, retract_zlift);
+      EEPROM_READ_VAR(i, retract_recover_length);
+      #if EXTRUDERS > 1
+        EEPROM_READ_VAR(i, retract_recover_length_swap);
+      #else
+        EEPROM_READ_VAR(i, dummy);
+      #endif
+      EEPROM_READ_VAR(i, retract_recover_feedrate);
+    #endif // FWRETRACT
+
+    EEPROM_READ_VAR(i, volumetric_enabled);
+
+    for (int q = 0; q < 4; q++) {
+      EEPROM_READ_VAR(i, dummy);
+      if (q < EXTRUDERS) filament_size[q] = dummy;
+    }
+
+    calculate_volumetric_multipliers();
+    // Call updatePID (similar to when we have processed M301)
+    updatePID();
+
+    // Report settings retrieved and length
+    SERIAL_ECHO_START;
+    SERIAL_ECHO(ver);
+    SERIAL_ECHOPAIR(" stored settings retrieved (", (unsigned long)i);
+    SERIAL_ECHOLNPGM(" bytes)");
+  }
+
+  #ifdef EEPROM_CHITCHAT
+    Config_PrintSettings();
+  #endif
+}
+
+#endif // EEPROM_SETTINGS
+
+void Config_ResetDefault() {
+  float tmp1[] = DEFAULT_AXIS_STEPS_PER_UNIT;
+  float tmp2[] = DEFAULT_MAX_FEEDRATE;
+  long tmp3[] = DEFAULT_MAX_ACCELERATION;
+  for (int i = 0; i < NUM_AXIS; i++) {
+    axis_steps_per_unit[i] = tmp1[i];
+    max_feedrate[i] = tmp2[i];
+    max_acceleration_units_per_sq_second[i] = tmp3[i];
+    #ifdef SCARA
+      if (i < sizeof(axis_scaling) / sizeof(*axis_scaling))
+        axis_scaling[i] = 1;
+    #endif
+  }
+
+  // steps per sq second need to be updated to agree with the units per sq second
+  reset_acceleration_rates();
+
+  acceleration = DEFAULT_ACCELERATION;
+  retract_acceleration = DEFAULT_RETRACT_ACCELERATION;
+  minimumfeedrate = DEFAULT_MINIMUMFEEDRATE;
+  minsegmenttime = DEFAULT_MINSEGMENTTIME;
+  mintravelfeedrate = DEFAULT_MINTRAVELFEEDRATE;
+  max_xy_jerk = DEFAULT_XYJERK;
+  max_z_jerk = DEFAULT_ZJERK;
+  max_e_jerk = DEFAULT_EJERK;
+  add_homing[X_AXIS] = add_homing[Y_AXIS] = add_homing[Z_AXIS] = 0;
+
+  #ifdef DELTA
+    endstop_adj[X_AXIS] = endstop_adj[Y_AXIS] = endstop_adj[Z_AXIS] = 0;
+    delta_radius =  DELTA_RADIUS;
+    delta_diagonal_rod =  DELTA_DIAGONAL_ROD;
+    delta_segments_per_second =  DELTA_SEGMENTS_PER_SECOND;
+    recalc_delta_settings(delta_radius, delta_diagonal_rod);
+  #endif
+
+  #ifdef ULTIPANEL
     plaPreheatHotendTemp = PLA_PREHEAT_HOTEND_TEMP;
     plaPreheatHPBTemp = PLA_PREHEAT_HPB_TEMP;
     plaPreheatFanSpeed = PLA_PREHEAT_FAN_SPEED;
     absPreheatHotendTemp = ABS_PREHEAT_HOTEND_TEMP;
     absPreheatHPBTemp = ABS_PREHEAT_HPB_TEMP;
     absPreheatFanSpeed = ABS_PREHEAT_FAN_SPEED;
-#endif//ULTIPANEL
-#ifdef ENABLE_AUTO_BED_LEVELING
+  #endif
+
+  #ifdef ENABLE_AUTO_BED_LEVELING
     zprobe_zoffset = -Z_PROBE_OFFSET_FROM_EXTRUDER;
-#endif//ENABLE_AUTO_BED_LEVELING
-#ifdef DOGLCD
+  #endif
+
+  #ifdef DOGLCD
     lcd_contrast = DEFAULT_LCD_CONTRAST;
-#endif//DOGLCD
-#ifdef PIDTEMP
-#ifdef PID_PARAMS_PER_EXTRUDER
-	for (int e = 0; e < EXTRUDERS; e++)
-#else // PID_PARAMS_PER_EXTRUDER
-	int e = 0; // only need to write once
-#endif // PID_PARAMS_PER_EXTRUDER
-	{
-      PID_PARAM(Kp,e) = DEFAULT_Kp;
-      PID_PARAM(Ki,e) = scalePID_i(DEFAULT_Ki);
-      PID_PARAM(Kd,e) = scalePID_d(DEFAULT_Kd);
+  #endif
+
+  #ifdef PIDTEMP
+    #ifdef PID_PARAMS_PER_EXTRUDER
+      for (int e = 0; e < EXTRUDERS; e++)
+    #else
+      int e = 0; // only need to write once
+    #endif
+    {
+      PID_PARAM(Kp, e) = DEFAULT_Kp;
+      PID_PARAM(Ki, e) = scalePID_i(DEFAULT_Ki);
+      PID_PARAM(Kd, e) = scalePID_d(DEFAULT_Kd);
       #ifdef PID_ADD_EXTRUSION_RATE
-        PID_PARAM(Kc,e) = DEFAULT_Kc;
-      #endif//PID_ADD_EXTRUSION_RATE
+        PID_PARAM(Kc, e) = DEFAULT_Kc;
+      #endif
     }
     // call updatePID (similar to when we have processed M301)
     updatePID();
-#endif//PIDTEMP
+  #endif // PIDTEMP
 
-#ifdef FWRETRACT
-	autoretract_enabled = false;
-	retract_length = RETRACT_LENGTH;
-#if EXTRUDERS > 1
-	retract_length_swap = RETRACT_LENGTH_SWAP;
-#endif//EXTRUDERS > 1
-	retract_feedrate = RETRACT_FEEDRATE;
-	retract_zlift = RETRACT_ZLIFT;
-	retract_recover_length = RETRACT_RECOVER_LENGTH;
-#if EXTRUDERS > 1
-	retract_recover_length_swap = RETRACT_RECOVER_LENGTH_SWAP;
-#endif//EXTRUDERS > 1
-	retract_recover_feedrate = RETRACT_RECOVER_FEEDRATE;
-#endif//FWRETRACT
+  #ifdef FWRETRACT
+    autoretract_enabled = false;
+    retract_length = RETRACT_LENGTH;
+    #if EXTRUDERS > 1
+      retract_length_swap = RETRACT_LENGTH_SWAP;
+    #endif
+    retract_feedrate = RETRACT_FEEDRATE;
+    retract_zlift = RETRACT_ZLIFT;
+    retract_recover_length = RETRACT_RECOVER_LENGTH;
+    #if EXTRUDERS > 1
+      retract_recover_length_swap = RETRACT_RECOVER_LENGTH_SWAP;
+    #endif
+    retract_recover_feedrate = RETRACT_RECOVER_FEEDRATE;
+  #endif
 
-	volumetric_enabled = false;
-	filament_size[0] = DEFAULT_NOMINAL_FILAMENT_DIA;
-#if EXTRUDERS > 1
-	filament_size[1] = DEFAULT_NOMINAL_FILAMENT_DIA;
-#if EXTRUDERS > 2
-	filament_size[2] = DEFAULT_NOMINAL_FILAMENT_DIA;
-#if EXTRUDERS > 3
-  filament_size[3] = DEFAULT_NOMINAL_FILAMENT_DIA;
-#endif //EXTRUDERS > 3
-#endif //EXTRUDERS > 2
-#endif //EXTRUDERS > 1
-	calculate_volumetric_multipliers();
+  volumetric_enabled = false;
+  filament_size[0] = DEFAULT_NOMINAL_FILAMENT_DIA;
+  #if EXTRUDERS > 1
+    filament_size[1] = DEFAULT_NOMINAL_FILAMENT_DIA;
+    #if EXTRUDERS > 2
+      filament_size[2] = DEFAULT_NOMINAL_FILAMENT_DIA;
+      #if EXTRUDERS > 3
+        filament_size[3] = DEFAULT_NOMINAL_FILAMENT_DIA;
+      #endif
+    #endif
+  #endif
+  calculate_volumetric_multipliers();
 
-SERIAL_ECHO_START;
-SERIAL_ECHOLNPGM("Hardcoded Default Settings Loaded");
-
+  SERIAL_ECHO_START;
+  SERIAL_ECHOLNPGM("Hardcoded Default Settings Loaded");
 }
+
+#ifndef DISABLE_M503
+
+void Config_PrintSettings(bool forReplay) {
+  // Always have this function, even with EEPROM_SETTINGS disabled, the current values will be shown
+
+  SERIAL_ECHO_START;
+
+  if (!forReplay) {
+    SERIAL_ECHOLNPGM("Steps per unit:");
+    SERIAL_ECHO_START;
+  }
+  SERIAL_ECHOPAIR("  M92 X", axis_steps_per_unit[X_AXIS]);
+  SERIAL_ECHOPAIR(" Y", axis_steps_per_unit[Y_AXIS]);
+  SERIAL_ECHOPAIR(" Z", axis_steps_per_unit[Z_AXIS]);
+  SERIAL_ECHOPAIR(" E", axis_steps_per_unit[E_AXIS]);
+  SERIAL_ECHOLN("");
+
+  SERIAL_ECHO_START;
+
+  #ifdef SCARA
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Scaling factors:");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("  M365 X", axis_scaling[X_AXIS]);
+    SERIAL_ECHOPAIR(" Y", axis_scaling[Y_AXIS]);
+    SERIAL_ECHOPAIR(" Z", axis_scaling[Z_AXIS]);
+    SERIAL_ECHOLN("");
+    SERIAL_ECHO_START;
+  #endif // SCARA
+
+  if (!forReplay) {
+    SERIAL_ECHOLNPGM("Maximum feedrates (mm/s):");
+    SERIAL_ECHO_START;
+  }
+  SERIAL_ECHOPAIR("  M203 X", max_feedrate[X_AXIS]);
+  SERIAL_ECHOPAIR(" Y", max_feedrate[Y_AXIS]);
+  SERIAL_ECHOPAIR(" Z", max_feedrate[Z_AXIS]);
+  SERIAL_ECHOPAIR(" E", max_feedrate[E_AXIS]);
+  SERIAL_ECHOLN("");
+
+  SERIAL_ECHO_START;
+  if (!forReplay) {
+    SERIAL_ECHOLNPGM("Maximum Acceleration (mm/s2):");
+    SERIAL_ECHO_START;
+  }
+  SERIAL_ECHOPAIR("  M201 X", max_acceleration_units_per_sq_second[X_AXIS] );
+  SERIAL_ECHOPAIR(" Y", max_acceleration_units_per_sq_second[Y_AXIS] );
+  SERIAL_ECHOPAIR(" Z", max_acceleration_units_per_sq_second[Z_AXIS] );
+  SERIAL_ECHOPAIR(" E", max_acceleration_units_per_sq_second[E_AXIS]);
+  SERIAL_ECHOLN("");
+  SERIAL_ECHO_START;
+  if (!forReplay) {
+    SERIAL_ECHOLNPGM("Acceleration: S=acceleration, T=retract acceleration");
+    SERIAL_ECHO_START;
+  }
+  SERIAL_ECHOPAIR("  M204 S", acceleration );
+  SERIAL_ECHOPAIR(" T", retract_acceleration);
+  SERIAL_ECHOLN("");
+
+  SERIAL_ECHO_START;
+  if (!forReplay) {
+    SERIAL_ECHOLNPGM("Advanced variables: S=Min feedrate (mm/s), T=Min travel feedrate (mm/s), B=minimum segment time (ms), X=maximum XY jerk (mm/s),  Z=maximum Z jerk (mm/s),  E=maximum E jerk (mm/s)");
+    SERIAL_ECHO_START;
+  }
+  SERIAL_ECHOPAIR("  M205 S", minimumfeedrate );
+  SERIAL_ECHOPAIR(" T", mintravelfeedrate );
+  SERIAL_ECHOPAIR(" B", minsegmenttime );
+  SERIAL_ECHOPAIR(" X", max_xy_jerk );
+  SERIAL_ECHOPAIR(" Z", max_z_jerk);
+  SERIAL_ECHOPAIR(" E", max_e_jerk);
+  SERIAL_ECHOLN("");
+
+  SERIAL_ECHO_START;
+  if (!forReplay) {
+    SERIAL_ECHOLNPGM("Home offset (mm):");
+    SERIAL_ECHO_START;
+  }
+  SERIAL_ECHOPAIR("  M206 X", add_homing[X_AXIS] );
+  SERIAL_ECHOPAIR(" Y", add_homing[Y_AXIS] );
+  SERIAL_ECHOPAIR(" Z", add_homing[Z_AXIS] );
+  SERIAL_ECHOLN("");
+
+  #ifdef DELTA
+    SERIAL_ECHO_START;
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Endstop adjustement (mm):");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("  M666 X", endstop_adj[X_AXIS] );
+    SERIAL_ECHOPAIR(" Y", endstop_adj[Y_AXIS] );
+    SERIAL_ECHOPAIR(" Z", endstop_adj[Z_AXIS] );
+    SERIAL_ECHOLN("");
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM("Delta settings: L=delta_diagonal_rod, R=delta_radius, S=delta_segments_per_second");
+    SERIAL_ECHO_START;
+    SERIAL_ECHOPAIR("  M665 L", delta_diagonal_rod );
+    SERIAL_ECHOPAIR(" R", delta_radius );
+    SERIAL_ECHOPAIR(" S", delta_segments_per_second );
+    SERIAL_ECHOLN("");
+  #endif // DELTA
+
+  #ifdef PIDTEMP
+    SERIAL_ECHO_START;
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("PID settings:");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("   M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echos values for E0
+    SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, 0)));
+    SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, 0)));
+    SERIAL_ECHOLN("");
+  #endif // PIDTEMP
+
+  #ifdef FWRETRACT
+
+    SERIAL_ECHO_START;
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Retract: S=Length (mm) F:Speed (mm/m) Z: ZLift (mm)");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("   M207 S", retract_length);
+    SERIAL_ECHOPAIR(" F", retract_feedrate*60);
+    SERIAL_ECHOPAIR(" Z", retract_zlift);
+    SERIAL_ECHOLN("");
+    SERIAL_ECHO_START;
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Recover: S=Extra length (mm) F:Speed (mm/m)");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("   M208 S", retract_recover_length);
+    SERIAL_ECHOPAIR(" F", retract_recover_feedrate*60);
+    SERIAL_ECHOLN("");
+    SERIAL_ECHO_START;
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Auto-Retract: S=0 to disable, 1 to interpret extrude-only moves as retracts or recoveries");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("   M209 S", (unsigned long)(autoretract_enabled ? 1 : 0));
+    SERIAL_ECHOLN("");
+
+    #if EXTRUDERS > 1
+      if (!forReplay) {
+        SERIAL_ECHO_START;
+        SERIAL_ECHOLNPGM("Multi-extruder settings:");
+        SERIAL_ECHO_START;
+        SERIAL_ECHOPAIR("   Swap retract length (mm):    ", retract_length_swap);
+        SERIAL_ECHOLN("");
+        SERIAL_ECHO_START;
+        SERIAL_ECHOPAIR("   Swap rec. addl. length (mm): ", retract_recover_length_swap);
+        SERIAL_ECHOLN("");
+      }
+    #endif // EXTRUDERS > 1
+
+  #endif // FWRETRACT
+
+  SERIAL_ECHO_START;
+  if (volumetric_enabled) {
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Filament settings:");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHOPAIR("   M200 D", filament_size[0]);
+    SERIAL_ECHOLN("");
+
+    #if EXTRUDERS > 1
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPAIR("   M200 T1 D", filament_size[1]);
+      SERIAL_ECHOLN("");
+      #if EXTRUDERS > 2
+        SERIAL_ECHO_START;
+        SERIAL_ECHOPAIR("   M200 T2 D", filament_size[2]);
+        SERIAL_ECHOLN("");
+        #if EXTRUDERS > 3
+          SERIAL_ECHO_START;
+          SERIAL_ECHOPAIR("   M200 T3 D", filament_size[3]);
+          SERIAL_ECHOLN("");
+        #endif
+      #endif
+    #endif
+
+  } else {
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Filament settings: Disabled");
+    }
+  }
+
+  #ifdef CUSTOM_M_CODES
+    SERIAL_ECHO_START;
+    if (!forReplay) {
+      SERIAL_ECHOLNPGM("Z-Probe Offset (mm):");
+      SERIAL_ECHO_START;
+    }
+    SERIAL_ECHO("   M");
+    SERIAL_ECHO(CUSTOM_M_CODE_SET_Z_PROBE_OFFSET);
+    SERIAL_ECHOPAIR(" Z", -zprobe_zoffset);
+    SERIAL_ECHOLN("");
+  #endif
+}
+
+#endif // !DISABLE_M503

--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -72,8 +72,8 @@ void _EEPROM_writeData(int &pos, uint8_t* value, uint8_t size) {
   uint8_t c;
   while(size--) {
     eeprom_write_byte((unsigned char*)pos, *value);
-    *c = eeprom_read_byte((unsigned char*)pos);
-    if (*c != *value) {
+    c = eeprom_read_byte((unsigned char*)pos);
+    if (c != *value) {
       SERIAL_ECHO_START;
       SERIAL_ECHOLNPGM(MSG_ERR_EEPROM_WRITE);
     }

--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -62,17 +62,24 @@
  *
  */
 #include "Marlin.h"
+#include "language.h"
 #include "planner.h"
 #include "temperature.h"
 #include "ultralcd.h"
 #include "ConfigurationStore.h"
 
 void _EEPROM_writeData(int &pos, uint8_t* value, uint8_t size) {
-  do {
+  uint8_t c;
+  while(size--) {
     eeprom_write_byte((unsigned char*)pos, *value);
+    eeprom_read_byte((unsigned char*)pos, *c);
+    if (*c != *value) {
+      SERIAL_ECHO_START;
+      SERIAL_ECHOLNPGM(MSG_ERR_EEPROM_WRITE);
+    }
     pos++;
     value++;
-  } while (--size);
+  };
 }
 void _EEPROM_readData(int &pos, uint8_t* value, uint8_t size) {
   do {
@@ -471,7 +478,7 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_ECHOPAIR(" Y", axis_steps_per_unit[Y_AXIS]);
   SERIAL_ECHOPAIR(" Z", axis_steps_per_unit[Z_AXIS]);
   SERIAL_ECHOPAIR(" E", axis_steps_per_unit[E_AXIS]);
-  SERIAL_ECHOLN("");
+  SERIAL_EOL;
 
   SERIAL_ECHO_START;
 
@@ -483,7 +490,7 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHOPAIR("  M365 X", axis_scaling[X_AXIS]);
     SERIAL_ECHOPAIR(" Y", axis_scaling[Y_AXIS]);
     SERIAL_ECHOPAIR(" Z", axis_scaling[Z_AXIS]);
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
     SERIAL_ECHO_START;
   #endif // SCARA
 
@@ -495,7 +502,7 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_ECHOPAIR(" Y", max_feedrate[Y_AXIS]);
   SERIAL_ECHOPAIR(" Z", max_feedrate[Z_AXIS]);
   SERIAL_ECHOPAIR(" E", max_feedrate[E_AXIS]);
-  SERIAL_ECHOLN("");
+  SERIAL_EOL;
 
   SERIAL_ECHO_START;
   if (!forReplay) {
@@ -506,7 +513,7 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_ECHOPAIR(" Y", max_acceleration_units_per_sq_second[Y_AXIS] );
   SERIAL_ECHOPAIR(" Z", max_acceleration_units_per_sq_second[Z_AXIS] );
   SERIAL_ECHOPAIR(" E", max_acceleration_units_per_sq_second[E_AXIS]);
-  SERIAL_ECHOLN("");
+  SERIAL_EOL;
   SERIAL_ECHO_START;
   if (!forReplay) {
     SERIAL_ECHOLNPGM("Acceleration: S=acceleration, T=retract acceleration");
@@ -514,7 +521,7 @@ void Config_PrintSettings(bool forReplay) {
   }
   SERIAL_ECHOPAIR("  M204 S", acceleration );
   SERIAL_ECHOPAIR(" T", retract_acceleration);
-  SERIAL_ECHOLN("");
+  SERIAL_EOL;
 
   SERIAL_ECHO_START;
   if (!forReplay) {
@@ -527,7 +534,7 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_ECHOPAIR(" X", max_xy_jerk );
   SERIAL_ECHOPAIR(" Z", max_z_jerk);
   SERIAL_ECHOPAIR(" E", max_e_jerk);
-  SERIAL_ECHOLN("");
+  SERIAL_EOL;
 
   SERIAL_ECHO_START;
   if (!forReplay) {
@@ -537,7 +544,7 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_ECHOPAIR("  M206 X", add_homing[X_AXIS] );
   SERIAL_ECHOPAIR(" Y", add_homing[Y_AXIS] );
   SERIAL_ECHOPAIR(" Z", add_homing[Z_AXIS] );
-  SERIAL_ECHOLN("");
+  SERIAL_EOL;
 
   #ifdef DELTA
     SERIAL_ECHO_START;
@@ -548,14 +555,14 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHOPAIR("  M666 X", endstop_adj[X_AXIS] );
     SERIAL_ECHOPAIR(" Y", endstop_adj[Y_AXIS] );
     SERIAL_ECHOPAIR(" Z", endstop_adj[Z_AXIS] );
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPGM("Delta settings: L=delta_diagonal_rod, R=delta_radius, S=delta_segments_per_second");
     SERIAL_ECHO_START;
     SERIAL_ECHOPAIR("  M665 L", delta_diagonal_rod );
     SERIAL_ECHOPAIR(" R", delta_radius );
     SERIAL_ECHOPAIR(" S", delta_segments_per_second );
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
   #endif // DELTA
 
   #ifdef PIDTEMP
@@ -567,7 +574,7 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHOPAIR("   M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echos values for E0
     SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, 0)));
     SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, 0)));
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
   #endif // PIDTEMP
 
   #ifdef FWRETRACT
@@ -580,7 +587,7 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHOPAIR("   M207 S", retract_length);
     SERIAL_ECHOPAIR(" F", retract_feedrate*60);
     SERIAL_ECHOPAIR(" Z", retract_zlift);
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
     SERIAL_ECHO_START;
     if (!forReplay) {
       SERIAL_ECHOLNPGM("Recover: S=Extra length (mm) F:Speed (mm/m)");
@@ -588,14 +595,14 @@ void Config_PrintSettings(bool forReplay) {
     }
     SERIAL_ECHOPAIR("   M208 S", retract_recover_length);
     SERIAL_ECHOPAIR(" F", retract_recover_feedrate*60);
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
     SERIAL_ECHO_START;
     if (!forReplay) {
       SERIAL_ECHOLNPGM("Auto-Retract: S=0 to disable, 1 to interpret extrude-only moves as retracts or recoveries");
       SERIAL_ECHO_START;
     }
     SERIAL_ECHOPAIR("   M209 S", (unsigned long)(autoretract_enabled ? 1 : 0));
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
 
     #if EXTRUDERS > 1
       if (!forReplay) {
@@ -603,10 +610,10 @@ void Config_PrintSettings(bool forReplay) {
         SERIAL_ECHOLNPGM("Multi-extruder settings:");
         SERIAL_ECHO_START;
         SERIAL_ECHOPAIR("   Swap retract length (mm):    ", retract_length_swap);
-        SERIAL_ECHOLN("");
+        SERIAL_EOL;
         SERIAL_ECHO_START;
         SERIAL_ECHOPAIR("   Swap rec. addl. length (mm): ", retract_recover_length_swap);
-        SERIAL_ECHOLN("");
+        SERIAL_EOL;
       }
     #endif // EXTRUDERS > 1
 
@@ -619,20 +626,20 @@ void Config_PrintSettings(bool forReplay) {
       SERIAL_ECHO_START;
     }
     SERIAL_ECHOPAIR("   M200 D", filament_size[0]);
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
 
     #if EXTRUDERS > 1
       SERIAL_ECHO_START;
       SERIAL_ECHOPAIR("   M200 T1 D", filament_size[1]);
-      SERIAL_ECHOLN("");
+      SERIAL_EOL;
       #if EXTRUDERS > 2
         SERIAL_ECHO_START;
         SERIAL_ECHOPAIR("   M200 T2 D", filament_size[2]);
-        SERIAL_ECHOLN("");
+        SERIAL_EOL;
         #if EXTRUDERS > 3
           SERIAL_ECHO_START;
           SERIAL_ECHOPAIR("   M200 T3 D", filament_size[3]);
-          SERIAL_ECHOLN("");
+          SERIAL_EOL;
         #endif
       #endif
     #endif
@@ -652,7 +659,7 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHO("   M");
     SERIAL_ECHO(CUSTOM_M_CODE_SET_Z_PROBE_OFFSET);
     SERIAL_ECHOPAIR(" Z", -zprobe_zoffset);
-    SERIAL_ECHOLN("");
+    SERIAL_EOL;
   #endif
 }
 

--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -161,11 +161,12 @@ void Config_StoreSettings()  {
       {
     #endif // !PIDTEMP
 
-      dummy = DUMMY_PID_VALUE;
-      EEPROM_WRITE_VAR(i, dummy);
-      dummy = 0.0f;
-      for (int q = 3; q--;) EEPROM_WRITE_VAR(i, dummy);
-    }
+        dummy = DUMMY_PID_VALUE;
+        EEPROM_WRITE_VAR(i, dummy);
+        dummy = 0.0f;
+        for (int q = 3; q--;) EEPROM_WRITE_VAR(i, dummy);
+      }
+
   } // Extruders Loop
 
   #ifndef DOGLCD
@@ -290,12 +291,12 @@ void Config_RetrieveSettings() {
           #endif
         }
         else {
-          for (int q=3; q--;) EEPROM_READ_VAR(i, dummy);
+          for (int q=3; q--;) EEPROM_READ_VAR(i, dummy); // Ki, Kd, Kc
         }
       }
     #else // !PIDTEMP
-      // 4 x 3 = 12 slots for PID parameters
-      for (int q=12; q--;) EEPROM_READ_VAR(i, dummy);
+      // 4 x 4 = 16 slots for PID parameters
+      for (int q=16; q--;) EEPROM_READ_VAR(i, dummy);  // 4x Kp, Ki, Kd, Kc
     #endif // !PIDTEMP
 
     #ifndef DOGLCD

--- a/Marlin/ConfigurationStore.h
+++ b/Marlin/ConfigurationStore.h
@@ -6,17 +6,17 @@
 void Config_ResetDefault();
 
 #ifndef DISABLE_M503
-void Config_PrintSettings();
+  void Config_PrintSettings(bool forReplay=false);
 #else
-FORCE_INLINE void Config_PrintSettings() {}
+  FORCE_INLINE void Config_PrintSettings(bool forReplay=false) {}
 #endif
 
 #ifdef EEPROM_SETTINGS
-void Config_StoreSettings();
-void Config_RetrieveSettings();
+  void Config_StoreSettings();
+  void Config_RetrieveSettings();
 #else
-FORCE_INLINE void Config_StoreSettings() {}
-FORCE_INLINE void Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); }
+  FORCE_INLINE void Config_StoreSettings() {}
+  FORCE_INLINE void Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); }
 #endif
 
-#endif//CONFIG_STORE_H
+#endif // __CONFIG_STORE_H

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -86,6 +86,8 @@ extern const char echomagic[] PROGMEM;
 
 #define SERIAL_ECHOPAIR(name,value) (serial_echopair_P(PSTR(name),(value)))
 
+#define SERIAL_EOL SERIAL_ECHOLN("")
+
 void serial_echopair_P(const char *s_P, float v);
 void serial_echopair_P(const char *s_P, double v);
 void serial_echopair_P(const char *s_P, unsigned long v);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -164,7 +164,7 @@
 // M500 - stores parameters in EEPROM
 // M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
 // M502 - reverts to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
-// M503 - print the current settings (from memory not from EEPROM)
+// M503 - print the current settings (from memory not from EEPROM). Use S0 to leave off headings.
 // M540 - Use S[0|1] to enable or disable the stop SD card print on endstop hit (requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
 // M600 - Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
 // M665 - set delta configurations
@@ -3581,7 +3581,7 @@ case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or disp
     break;
     case 503: // M503 print settings currently in memory
     {
-        Config_PrintSettings();
+        Config_PrintSettings(code_seen('S') && code_value == 0);
     }
     break;
     #ifdef ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -155,6 +155,8 @@
 #define MSG_BABYSTEPPING_Z                  "Babystepping Z"
 #define MSG_SERIAL_ERROR_MENU_STRUCTURE     "Error in menu structure"
 
+#define MSG_ERR_EEPROM_WRITE                "Error writing to EEPROM!"
+
 // LCD Menu Messages
 
 #include LANGUAGE_INCLUDE


### PR DESCRIPTION
Update ConfigurationStore to always write dummy values for disabled options, including FWRETRACT, DELTA, and SCARA. Update the EEPROM version to “V15.” Also fixed a buffer overrun with axis_scaling in Config_ResetDefault.
