### PR TITLE
faster compare

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -566,8 +566,8 @@ ISR(TIMER1_COMPA_vect) {
             if (z_test && current_block->steps[Z_AXIS] > 0) { // z_test = Z_MIN || Z2_MIN
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
-              if (!performing_homing || (performing_homing && !((~z_test) & 0x3)))  //if not performing home or if both endstops were trigged during homing...
-                step_events_completed = current_block->step_event_count;            //!((~z_test) & 0x3) = Z_MIN && Z2_MIN
+              if (!performing_homing || (performing_homing && z_test == & 0x3)))  //if not performing home or if both endstops were trigged during homing...
+                step_events_completed = current_block->step_event_count;
             }
           #else // !Z_DUAL_ENDSTOPS
 
@@ -577,7 +577,6 @@ ISR(TIMER1_COMPA_vect) {
 
         #ifdef Z_PROBE_ENDSTOP
           UPDATE_ENDSTOP(Z, PROBE);
-          SET_ENDSTOP_BIT(Z, PROBE);
 
           if (TEST_ENDSTOP(Z_PROBE))
           {
@@ -603,8 +602,8 @@ ISR(TIMER1_COMPA_vect) {
             if (z_test && current_block->steps[Z_AXIS] > 0) {  // t_test = Z_MAX || Z2_MAX
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
-              if (!performing_homing || (performing_homing && !((~z_test) & 0x3)))  //if not performing home or if both endstops were trigged during homing...
-                step_events_completed = current_block->step_event_count;            //!((~z_test) & 0x3) = Z_MAX && Z2_MAX
+              if (!performing_homing || (performing_homing && z_test == 0x3)))  //if not performing home or if both endstops were trigged during homing...
+                step_events_completed = current_block->step_event_count;
             }
 
           #else // !Z_DUAL_ENDSTOPS

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -566,7 +566,7 @@ ISR(TIMER1_COMPA_vect) {
             if (z_test && current_block->steps[Z_AXIS] > 0) { // z_test = Z_MIN || Z2_MIN
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
-              if (!performing_homing || (performing_homing && z_test == & 0x3)))  //if not performing home or if both endstops were trigged during homing...
+              if (!performing_homing || (z_test == 0x3))  //if not performing home or if both endstops were trigged during homing...
                 step_events_completed = current_block->step_event_count;
             }
           #else // !Z_DUAL_ENDSTOPS
@@ -602,7 +602,7 @@ ISR(TIMER1_COMPA_vect) {
             if (z_test && current_block->steps[Z_AXIS] > 0) {  // t_test = Z_MAX || Z2_MAX
               endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];
               endstop_hit_bits |= BIT(Z_MIN);
-              if (!performing_homing || (performing_homing && z_test == 0x3)))  //if not performing home or if both endstops were trigged during homing...
+              if (!performing_homing || (z_test == 0x3))  //if not performing home or if both endstops were trigged during homing...
                 step_events_completed = current_block->step_event_count;
             }
 
@@ -615,7 +615,7 @@ ISR(TIMER1_COMPA_vect) {
         
         #ifdef Z_PROBE_ENDSTOP
           UPDATE_ENDSTOP(Z, PROBE);
-          SET_ENDSTOP_BIT(Z, PROBE);
+          
           if (TEST_ENDSTOP(Z_PROBE))
           {
             endstops_trigsteps[Z_AXIS] = count_position[Z_AXIS];


### PR DESCRIPTION
- !(~(ab)&0x3) and ab == 0x3 are equal
- Remove double setting z-probe bit
