### PR TITLE
G5 X Y Z Babystepping, M19 Resume Failed Print From Z, Layer Counting, Save Extruder Offsets in EEPROM, Extrude From Multiple Extruders From An LCD Controller

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -634,7 +634,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
   //#define DISPLAY_CHARSET_HD44780_WESTERN
   //#define DISPLAY_CHARSET_HD44780_CYRILLIC
 
-//#define ULTRA_LCD  //general LCD support, also 16x2
+#define ULTRA_LCD  //general LCD support, also 16x2
 //#define DOGLCD  // Support for SPI LCD 128x64 (Controller ST7565R graphic Display Family)
 //#define SDSUPPORT // Enable SD Card Support in Hardware Console
 //#define SDSLOW // Use slower SD transfer mode (not normally needed - uncomment if you're getting volume init error)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -337,6 +337,7 @@
 // does not respect endstops!
 //#define BABYSTEPPING
 #ifdef BABYSTEPPING
+  #define BABYSTEP_OFFSET
   #define BABYSTEP_XY  //not only z, but also XY in the menu. more clutter, more functions
   #define BABYSTEP_INVERT_Z false  //true for inverse movements in Z
   #define BABYSTEP_Z_MULTIPLICATOR 2 //faster z movements

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -335,11 +335,17 @@
 // Babystepping enables the user to control the axis in tiny amounts, independently from the normal printing process
 // it can e.g. be used to change z-positions in the print startup phase in real-time
 // does not respect endstops!
-//#define BABYSTEPPING
+#define BABYSTEPPING
 #ifdef BABYSTEPPING
   #define BABYSTEP_XY  //not only z, but also XY in the menu. more clutter, more functions
   #define BABYSTEP_INVERT_Z false  //true for inverse movements in Z
   #define BABYSTEP_Z_MULTIPLICATOR 2 //faster z movements
+  #define X_BABY_DEFAULT_MAX_POS X_MAX_POS
+  #define Y_BABY_DEFAULT_MAX_POS Y_MAX_POS
+  #define Z_BABY_DEFAULT_MAX_POS Z_MAX_POS
+  #define X_BABY_DEFAULT_MIN_POS X_MIN_POS
+  #define Y_BABY_DEFAULT_MIN_POS Y_MIN_POS
+  #define Z_BABY_DEFAULT_MIN_POS Z_MIN_POS-10 //be careful, min hardware & software endstops are ignored/extended
 #endif
 
 // @section extruder

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -335,7 +335,7 @@
 // Babystepping enables the user to control the axis in tiny amounts, independently from the normal printing process
 // it can e.g. be used to change z-positions in the print startup phase in real-time
 // does not respect endstops!
-#define BABYSTEPPING
+//#define BABYSTEPPING
 #ifdef BABYSTEPPING
   #define BABYSTEP_XY  //not only z, but also XY in the menu. more clutter, more functions
   #define BABYSTEP_INVERT_Z false  //true for inverse movements in Z

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -272,7 +272,7 @@ extern float current_position[NUM_AXIS];
 extern unsigned long current_layer; // estimated current layer number
 extern float last_layer_z;
 #if EXTRUDERS > 1
-extern float extruder_offset[2][EXTRUDERS];
+extern float extruder_offset[EXTRUDERS][EXTRUDERS];
 #endif
 extern float home_offset[3];
 extern float planner_disabled_below_z;

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -271,6 +271,9 @@ extern float volumetric_multiplier[EXTRUDERS]; // reciprocal of cross-sectional 
 extern float current_position[NUM_AXIS];
 extern unsigned long current_layer; // estimated current layer number
 extern float last_layer_z;
+#if EXTRUDERS > 1
+extern float extruder_offset[2][EXTRUDERS];
+#endif
 extern float home_offset[3];
 extern float planner_disabled_below_z;
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -269,7 +269,10 @@ extern int extruder_multiply[EXTRUDERS]; // sets extrude multiply factor (in per
 extern float filament_size[EXTRUDERS]; // cross-sectional area of filament (in millimeters), typically around 1.75 or 2.85, 0 disables the volumetric calculations for the extruder.
 extern float volumetric_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS];
