### PR TITLE
Rename and repair MELZI_1284

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -23,7 +23,7 @@
 #define BOARD_MELZI             63   // Melzi
 #define BOARD_STB_11            64   // STB V1.1
 #define BOARD_AZTEEG_X1         65   // Azteeg X1
-#define BOARD_MELZI_1284        66   // Melzi with ATmega1284 (MaKr3d version)
+#define BOARD_MELZI_MAKR3D      66   // Melzi with ATmega1284 (MaKr3d version)
 #define BOARD_AZTEEG_X3         67   // Azteeg X3
 #define BOARD_AZTEEG_X3_PRO     68   // Azteeg X3 Pro
 #define BOARD_ULTIMAKER         7    // Ultimaker

--- a/Marlin/configurator/config/boards.h
+++ b/Marlin/configurator/config/boards.h
@@ -23,7 +23,7 @@
 #define BOARD_MELZI             63   // Melzi
 #define BOARD_STB_11            64   // STB V1.1
 #define BOARD_AZTEEG_X1         65   // Azteeg X1
-#define BOARD_MELZI_1284        66   // Melzi with ATmega1284 (MaKr3d version)
+#define BOARD_MELZI_MAKR3D      66   // Melzi with ATmega1284 (MaKr3d version)
 #define BOARD_AZTEEG_X3         67   // Azteeg X3
 #define BOARD_AZTEEG_X3_PRO     68   // Azteeg X3 Pro
 #define BOARD_ULTIMAKER         7    // Ultimaker

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -52,8 +52,8 @@
   #include "pins_STB_11.h"
 #elif MB(AZTEEG_X1)
   #include "pins_AZTEEG_X1.h"
-#elif MB(MELZI_1284)
-  #include "pins_MELZI_1284.h"
+#elif MB(MELZI_MAKR3D)
+  #include "pins_MELZI_MAKR3D.h"
 #elif MB(AZTEEG_X3)
   #include "pins_AZTEEG_X3.h"
 #elif MB(AZTEEG_X3_PRO)

--- a/Marlin/pins_MELZI_MAKR3D.h
+++ b/Marlin/pins_MELZI_MAKR3D.h
@@ -2,10 +2,8 @@
  * Melzi with ATmega1284 (MaKr3d version) pin assignments
  */
 
-#define MELZI
-
 #undef MOTHERBOARD
-#define MOTHERBOARD BOARD_SANGUINOLOLU_11
+#define MOTHERBOARD MELZI
 #define SANGUINOLOLU_V_1_2
 
 #if defined(__AVR_ATmega1284P__)

--- a/Marlin/pins_SANGUINOLOLU_12.h
+++ b/Marlin/pins_SANGUINOLOLU_12.h
@@ -5,7 +5,7 @@
  *
  *  AZTEEG_X1
  *  MELZI
- *  MELZI_1284
+ *  MELZI_MAKR3D
  *  SANGUINOLOLU_12
  *  STB_11
  */


### PR DESCRIPTION
to MELZI_MAKR3D.

Fix for #2288
As the normal MELZI also can have a 1284.
