### PR TITLE
Fix G29 E and M48 n

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2108,8 +2108,8 @@ inline void gcode_G28() {
    *
    * Global Parameters:
    *
-   * E/e By default G29 engages / disengages the probe for each point.
-   *     Include "E" to engage and disengage the probe just once.
+   * E/e By default G29 will engages the probe, test the bed, then disengage.
+   *     Include "E" to engage/disengage the probe for each sample.
    *     There's no extra effect if you have a fixed probe.
    *     Usage: "G29 E" or "G29 e"
    *
@@ -2135,7 +2135,7 @@ inline void gcode_G28() {
     }
 
     bool dryrun = code_seen('D') || code_seen('d');
-    bool enhanced_g29 = code_seen('E') || code_seen('e');
+    bool engage_probe_for_each_reading = code_seen('E') || code_seen('e');
 
     #ifdef AUTO_BED_LEVELING_GRID
 
@@ -2293,16 +2293,14 @@ inline void gcode_G28() {
 
           // Enhanced G29 - Do not retract servo between probes
           ProbeAction act;
-          if (enhanced_g29) {
-            if (yProbe == front_probe_bed_position && xCount == 0)
-              act = ProbeEngage;
-            else if (yProbe == front_probe_bed_position + (yGridSpacing * (auto_bed_leveling_grid_points - 1)) && xCount == auto_bed_leveling_grid_points - 1)
-              act = ProbeRetract;
-            else
-              act = ProbeStay;
-          }
-          else
+          if (engage_probe_for_each_reading)
             act = ProbeEngageAndRetract;
+          else if (yProbe == front_probe_bed_position && xCount == 0)
+            act = ProbeEngage;
+          else if (yProbe == front_probe_bed_position + (yGridSpacing * (auto_bed_leveling_grid_points - 1)) && xCount == auto_bed_leveling_grid_points - 1)
+            act = ProbeRetract;
+          else
+            act = ProbeStay;
 
           measured_z = probe_pt(xProbe, yProbe, z_before, act, verbose_level);
 
@@ -2386,18 +2384,14 @@ inline void gcode_G28() {
 
       // Probe at 3 arbitrary points
       float z_at_pt_1, z_at_pt_2, z_at_pt_3;
-
-      if (enhanced_g29) {
-        // Basic Enhanced G29
-        z_at_pt_1 = probe_pt(ABL_PROBE_PT_1_X, ABL_PROBE_PT_1_Y, Z_RAISE_BEFORE_PROBING, ProbeEngage, verbose_level);
-        z_at_pt_2 = probe_pt(ABL_PROBE_PT_2_X, ABL_PROBE_PT_2_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, ProbeStay, verbose_level);
-        z_at_pt_3 = probe_pt(ABL_PROBE_PT_3_X, ABL_PROBE_PT_3_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, ProbeRetract, verbose_level);
-      }
-      else {
-        z_at_pt_1 = probe_pt(ABL_PROBE_PT_1_X, ABL_PROBE_PT_1_Y, Z_RAISE_BEFORE_PROBING, ProbeEngageAndRetract, verbose_level);
-        z_at_pt_2 = probe_pt(ABL_PROBE_PT_2_X, ABL_PROBE_PT_2_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, ProbeEngageAndRetract, verbose_level);
-        z_at_pt_3 = probe_pt(ABL_PROBE_PT_3_X, ABL_PROBE_PT_3_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, ProbeEngageAndRetract, verbose_level);
-      }
+      ProbeAction p1, p2, p3;
+      if (engage_probe_for_each_reading)
+        p1 = p2 = p3 = ProbeEngageAndRetract;
+      else
+        p1 = ProbeEngage, p2 = ProbeStay, p3 = ProbeRetract;
+      z_at_pt_1 = probe_pt(ABL_PROBE_PT_1_X, ABL_PROBE_PT_1_Y, Z_RAISE_BEFORE_PROBING, p1, verbose_level);
+      z_at_pt_2 = probe_pt(ABL_PROBE_PT_2_X, ABL_PROBE_PT_2_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, p2, verbose_level);
+      z_at_pt_3 = probe_pt(ABL_PROBE_PT_3_X, ABL_PROBE_PT_3_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, p3, verbose_level);
       clean_up_after_endstop_move();
       if (!dryrun) set_bed_level_equation_3pts(z_at_pt_1, z_at_pt_2, z_at_pt_3);
 
@@ -2764,7 +2758,7 @@ inline void gcode_M42() {
    *
    * Usage:
    *   M48 <n#> <X#> <Y#> <V#> <E> <L#>
-   *     n = Number of samples (4-50, default 10)
+   *     P = Number of sampled points (4-50, default 10)
    *     X = Sample X position
    *     Y = Sample Y position
    *     V = Verbose level (0-4, default=1)
@@ -2798,10 +2792,10 @@ inline void gcode_M42() {
     if (verbose_level > 0)
       SERIAL_PROTOCOLPGM("M48 Z-Probe Repeatability test\n");
 
-    if (code_seen('n')) {
+    if (code_seen('P') || code_seen('p') || code_seen('n')) { // `n` for legacy support only - please use `P`!
       n_samples = code_value();
       if (n_samples < 4 || n_samples > 50) {
-        SERIAL_PROTOCOLPGM("?Specified sample size not plausible (4-50).\n");
+        SERIAL_PROTOCOLPGM("?Sample size not plausible (4-50).\n");
         return;
       }
     }
@@ -2818,7 +2812,7 @@ inline void gcode_M42() {
     if (code_seen('X') || code_seen('x')) {
       X_probe_location = code_value() - X_PROBE_OFFSET_FROM_EXTRUDER;
       if (X_probe_location < X_MIN_POS || X_probe_location > X_MAX_POS) {
-        SERIAL_PROTOCOLPGM("?Specified X position out of range.\n");
+        SERIAL_PROTOCOLPGM("?X position out of range.\n");
         return;
       }
     }
@@ -2826,7 +2820,7 @@ inline void gcode_M42() {
     if (code_seen('Y') || code_seen('y')) {
       Y_probe_location = code_value() -  Y_PROBE_OFFSET_FROM_EXTRUDER;
       if (Y_probe_location < Y_MIN_POS || Y_probe_location > Y_MAX_POS) {
-        SERIAL_PROTOCOLPGM("?Specified Y position out of range.\n");
+        SERIAL_PROTOCOLPGM("?Y position out of range.\n");
         return;
       }
     }
@@ -2835,7 +2829,7 @@ inline void gcode_M42() {
       n_legs = code_value();
       if (n_legs == 1) n_legs = 2;
       if (n_legs < 0 || n_legs > 15) {
-        SERIAL_PROTOCOLPGM("?Specified number of legs in movement not plausible (0-15).\n");
+        SERIAL_PROTOCOLPGM("?Number of legs in movement not plausible (0-15).\n");
         return;
       }
     }
@@ -2858,7 +2852,7 @@ inline void gcode_M42() {
     // use that as a starting point for each probe.
     //
     if (verbose_level > 2)
-      SERIAL_PROTOCOL("Positioning probe for the test.\n");
+      SERIAL_PROTOCOL("Positioning the probe...\n");
 
     plan_buffer_line( X_probe_location, Y_probe_location, Z_start_location,
         ext_position,
@@ -2907,7 +2901,7 @@ inline void gcode_M42() {
         //SERIAL_ECHOPAIR("starting radius: ",radius);
         //SERIAL_ECHOPAIR("   theta: ",theta);
         //SERIAL_ECHOPAIR("   direction: ",rotational_direction);
-        //SERIAL_PROTOCOLLNPGM("");
+        //SERIAL_EOL;
 
         float dir = rotational_direction ? 1 : -1;
         for (l = 0; l < n_legs - 1; l++) {
@@ -2926,7 +2920,7 @@ inline void gcode_M42() {
           if (verbose_level > 3) {
             SERIAL_ECHOPAIR("x: ", X_current);
             SERIAL_ECHOPAIR("y: ", Y_current);
-            SERIAL_PROTOCOLLNPGM("");
+            SERIAL_EOL;
           }
 
           do_blocking_move_to( X_current, Y_current, Z_current );

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4927,14 +4927,13 @@ void process_commands() {
         case 665: // M665 set delta configurations L<diagonal_rod> R<delta_radius> S<segments_per_sec>
           gcode_M665();
           break;
-        case 666: // M666 set delta endstop adjustment
+      #endif
+
+      #if defined(DELTA) || defined(Z_DUAL_ENDSTOPS)
+        case 666: // M666 set delta / dual endstop adjustment
           gcode_M666();
           break;
-      #elif defined(Z_DUAL_ENDSTOPS)
-        case 666: // M666 set delta endstop adjustment
-          gcode_M666();
-          break;
-      #endif // DELTA
+      #endif
 
       #ifdef FWRETRACT
         case 207: //M207 - set retract length S[positive mm] F[feedrate mm/min] Z[additional zlift/hop]

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2382,16 +2382,17 @@ inline void gcode_G28() {
 
     #else // !AUTO_BED_LEVELING_GRID
 
-      // Probe at 3 arbitrary points
-      float z_at_pt_1, z_at_pt_2, z_at_pt_3;
+      // Actions for each probe
       ProbeAction p1, p2, p3;
       if (engage_probe_for_each_reading)
         p1 = p2 = p3 = ProbeEngageAndRetract;
       else
         p1 = ProbeEngage, p2 = ProbeStay, p3 = ProbeRetract;
-      z_at_pt_1 = probe_pt(ABL_PROBE_PT_1_X, ABL_PROBE_PT_1_Y, Z_RAISE_BEFORE_PROBING, p1, verbose_level);
-      z_at_pt_2 = probe_pt(ABL_PROBE_PT_2_X, ABL_PROBE_PT_2_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, p2, verbose_level);
-      z_at_pt_3 = probe_pt(ABL_PROBE_PT_3_X, ABL_PROBE_PT_3_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, p3, verbose_level);
+
+      // Probe at 3 arbitrary points
+      float z_at_pt_1 = probe_pt(ABL_PROBE_PT_1_X, ABL_PROBE_PT_1_Y, Z_RAISE_BEFORE_PROBING, p1, verbose_level),
+            z_at_pt_2 = probe_pt(ABL_PROBE_PT_2_X, ABL_PROBE_PT_2_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, p2, verbose_level),
+            z_at_pt_3 = probe_pt(ABL_PROBE_PT_3_X, ABL_PROBE_PT_3_Y, current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS, p3, verbose_level);
       clean_up_after_endstop_move();
       if (!dryrun) set_bed_level_equation_3pts(z_at_pt_1, z_at_pt_2, z_at_pt_3);
 


### PR DESCRIPTION
- Users prefer `G29 E` to work like `M48 E` so fixed that
- `M48 n` replaced with `M48 P` (or `p`). `n` legacy support
- Shorten some strings to save precious bytes
- Smaller code for 3-point probing
