### PR TITLE
Fix for MAX6675 MINTEMP errors

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1585,15 +1585,17 @@ ISR(TIMER0_COMPB_vect) {
     for (int i = 0; i < EXTRUDERS; i++) raw_temp_value[i] = 0;
     raw_temp_bed_value = 0;
 
-    #if HEATER_0_RAW_LO_TEMP > HEATER_0_RAW_HI_TEMP
-      #define GE0 <=
-      #define LE0 >=
-    #else
-      #define GE0 >=
-      #define LE0 <=
+    #ifndef HEATER_0_USES_MAX6675
+      #if HEATER_0_RAW_LO_TEMP > HEATER_0_RAW_HI_TEMP
+        #define GE0 <=
+        #define LE0 >=
+      #else
+        #define GE0 >=
+        #define LE0 <=
+      #endif
+      if (current_temperature_raw[0] GE0 maxttemp_raw[0]) max_temp_error(0);
+      if (current_temperature_raw[0] LE0 minttemp_raw[0]) min_temp_error(0);
     #endif
-    if (current_temperature_raw[0] GE0 maxttemp_raw[0]) max_temp_error(0);
-    if (current_temperature_raw[0] LE0 minttemp_raw[0]) min_temp_error(0);
 
     #if EXTRUDERS > 1
       #if HEATER_1_RAW_LO_TEMP > HEATER_1_RAW_HI_TEMP


### PR DESCRIPTION
SD-Card and MAX6675, both use hardware SPI. They used to conflict.
For that reason the MAX code was puled out of the interrupt(#1402).
Since then for different reasons either the code did not compile or failed wit an MINTEMP error.
So a test was impossible until now.
Here I eliminate the MIN-MAX-Temp-Test for extruder0 in the interrupt when we are using MAX6675.

When tests are successful we can close #1226 and #1227 and https://github.com/MarlinFirmware/Marlin/milestones/Bug%20Fixing%20Round%203
