### PR TITLE
LCD WG12864U5 is not properly initialized.

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -192,7 +192,9 @@ static void lcd_implementation_init() {
 
   #ifdef LCD_PIN_BL // Enable LCD backlight
     pinMode(LCD_PIN_BL, OUTPUT);
-	  digitalWrite(LCD_PIN_BL, HIGH);
+    digitalWrite(LCD_PIN_BL, HIGH);
+    pinMode(LCD_PIN_RESET, OUTPUT);           
+    digitalWrite(LCD_PIN_RESET, HIGH);
   #endif
 
   u8g.setContrast(lcd_contrast);	


### PR DESCRIPTION
Used to reset the LCD when the reset pin is wired (instead of being routed to 5V).
Requires a definition not yet present, so keep it on hold for the time being.
