### PR TITLE
An alternate algorithm to detect failing heaters - thermometers.

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -500,5 +500,11 @@
     #define WRITE_FAN(v) WRITE(FAN_PIN, v)
   #endif
 
+  #if HAS_TEMP_BED
+    #define FIRST_HEATER -1
+  #else
+    #define FIRST_HEATER 0
+  #endif
+
 #endif //CONFIGURATION_LCD
 #endif //CONDITIONALS_H

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -52,13 +52,23 @@
  * When a heater is off, but the surrounding temperature is higher or equal to the heaters temperature, the temperature
  * can not fall. Therefore we do not test for this below MAX_AMBIENT_TEMPERATURE.
  * HEATER_STATE_DEBUG produces some output on the serial line to see how sharp or blunt these tests are.
- * Set MAX_TEMP_OVERSTOOT_TIME to 0 to deactivate.
+ *
+ * Temperatures are inert. If the value of any thermometer jumps, there is something wrong with it.
+ * Reasons can be: shorted wires, broken wires, leaking water-cooling, ...
+ * but also: electronic noise, ...
+ * MAX THERMO_JUMP_AMOUNT is the maximum allowed temperature difference between two measurements of the raw temperatures, (an abstract number).
+ * The fastest expected change is about (full range of the ADC) / minute / (temp measurements / second). 
+ * This is well below the noise. So we have to adjust for the noise.
+ * If you get 'unreasoned' "error: Thermometer Jumped" messages increase the next value. 50 is a good value to start. 0 disables.
+ *
+ * Set MAX_TEMP_OVERSTOOT_TIME to 0 to deactivate all this tests. 30 is a good value to start.
  */
+#define MAX_TEMP_OVERSTOOT_TIME 0
 #define TEMP_RAW_NOISE 6
 #define TEMP_CONSEC_COUNT 6
-#define MAX_TEMP_OVERSTOOT_TIME 30
 #define MAX_AMBIENT_TEMPERATURE 50
-//#define HEATER_STATE_DEBUG
+#define MAX_THERMO_JUMP_AMOUNT 0
+#define HEATER_STATE_DEBUG
 
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -48,26 +48,26 @@
  * In a second step we test if a heater is full on, full of, or somewhere in the PWM area and test if the
  * temperature changes as expected. This is accomplished by temperature overshoots. A temperature can rise 
  * fuhrer when a heater is turned off. The longest time between switching a heater off and the change to failing
- * temperatures we call MAX_TEMP_OVERSTOOT_TIME.
+ * temperatures we call MAX_TEMP_OVERSHOOT_TIME.
  * When a heater is off, but the surrounding temperature is higher or equal to the heaters temperature, the temperature
  * can not fall. Therefore we do not test for this below MAX_AMBIENT_TEMPERATURE.
- * HEATER_STATE_DEBUG produces some output on the serial line to see how sharp or blunt these tests are.
+ * HEATER_STATE_DEBUG produces some output on the serial line to find the right parameters.
  *
  * Temperatures are inert. If the value of any thermometer jumps, there is something wrong with it.
  * Reasons can be: shorted wires, broken wires, leaking water-cooling, ...
  * but also: electronic noise, ...
  * MAX THERMO_JUMP_AMOUNT is the maximum allowed temperature difference between two measurements of the raw temperatures, (an abstract number).
  * The fastest expected change is about (full range of the ADC) / minute / (temp measurements / second). 
- * This is well below the noise. So we have to adjust for the noise.
- * If you get 'unreasoned' "error: Thermometer Jumped" messages increase the next value. 50 is a good value to start. 0 disables.
+ * This is normally well below the noise. So we have to adjust for the noise.
+ * If you get 'unreasoned' "error: Thermal jump" messages increase the MAX_THERMO_JUMP_AMOUNT value. 30 is a good value to start. 0 disables.
  *
