### PR TITLE
Fix `code_value` (so `G1X1E2` isn't evaluated as `G1 X100 E2`)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -909,7 +909,12 @@ void get_command()
 
 float code_value()
 {
-  return (strtod(strchr_pointer + 1, NULL));
+  float ret;
+  char *e = strchr(strchr_pointer, 'E');
+  if (e != NULL) *e = 0;
+  ret = strtod(strchr_pointer+1, NULL);
+  if (e != NULL) *e = 'E';
+  return ret;
 }
 
 long code_value_long()


### PR DESCRIPTION
A standard-conforming strtod() will read the E address value as if it was a base 10 exponent.

I'm submitting this separately from the other strtod changes because it might be a little bit more contentious.  I can think of two reasons no one else would see this problem:
- everyone else's host software inserts a space between G-code parameters, i.e. "X1 E1" instead of "X1E1"
- everyone else is using a different libc (I am using debian's avr-libc) which has a strtod() that doesn't support the E exponent feature

Anyways, the change is harmless even so, so I think it is a good idea..
