### PR TITLE
Level Bed in Prepare submenu

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -172,6 +172,7 @@ char lcd_printPGM(const char* str) {
 
 static bool show_splashscreen = true;
 
+/* Warning: This function is called from interrupt context */
 static void lcd_implementation_init() {
 
   #ifdef LCD_PIN_BL // Enable LCD backlight

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -259,7 +259,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -258,7 +258,6 @@
 #define ENCODER_RATE_MULTIPLIER         // If defined, certain menu edit operations automatically multiply the steps when the encoder is moved quickly
 #define ENCODER_10X_STEPS_PER_SEC 75    // If the encoder steps per sec exceeds this value, multiply steps moved x10 to quickly advance the value
 #define ENCODER_100X_STEPS_PER_SEC 160  // If the encoder steps per sec exceeds this value, multiply steps moved x100 to really quickly advance the value
-//#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
 //#define CHDK 4        //Pin for triggering CHDK to take a picture see how to use it here http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
 #define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -173,6 +173,9 @@ static void lcd_status_screen();
   } while(0)
 
   #ifdef ENCODER_RATE_MULTIPLIER
+
+    //#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
+
     /**
      * MENU_MULTIPLIER_ITEM generates drawing and handling code for a multiplier menu item
      */
@@ -246,6 +249,9 @@ menuFunc_t callbackFunc;
 // place-holders for Ki and Kd edits
 float raw_Ki, raw_Kd;
 
+/**
+ * General function to go directly to a menu
+ */
 static void lcd_goto_menu(menuFunc_t menu, const bool feedback=false, const uint32_t encoder=0) {
   if (currentMenu != menu) {
     currentMenu = menu;
@@ -260,7 +266,13 @@ static void lcd_goto_menu(menuFunc_t menu, const bool feedback=false, const uint
   }
 }
 
-/* Main status screen. It's up to the implementation specific part to show what is needed. As this is very display dependent */
+/**
+ *
+ * "Info Screen"
+ *
+ * This is very display-dependent, so the lcd implementation draws this.
+ */
+
 static void lcd_status_screen() {
 	encoderRateMultiplierEnabled = false;
 
@@ -371,7 +383,12 @@ static void lcd_sdcard_stop() {
   lcd_setstatus(MSG_PRINT_ABORTED, true);
 }
 
-/* Menu implementation */
+/**
+ *
+ * "Main" menu
+ *
+ */
+
 static void lcd_main_menu() {
   START_MENU();
   MENU_ITEM(back, MSG_WATCH, lcd_status_screen);
@@ -452,6 +469,12 @@ void lcd_set_home_offsets() {
   static void lcd_babystep_z() { _lcd_babystep(Z_AXIS, PSTR(MSG_BABYSTEPPING_Z)); }
 
 #endif //BABYSTEPPING
+
+/**
+ *
+ * "Tune" submenu
+ *
+ */
 
 static void lcd_tune_menu() {
   START_MENU();
@@ -594,17 +617,55 @@ void lcd_cooldown() {
   lcd_return_to_status();
 }
 
+/**
+ *
+ * "Prepare" submenu
+ *
+ */
+
 static void lcd_prepare_menu() {
   START_MENU();
+
+  //
+  // ^ Main
+  //
   MENU_ITEM(back, MSG_MAIN, lcd_main_menu);
-  #if defined( SDSUPPORT ) && defined( MENU_ADDAUTOSTART )
-    MENU_ITEM(function, MSG_AUTOSTART, lcd_autostart_sd);
-  #endif
-  MENU_ITEM(gcode, MSG_DISABLE_STEPPERS, PSTR("M84"));
+
+  //
+  // Auto Home
+  //
   MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
+
+  //
+  // Set Home Offsets
+  //
   MENU_ITEM(function, MSG_SET_HOME_OFFSETS, lcd_set_home_offsets);
   //MENU_ITEM(gcode, MSG_SET_ORIGIN, PSTR("G92 X0 Y0 Z0"));
 
+  //
+  // Level Bed
+  //
+  #ifdef ENABLE_AUTO_BED_LEVELING
+    if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS])
+      MENU_ITEM(gcode, MSG_LEVEL_BED, PSTR("G29"));
+  #elif defined(MANUAL_BED_LEVELING)
+    MENU_ITEM(submenu, MSG_LEVEL_BED, lcd_level_bed);
+  #endif
+
+  //
+  // Move Axis
+  //
+  MENU_ITEM(submenu, MSG_MOVE_AXIS, lcd_move_menu);
+
+  //
+  // Disable Steppers
+  //
+  MENU_ITEM(gcode, MSG_DISABLE_STEPPERS, PSTR("M84"));
+
+  //
+  // Preheat PLA
+  // Preheat ABS
+  //
   #if TEMP_SENSOR_0 != 0
     #if TEMP_SENSOR_1 != 0 || TEMP_SENSOR_2 != 0 || TEMP_SENSOR_3 != 0 || TEMP_SENSOR_BED != 0
       MENU_ITEM(submenu, MSG_PREHEAT_PLA, lcd_preheat_pla_menu);
@@ -615,8 +676,14 @@ static void lcd_prepare_menu() {
     #endif
   #endif
 
+  //
+  // Cooldown
+  //
   MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
 
+  //
+  // Switch power on/off
+  //
   #if HAS_POWER_SWITCH
     if (powersupply)
       MENU_ITEM(gcode, MSG_SWITCH_PS_OFF, PSTR("M81"));
@@ -624,12 +691,13 @@ static void lcd_prepare_menu() {
       MENU_ITEM(gcode, MSG_SWITCH_PS_ON, PSTR("M80"));
   #endif
 
-  MENU_ITEM(submenu, MSG_MOVE_AXIS, lcd_move_menu);
-
-  #if defined(MANUAL_BED_LEVELING)
-    MENU_ITEM(submenu, MSG_LEVEL_BED, lcd_level_bed);
+  //
+  // Autostart
+  //
+  #if defined(SDSUPPORT) && defined(MENU_ADDAUTOSTART)
+    MENU_ITEM(function, MSG_AUTOSTART, lcd_autostart_sd);
   #endif
-	
+
   END_MENU();
 }
 
@@ -656,6 +724,12 @@ inline void line_to_current(AxisEnum axis) {
     plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], manual_feedrate[axis]/60, active_extruder);
   #endif
 }
+
+/**
+ *
+ * "Prepare" > "Move Axis" submenu
+ *
+ */
 
 float move_menu_scale;
 static void lcd_move_menu_axis();
@@ -687,6 +761,12 @@ static void lcd_move_e() {
   if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
 }
 
+/**
+ *
+ * "Prepare" > "Move Xmm" > "Move XYZ" submenu
+ *
+ */
+
 static void lcd_move_menu_axis() {
   START_MENU();
   MENU_ITEM(back, MSG_MOVE_AXIS, lcd_move_menu);
@@ -712,6 +792,12 @@ static void lcd_move_menu_01mm() {
   lcd_move_menu_axis();
 }
 
+/**
+ *
+ * "Prepare" > "Move Axis" submenu
+ *
+ */
+
 static void lcd_move_menu() {
   START_MENU();
   MENU_ITEM(back, MSG_PREPARE, lcd_prepare_menu);
@@ -721,6 +807,12 @@ static void lcd_move_menu() {
   //TODO:X,Y,Z,E
   END_MENU();
 }
+
+/**
+ *
+ * "Control" submenu
+ *
+ */
 
 static void lcd_control_menu() {
   START_MENU();
@@ -743,6 +835,12 @@ static void lcd_control_menu() {
   MENU_ITEM(function, MSG_RESTORE_FAILSAFE, Config_ResetDefault);
   END_MENU();
 }
+
+/**
+ *
+ * "Temperature" submenu
+ *
+ */
 
 #ifdef PIDTEMP
 
@@ -774,6 +872,12 @@ static void lcd_control_menu() {
   #endif //PID_PARAMS_PER_EXTRUDER
 
 #endif //PIDTEMP
+
+/**
+ *
+ * "Control" > "Temperature" submenu
+ *
+ */
 
 static void lcd_control_temperature_menu() {
   START_MENU();
@@ -863,6 +967,12 @@ static void lcd_control_temperature_menu() {
   END_MENU();
 }
 
+/**
+ *
+ * "Temperature" > "Preheat PLA conf" submenu
+ *
+ */
+
 static void lcd_control_temperature_preheat_pla_settings_menu() {
   START_MENU();
   MENU_ITEM(back, MSG_TEMPERATURE, lcd_control_temperature_menu);
@@ -879,6 +989,12 @@ static void lcd_control_temperature_preheat_pla_settings_menu() {
   END_MENU();
 }
 
+/**
+ *
+ * "Temperature" > "Preheat ABS conf" submenu
+ *
+ */
+
 static void lcd_control_temperature_preheat_abs_settings_menu() {
   START_MENU();
   MENU_ITEM(back, MSG_TEMPERATURE, lcd_control_temperature_menu);
@@ -894,6 +1010,12 @@ static void lcd_control_temperature_preheat_abs_settings_menu() {
   #endif
   END_MENU();
 }
+
+/**
+ *
+ * "Control" > "Motion" submenu
+ *
+ */
 
 static void lcd_control_motion_menu() {
   START_MENU();
@@ -931,6 +1053,12 @@ static void lcd_control_motion_menu() {
   END_MENU();
 }
 
+/**
+ *
+ * "Control" > "Filament" submenu
+ *
+ */
+
 static void lcd_control_volumetric_menu() {
   START_MENU();
   MENU_ITEM(back, MSG_CONTROL, lcd_control_menu);
@@ -953,6 +1081,12 @@ static void lcd_control_volumetric_menu() {
   END_MENU();
 }
 
+/**
+ *
+ * "Control" > "Contrast" submenu
+ *
+ */
+
 #ifdef HAS_LCD_CONTRAST
   static void lcd_set_contrast() {
     if (encoderPosition != 0) {
@@ -966,6 +1100,12 @@ static void lcd_control_volumetric_menu() {
     if (LCD_CLICKED) lcd_goto_menu(lcd_control_menu);
   }
 #endif // HAS_LCD_CONTRAST
+
+/**
+ *
+ * "Control" > "Retract" submenu
+ *
+ */
 
 #ifdef FWRETRACT
   static void lcd_control_retract_menu() {
@@ -998,6 +1138,12 @@ static void lcd_sd_updir() {
   card.updir();
   currentMenuViewOffset = 0;
 }
+
+/**
+ *
+ * "Print from SD" submenu
+ *
+ */
 
 void lcd_sdcard_menu() {
   if (lcdDrawUpdate == 0 && LCD_CLICKED == 0) return;	// nothing to do (so don't thrash the SD card)
@@ -1034,6 +1180,11 @@ void lcd_sdcard_menu() {
   END_MENU();
 }
 
+/**
+ *
+ * Functions for editing single values
+ *
+ */
 #define menu_edit_type(_type, _name, _strFunc, scale) \
   bool _menu_edit_ ## _name () { \
     bool isClicked = LCD_CLICKED; \
@@ -1080,6 +1231,11 @@ menu_edit_type(float, float51, ftostr51, 10)
 menu_edit_type(float, float52, ftostr52, 100)
 menu_edit_type(unsigned long, long5, ftostr5, 0.01)
 
+/**
+ *
+ * Handlers for RepRap World Keypad input
+ *
+ */
 #ifdef REPRAPWORLD_KEYPAD
   static void reprapworld_keypad_move_z_up() {
     encoderPosition = 1;
@@ -1114,10 +1270,14 @@ menu_edit_type(unsigned long, long5, ftostr5, 0.01)
   static void reprapworld_keypad_move_home() {
     enqueuecommands_P((PSTR("G28"))); // move all axis home
   }
-#endif //REPRAPWORLD_KEYPAD
+#endif // REPRAPWORLD_KEYPAD
 
-/** End of menus **/
 
+/**
+ *
+ * Audio feedback for controller clicks
+ *
+ */
 void lcd_quick_feedback() {
   lcdDrawUpdate = 2;
   next_button_update_ms = millis() + 500;
@@ -1146,11 +1306,15 @@ void lcd_quick_feedback() {
   #endif
 }
 
-/** Menu action functions **/
-static void menu_action_back(menuFunc_t data) { lcd_goto_menu(data); }
-static void menu_action_submenu(menuFunc_t data) { lcd_goto_menu(data); }
+/**
+ *
+ * Menu actions
+ *
+ */
+static void menu_action_back(menuFunc_t func) { lcd_goto_menu(func); }
+static void menu_action_submenu(menuFunc_t func) { lcd_goto_menu(func); }
 static void menu_action_gcode(const char* pgcode) { enqueuecommands_P(pgcode); }
-static void menu_action_function(menuFunc_t data) { (*data)(); }
+static void menu_action_function(menuFunc_t func) { (*func)(); }
 static void menu_action_sdfile(const char* filename, char* longFilename) {
   char cmd[30];
   char* c;
@@ -1243,6 +1407,19 @@ int lcd_strlen_P(const char *s) {
   return j;
 }
 
+/**
+ * Update the LCD, read encoder buttons, etc.
+ *   - Read button states
+ *   - Check the SD Card slot state
+ *   - Act on RepRap World keypad input
+ *   - Update the encoder position
+ *   - Apply acceleration to the encoder position
+ *   - Reset the Info Screen timeout if there's any input
+ *   - Update status indicators, if any
+ *   - Clear the LCD if lcdDrawUpdate == 2
+ *
+ * Warning: This function is called from interrupt context!
+ */
 void lcd_update() {
   #ifdef ULTIPANEL
     static millis_t return_to_status_ms = 0;
@@ -1381,7 +1558,7 @@ void lcd_update() {
 
     if (lcdDrawUpdate == 2) lcd_implementation_clear();
     if (lcdDrawUpdate) lcdDrawUpdate--;
-    next_lcd_update_ms = millis() + LCD_UPDATE_INTERVAL;
+    next_lcd_update_ms = ms + LCD_UPDATE_INTERVAL;
   }
 }
 
@@ -1454,112 +1631,116 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
 #ifdef ULTIPANEL
 
-////////////////////////
-// Setup Rotary Encoder Bit Values (for two pin encoders to indicate movement)
-// These values are independent of which pins are used for EN_A and EN_B indications
-// The rotary encoder part is also independent to the chipset used for the LCD
-#if defined(EN_A) && defined(EN_B)
-  #define encrot0 0
-  #define encrot1 2
-  #define encrot2 3
-  #define encrot3 1
-#endif 
+  /**
+   * Setup Rotary Encoder Bit Values (for two pin encoders to indicate movement)
+   * These values are independent of which pins are used for EN_A and EN_B indications
+   * The rotary encoder part is also independent to the chipset used for the LCD
+   */
+  #if defined(EN_A) && defined(EN_B)
+    #define encrot0 0
+    #define encrot1 2
+    #define encrot2 3
+    #define encrot3 1
+  #endif 
 
-/* Warning: This function is called from interrupt context */
-void lcd_buttons_update() {
-  #ifdef NEWPANEL
-    uint8_t newbutton = 0;
-    if (READ(BTN_EN1) == 0) newbutton |= EN_A;
-    if (READ(BTN_EN2) == 0) newbutton |= EN_B;
-    #if BTN_ENC > 0
-      if (millis() > next_button_update_ms && READ(BTN_ENC) == 0) newbutton |= EN_C;
-    #endif
-    buttons = newbutton;
-    #ifdef LCD_HAS_SLOW_BUTTONS
-      buttons |= slow_buttons;
-    #endif
-    #ifdef REPRAPWORLD_KEYPAD
-      // for the reprapworld_keypad
-      uint8_t newbutton_reprapworld_keypad=0;
+  /**
+   * Read encoder buttons from the hardware registers
+   * Warning: This function is called from interrupt context!
+   */
+  void lcd_buttons_update() {
+    #ifdef NEWPANEL
+      uint8_t newbutton = 0;
+      if (READ(BTN_EN1) == 0) newbutton |= EN_A;
+      if (READ(BTN_EN2) == 0) newbutton |= EN_B;
+      #if BTN_ENC > 0
+        if (millis() > next_button_update_ms && READ(BTN_ENC) == 0) newbutton |= EN_C;
+      #endif
+      buttons = newbutton;
+      #ifdef LCD_HAS_SLOW_BUTTONS
+        buttons |= slow_buttons;
+      #endif
+      #ifdef REPRAPWORLD_KEYPAD
+        // for the reprapworld_keypad
+        uint8_t newbutton_reprapworld_keypad=0;
+        WRITE(SHIFT_LD, LOW);
+        WRITE(SHIFT_LD, HIGH);
+        for(int8_t i = 0; i < 8; i++) {
+          newbutton_reprapworld_keypad >>= 1;
+          if (READ(SHIFT_OUT)) newbutton_reprapworld_keypad |= BIT(7);
+          WRITE(SHIFT_CLK, HIGH);
+          WRITE(SHIFT_CLK, LOW);
+        }
+        buttons_reprapworld_keypad=~newbutton_reprapworld_keypad; //invert it, because a pressed switch produces a logical 0
+      #endif
+    #else   //read it from the shift register
+      uint8_t newbutton = 0;
       WRITE(SHIFT_LD, LOW);
       WRITE(SHIFT_LD, HIGH);
-      for(int8_t i = 0; i < 8; i++) {
-        newbutton_reprapworld_keypad >>= 1;
-        if (READ(SHIFT_OUT)) newbutton_reprapworld_keypad |= BIT(7);
+      unsigned char tmp_buttons = 0;
+      for(int8_t i=0; i<8; i++) {
+        newbutton >>= 1;
+        if (READ(SHIFT_OUT)) newbutton |= BIT(7);
         WRITE(SHIFT_CLK, HIGH);
         WRITE(SHIFT_CLK, LOW);
       }
-      buttons_reprapworld_keypad=~newbutton_reprapworld_keypad; //invert it, because a pressed switch produces a logical 0
-    #endif
-  #else   //read it from the shift register
-    uint8_t newbutton = 0;
-    WRITE(SHIFT_LD, LOW);
-    WRITE(SHIFT_LD, HIGH);
-    unsigned char tmp_buttons = 0;
-    for(int8_t i=0; i<8; i++) {
-      newbutton >>= 1;
-      if (READ(SHIFT_OUT)) newbutton |= BIT(7);
-      WRITE(SHIFT_CLK, HIGH);
-      WRITE(SHIFT_CLK, LOW);
-    }
-    buttons = ~newbutton; //invert it, because a pressed switch produces a logical 0
-  #endif //!NEWPANEL
+      buttons = ~newbutton; //invert it, because a pressed switch produces a logical 0
+    #endif //!NEWPANEL
 
-  //manage encoder rotation
-  uint8_t enc=0;
-  if (buttons & EN_A) enc |= B01;
-  if (buttons & EN_B) enc |= B10;
-  if (enc != lastEncoderBits) {
-    switch(enc) {
-      case encrot0:
-        if (lastEncoderBits==encrot3) encoderDiff++;
-        else if (lastEncoderBits==encrot1) encoderDiff--;
-        break;
-      case encrot1:
-        if (lastEncoderBits==encrot0) encoderDiff++;
-        else if (lastEncoderBits==encrot2) encoderDiff--;
-        break;
-      case encrot2:
-        if (lastEncoderBits==encrot1) encoderDiff++;
-        else if (lastEncoderBits==encrot3) encoderDiff--;
-        break;
-      case encrot3:
-        if (lastEncoderBits==encrot2) encoderDiff++;
-        else if (lastEncoderBits==encrot0) encoderDiff--;
-        break;
+    //manage encoder rotation
+    uint8_t enc=0;
+    if (buttons & EN_A) enc |= B01;
+    if (buttons & EN_B) enc |= B10;
+    if (enc != lastEncoderBits) {
+      switch(enc) {
+        case encrot0:
+          if (lastEncoderBits==encrot3) encoderDiff++;
+          else if (lastEncoderBits==encrot1) encoderDiff--;
+          break;
+        case encrot1:
+          if (lastEncoderBits==encrot0) encoderDiff++;
+          else if (lastEncoderBits==encrot2) encoderDiff--;
+          break;
+        case encrot2:
+          if (lastEncoderBits==encrot1) encoderDiff++;
+          else if (lastEncoderBits==encrot3) encoderDiff--;
+          break;
+        case encrot3:
+          if (lastEncoderBits==encrot2) encoderDiff++;
+          else if (lastEncoderBits==encrot0) encoderDiff--;
+          break;
+      }
     }
+    lastEncoderBits = enc;
   }
-  lastEncoderBits = enc;
-}
 
-bool lcd_detected(void) {
-  #if (defined(LCD_I2C_TYPE_MCP23017) || defined(LCD_I2C_TYPE_MCP23008)) && defined(DETECT_DEVICE)
-    return lcd.LcdDetected() == 1;
-  #else
-    return true;
-  #endif
-}
-
-void lcd_buzz(long duration, uint16_t freq) {
-  if (freq > 0) {
-    #if BEEPER > 0
-      SET_OUTPUT(BEEPER);
-      tone(BEEPER, freq, duration);
-      delay(duration);
-    #elif defined(LCD_USE_I2C_BUZZER)
-      lcd.buzz(duration, freq);
+  bool lcd_detected(void) {
+    #if (defined(LCD_I2C_TYPE_MCP23017) || defined(LCD_I2C_TYPE_MCP23008)) && defined(DETECT_DEVICE)
+      return lcd.LcdDetected() == 1;
     #else
-      delay(duration);
+      return true;
     #endif
   }
-  else {
-    delay(duration);
+
+  void lcd_buzz(long duration, uint16_t freq) {
+    if (freq > 0) {
+      #if BEEPER > 0
+        SET_OUTPUT(BEEPER);
+        tone(BEEPER, freq, duration);
+        delay(duration);
+      #elif defined(LCD_USE_I2C_BUZZER)
+        lcd.buzz(duration, freq);
+      #else
+        delay(duration);
+      #endif
+    }
+    else {
+      delay(duration);
+    }
   }
-}
 
-bool lcd_clicked() { return LCD_CLICKED; }
+  bool lcd_clicked() { return LCD_CLICKED; }
 
-#endif //ULTIPANEL
+#endif // ULTIPANEL
 
 /*********************************/
 /** Number to string conversion **/
@@ -1621,8 +1802,7 @@ char *ftostr32(const float &x) {
 }
 
 // Convert float to string with 1.234 format
-char *ftostr43(const float &x)
-{
+char *ftostr43(const float &x) {
 	long xx = x * 1000;
     if (xx >= 0)
 		conv[0] = (xx / 1000) % 10 + '0';
@@ -1638,8 +1818,7 @@ char *ftostr43(const float &x)
 }
 
 // Convert float to string with 1.23 format
-char *ftostr12ns(const float &x)
-{
+char *ftostr12ns(const float &x) {
   long xx=x*100;
   
   xx=abs(xx);
@@ -1799,6 +1978,12 @@ char *ftostr52(const float &x) {
 #ifdef MANUAL_BED_LEVELING
 
   static int _lcd_level_bed_position;
+
+  /**
+   * MBL Wait for controller movement and clicks:
+   *   - Movement adjusts the Z axis
+   *   - Click saves the Z and goes to the next mesh point
+   */
   static void _lcd_level_bed() {
     if (encoderPosition != 0) {
       refresh_cmd_timeout();
@@ -1844,6 +2029,9 @@ char *ftostr52(const float &x) {
     }
   }
 
+  /**
+   * MBL Move to mesh starting point
+   */
   static void _lcd_level_bed_homing() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ"), "Homing");
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
@@ -1858,6 +2046,9 @@ char *ftostr52(const float &x) {
     lcdDrawUpdate = 2;
   }
 
+  /**
+   * MBL entry-point
+   */
   static void lcd_level_bed() {
     axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
     mbl.reset();


### PR DESCRIPTION
- Add “Level Bed” menu item for auto bed leveling
- Hide the option if homing has not been done yet
- Arrange the Prepare submenu more logically (?)
- Add documentation comments, some white-space
- Apply some coding standards here and there
- Move old encoder multiplier debug option to `ultralcd.cpp`
