### PR TITLE
Set gcode_LastN before throwing errors

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -797,6 +797,8 @@ void get_command() {
           return;
         }
 
+        gcode_LastN = gcode_N;
+
         if (apos) {
           byte checksum = 0, count = 0;
           while (command[count] != '*') checksum ^= command[count++];
@@ -811,8 +813,6 @@ void get_command() {
           gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM));
           return;
         }
-
-        gcode_LastN = gcode_N;
         // if no errors, continue parsing
       }
       else if (apos) { // No '*' without 'N'


### PR DESCRIPTION
Make sure that `gcode_LastN` is set before throwing errors, so minor errors don’t kill the print job.
