### PR TITLE
Negative times are unlikly

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1246,7 +1246,7 @@ void lcd_update() {
     }
   #endif//CARDINSERTED
 
-  long ms = millis();
+  uint32_t ms = millis();
   if (ms > lcd_next_update_millis) {
 
     #ifdef ULTIPANEL


### PR DESCRIPTION
While hunting an other bug I stumbled across:
ultralcd.cpp:1250: warning: comparison between signed and unsigned integer expressions
Changed to the type of lcd_next_update_millis.