+extern unsigned long current_layer; // estimated current layer number
+extern float last_layer_z;
 extern float home_offset[3];
+extern float planner_disabled_below_z;
 
 #ifdef DELTA
   extern float endstop_adj[3];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1059,7 +1059,11 @@ static void axis_is_at_home(AxisEnum axis) {
     else
   #endif
   {
-    current_position[axis] = base_home_pos(axis) + home_offset[axis];
+    current_position[axis] = base_home_pos(axis)
+    #ifndef BABYSTEPPING
+    + add_homing[axis]
+    #endif
+    ;
     min_pos[axis] = base_min_pos(axis) + home_offset[axis];
     max_pos[axis] = base_max_pos(axis) + home_offset[axis];
 
@@ -2367,6 +2371,16 @@ inline void gcode_G28() {
     #endif // Z_HOME_DIR < 0
 
     sync_plan_position();
+
+    if(code_seen(axis_codes[Z_AXIS])) {
+      if(code_value_long() != 0) {
+        current_position[Z_AXIS]=code_value()
+        #ifndef BABYSTEPPING // will move to the given (EEPROM saved) babystepped Z height offset when homing but not recognize it
+        + add_homing[Z_AXIS]
+        #endif
+        ;
+      }
+    }
 
   #endif // else DELTA
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2372,6 +2372,11 @@ inline void gcode_G28() {
   feedrate_multiplier = saved_feedrate_multiplier;
   refresh_cmd_timeout();
   endstops_hit_on_purpose(); // clear endstop hit flags
+  #ifdef BABYSTEPPING
+  baby_max_endstop[Z_AXIS] -= add_homing[Z_AXIS];
+  baby_min_endstop[Z_AXIS] -= add_homing[Z_AXIS];
+  babystepsTodo[Z_AXIS] += add_homing[Z_AXIS]*axis_steps_per_unit[Z_AXIS];
+  #endif
 }
 
 #ifdef MESH_BED_LEVELING

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1061,7 +1061,7 @@ static void axis_is_at_home(AxisEnum axis) {
   {
     current_position[axis] = base_home_pos(axis)
     #ifndef BABYSTEPPING
-    + add_homing[axis]
+    + home_offset[axis]
     #endif
     ;
     min_pos[axis] = base_min_pos(axis) + home_offset[axis];
@@ -2376,7 +2376,7 @@ inline void gcode_G28() {
       if(code_value_long() != 0) {
         current_position[Z_AXIS]=code_value()
         #ifndef BABYSTEPPING // will move to the given (EEPROM saved) babystepped Z height offset when homing but not recognize it
-        + add_homing[Z_AXIS]
+        + home_offset[Z_AXIS]
         #endif
         ;
       }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1060,7 +1060,7 @@ static void axis_is_at_home(AxisEnum axis) {
   #endif
   {
     current_position[axis] = base_home_pos(axis)
-    #ifndef BABYSTEPPING
+    #ifndef BABYSTEP_OFFSET
     + home_offset[axis]
     #endif
     ;
@@ -1718,7 +1718,7 @@ static void homeaxis(AxisEnum axis) {
       }
     #endif
 
-    #ifdef BABYSTEPPING
+    #ifdef BABYSTEP_OFFSET
     if(axis == X_AXIS)
     {
       baby_max_endstop[axis] = X_BABY_DEFAULT_MAX_POS;
@@ -1736,7 +1736,7 @@ static void homeaxis(AxisEnum axis) {
       baby_min_endstop[axis] = Z_BABY_DEFAULT_MIN_POS;
     }
     #endif //BABYSTEP_XY
-    #endif //BABYSTEPPING
+    #endif //BABYSTEP_OFFSET
 
   }
 }
@@ -2094,8 +2094,10 @@ inline void gcode_G5() {
     baby_min_endstop[axis] = current_position[axis];
     baby_max_endstop[axis] += baby_min_endstop[axis];
   }
+  #ifdef BABYSTEP_OFFSET
   if(axis == Z_AXIS) // will move to the given (EEPROM saved) babystepped Z height offset when homing but not recognize it
     home_offset[axis] = Z_BABY_DEFAULT_MIN_POS - baby_min_endstop[axis];
+  #endif //BABYSTEP_OFFSET
 }
 #endif //BABYSTEPPING
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2415,7 +2415,7 @@ inline void gcode_G28() {
   feedrate_multiplier = saved_feedrate_multiplier;
   refresh_cmd_timeout();
   endstops_hit_on_purpose(); // clear endstop hit flags
-  #ifdef BABYSTEPPING
+  #ifdef BABYSTEP_OFFSET
   baby_max_endstop[Z_AXIS] -= home_offset[Z_AXIS];
   baby_min_endstop[Z_AXIS] -= home_offset[Z_AXIS];
   babystepsTodo[Z_AXIS] += home_offset[Z_AXIS]*axis_steps_per_unit[Z_AXIS];

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -33,6 +33,7 @@
  *  M205 Z    max_z_jerk
  *  M205 E    max_e_jerk
  *  M206 XYZ  home_offset (x3)
+ *  M218 TXY  extruder_offset
  *
  * Mesh bed leveling:
  *  M420 S    active
@@ -150,6 +151,9 @@ void Config_StoreSettings()  {
   EEPROM_WRITE_VAR(i, max_z_jerk);
   EEPROM_WRITE_VAR(i, max_e_jerk);
   EEPROM_WRITE_VAR(i, home_offset);
+  #if EXTRUDERS > 1
+  EEPROM_WRITE_VAR(i,extruder_offset); // save extruder offset to the EEPROM memory (from github dob71 MarlinX2)
+  #endif // EXTRUDERS > 1
 
   uint8_t mesh_num_x = 3;
   uint8_t mesh_num_y = 3;
@@ -322,6 +326,9 @@ void Config_RetrieveSettings() {
     EEPROM_READ_VAR(i, max_z_jerk);
     EEPROM_READ_VAR(i, max_e_jerk);
     EEPROM_READ_VAR(i, home_offset);
+    #if EXTRUDERS > 1
+    EEPROM_READ_VAR(i,extruder_offset); // retrieve saved extruder offset (from github dob71 MarlinX2)
+    #endif // EXTRUDERS > 1
 
     uint8_t dummy_uint8 = 0, mesh_num_x = 0, mesh_num_y = 0;
     EEPROM_READ_VAR(i, dummy_uint8);
@@ -470,6 +477,10 @@ void Config_ResetDefault() {
   float tmp1[] = DEFAULT_AXIS_STEPS_PER_UNIT;
   float tmp2[] = DEFAULT_MAX_FEEDRATE;
   long tmp3[] = DEFAULT_MAX_ACCELERATION;
+ #if EXTRUDERS > 1
+  float tmp4[]=EXTRUDER_OFFSET_X;
+  float tmp5[]=EXTRUDER_OFFSET_Y;
+ #endif // EXTRUDERS > 1
   for (uint16_t i = 0; i < NUM_AXIS; i++) {
     axis_steps_per_unit[i] = tmp1[i];
     max_feedrate[i] = tmp2[i];
@@ -478,6 +489,13 @@ void Config_ResetDefault() {
       if (i < sizeof(axis_scaling) / sizeof(*axis_scaling))
         axis_scaling[i] = 1;
     #endif
+    #if EXTRUDERS > 1
+      if(i < EXTRUDERS)
+      {
+        extruder_offset[X_AXIS][i]=tmp4[i];
+        extruder_offset[Y_AXIS][i]=tmp5[i];
+      }
+    #endif // EXTRUDERS > 1
   }
 
   // steps per sq second need to be updated to agree with the units per sq second
@@ -603,6 +621,19 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_ECHOPAIR(" Z", axis_steps_per_unit[Z_AXIS]);
   SERIAL_ECHOPAIR(" E", axis_steps_per_unit[E_AXIS]);
   SERIAL_EOL;
+
+#if EXTRUDERS > 1 // print the extruder offsets (from github dob71 MarlinX2)
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM("Extruder offset:");
+    for(int i = 0; i < EXTRUDERS; i++)
+    {
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPAIR("   M218 T", float(i));
+      SERIAL_ECHOPAIR(" X", extruder_offset[X_AXIS][i]); 
+      SERIAL_ECHOPAIR(" Y", extruder_offset[Y_AXIS][i]);
+      SERIAL_ECHOLN("");
+    }
+#endif // EXTRUDERS > 1
 
   CONFIG_ECHO_START;
 

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -120,6 +120,15 @@
 #ifndef MSG_MOVE_E
 #define MSG_MOVE_E                          "Extruder"
 #endif
+#ifndef MSG_MOVE_E1
+#define MSG_MOVE_E1                          "Extruder1"
+#endif
+#ifndef MSG_MOVE_E2
+#define MSG_MOVE_E2                          "Extruder2"
+#endif
+#ifndef MSG_MOVE_E3
+#define MSG_MOVE_E3                          "Extruder3"
+#endif
 #ifndef MSG_MOVE_01MM
 #define MSG_MOVE_01MM                       "Move 0.1mm"
 #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -315,6 +315,9 @@
 #ifndef MSG_PAUSE_PRINT
 #define MSG_PAUSE_PRINT                     "Pause print"
 #endif
+#ifndef
+#define MSG_CARD_RESUME_MENU                "Resume SD from Z"
+#endif
 #ifndef MSG_RESUME_PRINT
 #define MSG_RESUME_PRINT                    "Resume print"
 #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -165,6 +165,9 @@
 #ifndef MSG_F3
 #define MSG_F3                              " 3"
 #endif
+#ifndef
+#define MSG_LAYER                           "Layer"
+#endif
 #ifndef MSG_CONTROL
 #define MSG_CONTROL                         "Control"
 #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -264,6 +264,24 @@
 #ifndef MSG_ESTEPS
 #define MSG_ESTEPS                          "Esteps/mm"
 #endif
+#ifndef MSG_X1OFFSET
+#define MSG_X1OFFSET                         "T1X Offset"
+#endif
+#ifndef MSG_Y1OFFSET
+#define MSG_Y1OFFSET                         "T1Y Offset"
+#endif
+#ifndef MSG_X2OFFSET
+#define MSG_X2OFFSET                         "T2X Offset"
+#endif
+#ifndef MSG_Y2OFFSET
+#define MSG_Y2OFFSET                         "T2Y Offset"
+#endif
+#ifndef MSG_X3OFFSET
+#define MSG_X3OFFSET                         "T3X Offset"
+#endif
+#ifndef MSG_Y3OFFSET
+#define MSG_Y3OFFSET                         "T3Y Offset"
+#endif
 #ifndef MSG_TEMPERATURE
 #define MSG_TEMPERATURE                     "Temperature"
 #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -165,7 +165,7 @@
 #ifndef MSG_F3
 #define MSG_F3                              " 3"
 #endif
-#ifndef
+#ifndef MSG_LAYER
 #define MSG_LAYER                           "Layer"
 #endif
 #ifndef MSG_CONTROL
@@ -315,7 +315,7 @@
 #ifndef MSG_PAUSE_PRINT
 #define MSG_PAUSE_PRINT                     "Pause print"
 #endif
-#ifndef
+#ifndef MSG_CARD_RESUME_MENU
 #define MSG_CARD_RESUME_MENU                "Resume SD from Z"
 #endif
 #ifndef MSG_RESUME_PRINT

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -67,6 +67,8 @@ unsigned char soft_pwm_bed;
   
 #ifdef BABYSTEPPING
   volatile int babystepsTodo[3] = { 0 };
+  volatile float baby_max_endstop[3] = {X_BABY_DEFAULT_MAX_POS, Y_BABY_DEFAULT_MAX_POS, Z_BABY_DEFAULT_MAX_POS};
+  volatile float baby_min_endstop[3] = {X_BABY_DEFAULT_MIN_POS, Y_BABY_DEFAULT_MIN_POS, Z_BABY_DEFAULT_MIN_POS};
 #endif
 
 #ifdef FILAMENT_SENSOR

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -79,6 +79,8 @@ extern float current_temperature_bed;
   
 #ifdef BABYSTEPPING
   extern volatile int babystepsTodo[3];
+  extern volatile float baby_max_endstop[3];
+  extern volatile float baby_min_endstop[3];
 #endif
   
 //high level conversion routines, for use outside of temperature.cpp

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -770,6 +770,51 @@ static void lcd_move_e() {
   if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Extruder"), ftostr31(current_position[E_AXIS]));
   if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
 }
+#if EXTRUDERS > 1
+static void lcd_move_e1() {
+  unsigned short original_active_extruder = active_extruder;
+  active_extruder = 1;
+  if (encoderPosition != 0) {
+    current_position[E_AXIS] += float((int)encoderPosition) * move_menu_scale;
+    encoderPosition = 0;
+    line_to_current(E_AXIS);
+    lcdDrawUpdate = 1;
+  }
+  if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Extruder"), ftostr31(current_position[E_AXIS]));
+  if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
+  active_extruder = original_active_extruder;
+}
+#endif //EXTRUDERS > 1
+#if EXTRUDERS > 2
+static void lcd_move_e2() {
+  unsigned short original_active_extruder = active_extruder;
+  active_extruder = 2;
+  if (encoderPosition != 0) {
+    current_position[E_AXIS] += float((int)encoderPosition) * move_menu_scale;
+    encoderPosition = 0;
+    line_to_current(E_AXIS);
+    lcdDrawUpdate = 1;
+  }
+  if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Extruder"), ftostr31(current_position[E_AXIS]));
+  if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
+  active_extruder = original_active_extruder;
+}
+#endif // EXTRUDERS > 2
+#if EXTRUDERS > 3
+static void lcd_move_e3() {
+  unsigned short original_active_extruder = active_extruder;
+  active_extruder = 3;
+  if (encoderPosition != 0) {
+    current_position[E_AXIS] += float((int)encoderPosition) * move_menu_scale;
+    encoderPosition = 0;
+    line_to_current(E_AXIS);
+    lcdDrawUpdate = 1;
+  }
+  if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Extruder"), ftostr31(current_position[E_AXIS]));
+  if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
+  active_extruder = original_active_extruder;
+}
+#endif // EXTRUDERS > 3
 
 /**
  *
@@ -782,10 +827,19 @@ static void lcd_move_menu_axis() {
   MENU_ITEM(back, MSG_MOVE_AXIS, lcd_move_menu);
   MENU_ITEM(submenu, MSG_MOVE_X, lcd_move_x);
   MENU_ITEM(submenu, MSG_MOVE_Y, lcd_move_y);
-  if (move_menu_scale < 10.0) {
+//if (move_menu_scale < 10.0) { //Why exclude Z and E from the 100mm menu ???
     MENU_ITEM(submenu, MSG_MOVE_Z, lcd_move_z);
     MENU_ITEM(submenu, MSG_MOVE_E, lcd_move_e);
-  }
+    #if EXTRUDERS > 1
+    MENU_ITEM(submenu, MSG_MOVE_E1, lcd_move_e1);
+    #endif //EXTRUDERS > 1
+    #if EXTRUDERS > 2
+    MENU_ITEM(submenu, MSG_MOVE_E2, lcd_move_e2);
+    #endif //EXTRUDERS > 2
+    #if EXTRUDERS > 3
+    MENU_ITEM(submenu, MSG_MOVE_E3, lcd_move_e3);
+    #endif //EXTRUDERS > 3
+//}
   END_MENU();
 }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1081,6 +1081,18 @@ static void lcd_control_motion_menu() {
   MENU_ITEM_EDIT(float52, MSG_YSTEPS, &axis_steps_per_unit[Y_AXIS], 5, 9999);
   MENU_ITEM_EDIT(float51, MSG_ZSTEPS, &axis_steps_per_unit[Z_AXIS], 5, 9999);
   MENU_ITEM_EDIT(float51, MSG_ESTEPS, &axis_steps_per_unit[E_AXIS], 5, 9999);
+  #if EXTRUDERS > 1
+    MENU_ITEM_EDIT(float52, MSG_X1OFFSET, &extruder_offset[X_AXIS][1], -200, 200);
+    MENU_ITEM_EDIT(float52, MSG_Y1OFFSET, &extruder_offset[Y_AXIS][1], -200, 200);
+  #endif // EXTRUDERS > 1
+  #if EXTRUDERS > 2
+    MENU_ITEM_EDIT(float52, MSG_X2OFFSET, &extruder_offset[X_AXIS][2], -200, 200);
+    MENU_ITEM_EDIT(float52, MSG_Y2OFFSET, &extruder_offset[Y_AXIS][2], -200, 200);
+  #endif // EXTRUDERS > 2
+  #if EXTRUDERS > 3
+    MENU_ITEM_EDIT(float52, MSG_X3OFFSET, &extruder_offset[X_AXIS][3], -200, 200);
+    MENU_ITEM_EDIT(float52, MSG_Y3OFFSET, &extruder_offset[Y_AXIS][3], -200, 200);
+  #endif // EXTRUDERS > 3
   #ifdef ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
     MENU_ITEM_EDIT(bool, MSG_ENDSTOP_ABORT, &abort_on_endstop_hit);
   #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -513,6 +513,9 @@ static void lcd_tune_menu() {
     MENU_ITEM_EDIT(int3, MSG_FLOW MSG_F3, &extruder_multiply[3], 10, 999);
   #endif
 
+    unsigned long layer = current_layer;
+    MENU_ITEM_EDIT(long5, MSG_LAYER, &layer, layer, layer);
+
   #ifdef BABYSTEPPING
     #ifdef BABYSTEP_XY
       MENU_ITEM(submenu, MSG_BABYSTEP_X, lcd_babystep_x);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -63,6 +63,15 @@ static void lcd_status_screen();
   #endif
   static void lcd_sdcard_menu();
 
+static void lcd_sdcard_resume_menu();
+static void lcd_sdcard_print_menu();
+extern float planner_disabled_below_z;
+extern float last_z;
+extern bool z_reached;
+extern bool layer_reached;
+extern bool hops;
+extern bool gone_up;
+
   #ifdef DELTA_CALIBRATION_MENU
     static void lcd_delta_calibrate_menu();
   #endif
@@ -378,6 +387,7 @@ static void lcd_sdcard_stop() {
   autotempShutdown();
   cancel_heatup = true;
   lcd_setstatus(MSG_PRINT_ABORTED, true);
+  planner_disabled_below_z = 0;
 }
 
 /**
@@ -410,6 +420,9 @@ static void lcd_main_menu() {
         MENU_ITEM(function, MSG_STOP_PRINT, lcd_sdcard_stop);
       }
       else {
+        MENU_ITEM(submenu, MSG_CARD_MENU, lcd_sdcard_print_menu);
+        MENU_ITEM(submenu, MSG_CARD_RESUME_MENU, lcd_sdcard_resume_menu);
+
         MENU_ITEM(submenu, MSG_CARD_MENU, lcd_sdcard_menu);
         #if SDCARDDETECT < 1
           MENU_ITEM(gcode, MSG_CNG_SDCARD, PSTR("M21"));  // SD-card changed by user
@@ -1156,6 +1169,25 @@ static void lcd_control_volumetric_menu() {
 static void lcd_sd_updir() {
   card.updir();
   currentMenuViewOffset = 0;
+}
+
+// Print from SD
+void lcd_sdcard_print_menu()
+{
+    planner_disabled_below_z = 0;
+    lcd_sdcard_menu();
+}
+
+// Print from SD but set flag to ignore movements below a certain Z
+void lcd_sdcard_resume_menu()
+{
+    planner_disabled_below_z = current_position[Z_AXIS];
+    last_z = 0;
+    z_reached = false;
+    layer_reached = false;
+    hops = false;
+    gone_up = false;
+    lcd_sdcard_menu();
 }
 
 /**


### PR DESCRIPTION
- G5 X Y Z — The argument is the number of steps to be performed in the positive or negative direction of the given axis (only one axis at a time for now). It attempts to prevent endstop crashes to the best of its ability. **\* Modified home_offset[Z_AXIS] to babystep the stored Z offset if BABYSTEP_OFFSET is defined ***
- Added layer counting — found using M114 or Menu > Tune > Layer from an LCD
- M19 Z and Resume From Z in LCD main menu — resumes a failed print from given Z height (modified Vince's Solidoodle code and included an algorithm to compensate for Z-lifts).
- **_NEW!**_ — Extruder offsets can be set from an LCD controller and saved to the EEPROM.
- **_NEW!**_ — There are menu items to extrude from multiple extruders.

I hope I didn't forget anything.
