### PR TITLE
Check compatibility for Teensy-based processor

### DIFF
--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -9,6 +9,8 @@
   #error Oops!  Make sure you have 'Brainwave Pro' selected from the 'Tools -> Boards' menu.
 #endif
 
+#include "fastio.h"
+
 #ifndef AT90USBxx_TEENSYPP_ASSIGNMENTS  // use Teensyduino Teensy++2.0 pin assignments instead of Marlin alphabetical.
   #error  Uncomment #define AT90USBxx_TEENSYPP_ASSIGNMENTS in fastio.h for this config
 #endif


### PR DESCRIPTION
The instruction say to set a #define in fastio.h
However, that value is not included before this test.
