### PR TITLE
Pre-sanitize gcode commands before processing

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -113,7 +113,7 @@ FORCE_INLINE void serialprintPGM(const char *str) {
 }
 
 void get_command();
-void process_commands();
+void process_next_command();
 
 void manage_inactivity(bool ignore_stepper_queue=false);
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5166,7 +5166,6 @@ void process_next_command() {
     while (*current_command == ' ') ++current_command;
   }
   char *starpos = strchr(current_command, '*');  // * should always be the last parameter
-
   if (starpos) *starpos = '\0';
 
   // Get the command code as a character

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5165,7 +5165,7 @@ void process_next_command() {
     while (*current_command != ' ') ++current_command;
     while (*current_command == ' ') ++current_command;
   }
-  char *starpos = strchr(command, '*');  // * should always be the last parameter
+  char *starpos = strchr(current_command, '*');  // * should always be the last parameter
   if (starpos) *starpos = '\0';
 
   // Get the command code as a character

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -232,6 +232,7 @@ bool axis_known_position[3] = { false };
 
 static long gcode_N, gcode_LastN, Stopped_gcode_LastN = 0;
 
+static char *current_command;
 static int cmd_queue_index_r = 0;
 static int cmd_queue_index_w = 0;
 static int commands_in_queue = 0;
@@ -697,17 +698,17 @@ void loop() {
           // Write the string from the read buffer to SD
           card.write_command(command);
           if (card.logging)
-            process_commands(); // The card is saving because it's logging
+            process_next_command(); // The card is saving because it's logging
           else
             SERIAL_PROTOCOLLNPGM(MSG_OK);
         }
       }
       else
-        process_commands();
+        process_next_command();
 
     #else
 
-      process_commands();
+      process_next_command();
 
     #endif // SDSUPPORT
 
@@ -933,7 +934,7 @@ long code_value_long() { return strtol(strchr_pointer + 1, NULL, 10); }
 int16_t code_value_short() { return (int16_t)strtol(strchr_pointer + 1, NULL, 10); }
 
 bool code_seen(char code) {
-  strchr_pointer = strchr(command_queue[cmd_queue_index_r], code);
+  strchr_pointer = strchr(current_command, code);
   return (strchr_pointer != NULL);  //Return True if a character was found
 }
 
