### PR TITLE
Rework buzzing V2

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -504,5 +504,7 @@
     #define WRITE_FAN(v) WRITE(FAN_PIN, v)
   #endif
 
+  #define HAS_BUZZER ((defined(BEEPER) && BEEPER >= 0) || defined(LCD_USE_I2C_BUZZER))
+
 #endif //CONFIGURATION_LCD
 #endif //CONDITIONALS_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -36,7 +36,6 @@
   #endif
 #endif // ENABLE_AUTO_BED_LEVELING
 
-#define HAS_LCD_BUZZ (defined(ULTRA_LCD) || (defined(BEEPER) && BEEPER >= 0) || defined(LCD_USE_I2C_BUZZER))
 #define SERVO_LEVELING (defined(ENABLE_AUTO_BED_LEVELING) && PROBE_SERVO_DEACTIVATION_DELAY > 0)
 
 #ifdef MESH_BED_LEVELING
@@ -4349,7 +4348,7 @@ inline void gcode_M226() {
 
 #endif // NUM_SERVOS > 0
 
-#if HAS_LCD_BUZZ
+#if HAS_BUZZER
 
   /**
    * M300: Play beep sound S<frequency Hz> P<duration ms>
@@ -4358,10 +4357,10 @@ inline void gcode_M226() {
     uint16_t beepS = code_seen('S') ? code_value_short() : 110;
     uint32_t beepP = code_seen('P') ? code_value_long() : 1000;
     if (beepP > 5000) beepP = 5000; // limit to 5 seconds
-    lcd_buzz(beepP, beepS);
+    buzz(beepP, beepS);
   }
 
-#endif // HAS_LCD_BUZZ
+#endif // HAS_BUZZER
 
 #ifdef PIDTEMP
 
@@ -4791,7 +4790,7 @@ inline void gcode_M428() {
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM(MSG_ERR_M428_TOO_FAR);
         LCD_ALERTMESSAGEPGM("Err: Too far!");
-        #if HAS_LCD_BUZZ
+        #if HAS_BUZZER
           enqueuecommands_P(PSTR("M300 S40 P200"));
         #endif
         err = true;
@@ -4805,7 +4804,7 @@ inline void gcode_M428() {
     memcpy(home_offset, new_offs, sizeof(new_offs));
     sync_plan_position();
     LCD_ALERTMESSAGEPGM("Offset applied.");
-    #if HAS_LCD_BUZZ
+    #if HAS_BUZZER
       enqueuecommands_P(PSTR("M300 S659 P200\nM300 S698 P200"));
     #endif
   }
@@ -5607,11 +5606,11 @@ void process_next_command() {
           break;
       #endif // NUM_SERVOS > 0
 
-      #if HAS_LCD_BUZZ
+      #if HAS_BUZZER
         case 300: // M300 - Play beep tone
           gcode_M300();
           break;
-      #endif // HAS_LCD_BUZZ
+      #endif // HAS_BUZZER
 
       #ifdef PIDTEMP
         case 301: // M301

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1313,7 +1313,7 @@ void lcd_quick_feedback() {
     #ifndef LCD_FEEDBACK_FREQUENCY_DURATION_MS
       #define LCD_FEEDBACK_FREQUENCY_DURATION_MS (1000/6)
     #endif    
-    lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+    buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
   #elif defined(BEEPER) && BEEPER >= 0
     #ifndef LCD_FEEDBACK_FREQUENCY_HZ
       #define LCD_FEEDBACK_FREQUENCY_HZ 5000
@@ -1321,7 +1321,7 @@ void lcd_quick_feedback() {
     #ifndef LCD_FEEDBACK_FREQUENCY_DURATION_MS
       #define LCD_FEEDBACK_FREQUENCY_DURATION_MS 2
     #endif
-    lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+    buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
   #else
     #ifndef LCD_FEEDBACK_FREQUENCY_DURATION_MS
       #define LCD_FEEDBACK_FREQUENCY_DURATION_MS 2
@@ -1745,7 +1745,12 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
     #endif
   }
 
-  void lcd_buzz(long duration, uint16_t freq) {
+  bool lcd_clicked() { return LCD_CLICKED; }
+
+#endif // ULTIPANEL
+
+#if HAS_BUZZER
+  void buzz(long duration, uint16_t freq) {
     if (freq > 0) {
       #ifdef LCD_USE_I2C_BUZZER
         lcd.buzz(duration, freq);
@@ -1761,10 +1766,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
       delay(duration);
     }
   }
-
-  bool lcd_clicked() { return LCD_CLICKED; }
-
-#endif // ULTIPANEL
+#endif
 
 /*********************************/
 /** Number to string conversion **/

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -52,8 +52,6 @@
   #ifdef FILAMENT_LCD_DISPLAY
     extern millis_t previous_lcd_status_ms;
   #endif
-
-  void lcd_buzz(long duration,uint16_t freq);
   void lcd_quick_feedback(); // Audible feedback for a button click - could also be visual
   bool lcd_clicked();
 
@@ -106,13 +104,16 @@
   FORCE_INLINE void lcd_setstatuspgm(const char* message, const uint8_t level=0) {}
   FORCE_INLINE void lcd_buttons_update() {}
   FORCE_INLINE void lcd_reset_alert_level() {}
-  FORCE_INLINE void lcd_buzz(long duration, uint16_t freq) {}
   FORCE_INLINE bool lcd_detected(void) { return true; }
 
   #define LCD_MESSAGEPGM(x) do{}while(0)
   #define LCD_ALERTMESSAGEPGM(x) do{}while(0)
 
 #endif //ULTRA_LCD
+
+#if HAS_BUZZER
+  void buzz(long duration,uint16_t freq);
+#endif
 
 char *itostr2(const uint8_t &x);
 char *itostr31(const int &xx);


### PR DESCRIPTION
by:
Moving HAS_LCD_BUZZ macro to Coditionals.h
Renaming HAS_LCD_BUZZ to HAS_BUZZER to make clear is has nothing to do with the lcd.
Removing the ULTRALCD condition.

Moving declaration of lcd_buzz() out of the ULTRA_LCD block in ultralcd.h
Moving definition of lcd_buzz() out of the ULTIPANEL block in ultralcd.cpp
Renaming lcd_buzz() to buzz() to make clear is has nothing to do with the lcd.

All buzzing code is now only dependent on the existence of a BEEPER-pin or the definition of a LCD_USE_I2C_BUZZER.

~~To do: Check the conditions for the BEEPER-pin in all pin-files.~~ The conditions for setting the BEEPER-pin in the pin-files (especially RAMPS) are still a bit mysterious to me - but should work - for now.

Fix for #2289

Rebased version of #2294
