### PR TITLE
Moved the definitions of the LCD_STR_* to Conditionals.h

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -144,14 +144,43 @@
     #endif
   #else //no panel but just LCD
     #ifdef ULTRA_LCD
-    #ifdef DOGLCD // Change number of lines to match the 128x64 graphics display
-      #define LCD_WIDTH 22
-      #define LCD_HEIGHT 5
-    #else
-      #define LCD_WIDTH 16
-      #define LCD_HEIGHT 2
+      #ifdef DOGLCD // Change number of lines to match the 128x64 graphics display
+        #define LCD_WIDTH 22
+        #define LCD_HEIGHT 5
+      #else
+        #define LCD_WIDTH 16
+        #define LCD_HEIGHT 2
+      #endif
     #endif
-    #endif
+  #endif
+
+  #ifdef DOGLCD
+    /* Custom characters defined in font font_6x10_marlin_symbols */
+    // \x00 intentionally skipped to avoid problems in strings
+    #define LCD_STR_REFRESH     "\x01"
+    #define LCD_STR_FOLDER      "\x02"
+    #define LCD_STR_ARROW_RIGHT "\x03"
+    #define LCD_STR_UPLEVEL     "\x04"
+    #define LCD_STR_CLOCK       "\x05"
+    #define LCD_STR_FEEDRATE    "\x06"
+    #define LCD_STR_BEDTEMP     "\x07"
+    #define LCD_STR_THERMOMETER "\x08"
+    #define LCD_STR_DEGREE      "\x09"
+
+    #define LCD_STR_SPECIAL_MAX '\x09'
+    // Maximum here is 0x1f because 0x20 is ' ' (space) and the normal charsets begin.
+    // Better stay below 0x10 because DISPLAY_CHARSET_HD44780_WESTERN begins here.
+  #else
+    /* Custom characters defined in the first 8 characters of the LCD */
+    #define LCD_STR_BEDTEMP     "\x00"  // this will have 'unexpected' results when used in a string!
+    #define LCD_STR_DEGREE      "\x01"
+    #define LCD_STR_THERMOMETER "\x02"
+    #define LCD_STR_UPLEVEL     "\x03"
+    #define LCD_STR_REFRESH     "\x04"
+    #define LCD_STR_FOLDER      "\x05"
+    #define LCD_STR_FEEDRATE    "\x06"
+    #define LCD_STR_CLOCK       "\x07"
+    #define LCD_STR_ARROW_RIGHT ">"  /* from the default character set */
   #endif
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1365,7 +1365,7 @@ inline void set_destination_to_current() { memcpy(destination, current_position,
     #endif
 
     if (verbose_level > 2) {
-      SERIAL_PROTOCOLPGM(MSG_BED);
+      SERIAL_PROTOCOLPGM("Bed");
       SERIAL_PROTOCOLPGM(" X: ");
       SERIAL_PROTOCOL_F(x, 3);
       SERIAL_PROTOCOLPGM(" Y: ");

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2514,7 +2514,7 @@ inline void gcode_G28() {
       feedrate = homing_feedrate[Z_AXIS];
 
       run_z_probe();
-      SERIAL_PROTOCOLPGM(MSG_BED);
+      SERIAL_PROTOCOLPGM("Bed");
       SERIAL_PROTOCOLPGM(" X: ");
       SERIAL_PROTOCOL(current_position[X_AXIS] + 0.0001);
       SERIAL_PROTOCOLPGM(" Y: ");
@@ -2852,8 +2852,8 @@ inline void gcode_M42() {
   inline void gcode_M48() {
 
     double sum = 0.0, mean = 0.0, sigma = 0.0, sample_set[50];
-    int verbose_level = 1, n_samples = 10, n_legs = 0;
-    
+    uint8_t verbose_level = 1, n_samples = 10, n_legs = 0;
+
     if (code_seen('V') || code_seen('v')) {
       verbose_level = code_value_short();
       if (verbose_level < 0 || verbose_level > 4 ) {
@@ -2960,7 +2960,7 @@ inline void gcode_M42() {
 
     if (deploy_probe_for_each_reading) stow_z_probe();
 
-    for (uint16_t n=0; n < n_samples; n++) {
+    for (uint8_t n=0; n < n_samples; n++) {
 
       do_blocking_move_to(X_probe_location, Y_probe_location, Z_start_location); // Make sure we are at the probe location
 
@@ -2975,7 +2975,7 @@ inline void gcode_M42() {
         //SERIAL_ECHOPAIR("   direction: ",dir);
         //SERIAL_EOL;
 
-        for (int l = 0; l < n_legs - 1; l++) {
+        for (uint8_t l = 0; l < n_legs - 1; l++) {
           ms = millis();
           theta += RADIANS(dir * (ms % 20L));
           radius += (ms % 10L) - 5L;
@@ -3014,7 +3014,7 @@ inline void gcode_M42() {
       // Get the current mean for the data points we have so far
       //
       sum = 0.0;
-      for (int j = 0; j <= n; j++) sum += sample_set[j];
+      for (uint8_t j = 0; j <= n; j++) sum += sample_set[j];
       mean = sum / (n + 1);
 
       //
@@ -3022,7 +3022,7 @@ inline void gcode_M42() {
       // data points we have so far
       //
       sum = 0.0;
-      for (int j = 0; j <= n; j++) {
+      for (uint8_t j = 0; j <= n; j++) {
         float ss = sample_set[j] - mean;
         sum += ss * ss;
       }

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -108,22 +108,6 @@
 
 #define START_ROW              0
 
-/* Custom characters defined in font font_6x10_marlin_symbols */
-// \x00 intentionally skipped to avoid problems in strings
-#define LCD_STR_REFRESH     "\x01"
-#define LCD_STR_FOLDER      "\x02"
-#define LCD_STR_ARROW_RIGHT "\x03"
-#define LCD_STR_UPLEVEL     "\x04"
-#define LCD_STR_CLOCK       "\x05"
-#define LCD_STR_FEEDRATE    "\x06"
-#define LCD_STR_BEDTEMP     "\x07"
-#define LCD_STR_THERMOMETER "\x08"
-#define LCD_STR_DEGREE      "\x09"
-
-#define LCD_STR_SPECIAL_MAX '\x09'
-// Maximum here is 0x1f because 0x20 is ' ' (space) and the normal charsets begin.
-// Better stay below 0x10 because DISPLAY_CHARSET_HD44780_WESTERN begins here.
-
 // LCD selection
 #ifdef U8GLIB_ST7920
   //U8GLIB_ST7920_128X64_RRD u8g(0,0,0);

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -201,18 +201,6 @@
   #define LCD_STR_PROGRESS  "\x03\x04\x05"
 #endif
 
-/* Custom characters defined in the first 8 characters of the LCD */
-#define LCD_STR_BEDTEMP     "\x00"  // this will have 'unexpected' results when used in a string!
-#define LCD_STR_DEGREE      "\x01"
-#define LCD_STR_THERMOMETER "\x02"
-#define LCD_STR_UPLEVEL     "\x03"
-#define LCD_STR_REFRESH     "\x04"
-#define LCD_STR_FOLDER      "\x05"
-#define LCD_STR_FEEDRATE    "\x06"
-#define LCD_STR_CLOCK       "\x07"
-//#define LCD_STR_ARROW_RIGHT "\x7E"  /* from the default character set. Only available on DISPLAY_CHARSET_HD44780_JAPAN - at this place!*/
-#define LCD_STR_ARROW_RIGHT ">"  /* from the default character set */
-
 static void lcd_set_custom_characters(
   #ifdef LCD_PROGRESS_BAR
     bool progress_bar_set=true


### PR DESCRIPTION
to avoid errors in Marlin_main.cpp. #1860

In the include tree of Marlin_main.cpp the decision between the display types is not made.
To include the right LCD_STR_\* ether 'dogm_lcd_implementation.h' or 'ultralcd_implementation_hitachi_HD44780.h' with all their code must be loaded..
A 'dogm_lcd_implementation.h.h' would be a curiosity.
So i moved both of the definition blocks to conditionals.h

On the long term it could make sense to use the same numbering for the u8glib and the hitachi symbols.
