### PR TITLE
codepos not used in gcode_M28()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2564,14 +2564,14 @@ inline void gcode_M17() {
    * M28: Start SD Write
    */
   inline void gcode_M28() {
-//    char* codepos = strchr_pointer + 4; // ??? not used ???
-    char* starpos = strchr(strchr_pointer + 4, '*');
+    char* codepos = strchr_pointer + 4;
+    char* starpos = strchr(codepos, '*');
     if (starpos) {
       char* npos = strchr(cmdbuffer[bufindr], 'N');
       strchr_pointer = strchr(npos, ' ') + 1;
       *(starpos) = '\0';
     }
-    card.openFile(strchr_pointer + 4, false);
+    card.openFile(codepos, false);
   }
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2564,7 +2564,7 @@ inline void gcode_M17() {
    * M28: Start SD Write
    */
   inline void gcode_M28() {
-    char* codepos = strchr_pointer + 4;
+//    char* codepos = strchr_pointer + 4; // ??? not used ???
     char* starpos = strchr(strchr_pointer + 4, '*');
     if (starpos) {
       char* npos = strchr(cmdbuffer[bufindr], 'N');


### PR DESCRIPTION
Got:
Marlin_main.cpp:2567: warning: unused variable 'codepos'

Needs revision.
Don't now how this should look like.
