### PR TITLE
Fix homing Z position

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1596,6 +1596,7 @@ static void homeaxis(AxisEnum axis) {
 
     // Set the axis position to its home position (plus home offsets)
     axis_is_at_home(axis);
+    sync_plan_position();
 
     destination[axis] = current_position[axis];
     feedrate = 0.0;


### PR DESCRIPTION
Add `sync_plan_position()` after `axis_is_at_home(axis)` to keep the planner position in sync when homing.
