### PR TITLE
Use USBCON rather than AT90USB for USB devices

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -210,7 +210,7 @@
 
   #include "pins.h"
 
-  #ifndef AT90USB
+  #ifndef USBCON
     #define HardwareSerial_h // trick to disable the standard HWserial
   #endif
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -43,7 +43,7 @@ typedef unsigned long millis_t;
   #define analogInputToDigitalPin(p) ((p) + 0xA0)
 #endif
 
-#ifdef AT90USB
+#ifdef USBCON
   #include "HardwareSerial.h"
 #endif
 
@@ -58,7 +58,7 @@ typedef unsigned long millis_t;
 
 #include "WString.h"
 
-#ifdef AT90USB
+#ifdef USBCON
   #ifdef BTENABLED
     #define MYSERIAL bt
   #else

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -23,7 +23,7 @@
 #include "Marlin.h"
 #include "MarlinSerial.h"
 
-#ifndef AT90USB
+#ifndef USBCON
 // this next line disables the entire HardwareSerial.cpp, 
 // this is so I can support Attiny series and any other chip without a UART
 #if defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(UBRR2H) || defined(UBRR3H)
@@ -284,9 +284,9 @@ void MarlinSerial::printFloat(double number, uint8_t digits) {
 MarlinSerial MSerial;
 
 #endif // whole file
-#endif // !AT90USB
+#endif // !USBCON
 
 // For AT90USB targets use the UART for BT interfacing
-#if defined(AT90USB) && defined(BTENABLED)
+#if defined(USBCON) && defined(BTENABLED)
   HardwareSerial bt;
 #endif

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -64,7 +64,7 @@
 #define BYTE 0
 
 
-#ifndef AT90USB
+#ifndef USBCON
 // Define constants and variables for buffering incoming serial data.  We're
 // using a ring buffer (I think), in which rx_buffer_head is the index of the
 // location to which to write the next incoming character and rx_buffer_tail
@@ -150,10 +150,10 @@ class MarlinSerial { //: public Stream
 };
 
 extern MarlinSerial MSerial;
-#endif // !AT90USB
+#endif // !USBCON
 
 // Use the UART for BT in AT90USB configurations
-#if defined(AT90USB) && defined(BTENABLED)
+#if defined(USBCON) && defined(BTENABLED)
   extern HardwareSerial bt;
 #endif
 

--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -8,8 +8,6 @@
   #error Oops!  Make sure you have 'Teensy++ 2.0' selected from the 'Tools -> Boards' menu.
 #endif
 
-#define AT90USB 1286  // Disable MarlinSerial etc.
-
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN          0

--- a/Marlin/pins_BRAINWAVE.h
+++ b/Marlin/pins_BRAINWAVE.h
@@ -9,8 +9,6 @@
   #error Oops!  Make sure you have 'Brainwave' selected from the 'Tools -> Boards' menu.
 #endif
 
-#define AT90USB 646  // Disable MarlinSerial etc.
-
 #define X_STEP_PIN         27
 #define X_DIR_PIN          29
 #define X_ENABLE_PIN       28

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -1,5 +1,5 @@
 /**
- * Brainwave Pro pin assignments (AT90USB186)
+ * Brainwave Pro pin assignments (AT90USB1286)
  *
  * Requires hardware bundle for Arduino:
  * https://github.com/unrepentantgeek/brainwave-arduino
@@ -15,7 +15,7 @@
   #error  Uncomment #define AT90USBxx_TEENSYPP_ASSIGNMENTS in fastio.h for this config
 #endif
 
-#define AT90USB 1286  // Disable MarlinSerial etc.
+#define LARGE_FLASH        true
 
 #define X_STEP_PIN         33
 #define X_DIR_PIN          32

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -13,8 +13,6 @@
   #error These Printrboard assignments depend on traditional Marlin assignments, not AT90USBxx_TEENSYPP_ASSIGNMENTS in fastio.h
 #endif
 
-#define AT90USB 1286  // Disable MarlinSerial etc.
-
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN          0

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -9,8 +9,6 @@
   #error Oops!  Make sure you have 'Teensy++ 2.0' selected from the 'Tools -> Boards' menu.
 #endif
 
-#define AT90USB 1286  // Disable MarlinSerial etc.
-
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN         0

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -52,8 +52,6 @@
   // (or build from command line)
 #endif
 
-#define AT90USB 1286  // Disable MarlinSerial etc.
-
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN         28 //  0 Marlin

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -13,8 +13,6 @@
   #error These Teensylu assignments depend on traditional Marlin assignments, not AT90USBxx_TEENSYPP_ASSIGNMENTS in fastio.h
 #endif
 
-#define AT90USB 1286  // Disable MarlinSerial etc.
-
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN          0

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -629,7 +629,7 @@ ISR(TIMER1_COMPA_vect) {
 
     // Take multiple steps per interrupt (For high speed moves)
     for (int8_t i = 0; i < step_loops; i++) {
-      #ifndef AT90USB
+      #ifndef USBCON
         MSerial.checkRx(); // Check for serial chars.
       #endif
 


### PR DESCRIPTION
The AVR compiler defines USBCON for USB devices. Therefore, we do not need to create our own selector for them.
