### PR TITLE
Some more corrections for warnings

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -347,11 +347,11 @@
   /**
    * Shorthand for pin tests, for temperature.cpp
    */
-  #define HAS_TEMP_0 (defined(TEMP_0_PIN) && TEMP_0_PIN >= 0)
-  #define HAS_TEMP_1 (defined(TEMP_1_PIN) && TEMP_1_PIN >= 0)
-  #define HAS_TEMP_2 (defined(TEMP_2_PIN) && TEMP_2_PIN >= 0)
-  #define HAS_TEMP_3 (defined(TEMP_3_PIN) && TEMP_3_PIN >= 0)
-  #define HAS_TEMP_BED (defined(TEMP_BED_PIN) && TEMP_BED_PIN >= 0)
+  #define HAS_TEMP_0 (defined(TEMP_0_PIN) && (TEMP_0_PIN >= 0) && TEMP_SENSOR_0)
+  #define HAS_TEMP_1 (defined(TEMP_1_PIN) && (TEMP_1_PIN >= 0) && TEMP_SENSOR_1)
+  #define HAS_TEMP_2 (defined(TEMP_2_PIN) && (TEMP_2_PIN >= 0) && TEMP_SENSOR_2)
+  #define HAS_TEMP_3 (defined(TEMP_3_PIN) && (TEMP_3_PIN >= 0) && TEMP_SENSOR_3)
+  #define HAS_TEMP_BED ((defined(TEMP_BED_PIN) && TEMP_BED_PIN >= 0) && TEMP_SENSOR_BED)
   #define HAS_FILAMENT_SENSOR (defined(FILAMENT_SENSOR) && defined(FILWIDTH_PIN) && FILWIDTH_PIN >= 0)
   #define HAS_HEATER_0 (defined(HEATER_0_PIN) && HEATER_0_PIN >= 0)
   #define HAS_HEATER_1 (defined(HEATER_1_PIN) && HEATER_1_PIN >= 0)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4283,7 +4283,7 @@ inline void gcode_M502() {
  * M503: print settings currently in memory
  */
 inline void gcode_M503() {
-  Config_PrintSettings(code_seen('S') && code_value == 0);
+  Config_PrintSettings(code_seen('S') && code_value() == 0);
 }
 
 #ifdef ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -489,7 +489,7 @@ void CardReader::updir() {
   if (workDirDepth > 0) {
     --workDirDepth;
     workDir = workDirParents[0];
-    for (int d = 0; d < workDirDepth; d++)
+    for (unsigned int d = 0; d < workDirDepth; d++)
       workDirParents[d] = workDirParents[d+1];
   }
 }

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1181,9 +1181,10 @@ static void set_current_temp_raw() {
   #endif
   #if HAS_TEMP_1
     #ifdef TEMP_SENSOR_1_AS_REDUNDANT
-      redundant_temperature_raw =
+      redundant_temperature_raw = raw_temp_value[1];
+    #else
+      current_temperature_raw[1] = raw_temp_value[1];
     #endif
-    current_temperature_raw[1] = raw_temp_value[1];
     #if HAS_TEMP_2
       current_temperature_raw[2] = raw_temp_value[2];
       #if HAS_TEMP_3


### PR DESCRIPTION
code_value is a function
else 0 is compared with the address of the function.

workDirDepth in CardReader.cpp is unsigned.

Define HAS_TEMP_X only when needed in Configuration.h …
For exanpe RAMPS has TEMP_1_PIN defined in its pin-file,
but it's only used when asked for with TEMP_SENSOR_1 != 0.
Avoids array-index problem in temperature.cpp
