### PR TITLE
Fix extruder motor running in DRYRUN V3

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6025,13 +6025,14 @@ void mesh_plan_buffer_line(float x, float y, float z, const float e, float feed_
 #ifdef PREVENT_DANGEROUS_EXTRUDE
 
   inline void prevent_dangerous_extrude(float &curr_e, float &dest_e) {
-    if (marlin_debug_flags & DEBUG_DRYRUN) return;
     float de = dest_e - curr_e;
     if (de) {
       if (degHotend(active_extruder) < extrude_min_temp) {
         curr_e = dest_e; // Behave as if the move really took place, but ignore E part
-        SERIAL_ECHO_START;
-        SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
+        if (!(marlin_debug_flags & DEBUG_DRYRUN)) {
+          SERIAL_ECHO_START;
+          SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
+        }
       }
       #ifdef PREVENT_LENGTHY_EXTRUDE
         if (labs(de) > EXTRUDE_MAXLENGTH) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6026,13 +6026,15 @@ void mesh_plan_buffer_line(float x, float y, float z, const float e, float feed_
 
   inline void prevent_dangerous_extrude(float &curr_e, float &dest_e) {
     float de = dest_e - curr_e;
+
+    // In DRYRUN mode Extruder movement set to zero
+    if (marlin_debug_flags & DEBUG_DRYRUN) de = 0;
+
     if (de) {
       if (degHotend(active_extruder) < extrude_min_temp) {
         curr_e = dest_e; // Behave as if the move really took place, but ignore E part
-        if (!(marlin_debug_flags & DEBUG_DRYRUN)) {
-          SERIAL_ECHO_START;
-          SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
-        }
+        SERIAL_ECHO_START;
+        SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
       }
       #ifdef PREVENT_LENGTHY_EXTRUDE
         if (labs(de) > EXTRUDE_MAXLENGTH) {

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -505,15 +505,16 @@ float junction_deviation = 0.1;
         dz = target[Z_AXIS] - position[Z_AXIS],
         de = target[E_AXIS] - position[E_AXIS];
 
+  // In DRYRUN mode Extruder movement set to zero
+  if (marlin_debug_flags & DEBUG_DRYRUN) de = 0;
+
   #ifdef PREVENT_DANGEROUS_EXTRUDE
     if (de) {
       if (degHotend(extruder) < extrude_min_temp) {
         position[E_AXIS] = target[E_AXIS]; // Behave as if the move really took place, but ignore E part
         de = 0; // no difference
-        if (!(marlin_debug_flags & DEBUG_DRYRUN)) {
-          SERIAL_ECHO_START;
-          SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
-        }
+        SERIAL_ECHO_START;
+        SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
       }
       #ifdef PREVENT_LENGTHY_EXTRUDE
         if (labs(de) > axis_steps_per_unit[E_AXIS] * EXTRUDE_MAXLENGTH) {

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -507,11 +507,13 @@ float junction_deviation = 0.1;
 
   #ifdef PREVENT_DANGEROUS_EXTRUDE
     if (de) {
-      if (degHotend(extruder) < extrude_min_temp && !(marlin_debug_flags & DEBUG_DRYRUN)) {
+      if (degHotend(extruder) < extrude_min_temp) {
         position[E_AXIS] = target[E_AXIS]; // Behave as if the move really took place, but ignore E part
         de = 0; // no difference
-        SERIAL_ECHO_START;
-        SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
+        if (!(marlin_debug_flags & DEBUG_DRYRUN)) {
+          SERIAL_ECHO_START;
+          SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
+        }
       }
       #ifdef PREVENT_LENGTHY_EXTRUDE
         if (labs(de) > axis_steps_per_unit[E_AXIS] * EXTRUDE_MAXLENGTH) {


### PR DESCRIPTION
#2221 introduced the dryrun-feature. You can print without using filament.

See #2242 for the discussion whether the extruder-motor should run or not. The consensus was to not move the motor, so you don't have to remove the filament.

Thanks @MagoKimbra 

Replacing #2354 
