### PR TITLE
Remove Contrast Menu for device U8GLIB_ST7920

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -163,7 +163,7 @@
   #ifdef DOGLCD
     #define HAS_LCD_CONTRAST
     #ifdef U8GLIB_ST7920
-      #undefine HAS_LCD_CONTRAST
+      #undef HAS_LCD_CONTRAST
     #endif
   #endif
 

--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -130,7 +130,6 @@
      #define NEWPANEL
   #endif
 
-
   #ifdef ULTIPANEL
     #define NEWPANEL  //enable this if you have a click-encoder panel
     #define SDSUPPORT
@@ -159,6 +158,13 @@
    */
   #if defined(DOGLCD) && !defined(DEFAULT_LCD_CONTRAST)
     #define DEFAULT_LCD_CONTRAST 32
+  #endif
+
+  #ifdef DOGLCD
+    #define HAS_LCD_CONTRAST
+    #ifdef U8GLIB_ST7920
+      #undefine HAS_LCD_CONTRAST
+    #endif
   #endif
 
 #else // CONFIGURATION_LCD

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4083,7 +4083,7 @@ inline void gcode_M226() {
 
 #endif // CHDK || PHOTOGRAPH_PIN
 
-#ifdef DOGLCD
+#ifdef HAS_LCD_CONTRAST
 
   /**
    * M250: Read and optionally set the LCD contrast
@@ -4095,7 +4095,7 @@ inline void gcode_M226() {
     SERIAL_EOL;
   }
 
-#endif // DOGLCD
+#endif // HAS_LCD_CONTRAST
 
 #ifdef PREVENT_DANGEROUS_EXTRUDE
 
@@ -5081,11 +5081,11 @@ void process_commands() {
           break;
       #endif // CHDK || PHOTOGRAPH_PIN
 
-      #ifdef DOGLCD
+      #ifdef HAS_LCD_CONTRAST
         case 250: // M250  Set LCD contrast value: C<value> (value 0..63)
           gcode_M250();
           break;
-      #endif // DOGLCD
+      #endif // HAS_LCD_CONTRAST
 
       #ifdef PREVENT_DANGEROUS_EXTRUDE
         case 302: // allow cold extrudes, or set the minimum extrude temperature

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -58,7 +58,7 @@ static void lcd_status_screen();
   static void lcd_control_temperature_preheat_abs_settings_menu();
   static void lcd_control_motion_menu();
   static void lcd_control_volumetric_menu();
-  #ifdef DOGLCD
+  #ifdef HAS_LCD_CONTRAST
     static void lcd_set_contrast();
   #endif
   #ifdef FWRETRACT
@@ -739,7 +739,7 @@ static void lcd_control_menu() {
   MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
   MENU_ITEM(submenu, MSG_VOLUMETRIC, lcd_control_volumetric_menu);
 
-  #ifdef DOGLCD
+  #ifdef HAS_LCD_CONTRAST
     //MENU_ITEM_EDIT(int3, MSG_CONTRAST, &lcd_contrast, 0, 63);
     MENU_ITEM(submenu, MSG_CONTRAST, lcd_set_contrast);
   #endif
@@ -963,8 +963,7 @@ static void lcd_control_volumetric_menu() {
   END_MENU();
 }
 
-#ifdef DOGLCD
-
+#ifdef HAS_LCD_CONTRAST
   static void lcd_set_contrast() {
     if (encoderPosition != 0) {
       lcd_contrast -= encoderPosition;
@@ -976,11 +975,9 @@ static void lcd_control_volumetric_menu() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_CONTRAST), itostr2(lcd_contrast));
     if (LCD_CLICKED) lcd_goto_menu(lcd_control_menu);
   }
-
-#endif // DOGLCD
+#endif // HAS_LCD_CONTRAST
 
 #ifdef FWRETRACT
-
   static void lcd_control_retract_menu() {
     START_MENU();
     MENU_ITEM(back, MSG_CONTROL, lcd_control_menu);
@@ -998,16 +995,13 @@ static void lcd_control_volumetric_menu() {
     MENU_ITEM_EDIT(float3, MSG_CONTROL_RETRACT_RECOVERF, &retract_recover_feedrate, 1, 999);
     END_MENU();
   }
-
 #endif // FWRETRACT
 
 #if SDCARDDETECT == -1
-
   static void lcd_sd_refresh() {
     card.initsd();
     currentMenuViewOffset = 0;
   }
-
 #endif
 
 static void lcd_sd_updir() {
@@ -1458,7 +1452,7 @@ void lcd_setalertstatuspgm(const char* message) {
 
 void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
-#ifdef DOGLCD
+#ifdef HAS_LCD_CONTRAST
   void lcd_setcontrast(uint8_t value) {
     lcd_contrast = value & 0x3F;
     u8g.setContrast(lcd_contrast);


### PR DESCRIPTION
The other two devices we use in u8glib have more than only dummy code.
Checked this in the library code.

Fix for #1857
