### PR TITLE
fix typo in delta example config introduced in commit 697ee2d

### DIFF
--- a/Marlin/example_configurations/delta/Configuration.h
+++ b/Marlin/example_configurations/delta/Configuration.h
@@ -1,4 +1,4 @@
-﻿#ifndef CONFIGURATION_H
+#ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
 #include "boards.h"


### PR DESCRIPTION
there was some extended ascii garbage at the top of this file
