### PR TITLE
Viki 2 Pins from Manual and Azteeg X3 Pro Endstop Reswap

### DIFF
--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -4,13 +4,33 @@
 
 #include "pins_RAMPS_13.h"
 
-#undef FAN_PIN
 #define FAN_PIN            9 // (Sprinter config)
-
-#undef HEATER_1_PIN
 #define HEATER_1_PIN       -1
 
-#ifdef TEMP_STAT_LEDS
+//LCD Pins//
+
+#if defined(VIKI2) || defined(miniVIKI)
+ #define BEEPER 33
+ // Pins for DOGM SPI LCD Support
+ #define DOGLCD_A0  31 
+ #define DOGLCD_CS  32 
+ #define LCD_SCREEN_ROT_180
+ 
+ //The encoder and click button 
+ #define BTN_EN1 22 
+ #define BTN_EN2 7
+ #define BTN_ENC 12  //the click switch
+ 
+ #define SDSS 53
+ #define SDCARDDETECT -1 // Pin 49 if using display sd interface   
+ 
+  #ifdef TEMP_STAT_LEDS
+   #define STAT_LED_RED 64
+   #define STAT_LED_BLUE 63
+  #endif
+#endif
+
+#elif define TEMP_STAT_LEDS
   #define STAT_LED_RED       6
   #define STAT_LED_BLUE     11
 #endif

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -20,19 +20,19 @@
 //Note: I had to solder on the additional MAX Endstop pins to attach a Z-Probe 
 //endstop switch.
 //
-#undef X_MIN_PIN
-#undef X_MAX_PIN
-#undef Y_MIN_PIN
-#undef Y_MAX_PIN
-#undef Z_MIN_PIN
-#undef Z_MAX_PIN
+//#undef X_MIN_PIN
+//#undef X_MAX_PIN
+//#undef Y_MIN_PIN
+//#undef Y_MAX_PIN
+//#undef Z_MIN_PIN
+//#undef Z_MAX_PIN
 
-#define X_MIN_PIN           2
-#define X_MAX_PIN           3
-#define Y_MIN_PIN          15
-#define Y_MAX_PIN          14
-#define Z_MIN_PIN          19
-#define Z_MAX_PIN          18
+//#define X_MIN_PIN           2
+//#define X_MAX_PIN           3
+//#define Y_MIN_PIN          15
+//#define Y_MAX_PIN          14
+//#define Z_MIN_PIN          19
+//#define Z_MAX_PIN          18
 //
 
 #define E2_STEP_PIN        23

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -16,21 +16,23 @@
 //
 //This section is to swap the MIN and MAX pins because the X3 Pro comes with only
 //MIN endstops soldered onto the board. Delta code wants the homing endstops to be 
-//the MAX so I swapped them here. UnComment the section below if you want this change.
+//the MAX so I swapped them here. Comment them out with // if you want them original.
+//Note: I had to solder on the additional MAX Endstop pins to attach a Z-Probe 
+//endstop switch.
 //
-//#undef X_MIN_PIN
-//#undef X_MAX_PIN
-//#undef Y_MIN_PIN
-//#undef Y_MAX_PIN
-//#undef Z_MIN_PIN
-//#undef Z_MAX_PIN
-//
-//#define X_MIN_PIN           2
-//#define X_MAX_PIN           3
-//#define Y_MIN_PIN          15
-//#define Y_MAX_PIN          14
-//#define Z_MIN_PIN          19
-//#define Z_MAX_PIN          18
+#undef X_MIN_PIN
+#undef X_MAX_PIN
+#undef Y_MIN_PIN
+#undef Y_MAX_PIN
+#undef Z_MIN_PIN
+#undef Z_MAX_PIN
+
+#define X_MIN_PIN           2
+#define X_MAX_PIN           3
+#define Y_MIN_PIN          15
+#define Y_MAX_PIN          14
+#define Z_MIN_PIN          19
+#define Z_MAX_PIN          18
 //
 
 #define E2_STEP_PIN        23
@@ -85,4 +87,27 @@
       #endif
     #endif
   #endif
