### PR TITLE
Extend the idea of dummy temperature sensors.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -118,7 +118,10 @@ Here are some standard links for getting your machine calibrated:
 // 1010 is Pt1000 with 1k pullup (non standard)
 // 147 is Pt100 with 4k7 pullup
 // 110 is Pt100 with 1k pullup (non standard)
-// 999 is a Dummy Table. It will ALWAYS read 25C.. Use it for Testing or Development purposes. NEVER for production machine.
+// 998 and 999 are Dummy Tables. They will ALWAYS read 25°C or the temperature defined below. 
+//     Use it for Testing or Development purposes. NEVER for production machine.
+//     #define DUMMY_THERMISTOR_998_VALUE 25
+//     #define DUMMY_THERMISTOR_999_VALUE 100
 
 #define TEMP_SENSOR_0 -1
 #define TEMP_SENSOR_1 -1

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -1096,13 +1096,26 @@ const short temptable_1047[][2] PROGMEM = {
 #endif
 
 #if (THERMISTORHEATER_0 == 999) || (THERMISTORHEATER_1 == 999) || (THERMISTORHEATER_2 == 999) || (THERMISTORHEATER_3 == 999) || (THERMISTORBED == 999) //User defined table
-// Dummy Thermistor table.. It will ALWAYS read 25C.
-const short temptable_999[][2] PROGMEM = {
-   {1*OVERSAMPLENR, 25},
-   {1023*OVERSAMPLENR, 25}
+  // Dummy Thermistor table.. It will ALWAYS read a fixed value.
+  #ifndef DUMMY_THERMISTOR_999_VALUE
+    #define DUMMY_THERMISTOR_999_VALUE 25
+  #endif
+  const short temptable_999[][2] PROGMEM = {
+    {1*OVERSAMPLENR, DUMMY_THERMISTOR_999_VALUE},
+    {1023*OVERSAMPLENR, DUMMY_THERMISTOR_999_VALUE}
 };
 #endif
 
+#if (THERMISTORHEATER_0 == 998) || (THERMISTORHEATER_1 == 998) || (THERMISTORHEATER_2 == 998) || (THERMISTORHEATER_3 == 998) || (THERMISTORBED == 998) //User defined table
+  // Dummy Thermistor table.. It will ALWAYS read a fixed value.
+  #ifndef DUMMY_THERMISTOR_998_VALUE
+    #define DUMMY_THERMISTOR_998_VALUE 25
+  #endif
+  const short temptable_998[][2] PROGMEM = {
+    {1*OVERSAMPLENR, DUMMY_THERMISTOR_998_VALUE},
+    {1023*OVERSAMPLENR, DUMMY_THERMISTOR_998_VALUE}
+};
+#endif
 
 
 #define _TT_NAME(_N) temptable_ ## _N


### PR DESCRIPTION
Added a second sensor and made them configurable.

"Mendel ready."
instead of "Err: MAXTEMP" during tests is now really easy. :-)

Ahhh. By the way. "Err: MAXTEMP" is an other 'untranslatable' text. :-(
