### PR TITLE
Split buzzing again

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -338,4 +338,8 @@ extern uint8_t active_extruder;
 
 extern void calculate_volumetric_multipliers();
 
+#if HAS_BUZZER
+  void buzz(long duration,uint16_t freq);
+#endif
+
 #endif //MARLIN_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6622,3 +6622,22 @@ void calculate_volumetric_multipliers() {
   for (int i=0; i<EXTRUDERS; i++)
     volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
 }
+
+#if HAS_BUZZER
+  void buzz(long duration, uint16_t freq) {
+    if (freq > 0) {
+      #ifdef LCD_USE_I2C_BUZZER
+        lcd_buzz(duration, freq);
+      #elif defined(BEEPER) && BEEPER >= 0 // on-board buzzers have no further condition
+        SET_OUTPUT(BEEPER);
+        tone(BEEPER, freq, duration);
+        delay(duration);
+      #else
+        delay(duration);
+      #endif
+    }
+    else {
+      delay(duration);
+    }
+  }
+#endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1302,6 +1302,13 @@ menu_edit_type(unsigned long, long5, ftostr5, 0.01)
  * Audio feedback for controller clicks
  *
  */
+ 
+#ifdef LCD_USE_I2C_BUZZER
+  void lcd_buzz(long duration, uint16_t freq) { // called from buzz() in Marlin_main.cpp where lcd is unknown
+    lcd.buzz(duration, freq);
+  }
+#endif
+
 void lcd_quick_feedback() {
   lcdDrawUpdate = 2;
   next_button_update_ms = millis() + 500;
@@ -1313,7 +1320,7 @@ void lcd_quick_feedback() {
     #ifndef LCD_FEEDBACK_FREQUENCY_DURATION_MS
       #define LCD_FEEDBACK_FREQUENCY_DURATION_MS (1000/6)
     #endif    
-    buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+    lcd.buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
   #elif defined(BEEPER) && BEEPER >= 0
     #ifndef LCD_FEEDBACK_FREQUENCY_HZ
       #define LCD_FEEDBACK_FREQUENCY_HZ 5000
@@ -1748,25 +1755,6 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
   bool lcd_clicked() { return LCD_CLICKED; }
 
 #endif // ULTIPANEL
-
-#if HAS_BUZZER
-  void buzz(long duration, uint16_t freq) {
-    if (freq > 0) {
-      #ifdef LCD_USE_I2C_BUZZER
-        lcd.buzz(duration, freq);
-      #elif defined(BEEPER) && BEEPER >= 0
-        SET_OUTPUT(BEEPER);
-        tone(BEEPER, freq, duration);
-        delay(duration);
-      #else
-        delay(duration);
-      #endif
-    }
-    else {
-      delay(duration);
-    }
-  }
-#endif
 
 /*********************************/
 /** Number to string conversion **/

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -15,6 +15,10 @@
   void lcd_reset_alert_level();
   bool lcd_detected(void);
 
+  #ifdef LCD_USE_I2C_BUZZER
+    void lcd_buzz(long duration, uint16_t freq);
+  #endif
+  
   #if defined(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0
     void dontExpireStatus();
   #endif
@@ -110,10 +114,6 @@
   #define LCD_ALERTMESSAGEPGM(x) do{}while(0)
 
 #endif //ULTRA_LCD
-
-#if HAS_BUZZER
-  void buzz(long duration,uint16_t freq);
-#endif
 
 char *itostr2(const uint8_t &x);
 char *itostr31(const int &xx);


### PR DESCRIPTION
in a LCD-dependent
and a pin-dependent function.

`lcd` in `lcd.buzz()` is unknown in `Marlin_main.cpp`,
while `ultralcd.cpp` is not compiled in for an on-board buzzer.