+#endif
+
+//LCD Pins//
+
+#if defined(VIKI2) || defined(miniVIKI)
+ #define BEEPER 33
+ // Pins for DOGM SPI LCD Support
+ #define DOGLCD_A0  44
+ #define DOGLCD_CS  45
+ #define LCD_SCREEN_ROT_180
+ 
+ //The encoder and click button
+ #define BTN_EN1 22
+ #define BTN_EN2 7
+ #define BTN_ENC 39  //the click switch
+
+ #define SDSS 53
+ #define SDCARDDETECT 49
+ 
+ #define KILL_PIN 31
+ 
+ #define STAT_LED_RED       32
+ #define STAT_LED_BLUE      35
 #endif

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -16,23 +16,21 @@
 //
 //This section is to swap the MIN and MAX pins because the X3 Pro comes with only
 //MIN endstops soldered onto the board. Delta code wants the homing endstops to be 
-//the MAX so I swapped them here. Comment them out with // if you want them original.
-//Note: I had to solder on the additional MAX Endstop pins to attach a Z-Probe 
-//endstop switch.
+//the MAX so I swapped them here. UnComment the section below if you want this change.
 //
-#undef X_MIN_PIN
-#undef X_MAX_PIN
-#undef Y_MIN_PIN
-#undef Y_MAX_PIN
-#undef Z_MIN_PIN
-#undef Z_MAX_PIN
-
-#define X_MIN_PIN           2
-#define X_MAX_PIN           3
-#define Y_MIN_PIN          15
-#define Y_MAX_PIN          14
-#define Z_MIN_PIN          19
-#define Z_MAX_PIN          18
+//#undef X_MIN_PIN
+//#undef X_MAX_PIN
+//#undef Y_MIN_PIN
+//#undef Y_MAX_PIN
+//#undef Z_MIN_PIN
+//#undef Z_MAX_PIN
+//
+//#define X_MIN_PIN           2
+//#define X_MAX_PIN           3
+//#define Y_MIN_PIN          15
+//#define Y_MAX_PIN          14
+//#define Z_MIN_PIN          19
+//#define Z_MAX_PIN          18
 //
 
 #define E2_STEP_PIN        23
@@ -87,27 +85,4 @@
       #endif
     #endif
   #endif
-#endif
-
-//LCD Pins//
-
-#if defined(VIKI2) || defined(miniVIKI)
- #define BEEPER 33
- // Pins for DOGM SPI LCD Support
- #define DOGLCD_A0  44
- #define DOGLCD_CS  45
- #define LCD_SCREEN_ROT_180
- 
- //The encoder and click button
- #define BTN_EN1 22
- #define BTN_EN2 7
- #define BTN_ENC 39  //the click switch
-
- #define SDSS 53
- #define SDCARDDETECT 49
- 
- #define KILL_PIN 31
- 
- #define STAT_LED_RED       32
- #define STAT_LED_BLUE      35
 #endif

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -88,3 +88,26 @@
     #endif
   #endif
 #endif
+
+//LCD Pins//
+
+#if defined(VIKI2) || defined(miniVIKI)
+ #define BEEPER 33
+ // Pins for DOGM SPI LCD Support
+ #define DOGLCD_A0  44
+ #define DOGLCD_CS  45
+ #define LCD_SCREEN_ROT_180
+ 
+ //The encoder and click button
+ #define BTN_EN1 22
+ #define BTN_EN2 7
+ #define BTN_ENC 39  //the click switch
+
+ #define SDSS 53
+ #define SDCARDDETECT 49
+ 
+ #define KILL_PIN 31
+ 
+ #define STAT_LED_RED       32
+ #define STAT_LED_BLUE      35
+#endif

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -16,23 +16,23 @@
 //
 //This section is to swap the MIN and MAX pins because the X3 Pro comes with only
 //MIN endstops soldered onto the board. Delta code wants the homing endstops to be 
-//the MAX so I swapped them here. Comment them out with // if you want them original.
-//Note: I had to solder on the additional MAX Endstop pins to attach a Z-Probe 
-//endstop switch.
+//the MAX so I swapped them here.
 //
-//#undef X_MIN_PIN
-//#undef X_MAX_PIN
-//#undef Y_MIN_PIN
-//#undef Y_MAX_PIN
-//#undef Z_MIN_PIN
-//#undef Z_MAX_PIN
+ #ifdef DELTA
+  #undef X_MIN_PIN
+  #undef X_MAX_PIN
+  #undef Y_MIN_PIN
+  #undef Y_MAX_PIN
+  #undef Z_MIN_PIN
+  #undef Z_MAX_PIN
 
