### PR TITLE
Disable splash-screen when done once

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -186,6 +186,8 @@ char lcd_printPGM(const char* str) {
   return n;
 }
 
+static int8_t show_splashscreed = 2;
+
 static void lcd_implementation_init()
 {
   #ifdef LCD_PIN_BL // Enable LCD backlight
@@ -219,15 +221,18 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
-    u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-    lcd_setFont(FONT_MENU);
-    #ifndef STRING_SPLASH_LINE2
-      u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
-    #else
-      int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
-      u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
-      u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
-    #endif
+    if (show_splashscreed) {
+      u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
+      lcd_setFont(FONT_MENU);
+      #ifndef STRING_SPLASH_LINE2
+        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
+      #else
+        int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
+        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
+        u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
+      #endif
+      show_splashscreed--;
+    }
 	} while (u8g.nextPage());
 }
 

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -186,7 +186,7 @@ char lcd_printPGM(const char* str) {
   return n;
 }
 
-int8_t show_splashscreen = 2;
+static int8_t show_splashscreed = 2;
 
 static void lcd_implementation_init()
 {
@@ -221,25 +221,18 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
-    switch (show_splashscreen) {
-      case 2 : {
-        u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-        break;
-      }
-      case 1 : {
-        lcd_setFont(FONT_MENU);
-        #ifndef STRING_SPLASH_LINE2
-          u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
-        #else
-          int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
-          u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
-          u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
-        #endif
-        break;
-      }
-      break;  
-    }  
-    if (show_splashscreen) show_splashscreen--;
+    if (show_splashscreed) {
+      u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
+      lcd_setFont(FONT_MENU);
+      #ifndef STRING_SPLASH_LINE2
+        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
+      #else
+        int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
+        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
+        u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
+      #endif
+      show_splashscreed--;
+    }
 	} while (u8g.nextPage());
 }
 

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -186,7 +186,7 @@ char lcd_printPGM(const char* str) {
   return n;
 }
 
-static int8_t show_splashscreed = 2;
+static bool show_splashscreen = true;
 
 static void lcd_implementation_init()
 {
@@ -221,7 +221,7 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
-    if (show_splashscreed) {
+    if (show_splashscreen) {
       u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
       lcd_setFont(FONT_MENU);
       #ifndef STRING_SPLASH_LINE2
@@ -231,9 +231,9 @@ static void lcd_implementation_init()
         u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
         u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
       #endif
-      show_splashscreed--;
     }
 	} while (u8g.nextPage());
+  show_splashscreen = false;
 }
 
 static void lcd_implementation_clear() { } // Automatically cleared by Picture Loop

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -186,7 +186,7 @@ char lcd_printPGM(const char* str) {
   return n;
 }
 
-static int8_t show_splashscreed = 2;
+int8_t show_splashscreen = 2;
 
 static void lcd_implementation_init()
 {
@@ -221,18 +221,25 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
-    if (show_splashscreed) {
-      u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-      lcd_setFont(FONT_MENU);
-      #ifndef STRING_SPLASH_LINE2
-        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
-      #else
-        int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
-        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
-        u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
-      #endif
-      show_splashscreed--;
-    }
+    switch (show_splashscreen) {
+      case 2 : {
+        u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
+        break;
+      }
+      case 1 : {
+        lcd_setFont(FONT_MENU);
+        #ifndef STRING_SPLASH_LINE2
+          u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
+        #else
+          int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
+          u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
+          u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
+        #endif
+        break;
+      }
+      break;  
+    }  
+    if (show_splashscreen) show_splashscreen--;
 	} while (u8g.nextPage());
 }
 


### PR DESCRIPTION
Splash screen was shown with every display init.
That means every time the menus were entered.

Note the "2" in the initialization.
The buffer is already written in two steps, each 512 bytes.
Without the "2" only the upper-half is shown.

Part two uses this to not draw everything twice.
