### PR TITLE
Multi-extruder filament measurement

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -806,13 +806,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM	0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM			14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY			20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/ConfigurationStore.cpp
+++ b/Marlin/ConfigurationStore.cpp
@@ -447,13 +447,13 @@ void Config_ResetDefault() {
   #endif
 
   volumetric_enabled = false;
-  filament_size[0] = DEFAULT_NOMINAL_FILAMENT_DIA;
+  filament_size[0] = EXTRUDER_0_NOMINAL_FILAMENT_DIA;
   #if EXTRUDERS > 1
-    filament_size[1] = DEFAULT_NOMINAL_FILAMENT_DIA;
+    filament_size[1] = EXTRUDER_1_NOMINAL_FILAMENT_DIA;
     #if EXTRUDERS > 2
-      filament_size[2] = DEFAULT_NOMINAL_FILAMENT_DIA;
+      filament_size[2] = EXTRUDER_2_NOMINAL_FILAMENT_DIA;
       #if EXTRUDERS > 3
-        filament_size[3] = DEFAULT_NOMINAL_FILAMENT_DIA;
+        filament_size[3] = EXTRUDER_3_NOMINAL_FILAMENT_DIA;
       #endif
     #endif
   #endif

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -252,7 +252,7 @@ extern unsigned char fanSpeedSoftPwm;
 #endif
 
 #ifdef FILAMENT_SENSOR
-  extern float filament_width_nominal;  //holds the theoretical filament diameter ie., 3.00 or 1.75
+  extern float filament_width_nominal[EXTRUDERS];  //holds the theoretical filament diameter ie., 3.00 or 1.75
   extern bool filament_sensor;  //indicates that filament sensor readings should control extrusion
   extern float filament_width_meas; //holds the filament diameter as accurately measured
   extern signed char measurement_delay[];  //ring buffer to delay measurement

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -812,13 +812,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM	0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM			14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY			20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -822,13 +822,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM	0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM			14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY			20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -813,13 +813,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM  0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM      14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY     20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -816,13 +816,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM	0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM			14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY			20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/example_configurations/delta/Configuration.h
+++ b/Marlin/example_configurations/delta/Configuration.h
@@ -725,13 +725,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM  0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM      14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY     20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -788,13 +788,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM	0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM			14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY			20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -801,13 +801,25 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define FILAMENT_SENSOR_EXTRUDER_NUM  0  //The number of the extruder that has the filament sensor (0,1,2)
 #define MEASUREMENT_DELAY_CM      14  //measurement delay in cm.  This is the distance from filament sensor to middle of barrel
 
-#define DEFAULT_NOMINAL_FILAMENT_DIA  3.0  //Enter the diameter (in mm) of the filament generally used (3.0 mm or 1.75 mm) - this is then used in the slicer software.  Used for sensor reading validation
-#define MEASURED_UPPER_LIMIT          3.30  //upper limit factor used for sensor reading validation in mm
-#define MEASURED_LOWER_LIMIT          1.90  //lower limit factor for sensor reading validation in mm
+// Enter the diameter (in mm) of the filament in each extruder (e.g., 3.0 or 1.75)
+// This is then used in the slicer software.  Used for sensor reading validation.
+#define EXTRUDER_0_NOMINAL_FILAMENT_DIA 3.0
+#if EXTRUDERS > 1
+  #define EXTRUDER_1_NOMINAL_FILAMENT_DIA 3.0
+  #if EXTRUDERS > 2
+    #define EXTRUDER_2_NOMINAL_FILAMENT_DIA 3.0
+    #if EXTRUDERS > 3
+      #define EXTRUDER_3_NOMINAL_FILAMENT_DIA 3.0
+    #endif
+  #endif
+#endif
+
+#define MEASURED_UPPER_MARGIN          0.3  // (mm) sensor reading validation upper margin (3.0 + 0.3 = 3.3 upper limit)
+#define MEASURED_LOWER_MARGIN          1.1  // (mm) sensor reading validation lower margin (3.0 - 1.1 = 1.9 lower limit)
 #define MAX_MEASUREMENT_DELAY     20  //delay buffer size in bytes (1 byte = 1cm)- limits maximum measurement delay allowable (must be larger than MEASUREMENT_DELAY_CM  and lower number saves RAM)
 
 //defines used in the code
-#define DEFAULT_MEASURED_FILAMENT_DIA  DEFAULT_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
+#define DEFAULT_MEASURED_FILAMENT_DIA  EXTRUDER_0_NOMINAL_FILAMENT_DIA  //set measured to nominal initially 
 
 //When using an LCD, uncomment the line below to display the Filament sensor data on the last line instead of status.  Status will appear for 5 sec.
 //#define FILAMENT_LCD_DISPLAY

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -835,9 +835,9 @@ static void updateTemperaturesFromRawValues()
   // Convert raw Filament Width to a ratio
   int widthFil_to_size_ratio() {
     float temp = filament_width_meas, nominal_width = filament_width_nominal[active_extruder];
-    if (filament_width_meas < nominal_width - MEASURED_LOWER_MARGIN)
+    if (temp < nominal_width - MEASURED_LOWER_MARGIN)
       temp = nominal_width;  //assume sensor cut out
-    else if (filament_width_meas > nominal_width + MEASURED_UPPER_MARGIN)
+    else if (temp > nominal_width + MEASURED_UPPER_MARGIN)
       temp = nominal_width + MEASURED_UPPER_MARGIN;
 
     return(nominal_width / temp * 100);

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -824,30 +824,26 @@ static void updateTemperaturesFromRawValues()
 }
 
 
-// For converting raw Filament Width to milimeters 
 #ifdef FILAMENT_SENSOR
-float analog2widthFil() { 
-return current_raw_filwidth/16383.0*5.0; 
-//return current_raw_filwidth; 
-} 
- 
-// For converting raw Filament Width to a ratio 
-int widthFil_to_size_ratio() { 
- 
-float temp; 
-      
-temp=filament_width_meas;
-if(filament_width_meas<MEASURED_LOWER_LIMIT)
-	temp=filament_width_nominal;  //assume sensor cut out
-else if (filament_width_meas>MEASURED_UPPER_LIMIT)
-	temp= MEASURED_UPPER_LIMIT;
 
+  // Convert raw Filament Width to millimeters
+  float analog2widthFil() {
+    return current_raw_filwidth / 16383.0 * 5.0;
+    //return current_raw_filwidth;
+  } 
+   
+  // Convert raw Filament Width to a ratio
+  int widthFil_to_size_ratio() {
+    float temp = filament_width_meas, nominal_width = filament_width_nominal[active_extruder];
+    if (filament_width_meas < nominal_width - MEASURED_LOWER_MARGIN)
+      temp = nominal_width;  //assume sensor cut out
+    else if (filament_width_meas > nominal_width + MEASURED_UPPER_MARGIN)
+      temp = nominal_width + MEASURED_UPPER_MARGIN;
 
-return(filament_width_nominal/temp*100); 
+    return(nominal_width / temp * 100);
+  }
 
-
-} 
-#endif
+#endif //FILAMENT_SENSOR
 
 
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -954,13 +954,13 @@ static void lcd_control_volumetric_menu()
 	MENU_ITEM_EDIT_CALLBACK(bool, MSG_VOLUMETRIC_ENABLED, &volumetric_enabled, calculate_volumetric_multipliers);
 
 	if (volumetric_enabled) {
-		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_0, &filament_size[0], DEFAULT_NOMINAL_FILAMENT_DIA - .5, DEFAULT_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
+		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_0, &filament_size[0], EXTRUDER_0_NOMINAL_FILAMENT_DIA - .5, .5, calculate_volumetric_multipliers);
 #if EXTRUDERS > 1
-		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_1, &filament_size[1], DEFAULT_NOMINAL_FILAMENT_DIA - .5, DEFAULT_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
+		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_1, &filament_size[1], EXTRUDER_1_NOMINAL_FILAMENT_DIA - .5, EXTRUDER_1_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
 #if EXTRUDERS > 2
-		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_2, &filament_size[2], DEFAULT_NOMINAL_FILAMENT_DIA - .5, DEFAULT_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
+		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_2, &filament_size[2], EXTRUDER_2_NOMINAL_FILAMENT_DIA - .5, EXTRUDER_2_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
 #if EXTRUDERS > 3
-		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_3, &filament_size[3], DEFAULT_NOMINAL_FILAMENT_DIA - .5, DEFAULT_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
+		MENU_ITEM_EDIT_CALLBACK(float43, MSG_FILAMENT_SIZE_EXTRUDER_3, &filament_size[3], EXTRUDER_3_NOMINAL_FILAMENT_DIA - .5, EXTRUDER_3_NOMINAL_FILAMENT_DIA + .5, calculate_volumetric_multipliers);
 #endif //EXTRUDERS > 3
 #endif //EXTRUDERS > 2
 #endif //EXTRUDERS > 1


### PR DESCRIPTION
- Redo starting with PR #1420 and extending
- Applies to all filament measurement operations
- Supports up to 4 extruders
- `MEASURED_UPPER_MARGIN` supplants `MEASURED_UPPER_LIMIT` (etc.)
- Affects `M200` and `M404` commands. `M404` gains “**S**” parameter.