-//#define X_MIN_PIN           2
-//#define X_MAX_PIN           3
-//#define Y_MIN_PIN          15
-//#define Y_MAX_PIN          14
-//#define Z_MIN_PIN          19
-//#define Z_MAX_PIN          18
+  #define X_MIN_PIN           2
+  #define X_MAX_PIN           3
+  #define Y_MIN_PIN          15
+  #define Y_MAX_PIN          14
+  #define Z_MIN_PIN          19
+  #define Z_MAX_PIN          18
+ #endif
 //
 
 #define E2_STEP_PIN        23

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -59,6 +59,8 @@
 #define TEMP_1_PIN         -1
 #define TEMP_2_PIN         -1
 
+////LCD Pin Setup////
+
 #define SDPOWER            -1
 #define SDSS                8
 #define LED_PIN            -1
@@ -86,3 +88,24 @@
   //not connected to a pin
   #define SDCARDDETECT -1    
 #endif // ULTRA_LCD && NEWPANEL
+
+#if defined(VIKI2) || defined(miniVIKI)
+ #define BEEPER 32 //FastIO
+ // Pins for DOGM SPI LCD Support
+ #define DOGLCD_A0  42 //Non-FastIO
+ #define DOGLCD_CS  43 //Non-FastIO
+ #define LCD_SCREEN_ROT_180
+ 
+ //The encoder and click button (FastIO Pins)
+ #define BTN_EN1 26 
+ #define BTN_EN2 27
+ #define BTN_ENC 47  //the click switch
+
+ #define SDSS 45
+ #define SDCARDDETECT -1 // FastIO (Manual says 72 I'm not certain cause I can't test) 
+
+ #ifdef TEMP_STAT_LEDS
+  #define STAT_LED_RED      12 //Non-FastIO
+  #define STAT_LED_BLUE     10 //Non-FastIO
+ #endif  
+#endif

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -22,6 +22,17 @@
   #endif
 #endif
 
+#undef X_MS1_PIN
+#undef X_MS2_PIN
+#undef Y_MS1_PIN
+#undef Y_MS2_PIN
+#undef Z_MS1_PIN
+#undef Z_MS2_PIN
+#undef E0_MS1_PIN
+#undef E0_MS2_PIN
+#undef E1_MS1_PIN
+#undef E1_MS2_PIN
+ 
 #define X_STEP_PIN 37
 #define X_DIR_PIN 48
 #define X_MIN_PIN 12
@@ -75,6 +86,7 @@
 #define E1_MS1_PIN 63
 #define E1_MS2_PIN 64
 
+#undef DIGIPOTSS_PIN
 #define DIGIPOTSS_PIN 38
 #define DIGIPOT_CHANNELS {4,5,3,0,1} // X Y Z E0 E1 digipot channels to stepper driver mapping
 

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -148,6 +148,26 @@
 
 #endif // ULTRA_LCD
 
+#if defined(VIKI2) || defined(miniVIKI)
+ #define BEEPER 44
+ // Pins for DOGM SPI LCD Support
+ #define DOGLCD_A0  70 
+ #define DOGLCD_CS  71 
+ #define LCD_SCREEN_ROT_180
+  
+ //The encoder and click button 
+ #define BTN_EN1 85 
+ #define BTN_EN2 84
+ #define BTN_ENC 83  //the click switch
+
+ #define SDCARDDETECT -1 // Pin 72 if using easy adapter board   
+
+  #ifdef TEMP_STAT_LEDS
+   #define STAT_LED_RED      22
+   #define STAT_LED_BLUE     32 
+  #endif
+#endif // VIKI2/miniVIKI
+
 #ifdef FILAMENT_SENSOR
   //Filip added pin for Filament sensor analog input 
   #define FILWIDTH_PIN        3


### PR DESCRIPTION
I added in the pins into the new board files for the Azteeg X3, X3 Pro,
Printrboard, and Rambo. I'm sure it can be added for others too but
these are the manual specified pins. Just like many things here though,
I can't test for the boards other than the Azteeg X3 Pro. Hopefully it
works smoothly for everyone who happens on this nifty display. :)
