### PR TITLE
Switch to Arduino IDE 1.6.4  for Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,37 +7,34 @@ before_install:
   # Also tags for the root(s) of the minor version(s)
   - git fetch origin --tags
   - mkdir ~/bin
-  - wget https://bootstrap.pypa.io/get-pip.py
-  - wget https://bintray.com/artifact/download/olikraus/u8glib/u8glib_arduino_v1.17.zip
 install:
+  # Install arduino 1.6.4
+  - wget http://downloads-02.arduino.cc/arduino-1.6.4-linux64.tar.xz
+  - tar Jxf arduino-1.6.4-linux64.tar.xz
+  - sudo mv arduino-1.6.4 /usr/local/share/arduino
+  - ln -s /usr/local/share/arduino/arduino ~/bin/arduino
+  # Our custom build commands
   - mv LinuxAddons/bin/*  ~/bin/
-  - sudo python get-pip.py
-  - sudo pip install ino
-  # add ppa for newer version of Arduino than available in ubuntu 12.04
-  - sudo add-apt-repository ppa:michael-gruz/elektronik -y
-  - sudo apt-get update -q 
-  - sudo apt-get install arduino
+  - ls -la ~/bin
+  # install our platform
+  - cp -r ArduinoAddons/Arduino_1.6.x/hardware/* /usr/local/share/arduino/hardware
+  # copy libraries to arduino dir, as conditional includes do not work in .ino files
+  - cp -r /usr/local/share/arduino/hardware/marlin/avr/libraries/* /usr/local/share/arduino/libraries/
+  - cp -r ArduinoAddons/Arduino_1.6.x/libraries/* /usr/local/share/arduino/libraries/
+  # add LiquidCrystal_I2C & LiquidTWI2 libraries
+  - git clone https://github.com/kiyoshigawa/LiquidCrystal_I2C.git
+  - mv LiquidCrystal_I2C/LiquidCrystal_I2C /usr/local/share/arduino/libraries/LiquidCrystal_I2C
+  - git clone https://github.com/lincomatic/LiquidTWI2.git
+  - mv LiquidTWI2 /usr/local/share/arduino/libraries/LiquidTWI2
 before_script:
-  # copy TMC and L6470 libraries to arduino dir, as conditional includes do not work in .ino files
-  - sudo cp -r ArduinoAddons/Arduino_1.x.x/libraries/ /usr/share/arduino
-  # add U8glib, LiquidCrystal_I2C & LiquidTWI2 libraries 
-  - sudo unzip u8glib_arduino_v1.17.zip -d /usr/share/arduino/libraries/
-  - cd /usr/share/arduino/libraries/
-  - sudo git clone https://github.com/kiyoshigawa/LiquidCrystal_I2C.git
-  - ls -la
-  - ls -la LiquidCrystal_I2C/
-  - sudo git clone https://github.com/lincomatic/LiquidTWI2.git
-  # remove Robot_Control library to stop compile error!
-  - sudo rm -rf /usr/share/arduino/libraries/Robot_Control
+  # arduino requires an X server even with command line
+  # https://github.com/arduino/Arduino/issues/1981
+  - Xvfb :1 -screen 0 1024x768x16 &> xvfb.log &
   # change back to home directory for compiling
   - cd $TRAVIS_BUILD_DIR
-  # ino needs files in src directory
-  - ln -s Marlin src
-  - generate_version_header_for_marlin . Marlin/_Version.h
-  - cat Marlin/_Version.h
 script:
   # build default config
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # backup configuration.h
   - cp Marlin/Configuration.h Marlin/Configuration.h.backup
   - cp Marlin/Configuration_adv.h Marlin/Configuration_adv.h.backup
@@ -45,55 +42,55 @@ script:
   # commented out for the moment fails build but compiles fine in Arduino
   #- sed -i 's/#define EXTRUDERS 1/#define EXTRUDERS 2/g' Marlin/Configuration.h
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # change extruder numbers from 2 to 3, needs to be a board with 3 extruders defined in pins.h 
   #- sed -i 's/#define MOTHERBOARD BOARD_ULTIMAKER/#define MOTHERBOARD BOARD_AZTEEG_X3_PRO/g' Marlin/Configuration.h
   #- sed -i 's/#define EXTRUDERS 2/#define EXTRUDERS 3/g' Marlin/Configuration.h
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # enable PIDTEMPBED 
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define PIDTEMPBED/#define PIDTEMPBED/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # enable AUTO_BED_LEVELING
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define ENABLE_AUTO_BED_LEVELING/#define ENABLE_AUTO_BED_LEVELING/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # enable EEPROM_SETTINGS & EEPROM_CHITCHAT
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define EEPROM_SETTINGS/#define EEPROM_SETTINGS/g' Marlin/Configuration.h
   - sed -i 's/\/\/#define EEPROM_CHITCHAT/#define EEPROM_CHITCHAT/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ### LCDS ###
   # ULTIMAKERCONTROLLER
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define ULTIMAKERCONTROLLER/#define ULTIMAKERCONTROLLER/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # MAKRPANEL
   # Needs to use melzi and sanguino hardware
   #- cp Marlin/Configuration.h.backup Marlin/Configuration.h
   #- sed -i 's/\/\/#define MAKRPANEL/#define MAKRPANEL/g' Marlin/Configuration.h
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # REPRAP_DISCOUNT_SMART_CONTROLLER
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define REPRAP_DISCOUNT_SMART_CONTROLLER/#define REPRAP_DISCOUNT_SMART_CONTROLLER/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # G3D_PANE
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define G3D_PANEL/#define G3D_PANEL/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER/#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # REPRAPWORLD_KEYPAD 
   # Cant find configuration details to get it to compile
   #- cp Marlin/Configuration.h.backup Marlin/Configuration.h
@@ -101,60 +98,60 @@ script:
   #- sed -i 's/\/\/#define REPRAPWORLD_KEYPAD/#define REPRAPWORLD_KEYPAD/g' Marlin/Configuration.h
   #- sed -i 's/\/\/#define REPRAPWORLD_KEYPAD_MOVE_STEP 10.0/#define REPRAPWORLD_KEYPAD_MOVE_STEP 10.0/g' Marlin/Configuration.h
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # RA_CONTROL_PANEL
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define RA_CONTROL_PANEL/#define RA_CONTROL_PANEL/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ### I2C PANELS ###
   # LCD_I2C_SAINSMART_YWROBOT
   # Failing at the moment needs different library 
   #- cp Marlin/Configuration.h.backup Marlin/Configuration.h
   #- sed -i 's/\/\/#define LCD_I2C_SAINSMART_YWROBOT/#define LCD_I2C_SAINSMART_YWROBOT/g' Marlin/Configuration.h
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # LCD_I2C_PANELOLU2
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define LCD_I2C_PANELOLU2/#define LCD_I2C_PANELOLU2/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # LCD_I2C_VIKI
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define LCD_I2C_VIKI/#define LCD_I2C_VIKI/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Enable filament sensor
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define FILAMENT_SENSOR/#define FILAMENT_SENSOR/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
    # Enable filament sensor with LCD display
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define ULTIMAKERCONTROLLER/#define ULTIMAKERCONTROLLER/g' Marlin/Configuration.h
   - sed -i 's/\/\/#define FILAMENT_SENSOR/#define FILAMENT_SENSOR/g' Marlin/Configuration.h
   - sed -i 's/\/\/#define FILAMENT_LCD_DISPLAY/#define FILAMENT_LCD_DISPLAY/g' Marlin/Configuration.h
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ######## Example Configurations ##############
   # Delta Config (generic)
   - cp Marlin/example_configurations/delta/generic/Configuration* Marlin/
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Delta Config (Mini Kossel)
   - cp Marlin/example_configurations/delta/kossel_mini/Configuration* Marlin/
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Makibox Config  need to check board type for Teensy++ 2.0
   #- cp Marlin/example_configurations/makibox/Configuration* Marlin/
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # SCARA Config
   - cp Marlin/example_configurations/SCARA/Configuration* Marlin/
   - rm -rf .build/
-  - ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # tvrrug Config need to check board type for sanguino atmega644p
   #- cp Marlin/example_configurations/tvrrug/Round2/Configuration* Marlin/
   #- rm -rf .build/
-  #- ino build -m mega2560 --cppflags="-DHAS_AUTOMATIC_VERSIONING -ffunction-sections -fdata-sections -g -Os -w"
+  #- DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ######## Board Types #############


### PR DESCRIPTION
This PR encompasses Issue #2246 and incorporates PR #2261.
PR #1745 is not useful in this environment.

First, builds are working under the Arduino IDE 1.6.4, at least to Mac OS X and Linux.
Travis CI testing is now performed USING the Arduino IDE code which actually processes the boards.txt and platforms.txt in the vendor structure of the current Arduino IDE.

Additionally, the refactoring of the Configuration*.h files has been started. The code presented is functionally identical to the previous code. However, it is now presented in a manner which will allow individual configurations to be "cleaned up" and presented in a more understandable format.

Builds on Windows based machines have not been tested.  Please provide feedback.