- * Set MAX_TEMP_OVERSTOOT_TIME to 0 to deactivate all this tests. 30 is a good value to start.
+ * Set MAX_TEMP_OVERSHOOT_TIME to 0 to deactivate all this tests. 30 is a good value to start.
  */
-#define MAX_TEMP_OVERSTOOT_TIME 0
+#define MAX_TEMP_OVERSHOOT_TIME 0
 #define TEMP_RAW_NOISE 6
 #define TEMP_CONSEC_COUNT 6
 #define MAX_AMBIENT_TEMPERATURE 50
-#define MAX_THERMO_JUMP_AMOUNT 0
+#define MAX_THERMO_JUMP_AMOUNT 30
 #define HEATER_STATE_DEBUG
 
 #ifdef PIDTEMP
@@ -261,7 +261,7 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
-#define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DEFAULT_STEPPER_DEACTIVE_TIME 0
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -36,6 +36,30 @@
   #define THERMAL_PROTECTION_BED_HYSTERESIS 2 // Degrees Celsius
 #endif
 
+/**
+ * An alternate algorithm to test if a heater works as expected.
+ * If a heater is full on its temperature should not drop.
+ * If a heater is full off its temperature should not rise.
+ * In a first step we detect if a temperature is rising or failing.
+ * This is accomplished by noise on the thermometers. Therefore we oversample the raw measurements an other 16 times.
+ * Than we test if the difference between the average and the momentary temperature is bigger than TEMP_RAW_NOISE.
+ * Than the sign of difference tells us the tendency. When we have more than TEMP_CONSEC_COUNT consecutive readings in one
+ * direction we report rising or falling, else constant.
+ * In a second step we test if a heater is full on, full of, or somewhere in the PWM area and test if the
+ * temperature changes as expected. This is accomplished by temperature overshoots. A temperature can rise 
+ * fuhrer when a heater is turned off. The longest time between switching a heater off and the change to failing
+ * temperatures we call MAX_TEMP_OVERSTOOT_TIME.
+ * When a heater is off, but the surrounding temperature is higher or equal to the heaters temperature, the temperature
+ * can not fall. Therefore we do not test for this below MAX_AMBIENT_TEMPERATURE.
+ * HEATER_STATE_DEBUG produces some output on the serial line to see how sharp or blunt these tests are.
+ * Set MAX_TEMP_OVERSTOOT_TIME to 0 to deactivate.
+ */
+#define TEMP_RAW_NOISE 6
+#define TEMP_CONSEC_COUNT 6
+#define MAX_TEMP_OVERSTOOT_TIME 30
+#define MAX_AMBIENT_TEMPERATURE 50
+//#define HEATER_STATE_DEBUG
+
 #ifdef PIDTEMP
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.
   // if Kc is chosen well, the additional required power due to increased melting should be compensated.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3434,7 +3434,7 @@ inline void gcode_M105() {
       SERIAL_PROTOCOLPGM("    ADC B:");
       SERIAL_PROTOCOL_F(degBed(),1);
       SERIAL_PROTOCOLPGM("C->");
