### PR TITLE
Auto bed leveling for DELTA printers

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -463,7 +463,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   
   // Allen key retractable z-probe as seen on many Kossel delta printers - http://reprap.org/wiki/Kossel#Automatic_bed_leveling_probe
   // Deploys by touching z-axis belt. Retracts by pushing the probe down. Uses Z_MIN_PIN.
-  #define Z_PROBE_ALLEN_KEY
+  //#define Z_PROBE_ALLEN_KEY
   #ifdef Z_PROBE_ALLEN_KEY
     #define Z_PROBE_ALLEN_KEY_DEPLOY_X 30
     #define Z_PROBE_ALLEN_KEY_DEPLOY_Y DELTA_PRINTABLE_RADIUS

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -398,15 +398,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -435,6 +453,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
   //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -454,10 +454,26 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
-  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
+  #define Z_RAISE_AFTER_PROBING 50    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
-  //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.
+  #ifdef Z_PROBE_SLED
+    //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.
+  #endif
+  
+  // Allen key retractable z-probe as seen on many Kossel delta printers - http://reprap.org/wiki/Kossel#Automatic_bed_leveling_probe
+  // Deploys by touching z-axis belt. Retracts by pushing the probe down. Uses Z_MIN_PIN.
+  #define Z_PROBE_ALLEN_KEY
+  #ifdef Z_PROBE_ALLEN_KEY
+    #define Z_PROBE_ALLEN_KEY_DEPLOY_X 30
+    #define Z_PROBE_ALLEN_KEY_DEPLOY_Y DELTA_PRINTABLE_RADIUS
+    #define Z_PROBE_ALLEN_KEY_DEPLOY_Z 100
+    
+    #define Z_PROBE_ALLEN_KEY_RETRACT_X     -64
+    #define Z_PROBE_ALLEN_KEY_RETRACT_Y     56
+    #define Z_PROBE_ALLEN_KEY_RETRACT_Z     23
+    #define Z_PROBE_ALLEN_KEY_RETRACT_DEPTH 20
+  #endif
 
   //If defined, the Probe servo will be turned on only during movement and then turned off to avoid jerk
   //The value is the delay to turn the servo off after powered on - depends on the servo speed; 300ms is good value, but you can try lower it.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -466,7 +466,19 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 
 #if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
-  #error "Bed Auto Leveling is still not compatible with Delta Kinematics."
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
 #endif
 
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -481,6 +481,12 @@ const unsigned int dropsegments=5; //everything with less than this number of st
   
 #endif
 
+#if defined(Z_PROBE_ALLEN_KEY)
+  #if !defined(AUTO_BED_LEVELING_GRID) || !defined(DELTA)
+    #error "Invalid use of Z_PROBE_ALLEN_KEY."
+  #endif
+#endif
+
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT
   #error "You cannot use TEMP_SENSOR_1_AS_REDUNDANT if EXTRUDERS > 1"
 #endif

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -189,12 +189,17 @@ void ClearToSend();
 void get_coordinates();
 #ifdef DELTA
 void calculate_delta(float cartesian[3]);
+  #ifdef ENABLE_AUTO_BED_LEVELING
+  void adjust_delta(float cartesian[3]);
+  #endif
 extern float delta[3];
+void prepare_move_raw();
 #endif
 #ifdef SCARA
 void calculate_delta(float cartesian[3]);
 void calculate_SCARA_forward_Transform(float f_scara[3]);
 #endif
+void reset_bed_level();
 void prepare_move();
 void kill();
 void Stop();

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -409,15 +409,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -446,6 +464,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
   //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -466,7 +466,19 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 
 #if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
-  #error "Bed Auto Leveling is still not compatible with Delta Kinematics."
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
 #endif
 
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -417,15 +417,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -454,6 +472,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
   //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -466,7 +466,19 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 
 #if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
-  #error "Bed Auto Leveling is still not compatible with Delta Kinematics."
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
 #endif
 
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -437,15 +437,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -473,6 +491,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
 
   //If defined, the Probe servo will be turned on only during movement and then turned off to avoid jerk

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -464,6 +464,23 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 //=============================  Define Defines  ============================
 //===========================================================================
