### PR TITLE
Compare indices instead of floats for probe actions

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -227,7 +227,8 @@ void enquecommands_P(const char *cmd); //put one or many ASCII commands at the e
 void prepare_arc_move(char isclockwise);
 void clamp_to_software_endstops(float target[3]);
 
-void refresh_cmd_timeout();
+extern unsigned long previous_millis_cmd;
+inline void refresh_cmd_timeout() { previous_millis_cmd = millis(); }
 
 #ifdef FAST_PWM_FAN
   void setPwmFrequency(uint8_t pin, int val);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -238,7 +238,7 @@ static char *strchr_pointer; ///< A pointer to find chars in the command string 
 const char* queued_commands_P= NULL; /* pointer to the current line in the active sequence of commands, or NULL when none */
 const int sensitive_pins[] = SENSITIVE_PINS; ///< Sensitive pin list for M42
 // Inactivity shutdown
-static unsigned long previous_millis_cmd = 0;
+unsigned long previous_millis_cmd = 0;
 static unsigned long max_inactive_time = 0;
 static unsigned long stepper_inactive_time = DEFAULT_STEPPER_DEACTIVE_TIME*1000l;
 unsigned long starttime = 0; ///< Print job start time
@@ -986,8 +986,6 @@ static void axis_is_at_home(int axis) {
   #endif
 }
 
-inline void refresh_cmd_timeout() { previous_millis_cmd = millis(); }
-
 /**
  * Some planner shorthand inline functions
  */
