### PR TITLE
Remove a test from pins_RAMPS_13.h

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -34,7 +34,10 @@
   #include "pins_SETHI.h"
 #elif MB(RAMPS_OLD)
   #include "pins_RAMPS_OLD.h"
-#elif MB(RAMPS_13_EFB) || MB(RAMPS_13_EEB) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
+#elif MB(RAMPS_13_EFB)
+  #define IS_RAMPS_EFB
+  #include "pins_RAMPS_13.h"
+#elif MB(RAMPS_13_EEB) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
   #include "pins_RAMPS_13.h"
 #elif MB(GEN6)
   #include "pins_GEN6.h"

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -35,8 +35,7 @@
 #elif MB(RAMPS_OLD)
   #include "pins_RAMPS_OLD.h"
 #elif MB(RAMPS_13_EFB)
-  #define IS_RAMPS_EFB
-  #include "pins_RAMPS_13.h"
+  #include "pins_RAMPS_13_EFB.h"
 #elif MB(RAMPS_13_EEB) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
   #include "pins_RAMPS_13.h"
 #elif MB(GEN6)

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -2,9 +2,7 @@
  * AZTEEG_X3 Arduino Mega with RAMPS v1.3 pin assignments
  */
 
-#define IS_RAMPS_EFB
-
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_13_EFB.h"
 
 //LCD Pins//
 

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -2,9 +2,7 @@
  * BAM&DICE Due (Arduino Mega) pin assignments
  */
 
-#define IS_RAMPS_EFB
-
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_13_EFB.h"
 
 #undef TEMP_0_PIN
 #undef TEMP_1_PIN

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -2,9 +2,7 @@
  * FELIXprinters v2.0/3.0 (RAMPS v1.3) pin assignments
  */
 
-#define IS_RAMPS_EFB
-
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_13_EFB.h"
 
 #undef HEATER_1_PIN
 #define HEATER_1_PIN        7 // EXTRUDER 2

--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -2,9 +2,7 @@
  * MKS BASE 1.0 – Arduino Mega2560 with RAMPS v1.4 pin assignments
  */
 
-#define IS_RAMPS_EFB
-
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_13_EFB.h"
 
 #undef HEATER_1_PIN
 #define HEATER_1_PIN        7

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -77,7 +77,7 @@
   #define FILRUNOUT_PIN        4
 #endif
 
-#if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF) || defined(IS_RAMPS_EFB)
+#if MB(RAMPS_13_EFF) || defined(IS_RAMPS_EFB)
   #define FAN_PIN            9 // (Sprinter config)
   #if MB(RAMPS_13_EFF)
     #define CONTROLLERFAN_PIN  -1 // Pin used for the fan to cool controller
@@ -102,7 +102,7 @@
   #define HEATER_0_PIN       10   // EXTRUDER 1
 #endif
 
-#if MB(RAMPS_13_EFB) || MB(RAMPS_13_SF) || defined(IS_RAMPS_EFB)
+#if MB(RAMPS_13_SF) || defined(IS_RAMPS_EFB)
   #define HEATER_1_PIN       -1
 #else
   #define HEATER_1_PIN       9    // EXTRUDER 2 (FAN On Sprinter)

--- a/Marlin/pins_RAMPS_13_EFB.h
+++ b/Marlin/pins_RAMPS_13_EFB.h
@@ -1,0 +1,9 @@
+/**
+ * Arduino Mega with RAMPS v1.3 pin assignments
+ *
+ *  RAMPS_13_EFB (Extruder, Fan, Bed)
+ */
+
+#define IS_RAMPS_EFB
+
+#include "pins_RAMPS_13.h"


### PR DESCRIPTION
- Add 3 new lines to `pins.h` to remove 2 redundant tests in `pins_RAMPS_13.h`
- Move `IS_RAMPS_EFB` define to `pins_RAMPS_13_EFB.h` and include where appropriate.
