### PR TITLE
Add support for solenoid articulated extruders

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -154,6 +154,8 @@
 // M302 - Allow cold extrudes, or set the minimum extrude S<temperature>.
 // M303 - PID relay autotune S<temperature> sets the target temperature. (default target temperature = 150C)
 // M304 - Set bed PID parameters P I and D
+// M380 - Activate solenoid on active extruder
+// M381 - Disable all solenoids
 // M400 - Finish all moves
 // M401 - Lower z-probe if present
 // M402 - Raise z-probe if present
@@ -3497,6 +3499,17 @@ Sigma_Exit:
       }
       break;
 	#endif
+    
+#ifdef EXT_SOLENOID
+    case 380:
+        enable_solenoid_on_active_extruder();
+        break;
+
+    case 381:
+        disable_all_solenoids();
+        break;
+#endif //EXT_SOLENOID
+
     case 400: // M400 finish all moves
     {
       st_synchronize();
@@ -4000,6 +4013,13 @@ case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or disp
            prepare_move();
         }
       }
+
+#ifdef EXT_SOLENOID
+      st_synchronize();
+      disable_all_solenoids();
+      enable_solenoid_on_active_extruder();
+#endif //EXT_SOLENOID
+
       #endif
       SERIAL_ECHO_START;
       SERIAL_ECHO(MSG_ACTIVE_EXTRUDER);
@@ -4707,7 +4727,6 @@ bool setTargetedHotend(int code){
   return false;
 }
 
-
 float calculate_volumetric_multiplier(float diameter) {
   if (!volumetric_enabled || diameter == 0) return 1.0;
   float d2 = diameter * 0.5;
@@ -4718,3 +4737,49 @@ void calculate_volumetric_multipliers() {
   for (int i=0; i<EXTRUDERS; i++)
     volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
 }
+
+#ifdef EXT_SOLENOID
+void enable_solenoid(uint8_t num) {
+         if(num == 0) {
+         SET_OUTPUT(SOL0_PIN);
+         WRITE(SOL0_PIN,HIGH);
+    }
+        
+         if(num == 1){
+         SET_OUTPUT(SOL1_PIN);
+         WRITE(SOL1_PIN,HIGH);
+    }
+         
+         if(num == 2){
+         SET_OUTPUT(SOL2_PIN);
+         WRITE(SOL2_PIN,HIGH);
+    }
+         
+         if(num == 3){
+         SET_OUTPUT(SOL3_PIN);
+         WRITE(SOL3_PIN,HIGH);
+    }
+         
+         return;
+    }
+
+void enable_solenoid_on_active_extruder() {
+         enable_solenoid(active_extruder);
+         return;
+    }
+
+void disable_all_solenoids() {
+         SET_OUTPUT(SOL0_PIN);
+         SET_OUTPUT(SOL1_PIN);
+         SET_OUTPUT(SOL2_PIN);
+         SET_OUTPUT(SOL3_PIN);
+         
+         WRITE(SOL0_PIN,LOW);
+         WRITE(SOL1_PIN,LOW);
+         WRITE(SOL2_PIN,LOW);
+         WRITE(SOL3_PIN,LOW);
+         
+         return;
+    }
+
+#endif //EXT_SOLENOID

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -531,32 +531,28 @@ void setup_homepin(void)
 void setup_photpin()
 {
   #if defined(PHOTOGRAPH_PIN) && PHOTOGRAPH_PIN > -1
-    SET_OUTPUT(PHOTOGRAPH_PIN);
-    WRITE(PHOTOGRAPH_PIN, LOW);
+    OUT_WRITE(PHOTOGRAPH_PIN, LOW);
   #endif
 }
 
 void setup_powerhold()
 {
   #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
-    SET_OUTPUT(SUICIDE_PIN);
-    WRITE(SUICIDE_PIN, HIGH);
+    OUT_WRITE(SUICIDE_PIN, HIGH);
   #endif
   #if defined(PS_ON_PIN) && PS_ON_PIN > -1
-    SET_OUTPUT(PS_ON_PIN);
-	#if defined(PS_DEFAULT_OFF)
-	  WRITE(PS_ON_PIN, PS_ON_ASLEEP);
-    #else
-	  WRITE(PS_ON_PIN, PS_ON_AWAKE);
-	#endif
+    #if defined(PS_DEFAULT_OFF)
+      OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+      #else
+      OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE);
+    #endif
   #endif
 }
 
 void suicide()
 {
   #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
-    SET_OUTPUT(SUICIDE_PIN);
-    WRITE(SUICIDE_PIN, LOW);
+    OUT_WRITE(SUICIDE_PIN, LOW);
   #endif
 }
 
