### PR TITLE
Correct output of M48

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3352,7 +3352,7 @@ inline void gcode_M42() {
       if (verbose_level > 1) {
         SERIAL_PROTOCOL(n+1);
         SERIAL_PROTOCOLPGM(" of ");
-        SERIAL_PROTOCOL(n_samples);
+        SERIAL_PROTOCOL((int)n_samples);
         SERIAL_PROTOCOLPGM("   z: ");
         SERIAL_PROTOCOL_F(current_position[Z_AXIS], 6);
         if (verbose_level > 2) {


### PR DESCRIPTION
n_samples is an uint8_t .
Got printouts like:
50 of 2  ...
