### PR TITLE
Fix undefined *_PROBE_BED_POSITION error

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1734,16 +1734,6 @@ void process_commands()
                 SERIAL_ECHOLNPGM(MSG_POSITION_UNKNOWN);
                 break; // abort G29, since we don't know where we are
             }
-            int left_probe_bed_position=LEFT_PROBE_BED_POSITION;
-            int right_probe_bed_position=RIGHT_PROBE_BED_POSITION;
-            int back_probe_bed_position=BACK_PROBE_BED_POSITION;
-            int front_probe_bed_position=FRONT_PROBE_BED_POSITION;
-            int auto_bed_leveling_grid_points=AUTO_BED_LEVELING_GRID_POINTS;
-            if (code_seen('L')) left_probe_bed_position=(int)code_value();
-            if (code_seen('R')) right_probe_bed_position=(int)code_value();
-            if (code_seen('B')) back_probe_bed_position=(int)code_value();
-            if (code_seen('F')) front_probe_bed_position=(int)code_value();
-            if (code_seen('P')) auto_bed_leveling_grid_points=(int)code_value();
 
 #ifdef Z_PROBE_SLED
             dock_sled(false);
@@ -1764,6 +1754,16 @@ void process_commands()
             feedrate = homing_feedrate[Z_AXIS];
 #ifdef AUTO_BED_LEVELING_GRID
             // probe at the points of a lattice grid
+            int left_probe_bed_position=LEFT_PROBE_BED_POSITION;
+            int right_probe_bed_position=RIGHT_PROBE_BED_POSITION;
+            int back_probe_bed_position=BACK_PROBE_BED_POSITION;
+            int front_probe_bed_position=FRONT_PROBE_BED_POSITION;
+            int auto_bed_leveling_grid_points=AUTO_BED_LEVELING_GRID_POINTS;
+            if (code_seen('L')) left_probe_bed_position=(int)code_value();
+            if (code_seen('R')) right_probe_bed_position=(int)code_value();
+            if (code_seen('B')) back_probe_bed_position=(int)code_value();
+            if (code_seen('F')) front_probe_bed_position=(int)code_value();
+            if (code_seen('P')) auto_bed_leveling_grid_points=(int)code_value();
 
             int xGridSpacing = (right_probe_bed_position - left_probe_bed_position) / (auto_bed_leveling_grid_points-1);
             int yGridSpacing = (back_probe_bed_position - front_probe_bed_position) / (auto_bed_leveling_grid_points-1);


### PR DESCRIPTION
- Resolves #1547
- Can now compile with `AUTO_BED_LEVELING_GRID` disabled and `ENABLE_AUTO_BED_LEVELING` enabled