+
+#if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
+#endif
+
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT
   #error "You cannot use TEMP_SENSOR_1_AS_REDUNDANT if EXTRUDERS > 1"
 #endif

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -413,15 +413,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -450,6 +468,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
   //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -466,7 +466,19 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 
 #if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
-  #error "Bed Auto Leveling is still not compatible with Delta Kinematics."
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
 #endif
 
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT

--- a/Marlin/example_configurations/delta/Configuration.h
+++ b/Marlin/example_configurations/delta/Configuration.h
@@ -105,6 +105,9 @@ Here are some standard links for getting your machine calibrated:
 // Effective horizontal distance bridged by diagonal push rods.
 #define DELTA_RADIUS (DELTA_SMOOTH_ROD_OFFSET-DELTA_EFFECTOR_OFFSET-DELTA_CARRIAGE_OFFSET)
 
+// Print surface diameter/2 minus unreachable space (avoid collisions with vertical towers).
+#define DELTA_PRINTABLE_RADIUS 90
+
 
 //===========================================================================
 //============================= Thermal Settings ============================
@@ -386,10 +389,10 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 #define max_software_endstops true  // If true, axis won't move to coordinates greater than the defined lengths below.
 
 // Travel limits after homing (units are in mm)
-#define X_MAX_POS 90
-#define X_MIN_POS -90
-#define Y_MAX_POS 90
-#define Y_MIN_POS -90
+#define X_MAX_POS DELTA_PRINTABLE_RADIUS
+#define X_MIN_POS -DELTA_PRINTABLE_RADIUS
+#define Y_MAX_POS DELTA_PRINTABLE_RADIUS
+#define Y_MIN_POS -DELTA_PRINTABLE_RADIUS
 #define Z_MAX_POS MANUAL_Z_HOME_POS
 #define Z_MIN_POS 0
 

--- a/Marlin/example_configurations/delta/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/Configuration_adv.h
@@ -455,8 +455,20 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 
 #if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
-  #error "Bed Auto Leveling is still not compatible with Delta Kinematics."
-#endif  
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
+#endif 
 
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT
   #error "You cannot use TEMP_SENSOR_1_AS_REDUNDANT if EXTRUDERS > 1"

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -411,15 +411,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -447,6 +465,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
   //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -455,6 +455,23 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 //=============================  Define Defines  ============================
 //===========================================================================
+
+#if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
+#endif
+
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT
   #error "You cannot use TEMP_SENSOR_1_AS_REDUNDANT if EXTRUDERS > 1"
 #endif

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -414,15 +414,33 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
   #ifdef AUTO_BED_LEVELING_GRID
 
     // set the rectangle in which to probe
-    #define LEFT_PROBE_BED_POSITION 15
-    #define RIGHT_PROBE_BED_POSITION 170
-    #define BACK_PROBE_BED_POSITION 180
-    #define FRONT_PROBE_BED_POSITION 20
+    #ifdef DELTA
+      #define DELTA_PROBABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
+      #define LEFT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS
+      #define RIGHT_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define BACK_PROBE_BED_POSITION DELTA_PROBABLE_RADIUS
+      #define FRONT_PROBE_BED_POSITION -DELTA_PROBABLE_RADIUS      
+    #else
+      #define LEFT_PROBE_BED_POSITION 15
+      #define RIGHT_PROBE_BED_POSITION 170
+      #define BACK_PROBE_BED_POSITION 180
+      #define FRONT_PROBE_BED_POSITION 20
+    #endif
 
-     // set the number of grid points per dimension
-     // I wouldn't see a reason to go above 3 (=9 probing points on the bed)
-    #define AUTO_BED_LEVELING_GRID_POINTS 2
+    // set the number of grid points per dimension
+    #ifdef DELTA
+      // Non-linear bed leveling will be used.
+      // Compensate by interpolating between the nearest four Z probe values for each point.
+      // Useful for deltas where the print surface may appear like a bowl or dome shape.
+      // Works best with ACCURATE_BED_LEVELING_POINTS 5 or higher.
+      #define AUTO_BED_LEVELING_GRID_POINTS 9
+    #else
+      // I wouldn't see a reason to go above 3 (=9 probing points on the bed) for cartesian printers
+      #define AUTO_BED_LEVELING_GRID_POINTS 2
+    #endif
 
