### PR TITLE
Replace "target" with "destination" in M600

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4987,14 +4987,15 @@ inline void gcode_M503() {
         lcd_update();
       #else
         current_position[E_AXIS] += AUTO_FILAMENT_CHANGE_LENGTH;
-        plan_buffer_line(target[X_AXIS],target[Y_AXIS],target[Z_MAX_ENDSTOP_INVERTING],current_position[E_AXIS],AUTO_FILAMENT_CHANGE_FEEDRATE/60,active_extruder);
+        destination[E_AXIS] = current_position[E_AXIS];
+        line_to_destination(AUTO_FILAMENT_CHANGE_FEEDRATE);
         st_synchronize();
       #endif
     } // while(!lcd_clicked)
     lcd_quick_feedback(); // click sound feedback
 
     #ifdef AUTO_FILAMENT_CHANGE
-      current_position[E_AXIS]= 0;
+      current_position[E_AXIS] = 0;
       st_synchronize();
     #endif
           


### PR DESCRIPTION
- Also fix a bug in `M600` where `Z_MAX_ENDSTOP_INVERTING` is being used as the index into the `destination[AxisEnum]` array.
