### PR TITLE
Remove Conflict  with Azteeg X3 Pro of Fan and Heater_1

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -655,8 +655,10 @@
     #define LED_PIN            13
   #endif
 
-  #if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF) || MB(AZTEEG_X3) || MB(AZTEEG_X3_PRO)
+  #if MB(RAMPS_13_EFB) || MB(RAMPS_13_EFF) || MB(AZTEEG_X3)
     #define FAN_PIN            9 // (Sprinter config)
+  #elif MB(AZTEEG_X3_PRO)
+    #define FAN_PIN            11 // Last Heater Pin on board
   #else
     #define FAN_PIN            4 // IO pin. Buffer needed
   #endif


### PR DESCRIPTION
Removes a default conflict on Azteeg X3 Pro boards with the Fan and second heater (Heater_1). Change sets fan to 8th heater terminal on board.
