### PR TITLE
Feature/store position in sdcard

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -293,6 +293,14 @@ extern float min_pos[3];
 extern float max_pos[3];
 extern bool axis_known_position[3];
 
+//this is for storing the position on a card so that when turned off the position can be restored without using the z endstop.
+#ifdef SDSUPPORT
+  void writeposition();
+  extern bool stored_position_valid;
+  extern long unsigned last_stored_position_timer;
+  extern float stored_position[NUM_AXIS];
+#endif
+
 #ifdef ENABLE_AUTO_BED_LEVELING
   extern float zprobe_zoffset;
 #endif

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -296,6 +296,7 @@ extern bool axis_known_position[3];
 //this is for storing the position on a card so that when turned off the position can be restored without using the z endstop.
 #ifdef SDSUPPORT
   void writeposition();
+  void positiondirty();
   extern bool stored_position_valid;
   extern long unsigned last_stored_position_timer;
   extern float stored_position[NUM_AXIS];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6569,8 +6569,7 @@ void calculate_volumetric_multipliers() {
 #ifdef SDSUPPORT
 void writeposition()
 {
-  SERIAL_ECHOLNPGM("Start write to file \n");
-  card.openFile("auto0.g", false);
+  card.openFile("position.g", false);
   String g92command;
   char g92commandchar[32];
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -680,6 +680,10 @@ void setup() {
     pinMode(STAT_LED_BLUE, OUTPUT);
     digitalWrite(STAT_LED_BLUE, LOW); // turn it off
   #endif  
+  #ifdef SDSUPPORT
+    enqueuecommands_P(PSTR("M23 position.g"));
+    enqueuecommands_P(PSTR("M24"));
+  #endif
 }
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -740,7 +740,6 @@ void loop() {
     if (stored_position_valid == false) {
       if ((millis() - last_stored_position_timer) > 5000) {
         writeposition();
-        stored_position_valid = true;
       }
     }
   }
@@ -2860,6 +2859,9 @@ inline void gcode_G92() {
       sync_plan_position_delta();
     #else
       sync_plan_position();
+    #endif
+    #ifdef SDSUPPORT
+      positiondirty();
     #endif
   }
 }
@@ -6585,5 +6587,12 @@ void writeposition()
 
   card.write_command( g92command );
   card.closefile();
+  stored_position_valid = true;
+}
+
+void positiondirty()
+{
+  stored_position_valid = false;
+  last_stored_position_timer = millis();
 }
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6570,12 +6570,16 @@ void calculate_volumetric_multipliers() {
 void writeposition()
 {
   card.openFile("position.g", false);
-  String g92command;
-  char g92commandchar[32];
+  char g92command[32];
+  char xpos[10], ypos[10], zpos[10];
 
-  g92command = String("G92 Z" + String(current_position[Z_AXIS],3) + " X"+String(current_position[X_AXIS],3) + " Y" + String(current_position[Y_AXIS],3) );
-  g92command.toCharArray(g92commandchar,32);
-  card.write_command( g92commandchar );
+  dtostrf(current_position[X_AXIS], 7, 3, xpos);
+  dtostrf(current_position[Y_AXIS], 7, 3, ypos);
+  dtostrf(current_position[Z_AXIS], 7, 3, zpos);
+
+  snprintf_P(g92command, 32, PSTR("G92 Z%s X%s Y%s"), zpos, xpos, ypos);
+
+  card.write_command( g92command );
   card.closefile();
 }
 #endif

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -503,12 +503,18 @@ void CardReader::checkautostart(bool force) {
   bool found = false;
   while (root.readDir(p, NULL) > 0) {
     for (int8_t i = 0; i < (int8_t)strlen((char*)p.name); i++) p.name[i] = tolower(p.name[i]);
-    if (p.name[9] != '~' && strncmp((char*)p.name, autoname, 5) == 0) {
-      char cmd[4 + (FILENAME_LENGTH + 1) * MAX_DIR_DEPTH + 2];
-      sprintf_P(cmd, PSTR("M23 %s"), autoname);
-      enqueuecommand(cmd);
-      enqueuecommands_P(PSTR("M24"));
-      found = true;
+    if (p.name[9] != '~') {
+      if (strncmp((char*)p.name, autoname, 5) == 0) {
+        char cmd[4 + (FILENAME_LENGTH + 1) * MAX_DIR_DEPTH + 2];
+        sprintf_P(cmd, PSTR("M23 %s"), autoname);
+        enqueuecommand(cmd);
+        enqueuecommands_P(PSTR("M24"));
+        found = true;
+      }
+      if (strncmp((char*)p.name, "position.g", 10) == 0) {
+        enqueuecommand("M23 position.g");
+        enqueuecommands_P(PSTR("M24"));
+      }
     }
   }
   if (!found)

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -511,10 +511,6 @@ void CardReader::checkautostart(bool force) {
         enqueuecommands_P(PSTR("M24"));
         found = true;
       }
-      if (strncmp((char*)p.name, "position.g", 10) == 0) {
-        enqueuecommand("M23 position.g");
-        enqueuecommands_P(PSTR("M24"));
-      }
     }
   }
   if (!found)

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -694,8 +694,7 @@ float junction_deviation = 0.1;
   // if the head moves, mark the stored sd card position as dirty
   #ifdef SDSUPPORT
   if ( block->millimeters != 0.0 ) {
-    stored_position_valid = false;
-    last_stored_position_timer = millis();
+    positiondirty();
   }
   #endif
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -691,6 +691,14 @@ float junction_deviation = 0.1;
   }
   float inverse_millimeters = 1.0 / block->millimeters;  // Inverse millimeters to remove multiple divides 
 
+  // if the head moves, mark the stored sd card position as dirty
+  #ifdef SDSUPPORT
+  if ( block->millimeters != 0.0 ) {
+    stored_position_valid = false;
+    last_stored_position_timer = millis();
+  }
+  #endif
+
   // Calculate speed in mm/second for each axis. No divide by zero due to previous checks.
   float inverse_second = feed_rate * inverse_millimeters;
 


### PR DESCRIPTION
Problem: This happens with many 3D printers: z endstops are unreliable and make it hard to consistently start at the same height on the bed at the beginning of a print.

Generally its better to only home Z when you know there is an issue, not at the start of every print, and not when the printer is turned off and on. After that operation the thumbscrews usually need to be turned to get the first layer printed correctly.

Solution: This feature writes out the position to the SD card when the motors have been stationary for 5 seconds.  It reads the position back in again when the firmware is reset, so that the axis doesn't have to be homed, though it is most useful for Z.
