### PR TITLE
K8200: Example Configuration.h fixed

### DIFF
--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1,6 +1,6 @@
-﻿#ifndef CONFIGURATION_H
+#ifndef CONFIGURATION_H
 #define CONFIGURATION_H
-﻿
+
 #include "boards.h"
 
 


### PR DESCRIPTION
- Example Configuration.h: fixed strange white characters preventing
  compilation in lines 1 and 3 - oops
