### PR TITLE
More thermal protection

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3168,7 +3168,7 @@ inline void gcode_M104() {
     #endif
 
     #ifdef WATCH_TEMP_PERIOD
-      start_watching_heaters();
+      start_watching_heater(target_extruder);
     #endif
   }
 }
@@ -3282,7 +3282,7 @@ inline void gcode_M109() {
   #endif
 
   #ifdef WATCH_TEMP_PERIOD
-    start_watching_heaters();
+    start_watching_heater(target_extruder);
   #endif
 
   millis_t temp_ms = millis();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3166,7 +3166,10 @@ inline void gcode_M104() {
       if (dual_x_carriage_mode == DXC_DUPLICATION_MODE && target_extruder == 0)
         setTargetHotend1(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset);
     #endif
-    setWatch();
+
+    #ifdef WATCH_TEMP_PERIOD
+      start_watching_heaters();
+    #endif
   }
 }
 
@@ -3278,7 +3281,9 @@ inline void gcode_M109() {
     if (code_seen('B')) autotemp_max = code_value();
   #endif
 
-  setWatch();
+  #ifdef WATCH_TEMP_PERIOD
+    start_watching_heaters();
+  #endif
 
   millis_t temp_ms = millis();
 

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 3000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 40000 //40 seconds
-#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 #define WATCH_TEMP_PERIOD 40000 //40 seconds
 #define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -17,8 +17,8 @@
 //// Heating sanity check:
 // This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and the current temperature
-//  differ by at least 2x WATCH_TEMP_INCREASE
+// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
+// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
 //#define WATCH_TEMP_PERIOD 40000 //40 seconds
 //#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-#define WATCH_TEMP_PERIOD 10000 // 10 seconds
-#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
+#define WATCH_TEMP_PERIOD 16000 // 16 seconds
+#define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -19,8 +19,8 @@
 // If the temperature has not increased at the end of that period, the target temperature is set to zero.
 // It can be reset with another M104/M109. This check is also only triggered if the target temperature and
 // the current temperature differ by at least 2x WATCH_TEMP_INCREASE
-//#define WATCH_TEMP_PERIOD 40000 //40 seconds
-//#define WATCH_TEMP_INCREASE 10  //Heat up at least 10 degree in 20 seconds
+#define WATCH_TEMP_PERIOD 10000 // 10 seconds
+#define WATCH_TEMP_INCREASE 2  // Heat up at least 2 degrees in 10 seconds
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -14,11 +14,14 @@
 #endif
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
-//// Heating sanity check:
-// This waits for the watch period in milliseconds whenever an M104 or M109 increases the target temperature
-// If the temperature has not increased at the end of that period, the target temperature is set to zero.
-// It can be reset with another M104/M109. This check is also only triggered if the target temperature and
-// the current temperature differ by at least 2x WATCH_TEMP_INCREASE
+/**
+ * Heating Sanity Check
+ *
+ * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
+ * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
+ * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
+ * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ */
 #define WATCH_TEMP_PERIOD 16000 // 16 seconds
 #define WATCH_TEMP_INCREASE 4  // Heat up at least 4 degrees in 16 seconds
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -627,6 +627,7 @@ void manage_heater() {
         // Has it failed to increase enough?
         if (degHotend(e) < watch_target_temp[e]) {
           // Stop!
+          disable_all_heaters();
           _temp_error(e, MSG_HEATING_FAILED, MSG_HEATING_FAILED_LCD);
         }
         else {

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1005,16 +1005,14 @@ void tp_init() {
    * their target temperature by a configurable margin.
    * This is called when the temperature is set. (M104, M109)
    */
-  void start_watching_heaters() {
-      millis_t ms = millis() + WATCH_TEMP_PERIOD;
-      for (int e = 0; e < EXTRUDERS; e++) {
-        if (degHotend(e) < degTargetHotend(e) - (WATCH_TEMP_INCREASE * 2)) {
-          watch_target_temp[e] = degHotend(e) + WATCH_TEMP_INCREASE;
-          watch_heater_next_ms[e] = ms;
-        }
-        else
-          watch_heater_next_ms[e] = 0;
-      }
+  void start_watching_heater(int e) {
+    millis_t ms = millis() + WATCH_TEMP_PERIOD;
+    if (degHotend(e) < degTargetHotend(e) - (WATCH_TEMP_INCREASE * 2)) {
+      watch_target_temp[e] = degHotend(e) + WATCH_TEMP_INCREASE;
+      watch_heater_next_ms[e] = ms;
+    }
+    else
+      watch_heater_next_ms[e] = 0;
   }
 #endif
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -172,8 +172,8 @@ static void updateTemperaturesFromRawValues();
 
 #ifdef WATCH_TEMP_PERIOD
   int watch_start_temp[EXTRUDERS] = { 0 };
-  millis_t watchmillis[EXTRUDERS] = { 0 };
-#endif //WATCH_TEMP_PERIOD
+  millis_t watch_heater_next_ms[EXTRUDERS] = { 0 };
+#endif
 
 #ifndef SOFT_PWM_SCALE
   #define SOFT_PWM_SCALE 0
@@ -447,14 +447,14 @@ void checkExtruderAutoFans()
 //
 // Temperature Error Handlers
 //
-inline void _temp_error(int e, const char *msg1, const char *msg2) {
+inline void _temp_error(int e, const char *serial_msg, const char *lcd_msg) {
   if (IsRunning()) {
     SERIAL_ERROR_START;
     if (e >= 0) SERIAL_ERRORLN((int)e);
-    serialprintPGM(msg1);
+    serialprintPGM(serial_msg);
     MYSERIAL.write('\n');
     #ifdef ULTRA_LCD
-      lcd_setalertstatuspgm(msg2);
+      lcd_setalertstatuspgm(lcd_msg);
     #endif
   }
   #ifndef BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
@@ -602,7 +602,7 @@ void manage_heater() {
     float ct = current_temperature[0];
     if (ct > min(HEATER_0_MAXTEMP, 1023)) max_temp_error(0);
     if (ct < max(HEATER_0_MINTEMP, 0.01)) min_temp_error(0);
-  #endif //HEATER_0_USES_MAX6675
+  #endif
 
   #if defined(WATCH_TEMP_PERIOD) || !defined(PIDTEMPBED) || HAS_AUTO_FAN
     millis_t ms = millis();
@@ -620,26 +620,27 @@ void manage_heater() {
     // Check if temperature is within the correct range
     soft_pwm[e] = current_temperature[e] > minttemp[e] && current_temperature[e] < maxttemp[e] ? (int)pid_output >> 1 : 0;
 
+    // Check if the temperature is failing to increase
     #ifdef WATCH_TEMP_PERIOD
-      if (watchmillis[e] && ms > watchmillis[e] + WATCH_TEMP_PERIOD) {
+      // Is it time to check this extruder's heater?
+      if (watch_heater_next_ms[e] && ms > watch_heater_next_ms[e]) {
+        // Has it failed to increase enough?
         if (degHotend(e) < watch_start_temp[e] + WATCH_TEMP_INCREASE) {
-          setTargetHotend(0, e);
-          LCD_MESSAGEPGM(MSG_HEATING_FAILED_LCD); // translatable
-          SERIAL_ECHO_START;
-          SERIAL_ECHOLNPGM(MSG_HEATING_FAILED);
+          // Stop!
+          _temp_error(e, MSG_HEATING_FAILED, MSG_HEATING_FAILED_LCD);
         }
         else {
-          watchmillis[e] = 0;
+          watch_heater_next_ms[e] = 0;
         }
       }
-    #endif //WATCH_TEMP_PERIOD
+    #endif // WATCH_TEMP_PERIOD
 
     #ifdef TEMP_SENSOR_1_AS_REDUNDANT
       if (fabs(current_temperature[0] - redundant_temperature) > MAX_REDUNDANT_TEMP_SENSOR_DIFF) {
         disable_all_heaters();
         _temp_error(0, PSTR(MSG_EXTRUDER_SWITCHED_OFF), PSTR(MSG_ERR_REDUNDANT_TEMP));
       }
-    #endif // TEMP_SENSOR_1_AS_REDUNDANT
+    #endif
 
   } // Extruders Loop
 
@@ -996,16 +997,23 @@ void tp_init() {
   #endif //BED_MAXTEMP
 }
 
+/**
+ * Start Heating Sanity Check for hotends that are below
+ * their target temperature by a configurable margin.
+ * This is called when the temperature is set. (M104, M109)
+ */
 void setWatch() {
   #ifdef WATCH_TEMP_PERIOD
-    millis_t ms = millis();
+    millis_t ms = millis() + WATCH_TEMP_PERIOD;
     for (int e = 0; e < EXTRUDERS; e++) {
       if (degHotend(e) < degTargetHotend(e) - (WATCH_TEMP_INCREASE * 2)) {
         watch_start_temp[e] = degHotend(e);
-        watchmillis[e] = ms;
-      } 
+        watch_heater_next_ms[e] = ms;
+      }
+      else
+        watch_heater_next_ms[e] = 0;
     }
-  #endif 
+  #endif
 }
 
 #if HAS_HEATER_THERMAL_PROTECTION || HAS_BED_THERMAL_PROTECTION

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -138,7 +138,7 @@ void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();
 
 #ifdef WATCH_TEMP_PERIOD
-  void start_watching_heaters();
+  void start_watching_heater(int e=0);
 #endif
 
 FORCE_INLINE void autotempShutdown() {

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -130,13 +130,16 @@ HOTEND_ROUTINES(0);
 
 int getHeaterPower(int heater);
 void disable_all_heaters();
-void setWatch();
 void updatePID();
 
 void PID_autotune(float temp, int extruder, int ncycles);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();
+
+#ifdef WATCH_TEMP_PERIOD
+  void start_watching_heaters();
+#endif
 
 FORCE_INLINE void autotempShutdown() {
   #ifdef AUTOTEMP

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -522,7 +522,7 @@ void _lcd_preheat(int endnum, const float temph, const float tempb, const int fa
   fanSpeed = fan;
   lcd_return_to_status();
   #ifdef WATCH_TEMP_PERIOD
-    start_watching_heaters();
+    if (endnum >= 0) start_watching_heater(endnum);
   #endif
 }
 void lcd_preheat_pla0() { _lcd_preheat(0, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -521,7 +521,9 @@ void _lcd_preheat(int endnum, const float temph, const float tempb, const int fa
   setTargetBed(tempb);
   fanSpeed = fan;
   lcd_return_to_status();
-  setWatch(); // heater sanity check timer
+  #ifdef WATCH_TEMP_PERIOD
+    start_watching_heaters();
+  #endif
 }
 void lcd_preheat_pla0() { _lcd_preheat(0, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
 void lcd_preheat_abs0() { _lcd_preheat(0, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }


### PR DESCRIPTION
- Enable `WATCH_TEMP_PERIOD` by default
- Make the default check for 4°C in 16s so it will catch problems sooner
- Better function documentation
- Use next_ms instead of start_ms as a convention
- If this test fails `Stop()` the machine just like thermal runaway
