### PR TITLE
delta[3] not used when DELTA not defined.

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -383,10 +383,6 @@ const char echomagic[] PROGMEM = "echo:";
 const char axis_codes[NUM_AXIS] = {'X', 'Y', 'Z', 'E'};
 static float destination[NUM_AXIS] = { 0, 0, 0, 0 };
 
-#ifndef DELTA
-  static float delta[3] = { 0, 0, 0 };
-#endif
-
 static float offset[3] = { 0, 0, 0 };
 static bool home_all_axis = true;
 static float feedrate = 1500.0, next_feedrate, saved_feedrate;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -357,6 +357,7 @@ int fanSpeed = 0;
 
 #ifdef SCARA
   float axis_scaling[3] = { 1, 1, 1 };    // Build size scaling, default to 1
+  static float delta[3] = { 0, 0, 0 };		
 #endif        
 
 bool cancel_heatup = false;


### PR DESCRIPTION
got:
Marlin_main.cpp:387: warning: 'delta' defined but not used

Compiles cleaner when definition is removed.
