### PR TITLE
Issue #1504 – K8200 Z_ENABLE_PIN

### DIFF
--- a/Marlin/pins_3DRAG.h
+++ b/Marlin/pins_3DRAG.h
@@ -4,6 +4,8 @@
 
 #include "pins_RAMPS_13.h"
 
+#define Z_ENABLE_PIN       63
+
 #define X_MAX_PIN          2
 #define Y_MAX_PIN          15
 #define Z_MAX_PIN          -1


### PR DESCRIPTION
- K8200 uses a non-standard RAMPS with Z_ENABLE=63 ??
- Assuming from previous input that 3DRAG is the same.
