### PR TITLE
Reverse encoder for displays where turning clockwise decrease values.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -558,6 +558,7 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 //#define SD_CHECK_AND_RETRY // Use CRC checks and retries on the SD communication
 //#define ENCODER_PULSES_PER_STEP 1 // Increase if you have a high resolution encoder
 //#define ENCODER_STEPS_PER_MENU_ITEM 5 // Set according to ENCODER_PULSES_PER_STEP or your liking
+//#define ENCODER_COUNT_REVERSED 1 // Use to reverse direction of encoder, ie if clockwise turn decrement values
 //#define ULTIMAKERCONTROLLER //as available from the Ultimaker online store.
 //#define ULTIPANEL  //the UltiPanel as on Thingiverse
 //#define LCD_FEEDBACK_FREQUENCY_HZ 1000	// this is the tone frequency the buzzer plays when on UI feedback. ie Screen Click

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -9,6 +9,13 @@
 #include "ConfigurationStore.h"
 
 int8_t encoderDiff; /* encoderDiff is updated from interrupt context and added to encoderPosition every LCD update */
+#if ENCODER_COUNT_REVERSED
+  #define ENC_INC(_v) (_v--)
+  #define ENC_DEC(_v) (_v++)
+#else
+  #define ENC_INC(_v) (_v++)
+  #define ENC_DEC(_v) (_v--)
+#endif
 
 bool encoderRateMultiplierEnabled;
 int32_t lastEncoderMovementMillis;
@@ -1452,20 +1459,20 @@ void lcd_buttons_update() {
   if (enc != lastEncoderBits) {
     switch(enc) {
       case encrot0:
-        if (lastEncoderBits==encrot3) encoderDiff++;
-        else if (lastEncoderBits==encrot1) encoderDiff--;
+        if (lastEncoderBits==encrot3) ENC_INC(encoderDiff);
+        else if (lastEncoderBits==encrot1) ENC_DEC(encoderDiff);
         break;
       case encrot1:
-        if (lastEncoderBits==encrot0) encoderDiff++;
-        else if (lastEncoderBits==encrot2) encoderDiff--;
+        if (lastEncoderBits==encrot0) ENC_INC(encoderDiff);
+        else if (lastEncoderBits==encrot2) ENC_DEC(encoderDiff);
         break;
       case encrot2:
-        if (lastEncoderBits==encrot1) encoderDiff++;
-        else if (lastEncoderBits==encrot3) encoderDiff--;
+        if (lastEncoderBits==encrot1) ENC_INC(encoderDiff);
+        else if (lastEncoderBits==encrot3) ENC_DEC(encoderDiff);
         break;
       case encrot3:
-        if (lastEncoderBits==encrot2) encoderDiff++;
-        else if (lastEncoderBits==encrot0) encoderDiff--;
+        if (lastEncoderBits==encrot2) ENC_INC(encoderDiff);
+        else if (lastEncoderBits==encrot0) ENC_DEC(encoderDiff);
         break;
     }
   }


### PR DESCRIPTION
I am building a new printer and I am using RAMP 1.4 + a 128x64 LCD display from SainSmart.
The encoder direction felt totally wrong so I added this option to be able to change it.
