### PR TITLE
Also nul spaces before the checksum asterisk

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5293,7 +5293,7 @@ void process_next_command() {
     while (*current_command == ' ') ++current_command; // skip [ ]*
   }
   char *starpos = strchr(current_command, '*');  // * should always be the last parameter
-  if (starpos) *starpos = '\0';
+  if (starpos) while (*starpos == ' ' || *starpos == '*') *starpos-- = '\0'; // nullify '*' and ' '
 
   // Get the command code, which must be G, M, or T
   char command_code = *current_command;


### PR DESCRIPTION
Addressing #1080. Commands that take a filename may be confused by trailing spaces in the command arguments. This ensures that any spaces before an asterisk are set to nul ‘\0’ so commands like `M23` will work properly.
