### PR TITLE
Fix thermal protection state machine target temp. V2

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1042,7 +1042,6 @@ void tp_init() {
       case TRReset:
         *timer = 0;
         *state = TRInactive;
-        break;
       // Inactive state waits for a target temperature to be set
       case TRInactive:
         if (target_temperature > 0) {


### PR DESCRIPTION
If the target temperature is changed then it would always stay in the reset state.
Thanks to @tonokip.

Replaces #2199
