### PR TITLE
Ignore unknown commands if they start with G, M, or T

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5301,7 +5301,7 @@ void process_next_command() {
         gcode_G92();
         break;
 
-      default: code_is_good = false;
+      // default: code_is_good = false;
     }
     break;
 
@@ -5391,8 +5391,6 @@ void process_next_command() {
       case 109: // M109: Wait for temperature
         gcode_M109();
         break;
-
-      case 110: break; // M110: Set line number - don't show "unknown command"
 
       #if HAS_TEMP_BED
         case 190: // M190: Wait for bed heater to reach target
@@ -5735,13 +5733,15 @@ void process_next_command() {
         gcode_M999();
         break;
 
-      default: code_is_good = false;
+      // default: code_is_good = false;
     }
     break;
 
     case 'T':
       gcode_T(codenum);
     break;
+
+    default: code_is_good = false;
   }
 
 ExitUnknownCommand:

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5300,8 +5300,6 @@ void process_next_command() {
       case 92: // G92
         gcode_G92();
         break;
-
-      // default: code_is_good = false;
     }
     break;
 
@@ -5732,8 +5730,6 @@ void process_next_command() {
       case 999: // M999: Restart after being Stopped
         gcode_M999();
         break;
-
-      // default: code_is_good = false;
     }
     break;
 


### PR DESCRIPTION
Revert to the previous behavior of `process_next_command` which is to throw an error if a command is given which doesn't start with `G`, `M`, or `T`. If a command starting with `G`, `M`, or `T` is unknown, it will fail silently.

(This might be a good candidate for a new `M111` debugging flag.)
