### PR TITLE
NO_TIMEOUTS and ADVANCED_OK off by default

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -393,12 +393,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -402,12 +402,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -402,12 +402,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -401,12 +401,13 @@ const unsigned int dropsegments=5; //everything with less than this number of st
 #define BUFSIZE 4
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
-// Therefore some clients go after 30 seconds in a timeout. Some other clients start sending commands while receiving a 'wait'.
-// This wait is only send when the buffer is empty. The timeout-length is in milliseconds. 1000 is a good value.
-#define NO_TIMEOUTS 1000
+// Therefore some clients abort after 30 seconds in a timeout.
+// Some other clients start sending commands while receiving a 'wait'.
+// This "wait" is only sent when the buffer is empty. 1 second is a good value here.
+//#define NO_TIMEOUTS 1000 // Milliseconds
 
 // Some clients will have this feature soon. This could make the NO_TIMEOUTS unnecessary.
-#define ADVANCED_OK
+//#define ADVANCED_OK
 
 // @section fwretract
 


### PR DESCRIPTION
- The Pronterface log fills up with “wait” making its console useless, so disable `NO_TIMEOUTS` by default. Should host software announce when it is starting a print, so this can be suppressed until it actually matters? Or Printrun ignore “wait” instead?
- Adjust documentation comments
- Supplants #2078
