### PR TITLE
Update of servo.h

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -60,7 +60,7 @@
 #endif
 
 #if NUM_SERVOS > 0
-  #include "servo.h"
+  #include "Servo.h"
 #endif
 
 #if HAS_DIGIPOTSS

--- a/Marlin/Servo.cpp
+++ b/Marlin/Servo.cpp
@@ -48,7 +48,7 @@
 #include <avr/interrupt.h>
 #include <Arduino.h>
 
-#include "servo.h"
+#include "Servo.h"
 
 #define usToTicks(_us)    (( clockCyclesPerMicrosecond()* _us) / 8)     // converts microseconds to tick (assumes prescale of 8)  // 12 Aug 2009
 #define ticksToUs(_ticks) (( (unsigned)_ticks * 8)/ clockCyclesPerMicrosecond() ) // converts from ticks back to microseconds


### PR DESCRIPTION
Changed the "servo.h" reference to the new file name "Servo.h" fixing bugs like 

> Marlin_main.cpp:562:5: error: ‘servo’ was not declared in this scope
