### PR TITLE
Rename Pins_megatronics_1 to Pins_minitronics

### DIFF
--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -1,5 +1,5 @@
 /**
- * Minitronics v1.0 pin assignments
+ * Minitronics v1.0/1.1 pin assignments
  */
 
 #ifndef __AVR_ATmega1281__


### PR DESCRIPTION
Renamed PINS_MEGATRONICS_1 to PINS_MINITRONICS since megatronics_1 is the minitronics.
Also added minitronics 1.1 on the description
