### PR TITLE
Remove set-coordinate extension of G28

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1790,12 +1790,6 @@ inline void gcode_G4() {
  *  Y   Home to the Y endstop
  *  Z   Home to the Z endstop
  *
- * If numbers are included with XYZ set the position as with G92
- * Currently adds the home_offset, which may be wrong and removed soon.
- *
- *  Xn  Home X, setting X to n + home_offset[X_AXIS]
- *  Yn  Home Y, setting Y to n + home_offset[Y_AXIS]
- *  Zn  Home Z, setting Z to n + home_offset[Z_AXIS]
  */
 inline void gcode_G28() {
 
@@ -1855,7 +1849,7 @@ inline void gcode_G28() {
           homeY = code_seen(axis_codes[Y_AXIS]),
           homeZ = code_seen(axis_codes[Z_AXIS]);
 
-    home_all_axis = !(homeX || homeY || homeZ) || (homeX && homeY && homeZ);
+    home_all_axis = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
 
     if (home_all_axis || homeZ) {
 
@@ -1942,18 +1936,6 @@ inline void gcode_G28() {
     // Home Y
     if (home_all_axis || homeY) HOMEAXIS(Y);
 
-    // Set the X position, if included
-    if (code_seen(axis_codes[X_AXIS]) && code_has_value()) {
-      if (code_value_long() != 0) // filter 0
-        current_position[X_AXIS] = code_value();
-    }
-
-    // Set the Y position, if included
-    if (code_seen(axis_codes[Y_AXIS]) && code_has_value()) {
-      if (code_value_long() != 0) // filter 0
-        current_position[Y_AXIS] = code_value();
-    }
-
     // Home Z last if homing towards the bed
     #if Z_HOME_DIR < 0
 
@@ -2036,12 +2018,6 @@ inline void gcode_G28() {
       } // home_all_axis || homeZ
 
     #endif // Z_HOME_DIR < 0
-
-    // Set the Z position, if included
-    if (code_seen(axis_codes[Z_AXIS]) && code_has_value()) {
-      if (code_value_long() != 0) // filter 0
-        current_position[Z_AXIS] = code_value();
-    }
 
     #if defined(ENABLE_AUTO_BED_LEVELING) && (Z_HOME_DIR < 0)
       if (home_all_axis || homeZ) current_position[Z_AXIS] += zprobe_zoffset;  // Add Z_Probe offset (the distance is negative)


### PR DESCRIPTION
- The [documentation for G28](http://reprap.org/wiki/G-code#G28:_Move_to_Origin_.28Home.29) on the RepRap wiki states that `XYZ` are _flags_ – not used for setting the current position. This updates `G28` to ignore _any_ values and only treat `XYZ` as flags.