@@ -2833,7 +2834,7 @@ inline void gcode_G92() {
    * M1: // M1 - Conditional stop - Wait for user button press on LCD
    */
   inline void gcode_M0_M1() {
-    char *src = strchr_pointer + 2;
+    char *src = strchr_pointer + 3;
 
     millis_t codenum = 0;
     bool hasP = false, hasS = false;
@@ -2845,9 +2846,7 @@ inline void gcode_G92() {
       codenum = code_value() * 1000; // seconds to wait
       hasS = codenum > 0;
     }
-    char* starpos = strchr(src, '*');
-    if (starpos != NULL) *(starpos) = '\0';
-    while (*src == ' ') ++src;
+
     if (!hasP && !hasS && *src != '\0')
       lcd_setstatus(src, true);
     else {
@@ -2922,10 +2921,7 @@ inline void gcode_M17() {
    * M23: Select a file
    */
   inline void gcode_M23() {
-    char* codepos = strchr_pointer + 4;
-    char* starpos = strchr(codepos, '*');
-    if (starpos) *starpos = '\0';
-    card.openFile(codepos, true);
+    card.openFile(strchr_pointer + 4, true);
   }
 
   /**
@@ -2962,14 +2958,7 @@ inline void gcode_M17() {
    * M28: Start SD Write
    */
   inline void gcode_M28() {
-    char* codepos = strchr_pointer + 4;
-    char* starpos = strchr(codepos, '*');
-    if (starpos) {
-      char* npos = strchr(command_queue[cmd_queue_index_r], 'N');
-      strchr_pointer = strchr(npos, ' ') + 1;
-      *(starpos) = '\0';
-    }
-    card.openFile(codepos, false);
+    card.openFile(strchr_pointer + 4, false);
   }
 
   /**
@@ -2986,12 +2975,6 @@ inline void gcode_M17() {
   inline void gcode_M30() {
     if (card.cardOK) {
       card.closefile();
-      char* starpos = strchr(strchr_pointer + 4, '*');
-      if (starpos) {
-        char* npos = strchr(command_queue[cmd_queue_index_r], 'N');
-        strchr_pointer = strchr(npos, ' ') + 1;
-        *(starpos) = '\0';
-      }
       card.removeFile(strchr_pointer + 4);
     }
   }
@@ -3022,16 +3005,13 @@ inline void gcode_M31() {
     if (card.sdprinting)
       st_synchronize();
 
-    char* codepos = strchr_pointer + 4;
+    char* src = strchr_pointer + 4;
 
-    char* namestartpos = strchr(codepos, '!');   //find ! to indicate filename string start.
-    if (! namestartpos)
-      namestartpos = codepos; //default name position, 4 letters after the M
+    char* namestartpos = strchr(src, '!');   //find ! to indicate filename string start.
+    if (!namestartpos)
+      namestartpos = src; //default name position, 4 letters after the M
     else
       namestartpos++; //to skip the '!'
-
-    char* starpos = strchr(codepos, '*');
-    if (starpos) *(starpos) = '\0';
 
     bool call_procedure = code_seen('P') && (strchr_pointer < namestartpos);
 
@@ -3051,12 +3031,6 @@ inline void gcode_M31() {
    * M928: Start SD Write
    */
   inline void gcode_M928() {
-    char* starpos = strchr(strchr_pointer + 5, '*');
-    if (starpos) {
-      char* npos = strchr(command_queue[cmd_queue_index_r], 'N');
-      strchr_pointer = strchr(npos, ' ') + 1;
-      *(starpos) = '\0';
-    }
     card.openLogFile(strchr_pointer + 5);
   }
 
@@ -3858,10 +3832,7 @@ inline void gcode_M115() {
  * M117: Set LCD Status Message
  */
 inline void gcode_M117() {
-  char* codepos = strchr_pointer + 5;
-  char* starpos = strchr(codepos, '*');
-  if (starpos) *starpos = '\0';
-  lcd_setstatus(codepos);
+  lcd_setstatus(strchr_pointer + 5);
 }
 
 /**
@@ -4152,7 +4123,7 @@ inline void gcode_M206() {
         default:
           SERIAL_ECHO_START;
           SERIAL_ECHOPGM(MSG_UNKNOWN_COMMAND);
-          SERIAL_ECHO(command_queue[cmd_queue_index_r]);
+          SERIAL_ECHO(current_command);
           SERIAL_ECHOLNPGM("\"");
           return;
       }
@@ -5071,8 +5042,7 @@ inline void gcode_M999() {
 /**
  * T0-T3: Switch tool, usually switching extruders
  */
-inline void gcode_T() {
-  int tmp_extruder = code_value();
+inline void gcode_T(uint8_t tmp_extruder) {
   if (tmp_extruder >= EXTRUDERS) {
     SERIAL_ECHO_START;
     SERIAL_CHAR('T');
@@ -5175,21 +5145,40 @@ inline void gcode_T() {
 }
 
 /**
- * Process Commands and dispatch them to handlers
+ * Process a single command and dispatch it to its handler
  * This is called from the main loop()
  */
-void process_commands() {
+void process_next_command() {
+  current_command = command_queue[cmd_queue_index_r];
 
   if ((marlin_debug_flags & DEBUG_ECHO)) {
     SERIAL_ECHO_START;
-    SERIAL_ECHOLN(command_queue[cmd_queue_index_r]);
+    SERIAL_ECHOLN(current_command);
   }
 
-  if (code_seen('G')) {
+  // Sanitize the current command:
+  //  - Skip leading spaces
+  //  - Bypass N...
+  //  - Overwrite * with nul to mark the end
+  while (*current_command == ' ') ++current_command;
+  if (*current_command == 'N' && current_command[1] >= '0' && current_command[1] <= '9') {
+    while (*current_command != ' ') ++current_command;
+    while (*current_command == ' ') ++current_command;
+  }
+  char *starpos = strchr(command, '*');  // * should always be the last parameter
+  if (starpos) *starpos = '\0';
 
-    int gCode = code_value_short();
+  // Get the command code as a character
+  char command_code = *current_command;
 
-    switch(gCode) {
+  // code_value routines look at strchr_pointer + 1
+  strchr_pointer = current_command;
+
+  if (command_code == 'G' && code_has_value()) {
+
+    int codenum = code_value_short();
+
+    switch (codenum) {
 
     // G0, G1
     case 0:
@@ -5201,7 +5190,7 @@ void process_commands() {
     #ifndef SCARA
       case 2: // G2  - CW ARC
       case 3: // G3  - CCW ARC
-        gcode_G2_G3(gCode == 2);
+        gcode_G2_G3(codenum == 2);
         break;
     #endif
 
@@ -5214,7 +5203,7 @@ void process_commands() {
 
       case 10: // G10: retract
       case 11: // G11: retract_recover
-        gcode_G10_G11(gCode == 10);
+        gcode_G10_G11(codenum == 10);
         break;
 
     #endif //FWRETRACT
@@ -5241,7 +5230,7 @@ void process_commands() {
 
           case 31: // G31: dock the sled
           case 32: // G32: undock the sled
-            dock_sled(gCode == 31);
+            dock_sled(codenum == 31);
             break;
 
       #endif // Z_PROBE_SLED
@@ -5261,8 +5250,8 @@ void process_commands() {
     }
   }
 
-  else if (code_seen('M')) {
-    switch(code_value_short()) {
+  else if (command_code == 'M' && code_has_value()) {
+    switch (code_value_short()) {
       #ifdef ULTIPANEL
         case 0: // M0 - Unconditional stop - Wait for user button press on LCD
         case 1: // M1 - Conditional stop - Wait for user button press on LCD
@@ -5687,14 +5676,14 @@ void process_commands() {
     }
   }
 
-  else if (code_seen('T')) {
-    gcode_T();
+  else if (command_code == 'T' && code_has_value()) {
+    gcode_T(code_value_short());
   }
 
   else {
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM(MSG_UNKNOWN_COMMAND);
-    SERIAL_ECHO(command_queue[cmd_queue_index_r]);
+    SERIAL_ECHO(current_command);
     SERIAL_ECHOLNPGM("\"");
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5166,6 +5166,7 @@ void process_next_command() {
     while (*current_command == ' ') ++current_command;
   }
   char *starpos = strchr(current_command, '*');  // * should always be the last parameter
+
   if (starpos) *starpos = '\0';
 
   // Get the command code as a character


### PR DESCRIPTION
- Make a global pointer to the current sanitized command
- Pre-sanitize the current command to bypass `N` and nullify `*`, removing the need for handlers to bypass, ignore, or nullify these parts.
- Pre-skip leading whitespace.
- Only look for G, M, T codes at the start of the command.
- Verify that G, M, T codes are followed by command codes.
