### PR TITLE
Fix implementation of PID menu items

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -806,6 +806,7 @@ static void lcd_control_menu()
 }
 
 #ifdef PIDTEMP
+
   // Helpers for editing PID Ki & Kd values
   // grab the PID value out of the temp variable; scale it; then update the PID driver
   void copy_and_scalePID_i(int e) {
@@ -818,19 +819,22 @@ static void lcd_control_menu()
   }
   void copy_and_scalePID_i_E1() { copy_and_scalePID_i(0); }
   void copy_and_scalePID_d_E1() { copy_and_scalePID_d(0); }
-  #if EXTRUDERS > 1
-    void copy_and_scalePID_i_E2() { copy_and_scalePID_i(1); }
-    void copy_and_scalePID_d_E2() { copy_and_scalePID_d(1); }
-    #if EXTRUDERS > 2
-      void copy_and_scalePID_i_E3() { copy_and_scalePID_i(2); }
-      void copy_and_scalePID_d_E3() { copy_and_scalePID_d(2); }
-      #if EXTRUDERS > 3
-        void copy_and_scalePID_i_E4() { copy_and_scalePID_i(3); }
-        void copy_and_scalePID_d_E5() { copy_and_scalePID_d(3); }
-      #endif
-    #endif
-  #endif
-#endif
+  #ifdef PID_PARAMS_PER_EXTRUDER
+    #if EXTRUDERS > 1
+      void copy_and_scalePID_i_E2() { copy_and_scalePID_i(1); }
+      void copy_and_scalePID_d_E2() { copy_and_scalePID_d(1); }
+      #if EXTRUDERS > 2
+        void copy_and_scalePID_i_E3() { copy_and_scalePID_i(2); }
+        void copy_and_scalePID_d_E3() { copy_and_scalePID_d(2); }
+        #if EXTRUDERS > 3
+          void copy_and_scalePID_i_E4() { copy_and_scalePID_i(3); }
+          void copy_and_scalePID_d_E5() { copy_and_scalePID_d(3); }
+        #endif //EXTRUDERS > 3
+      #endif //EXTRUDERS > 2
+    #endif //EXTRUDERS > 1
+  #endif //PID_PARAMS_PER_EXTRUDER
+
+#endif //PIDTEMP
 
 static void lcd_control_temperature_menu()
 {

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -41,11 +41,6 @@ char lcd_status_message[LCD_WIDTH+1] = WELCOME_MSG;
 #include "ultralcd_implementation_hitachi_HD44780.h"
 #endif
 
-/** forward declarations **/
-
-void copy_and_scalePID_i();
-void copy_and_scalePID_d();
-
 /* Different menus */
 static void lcd_status_screen();
 #ifdef ULTIPANEL
@@ -185,9 +180,8 @@ void* editValue;
 int32_t minEditValue, maxEditValue;
 menuFunc_t callbackFunc;
 
-// place-holders for Ki and Kd edits, and the extruder # being edited
+// place-holders for Ki and Kd edits
 float raw_Ki, raw_Kd;
-int pid_current_extruder;
 
 static void lcd_goto_menu(menuFunc_t menu, const uint32_t encoder=0, const bool feedback=true) {
   if (currentMenu != menu) {
@@ -811,76 +805,120 @@ static void lcd_control_menu()
     END_MENU();
 }
 
+#ifdef PIDTEMP
+  // Helpers for editing PID Ki & Kd values
+  // grab the PID value out of the temp variable; scale it; then update the PID driver
+  void copy_and_scalePID_i(int e) {
+    PID_PARAM(Ki, e) = scalePID_i(raw_Ki);
+    updatePID();
+  }
+  void copy_and_scalePID_d(int e) {
+    PID_PARAM(Kd, e) = scalePID_d(raw_Kd);
+    updatePID();
+  }
+  void copy_and_scalePID_i_E1() { copy_and_scalePID_i(0); }
+  void copy_and_scalePID_d_E1() { copy_and_scalePID_d(0); }
+  #if EXTRUDERS > 1
+    void copy_and_scalePID_i_E2() { copy_and_scalePID_i(1); }
+    void copy_and_scalePID_d_E2() { copy_and_scalePID_d(1); }
+    #if EXTRUDERS > 2
+      void copy_and_scalePID_i_E3() { copy_and_scalePID_i(2); }
+      void copy_and_scalePID_d_E3() { copy_and_scalePID_d(2); }
+      #if EXTRUDERS > 3
+        void copy_and_scalePID_i_E4() { copy_and_scalePID_i(3); }
+        void copy_and_scalePID_d_E5() { copy_and_scalePID_d(3); }
+      #endif
+    #endif
+  #endif
+#endif
+
 static void lcd_control_temperature_menu()
 {
   START_MENU();
   MENU_ITEM(back, MSG_CONTROL, lcd_control_menu);
-#if TEMP_SENSOR_0 != 0
-  MENU_ITEM_EDIT(int3, MSG_NOZZLE, &target_temperature[0], 0, HEATER_0_MAXTEMP - 15);
-#endif
-#if TEMP_SENSOR_1 != 0 && EXTRUDERS > 1
-  MENU_ITEM_EDIT(int3, MSG_NOZZLE " 2", &target_temperature[1], 0, HEATER_1_MAXTEMP - 15);
-#endif
-#if TEMP_SENSOR_2 != 0 && EXTRUDERS > 2
-  MENU_ITEM_EDIT(int3, MSG_NOZZLE " 3", &target_temperature[2], 0, HEATER_2_MAXTEMP - 15);
-#endif
-#if TEMP_SENSOR_3 != 0 && EXTRUDERS > 3
-  MENU_ITEM_EDIT(int3, MSG_NOZZLE " 4", &target_temperature[3], 0, HEATER_3_MAXTEMP - 15);
-#endif
-#if TEMP_SENSOR_BED != 0
-  MENU_ITEM_EDIT(int3, MSG_BED, &target_temperature_bed, 0, BED_MAXTEMP - 15);
-#endif
-  MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &fanSpeed, 0, 255);
-#if defined AUTOTEMP && (TEMP_SENSOR_0 != 0)
-  MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &autotemp_enabled);
-  MENU_ITEM_EDIT(float3, MSG_MIN, &autotemp_min, 0, HEATER_0_MAXTEMP - 15);
-  MENU_ITEM_EDIT(float3, MSG_MAX, &autotemp_max, 0, HEATER_0_MAXTEMP - 15);
-  MENU_ITEM_EDIT(float32, MSG_FACTOR, &autotemp_factor, 0.0, 1.0);
-#endif
-#ifdef PIDTEMP
-	// set up temp variables - undo the default scaling
-	pid_current_extruder = 0;
-	raw_Ki = unscalePID_i(PID_PARAM(Ki,0));
-	raw_Kd = unscalePID_d(PID_PARAM(Kd,0));
-	MENU_ITEM_EDIT(float52, MSG_PID_P, &PID_PARAM(Kp,0), 1, 9990);
-	// i is typically a small value so allows values below 1
-	MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I, &raw_Ki, 0.01, 9990, copy_and_scalePID_i);
-	MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D, &raw_Kd, 1, 9990, copy_and_scalePID_d);
-    #ifdef PID_ADD_EXTRUSION_RATE
-	  MENU_ITEM_EDIT(float3, MSG_PID_C, &PID_PARAM(Kc,0), 1, 9990);
-    #endif//PID_ADD_EXTRUSION_RATE
-#ifdef PID_PARAMS_PER_EXTRUDER
+  #if TEMP_SENSOR_0 != 0
+    MENU_ITEM_EDIT(int3, MSG_NOZZLE, &target_temperature[0], 0, HEATER_0_MAXTEMP - 15);
+  #endif
   #if EXTRUDERS > 1
