### PR TITLE
Cleanup pins in RAMPS_13_EFB boards

### DIFF
--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -2,10 +2,9 @@
  * AZTEEG_X3 Arduino Mega with RAMPS v1.3 pin assignments
  */
 
-#include "pins_RAMPS_13.h"
+#define IS_RAMPS_EFB
 
-#define FAN_PIN            9 // (Sprinter config)
-#define HEATER_1_PIN       -1
+#include "pins_RAMPS_13.h"
 
 //LCD Pins//
 

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -2,13 +2,9 @@
  * BAM&DICE Due (Arduino Mega) pin assignments
  */
 
+#define IS_RAMPS_EFB
+
 #include "pins_RAMPS_13.h"
-
-#undef FAN_PIN
-#define FAN_PIN             9 // (Sprinter config)
-
-#undef HEATER_1_PIN
-#define HEATER_1_PIN       -1
 
 #undef TEMP_0_PIN
 #undef TEMP_1_PIN

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -2,42 +2,19 @@
  * FELIXprinters v2.0/3.0 (RAMPS v1.3) pin assignments
  */
 
+#define IS_RAMPS_EFB
+
 #include "pins_RAMPS_13.h"
 
-#undef X_MAX_PIN
-#undef Y_MAX_PIN
-#undef Z_MAX_PIN
-#define X_MAX_PIN          -1
-#define Y_MAX_PIN          -1
-#define Z_MAX_PIN          -1
+#undef HEATER_1_PIN
+#define HEATER_1_PIN        7 // EXTRUDER 2
 
-#undef Y2_STEP_PIN
-#undef Y2_DIR_PIN
-#undef Y2_ENABLE_PIN
-#define Y2_STEP_PIN        -1
-#define Y2_DIR_PIN         -1
-#define Y2_ENABLE_PIN      -1
-
-#undef Z2_STEP_PIN
-#undef Z2_DIR_PIN
-#undef Z2_ENABLE_PIN
-#define Z2_STEP_PIN        -1
-#define Z2_DIR_PIN         -1
-#define Z2_ENABLE_PIN      -1
-
-#define E1_STEP_PIN        36 // FELIX E1 uses RAMPS Y2/Z2 pins
-#define E1_DIR_PIN         34
-#define E1_ENABLE_PIN      30
+#define DISABLE_MAX_ENDSTOPS
 
 #undef SDPOWER
 #define SDPOWER             1
 
-#undef FAN_PIN
-#define FAN_PIN             9 // (Sprinter config)
 #define PS_ON_PIN          12
-
-#undef HEATER_1_PIN
-#define HEATER_1_PIN        7 // EXTRUDER 2
 
 #if defined(ULTRA_LCD) && defined(NEWPANEL)
 

--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -2,10 +2,9 @@
  * MKS BASE 1.0 – Arduino Mega2560 with RAMPS v1.4 pin assignments
  */
 
-#include "pins_RAMPS_13.h"
+#define IS_RAMPS_EFB
 
-#undef FAN_PIN
-#define FAN_PIN             9 // (Sprinter config)
+#include "pins_RAMPS_13.h"
 
 #undef HEATER_1_PIN
 #define HEATER_1_PIN        7

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -77,7 +77,7 @@
   #define FILRUNOUT_PIN        4
 #endif
 
-#if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF)
+#if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF) || defined(IS_RAMPS_EFB)
   #define FAN_PIN            9 // (Sprinter config)
   #if MB(RAMPS_13_EFF)
     #define CONTROLLERFAN_PIN  -1 // Pin used for the fan to cool controller
@@ -102,7 +102,7 @@
   #define HEATER_0_PIN       10   // EXTRUDER 1
 #endif
 
-#if MB(RAMPS_13_EFB) || MB(RAMPS_13_SF)
+#if MB(RAMPS_13_EFB) || MB(RAMPS_13_SF) || defined(IS_RAMPS_EFB)
   #define HEATER_1_PIN       -1
 #else
   #define HEATER_1_PIN       9    // EXTRUDER 2 (FAN On Sprinter)


### PR DESCRIPTION
- Add a check for `IS_RAMPS_EFB` so pins files that include `pins_RAMPS_13.h` can get the EFB pin mapping
- Includes `MKS_BASE`, `FELIX2`, `AZTEEG_X3`, `BAM_DICE_DUE`
- Clean up Felix2, which doesn't need to un-define `Y2` and `Z2` (have at it, modders!)
