### PR TITLE
M110 is a known command

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5392,6 +5392,8 @@ void process_next_command() {
         gcode_M109();
         break;
 
+      case 110: break; // M110: Set line number - don't show "unknown command"
+
       #if HAS_TEMP_BED
         case 190: // M190: Wait for bed heater to reach target
           gcode_M190();


### PR DESCRIPTION
- The command parser now displays “unknown command” in more cases. Known commands must be added to the `switch` inside `process_commands` to suppress the error.
