### PR TITLE
Execute DOGM display-loop less often

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -318,9 +318,9 @@ static void lcd_implementation_status_screen() {
   lcd_setFont(FONT_STATUSMENU);
 
   #ifdef USE_SMALL_INFOFONT
-    u8g.drawBox(0,30,127,10);
+    u8g.drawBox(0,30,128,10);
   #else
-    u8g.drawBox(0,30,127,9);
+    u8g.drawBox(0,30,128,9);
   #endif
   u8g.setColorIndex(0); // white on black
   u8g.setPrintPos(2,XYZ_BASELINE);

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -318,9 +318,9 @@ static void lcd_implementation_status_screen() {
   lcd_setFont(FONT_STATUSMENU);
 
   #ifdef USE_SMALL_INFOFONT
-    u8g.drawBox(0,30,128,10);
+    u8g.drawBox(0,30,127,10);
   #else
-    u8g.drawBox(0,30,128,9);
+    u8g.drawBox(0,30,127,9);
   #endif
   u8g.setColorIndex(0); // white on black
   u8g.setPrintPos(2,XYZ_BASELINE);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -262,8 +262,7 @@ static void lcd_goto_menu(menuFunc_t menu, const uint32_t encoder=0, const bool 
 }
 
 /* Main status screen. It's up to the implementation specific part to show what is needed. As this is very display dependent */
-static void lcd_status_screen()
-{
+static void lcd_status_screen() {
 	encoderRateMultiplierEnabled = false;
 
   #ifdef LCD_PROGRESS_BAR
@@ -296,15 +295,7 @@ static void lcd_status_screen()
     #endif
   #endif //LCD_PROGRESS_BAR
 
-  if (lcd_status_update_delay)
-    lcd_status_update_delay--;
-  else
-    lcdDrawUpdate = 1;
-
-  if (lcdDrawUpdate) {
     lcd_implementation_status_screen();
-    lcd_status_update_delay = 10;   /* redraw the main screen every second. This is easier then trying keep track of all things that change on the screen */
-  }
 
 #ifdef ULTIPANEL
 
@@ -1298,8 +1289,6 @@ void lcd_update() {
       }
     }
   #endif//CARDINSERTED
-
-  static uint8_t dotcounter = 63;
   
   uint32_t ms = millis();
   if (ms > lcd_next_update_millis) {
@@ -1351,27 +1340,33 @@ void lcd_update() {
             } // encoderRateMultiplierEnabled
           #endif //ENCODER_RATE_MULTIPLIER
 
-          lcdDrawUpdate = 1;
           encoderPosition += (encoderDiff * encoderMultiplier) / ENCODER_PULSES_PER_STEP;
           encoderDiff = 0;
         }
         timeoutToStatus = ms + LCD_TIMEOUT_TO_STATUS;
+        lcdDrawUpdate = 1;
       }
-
     #endif //ULTIPANEL
 
+    if (currentMenu == lcd_status_screen) {
+      if (!lcd_status_update_delay) {
+        lcdDrawUpdate = 1;
+        lcd_status_update_delay = 10;   /* redraw the main screen every second. This is easier then trying keep track of all things that change on the screen */
+      }
+      else {
+        lcd_status_update_delay--;
+      }
+    }
     #ifdef DOGLCD  // Changes due to different driver architecture of the DOGM display
-      blink++;     // Variable for fan animation and alive dot
-      u8g.firstPage();
-      (*currentMenu)();
       if (lcdDrawUpdate) {
+        blink++;     // Variable for fan animation and alive dot
+        u8g.firstPage();
         do {
-          if (!dotcounter) dotcounter = 63;
           lcd_setFont(FONT_MENU);
           u8g.setPrintPos(125, 0);
-  //        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
-          u8g.drawPixel(127, dotcounter--); // draw alive dot
-  //        u8g.setColorIndex(1); // black on white
+          if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
+          u8g.drawPixel(127, 63); // draw alive dot
+          u8g.setColorIndex(1); // black on white
           (*currentMenu)();
         } while( u8g.nextPage() );
       }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1299,6 +1299,8 @@ void lcd_update() {
     }
   #endif//CARDINSERTED
 
+  static uint8_t dotcounter = 63;
+  
   uint32_t ms = millis();
   if (ms > lcd_next_update_millis) {
 
@@ -1364,11 +1366,12 @@ void lcd_update() {
       (*currentMenu)();
       if (lcdDrawUpdate) {
         do {
+          if (!dotcounter) dotcounter = 63;
           lcd_setFont(FONT_MENU);
           u8g.setPrintPos(125, 0);
-          if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
-          u8g.drawPixel(127, 63); // draw alive dot
-          u8g.setColorIndex(1); // black on white
+  //        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
+          u8g.drawPixel(127, dotcounter--); // draw alive dot
+  //        u8g.setColorIndex(1); // black on white
           (*currentMenu)();
         } while( u8g.nextPage() );
       }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1299,8 +1299,6 @@ void lcd_update() {
     }
   #endif//CARDINSERTED
 
-  static uint8_t dotcounter = 63;
-  
   uint32_t ms = millis();
   if (ms > lcd_next_update_millis) {
 
@@ -1366,12 +1364,11 @@ void lcd_update() {
       (*currentMenu)();
       if (lcdDrawUpdate) {
         do {
-          if (!dotcounter) dotcounter = 63;
           lcd_setFont(FONT_MENU);
           u8g.setPrintPos(125, 0);
-  //        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
-          u8g.drawPixel(127, dotcounter--); // draw alive dot
-  //        u8g.setColorIndex(1); // black on white
+          if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
+          u8g.drawPixel(127, 63); // draw alive dot
+          u8g.setColorIndex(1); // black on white
           (*currentMenu)();
         } while( u8g.nextPage() );
       }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1363,16 +1363,18 @@ void lcd_update() {
     #ifdef DOGLCD  // Changes due to different driver architecture of the DOGM display
       blink++;     // Variable for fan animation and alive dot
       u8g.firstPage();
-      do {
-        if (!dotcounter) dotcounter = 63;
-        lcd_setFont(FONT_MENU);
-        u8g.setPrintPos(125, 0);
-//        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
-        u8g.drawPixel(127, dotcounter--); // draw alive dot
-//        u8g.setColorIndex(1); // black on white
-        (*currentMenu)();
-        if (!lcdDrawUpdate) break; // Terminate display update, when nothing new to draw. This must be done before the last dogm.next()
-      } while( u8g.nextPage() );
+      (*currentMenu)();
+      if (lcdDrawUpdate) {
+        do {
+          if (!dotcounter) dotcounter = 63;
+          lcd_setFont(FONT_MENU);
+          u8g.setPrintPos(125, 0);
+  //        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
+          u8g.drawPixel(127, dotcounter--); // draw alive dot
+  //        u8g.setColorIndex(1); // black on white
+          (*currentMenu)();
+        } while( u8g.nextPage() );
+      }
     #else
       (*currentMenu)();
     #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1299,6 +1299,8 @@ void lcd_update() {
     }
   #endif//CARDINSERTED
 
+  static uint8_t dotcounter = 63;
+  
   uint32_t ms = millis();
   if (ms > lcd_next_update_millis) {
 
@@ -1362,11 +1364,12 @@ void lcd_update() {
       blink++;     // Variable for fan animation and alive dot
       u8g.firstPage();
       do {
+        if (!dotcounter) dotcounter = 63;
         lcd_setFont(FONT_MENU);
         u8g.setPrintPos(125, 0);
-        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
-        u8g.drawPixel(127, 63); // draw alive dot
-        u8g.setColorIndex(1); // black on white
+//        if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
+        u8g.drawPixel(127, dotcounter--); // draw alive dot
+//        u8g.setColorIndex(1); // black on white
         (*currentMenu)();
         if (!lcdDrawUpdate) break; // Terminate display update, when nothing new to draw. This must be done before the last dogm.next()
       } while( u8g.nextPage() );


### PR DESCRIPTION
While reading: https://code.google.com/p/u8glib/wiki/tpictureloop
I got the suspicion that the content of the display loop is executed more frequent than expected.
Commit 1 proves that.
https://youtu.be/tdu7J0i-c4g
Commit 2 improves that a bit.
https://youtu.be/AEnBzdu9_tk
More to come.
