### PR TITLE
Fix BEEPER duration

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1544,11 +1544,10 @@ void lcd_buzz(long duration, uint16_t freq) {
   if (freq > 0) {
     #if BEEPER > 0
       SET_OUTPUT(BEEPER);
-      tone(BEEPER, freq);
+      tone(BEEPER, freq, duration);
       delay(duration);
-      noTone(BEEPER);
     #elif defined(LCD_USE_I2C_BUZZER)
-      lcd.buzz(duration,freq);
+      lcd.buzz(duration, freq);
     #else
       delay(duration);
     #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1544,7 +1544,9 @@ void lcd_buzz(long duration, uint16_t freq) {
   if (freq > 0) {
     #if BEEPER > 0
       SET_OUTPUT(BEEPER);
-      tone(BEEPER, freq, duration);
+      tone(BEEPER, freq);
+      delay(duration);
+      noTone(BEEPER);
     #elif defined(LCD_USE_I2C_BUZZER)
       lcd.buzz(duration,freq);
     #else


### PR DESCRIPTION
The function `tone(BEEPER, freq, duration)` doesn't block, so we still need to use a `delay`.
