### PR TITLE
new bits for endstops

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -33,6 +33,7 @@
 
 #define BIT(b) (1<<(b))
 #define TEST(n,b) (((n)&BIT(b))!=0)
+#define SET_BIT(n,b,value) (n) ^= ((-value)^(n)) & (BIT(b))
 #define RADIANS(d) ((d)*M_PI/180.0)
 #define DEGREES(r) ((d)*180.0/M_PI)
 #define NOLESS(v,n) do{ if (v < n) v = n; }while(0)

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -199,7 +199,7 @@ void manage_inactivity(bool ignore_stepper_queue=false);
  */
 enum AxisEnum {X_AXIS=0, Y_AXIS=1, A_AXIS=0, B_AXIS=1, Z_AXIS=2, E_AXIS=3, X_HEAD=4, Y_HEAD=5};
 
-enum EndstopEnum {X_MIN=0, Y_MIN=1, Z_MIN=2, Z_PROBE=3, X_MAX=4, Y_MAX=5, Z_MAX=6};
+enum EndstopEnum {X_MIN=0, Y_MIN=1, Z_MIN=2, Z_PROBE=3, X_MAX=4, Y_MAX=5, Z_MAX=6, Z2_MIN=7, Z2_MAX=8};
 
 void enable_all_steppers();
 void disable_all_steppers();

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -565,13 +565,7 @@ ISR(TIMER1_COMPA_vect) {
                 COPY_BIT(current_endstop_bits, Z_MIN, Z2_MIN)
               #endif
 
-            byte z_test = TEST_ENDSTOP(Z_MIN) << 0 + // bit 0 for Z, bit 1 for Z2
-            #if HAS_Z2_MIN
-              TEST_ENDSTOP(Z2_MIN)
-            #else
-              TEST_ENDSTOP(Z_MIN)
-            #endif
-            << 1;
+            byte z_test = TEST_ENDSTOP(Z_MIN) << 0 + TEST_ENDSTOP(Z2_MIN) << 1; // bit 0 for Z, bit 1 for Z2
 
             if (z_test && current_block->steps[Z_AXIS] > 0) { // z_test = Z_MIN || Z2_MIN
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
@@ -608,13 +602,7 @@ ISR(TIMER1_COMPA_vect) {
                 COPY_BIT(current_endstop_bits, Z_MAX, Z2_MAX)
               #endif
 
-            byte z_test = TEST_ENDSTOP(Z_MAX) << 0 + // bit 0 for Z, bit 1 for Z2
-            #if HAS_Z2_MAX
-              TEST_ENDSTOP(Z2_MAX)
-            #else
-              TEST_ENDSTOP(Z_MAX)
-            #endif
-            << 1;
+            byte z_test = TEST_ENDSTOP(Z_MAX) << 0 + TEST_ENDSTOP(Z2_MAX) << 1; // bit 0 for Z, bit 1 for Z2
 
             if (z_test && current_block->steps[Z_AXIS] > 0) {  // t_test = Z_MAX || Z2_MAX
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -76,37 +76,17 @@ volatile long endstops_trigsteps[3] = { 0 };
 volatile long endstops_stepsTotal, endstops_stepsDone;
 static volatile char endstop_hit_bits = 0; // use X_MIN, Y_MIN, Z_MIN and Z_PROBE as BIT value
 
+static char old_endstop_bits = 0; // use X_MIN, X_MAX... Z_MAX, Z_PROBE
+#ifdef Z_DUAL_ENDSTOPS
+  static char old_dual_endstop_bits = 0; // actually only implemented for Z
+#endif
+
 #ifdef ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
   bool abort_on_endstop_hit = false;
 #endif
 
 #ifdef MOTOR_CURRENT_PWM_XY_PIN
   int motor_current_setting[3] = DEFAULT_PWM_MOTOR_CURRENT;
-#endif
-
-#if HAS_X_MIN
-  static bool old_x_min_endstop = false;
-#endif
-#if HAS_X_MAX
-  static bool old_x_max_endstop = false;
-#endif
-#if HAS_Y_MIN
-  static bool old_y_min_endstop = false;
-#endif
-#if HAS_Y_MAX
-  static bool old_y_max_endstop = false;
-#endif
-
-static bool old_z_min_endstop = false;
-static bool old_z_max_endstop = false;
-
-#ifdef Z_DUAL_ENDSTOPS
-  static bool old_z2_min_endstop = false;
-  static bool old_z2_max_endstop = false;
-#endif
-
-#ifdef Z_PROBE_ENDSTOP // No need to check for valid pin, SanityCheck.h already does this.
-  static bool old_z_probe_endstop = false;
 #endif
 
 static bool check_endstops = true;
@@ -155,11 +135,11 @@ volatile signed char count_direction[NUM_AXIS] = { 1, 1, 1, 1 };
     #define Z_APPLY_STEP(v,Q) \
     if (performing_homing) { \
       if (Z_HOME_DIR > 0) {\
-        if (!(old_z_max_endstop && (count_direction[Z_AXIS] > 0)) && !locked_z_motor) Z_STEP_WRITE(v); \
-        if (!(old_z2_max_endstop && (count_direction[Z_AXIS] > 0)) && !locked_z2_motor) Z2_STEP_WRITE(v); \
+        if (!(TEST(old_endstop_bits, Z_MAX) && (count_direction[Z_AXIS] > 0)) && !locked_z_motor) Z_STEP_WRITE(v); \
+        if (!(TEST(old_dual_endstop_bits, Z_MAX) && (count_direction[Z_AXIS] > 0)) && !locked_z2_motor) Z2_STEP_WRITE(v); \
       } else {\
-        if (!(old_z_min_endstop && (count_direction[Z_AXIS] < 0)) && !locked_z_motor) Z_STEP_WRITE(v); \
-        if (!(old_z2_min_endstop && (count_direction[Z_AXIS] < 0)) && !locked_z2_motor) Z2_STEP_WRITE(v); \
+        if (!(TEST(old_endstop_bits, Z_MIN) && (count_direction[Z_AXIS] < 0)) && !locked_z_motor) Z_STEP_WRITE(v); \
+        if (!(TEST(old_dual_endstop_bits, Z_MIN) && (count_direction[Z_AXIS] < 0)) && !locked_z2_motor) Z2_STEP_WRITE(v); \
       } \
     } else { \
       Z_STEP_WRITE(v); \
@@ -266,7 +246,7 @@ void endstops_hit_on_purpose() {
 }
 
 void checkHitEndstops() {
-  if (endstop_hit_bits) { // #ifdef || endstop_z_probe_hit to save space if needed.
+  if (endstop_hit_bits) {
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM(MSG_ENDSTOPS_HIT);
     if (endstop_hit_bits & BIT(X_MIN)) {
@@ -492,22 +472,31 @@ ISR(TIMER1_COMPA_vect) {
     // Check endstops
     if (check_endstops) {
       
-      #define _ENDSTOP(axis, minmax) axis ##_## minmax ##_endstop
+      char current_endstop_bits;
+      #ifdef Z_DUAL_ENDSTOPS
+        char current_dual_endstop_bits;
+      #endif
+
       #define _ENDSTOP_PIN(AXIS, MINMAX) AXIS ##_## MINMAX ##_PIN
       #define _ENDSTOP_INVERTING(AXIS, MINMAX) AXIS ##_## MINMAX ##_ENDSTOP_INVERTING
-      #define _OLD_ENDSTOP(axis, minmax) old_## axis ##_## minmax ##_endstop
       #define _AXIS(AXIS) AXIS ##_AXIS
-      #define _HIT_BIT(AXIS) AXIS ##_MIN
-      #define _ENDSTOP_HIT(AXIS) endstop_hit_bits |= BIT(_HIT_BIT(AXIS))
+      #define _ENDSTOP_HIT(AXIS) endstop_hit_bits |= BIT(_ENDSTOP(AXIS, MIN))
+      #define _ENDSTOP(AXIS, MINMAX) AXIS ##_## MINMAX
 
-      #define UPDATE_ENDSTOP(axis,AXIS,minmax,MINMAX) \
-        bool _ENDSTOP(axis, minmax) = (READ(_ENDSTOP_PIN(AXIS, MINMAX)) != _ENDSTOP_INVERTING(AXIS, MINMAX)); \
-        if (_ENDSTOP(axis, minmax) && _OLD_ENDSTOP(axis, minmax) && (current_block->steps[_AXIS(AXIS)] > 0)) { \
+      // GET_ENDSTOP_STATUS: set the current endstop bits for an endstop to its status
+      #define GET_ENDSTOP_STATUS(endstop, AXIS, MINMAX) SET_BIT(endstop, _ENDSTOP(AXIS, MINMAX), (READ(_ENDSTOP_PIN(AXIS, MINMAX)) != _ENDSTOP_INVERTING(AXIS, MINMAX)))
+      // TEST_ENDSTOP: test the old and the current status of an endstop
+      #define TEST_ENDSTOPS(AXIS, MINMAX) (TEST(current_endstop_bits, _ENDSTOP(AXIS, MINMAX)) && TEST(old_endstop_bits, _ENDSTOP(AXIS, MINMAX)))
+      // TEST_DUAL_ENDSTOP: same like TEST_ENDSTOP for dual endstops
+      #define TEST_DUAL_ENDSTOPS(AXIS, MINMAX) (TEST(current_dual_endstop_bits, _ENDSTOP(AXIS, MINMAX)) && TEST(old_dual_endstop_bits, _ENDSTOP(AXIS, MINMAX)))
+
+      #define UPDATE_ENDSTOP(AXIS,MINMAX) \
+        GET_ENDSTOP_STATUS(current_endstop_bits, AXIS, MINMAX); \
+        if (TEST_ENDSTOPS(AXIS, MINMAX)  && (current_block->steps[_AXIS(AXIS)] > 0)) { \
           endstops_trigsteps[_AXIS(AXIS)] = count_position[_AXIS(AXIS)]; \
           _ENDSTOP_HIT(AXIS); \
           step_events_completed = current_block->step_event_count; \
-        } \
-        _OLD_ENDSTOP(axis, minmax) = _ENDSTOP(axis, minmax);
+        }
       
       #ifdef COREXY
         // Head direction in -X axis for CoreXY bots.
@@ -524,7 +513,7 @@ ISR(TIMER1_COMPA_vect) {
             #endif
               {
                 #if HAS_X_MIN
-                  UPDATE_ENDSTOP(x, X, min, MIN);
+                  UPDATE_ENDSTOP(X, MIN);
                 #endif
               }
           }
@@ -535,7 +524,7 @@ ISR(TIMER1_COMPA_vect) {
             #endif
               {
                 #if HAS_X_MAX
-                  UPDATE_ENDSTOP(x, X, max, MAX);
+                  UPDATE_ENDSTOP(X, MAX);
                 #endif
               }
           }
@@ -550,12 +539,12 @@ ISR(TIMER1_COMPA_vect) {
       #endif
           { // -direction
             #if HAS_Y_MIN
-              UPDATE_ENDSTOP(y, Y, min, MIN);
+              UPDATE_ENDSTOP(Y, MIN);
             #endif
           }
           else { // +direction
             #if HAS_Y_MAX
-              UPDATE_ENDSTOP(y, Y, max, MAX);
+              UPDATE_ENDSTOP(Y, MAX);
             #endif
           }
       #ifdef COREXY
@@ -565,45 +554,38 @@ ISR(TIMER1_COMPA_vect) {
         #if HAS_Z_MIN
 
           #ifdef Z_DUAL_ENDSTOPS
+            GET_ENDSTOP_STATUS(current_endstop_bits, Z, MIN);
+              #if HAS_Z2_MIN
+                GET_ENDSTOP_STATUS(current_dual_endstop_bits, Z, MIN);
+              #endif
 
-            bool z_min_endstop = READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING,
-                z2_min_endstop =
-                  #if HAS_Z2_MIN
-                    READ(Z2_MIN_PIN) != Z2_MIN_ENDSTOP_INVERTING
-                  #else
-                    z_min_endstop
-                  #endif
-                ;
+            bool z_test = TEST_ENDSTOPS(Z, MIN) 
+            #if HAS_Z2_MIN
+              && TEST_DUAL_ENDSTOPS(Z, MIN)
+            #endif
+            ;
 
-            bool z_min_both = z_min_endstop && old_z_min_endstop,
-                z2_min_both = z2_min_endstop && old_z2_min_endstop;
-            if ((z_min_both || z2_min_both) && current_block->steps[Z_AXIS] > 0) {
+            if (z_test && current_block->steps[Z_AXIS] > 0) {
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
-              if (!performing_homing || (performing_homing && z_min_both && z2_min_both)) //if not performing home or if both endstops were trigged during homing...
+              if (!performing_homing || (performing_homing && !z_test)) //if not performing home or if both endstops were trigged during homing...
                 step_events_completed = current_block->step_event_count;
             }
-            old_z_min_endstop = z_min_endstop;
-            old_z2_min_endstop = z2_min_endstop;
-
           #else // !Z_DUAL_ENDSTOPS
 
-            UPDATE_ENDSTOP(z, Z, min, MIN);
-
+            UPDATE_ENDSTOP(Z, MIN);
           #endif // !Z_DUAL_ENDSTOPS
-
         #endif // Z_MIN_PIN
 
         #ifdef Z_PROBE_ENDSTOP
-          UPDATE_ENDSTOP(z, Z, probe, PROBE);
-          z_probe_endstop=(READ(Z_PROBE_PIN) != Z_PROBE_ENDSTOP_INVERTING);
-          if(z_probe_endstop && old_z_probe_endstop)
+          UPDATE_ENDSTOP(Z, PROBE);
+          GET_ENDSTOP_STATUS(current_endstop_bits, Z, PROBE);
+
+          if(TEST_ENDSTOPS(Z, PROBE))
           {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
             endstop_hit_bits |= BIT(Z_PROBE);
-  //        if (z_probe_endstop && old_z_probe_endstop) SERIAL_ECHOLN("z_probe_endstop = true");
           }
-          old_z_probe_endstop = z_probe_endstop;
         #endif
       }
       else { // z +direction
@@ -611,53 +593,46 @@ ISR(TIMER1_COMPA_vect) {
 
           #ifdef Z_DUAL_ENDSTOPS
 
-            bool z_max_endstop = READ(Z_MAX_PIN) != Z_MAX_ENDSTOP_INVERTING,
-                z2_max_endstop =
-                  #if HAS_Z2_MAX
-                    READ(Z2_MAX_PIN) != Z2_MAX_ENDSTOP_INVERTING
-                  #else
-                    z_max_endstop
-                  #endif
-                ;
+            GET_ENDSTOP_STATUS(current_endstop_bits, Z, MAX);
+              #if HAS_Z2_MAX
+                GET_ENDSTOP_STATUS(current_dual_endstop_bits, Z, MAX);
+              #endif
 
-            bool z_max_both = z_max_endstop && old_z_max_endstop,
-                z2_max_both = z2_max_endstop && old_z2_max_endstop;
-            if ((z_max_both || z2_max_both) && current_block->steps[Z_AXIS] > 0) {
+            bool z_test = TEST_ENDSTOPS(Z, MAX) 
+            #if HAS_Z2_MAX
+              && TEST_DUAL_ENDSTOPS(Z, MAX)
+            #endif
+            ;
+
+            if (z_test && current_block->steps[Z_AXIS] > 0) {
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
-
-             // if (z_max_both) SERIAL_ECHOLN("z_max_endstop = true");
-             // if (z2_max_both) SERIAL_ECHOLN("z2_max_endstop = true");
-
-              if (!performing_homing || (performing_homing && z_max_both && z2_max_both)) //if not performing home or if both endstops were trigged during homing...
+              if (!performing_homing || (performing_homing && !z_test)) //if not performing home or if both endstops were trigged during homing...
                 step_events_completed = current_block->step_event_count;
             }
-            old_z_max_endstop = z_max_endstop;
-            old_z2_max_endstop = z2_max_endstop;
 
           #else // !Z_DUAL_ENDSTOPS
 
-            UPDATE_ENDSTOP(z, Z, max, MAX);
+            UPDATE_ENDSTOP(Z, MAX);
 
           #endif // !Z_DUAL_ENDSTOPS
-
         #endif // Z_MAX_PIN
         
         #ifdef Z_PROBE_ENDSTOP
-          UPDATE_ENDSTOP(z, Z, probe, PROBE);
-          z_probe_endstop=(READ(Z_PROBE_PIN) != Z_PROBE_ENDSTOP_INVERTING);
-          if(z_probe_endstop && old_z_probe_endstop)
+          UPDATE_ENDSTOP(Z, PROBE);
+          GET_ENDSTOP_STATUS(current_endstop_bits, Z, PROBE);
+          if(TEST_ENDSTOPS(Z, PROBE))
           {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
             endstop_hit_bits |= BIT(Z_PROBE);
-//          if (z_probe_endstop && old_z_probe_endstop) SERIAL_ECHOLN("z_probe_endstop = true");
           }
-          old_z_probe_endstop = z_probe_endstop;
         #endif
       }
-
+      old_endstop_bits = current_endstop_bits;
+      #ifdef Z_DUAL_ENDSTOPS
+        old_dual_endstop_bits = current_dual_endstop_bits;
+      #endif
     }
-
 
 
     // Take multiple steps per interrupt (For high speed moves)

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -571,7 +571,7 @@ ISR(TIMER1_COMPA_vect) {
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
               if (!performing_homing || (performing_homing && !((~z_test) & 0x3)))  //if not performing home or if both endstops were trigged during homing...
-                step_events_completed = current_block->step_event_count;            //!((~z_test) & 0x3) = !Z_MIN && !Z2_MIN
+                step_events_completed = current_block->step_event_count;            //!((~z_test) & 0x3) = Z_MIN && Z2_MIN
             }
           #else // !Z_DUAL_ENDSTOPS
 
@@ -608,7 +608,7 @@ ISR(TIMER1_COMPA_vect) {
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
               if (!performing_homing || (performing_homing && !((~z_test) & 0x3)))  //if not performing home or if both endstops were trigged during homing...
-                step_events_completed = current_block->step_event_count;            //!((~z_test) & 0x3) = !Z_MAX && !Z2_MAX
+                step_events_completed = current_block->step_event_count;            //!((~z_test) & 0x3) = Z_MAX && Z2_MAX
             }
 
           #else // !Z_DUAL_ENDSTOPS

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -562,11 +562,13 @@ ISR(TIMER1_COMPA_vect) {
                 GET_ENDSTOP_STATUS(current_endstop_bits, Z2, MIN);
               #endif
 
-            byte z_test = TEST_ENDSTOP(Z_MIN) << 0 // bit 0 for Z, bit 1 for Z2
+            byte z_test = TEST_ENDSTOP(Z_MIN) << 0 + // bit 0 for Z, bit 1 for Z2
             #if HAS_Z2_MIN
-              + TEST_ENDSTOP(Z2_MIN) << 1
+              TEST_ENDSTOP(Z2_MIN)
+            #else
+              TEST_ENDSTOP(Z_MIN)
             #endif
-            ;
+            << 1;
 
             if (!((~z_test) & 0x3) && current_block->steps[Z_AXIS] > 0) { // !(~ab & 0x3) is equal to a && b
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
@@ -601,11 +603,13 @@ ISR(TIMER1_COMPA_vect) {
                 GET_ENDSTOP_STATUS(current_endstop_bits, Z2, MAX);
               #endif
 
-            byte z_test = TEST_ENDSTOP(Z_MAX) << 0 // bit 0 for Z, bit 1 for Z2
+            byte z_test = TEST_ENDSTOP(Z_MAX) << 0 + // bit 0 for Z, bit 1 for Z2
             #if HAS_Z2_MAX
-              + TEST_ENDSTOP(Z2_MAX) << 1
+              TEST_ENDSTOP(Z2_MAX)
+            #else
+              TEST_ENDSTOP(Z_MAX)
             #endif
-            ;
+            << 1;
 
             if (!((~z_test) & 0x3)  && current_block->steps[Z_AXIS] > 0) {
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];


### PR DESCRIPTION
removed boolean endstop-flags
add up to 2 char endstop_bits-flags

in standard-config (out of the box)
new 51740/3048 | old 51818/3053 bytes

actually i can test only x/y/z-max
anyone who can test x/y/z-min, z-probe and maybe the dual-z-endstops?
