### PR TITLE
Take apart kill()

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -221,6 +221,7 @@ void ok_to_send();
 void reset_bed_level();
 void prepare_move();
 void kill();
+void kill_();
 void Stop();
 
 #ifdef FILAMENT_RUNOUT_SENSOR

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6373,11 +6373,15 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
   check_axes_activity();
 }
 
-void kill()
+void kill() {
+  LCD_ALERTMESSAGEPGM(MSG_KILLED);
+  kill_();
+}
+
+void kill_()
 {
   cli(); // Stop interrupts
   disable_all_heaters();
-
   disable_all_steppers();
 
   #if HAS_POWER_SWITCH
@@ -6386,7 +6390,6 @@ void kill()
 
   SERIAL_ERROR_START;
   SERIAL_ERRORLNPGM(MSG_ERR_KILLED);
-  LCD_ALERTMESSAGEPGM(MSG_KILLED);
   
   // FMC small patch to update the LCD before ending
   sei();   // enable interrupts


### PR DESCRIPTION
in kill() and kill_()
to separate the message on the display.

kill() will display MSG_KILLED on the display as before and call kill_().
kill_() has all the functionality of the former kill() but the message on the display.

This change gives the possibility to use kill_() with a reason for the kill without overwriting it by MSG_KILLED.
The output on the serial is not changed.
