### PR TITLE
Speed up for 12864 displays - not for U8GLIB_ST7920

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -127,17 +127,23 @@
 // LCD selection
 #ifdef U8GLIB_ST7920
 //U8GLIB_ST7920_128X64_RRD u8g(0,0,0);
-U8GLIB_ST7920_128X64_RRD u8g(0);
+U8GLIB_ST7920_128X64_RRD u8g(0);  // while( u8g.nextPage() ) loops 2 times. Display buffer is 512 byte.
+
 #elif defined(MAKRPANEL)
 // The MaKrPanel display, ST7565 controller as well
-U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);
+//U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // while( u8g.nextPage() ) loops 8 times. Display buffer is 128 byte.
+U8GLIB_NHD_C12864_2X u8g(DOGLCD_CS, DOGLCD_A0);  // while( u8g.nextPage() ) loops 4 times. Display buffer is 256 byte.
 #elif defined(VIKI2) || defined(miniVIKI)
 // Mini Viki and Viki 2.0 LCD, ST7565 controller as well
-U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);
+//U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // while( u8g.nextPage() ) loops 8 times. Display buffer is 128 byte.
+U8GLIB_NHD_C12864_2X u8g(DOGLCD_CS, DOGLCD_A0);  // while( u8g.nextPage() ) loops 4 times. Display buffer is 256 byte.
 #else
 // for regular DOGM128 display with HW-SPI
-U8GLIB_DOGM128 u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0
+//U8GLIB_DOGM128 u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0  // while( u8g.nextPage() ) loops 8 times. Display buffer is 128 byte.
+U8GLIB_DOGM128_2X u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0  // while( u8g.nextPage() ) loops 4 times. Display buffer is 256 byte.
 #endif
+
+
 
 #include "utf_mapper.h"
 
@@ -186,6 +192,8 @@ char lcd_printPGM(const char* str) {
   return n;
 }
 
+static bool show_splashscreen = true;
+
 static void lcd_implementation_init()
 {
   #ifdef LCD_PIN_BL // Enable LCD backlight
@@ -219,16 +227,19 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
-    u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-    lcd_setFont(FONT_MENU);
-    #ifndef STRING_SPLASH_LINE2
-      u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
-    #else
-      int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
-      u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
-      u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
-    #endif
+    if (show_splashscreen) {
+      u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
+      lcd_setFont(FONT_MENU);
+      #ifndef STRING_SPLASH_LINE2
+        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
+      #else
+        int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
+        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
+        u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
+      #endif
+    }
 	} while (u8g.nextPage());
+  show_splashscreen = false;
 }
 
 static void lcd_implementation_clear() { } // Automatically cleared by Picture Loop

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -30,9 +30,7 @@
 
 #include <U8glib.h>
 #include "DOGMbitmaps.h"
-
 #include "ultralcd.h"
-#include "ultralcd_st7920_u8glib_rrd.h"
 #include "Configuration.h"
 
 // save 3120 bytes of PROGMEM by commenting out #define USE_BIG_EDIT_FONT
@@ -126,9 +124,10 @@
 
 // LCD selection
 #ifdef U8GLIB_ST7920
+//#include "ultralcd_st7920_u8glib_rrd.h"
 //U8GLIB_ST7920_128X64_RRD u8g(0,0,0);
-U8GLIB_ST7920_128X64_RRD u8g(0);  // while( u8g.nextPage() ) loops 2 times. Display buffer is 512 byte.
-
+//U8GLIB_ST7920_128X64_RRD u8g(0);  // while( u8g.nextPage() ) loops 2 times. Display buffer is 512 byte.
+U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // min u8glib v1.11
 #elif defined(MAKRPANEL)
 // The MaKrPanel display, ST7565 controller as well
 //U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // while( u8g.nextPage() ) loops 8 times. Display buffer is 128 byte.
@@ -225,6 +224,13 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
+/*    u8g_pb_t *PageBox;
+    u8g_box_t *Box;
+    u8g_pb_GetPageBox(PageBox, Box);
+//    u8g_pb_IsIntersection(PageBox, Box);
+    u8g_pb_IsIntersection(PageBox, offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT);
+//uint8_t u8g_is_box_bbx_intersection(u8g_box_t *box, u8g_dev_arg_bbx_t *bbx);
+*/
     u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
     lcd_setFont(FONT_MENU);
     #ifndef STRING_SPLASH_LINE2

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -124,10 +124,10 @@
 
 // LCD selection
 #ifdef U8GLIB_ST7920
-//#include "ultralcd_st7920_u8glib_rrd.h"
+#include "ultralcd_st7920_u8glib_rrd.h"
 //U8GLIB_ST7920_128X64_RRD u8g(0,0,0);
-//U8GLIB_ST7920_128X64_RRD u8g(0);  // while( u8g.nextPage() ) loops 2 times. Display buffer is 512 byte.
-U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // min u8glib v1.11
+U8GLIB_ST7920_128X64_RRD u8g(0);  // while( u8g.nextPage() ) loops 2 times. Display buffer is 512 byte.
+//U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // min u8glib v1.11
 #elif defined(MAKRPANEL)
 // The MaKrPanel display, ST7565 controller as well
 //U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // while( u8g.nextPage() ) loops 8 times. Display buffer is 128 byte.

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -192,8 +192,6 @@ char lcd_printPGM(const char* str) {
   return n;
 }
 
-static bool show_splashscreen = true;
-
 static void lcd_implementation_init()
 {
   #ifdef LCD_PIN_BL // Enable LCD backlight
@@ -227,19 +225,16 @@ static void lcd_implementation_init()
 
 	u8g.firstPage();
 	do {
-    if (show_splashscreen) {
-      u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-      lcd_setFont(FONT_MENU);
-      #ifndef STRING_SPLASH_LINE2
-        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
-      #else
-        int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
-        u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
-        u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
-      #endif
-    }
-	} while (u8g.nextPage());
-  show_splashscreen = false;
+    u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
+    lcd_setFont(FONT_MENU);
+    #ifndef STRING_SPLASH_LINE2
+      u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT, STRING_SPLASH_LINE1);
+    #else
+      int txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1)*DOG_CHAR_WIDTH) / 2;
+      u8g.drawStr(txt1X, u8g.getHeight() - DOG_CHAR_HEIGHT*3/2, STRING_SPLASH_LINE1);
+      u8g.drawStr(txt2X, u8g.getHeight() - DOG_CHAR_HEIGHT*1/2, STRING_SPLASH_LINE2);
+    #endif
+  } while (u8g.nextPage());
 }
 
 static void lcd_implementation_clear() { } // Automatically cleared by Picture Loop


### PR DESCRIPTION
by selecting devices with more display buffer but less loops in the nextPage() loop.