@@ -1327,20 +1325,20 @@ inline void set_destination_to_current() { memcpy(destination, current_position,
   }
 
   enum ProbeAction {
-    ProbeStay             = 0,
-    ProbeEngage           = BIT(0),
-    ProbeRetract          = BIT(1),
-    ProbeEngageAndRetract = (ProbeEngage | ProbeRetract)
+    ProbeStay          = 0,
+    ProbeDeploy        = BIT(0),
+    ProbeStow          = BIT(1),
+    ProbeDeployAndStow = (ProbeDeploy | ProbeStow)
   };
 
   // Probe bed height at position (x,y), returns the measured z value
-  static float probe_pt(float x, float y, float z_before, ProbeAction retract_action=ProbeEngageAndRetract, int verbose_level=1) {
+  static float probe_pt(float x, float y, float z_before, ProbeAction retract_action=ProbeDeployAndStow, int verbose_level=1) {
     // move to right place
     do_blocking_move_to(current_position[X_AXIS], current_position[Y_AXIS], z_before);
     do_blocking_move_to(x - X_PROBE_OFFSET_FROM_EXTRUDER, y - Y_PROBE_OFFSET_FROM_EXTRUDER, current_position[Z_AXIS]);
 
     #if !defined(Z_PROBE_SLED) && !defined(Z_PROBE_ALLEN_KEY)
-      if (retract_action & ProbeEngage) deploy_z_probe();
+      if (retract_action & ProbeDeploy) deploy_z_probe();
     #endif
 
     run_z_probe();
@@ -1354,7 +1352,7 @@ inline void set_destination_to_current() { memcpy(destination, current_position,
     #endif
 
     #if !defined(Z_PROBE_SLED) && !defined(Z_PROBE_ALLEN_KEY)
-      if (retract_action & ProbeRetract) stow_z_probe();
+      if (retract_action & ProbeStow) stow_z_probe();
     #endif
 
     if (verbose_level > 2) {
@@ -2167,7 +2165,7 @@ inline void gcode_G28() {
     }
 
     bool dryrun = code_seen('D') || code_seen('d'),
-         engage_probe_for_each_reading = code_seen('E') || code_seen('e');
+         deploy_probe_for_each_reading = code_seen('E') || code_seen('e');
 
     #ifdef AUTO_BED_LEVELING_GRID
 
@@ -2319,14 +2317,13 @@ inline void gcode_G28() {
             if (distance_from_center > DELTA_PROBABLE_RADIUS) continue;
           #endif //DELTA
 
-          // Enhanced G29 - Do not retract servo between probes
           ProbeAction act;
-          if (engage_probe_for_each_reading)
-            act = ProbeEngageAndRetract;
-          else if (yProbe == front_probe_bed_position && xCount == 0)
-            act = ProbeEngage;
-          else if (yProbe == front_probe_bed_position + (yGridSpacing * (auto_bed_leveling_grid_points - 1)) && xCount == auto_bed_leveling_grid_points - 1)
-            act = ProbeRetract;
+          if (deploy_probe_for_each_reading) // G29 E - Stow between probes
+            act = ProbeDeployAndStow;
+          else if (yCount == 0 && xCount == 0)
+            act = ProbeDeploy;
+          else if (yCount == auto_bed_leveling_grid_points - 1 && xCount == auto_bed_leveling_grid_points - 1)
+            act = ProbeStow;
           else
             act = ProbeStay;
 
@@ -2417,10 +2414,10 @@ inline void gcode_G28() {
 
       // Actions for each probe
       ProbeAction p1, p2, p3;
-      if (engage_probe_for_each_reading)
-        p1 = p2 = p3 = ProbeEngageAndRetract;
+      if (deploy_probe_for_each_reading)
+        p1 = p2 = p3 = ProbeDeployAndStow;
       else
-        p1 = ProbeEngage, p2 = ProbeStay, p3 = ProbeRetract;
+        p1 = ProbeDeploy, p2 = ProbeStay, p3 = ProbeStow;
 
       // Probe at 3 arbitrary points
       float z_at_pt_1 = probe_pt(ABL_PROBE_PT_1_X, ABL_PROBE_PT_1_Y, Z_RAISE_BEFORE_PROBING, p1, verbose_level),
@@ -2839,7 +2836,7 @@ inline void gcode_M42() {
            Z_start_location = Z_current + Z_RAISE_BEFORE_PROBING,
            ext_position = st_get_position_mm(E_AXIS);
 
-    bool engage_probe_for_each_reading = code_seen('E') || code_seen('e');
+    bool deploy_probe_for_each_reading = code_seen('E') || code_seen('e');
 
     if (code_seen('X') || code_seen('x')) {
       X_probe_location = code_value() - X_PROBE_OFFSET_FROM_EXTRUDER;
@@ -2917,7 +2914,7 @@ inline void gcode_M42() {
     st_synchronize();
     current_position[Z_AXIS] = Z_current = st_get_position_mm(Z_AXIS);
 
-    if (engage_probe_for_each_reading) stow_z_probe();
+    if (deploy_probe_for_each_reading) stow_z_probe();
 
     for (uint16_t n=0; n < n_samples; n++) {
 
@@ -2959,7 +2956,7 @@ inline void gcode_M42() {
 
       } // n_legs
 
-      if (engage_probe_for_each_reading)  {
+      if (deploy_probe_for_each_reading)  {
         deploy_z_probe(); 
         delay(1000);
       }
@@ -3006,13 +3003,13 @@ inline void gcode_M42() {
       plan_buffer_line(X_probe_location, Y_probe_location, Z_start_location, current_position[E_AXIS], homing_feedrate[Z_AXIS]/60, active_extruder);
       st_synchronize();
 
-      if (engage_probe_for_each_reading) {
+      if (deploy_probe_for_each_reading) {
         stow_z_probe();
         delay(1000);
       }
     }
 
-    if (!engage_probe_for_each_reading) {
+    if (!deploy_probe_for_each_reading) {
       stow_z_probe();
       delay(1000);
     }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1789,7 +1789,7 @@ char *ftostr52(const float &x) {
   return conv;
 }
 
-#if defined(MANUAL_BED_LEVELING)
+#ifdef MANUAL_BED_LEVELING
 static int _lcd_level_bed_position;
 static void _lcd_level_bed()
 {
@@ -1849,8 +1849,7 @@ static void _lcd_level_bed_homing()
     lcd_goto_menu(_lcd_level_bed);
   }
 }
-static void lcd_level_bed()
-{
+static void lcd_level_bed() {
   axis_known_position[X_AXIS] = false;
   axis_known_position[Y_AXIS] = false;
   axis_known_position[Z_AXIS] = false;


### PR DESCRIPTION
- Rename probe actions to remove "retract"
- Fix compile error in `ultralcd.cpp` #1804 
