### PR TITLE
Fix Syntax Error Filament Runout Statement

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5921,7 +5921,7 @@ void kill()
 #ifdef FILAMENT_RUNOUT_SENSOR
    void filrunout()
    {
-      if filrunoutEnqued == false {
+      if (filrunoutEnqued == false) {
          filrunoutEnqued = true;
          enqueuecommand("M600");
       }


### PR DESCRIPTION
Fix a syntax error on filament runout which was not seen before.
