### PR TITLE
Add variant for MAX6675 in M104

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3152,7 +3152,7 @@ inline void gcode_M104() {
 inline void gcode_M105() {
   if (setTargetedHotend(105)) return;
 
-  #if HAS_TEMP_0 || HAS_TEMP_BED
+  #if HAS_TEMP_0 || HAS_TEMP_BED || defined(HEATER_0_USES_MAX6675)
     SERIAL_PROTOCOLPGM("ok");
     #if HAS_TEMP_0
       SERIAL_PROTOCOLPGM(" T:");


### PR DESCRIPTION
Else will throw error:
@:0 B@:0
Error:No thermistors - no temperature
[ERROR] Error:No thermistors - no temperature

when no bed is defined