@@ -2725,15 +2721,13 @@ Sigma_Exit:
 
     #if defined(PS_ON_PIN) && PS_ON_PIN > -1
       case 80: // M80 - Turn on Power Supply
-        SET_OUTPUT(PS_ON_PIN); //GND
-        WRITE(PS_ON_PIN, PS_ON_AWAKE);
+        OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE); // GND
 
         // If you have a switch on suicide pin, this is useful
         // if you want to start another print with suicide feature after
         // a print without suicide...
         #if defined SUICIDE_PIN && SUICIDE_PIN > -1
-            SET_OUTPUT(SUICIDE_PIN);
-            WRITE(SUICIDE_PIN, HIGH);
+            OUT_WRITE(SUICIDE_PIN, HIGH);
         #endif
 
         #ifdef ULTIPANEL
@@ -2757,8 +2751,7 @@ Sigma_Exit:
         st_synchronize();
         suicide();
       #elif defined(PS_ON_PIN) && PS_ON_PIN > -1
-        SET_OUTPUT(PS_ON_PIN);
-        WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+        OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
       #endif
       #ifdef ULTIPANEL
         powersupply = false;
@@ -3120,7 +3113,7 @@ Sigma_Exit:
          SERIAL_ECHO(extruder_offset[Z_AXIS][tmp_extruder]);
       #endif
       }
-      SERIAL_ECHOLN("");
+      SERIAL_EOL;
     }break;
     #endif
     case 220: // M220 S<factor in percent>- set speed factor override percentage
