### PR TITLE
Allow Y to home before X with option in Configuration_adv.h.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1924,6 +1924,11 @@ inline void gcode_G28() {
 
     #endif // QUICK_HOME
 
+    #ifdef HOME_Y_BEFORE_X
+      // Home Y
+      if (home_all_axis || homeY) HOMEAXIS(Y);
+    #endif
+
     // Home X
     if (home_all_axis || homeX) {
       #ifdef DUAL_X_CARRIAGE
@@ -1943,8 +1948,10 @@ inline void gcode_G28() {
       #endif
     }
 
-    // Home Y
-    if (home_all_axis || homeY) HOMEAXIS(Y);
+    #ifndef HOME_Y_BEFORE_X
+      // Home Y
+      if (home_all_axis || homeY) HOMEAXIS(Y);
+    #endif
 
     // Set the X position, if included
     if (code_seen(axis_codes[X_AXIS]) && code_has_value())

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {10, 10, 20}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {10, 10, 20}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -195,6 +195,9 @@
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 
+// When G28 is called, this option will make Y home before X
+// #define HOME_Y_BEFORE_X
+
 // @section machine
 
 #define AXIS_RELATIVE_MODES {false, false, false, false}


### PR DESCRIPTION
This addresses comments in #1956 and #1079. In particular, this is useful
when both endstops are stationary on a CoreXY system, and the Y axis needs
to be homed before the X so the flags are aligned.
