### PR TITLE
Fix up LCD_PROGRESS_BAR

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -846,7 +846,7 @@ void get_command()
         sprintf_P(time, PSTR("%i hours %i minutes"),hours, minutes);
         SERIAL_ECHO_START;
         SERIAL_ECHOLN(time);
-        lcd_setstatus(time);
+        lcd_setstatus(time, true);
         card.printingHasFinished();
         card.checkautostart(true);
 
@@ -2536,9 +2536,13 @@ inline void gcode_G92() {
     if (starpos != NULL) *(starpos) = '\0';
     while (*src == ' ') ++src;
     if (!hasP && !hasS && *src != '\0')
-      lcd_setstatus(src);
-    else
+      lcd_setstatus(src, true);
+    else {
       LCD_MESSAGEPGM(MSG_USERWAIT);
+      #if defined(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0
+        dontExpireStatus();
+      #endif
+    }
 
     lcd_ignore_click();
     st_synchronize();

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -17,8 +17,11 @@
    * Progress Bar
    */
   #ifdef LCD_PROGRESS_BAR
+    #ifndef SDSUPPORT
+      #error LCD_PROGRESS_BAR requires SDSUPPORT.
+    #endif
     #ifdef DOGLCD
-      #warning LCD_PROGRESS_BAR does not apply to graphical displays.
+      #error LCD_PROGRESS_BAR does not apply to graphical displays.
     #endif
     #ifdef FILAMENT_LCD_DISPLAY
       #error LCD_PROGRESS_BAR and FILAMENT_LCD_DISPLAY are not fully compatible. Comment out this line to use both.

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -252,7 +252,7 @@ static void lcd_goto_menu(menuFunc_t menu, const uint32_t encoder=0, const bool 
     if (feedback) lcd_quick_feedback();
 
     // For LCD_PROGRESS_BAR re-initialize the custom characters
-    #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT) && !defined(DOGLCD)
+    #ifdef LCD_PROGRESS_BAR
       lcd_set_custom_characters(menu == lcd_status_screen);
     #endif
   }
@@ -262,29 +262,32 @@ static void lcd_goto_menu(menuFunc_t menu, const uint32_t encoder=0, const bool 
 static void lcd_status_screen()
 {
 	encoderRateMultiplierEnabled = false;
-  #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT) && !defined(DOGLCD)
-    uint16_t mil = millis();
+
+  #ifdef LCD_PROGRESS_BAR
+    unsigned long ms = millis();
     #ifndef PROGRESS_MSG_ONCE
-      if (mil > progressBarTick + PROGRESS_BAR_MSG_TIME + PROGRESS_BAR_BAR_TIME) {
-        progressBarTick = mil;
+      if (ms > progressBarTick + PROGRESS_BAR_MSG_TIME + PROGRESS_BAR_BAR_TIME) {
+        progressBarTick = ms;
       }
     #endif
     #if PROGRESS_MSG_EXPIRE > 0
-      // keep the message alive if paused, count down otherwise
-      if (messageTick > 0) {
+      // Handle message expire
+      if (expireStatusMillis > 0) {
         if (card.isFileOpen()) {
+          // Expire the message when printing is active
           if (IS_SD_PRINTING) {
-            if ((mil-messageTick) >= PROGRESS_MSG_EXPIRE) {
+            // Expire the message when printing is active
+            if (ms >= expireStatusMillis) {
               lcd_status_message[0] = '\0';
-              messageTick = 0;
+              expireStatusMillis = 0;
             }
           }
           else {
-            messageTick += LCD_UPDATE_INTERVAL;
+            expireStatusMillis += LCD_UPDATE_INTERVAL;
           }
         }
         else {
-          messageTick = 0;
+          expireStatusMillis = 0;
         }
       }
     #endif
@@ -324,7 +327,7 @@ static void lcd_status_screen()
     {
         lcd_goto_menu(lcd_main_menu);
         lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
-          #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT) && !defined(DOGLCD)
+          #ifdef LCD_PROGRESS_BAR
             currentMenu == lcd_status_screen
           #endif
         );
@@ -380,7 +383,7 @@ static void lcd_sdcard_stop() {
   card.closefile();
   autotempShutdown();
   cancel_heatup = true;
-  lcd_setstatus(MSG_PRINT_ABORTED);
+  lcd_setstatus(MSG_PRINT_ABORTED, true);
 }
 
 /* Menu implementation */
@@ -1275,7 +1278,7 @@ void lcd_update() {
       lcdDrawUpdate = 2;
       lcd_oldcardstatus = IS_SD_INSERTED;
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
-        #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT) && !defined(DOGLCD)
+        #ifdef LCD_PROGRESS_BAR
           currentMenu == lcd_status_screen
         #endif
       );
@@ -1393,7 +1396,7 @@ void lcd_ignore_click(bool b) {
   wait_for_unclick = false;
 }
 
-void lcd_finishstatus() {
+void lcd_finishstatus(bool persist=false) {
   int len = lcd_strlen(lcd_status_message);
   if (len > 0) {
     while (len < LCD_WIDTH) {
@@ -1401,11 +1404,11 @@ void lcd_finishstatus() {
     }
   }
   lcd_status_message[LCD_WIDTH] = '\0';
-  #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT) && !defined(DOGLCD)
-    #if PROGRESS_MSG_EXPIRE > 0
-      messageTick =
-    #endif
+  #ifdef LCD_PROGRESS_BAR
     progressBarTick = millis();
+    #if PROGRESS_MSG_EXPIRE > 0
+      expireStatusMillis = persist ? 0 : progressBarTick + PROGRESS_MSG_EXPIRE;
+    #endif
   #endif
   lcdDrawUpdate = 2;
 
@@ -1414,21 +1417,26 @@ void lcd_finishstatus() {
   #endif
 }
 
-void lcd_setstatus(const char* message) {
+#if defined(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0
+  void dontExpireStatus() { expireStatusMillis = 0; }
+#endif
+
+void lcd_setstatus(const char* message, bool persist) {
   if (lcd_status_message_level > 0) return;
   strncpy(lcd_status_message, message, LCD_WIDTH);
-  lcd_finishstatus();
+  lcd_finishstatus(persist);
 }
 
-void lcd_setstatuspgm(const char* message) {
-  if (lcd_status_message_level > 0) return;
-  strncpy_P(lcd_status_message, message, LCD_WIDTH);
-  lcd_finishstatus();
+void lcd_setstatuspgm(const char* message, uint8_t level) {
+  if (level >= lcd_status_message_level) {
+    strncpy_P(lcd_status_message, message, LCD_WIDTH);
+    lcd_status_message_level = level;
+    lcd_finishstatus(level > 0);
+  }
 }
 
 void lcd_setalertstatuspgm(const char* message) {
-  lcd_setstatuspgm(message);
-  lcd_status_message_level = 1;
+  lcd_setstatuspgm(message, 1);
   #ifdef ULTIPANEL
     lcd_return_to_status();
   #endif

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -8,11 +8,15 @@
   int lcd_strlen_P(const char *s);
   void lcd_update();
   void lcd_init();
-  void lcd_setstatus(const char* message);
-  void lcd_setstatuspgm(const char* message);
+  void lcd_setstatus(const char* message, const bool persist=false);
+  void lcd_setstatuspgm(const char* message, const uint8_t level=0);
   void lcd_setalertstatuspgm(const char* message);
   void lcd_reset_alert_level();
   bool lcd_detected(void);
+
+  #if defined(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0
+    void dontExpireStatus();
+  #endif
 
   #ifdef DOGLCD
     extern int lcd_contrast;

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -193,10 +193,10 @@
 
 #include "utf_mapper.h"
 
-#if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
+#ifdef LCD_PROGRESS_BAR
   static uint16_t progressBarTick = 0;
   #if PROGRESS_MSG_EXPIRE > 0
-    static uint16_t messageTick = 0;
+    static uint16_t expireStatusMillis = 0;
   #endif
   #define LCD_STR_PROGRESS  "\x03\x04\x05"
 #endif
@@ -214,7 +214,7 @@
 #define LCD_STR_ARROW_RIGHT ">"  /* from the default character set */
 
 static void lcd_set_custom_characters(
-  #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
+  #ifdef LCD_PROGRESS_BAR
     bool progress_bar_set=true
   #endif
 ) {
@@ -299,7 +299,7 @@ static void lcd_set_custom_characters(
     B00000
   }; //thanks Sonny Mounicou
 
-  #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
+  #ifdef LCD_PROGRESS_BAR
     static bool char_mode = false;
     byte progress[3][8] = { {
       B00000,
@@ -360,7 +360,7 @@ static void lcd_set_custom_characters(
 }
 
 static void lcd_implementation_init(
-  #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
+  #ifdef LCD_PROGRESS_BAR
     bool progress_bar_set=true
   #endif
 ) {
@@ -390,7 +390,7 @@ static void lcd_implementation_init(
 #endif
 
     lcd_set_custom_characters(
-        #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
+        #ifdef LCD_PROGRESS_BAR
             progress_bar_set
         #endif
     );
@@ -583,7 +583,7 @@ static void lcd_implementation_status_screen()
   // Status message line at the bottom
   lcd.setCursor(0, LCD_HEIGHT - 1);
 
-  #if defined(LCD_PROGRESS_BAR) && defined(SDSUPPORT)
+  #ifdef LCD_PROGRESS_BAR
 
     if (card.isFileOpen()) {
       uint16_t mil = millis(), diff = mil - progressBarTick;


### PR DESCRIPTION
- Some messages should not expire with `PROGRESS_MSG_EXPIRE`.
- Simplify conditional for progress bar with sanity checks.
- Rename `messageTick` to `expireStatusMillis` and make it the expire
  time.
