### PR TITLE
Allow POWER_SUPPLY to be 0

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -265,15 +265,14 @@
   #ifndef POWER_SUPPLY
     #define POWER_SUPPLY 1
   #endif
-  #if (POWER_SUPPLY == 1)   // 1 = ATX
+  #if (POWER_SUPPLY == 1)     // 1 = ATX
     #define PS_ON_AWAKE  LOW
     #define PS_ON_ASLEEP HIGH
-  #endif
-  #if (POWER_SUPPLY == 2)   // 2 = X-Box 360 203W
+  #elif (POWER_SUPPLY == 2)   // 2 = X-Box 360 203W
     #define PS_ON_AWAKE  HIGH
     #define PS_ON_ASLEEP LOW
   #endif
-  HAS_POWER_SWITCH = POWER_SUPPLY > 0 && defined(PS_ON_PIN) && PS_ON_PIN >= 0
+  HAS_POWER_SWITCH = (POWER_SUPPLY > 0 && defined(PS_ON_PIN) && PS_ON_PIN >= 0)
 
   /**
    * Temp Sensor defines

--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -265,16 +265,15 @@
   #ifndef POWER_SUPPLY
     #define POWER_SUPPLY 1
   #endif
-  // 1 = ATX
-  #if (POWER_SUPPLY == 1)
+  #if (POWER_SUPPLY == 1)   // 1 = ATX
     #define PS_ON_AWAKE  LOW
     #define PS_ON_ASLEEP HIGH
   #endif
-  // 2 = X-Box 360 203W
-  #if (POWER_SUPPLY == 2)
+  #if (POWER_SUPPLY == 2)   // 2 = X-Box 360 203W
     #define PS_ON_AWAKE  HIGH
     #define PS_ON_ASLEEP LOW
   #endif
+  HAS_POWER_SWITCH = POWER_SUPPLY > 0 && defined(PS_ON_PIN) && PS_ON_PIN >= 0
 
   /**
    * Temp Sensor defines

--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -272,7 +272,7 @@
     #define PS_ON_AWAKE  HIGH
     #define PS_ON_ASLEEP LOW
   #endif
-  HAS_POWER_SWITCH = (POWER_SUPPLY > 0 && defined(PS_ON_PIN) && PS_ON_PIN >= 0)
+  #define HAS_POWER_SWITCH (POWER_SUPPLY > 0 && defined(PS_ON_PIN) && PS_ON_PIN >= 0)
 
   /**
    * Temp Sensor defines

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -168,12 +168,12 @@
 // M401 - Lower z-probe if present
 // M402 - Raise z-probe if present
 // M404 - N<dia in mm> Enter the nominal filament width (3mm, 1.75mm ) or will display nominal filament width without parameters
-// M405 - Turn on Filament Sensor extrusion control.  Optional D<delay in cm> to set delay in centimeters between sensor and extruder 
-// M406 - Turn off Filament Sensor extrusion control 
-// M407 - Displays measured filament diameter 
+// M405 - Turn on Filament Sensor extrusion control.  Optional D<delay in cm> to set delay in centimeters between sensor and extruder
+// M406 - Turn off Filament Sensor extrusion control
+// M407 - Display measured filament diameter
 // M500 - Store parameters in EEPROM
 // M501 - Read parameters from EEPROM (if you need reset them after you changed them temporarily).
-// M502 - Revert to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
+// M502 - Revert to the default "factory settings". You still need to store them in EEPROM afterwards if you want to.
 // M503 - Print the current settings (from memory not from EEPROM). Use S0 to leave off headings.
 // M540 - Use S[0|1] to enable or disable the stop SD card print on endstop hit (requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
 // M600 - Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
@@ -310,14 +310,14 @@ int fanSpeed = 0;
 bool cancel_heatup = false;
 
 #ifdef FILAMENT_SENSOR
-  //Variables for Filament Sensor input 
-  float filament_width_nominal=DEFAULT_NOMINAL_FILAMENT_DIA;  //Set nominal filament width, can be changed with M404 
-  bool filament_sensor=false;  //M405 turns on filament_sensor control, M406 turns it off 
-  float filament_width_meas=DEFAULT_MEASURED_FILAMENT_DIA; //Stores the measured filament diameter 
-  signed char measurement_delay[MAX_MEASUREMENT_DELAY+1];  //ring buffer to delay measurement  store extruder factor after subtracting 100 
-  int delay_index1=0;  //index into ring buffer
-  int delay_index2=-1;  //index into ring buffer - set to -1 on startup to indicate ring buffer needs to be initialized
-  float delay_dist=0; //delay distance counter  
+  //Variables for Filament Sensor input
+  float filament_width_nominal = DEFAULT_NOMINAL_FILAMENT_DIA;  //Set nominal filament width, can be changed with M404
+  bool filament_sensor = false;  //M405 turns on filament_sensor control, M406 turns it off
+  float filament_width_meas = DEFAULT_MEASURED_FILAMENT_DIA; //Stores the measured filament diameter
+  signed char measurement_delay[MAX_MEASUREMENT_DELAY+1];  //ring buffer to delay measurement  store extruder factor after subtracting 100
+  int delay_index1 = 0;  //index into ring buffer
+  int delay_index2 = -1;  //index into ring buffer - set to -1 on startup to indicate ring buffer needs to be initialized
+  float delay_dist = 0; //delay distance counter
   int meas_delay_cm = MEASUREMENT_DELAY_CM;  //distance delay setting
 #endif
 
@@ -516,7 +516,7 @@ void setup_powerhold()
   #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
     OUT_WRITE(SUICIDE_PIN, HIGH);
   #endif
-  #if defined(PS_ON_PIN) && PS_ON_PIN > -1
+  #if HAS_POWER_SWITCH
     #if defined(PS_DEFAULT_OFF)
       OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
     #else
@@ -898,7 +898,7 @@ bool code_seen(char code) {
   strchr_pointer = strchr(cmdbuffer[bufindr], code);
   return (strchr_pointer != NULL);  //Return True if a character was found
 }
-  
+
 #define DEFINE_PGM_READ_ANY(type, reader)       \
     static inline type pgm_read_any(const type *p)  \
     { return pgm_read_##reader##_near(p); }
@@ -3291,7 +3291,7 @@ inline void gcode_M140() {
   if (code_seen('S')) setTargetBed(code_value());
 }
 
-#if defined(PS_ON_PIN) && PS_ON_PIN > -1
+#if HAS_POWER_SWITCH
 
   /**
    * M80: Turn on Power Supply
@@ -3313,33 +3313,33 @@ inline void gcode_M140() {
     #endif
   }
 
-#endif // PS_ON_PIN
-
-/**
- * M81: Turn off Power Supply
- */
-inline void gcode_M81() {
-  disable_heater();
-  st_synchronize();
-  disable_e0();
-  disable_e1();
-  disable_e2();
-  disable_e3();
-  finishAndDisableSteppers();
-  fanSpeed = 0;
-  delay(1000); // Wait 1 second before switching off
-  #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
+  /**
+   * M81: Turn off Power Supply
+   */
+  inline void gcode_M81() {
+    disable_heater();
     st_synchronize();
-    suicide();
-  #elif defined(PS_ON_PIN) && PS_ON_PIN > -1
-    OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
-  #endif
-  #ifdef ULTIPANEL
-    powersupply = false;
-    LCD_MESSAGEPGM(MACHINE_NAME " " MSG_OFF ".");
-    lcd_update();
-  #endif
-}
+    disable_e0();
+    disable_e1();
+    disable_e2();
+    disable_e3();
+    finishAndDisableSteppers();
+    fanSpeed = 0;
+    delay(1000); // Wait 1 second before switching off
+    #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
+      st_synchronize();
+      suicide();
+    #elif HAS_POWER_SWITCH
+      OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+    #endif
+    #ifdef ULTIPANEL
+      powersupply = false;
+      LCD_MESSAGEPGM(MACHINE_NAME " " MSG_OFF ".");
+      lcd_update();
+    #endif
+  }
+
+#endif // PS_ON_PIN
 
 /**
  * M82: Set E codes absolute (default)

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -44,7 +44,9 @@ static void lcd_status_screen();
 
 #ifdef ULTIPANEL
 
-  extern bool powersupply;
+  #if HAS_POWER_SWITCH
+    extern bool powersupply;
+  #endif
   static float manual_feedrate[] = MANUAL_FEEDRATE;
   static void lcd_main_menu();
   static void lcd_tune_menu();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -616,6 +616,7 @@ static void lcd_prepare_menu() {
   MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
   MENU_ITEM(function, MSG_SET_HOME_OFFSETS, lcd_set_home_offsets);
   //MENU_ITEM(gcode, MSG_SET_ORIGIN, PSTR("G92 X0 Y0 Z0"));
+
   #if TEMP_SENSOR_0 != 0
     #if TEMP_SENSOR_1 != 0 || TEMP_SENSOR_2 != 0 || TEMP_SENSOR_3 != 0 || TEMP_SENSOR_BED != 0
       MENU_ITEM(submenu, MSG_PREHEAT_PLA, lcd_preheat_pla_menu);
@@ -625,15 +626,16 @@ static void lcd_prepare_menu() {
       MENU_ITEM(function, MSG_PREHEAT_ABS, lcd_preheat_abs0);
     #endif
   #endif
+
   MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
-  #if defined(POWER_SUPPLY) && POWER_SUPPLY > 0 && defined(PS_ON_PIN) && PS_ON_PIN > -1
-    if (powersupply) {
+
+  #if HAS_POWER_SWITCH
+    if (powersupply)
       MENU_ITEM(gcode, MSG_SWITCH_PS_OFF, PSTR("M81"));
-    }
-    else {
+    else
       MENU_ITEM(gcode, MSG_SWITCH_PS_ON, PSTR("M80"));
-    }
   #endif
+
   MENU_ITEM(submenu, MSG_MOVE_AXIS, lcd_move_menu);
 
   #if defined(MANUAL_BED_LEVELING)
@@ -1338,7 +1340,7 @@ void lcd_update() {
               }
 
               lastEncoderMovementMillis = ms;
-            }
+            } // encoderRateMultiplierEnabled
           #endif //ENCODER_RATE_MULTIPLIER
 
           lcdDrawUpdate = 1;
@@ -1541,70 +1543,62 @@ bool lcd_clicked() { return LCD_CLICKED; }
 
 #endif //ULTIPANEL
 
-/********************************/
-/** Float conversion utilities **/
-/********************************/
-//  convert float to string with +123.4 format
+/*********************************/
+/** Number to string conversion **/
+/*********************************/
+
 char conv[8];
