### PR TITLE
Cleanup ramps boards

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -50,10 +50,11 @@
 #define BOARD_LEAPFROG          999  // Leapfrog
 #define BOARD_WITBOX            41   // bq WITBOX
 #define BOARD_HEPHESTOS         42   // bq Prusa i3 Hephestos
+#define BOARD_BAM_DICE          401  // 2PrintBeta BAM&DICE with STK drivers
+#define BOARD_BAM_DICE_DUE      402  // 2PrintBeta BAM&DICE Due with STK drivers
 
 #define BOARD_99                99   // This is in pins.h but...?
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)
-#define IS_RAMPS (MB(RAMPS_OLD) || MB(RAMPS_13_EFB) || MB(RAMPS_13_EEB) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF))
 
 #endif //__BOARDS_H

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -36,7 +36,7 @@
   #include "pins_SETHI.h"
 #elif MB(RAMPS_OLD)
   #include "pins_RAMPS_OLD.h"
-#elif IS_RAMPS
+#elif MB(RAMPS_13_EFB) || MB(RAMPS_13_EEB) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF)
   #include "pins_RAMPS_13.h"
 #elif MB(DUEMILANOVE_328P)
   #include "pins_DUEMILANOVE_328P.h"
@@ -110,6 +110,10 @@
   #include "pins_WITBOX.h"
 #elif MB(HEPHESTOS)
   #include "pins_HEPHESTOS.h"
+#elif MB(BAM_DICE)
+  #include "pins_RAMPS_13.h"
+#elif MB(BAM_DICE_DUE)
+  #include "pins_BAM_DICE_DUE.h"
 #elif MB(99)
   #include "pins_99.h"
 #else

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -1,0 +1,13 @@
+/**
+ * AZTEEG_X3 Arduino Mega with RAMPS v1.3 pin assignments
+ */
+
+#include "pins_RAMPS_13.h"
+
+#define FAN_PIN            9 // (Sprinter config)
+#define HEATER_1_PIN       -1
+
+#ifdef TEMP_STAT_LEDS
+  #define STAT_LED_RED       6
+  #define STAT_LED_BLUE     11
+#endif

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -1,5 +1,0 @@
-/**
- * AZTEEG_X3 Arduino Mega with RAMPS v1.3 pin assignments
- */
-
-#include "pins_RAMPS_13.h"

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -4,6 +4,9 @@
 
 #include "pins_RAMPS_13.h"
 
+#define FAN_PIN             9 // (Sprinter config)
+#define BEEPER             33
+
 #define E2_STEP_PIN        23
 #define E2_DIR_PIN         25
 #define E2_ENABLE_PIN      40
@@ -16,15 +19,16 @@
 #define E4_DIR_PIN         37
 #define E4_ENABLE_PIN      42
 
+#define HEATER_1_PIN       -1
 #define HEATER_2_PIN       16
 #define HEATER_3_PIN       17
-#define HEATER_4_PIN       4
-#define HEATER_5_PIN       5
-#define HEATER_6_PIN       6
+#define HEATER_4_PIN        4
+#define HEATER_5_PIN        5
+#define HEATER_6_PIN        6
 #define HEATER_7_PIN       11
 
 #define TEMP_2_PIN         12   // ANALOG NUMBERING
 #define TEMP_3_PIN         11   // ANALOG NUMBERING
 #define TEMP_4_PIN         10   // ANALOG NUMBERING
-#define TC1                4    // ANALOG NUMBERING Thermo couple on Azteeg X3Pro
-#define TC2                5    // ANALOG NUMBERING Thermo couple on Azteeg X3Pro
+#define TC1                 4   // ANALOG NUMBERING Thermo couple on Azteeg X3Pro
+#define TC2                 5   // ANALOG NUMBERING Thermo couple on Azteeg X3Pro

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -1,0 +1,11 @@
+/**
+ * BAM&DICE Due (Arduino Mega) pin assignments
+ */
+
+#include "pins_RAMPS_13.h"
+
+#define FAN_PIN             9 // (Sprinter config)
+#define HEATER_1_PIN       -1
+
+#define TEMP_0_PIN          9 // ANALOG NUMBERING
+#define TEMP_1_PIN         11 // ANALOG NUMBERING

--- a/Marlin/pins_HEPHESTOS.h
+++ b/Marlin/pins_HEPHESTOS.h
@@ -3,3 +3,6 @@
  */
 
 #include "pins_RAMPS_13.h"
+
+#define FAN_PIN             9 // (Sprinter config)
+#define HEATER_1_PIN       -1

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -7,10 +7,8 @@
  *  RAMPS_13_EEB (Extruder, Extruder, Bed)
  *  RAMPS_13_EFF (Extruder, Fan, Fan)
  *  RAMPS_13_EEF (Extruder, Extruder, Fan)
- *  3DRAG
- *  K8200
- *  AZTEEG_X3
- *  AZTEEG_X3_PRO
+ *
+ *  Other pins_MYBOARD.h files may override these defaults
  */
 
 #if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
@@ -63,7 +61,7 @@
   #define FILWIDTH_PIN        5
 #endif
 
-#if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF) || MB(AZTEEG_X3) || MB(AZTEEG_X3_PRO) || MB(WITBOX) || MB(HEPHESTOS)
+#if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF)
   #define FAN_PIN            9 // (Sprinter config)
   #if MB(RAMPS_13_EFF)
     #define CONTROLLERFAN_PIN  -1 // Pin used for the fan to cool controller
@@ -88,7 +86,7 @@
   #define HEATER_0_PIN       10   // EXTRUDER 1
 #endif
 
-#if MB(RAMPS_13_EFB) || MB(AZTEEG_X3) || MB(WITBOX) || MB(HEPHESTOS)
+#if MB(RAMPS_13_EFB)
   #define HEATER_1_PIN       -1
 #else
   #define HEATER_1_PIN       9    // EXTRUDER 2 (FAN On Sprinter)
@@ -110,28 +108,14 @@
 
 #ifdef NUM_SERVOS
   #define SERVO0_PIN         11
-
   #if NUM_SERVOS > 1
-    #define SERVO1_PIN         6
-  #endif
-
-  #if NUM_SERVOS > 2
-    #define SERVO2_PIN         5
-  #endif
-
-  #if NUM_SERVOS > 3
-    #define SERVO3_PIN         4
-  #endif
-#endif
-
-#if MB(AZTEEG_X3_PRO)
-  #define BEEPER 33
-#endif
-
-#ifdef TEMP_STAT_LEDS
-  #if MB(AZTEEG_X3)
-    #define STAT_LED_RED       6
-    #define STAT_LED_BLUE     11
+    #define SERVO1_PIN        6
+    #if NUM_SERVOS > 2
+      #define SERVO2_PIN      5
+      #if NUM_SERVOS > 3
+        #define SERVO3_PIN    4
+      #endif
+    #endif
   #endif
 #endif
 

--- a/Marlin/pins_WITBOX.h
+++ b/Marlin/pins_WITBOX.h
@@ -3,3 +3,6 @@
  */
 
 #include "pins_RAMPS_13.h"
+
+#define FAN_PIN             9 // (Sprinter config)
+#define HEATER_1_PIN       -1


### PR DESCRIPTION
- Default pins in main RAMPS_13 file, overrides for specific boards in `pins_MYBOARD.h` files
- Remove `IS_RAMPS` and just be more explicit in `pins.h`
- Includes BAM&DICE from #1514 
