### PR TITLE
Specify print format for reporting invalid tmp_extruder

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5199,7 +5199,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
   if (tmp_extruder >= EXTRUDERS) {
     SERIAL_ECHO_START;
     SERIAL_CHAR('T');
-    SERIAL_ECHO(tmp_extruder);
+    SERIAL_PROTOCOL_F(tmp_extruder,DEC);
     SERIAL_ECHOLN(MSG_INVALID_EXTRUDER);
   }
   else {


### PR DESCRIPTION
Small change, but an invalid toolhead selection (e.g., "T1" with default config) was printing the character 0x01 (SOH) instead of 0x31 ('1').
