### PR TITLE
Compiling error temperature.cpp with multiple extruders defined

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1556,7 +1556,7 @@ ISR(TIMER0_COMPB_vect) {
       #else
         #define GE2 >=
       #endif
-      if (current_temperature_raw[2] GE2 (maxttemp_raw[2]) max_temp_error(2);
+      if (current_temperature_raw[2] GE2 maxttemp_raw[2]) max_temp_error(2);
       if (minttemp_raw[2] GE2 current_temperature_raw[2]) min_temp_error(2);
     #endif // TEMP_SENSOR_2
 


### PR DESCRIPTION
It wouldn't compile because of this line in temperature.cpp it turns out
it was just a stray ( that didn't line up with the previous lines so I
just made it in line with the rest and it compiled fine.
