### PR TITLE
Feature: Add new board - RAMPS CNC Controller

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -14,7 +14,7 @@
 #define BOARD_RAMPS_13_EEB      34   // RAMPS 1.3 / 1.4 (Power outputs: Extruder0, Extruder1, Bed)
 #define BOARD_RAMPS_13_EFF      35   // RAMPS 1.3 / 1.4 (Power outputs: Extruder, Fan, Fan)
 #define BOARD_RAMPS_13_EEF      36   // RAMPS 1.3 / 1.4 (Power outputs: Extruder0, Extruder1, Fan)
-#define BOARD_RAMPS_13_SFA		38   // RAMPS 1.3 / 1.4 (Power outputs: Spindle, Controller Fan, Available)
+#define BOARD_RAMPS_13_SFA	    38   // RAMPS 1.3 / 1.4 (Power outputs: Spindle, Controller Fan, Available)
 #define BOARD_FELIX2            37   // Felix 2.0+ Electronics Board (RAMPS like)
 #define BOARD_DUEMILANOVE_328P  4    // Duemilanove w/ ATMega328P pin assignments
 #define BOARD_GEN6              5    // Gen6

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -14,6 +14,7 @@
 #define BOARD_RAMPS_13_EEB      34   // RAMPS 1.3 / 1.4 (Power outputs: Extruder0, Extruder1, Bed)
 #define BOARD_RAMPS_13_EFF      35   // RAMPS 1.3 / 1.4 (Power outputs: Extruder, Fan, Fan)
 #define BOARD_RAMPS_13_EEF      36   // RAMPS 1.3 / 1.4 (Power outputs: Extruder0, Extruder1, Fan)
+#define BOARD_RAMPS_13_SFA		38   // RAMPS 1.3 / 1.4 (Power outputs: Spindle, Controller Fan, Available)
 #define BOARD_FELIX2            37   // Felix 2.0+ Electronics Board (RAMPS like)
 #define BOARD_DUEMILANOVE_328P  4    // Duemilanove w/ ATMega328P pin assignments
 #define BOARD_GEN6              5    // Gen6

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -14,7 +14,7 @@
 #define BOARD_RAMPS_13_EEB      34   // RAMPS 1.3 / 1.4 (Power outputs: Extruder0, Extruder1, Bed)
 #define BOARD_RAMPS_13_EFF      35   // RAMPS 1.3 / 1.4 (Power outputs: Extruder, Fan, Fan)
 #define BOARD_RAMPS_13_EEF      36   // RAMPS 1.3 / 1.4 (Power outputs: Extruder0, Extruder1, Fan)
-#define BOARD_RAMPS_13_SFA	    38   // RAMPS 1.3 / 1.4 (Power outputs: Spindle, Controller Fan, Available)
+#define BOARD_RAMPS_13_SFA      38   // RAMPS 1.3 / 1.4 (Power outputs: Spindle, Controller Fan, Available)
 #define BOARD_FELIX2            37   // Felix 2.0+ Electronics Board (RAMPS like)
 #define BOARD_DUEMILANOVE_328P  4    // Duemilanove w/ ATMega328P pin assignments
 #define BOARD_GEN6              5    // Gen6

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -7,7 +7,7 @@
  *  RAMPS_13_EEB (Extruder, Extruder, Bed)
  *  RAMPS_13_EFF (Extruder, Fan, Fan)
  *  RAMPS_13_EEF (Extruder, Extruder, Fan)
- *	RAMPS_13_SFA (Spindle, Controller Fan, Available)
+ *  RAMPS_13_SFA (Spindle, Controller Fan, Available)
  *
  *  Other pins_MYBOARD.h files may override these defaults
  */

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -7,6 +7,7 @@
  *  RAMPS_13_EEB (Extruder, Extruder, Bed)
  *  RAMPS_13_EFF (Extruder, Fan, Fan)
  *  RAMPS_13_EEF (Extruder, Extruder, Fan)
+ *	RAMPS_13_SFA (Spindle, Controller Fan, Available)
  *
  *  Other pins_MYBOARD.h files may override these defaults
  */
@@ -81,7 +82,7 @@
   #if MB(RAMPS_13_EFF)
     #define CONTROLLERFAN_PIN  -1 // Pin used for the fan to cool controller
   #endif
-#elif MB(RAMPS_13_EEF)
+#elif MB(RAMPS_13_EEF) || MB(RAMPS_13_SFA)
   #define FAN_PIN            8
 #else
   #define FAN_PIN            4 // IO pin. Buffer needed
@@ -97,11 +98,13 @@
 
 #if MB(RAMPS_13_EFF)
   #define HEATER_0_PIN       8
+#elif MB(RAMPS_13_SFA)
+  #define HEATER_0_PIN		 -1	  // Leave pin 10 free for either Controller Fan control or any other use
 #else
   #define HEATER_0_PIN       10   // EXTRUDER 1
 #endif
 
-#if MB(RAMPS_13_EFB)
+#if MB(RAMPS_13_EFB) || MB(RAMPS_13_SFA)
   #define HEATER_1_PIN       -1
 #else
   #define HEATER_1_PIN       9    // EXTRUDER 2 (FAN On Sprinter)
@@ -113,7 +116,7 @@
 #define TEMP_1_PIN         15   // ANALOG NUMBERING
 #define TEMP_2_PIN         -1   // ANALOG NUMBERING
 
-#if MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF)
+#if MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SFA)
   #define HEATER_BED_PIN     -1    // NO BED
 #else
   #define HEATER_BED_PIN     8    // BED


### PR DESCRIPTION
Added a new board to make using RAMPS to control a CNC machine easier.
Maps the spindle to pin 8, and leaves either 9 or 10 free to power the
controller fan. Whichever pin is not used can then be controlled via an
M42 command