+    #define AUTO_BED_LEVELING_GRID_X ((RIGHT_PROBE_BED_POSITION - LEFT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
+    #define AUTO_BED_LEVELING_GRID_Y ((BACK_PROBE_BED_POSITION - FRONT_PROBE_BED_POSITION) / (AUTO_BED_LEVELING_GRID_POINTS-1))
 
   #else  // not AUTO_BED_LEVELING_GRID
     // with no grid, just probe 3 arbitrary points.  A simple cross-product
@@ -450,6 +468,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 
   #define Z_RAISE_BEFORE_PROBING 15    //How much the extruder will be raised before traveling to the first probing point.
   #define Z_RAISE_BETWEEN_PROBINGS 5  //How much the extruder will be raised when traveling from between next probing points
+  #define Z_RAISE_AFTER_PROBING 15    //How much the extruder will be raised after the last probing point.
 
   //#define Z_PROBE_SLED // turn on if you have a z-probe mounted on a sled like those designed by Charles Bell
   //#define SLED_DOCKING_OFFSET 5 // the extra distance the X axis must travel to pickup the sled. 0 should be fine but you can push it further if you'd like.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -458,6 +458,23 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 //===========================================================================
 //=============================  Define Defines  ============================
 //===========================================================================
+
+#if defined (ENABLE_AUTO_BED_LEVELING) && defined (DELTA)
+  
+  #if not defined(AUTO_BED_LEVELING_GRID)
+    #error "Only Grid Bed Auto Leveling is supported on Deltas."
+  #endif
+  
+  #if defined(Z_PROBE_SLED)
+    #error "You cannot use Z_PROBE_SLED together with DELTA."
+  #endif
+
+  #if defined(Z_PROBE_REPEATABILITY_TEST)
+    #error "Z-probe repeatability test is not supported on Deltas yet."
+  #endif
+  
+#endif
+
 #if EXTRUDERS > 1 && defined TEMP_SENSOR_1_AS_REDUNDANT
   #error "You cannot use TEMP_SENSOR_1_AS_REDUNDANT if EXTRUDERS > 1"
 #endif

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1057,7 +1057,7 @@ Having the real displacement of the head, we can calculate the total movement le
   st_wake_up();
 }
 
-#ifdef ENABLE_AUTO_BED_LEVELING
+#if defined(ENABLE_AUTO_BED_LEVELING) && not defined(DELTA)
 vector_3 plan_get_position() {
 	vector_3 position = vector_3(st_get_position_mm(X_AXIS), st_get_position_mm(Y_AXIS), st_get_position_mm(Z_AXIS));
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -85,8 +85,10 @@ void plan_init();
 #ifdef ENABLE_AUTO_BED_LEVELING
 void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate, const uint8_t &extruder);
 
-// Get the position applying the bed level matrix if enabled
-vector_3 plan_get_position();
+  #ifndef DELTA
+  // Get the position applying the bed level matrix if enabled
+  vector_3 plan_get_position();
+  #endif
 #else
 void plan_buffer_line(const float &x, const float &y, const float &z, const float &e, float feed_rate, const uint8_t &extruder);
 #endif // ENABLE_AUTO_BED_LEVELING


### PR DESCRIPTION
Ported over Johann Rocholl's auto bed leveling code for delta printers.

Full list of improvements:
- Non-linear auto bed leveling with extrapolation for delta printers (based on existing grid probing code).
- Support for retractable allen key z-probes (https://www.youtube.com/watch?v=1eNz1l56H5E and http://reprap.org/wiki/Kossel#Autolevel_probe)
- Security checks in case z-probe fails to deploy or retract.
- Z_RAISE_AFTER_PROBING
- Support for G29, G30, M401 and M402.
- General code cleanup.