-      SERIAL_PROTOCOL_F(rawBedTemp()/OVERSAMPLENR,0);
+      SERIAL_PROTOCOL_F(rawBedTemp() >> OVESRAMPLESHIFT,0);
     #endif
     for (int8_t cur_extruder = 0; cur_extruder < EXTRUDERS; ++cur_extruder) {
       SERIAL_PROTOCOLPGM("  T");
@@ -3442,7 +3442,7 @@ inline void gcode_M105() {
       SERIAL_PROTOCOLCHAR(':');
       SERIAL_PROTOCOL_F(degHotend(cur_extruder),1);
       SERIAL_PROTOCOLPGM("C->");
-      SERIAL_PROTOCOL_F(rawHotendTemp(cur_extruder)/OVERSAMPLENR,0);
+      SERIAL_PROTOCOL_F(rawHotendTemp(cur_extruder) >> OVESRAMPLESHIFT,0);
     }
   #endif
 

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -220,6 +220,7 @@
 #define MSG_T_THERMAL_RUNAWAY               "Thermal Runaway"
 #define MSG_T_MAXTEMP                       "MAXTEMP triggered"
 #define MSG_T_MINTEMP                       "MINTEMP triggered"
+#define MSG_T_JUMP                          "Thermal jump"
 
 
 // LCD Menu Messages

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -408,6 +408,9 @@
 #ifndef MSG_THERMAL_RUNAWAY
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #endif
+#ifndef MSG_ERR_THERMAL_JUMP
+#define MSG_ERR_THERMAL_JUMP                "Err: THER. JUMP"
+#endif
 #ifndef MSG_ERR_MAXTEMP
 #define MSG_ERR_MAXTEMP                     "Err: MAXTEMP"
 #endif

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1650,6 +1650,10 @@ ISR(TIMER0_COMPB_vect) {
       return 0;
     }
 
+    #if MAX_THERMO_JUMP_AMOUNT > 0
+      if (abs(dt) > MAX_THERMO_JUMP_AMOUNT) _temp_error(hh, PSTR(MSG_T_JUMP), PSTR(MSG_ERR_THERMAL_JUMP));
+    #endif
+
     if (abs(dt) < TEMP_RAW_NOISE) { counter[h] = 0; return 0;} // constant
     switch (h) {
       case 0: {

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -748,7 +748,7 @@ static float analog2temp(int raw, uint8_t e) {
 
     return celsius;
   }
-  return ((raw * ((5.0 * 100.0) / 1024.0) / OVERSAMPLENR) * TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET;
+  return (((raw >> OVESRAMPLESHIFT) * ((5.0 * 100.0) / 1024.0)) * TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET;
 }
 
 // Derived from RepRap FiveD extruder::getTemperature()
@@ -773,7 +773,7 @@ static float analog2tempBed(int raw) {
 
     return celsius;
   #elif defined BED_USES_AD595
-    return ((raw * ((5.0 * 100.0) / 1024.0) / OVERSAMPLENR) * TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET;
+    return (((raw >> OVESRAMPLESHIFT) * ((5.0 * 100.0) / 1024.0)) * TEMP_SENSOR_AD595_GAIN) + TEMP_SENSOR_AD595_OFFSET;
   #else
     return 0;
   #endif
@@ -789,6 +789,15 @@ static void updateTemperaturesFromRawValues() {
     current_temperature[e] = analog2temp(current_temperature_raw[e], e);
   }
   current_temperature_bed = analog2tempBed(current_temperature_bed_raw);
+
+  #if MAX_TEMP_OVERSTOOT_TIME > 0
+    for (int8_t h = FIRST_HEATER; h < EXTRUDERS; h++) {
+      //SERIAL_PROTOCOLPGM("Heater: "); SERIAL_PROTOCOL(h+1); SERIAL_PROTOCOLPGM(" H_State: "); SERIAL_PROTOCOLLN(heater_state(h));
+      if (heater_state(h) && (MAX_AMBIENT_TEMPERATURE < ((h<0) ? current_temperature_bed : current_temperature[h]))) 
+        _temp_error(h, PSTR(MSG_T_THERMAL_RUNAWAY), PSTR(MSG_THERMAL_RUNAWAY));
+    }
+  #endif
+
   #ifdef TEMP_SENSOR_1_AS_REDUNDANT
     redundant_temperature = analog2temp(redundant_temperature_raw, 1);
   #endif
@@ -1611,3 +1620,138 @@ ISR(TIMER0_COMPB_vect) {
   float scalePID_d(float d)   { return d / PID_dT; }
   float unscalePID_d(float d) { return d * PID_dT; }
 #endif //PIDTEMP
+
+#if MAX_TEMP_OVERSTOOT_TIME > 0
+  int8_t temperature_state(int8_t hh) {
+    static int last_temp_raw[5] = { 0 };
+    static int8_t counter[5] = { 127, 127, 127, 127, 127 }; //init 127
+
+    int8_t h = hh + 1; // index correctur
+    // get current_temperature_raw[hh] and divide by OVERSAMPLENR
+    #ifdef HEATER_0_USES_MAX6675
+      int t = ((h) ? ((hh) ? current_temperature_raw[hh] >> OVESRAMPLESHIFT: current_temperature_raw[hh]) : current_temperature_bed_raw >> OVESRAMPLESHIFT);
+    #else
+      int t = ((h) ? current_temperature_raw[hh]: current_temperature_bed_raw) >> OVESRAMPLESHIFT;
+    #endif
+
+    // floating average over 16 values (MAX6675 is not oversampled until now. Thermistors are still a bit nervous)
+    int average = (last_temp_raw[h] >> OVESRAMPLESHIFT); // /16
+    int dt = t - average;
+    last_temp_raw[h] += dt;
+
+    #ifdef HEATER_STATE_DEBUG
+      SERIAL_PROTOCOLPGM("Temperature: "); SERIAL_PROTOCOL(h); SERIAL_PROTOCOLPGM(" count: "); SERIAL_PROTOCOL((int)counter[h]); SERIAL_PROTOCOLPGM(" Temp.: "); SERIAL_PROTOCOL((int)t); SERIAL_PROTOCOLPGM(" Temp.A.:"); SERIAL_PROTOCOL(average);
+    #endif
+
+    // init
+    if (counter[h] == 127) {
+      last_temp_raw[h] = (t << OVESRAMPLESHIFT); // *16
+      counter[h] = 0;
+      return 0;
+    }
+
+    if (abs(dt) < TEMP_RAW_NOISE) { counter[h] = 0; return 0;} // constant
+    switch (h) {
+      case 0: {
+        #if HAS_TEMP_BED
+          counter[h] += (dt GEBED 0) ? 1 : -1;
+        #endif
+        break;
+      }
+      case 1: {
+        #if HAS_TEMP_0 && !defined(HEATER_0_USES_MAX6675)
+          counter[h] += (dt GE0 0) ? 1 : -1;
+        #endif
+        #ifdef HEATER_0_USES_MAX6675
+          counter[h] += (dt >= 0) ? 1 : -1;
+        #endif
+        break;
+      }
+      case 2: {
+        #if HAS_TEMP_1
+          counter[h] += (dt GE1 0) ? 1 : -1;
+        #endif
+        break;
+      }
+      case 3: {
+        #if HAS_TEMP_2
+          counter[h] += (dt GE2 0) ? 1 : -1;
+        #endif
+        break;
+      }
+      case 4: {
+        #if HAS_TEMP_3
+          counter[h] += (dt GE3 0) ? 1 : -1;
+        #endif
+        break;
+      }
+      break;
+    }
+    // when we have n consecutive rising or falling values we are sure enough to return that
+    if (abs(counter[h]) >= TEMP_CONSEC_COUNT) return (counter[h] < 0) ? -1 : 1;
+    // else return constant
+    return 0;
+  }
+
+  int8_t heater_state(int8_t hh) {
+    enum hstate_t { FULL_ON_S, ON_S, OFF_S };
+    static hstate_t hstate[5] = { ON_S, ON_S, ON_S, ON_S, ON_S, };
+    static int8_t tstate[5] = {0, 0, 0, 0, 0};
+    static millis_t timerc[5] = {0, 0, 0, 0, 0};
+    static float initial_temp[5] = {0.0, 0.0, 0.0, 0.0, 0.0};
+
+    uint8_t h = hh + 1;
+    int8_t current_tstate = temperature_state(hh);
+
+    #ifdef HEATER_STATE_DEBUG
+      SERIAL_PROTOCOLPGM(" Heater: "); SERIAL_PROTOCOL((int)h); SERIAL_PROTOCOLPGM(" T_State: "); SERIAL_PROTOCOL((int)current_tstate); SERIAL_PROTOCOLPGM(" Time:"); SERIAL_PROTOCOL(timerc[h]-millis()); SERIAL_PROTOCOLPGM(" H_State:"); SERIAL_PROTOCOLLN((int)hstate[h]);
+    #endif
+
+    if (((h) ? soft_pwm[hh] : soft_pwm_bed) == ((h) ? PID_MAX >> 1: MAX_BED_POWER >> 1)) {// FULL_ON
+      if (hstate[h] != FULL_ON_S) {
+        hstate[h]  = FULL_ON_S;
+        tstate[h] = current_tstate;
+        timerc[h] = millis() + MAX_TEMP_OVERSTOOT_TIME * 1000UL;
+        return 0;
+      }
+      else {
+        if (current_tstate != tstate[h]) {
+          if (current_tstate == 1) return 0;
+          if (current_tstate == -1)  _temp_error(hh, PSTR(MSG_T_HEATING_FAILED), PSTR(MSG_HEATING_FAILED_LCD));
+        }
+        if (millis() > timerc[h]) {// timeout
+          hstate[h] = ON_S; // retest
+          if (current_tstate != -1) return 0;
+          else _temp_error(hh, PSTR(MSG_T_HEATING_FAILED), PSTR(MSG_HEATING_FAILED_LCD));
+        }
+        else
+          return 0;
+      }
+    }
+    else if (((h) ? soft_pwm[hh] : soft_pwm_bed) == 0) // FULL_OFF
+      if (hstate[h] != OFF_S) {
+        hstate[h] = OFF_S;
+        tstate[h] = current_tstate;
+        timerc[h] = millis() + MAX_TEMP_OVERSTOOT_TIME * 1000UL;
+        return 0;
+      }
+      else {
+        if (current_tstate != tstate[h]) {
+          if (current_tstate == 1) _temp_error(hh, PSTR(MSG_T_THERMAL_RUNAWAY), PSTR(MSG_THERMAL_RUNAWAY));
+          else return 0;
+        }
+        if (millis() > timerc[h]) {// timeout
+          hstate[h] = ON_S; // retest
+          if (current_tstate != 1) return 0;
+          else return 1; // test for MAX_AMBIENT_TEMPERATURE
+        }
+        else
+          return 0;
+      }
+    else {
+      hstate[h] = ON_S; // on, but not full power so can't say anything about the temperature change
+      return 0;
+    }
+  return 0;
+  }
+#endif // MAX_TEMP_OVERSTOOT_TIME > 0

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -146,6 +146,10 @@ void PID_autotune(float temp, int extruder, int ncycles);
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();
 
+#if MAX_TEMP_OVERSTOOT_TIME > 0
+  int8_t heater_state(int8_t);
+#endif
+
 FORCE_INLINE void autotempShutdown() {
   #ifdef AUTOTEMP
     if (autotemp_enabled) {

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -146,7 +146,7 @@ void PID_autotune(float temp, int extruder, int ncycles);
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();
 
-#if MAX_TEMP_OVERSTOOT_TIME > 0
+#if MAX_TEMP_OVERSHOOT_TIME > 0
   int8_t heater_state(int8_t);
 #endif
 

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -4,6 +4,7 @@
 #include "Marlin.h"
 
 #define OVERSAMPLENR 16
+#define OVESRAMPLESHIFT 4 // x >> OVESRAMPLESHIFT == x / OVERSAMPLENR
 
 #if (THERMISTORHEATER_0 == 1) || (THERMISTORHEATER_1 == 1)  || (THERMISTORHEATER_2 == 1) || (THERMISTORHEATER_3 == 1) || (THERMISTORBED == 1) //100k bed thermistor
 


### PR DESCRIPTION
Using an algorithm of @nophead (https://github.com/MarlinFirmware/Marlin/issues/2025#issuecomment-99823546).
Compared to the last version we now detect rising and falling temperatures, not temperatures higher/lower than the start temperature. (https://github.com/MarlinFirmware/Marlin/pull/2092#issuecomment-102838024)

Comments on configurable parameters in Configuration_adv.h

Replaces #2092
