### PR TITLE
M404 should not use 'N' address as parameter because 'N' is reserved

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3861,11 +3861,11 @@ inline void gcode_M400() { st_synchronize(); }
 #ifdef FILAMENT_SENSOR
 
   /**
-   * M404: Display or set the nominal filament width (3mm, 1.75mm ) N<3.0>
+   * M404: Display or set the nominal filament width (3mm, 1.75mm ) W<3.0>
    */
   inline void gcode_M404() {
     #if FILWIDTH_PIN > -1
-      if (code_seen('N')) {
+      if (code_seen('W')) {
         filament_width_nominal = code_value();
       }
       else {


### PR DESCRIPTION
The current M404 command (display/set nominal filament width) uses the 'N' address for its parameter.  However, 'N' is globally reserved for line number -- it is supposed to be programatically generated by the host to protect against line noise.  So it is absolutely wrong to use 'N' address as a parameter for an M-code.  This pull request changes it to 'W', for width.  

I don't care what is actually used, but 'N' is wrong.