-	  // set up temp variables - undo the default scaling
-	  pid_current_extruder = 0;
-	  raw_Ki = unscalePID_i(PID_PARAM(Ki,1));
-	  raw_Kd = unscalePID_d(PID_PARAM(Kd,1));
-	  MENU_ITEM_EDIT(float52, MSG_PID_P " E2", &PID_PARAM(Kp,1), 1, 9990);
-	  // i is typically a small value so allows values below 1
-	  MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I " E2", &raw_Ki, 0.01, 9990, copy_and_scalePID_i);
-	  MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D " E2", &raw_Kd, 1, 9990, copy_and_scalePID_d);
-      #ifdef PID_ADD_EXTRUSION_RATE
-	    MENU_ITEM_EDIT(float3, MSG_PID_C " E2", &PID_PARAM(Kc,1), 1, 9990);
-      #endif//PID_ADD_EXTRUSION_RATE
-  #endif//EXTRUDERS > 1
-  #if EXTRUDERS > 2
-	    // set up temp variables - undo the default scaling
-	    pid_current_extruder = 0;
-	    raw_Ki = unscalePID_i(PID_PARAM(Ki,2));
-	    raw_Kd = unscalePID_d(PID_PARAM(Kd,2));
-	    MENU_ITEM_EDIT(float52, MSG_PID_P " E3", &PID_PARAM(Kp,2), 1, 9990);
-	    // i is typically a small value so allows values below 1
-	    MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I " E3", &raw_Ki, 0.01, 9990, copy_and_scalePID_i);
-	    MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D " E3", &raw_Kd, 1, 9990, copy_and_scalePID_d);
+    #if TEMP_SENSOR_1 != 0
+      MENU_ITEM_EDIT(int3, MSG_NOZZLE " 2", &target_temperature[1], 0, HEATER_1_MAXTEMP - 15);
+    #endif
+    #if EXTRUDERS > 2
+      #if TEMP_SENSOR_2 != 0
+        MENU_ITEM_EDIT(int3, MSG_NOZZLE " 3", &target_temperature[2], 0, HEATER_2_MAXTEMP - 15);
+      #endif
+      #if EXTRUDERS > 2
+        #if TEMP_SENSOR_3 != 0
+          MENU_ITEM_EDIT(int3, MSG_NOZZLE " 4", &target_temperature[3], 0, HEATER_3_MAXTEMP - 15);
+        #endif
+      #endif
+    #endif
+  #endif
+  #if TEMP_SENSOR_BED != 0
+    MENU_ITEM_EDIT(int3, MSG_BED, &target_temperature_bed, 0, BED_MAXTEMP - 15);
+  #endif
+  MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &fanSpeed, 0, 255);
+  #if defined AUTOTEMP && (TEMP_SENSOR_0 != 0)
+    MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &autotemp_enabled);
+    MENU_ITEM_EDIT(float3, MSG_MIN, &autotemp_min, 0, HEATER_0_MAXTEMP - 15);
+    MENU_ITEM_EDIT(float3, MSG_MAX, &autotemp_max, 0, HEATER_0_MAXTEMP - 15);
+    MENU_ITEM_EDIT(float32, MSG_FACTOR, &autotemp_factor, 0.0, 1.0);
+  #endif
+  #ifdef PIDTEMP
+    // set up temp variables - undo the default scaling
+    raw_Ki = unscalePID_i(PID_PARAM(Ki,0));
+    raw_Kd = unscalePID_d(PID_PARAM(Kd,0));
+    MENU_ITEM_EDIT(float52, MSG_PID_P, &PID_PARAM(Kp,0), 1, 9990);
+    // i is typically a small value so allows values below 1
+    MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E1);
+    MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D, &raw_Kd, 1, 9990, copy_and_scalePID_d_E1);
+    #ifdef PID_ADD_EXTRUSION_RATE
+      MENU_ITEM_EDIT(float3, MSG_PID_C, &PID_PARAM(Kc,0), 1, 9990);
+    #endif//PID_ADD_EXTRUSION_RATE
+    #ifdef PID_PARAMS_PER_EXTRUDER
+      #if EXTRUDERS > 1
+        // set up temp variables - undo the default scaling
+        raw_Ki = unscalePID_i(PID_PARAM(Ki,1));
+        raw_Kd = unscalePID_d(PID_PARAM(Kd,1));
+        MENU_ITEM_EDIT(float52, MSG_PID_P " E2", &PID_PARAM(Kp,1), 1, 9990);
+        // i is typically a small value so allows values below 1
+        MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I " E2", &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E2);
+        MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D " E2", &raw_Kd, 1, 9990, copy_and_scalePID_d_E2);
         #ifdef PID_ADD_EXTRUSION_RATE
