### PR TITLE
A different heater check (V3)

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -500,5 +500,11 @@
     #define WRITE_FAN(v) WRITE(FAN_PIN, v)
   #endif
 
+  #if HAS_TEMP_BED
+    #define FIRST_HEATER -1
+  #else
+    #define FIRST_HEATER 0
+  #endif
+
 #endif //CONFIGURATION_LCD
 #endif //CONDITIONALS_H

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -36,7 +36,41 @@
   #define THERMAL_PROTECTION_BED_HYSTERESIS 2 // Degrees Celsius
 #endif
 
+/**
+ * An alternate algorithm to test if a heater works as expected.
+ * If a heater is full on its temperature should not drop.
+ * If a heater is full off its temperature should not rise.
+ * In a first step we detect if a temperature is rising or failing.
+ * This is accomplished by noise on the thermometers. Therefore we oversample the raw measurements an other 16 times.
+ * Than we test if the difference between the average and the momentary temperature is bigger than TEMP_RAW_NOISE.
+ * Than the sign of difference tells us the tendency. When we have more than TEMP_CONSEC_COUNT consecutive readings in one
+ * direction we report rising or falling, else constant.
+ * In a second step we test if a heater is full on, full of, or somewhere in the PWM area and test if the
+ * temperature changes as expected. This is accomplished by temperature overshoots. A temperature can rise 
+ * fuhrer when a heater is turned off. The longest time between switching a heater off and the change to failing
+ * temperatures we call MAX_TEMP_OVERSHOOT_TIME.
+ * When a heater is off, but the surrounding temperature is higher or equal to the heaters temperature, the temperature
+ * can not fall. Therefore we do not test for this below MAX_AMBIENT_TEMPERATURE.
+ * HEATER_STATE_DEBUG produces some output on the serial line to find the right parameters.
+ *
+ * Temperatures are inert. If the value of any thermometer jumps, there is something wrong with it.
+ * Reasons can be: shorted wires, broken wires, leaking water-cooling, ...
+ * but also: electronic noise, ...
+ * MAX THERMO_JUMP_AMOUNT is the maximum allowed temperature difference between two measurements of the raw temperatures, (an abstract number).
+ * The fastest expected change is about (full range of the ADC) / minute / (temp measurements / second). 
+ * This is normally well below the noise. So we have to adjust for the noise.
+ * If you get 'unreasoned' "error: Thermal jump" messages increase the MAX_THERMO_JUMP_AMOUNT value. 30 is a good value to start. 0 disables.
+ *
+ * Set MAX_TEMP_OVERSHOOT_TIME to 0 to deactivate all this tests. 30 is a good value to start.
+ */
+#define MAX_TEMP_OVERSHOOT_TIME 0
+#define TEMP_RAW_NOISE 6
+#define TEMP_CONSEC_COUNT 6
+#define MAX_AMBIENT_TEMPERATURE 50
+#define MAX_THERMO_JUMP_AMOUNT 30
+#define HEATER_STATE_DEBUG
 #ifdef PIDTEMP
+
   // this adds an experimental additional term to the heating power, proportional to the extrusion speed.
   // if Kc is chosen well, the additional required power due to increased melting should be compensated.
   #define PID_ADD_EXTRUSION_RATE

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3414,7 +3414,7 @@ inline void gcode_M105() {
       SERIAL_PROTOCOLPGM("    ADC B:");
       SERIAL_PROTOCOL_F(degBed(),1);
       SERIAL_PROTOCOLPGM("C->");
-      SERIAL_PROTOCOL_F(rawBedTemp()/OVERSAMPLENR,0);
+      SERIAL_PROTOCOL_F(rawBedTemp() >> OVESRAMPLESHIFT,0);
     #endif
     for (int8_t cur_extruder = 0; cur_extruder < EXTRUDERS; ++cur_extruder) {
       SERIAL_PROTOCOLPGM("  T");
@@ -3422,7 +3422,7 @@ inline void gcode_M105() {
       SERIAL_PROTOCOLCHAR(':');
       SERIAL_PROTOCOL_F(degHotend(cur_extruder),1);
       SERIAL_PROTOCOLPGM("C->");
-      SERIAL_PROTOCOL_F(rawHotendTemp(cur_extruder)/OVERSAMPLENR,0);
+      SERIAL_PROTOCOL_F(rawHotendTemp(cur_extruder) >> OVESRAMPLESHIFT,0);
     }
   #endif
 

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -214,7 +214,7 @@
 #define MSG_T_THERMAL_RUNAWAY               "Thermal Runaway"
 #define MSG_T_MAXTEMP                       "MAXTEMP triggered"
 #define MSG_T_MINTEMP                       "MINTEMP triggered"
-
+#define MSG_T_JUMP                          "Thermal jump"
 
 // LCD Menu Messages
 

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -402,6 +402,9 @@
 #ifndef MSG_THERMAL_RUNAWAY
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #endif
+#ifndef MSG_ERR_THERMAL_JUMP
+#define MSG_ERR_THERMAL_JUMP                "Err: THER. JUMP"
+#endif
 #ifndef MSG_ERR_MAXTEMP
 #define MSG_ERR_MAXTEMP                     "Err: MAXTEMP"
 #endif

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -146,6 +146,10 @@ void PID_autotune(float temp, int extruder, int ncycles);
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();
 
+#if MAX_TEMP_OVERSHOOT_TIME > 0
+  int8_t heater_state(int8_t);
+#endif
+
 FORCE_INLINE void autotempShutdown() {
   #ifdef AUTOTEMP
     if (autotemp_enabled) {

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -4,6 +4,7 @@
 #include "Marlin.h"
 
 #define OVERSAMPLENR 16
+#define OVESRAMPLESHIFT 4 // x >> OVESRAMPLESHIFT == x / OVERSAMPLENR
 
 #if (THERMISTORHEATER_0 == 1) || (THERMISTORHEATER_1 == 1)  || (THERMISTORHEATER_2 == 1) || (THERMISTORHEATER_3 == 1) || (THERMISTORBED == 1) //100k bed thermistor
 


### PR DESCRIPTION
Based on an idea by @nophead:
- If a heater is full on the temperature shall not decrease;
- If a heater is full off the temperature shall not rise;
  The test is made after a delay to give the heater time to react
  and only when above a settable ambient temperature.

A test(by @AnHardt)for sudden temperature jumps is integrated.
If thermal systems are inert.
-  If a temperature is jumping something is wrong.

All this is accomplished by noise on the thermometers

Some more explanations in `Configuration_adv.h`
A proposal for a setup-guide in the next comment.