-char *ftostr3(const float &x)
-{
+
+// Convert float to string with +123.4 format
+char *ftostr3(const float &x) {
   return itostr3((int)x);
 }
 
-char *itostr2(const uint8_t &x)
-{
+// Convert int to string with 12 format
+char *itostr2(const uint8_t &x) {
   //sprintf(conv,"%5.1f",x);
-  int xx=x;
-  conv[0]=(xx/10)%10+'0';
-  conv[1]=(xx)%10+'0';
-  conv[2]=0;
+  int xx = x;
+  conv[0] = (xx / 10) % 10 + '0';
+  conv[1] = xx % 10 + '0';
+  conv[2] = 0;
+  return conv;
+}
+
+// Convert float to string with +123.4 format
+char *ftostr31(const float &x) {
+  int xx = abs(x * 10);
+  conv[0] = (x >= 0) ? '+' : '-';
+  conv[1] = (xx / 1000) % 10 + '0';
+  conv[2] = (xx / 100) % 10 + '0';
+  conv[3] = (xx / 10) % 10 + '0';
+  conv[4] = '.';
+  conv[5] = xx % 10 + '0';
+  conv[6] = 0;
   return conv;
 }
 
 // Convert float to string with 123.4 format, dropping sign
-char *ftostr31(const float &x)
-{
-  int xx=x*10;
-  conv[0]=(xx>=0)?'+':'-';
-  xx=abs(xx);
-  conv[1]=(xx/1000)%10+'0';
-  conv[2]=(xx/100)%10+'0';
-  conv[3]=(xx/10)%10+'0';
-  conv[4]='.';
-  conv[5]=(xx)%10+'0';
-  conv[6]=0;
+char *ftostr31ns(const float &x) {
+  int xx = abs(x * 10);
+  conv[0] = (xx / 1000) % 10 + '0';
+  conv[1] = (xx / 100) % 10 + '0';
+  conv[2] = (xx / 10) % 10 + '0';
+  conv[3] = '.';
+  conv[4] = xx % 10 + '0';
+  conv[5] = 0;
   return conv;
 }
 
 // Convert float to string with 123.4 format
-char *ftostr31ns(const float &x)
-{
-  int xx=x*10;
-  //conv[0]=(xx>=0)?'+':'-';
-  xx=abs(xx);
-  conv[0]=(xx/1000)%10+'0';
-  conv[1]=(xx/100)%10+'0';
-  conv[2]=(xx/10)%10+'0';
-  conv[3]='.';
-  conv[4]=(xx)%10+'0';
-  conv[5]=0;
-  return conv;
-}
-
-char *ftostr32(const float &x)
-{
-  long xx=x*100;
-  if (xx >= 0)
-    conv[0]=(xx/10000)%10+'0';
-  else
-    conv[0]='-';
-  xx=abs(xx);
-  conv[1]=(xx/1000)%10+'0';
-  conv[2]=(xx/100)%10+'0';
-  conv[3]='.';
-  conv[4]=(xx/10)%10+'0';
-  conv[5]=(xx)%10+'0';
-  conv[6]=0;
+char *ftostr32(const float &x) {
+  long xx = abs(x * 100);
+  conv[0] = x >= 0 ? (xx / 10000) % 10 + '0' : '-';
+  conv[1] = (xx / 1000) % 10 + '0';
+  conv[2] = (xx / 100) % 10 + '0';
+  conv[3] = '.';
+  conv[4] = (xx / 10) % 10 + '0';
+  conv[5] = xx % 10 + '0';
+  conv[6] = 0;
   return conv;
 }
 
@@ -1625,7 +1619,7 @@ char *ftostr43(const float &x)
 	return conv;
 }
 
-//Float to string with 1.23 format
+// Convert float to string with 1.23 format
 char *ftostr12ns(const float &x)
 {
   long xx=x*100;
@@ -1639,7 +1633,7 @@ char *ftostr12ns(const float &x)
   return conv;
 }
 
-//  convert float to space-padded string with -_23.4_ format
+// Convert float to space-padded string with -_23.4_ format
 char *ftostr32sp(const float &x) {
   long xx = abs(x * 100);
   uint8_t dig;
@@ -1685,58 +1679,51 @@ char *ftostr32sp(const float &x) {
   return conv;
 }
 
-char *itostr31(const int &xx)
-{
-  conv[0]=(xx>=0)?'+':'-';
-  conv[1]=(xx/1000)%10+'0';
-  conv[2]=(xx/100)%10+'0';
-  conv[3]=(xx/10)%10+'0';
-  conv[4]='.';
-  conv[5]=(xx)%10+'0';
-  conv[6]=0;
+// Convert int to lj string with +123.0 format
+char *itostr31(const int &x) {
+  conv[0] = x >= 0 ? '+' : '-';
+  int xx = abs(x);
+  conv[1] = (xx / 100) % 10 + '0';
+  conv[2] = (xx / 10) % 10 + '0';
+  conv[3] = xx % 10 + '0';
+  conv[4] = '.';
+  conv[5] = '0';
+  conv[6] = 0;
   return conv;
 }
 
 // Convert int to rj string with 123 or -12 format
-char *itostr3(const int &x)
-{
+char *itostr3(const int &x) {
   int xx = x;
   if (xx < 0) {
-     conv[0]='-';
+     conv[0] = '-';
      xx = -xx;
-  } else if (xx >= 100)
-    conv[0]=(xx/100)%10+'0';
+  }
   else
-    conv[0]=' ';
-  if (xx >= 10)
-    conv[1]=(xx/10)%10+'0';
-  else
-    conv[1]=' ';
-  conv[2]=(xx)%10+'0';
-  conv[3]=0;
+    conv[0] = xx >= 100 ? (xx / 100) % 10 + '0' : ' ';
+
+  conv[1] = xx >= 10 ? (xx / 10) % 10 + '0' : ' ';
+  conv[2] = xx % 10 + '0';
+  conv[3] = 0;
   return conv;
 }
 
 // Convert int to lj string with 123 format
-char *itostr3left(const int &xx)
-{
-  if (xx >= 100)
-  {
-    conv[0]=(xx/100)%10+'0';
-    conv[1]=(xx/10)%10+'0';
-    conv[2]=(xx)%10+'0';
-    conv[3]=0;
+char *itostr3left(const int &xx) {
+  if (xx >= 100) {
+    conv[0] = (xx / 100) % 10 + '0';
+    conv[1] = (xx / 10) % 10 + '0';
+    conv[2] = xx % 10 + '0';
+    conv[3] = 0;
   }
-  else if (xx >= 10)
-  {
-    conv[0]=(xx/10)%10+'0';
-    conv[1]=(xx)%10+'0';
-    conv[2]=0;
+  else if (xx >= 10) {
+    conv[0] = (xx / 10) % 10 + '0';
+    conv[1] = xx % 10 + '0';
+    conv[2] = 0;
   }
-  else
-  {
-    conv[0]=(xx)%10+'0';
-    conv[1]=0;
+  else {
+    conv[0] = xx % 10 + '0';
+    conv[1] = 0;
   }
   return conv;
 }
@@ -1764,34 +1751,30 @@ char *ftostr5(const float &x) {
 }
 
 // Convert float to string with +1234.5 format
-char *ftostr51(const float &x)
-{
-  long xx=x*10;
-  conv[0]=(xx>=0)?'+':'-';
-  xx=abs(xx);
-  conv[1]=(xx/10000)%10+'0';
-  conv[2]=(xx/1000)%10+'0';
-  conv[3]=(xx/100)%10+'0';
-  conv[4]=(xx/10)%10+'0';
-  conv[5]='.';
-  conv[6]=(xx)%10+'0';
-  conv[7]=0;
+char *ftostr51(const float &x) {
+  long xx = abs(x * 10);
+  conv[0] = (x >= 0) ? '+' : '-';
+  conv[1] = (xx / 10000) % 10 + '0';
+  conv[2] = (xx / 1000) % 10 + '0';
+  conv[3] = (xx / 100) % 10 + '0';
+  conv[4] = (xx / 10) % 10 + '0';
+  conv[5] = '.';
+  conv[6] = xx % 10 + '0';
+  conv[7] = 0;
   return conv;
 }
 
 // Convert float to string with +123.45 format
-char *ftostr52(const float &x)
-{
-  long xx=x*100;
-  conv[0]=(xx>=0)?'+':'-';
-  xx=abs(xx);
-  conv[1]=(xx/10000)%10+'0';
-  conv[2]=(xx/1000)%10+'0';
-  conv[3]=(xx/100)%10+'0';
-  conv[4]='.';
-  conv[5]=(xx/10)%10+'0';
-  conv[6]=(xx)%10+'0';
-  conv[7]=0;
+char *ftostr52(const float &x) {
+  conv[0] = (x >= 0) ? '+' : '-';
+  long xx = abs(x * 100);
+  conv[1] = (xx / 10000) % 10 + '0';
+  conv[2] = (xx / 1000) % 10 + '0';
+  conv[3] = (xx / 100) % 10 + '0';
+  conv[4] = '.';
+  conv[5] = (xx / 10) % 10 + '0';
+  conv[6] = xx % 10 + '0';
+  conv[7] = 0;
   return conv;
 }
 


### PR DESCRIPTION
Some printers have no power switch, so disable those options when POWER_SUPPLY is 0.
- Includes cleanup of number-to-string functions