-	      MENU_ITEM_EDIT(float3, MSG_PID_C " E3", &PID_PARAM(Kc,2), 1, 9990);
+          MENU_ITEM_EDIT(float3, MSG_PID_C " E2", &PID_PARAM(Kc,1), 1, 9990);
         #endif//PID_ADD_EXTRUSION_RATE
-  #endif//EXTRUDERS > 2
-#endif // PID_PARAMS_PER_EXTRUDER
-#endif//PIDTEMP
-    MENU_ITEM(submenu, MSG_PREHEAT_PLA_SETTINGS, lcd_control_temperature_preheat_pla_settings_menu);
-    MENU_ITEM(submenu, MSG_PREHEAT_ABS_SETTINGS, lcd_control_temperature_preheat_abs_settings_menu);
-    END_MENU();
+
+        #if EXTRUDERS > 2
+          // set up temp variables - undo the default scaling
+          raw_Ki = unscalePID_i(PID_PARAM(Ki,2));
+          raw_Kd = unscalePID_d(PID_PARAM(Kd,2));
+          MENU_ITEM_EDIT(float52, MSG_PID_P " E3", &PID_PARAM(Kp,2), 1, 9990);
+          // i is typically a small value so allows values below 1
+          MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I " E3", &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E3);
+          MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D " E3", &raw_Kd, 1, 9990, copy_and_scalePID_d_E3);
+          #ifdef PID_ADD_EXTRUSION_RATE
+            MENU_ITEM_EDIT(float3, MSG_PID_C " E3", &PID_PARAM(Kc,2), 1, 9990);
+          #endif//PID_ADD_EXTRUSION_RATE
+
+          #if EXTRUDERS > 3
+            // set up temp variables - undo the default scaling
+            raw_Ki = unscalePID_i(PID_PARAM(Ki,3));
+            raw_Kd = unscalePID_d(PID_PARAM(Kd,3));
+            MENU_ITEM_EDIT(float52, MSG_PID_P " E4", &PID_PARAM(Kp,3), 1, 9990);
+            // i is typically a small value so allows values below 1
+            MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I " E4", &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E4);
+            MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D " E4", &raw_Kd, 1, 9990, copy_and_scalePID_d_E4);
+            #ifdef PID_ADD_EXTRUSION_RATE
+              MENU_ITEM_EDIT(float3, MSG_PID_C " E4", &PID_PARAM(Kc,3), 1, 9990);
+            #endif//PID_ADD_EXTRUSION_RATE
+          #endif//EXTRUDERS > 3
+        #endif//EXTRUDERS > 2
+      #endif//EXTRUDERS > 1
+    #endif //PID_PARAMS_PER_EXTRUDER
+  #endif//PIDTEMP
+  MENU_ITEM(submenu, MSG_PREHEAT_PLA_SETTINGS, lcd_control_temperature_preheat_pla_settings_menu);
+  MENU_ITEM(submenu, MSG_PREHEAT_ABS_SETTINGS, lcd_control_temperature_preheat_abs_settings_menu);
+  END_MENU();
 }
 
 static void lcd_control_temperature_preheat_pla_settings_menu()
@@ -1783,26 +1821,6 @@ char *ftostr52(const float &x)
   conv[6]=(xx)%10+'0';
   conv[7]=0;
   return conv;
-}
-
-// Callback for after editing PID i value
-// grab the PID i value out of the temp variable; scale it; then update the PID driver
-void copy_and_scalePID_i()
-{
-#ifdef PIDTEMP
-  PID_PARAM(Ki, pid_current_extruder) = scalePID_i(raw_Ki);
-  updatePID();
-#endif
-}
-
-// Callback for after editing PID d value
-// grab the PID d value out of the temp variable; scale it; then update the PID driver
-void copy_and_scalePID_d()
-{
-#ifdef PIDTEMP
-	PID_PARAM(Kd, pid_current_extruder) = scalePID_d(raw_Kd);
-  updatePID();
-#endif
 }
 
 #endif //ULTRA_LCD


### PR DESCRIPTION
Make this work per #1344. The global parameter `pid_current_extruder` can't be set at menu creation time. The PID index needs to be supplied during the callback. This patches the oversight and adds support for a 4th extruder.
