### PR TITLE
Buzzing has nothing to do with the LCD

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -338,4 +338,8 @@ extern uint8_t active_extruder;
 
 extern void calculate_volumetric_multipliers();
 
+#if HAS_BUZZER
+  void buzz(long duration,uint16_t freq);
+#endif
+
 #endif //MARLIN_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6620,3 +6620,22 @@ void calculate_volumetric_multipliers() {
   for (int i=0; i<EXTRUDERS; i++)
     volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
 }
+
+#if HAS_BUZZER
+  void buzz(long duration, uint16_t freq) {
+    if (freq > 0) {
+      #ifdef LCD_USE_I2C_BUZZER
+        lcd.buzz(duration, freq);
+      #elif defined(BEEPER) && BEEPER >= 0
+        SET_OUTPUT(BEEPER);
+        tone(BEEPER, freq, duration);
+        delay(duration);
+      #else
+        delay(duration);
+      #endif
+    }
+    else {
+      delay(duration);
+    }
+  }
+#endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1749,25 +1749,6 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
 #endif // ULTIPANEL
 
-#if HAS_BUZZER
-  void buzz(long duration, uint16_t freq) {
-    if (freq > 0) {
-      #ifdef LCD_USE_I2C_BUZZER
-        lcd.buzz(duration, freq);
-      #elif defined(BEEPER) && BEEPER >= 0
-        SET_OUTPUT(BEEPER);
-        tone(BEEPER, freq, duration);
-        delay(duration);
-      #else
-        delay(duration);
-      #endif
-    }
-    else {
-      delay(duration);
-    }
-  }
-#endif
-
 /*********************************/
 /** Number to string conversion **/
 /*********************************/

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -111,10 +111,6 @@
 
 #endif //ULTRA_LCD
 
-#if HAS_BUZZER
-  void buzz(long duration,uint16_t freq);
-#endif
-
 char *itostr2(const uint8_t &x);
 char *itostr31(const int &xx);
 char *itostr3(const int &xx);


### PR DESCRIPTION
As stated in #2296. Argh!

Shift declaration of buzz() from ultralcd.h to Marlin.h
Shift buzz() from ultralcd.cpp to Marlin_main.cpp

This is necessary because there are boards like MEGATRONICS, that have
buzzers on board, that do not need a further condition.

Alternative we could make a buzzer.h and buzzer.cpp. A bit of overkill
for a single function.
