### PR TITLE
Update Marlin_main.cpp

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1502,8 +1502,8 @@ static void homeaxis(AxisEnum axis) {
 
     int axis_home_dir;
 
-    #ifdef DUAL_X_CARRIAGE
-      if (axis == X_AXIS) axis_home_dir = x_home_dir(active_extruder);
+    #if defined(DUAL_X_CARRIAGE) && (axis == X_AXIS)
+       axis_home_dir = x_home_dir(active_extruder);
     #else
       axis_home_dir = home_dir(axis);
     #endif


### PR DESCRIPTION
Y home issue with dual x carriage
if def DUAL_X_CARRIAGE home only with x direction
