### PR TITLE
Shift call of start_watching_heater() into setTargetHotend()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3367,10 +3367,6 @@ inline void gcode_M104() {
       if (dual_x_carriage_mode == DXC_DUPLICATION_MODE && target_extruder == 0)
         setTargetHotend1(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset);
     #endif
-
-    #ifdef THERMAL_PROTECTION_HOTENDS
-      start_watching_heater(target_extruder);
-    #endif
   }
 }
 
@@ -3480,10 +3476,6 @@ inline void gcode_M109() {
     if (autotemp_enabled) autotemp_factor = code_value();
     if (code_seen('S')) autotemp_min = code_value();
     if (code_seen('B')) autotemp_max = code_value();
-  #endif
-
-  #ifdef THERMAL_PROTECTION_HOTENDS
-    start_watching_heater(target_extruder);
   #endif
 
   millis_t temp_ms = millis();

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -296,11 +296,7 @@ void checkHitEndstops() {
         card.sdprinting = false;
         card.closefile();
         quickStop();
-        setTargetHotend0(0);
-        setTargetHotend1(0);
-        setTargetHotend2(0);
-        setTargetHotend3(0);
-        setTargetBed(0);
+        disable_all_heaters(); // switch off all heaters.
       }
     #endif
   }

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -96,7 +96,12 @@ FORCE_INLINE float degBed() { return current_temperature_bed; }
 FORCE_INLINE float degTargetHotend(uint8_t extruder) { return target_temperature[extruder]; }
 FORCE_INLINE float degTargetBed() { return target_temperature_bed; }
 
-FORCE_INLINE void setTargetHotend(const float &celsius, uint8_t extruder) { target_temperature[extruder] = celsius; }
+FORCE_INLINE void setTargetHotend(const float &celsius, uint8_t extruder) {
+  target_temperature[extruder] = celsius;
+  #ifdef WATCH_TEMP_PERIOD
+    start_watching_heater(extruder);
+  #endif
+}
 FORCE_INLINE void setTargetBed(const float &celsius) { target_temperature_bed = celsius; }
 
 FORCE_INLINE bool isHeatingHotend(uint8_t extruder) { return target_temperature[extruder] > current_temperature[extruder]; }

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -96,9 +96,13 @@ FORCE_INLINE float degBed() { return current_temperature_bed; }
 FORCE_INLINE float degTargetHotend(uint8_t extruder) { return target_temperature[extruder]; }
 FORCE_INLINE float degTargetBed() { return target_temperature_bed; }
 
+#ifdef THERMAL_PROTECTION_HOTENDS
+  void start_watching_heater(int e=0);
+#endif
+
 FORCE_INLINE void setTargetHotend(const float &celsius, uint8_t extruder) {
   target_temperature[extruder] = celsius;
-  #ifdef WATCH_TEMP_PERIOD
+  #ifdef THERMAL_PROTECTION_HOTENDS
     start_watching_heater(extruder);
   #endif
 }
@@ -141,10 +145,6 @@ void PID_autotune(float temp, int extruder, int ncycles);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();
-
-#ifdef THERMAL_PROTECTION_HOTENDS
-  void start_watching_heater(int e=0);
-#endif
 
 FORCE_INLINE void autotempShutdown() {
   #ifdef AUTOTEMP

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -515,12 +515,11 @@ static void lcd_tune_menu() {
 
 void _lcd_preheat(int endnum, const float temph, const float tempb, const int fan) {
   if (temph > 0) setTargetHotend(temph, endnum);
-  setTargetBed(tempb);
+  #if TEMP_SENSOR_BED != 0
+    setTargetBed(tempb);
+  #endif
   fanSpeed = fan;
   lcd_return_to_status();
-  #ifdef WATCH_TEMP_PERIOD
-    if (endnum >= 0) start_watching_heater(endnum);
-  #endif
 }
 void lcd_preheat_pla0() { _lcd_preheat(0, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
 void lcd_preheat_abs0() { _lcd_preheat(0, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
@@ -602,11 +601,7 @@ void lcd_preheat_abs0() { _lcd_preheat(0, absPreheatHotendTemp, absPreheatHPBTem
 #endif // more than one temperature sensor present
 
 void lcd_cooldown() {
-  setTargetHotend0(0);
-  setTargetHotend1(0);
-  setTargetHotend2(0);
-  setTargetHotend3(0);
-  setTargetBed(0);
+  disable_all_heaters();
   fanSpeed = 0;
   lcd_return_to_status();
 }


### PR DESCRIPTION
to warrant watching is set or reset.

Make `setTargetBed()` in`_lcd_preheat()` dependent of `TEMP_SENSOR_BED`.
Use `disable_all_heaters()` in `lcd_cooldown()` and `abort_on_endstop_hit` to save space and handle the right ones..
