### PR TITLE
Ignore G21 (set units to millimeters).

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5252,6 +5252,10 @@ void process_next_command() {
         gcode_G4();
         break;
 
+      // G21: Set units to millimeters
+      case 21:
+        break;
+
       #ifdef FWRETRACT
 
         case 10: // G10: retract


### PR DESCRIPTION
Emitted by Slic3r and others. Triggers an "unknown command" error
otherwise. It is pretty much a no-op on Marlin.

In some cases, it might trigger a "Wait for user" prompt on the display.
