### PR TITLE
G4 could wait for an undefined time

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1690,7 +1690,7 @@ inline void gcode_G2_G3(bool clockwise) {
  * G4: Dwell S<seconds> or P<milliseconds>
  */
 inline void gcode_G4() {
-  unsigned long codenum;
+  unsigned long codenum=0;
 
   LCD_MESSAGEPGM(MSG_DWELL);
 


### PR DESCRIPTION
Got:
Marlin_main.cpp:1689: warning: 'codenum' may be used uninitialized in this function

And indeed codenum is undefined when no parameter is given.
