### PR TITLE
Fix compile error in gcode_G29

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1772,8 +1772,6 @@ inline void gcode_G28() {
 
   inline void gcode_G29() {
 
-    float x_tmp, y_tmp, z_tmp, real_z;
-
     // Prevent user from running a G29 without first homing in X and Y
     if (!axis_known_position[X_AXIS] || !axis_known_position[Y_AXIS]) {
       LCD_MESSAGEPGM(MSG_POSITION_UNKNOWN);
@@ -1782,27 +1780,25 @@ inline void gcode_G28() {
       return;
     }
 
+    int verbose_level = 1;
+    float x_tmp, y_tmp, z_tmp, real_z;
+
+    if (code_seen('V') || code_seen('v')) {
+      verbose_level = code_value_long();
+      if (verbose_level < 0 || verbose_level > 4) {
+        SERIAL_PROTOCOLPGM("?(V)erbose Level is implausible (0-4).\n");
+        return;
+      }
+    }
+
     bool enhanced_g29 = code_seen('E') || code_seen('e');
 
     #ifdef AUTO_BED_LEVELING_GRID
 
-      // Example Syntax:  G29 N4 V2 E T
-      int verbose_level = 1;
+      bool topo_flag = verbose_level > 2 || code_seen('T') || code_seen('t');
 
-      bool topo_flag = code_seen('T') || code_seen('t');
-
-      if (code_seen('V') || code_seen('v')) {
-        verbose_level = code_value();
-        if (verbose_level < 0 || verbose_level > 4) {
-          SERIAL_PROTOCOLPGM("?(V)erbose Level is implausible (0-4).\n");
-          return;
-        }
-        if (verbose_level > 0) {
-          SERIAL_PROTOCOLPGM("G29 Enhanced Auto Bed Leveling Code V1.25:\n");
-          SERIAL_PROTOCOLPGM("Full support at: http://3dprintboard.com/forum.php\n");
-          if (verbose_level > 2) topo_flag = true;
-        }
-      }
+      if (verbose_level > 0)
+        SERIAL_PROTOCOLPGM("G29 Auto Bed Leveling\n");
 
       int auto_bed_leveling_grid_points = code_seen('P') ? code_value_long() : AUTO_BED_LEVELING_GRID_POINTS;
       if (auto_bed_leveling_grid_points < 2 || auto_bed_leveling_grid_points > AUTO_BED_LEVELING_GRID_POINTS) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2414,10 +2414,8 @@ inline void gcode_M42() {
       }
     }
 
-    if (verbose_level > 0)   {
-      SERIAL_PROTOCOLPGM("M48 Z-Probe Repeatability test.   Version 2.00\n");
-      SERIAL_PROTOCOLPGM("Full support at: http://3dprintboard.com/forum.php\n");
-    }
+    if (verbose_level > 0)
+      SERIAL_PROTOCOLPGM("M48 Z-Probe Repeatability test\n");
 
     if (code_seen('n')) {
       n_samples = code_value();
@@ -2431,7 +2429,7 @@ inline void gcode_M42() {
     Y_current = Y_probe_location = st_get_position_mm(Y_AXIS);
     Z_current = st_get_position_mm(Z_AXIS);
     Z_start_location = st_get_position_mm(Z_AXIS) + Z_RAISE_BEFORE_PROBING;
-    ext_position   = st_get_position_mm(E_AXIS);
+    ext_position = st_get_position_mm(E_AXIS);
 
     if (code_seen('E') || code_seen('e'))
       engage_probe_for_each_reading++;


### PR DESCRIPTION
- A redo of #1576, which missed topo_flag
- Always set verbose_level
- Remove credits lines
