### PR TITLE
First aid for #1703

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1787,7 +1787,7 @@ inline void gcode_G28() {
 
   enable_endstops(true);
 
-  for (int i = X_AXIS; i <= NUM_AXIS; i++) destination[i] = current_position[i];
+  for (int i = X_AXIS; i < NUM_AXIS; i++) destination[i] = current_position[i];
 
   feedrate = 0.0;
 


### PR DESCRIPTION
< like in the other comparable loops

to avoid:
Marlin_main.cpp:1790: warning: array subscript is above array bounds.
