### PR TITLE
QUICK_HOME and CoreXY

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -490,13 +490,25 @@ ISR(TIMER1_COMPA_vect) {
       // TEST_ENDSTOP: test the old and the current status of an endstop
       #define TEST_ENDSTOP(ENDSTOP) (TEST(current_endstop_bits, ENDSTOP) && TEST(old_endstop_bits, ENDSTOP))
 
-      #define UPDATE_ENDSTOP(AXIS,MINMAX) \
-        SET_ENDSTOP_BIT(AXIS, MINMAX); \
-        if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX))  && (current_block->steps[_AXIS(AXIS)] > 0)) { \
-          endstops_trigsteps[_AXIS(AXIS)] = count_position[_AXIS(AXIS)]; \
-          _ENDSTOP_HIT(AXIS); \
-          step_events_completed = current_block->step_event_count; \
-        }
+      //Quick home causes the head to move in diagonal, when core xy is enabled this is performed only with the A('X') motor
+      //Made an exception so it doesn't checks if there is steps in the axis the endstop is mounted on
+	  #ifdef COREXY && QUICK_HOME 
+        #define UPDATE_ENDSTOP(AXIS,MINMAX) \
+          SET_ENDSTOP_BIT(AXIS, MINMAX); \
+          if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX)))  { \
+            endstops_trigsteps[_AXIS(AXIS)] = count_position[_AXIS(AXIS)]; \
+            _ENDSTOP_HIT(AXIS); \
+            step_events_completed = current_block->step_event_count; \
+          }	  
+	  #else
+        #define UPDATE_ENDSTOP(AXIS,MINMAX) \
+          SET_ENDSTOP_BIT(AXIS, MINMAX); \
+          if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX))  && (current_block->steps[_AXIS(AXIS)] > 0)) { \
+            endstops_trigsteps[_AXIS(AXIS)] = count_position[_AXIS(AXIS)]; \
+            _ENDSTOP_HIT(AXIS); \
+            step_events_completed = current_block->step_event_count; \
+          }
+	  #endif
       
       #ifdef COREXY
         // Head direction in -X axis for CoreXY bots.


### PR DESCRIPTION
I tested the latest development branch on my corexy printer, and found that QUICK_HOME was making the Y axis to crash when homing.
Looking a bit into it I realized that even that there is 50% chance of hitting Y first (while moving diagonally) it was expecting to hit X first, then Y, causing the X gantry to crash until the X endstop was hit.

Looking up the code I narrowed down to a macro on stepper.cpp

``` C
        #define UPDATE_ENDSTOP(AXIS,MINMAX) \
          SET_ENDSTOP_BIT(AXIS, MINMAX); \
          if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX))  && (current_block->steps[_AXIS(AXIS)] > 0)) { \
            endstops_trigsteps[_AXIS(AXIS)] = count_position[_AXIS(AXIS)]; \
            _ENDSTOP_HIT(AXIS); \
            step_events_completed = current_block->step_event_count; \
```

More concrete to this conditional:

``` C
 if (TEST_ENDSTOP(_ENDSTOP(AXIS, MINMAX))  && (current_block->steps[_AXIS(AXIS)] > 0))
```

This tests if the endstop is hit and also moving in the axis the endstop is on.
Problem here is that a diagonal move towards home is performed only with the A('X') motor, thus the conditional fails looking for steps in the wrong motor.

In a lack of deeper knowledge I worked around it removing the check of steps in case COREXY && QUICK_HOME are enabled. I could rework it if any advise is given