@@ -3339,8 +3332,7 @@ Sigma_Exit:
      {
      	#ifdef CHDK
        
-         SET_OUTPUT(CHDK);
-         WRITE(CHDK, HIGH);
+         OUT_WRITE(CHDK, HIGH);
          chdkHigh = millis();
          chdkActive = true;
        
@@ -3750,9 +3742,7 @@ case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or disp
           if(cnt==0)
           {
           #if BEEPER > 0
-            SET_OUTPUT(BEEPER);
-
-            WRITE(BEEPER,HIGH);
+            OUT_WRITE(BEEPER,HIGH);
             delay(3);
             WRITE(BEEPER,LOW);
             delay(3);
@@ -4739,47 +4729,41 @@ void calculate_volumetric_multipliers() {
 }
 
 #ifdef EXT_SOLENOID
-void enable_solenoid(uint8_t num) {
-         if(num == 0) {
-         SET_OUTPUT(SOL0_PIN);
-         WRITE(SOL0_PIN,HIGH);
-    }
-        
-         if(num == 1){
-         SET_OUTPUT(SOL1_PIN);
-         WRITE(SOL1_PIN,HIGH);
-    }
-         
-         if(num == 2){
-         SET_OUTPUT(SOL2_PIN);
-         WRITE(SOL2_PIN,HIGH);
-    }
-         
-         if(num == 3){
-         SET_OUTPUT(SOL3_PIN);
-         WRITE(SOL3_PIN,HIGH);
-    }
-         
-         return;
-    }
 
-void enable_solenoid_on_active_extruder() {
-         enable_solenoid(active_extruder);
-         return;
-    }
+void enable_solenoid(uint8_t num) {
+  switch(num) {
+    case 0:
+      OUT_WRITE(SOL0_PIN, HIGH);
+      break;
+      #if defined(SOL1_PIN) && SOL1_PIN > -1
+        case 1:
+          OUT_WRITE(SOL1_PIN, HIGH);
+          break;
+      #endif
+      #if defined(SOL2_PIN) && SOL2_PIN > -1
+        case 2:
+          OUT_WRITE(SOL2_PIN, HIGH);
+          break;
+      #endif
+      #if defined(SOL3_PIN) && SOL3_PIN > -1
+        case 3:
+          OUT_WRITE(SOL3_PIN, HIGH);
+          break;
+      #endif
+    default:
+      SERIAL_ECHO_START;
+      SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);
+      break;
+  }
+}
+
+void enable_solenoid_on_active_extruder() { enable_solenoid(active_extruder); }
 
 void disable_all_solenoids() {
-         SET_OUTPUT(SOL0_PIN);
-         SET_OUTPUT(SOL1_PIN);
-         SET_OUTPUT(SOL2_PIN);
-         SET_OUTPUT(SOL3_PIN);
-         
-         WRITE(SOL0_PIN,LOW);
-         WRITE(SOL1_PIN,LOW);
-         WRITE(SOL2_PIN,LOW);
-         WRITE(SOL3_PIN,LOW);
-         
-         return;
-    }
+  OUT_WRITE(SOL0_PIN, LOW);
+  OUT_WRITE(SOL1_PIN, LOW);
+  OUT_WRITE(SOL2_PIN, LOW);
+  OUT_WRITE(SOL3_PIN, LOW);
+}
 
 #endif //EXT_SOLENOID

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -22,8 +22,7 @@ CardReader::CardReader() {
   autostart_index = 0;
   //power to SD reader
   #if SDPOWER > -1
-    SET_OUTPUT(SDPOWER);
-    WRITE(SDPOWER, HIGH);
+    OUT_WRITE(SDPOWER, HIGH);
   #endif //SDPOWER
 
   autostart_atmillis = millis() + 5000;

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -83,6 +83,9 @@
 /// check if pin is an timer wrapper
 #define GET_TIMER(IO)  _GET_TIMER(IO)
 
+// Shorthand
+#define OUT_WRITE(IO, v) { SET_OUTPUT(IO); WRITE(IO, v); }
+
 /*
 	ports and functions
 

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -121,6 +121,7 @@
 #define MSG_UNKNOWN_COMMAND                 "Unknown command: \""
 #define MSG_ACTIVE_EXTRUDER                 "Active Extruder: "
 #define MSG_INVALID_EXTRUDER                "Invalid extruder"
+#define MSG_INVALID_SOLENOID                "Invalid solenoid"
 #define MSG_X_MIN                           "x_min: "
 #define MSG_X_MAX                           "x_max: "
 #define MSG_Y_MIN                           "y_min: "

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -187,7 +187,7 @@ void checkHitEndstops()
      SERIAL_ECHOPAIR(" Z:",(float)endstops_trigsteps[Z_AXIS]/axis_steps_per_unit[Z_AXIS]);
      LCD_MESSAGEPGM(MSG_ENDSTOPS_HIT "Z");
    }
-   SERIAL_ECHOLN("");
+   SERIAL_EOL;
    endstop_x_hit=false;
    endstop_y_hit=false;
    endstop_z_hit=false;
@@ -959,51 +959,41 @@ void st_init()
 
   //Initialize Step Pins
   #if defined(X_STEP_PIN) && (X_STEP_PIN > -1)
-    SET_OUTPUT(X_STEP_PIN);
-    WRITE(X_STEP_PIN,INVERT_X_STEP_PIN);
+    OUT_WRITE(X_STEP_PIN,INVERT_X_STEP_PIN);
     disable_x();
   #endif
   #if defined(X2_STEP_PIN) && (X2_STEP_PIN > -1)
-    SET_OUTPUT(X2_STEP_PIN);
-    WRITE(X2_STEP_PIN,INVERT_X_STEP_PIN);
+    OUT_WRITE(X2_STEP_PIN,INVERT_X_STEP_PIN);
     disable_x();
   #endif
   #if defined(Y_STEP_PIN) && (Y_STEP_PIN > -1)
-    SET_OUTPUT(Y_STEP_PIN);
-    WRITE(Y_STEP_PIN,INVERT_Y_STEP_PIN);
+    OUT_WRITE(Y_STEP_PIN,INVERT_Y_STEP_PIN);
     #if defined(Y_DUAL_STEPPER_DRIVERS) && defined(Y2_STEP_PIN) && (Y2_STEP_PIN > -1)
-      SET_OUTPUT(Y2_STEP_PIN);
-      WRITE(Y2_STEP_PIN,INVERT_Y_STEP_PIN);
+      OUT_WRITE(Y2_STEP_PIN,INVERT_Y_STEP_PIN);
     #endif
     disable_y();
   #endif
   #if defined(Z_STEP_PIN) && (Z_STEP_PIN > -1)
-    SET_OUTPUT(Z_STEP_PIN);
-    WRITE(Z_STEP_PIN,INVERT_Z_STEP_PIN);
+    OUT_WRITE(Z_STEP_PIN,INVERT_Z_STEP_PIN);
     #if defined(Z_DUAL_STEPPER_DRIVERS) && defined(Z2_STEP_PIN) && (Z2_STEP_PIN > -1)
-      SET_OUTPUT(Z2_STEP_PIN);
-      WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
+      OUT_WRITE(Z2_STEP_PIN,INVERT_Z_STEP_PIN);
     #endif
     disable_z();
   #endif
   #if defined(E0_STEP_PIN) && (E0_STEP_PIN > -1)
-    SET_OUTPUT(E0_STEP_PIN);
-    WRITE(E0_STEP_PIN,INVERT_E_STEP_PIN);
+    OUT_WRITE(E0_STEP_PIN,INVERT_E_STEP_PIN);
     disable_e0();
   #endif
   #if defined(E1_STEP_PIN) && (E1_STEP_PIN > -1)
-    SET_OUTPUT(E1_STEP_PIN);
-    WRITE(E1_STEP_PIN,INVERT_E_STEP_PIN);
+    OUT_WRITE(E1_STEP_PIN,INVERT_E_STEP_PIN);
     disable_e1();
   #endif
   #if defined(E2_STEP_PIN) && (E2_STEP_PIN > -1)
-    SET_OUTPUT(E2_STEP_PIN);
-    WRITE(E2_STEP_PIN,INVERT_E_STEP_PIN);
+    OUT_WRITE(E2_STEP_PIN,INVERT_E_STEP_PIN);
     disable_e2();
   #endif
   #if defined(E3_STEP_PIN) && (E3_STEP_PIN > -1)
-    SET_OUTPUT(E3_STEP_PIN);
-    WRITE(E3_STEP_PIN,INVERT_E_STEP_PIN);
+    OUT_WRITE(E3_STEP_PIN,INVERT_E_STEP_PIN);
     disable_e3();
   #endif
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -901,21 +901,15 @@ void tp_init()
   #ifdef HEATER_0_USES_MAX6675
 
     #ifndef SDSUPPORT
-      SET_OUTPUT(SCK_PIN);
-      WRITE(SCK_PIN,0);
-    
-      SET_OUTPUT(MOSI_PIN);
-      WRITE(MOSI_PIN,1);
-    
-      SET_INPUT(MISO_PIN);
-      WRITE(MISO_PIN,1);
+      OUT_WRITE(SCK_PIN, LOW);
+      OUT_WRITE(MOSI_PIN, HIGH);
+      OUT_WRITE(MISO_PIN, HIGH);
     #else
       pinMode(SS_PIN, OUTPUT);
       digitalWrite(SS_PIN, HIGH);
     #endif
     
-    SET_OUTPUT(MAX6675_SS);
-    WRITE(MAX6675_SS,1);
+    OUT_WRITE(MAX6675_SS,HIGH);
 
   #endif //HEATER_0_USES_MAX6675
 

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -832,32 +832,28 @@ static void lcd_implementation_drawmenu_sddirectory(uint8_t row, const char* pst
 
 static void lcd_implementation_quick_feedback()
 {
-#ifdef LCD_USE_I2C_BUZZER
-	#if !defined(LCD_FEEDBACK_FREQUENCY_HZ) || !defined(LCD_FEEDBACK_FREQUENCY_DURATION_MS)
-	  lcd_buzz(1000/6,100);
-	#else
-	  lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS,LCD_FEEDBACK_FREQUENCY_HZ);
-	#endif
-#elif defined(BEEPER) && BEEPER > -1
-    SET_OUTPUT(BEEPER);
-	#if !defined(LCD_FEEDBACK_FREQUENCY_HZ) || !defined(LCD_FEEDBACK_FREQUENCY_DURATION_MS)
-    for(int8_t i=0;i<10;i++)
-    {
-      WRITE(BEEPER,HIGH);
-      delayMicroseconds(100);
-      WRITE(BEEPER,LOW);
-      delayMicroseconds(100);
-    }
+  #ifdef LCD_USE_I2C_BUZZER
+    #if defined(LCD_FEEDBACK_FREQUENCY_DURATION_MS) && defined(LCD_FEEDBACK_FREQUENCY_HZ)
+      lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
     #else
-    for(int8_t i=0;i<(LCD_FEEDBACK_FREQUENCY_DURATION_MS / (1000 / LCD_FEEDBACK_FREQUENCY_HZ));i++)
-    {
-      WRITE(BEEPER,HIGH);
-      delayMicroseconds(1000000 / LCD_FEEDBACK_FREQUENCY_HZ / 2);
-      WRITE(BEEPER,LOW);
-      delayMicroseconds(1000000 / LCD_FEEDBACK_FREQUENCY_HZ / 2);
-    }
+      lcd_buzz(1000/6, 100);
     #endif
-#endif
+  #elif defined(BEEPER) && BEEPER > -1
+    SET_OUTPUT(BEEPER);
+    #if !defined(LCD_FEEDBACK_FREQUENCY_HZ) || !defined(LCD_FEEDBACK_FREQUENCY_DURATION_MS)
+      const unsigned int delay = 100;
+      uint8_t i = 10;
+    #else
+      const unsigned int delay = 1000000 / LCD_FEEDBACK_FREQUENCY_HZ / 2;
+      int8_t i = LCD_FEEDBACK_FREQUENCY_DURATION_MS * LCD_FEEDBACK_FREQUENCY_HZ / 1000;
+    #endif
+    while (i--) {
+      WRITE(BEEPER,HIGH);
+      delayMicroseconds(delay);
+      WRITE(BEEPER,LOW);
+      delayMicroseconds(delay);
+    }
+  #endif
 }
 
 #ifdef LCD_HAS_STATUS_INDICATORS

--- a/Marlin/ultralcd_st7920_u8glib_rrd.h
+++ b/Marlin/ultralcd_st7920_u8glib_rrd.h
@@ -47,12 +47,9 @@ uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
   {
     case U8G_DEV_MSG_INIT:
       {
-        SET_OUTPUT(ST7920_CS_PIN);
-        WRITE(ST7920_CS_PIN,0);
-        SET_OUTPUT(ST7920_DAT_PIN);
-        WRITE(ST7920_DAT_PIN,0);
-        SET_OUTPUT(ST7920_CLK_PIN);
-        WRITE(ST7920_CLK_PIN,1);
+        OUT_WRITE(ST7920_CS_PIN,LOW);
+        OUT_WRITE(ST7920_DAT_PIN,LOW);
+        OUT_WRITE(ST7920_CLK_PIN,HIGH);
 
         ST7920_CS();
         u8g_Delay(120);                 //initial delay for boot up


### PR DESCRIPTION
Adding support for articulating extruders using solenoids. This is useful for printers designed to "push down" the active extruder from the gantry.

M-Codes 380 and 381 have been added for the ability to manually control the solenoids.

Tool change will disable the current solenoid and activate the corresponding one for the newly selected extruder.
