### PR TITLE
Reduce lsDive stack usage to the minimum

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -56,22 +56,28 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
     // If the entry is a directory and the action is LS_SerialPrint
     if (DIR_IS_SUBDIR(&p) && lsAction != LS_Count && lsAction != LS_GetFilename) {
 
-      // Allocate enough stack space for the full path to a folder, trailing slash, and nul
-      int len = strlen(prepend) + FILENAME_LENGTH + 1 + 1;
-      char path[len];
-
       // Get the short name for the item, which we know is a folder
       char lfilename[FILENAME_LENGTH];
       createFilename(lfilename, p);
 
+      // Allocate enough stack space for the full path to a folder, trailing slash, and nul
+      boolean prepend_is_empty = (prepend[0] == '\0');
+      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1;
+      char path[len];
+
       // Append the FOLDERNAME12/ to the passed string.
       // It contains the full path to the "parent" argument.
       // We now have the full path to the item in this folder.
-      path[0] = '\0';
-      if (prepend[0] == '\0') strcat(path, "/"); // a root slash if prepend is empty
-      strcat(path, prepend);
-      strcat(path, lfilename);
-      strcat(path, "/");
+      if (prepend_is_empty) {
+        path[0] = '/'; // a root slash if prepend is empty
+        path[1] = '\0';
+      }
+      else
+        path[0] = '\0';
+
+      strcat(path, prepend);   // 1 character minimum
+      strcat(path, lfilename); // FILENAME_LENGTH-1 characters maximum
+      strcat(path, "/");       // 1 character
 
       // Serial.print(path);
 

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -62,7 +62,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
       // Allocate enough stack space for the full path to a folder, trailing slash, and nul
       boolean prepend_is_empty = (prepend[0] == '\0');
-      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1;
+      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1 + 1;
       char path[len];
 
       // Append the FOLDERNAME12/ to the passed string.

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -62,20 +62,13 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
       // Allocate enough stack space for the full path to a folder, trailing slash, and nul
       boolean prepend_is_empty = (prepend[0] == '\0');
-      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1 + 1;
+      int len = (prepend_is_empty ? 1 : strlen(prepend)) + strlen(lfilename) + 1 + 1;
       char path[len];
 
       // Append the FOLDERNAME12/ to the passed string.
       // It contains the full path to the "parent" argument.
       // We now have the full path to the item in this folder.
-      if (prepend_is_empty) {
-        path[0] = '/'; // a root slash if prepend is empty
-        path[1] = '\0';
-      }
-      else
-        path[0] = '\0';
-
-      strcat(path, prepend);   // 1 character minimum
+      strcpy(path, prepend_is_empty ? "/" : prepend); // root slash if prepend is empty
       strcat(path, lfilename); // FILENAME_LENGTH-1 characters maximum
       strcat(path, "/");       // 1 character
 


### PR DESCRIPTION
Reduce the stored path allocation, basing it on the `strlen` of the filename. This augments #2449 and addresses concerns raised in #2434.
