### PR TITLE
fix a handful of cases where strtod() was cast to int, instead of just using strtol()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -765,7 +765,7 @@ void get_command()
           while(cmdbuffer[bufindw][count] != '*') checksum = checksum^cmdbuffer[bufindw][count++];
           strchr_pointer = strchr(cmdbuffer[bufindw], '*');
 
-          if( (int)(strtod(strchr_pointer + 1, NULL)) != checksum) {
+          if(strtol(strchr_pointer + 1, NULL, 10) != checksum) {
             SERIAL_ERROR_START;
             SERIAL_ERRORPGM(MSG_ERR_CHECKSUM_MISMATCH);
             SERIAL_ERRORLN(gcode_LastN);
@@ -801,7 +801,7 @@ void get_command()
       }
       if((strchr(cmdbuffer[bufindw], 'G') != NULL)){
         strchr_pointer = strchr(cmdbuffer[bufindw], 'G');
-        switch((int)((strtod(strchr_pointer + 1, NULL)))){
+        switch(strtol(strchr_pointer + 1, NULL, 10)){
         case 0:
         case 1:
         case 2:

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4198,7 +4198,7 @@ inline void gcode_M350() {
  */
 inline void gcode_M351() {
   #if defined(X_MS1_PIN) && X_MS1_PIN > -1
-    if (code_seen('S')) switch((int)code_value()) {
+    if (code_seen('S')) switch(code_value_long()) {
       case 1:
         for(int i=0;i<NUM_AXIS;i++) if (code_seen(axis_codes[i])) microstep_ms(i, code_value(), -1);
         if (code_seen('B')) microstep_ms(4, code_value(), -1);
@@ -4397,7 +4397,7 @@ void process_commands() {
   }
 
   else if (code_seen('M')) {
-    switch( (int)code_value() ) {
+    switch( code_value_long() ) {
       #ifdef ULTIPANEL
         case 0: // M0 - Unconditional stop - Wait for user button press on LCD
         case 1: // M1 - Conditional stop - Wait for user button press on LCD


### PR DESCRIPTION
Sometimes there was a strtod() or code_value() call that was cast to int, when really all that is wanted is to strtol() or code_value_long().  strtol() is faster, but most importantly, it is never wrong because of rounding errors.
