### PR TITLE
Corrected a typo in ArduinoAddons/Arduino_1.5.x/(...)/boards.txt

### DIFF
--- a/ArduinoAddons/Arduino_1.5.x/hardware/marlin/avr/boards.txt
+++ b/ArduinoAddons/Arduino_1.5.x/hardware/marlin/avr/boards.txt
@@ -33,7 +33,7 @@ rambo.build.variant=rambo
 ########################################
 sanguino.name=Sanguino
 
-sanguino.upload.tool=ardunio:avrdude
+sanguino.upload.tool=arduino:avrdude
 sanguino.upload.protocol=stk500
 sanguino.upload.maximum_size=131072
 sanguino.upload.speed=57600


### PR DESCRIPTION
Hi,
Now there is no more error in the Arduino IDE when uploading Marlin to a Sanguino

Well, it's not a very big deal but I just have some trouble understanding why I cannot upload a new firmware
