### PR TITLE
Extruder behavior in DRYRUN mode

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -279,6 +279,8 @@
     #define MAX_PROBE_Y (min(Y_MAX_POS, Y_MAX_POS + Y_PROBE_OFFSET_FROM_EXTRUDER))
   #endif
 
+  #define SERVO_LEVELING (defined(ENABLE_AUTO_BED_LEVELING) && defined(DEACTIVATE_SERVOS_AFTER_MOVE))
+
    /**
     * Sled Options
     */ 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -112,7 +112,11 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -227,6 +227,11 @@ enum DebugFlags {
 };
 extern uint8_t marlin_debug_flags;
 
+void check_dryrun_extrusion(float &curr_e, float &dest_e, const uint8_t extruder);
+#ifdef PREVENT_DANGEROUS_EXTRUDE
+  void prevent_dangerous_extrude(float &curr_e, float &dest_e, const uint8_t extruder);
+#endif // PREVENT_DANGEROUS_EXTRUDE
+
 extern bool Running;
 inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -36,8 +36,6 @@
   #endif
 #endif // ENABLE_AUTO_BED_LEVELING
 
-#define SERVO_LEVELING (defined(ENABLE_AUTO_BED_LEVELING) && defined(DEACTIVATE_SERVOS_AFTER_MOVE))
-
 #ifdef MESH_BED_LEVELING
   #include "mesh_bed_leveling.h"
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -412,6 +412,8 @@ bool target_direction;
 
 void process_next_command();
 
+void plan_arc(float target[NUM_AXIS], float *offset, uint8_t clockwise);
+
 bool setTargetedHotend(int code);
 
 void serial_echopair_P(const char *s_P, float v)         { serialprintPGM(s_P); SERIAL_ECHO(v); }
@@ -1897,9 +1899,9 @@ inline void gcode_G0_G1() {
  * options for G2/G3 arc generation. In future these options may be GCode tunable.
  */
 void plan_arc(
-  float *target,    // Destination position
-  float *offset,    // Center of rotation relative to current_position
-  uint8_t clockwise // Clockwise?
+  float target[NUM_AXIS], // Destination position
+  float *offset,          // Center of rotation relative to current_position
+  uint8_t clockwise       // Clockwise?
 ) {
 
   float radius = hypot(offset[X_AXIS], offset[Y_AXIS]),
@@ -1959,7 +1961,7 @@ void plan_arc(
   float cos_T = 1-0.5*theta_per_segment*theta_per_segment; // Small angle approximation
   float sin_T = theta_per_segment;
   
-  float arc_target[4];
+  float arc_target[NUM_AXIS];
   float sin_Ti;
   float cos_Ti;
   float r_axisi;
@@ -2000,10 +2002,28 @@ void plan_arc(
     arc_target[E_AXIS] += extruder_per_segment;
 
     clamp_to_software_endstops(arc_target);
-    plan_buffer_line(arc_target[X_AXIS], arc_target[Y_AXIS], arc_target[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
+
+    #if defined(DELTA) || defined(SCARA)
+      calculate_delta(arc_target);
+      #ifdef ENABLE_AUTO_BED_LEVELING
+        adjust_delta(arc_target);
+      #endif
+      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
+    #else
+      plan_buffer_line(arc_target[X_AXIS], arc_target[Y_AXIS], arc_target[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
+    #endif
   }
+
   // Ensure last segment arrives at target location.
-  plan_buffer_line(target[X_AXIS], target[Y_AXIS], target[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
+  #if defined(DELTA) || defined(SCARA)
+    calculate_delta(target);
+    #ifdef ENABLE_AUTO_BED_LEVELING
+      adjust_delta(target);
+    #endif
+    plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
+  #else
+    plan_buffer_line(target[X_AXIS], target[Y_AXIS], target[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
+  #endif
 
   // As far as the parser is concerned, the position is now == target. In reality the
   // motion control system might still be processing the action and the real tool position
@@ -6076,9 +6096,9 @@ void mesh_plan_buffer_line(float x, float y, float z, const float e, float feed_
 
 #if defined(DELTA) || defined(SCARA)
 
-  inline bool prepare_move_delta() {
+  inline bool prepare_move_delta(float target[NUM_AXIS]) {
     float difference[NUM_AXIS];
-    for (int8_t i=0; i < NUM_AXIS; i++) difference[i] = destination[i] - current_position[i];
+    for (int8_t i=0; i < NUM_AXIS; i++) difference[i] = target[i] - current_position[i];
 
     float cartesian_mm = sqrt(sq(difference[X_AXIS]) + sq(difference[Y_AXIS]) + sq(difference[Z_AXIS]));
     if (cartesian_mm < 0.000001) cartesian_mm = abs(difference[E_AXIS]);
@@ -6095,22 +6115,22 @@ void mesh_plan_buffer_line(float x, float y, float z, const float e, float feed_
       float fraction = float(s) / float(steps);
 
       for (int8_t i = 0; i < NUM_AXIS; i++)
-        destination[i] = current_position[i] + difference[i] * fraction;
+        target[i] = current_position[i] + difference[i] * fraction;
 
-      calculate_delta(destination);
+      calculate_delta(target);
 
       #ifdef ENABLE_AUTO_BED_LEVELING
-        adjust_delta(destination);
+        adjust_delta(target);
       #endif
 
-      //SERIAL_ECHOPGM("destination[X_AXIS]="); SERIAL_ECHOLN(destination[X_AXIS]);
-      //SERIAL_ECHOPGM("destination[Y_AXIS]="); SERIAL_ECHOLN(destination[Y_AXIS]);
-      //SERIAL_ECHOPGM("destination[Z_AXIS]="); SERIAL_ECHOLN(destination[Z_AXIS]);
+      //SERIAL_ECHOPGM("target[X_AXIS]="); SERIAL_ECHOLN(target[X_AXIS]);
+      //SERIAL_ECHOPGM("target[Y_AXIS]="); SERIAL_ECHOLN(target[Y_AXIS]);
+      //SERIAL_ECHOPGM("target[Z_AXIS]="); SERIAL_ECHOLN(target[Z_AXIS]);
       //SERIAL_ECHOPGM("delta[X_AXIS]="); SERIAL_ECHOLN(delta[X_AXIS]);
       //SERIAL_ECHOPGM("delta[Y_AXIS]="); SERIAL_ECHOLN(delta[Y_AXIS]);
       //SERIAL_ECHOPGM("delta[Z_AXIS]="); SERIAL_ECHOLN(delta[Z_AXIS]);
 
-      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], feedrate/60*feedrate_multiplier/100.0, active_extruder);
+      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], target[E_AXIS], feedrate/60*feedrate_multiplier/100.0, active_extruder);
     }
     return true;
   }
@@ -6118,7 +6138,7 @@ void mesh_plan_buffer_line(float x, float y, float z, const float e, float feed_
 #endif // DELTA || SCARA
 
 #ifdef SCARA
-  inline bool prepare_move_scara() { return prepare_move_delta(); }
+  inline bool prepare_move_scara(float target[NUM_AXIS]) { return prepare_move_delta(target); }
 #endif
 
 #ifdef DUAL_X_CARRIAGE
@@ -6195,9 +6215,9 @@ void prepare_move() {
   #endif
 
   #ifdef SCARA
-    if (!prepare_move_scara()) return;
+    if (!prepare_move_scara(destination)) return;
   #elif defined(DELTA)
-    if (!prepare_move_delta()) return;
+    if (!prepare_move_delta(destination)) return;
   #endif
 
   #ifdef DUAL_X_CARRIAGE

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1890,148 +1890,6 @@ inline void gcode_G0_G1() {
 }
 
 /**
- * Plan an arc in 2 dimensions
- *
- * The arc is approximated by generating many small linear segments.
- * The length of each segment is configured in MM_PER_ARC_SEGMENT (Default 1mm)
- * Arcs should only be made relatively large (over 5mm), as larger arcs with
- * larger segments will tend to be more efficient. Your slicer should have
- * options for G2/G3 arc generation. In future these options may be GCode tunable.
- */
-void plan_arc(
-  float target[NUM_AXIS], // Destination position
-  float *offset,          // Center of rotation relative to current_position
-  uint8_t clockwise       // Clockwise?
-) {
-
-  float radius = hypot(offset[X_AXIS], offset[Y_AXIS]),
-        center_axis0 = current_position[X_AXIS] + offset[X_AXIS],
-        center_axis1 = current_position[Y_AXIS] + offset[Y_AXIS],
-        linear_travel = target[Z_AXIS] - current_position[Z_AXIS],
-        extruder_travel = target[E_AXIS] - current_position[E_AXIS],
-        r_axis0 = -offset[X_AXIS],  // Radius vector from center to current location
-        r_axis1 = -offset[Y_AXIS],
-        rt_axis0 = target[X_AXIS] - center_axis0,
-        rt_axis1 = target[Y_AXIS] - center_axis1;
-  
-  // CCW angle of rotation between position and target from the circle center. Only one atan2() trig computation required.
-  float angular_travel = atan2(r_axis0*rt_axis1-r_axis1*rt_axis0, r_axis0*rt_axis0+r_axis1*rt_axis1);
-  if (angular_travel < 0) { angular_travel += RADIANS(360); }
-  if (clockwise) { angular_travel -= RADIANS(360); }
-  
-  // Make a circle if the angular rotation is 0
-  if (current_position[X_AXIS] == target[X_AXIS] && current_position[Y_AXIS] == target[Y_AXIS] && angular_travel == 0)
-    angular_travel += RADIANS(360);
-  
-  float mm_of_travel = hypot(angular_travel*radius, fabs(linear_travel));
-  if (mm_of_travel < 0.001) { return; }
-  uint16_t segments = floor(mm_of_travel / MM_PER_ARC_SEGMENT);
-  if (segments == 0) segments = 1;
-  
-  float theta_per_segment = angular_travel/segments;
-  float linear_per_segment = linear_travel/segments;
-  float extruder_per_segment = extruder_travel/segments;
-  
-  /* Vector rotation by transformation matrix: r is the original vector, r_T is the rotated vector,
-     and phi is the angle of rotation. Based on the solution approach by Jens Geisler.
-         r_T = [cos(phi) -sin(phi);
-                sin(phi)  cos(phi] * r ;
-     
-     For arc generation, the center of the circle is the axis of rotation and the radius vector is 
-     defined from the circle center to the initial position. Each line segment is formed by successive
-     vector rotations. This requires only two cos() and sin() computations to form the rotation
-     matrix for the duration of the entire arc. Error may accumulate from numerical round-off, since
-     all double numbers are single precision on the Arduino. (True double precision will not have
-     round off issues for CNC applications.) Single precision error can accumulate to be greater than
-     tool precision in some cases. Therefore, arc path correction is implemented. 
-
-     Small angle approximation may be used to reduce computation overhead further. This approximation
-     holds for everything, but very small circles and large MM_PER_ARC_SEGMENT values. In other words,
-     theta_per_segment would need to be greater than 0.1 rad and N_ARC_CORRECTION would need to be large
-     to cause an appreciable drift error. N_ARC_CORRECTION~=25 is more than small enough to correct for 
-     numerical drift error. N_ARC_CORRECTION may be on the order a hundred(s) before error becomes an
-     issue for CNC machines with the single precision Arduino calculations.
-     
-     This approximation also allows plan_arc to immediately insert a line segment into the planner 
-     without the initial overhead of computing cos() or sin(). By the time the arc needs to be applied
-     a correction, the planner should have caught up to the lag caused by the initial plan_arc overhead. 
-     This is important when there are successive arc motions. 
-  */
-  // Vector rotation matrix values
-  float cos_T = 1-0.5*theta_per_segment*theta_per_segment; // Small angle approximation
-  float sin_T = theta_per_segment;
-  
-  float arc_target[NUM_AXIS];
-  float sin_Ti;
-  float cos_Ti;
-  float r_axisi;
-  uint16_t i;
-  int8_t count = 0;
-
-  // Initialize the linear axis
-  arc_target[Z_AXIS] = current_position[Z_AXIS];
-  
-  // Initialize the extruder axis
-  arc_target[E_AXIS] = current_position[E_AXIS];
-
-  float feed_rate = feedrate*feedrate_multiplier/60/100.0;
-
-  for (i = 1; i < segments; i++) { // Increment (segments-1)
-
-    if (count < N_ARC_CORRECTION) {
-      // Apply vector rotation matrix to previous r_axis0 / 1
-      r_axisi = r_axis0*sin_T + r_axis1*cos_T;
-      r_axis0 = r_axis0*cos_T - r_axis1*sin_T;
-      r_axis1 = r_axisi;
-      count++;
-    }
-    else {
-      // Arc correction to radius vector. Computed only every N_ARC_CORRECTION increments.
-      // Compute exact location by applying transformation matrix from initial radius vector(=-offset).
-      cos_Ti = cos(i*theta_per_segment);
-      sin_Ti = sin(i*theta_per_segment);
-      r_axis0 = -offset[X_AXIS]*cos_Ti + offset[Y_AXIS]*sin_Ti;
-      r_axis1 = -offset[X_AXIS]*sin_Ti - offset[Y_AXIS]*cos_Ti;
-      count = 0;
-    }
-
-    // Update arc_target location
-    arc_target[X_AXIS] = center_axis0 + r_axis0;
-    arc_target[Y_AXIS] = center_axis1 + r_axis1;
-    arc_target[Z_AXIS] += linear_per_segment;
-    arc_target[E_AXIS] += extruder_per_segment;
-
-    clamp_to_software_endstops(arc_target);
-
-    #if defined(DELTA) || defined(SCARA)
-      calculate_delta(arc_target);
-      #ifdef ENABLE_AUTO_BED_LEVELING
-        adjust_delta(arc_target);
-      #endif
-      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
-    #else
-      plan_buffer_line(arc_target[X_AXIS], arc_target[Y_AXIS], arc_target[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
-    #endif
-  }
-
-  // Ensure last segment arrives at target location.
-  #if defined(DELTA) || defined(SCARA)
-    calculate_delta(target);
-    #ifdef ENABLE_AUTO_BED_LEVELING
-      adjust_delta(target);
-    #endif
-    plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
-  #else
-    plan_buffer_line(target[X_AXIS], target[Y_AXIS], target[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
-  #endif
-
-  // As far as the parser is concerned, the position is now == target. In reality the
-  // motion control system might still be processing the action and the real tool position
-  // in any intermediate location.
-  set_current_to_destination();
-}
-
-/**
  * G2: Clockwise Arc
  * G3: Counterclockwise Arc
  */
@@ -6228,6 +6086,148 @@ void prepare_move() {
     if (!prepare_move_cartesian()) return;
   #endif
 
+  set_current_to_destination();
+}
+
+/**
+ * Plan an arc in 2 dimensions
+ *
+ * The arc is approximated by generating many small linear segments.
+ * The length of each segment is configured in MM_PER_ARC_SEGMENT (Default 1mm)
+ * Arcs should only be made relatively large (over 5mm), as larger arcs with
+ * larger segments will tend to be more efficient. Your slicer should have
+ * options for G2/G3 arc generation. In future these options may be GCode tunable.
+ */
+void plan_arc(
+  float target[NUM_AXIS], // Destination position
+  float *offset,          // Center of rotation relative to current_position
+  uint8_t clockwise       // Clockwise?
+) {
+
+  float radius = hypot(offset[X_AXIS], offset[Y_AXIS]),
+        center_axis0 = current_position[X_AXIS] + offset[X_AXIS],
+        center_axis1 = current_position[Y_AXIS] + offset[Y_AXIS],
+        linear_travel = target[Z_AXIS] - current_position[Z_AXIS],
+        extruder_travel = target[E_AXIS] - current_position[E_AXIS],
+        r_axis0 = -offset[X_AXIS],  // Radius vector from center to current location
+        r_axis1 = -offset[Y_AXIS],
+        rt_axis0 = target[X_AXIS] - center_axis0,
+        rt_axis1 = target[Y_AXIS] - center_axis1;
+  
+  // CCW angle of rotation between position and target from the circle center. Only one atan2() trig computation required.
+  float angular_travel = atan2(r_axis0*rt_axis1-r_axis1*rt_axis0, r_axis0*rt_axis0+r_axis1*rt_axis1);
+  if (angular_travel < 0) { angular_travel += RADIANS(360); }
+  if (clockwise) { angular_travel -= RADIANS(360); }
+  
+  // Make a circle if the angular rotation is 0
+  if (current_position[X_AXIS] == target[X_AXIS] && current_position[Y_AXIS] == target[Y_AXIS] && angular_travel == 0)
+    angular_travel += RADIANS(360);
+  
+  float mm_of_travel = hypot(angular_travel*radius, fabs(linear_travel));
+  if (mm_of_travel < 0.001) { return; }
+  uint16_t segments = floor(mm_of_travel / MM_PER_ARC_SEGMENT);
+  if (segments == 0) segments = 1;
+  
+  float theta_per_segment = angular_travel/segments;
+  float linear_per_segment = linear_travel/segments;
+  float extruder_per_segment = extruder_travel/segments;
+  
+  /* Vector rotation by transformation matrix: r is the original vector, r_T is the rotated vector,
+     and phi is the angle of rotation. Based on the solution approach by Jens Geisler.
+         r_T = [cos(phi) -sin(phi);
+                sin(phi)  cos(phi] * r ;
+     
+     For arc generation, the center of the circle is the axis of rotation and the radius vector is 
+     defined from the circle center to the initial position. Each line segment is formed by successive
+     vector rotations. This requires only two cos() and sin() computations to form the rotation
+     matrix for the duration of the entire arc. Error may accumulate from numerical round-off, since
+     all double numbers are single precision on the Arduino. (True double precision will not have
+     round off issues for CNC applications.) Single precision error can accumulate to be greater than
+     tool precision in some cases. Therefore, arc path correction is implemented. 
+
+     Small angle approximation may be used to reduce computation overhead further. This approximation
+     holds for everything, but very small circles and large MM_PER_ARC_SEGMENT values. In other words,
+     theta_per_segment would need to be greater than 0.1 rad and N_ARC_CORRECTION would need to be large
+     to cause an appreciable drift error. N_ARC_CORRECTION~=25 is more than small enough to correct for 
+     numerical drift error. N_ARC_CORRECTION may be on the order a hundred(s) before error becomes an
+     issue for CNC machines with the single precision Arduino calculations.
+     
+     This approximation also allows plan_arc to immediately insert a line segment into the planner 
+     without the initial overhead of computing cos() or sin(). By the time the arc needs to be applied
+     a correction, the planner should have caught up to the lag caused by the initial plan_arc overhead. 
+     This is important when there are successive arc motions. 
+  */
+  // Vector rotation matrix values
+  float cos_T = 1-0.5*theta_per_segment*theta_per_segment; // Small angle approximation
+  float sin_T = theta_per_segment;
+  
+  float arc_target[NUM_AXIS];
+  float sin_Ti;
+  float cos_Ti;
+  float r_axisi;
+  uint16_t i;
+  int8_t count = 0;
+
+  // Initialize the linear axis
+  arc_target[Z_AXIS] = current_position[Z_AXIS];
+  
+  // Initialize the extruder axis
+  arc_target[E_AXIS] = current_position[E_AXIS];
+
+  float feed_rate = feedrate*feedrate_multiplier/60/100.0;
+
+  for (i = 1; i < segments; i++) { // Increment (segments-1)
+
+    if (count < N_ARC_CORRECTION) {
+      // Apply vector rotation matrix to previous r_axis0 / 1
+      r_axisi = r_axis0*sin_T + r_axis1*cos_T;
+      r_axis0 = r_axis0*cos_T - r_axis1*sin_T;
+      r_axis1 = r_axisi;
+      count++;
+    }
+    else {
+      // Arc correction to radius vector. Computed only every N_ARC_CORRECTION increments.
+      // Compute exact location by applying transformation matrix from initial radius vector(=-offset).
+      cos_Ti = cos(i*theta_per_segment);
+      sin_Ti = sin(i*theta_per_segment);
+      r_axis0 = -offset[X_AXIS]*cos_Ti + offset[Y_AXIS]*sin_Ti;
+      r_axis1 = -offset[X_AXIS]*sin_Ti - offset[Y_AXIS]*cos_Ti;
+      count = 0;
+    }
+
+    // Update arc_target location
+    arc_target[X_AXIS] = center_axis0 + r_axis0;
+    arc_target[Y_AXIS] = center_axis1 + r_axis1;
+    arc_target[Z_AXIS] += linear_per_segment;
+    arc_target[E_AXIS] += extruder_per_segment;
+
+    clamp_to_software_endstops(arc_target);
+
+    #if defined(DELTA) || defined(SCARA)
+      calculate_delta(arc_target);
+      #ifdef ENABLE_AUTO_BED_LEVELING
+        adjust_delta(arc_target);
+      #endif
+      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
+    #else
+      plan_buffer_line(arc_target[X_AXIS], arc_target[Y_AXIS], arc_target[Z_AXIS], arc_target[E_AXIS], feed_rate, active_extruder);
+    #endif
+  }
+
+  // Ensure last segment arrives at target location.
+  #if defined(DELTA) || defined(SCARA)
+    calculate_delta(target);
+    #ifdef ENABLE_AUTO_BED_LEVELING
+      adjust_delta(target);
+    #endif
+    plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
+  #else
+    plan_buffer_line(target[X_AXIS], target[Y_AXIS], target[Z_AXIS], target[E_AXIS], feed_rate, active_extruder);
+  #endif
+
+  // As far as the parser is concerned, the position is now == target. In reality the
+  // motion control system might still be processing the action and the real tool position
+  // in any intermediate location.
   set_current_to_destination();
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6051,16 +6051,45 @@ void mesh_plan_buffer_line(float x, float y, float z, const float e, float feed_
 }
 #endif  // MESH_BED_LEVELING
 
+// Prevent extrusion of the active extruder (can be overridden by EXTRUDER_X_DRYRUN_EXCLUDE) while in dry run mode.
+void check_dryrun_extrusion(float &curr_e, float &dest_e, const uint8_t extruder) {
+  float de = dest_e - curr_e;
+  // Check if the active extruder must be enabled while in dry run mode. 
+  if (de && (marlin_debug_flags & DEBUG_DRYRUN)) {
+    switch(extruder) {
+      case 0:
+        if (!EXTRUDER_0_DRYRUN_ENABLE) curr_e = dest_e; // Behave as if the move really took place, but ignore E part
+        break;
+      #if EXTRUDERS > 1
+        case 1:
+          if (!EXTRUDER_1_DRYRUN_ENABLE) curr_e = dest_e; // Behave as if the move really took place, but ignore E part
+          break;
+        #if EXTRUDERS > 2
+          case 2:
+            if (!EXTRUDER_2_DRYRUN_ENABLE) curr_e = dest_e; // Behave as if the move really took place, but ignore E part
+            break;
+          #if EXTRUDERS > 3
+            case 3:
+              if (!EXTRUDER_3_DRYRUN_ENABLE) curr_e = dest_e; // Behave as if the move really took place, but ignore E part
+              break;
+          #endif
+        #endif
+      #endif
+    }
+  }
+}
+
 #ifdef PREVENT_DANGEROUS_EXTRUDE
 
-  inline void prevent_dangerous_extrude(float &curr_e, float &dest_e) {
-    if (marlin_debug_flags & DEBUG_DRYRUN) return;
+  void prevent_dangerous_extrude(float &curr_e, float &dest_e, const uint8_t extruder) {
     float de = dest_e - curr_e;
     if (de) {
-      if (degHotend(active_extruder) < extrude_min_temp) {
+      if ((degHotend(extruder) < extrude_min_temp) && !(marlin_debug_flags & DEBUG_DRYRUN)) {
         curr_e = dest_e; // Behave as if the move really took place, but ignore E part
-        SERIAL_ECHO_START;
-        SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
+        if (!(marlin_debug_flags & DEBUG_DRYRUN)) {
+          SERIAL_ECHO_START;
+          SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
+        }
       }
       #ifdef PREVENT_LENGTHY_EXTRUDE
         if (labs(de) > EXTRUDE_MAXLENGTH) {
@@ -6190,8 +6219,10 @@ void prepare_move() {
   clamp_to_software_endstops(destination);
   refresh_cmd_timeout();
 
+  check_dryrun_extrusion(current_position[E_AXIS], destination[E_AXIS], active_extruder);
+
   #ifdef PREVENT_DANGEROUS_EXTRUDE
-    prevent_dangerous_extrude(current_position[E_AXIS], destination[E_AXIS]);
+    prevent_dangerous_extrude(current_position[E_AXIS], destination[E_AXIS], active_extruder);
   #endif
 
   #ifdef SCARA

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -56,22 +56,28 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
     // If the entry is a directory and the action is LS_SerialPrint
     if (DIR_IS_SUBDIR(&p) && lsAction != LS_Count && lsAction != LS_GetFilename) {
 
-      // Allocate enough stack space for the full path to a folder, trailing slash, and nul
-      int len = strlen(prepend) + FILENAME_LENGTH + 1 + 1;
-      char path[len];
-
       // Get the short name for the item, which we know is a folder
       char lfilename[FILENAME_LENGTH];
       createFilename(lfilename, p);
 
+      // Allocate enough stack space for the full path to a folder, trailing slash, and nul
+      boolean prepend_is_empty = (prepend[0] == '\0');
+      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1;
+      char path[len];
+
       // Append the FOLDERNAME12/ to the passed string.
       // It contains the full path to the "parent" argument.
       // We now have the full path to the item in this folder.
-      path[0] = '\0';
-      if (prepend[0] == '\0') strcat(path, "/"); // a root slash if prepend is empty
-      strcat(path, prepend);
-      strcat(path, lfilename);
-      strcat(path, "/");
+      if (prepend_is_empty) {
+        path[0] = '/'; // a root slash if prepend is empty
+        path[1] = '\0';
+      }
+      else
+        path[0] = '\0';
+
+      strcat(path, prepend);   // 1 character minimum
+      strcat(path, lfilename); // FILENAME_LENGTH-1 characters maximum
+      strcat(path, "/");       // 1 character
 
       // Serial.print(path);
 

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -62,7 +62,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
       // Allocate enough stack space for the full path to a folder, trailing slash, and nul
       boolean prepend_is_empty = (prepend[0] == '\0');
-      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1;
+      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1 + 1;
       char path[len];
 
       // Append the FOLDERNAME12/ to the passed string.

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -62,20 +62,13 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
       // Allocate enough stack space for the full path to a folder, trailing slash, and nul
       boolean prepend_is_empty = (prepend[0] == '\0');
-      int len = strlen(prepend) + (prepend_is_empty ? 1 : 0) + strlen(lfilename) + 1 + 1;
+      int len = (prepend_is_empty ? 1 : strlen(prepend)) + strlen(lfilename) + 1 + 1;
       char path[len];
 
       // Append the FOLDERNAME12/ to the passed string.
       // It contains the full path to the "parent" argument.
       // We now have the full path to the item in this folder.
-      if (prepend_is_empty) {
-        path[0] = '/'; // a root slash if prepend is empty
-        path[1] = '\0';
-      }
-      else
-        path[0] = '\0';
-
-      strcat(path, prepend);   // 1 character minimum
+      strcpy(path, prepend_is_empty ? "/" : prepend); // root slash if prepend is empty
       strcat(path, lfilename); // FILENAME_LENGTH-1 characters maximum
       strcat(path, "/");       // 1 character
 

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -107,7 +107,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -114,7 +114,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_EXCLUDE false
+#define EXTRUDER_1_DRYRUN_EXCLUDE false
+#define EXTRUDER_2_DRYRUN_EXCLUDE false
+#define EXTRUDER_3_DRYRUN_EXCLUDE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -120,7 +120,12 @@
 #define EXTRUDER_3_AUTO_FAN_PIN -1
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
-
+// Set the following to true if you want to enable the extruder motor while in dry run mode (AKA test mode).
+// Set to false if you want to prevent extrusion while in dry run mode.
+#define EXTRUDER_0_DRYRUN_ENABLE false
+#define EXTRUDER_1_DRYRUN_ENABLE false
+#define EXTRUDER_2_DRYRUN_ENABLE false
+#define EXTRUDER_3_DRYRUN_ENABLE false
 
 //===========================================================================
 //=============================Mechanical Settings===========================

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -28,7 +28,7 @@
 #define MSG_PREHEAT_PLA_BEDONLY             "Греть PLA Стол"
 #define MSG_PREHEAT_PLA_SETTINGS            "Настройки PLA"
 #define MSG_PREHEAT_ABS                     "Преднагрев ABS"
-#define MSG_PREHEAT_ABS_N                   "Греть ABS Сопло "
+#define MSG_PREHEAT_ABS_N                   "Греть ABS Сопло"
 #define MSG_PREHEAT_ABS_ALL                 "Греть ABS Все"
 #define MSG_PREHEAT_ABS_BEDONLY             "Греть ABS Стол"
 #define MSG_PREHEAT_ABS_SETTINGS            "Настройки ABS"

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -28,7 +28,7 @@
 #define MSG_PREHEAT_PLA_BEDONLY             "Греть PLA Стол"
 #define MSG_PREHEAT_PLA_SETTINGS            "Настройки PLA"
 #define MSG_PREHEAT_ABS                     "Преднагрев ABS"
-#define MSG_PREHEAT_ABS_N                   "Греть ABS Сопло"
+#define MSG_PREHEAT_ABS_N                   "Греть ABS Сопло "
 #define MSG_PREHEAT_ABS_ALL                 "Греть ABS Все"
 #define MSG_PREHEAT_ABS_BEDONLY             "Греть ABS Стол"
 #define MSG_PREHEAT_ABS_SETTINGS            "Настройки ABS"

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -502,12 +502,17 @@ float junction_deviation = 0.1;
 
   float dx = target[X_AXIS] - position[X_AXIS],
         dy = target[Y_AXIS] - position[Y_AXIS],
-        dz = target[Z_AXIS] - position[Z_AXIS],
-        de = target[E_AXIS] - position[E_AXIS];
+        dz = target[Z_AXIS] - position[Z_AXIS];
+
+  // DRYRUN ignores all temperature constraints and assures that the extruder is instantly satisfied
+  if (marlin_debug_flags & DEBUG_DRYRUN)
+    position[E_AXIS] = target[E_AXIS];
+
+  float de = target[E_AXIS] - position[E_AXIS];
 
   #ifdef PREVENT_DANGEROUS_EXTRUDE
     if (de) {
-      if (degHotend(extruder) < extrude_min_temp && !(marlin_debug_flags & DEBUG_DRYRUN)) {
+      if (degHotend(extruder) < extrude_min_temp) {
         position[E_AXIS] = target[E_AXIS]; // Behave as if the move really took place, but ignore E part
         de = 0; // no difference
         SERIAL_ECHO_START;

--- a/Marlin/servo.cpp
+++ b/Marlin/servo.cpp
@@ -59,7 +59,7 @@
 
 //#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
 
-static servo_t servos[MAX_SERVOS];                          // static array of servo structures
+static ServoInfo_t servo_info[MAX_SERVOS];                  // static array of servo info structures
 static volatile int8_t Channel[_Nbr_16timers ];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
 
 uint8_t ServoCount = 0;                                     // the total number of attached servos
@@ -69,7 +69,7 @@ uint8_t ServoCount = 0;                                     // the total number 
 #define SERVO_INDEX_TO_TIMER(_servo_nbr) ((timer16_Sequence_t)(_servo_nbr / SERVOS_PER_TIMER)) // returns the timer controlling this servo
 #define SERVO_INDEX_TO_CHANNEL(_servo_nbr) (_servo_nbr % SERVOS_PER_TIMER)       // returns the index of the servo on this timer
 #define SERVO_INDEX(_timer,_channel)  ((_timer*SERVOS_PER_TIMER) + _channel)     // macro to access servo index by timer and channel
-#define SERVO(_timer,_channel)  (servos[SERVO_INDEX(_timer,_channel)])            // macro to access servo class by timer and channel
+#define SERVO(_timer,_channel)  (servo_info[SERVO_INDEX(_timer,_channel)])       // macro to access servo class by timer and channel
 
 #define SERVO_MIN() (MIN_PULSE_WIDTH - this->min * 4)  // minimum value in uS for this servo
 #define SERVO_MAX() (MAX_PULSE_WIDTH - this->max * 4)  // maximum value in uS for this servo
@@ -232,7 +232,7 @@ static boolean isTimerActive(timer16_Sequence_t timer) {
 Servo::Servo() {
   if ( ServoCount < MAX_SERVOS) {
     this->servoIndex = ServoCount++;                    // assign a servo index to this instance
-    servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
+    servo_info[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
   }
   else
     this->servoIndex = INVALID_SERVO;  // too many servos
@@ -246,8 +246,8 @@ int8_t Servo::attach(int pin, int min, int max) {
 
   if (this->servoIndex >= MAX_SERVOS) return -1;
 
-  if (pin > 0) servos[this->servoIndex].Pin.nbr = pin;
-  pinMode(servos[this->servoIndex].Pin.nbr, OUTPUT); // set servo pin to output
+  if (pin > 0) servo_info[this->servoIndex].Pin.nbr = pin;
+  pinMode(servo_info[this->servoIndex].Pin.nbr, OUTPUT); // set servo pin to output
 
   // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
   this->min = (MIN_PULSE_WIDTH - min) / 4; //resolution of min/max is 4 uS
@@ -256,13 +256,13 @@ int8_t Servo::attach(int pin, int min, int max) {
   // initialize the timer if it has not already been initialized
   timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
   if (!isTimerActive(timer)) initISR(timer);
-  servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
+  servo_info[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
 
   return this->servoIndex;
 }
 
 void Servo::detach() {
-  servos[this->servoIndex].Pin.isActive = false;
+  servo_info[this->servoIndex].Pin.isActive = false;
   timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
   if (!isTimerActive(timer)) finISR(timer);
 }
@@ -290,7 +290,7 @@ void Servo::writeMicroseconds(int value) {
 
     uint8_t oldSREG = SREG;
     cli();
-    servos[channel].ticks = value;
+    servo_info[channel].ticks = value;
     SREG = oldSREG;
   }
 }
@@ -299,10 +299,10 @@ void Servo::writeMicroseconds(int value) {
 int Servo::read() { return map( this->readMicroseconds()+1, SERVO_MIN(), SERVO_MAX(), 0, 180); }
 
 int Servo::readMicroseconds() {
-  return (this->servoIndex == INVALID_SERVO) ? 0 : ticksToUs(servos[this->servoIndex].ticks) + TRIM_DURATION;
+  return (this->servoIndex == INVALID_SERVO) ? 0 : ticksToUs(servo_info[this->servoIndex].ticks) + TRIM_DURATION;
 }
 
-bool Servo::attached() { return servos[this->servoIndex].Pin.isActive; }
+bool Servo::attached() { return servo_info[this->servoIndex].Pin.isActive; }
 
 int8_t Servo::move(int pin, int value) {
   int8_t ret;

--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -112,7 +112,7 @@ typedef struct {
 typedef struct {
   ServoPin_t Pin;
   unsigned int ticks;
-} servo_t;
+} ServoInfo_t;
 
 class Servo {
   public:

--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -117,12 +117,12 @@ typedef struct {
 class Servo {
   public:
     Servo();
-    uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
-    uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
+    int8_t attach(int pin);           // attach the given pin to the next free channel, set pinMode, return channel number (-1 on fail)
+    int8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
     void detach();
     void write(int value);             // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
     void writeMicroseconds(int value); // Write pulse width in microseconds
-    uint8_t move(int pin, int value);  // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure.
+    int8_t move(int pin, int value);  // attach the given pin to the next free channel, set pinMode, return channel number (-1 if attach fails)
                                        // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds.
                                        // if DEACTIVATE_SERVOS_AFTER_MOVE is defined waits SERVO_DEACTIVATION_DELAY, than detaches.
     int read();                        // returns current pulse width as an angle between 0 and 180 degrees

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -524,19 +524,16 @@ void _lcd_preheat(int endnum, const float temph, const float tempb, const int fa
 void lcd_preheat_pla0() { _lcd_preheat(0, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
 void lcd_preheat_abs0() { _lcd_preheat(0, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
 
-#if TEMP_SENSOR_1 != 0 || TEMP_SENSOR_2 != 0 || TEMP_SENSOR_3 != 0 || TEMP_SENSOR_BED != 0 //more than one extruder present
-
-  #if TEMP_SENSOR_1 != 0
-    void lcd_preheat_pla1() { _lcd_preheat(1, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
-    void lcd_preheat_abs1() { _lcd_preheat(1, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
-  #endif
-  #if TEMP_SENSOR_2 != 0
+#if EXTRUDERS > 1
+  void lcd_preheat_pla1() { _lcd_preheat(1, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
+  void lcd_preheat_abs1() { _lcd_preheat(1, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
+  #if EXTRUDERS > 2
     void lcd_preheat_pla2() { _lcd_preheat(2, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
     void lcd_preheat_abs2() { _lcd_preheat(2, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
-  #endif
-  #if TEMP_SENSOR_3 != 0
-    void lcd_preheat_pla3() { _lcd_preheat(3, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
-    void lcd_preheat_abs3() { _lcd_preheat(3, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
+    #if EXTRUDERS > 3
+      void lcd_preheat_pla3() { _lcd_preheat(3, plaPreheatHotendTemp, plaPreheatHPBTemp, plaPreheatFanSpeed); }
+      void lcd_preheat_abs3() { _lcd_preheat(3, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed); }
+    #endif
   #endif
 
   void lcd_preheat_pla0123() {
@@ -552,53 +549,60 @@ void lcd_preheat_abs0() { _lcd_preheat(0, absPreheatHotendTemp, absPreheatHPBTem
     _lcd_preheat(3, absPreheatHotendTemp, absPreheatHPBTemp, absPreheatFanSpeed);
   }
 
-  #if TEMP_SENSOR_0 != 0
+#endif // EXTRUDERS > 1
 
-    void lcd_preheat_pla_bedonly() { _lcd_preheat(0, 0, plaPreheatHPBTemp, plaPreheatFanSpeed); }
-    void lcd_preheat_abs_bedonly() { _lcd_preheat(0, 0, absPreheatHPBTemp, absPreheatFanSpeed); }
+#if TEMP_SENSOR_BED != 0
+  void lcd_preheat_pla_bedonly() { _lcd_preheat(0, 0, plaPreheatHPBTemp, plaPreheatFanSpeed); }
+  void lcd_preheat_abs_bedonly() { _lcd_preheat(0, 0, absPreheatHPBTemp, absPreheatFanSpeed); }
+#endif
 
-    static void lcd_preheat_pla_menu() {
-      START_MENU();
-      MENU_ITEM(back, MSG_PREPARE, lcd_prepare_menu);
-      MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H1, lcd_preheat_pla0);
-      #if TEMP_SENSOR_1 != 0
-        MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H2, lcd_preheat_pla1);
-      #endif
-      #if TEMP_SENSOR_2 != 0
+static void lcd_preheat_pla_menu() {
+  START_MENU();
+  MENU_ITEM(back, MSG_PREPARE, lcd_prepare_menu);
+  #if EXTRUDERS == 1
+    MENU_ITEM(function, MSG_PREHEAT_PLA, lcd_preheat_pla0);
+  #else
+    MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H1, lcd_preheat_pla0);
+    #if EXTRUDERS > 1
+      MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H2, lcd_preheat_pla1);
+      #if EXTRUDERS > 2
         MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H3, lcd_preheat_pla2);
+        #if EXTRUDERS > 3
+          MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H4, lcd_preheat_pla3);
+        #endif
       #endif
-      #if TEMP_SENSOR_3 != 0
-        MENU_ITEM(function, MSG_PREHEAT_PLA_N MSG_H4, lcd_preheat_pla3);
-      #endif
-      MENU_ITEM(function, MSG_PREHEAT_PLA_ALL, lcd_preheat_pla0123);
-      #if TEMP_SENSOR_BED != 0
-        MENU_ITEM(function, MSG_PREHEAT_PLA_BEDONLY, lcd_preheat_pla_bedonly);
-      #endif
-      END_MENU();
-    }
-
-    static void lcd_preheat_abs_menu() {
-      START_MENU();
-      MENU_ITEM(back, MSG_PREPARE, lcd_prepare_menu);
-      MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H1, lcd_preheat_abs0);
-      #if TEMP_SENSOR_1 != 0
-        MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H2, lcd_preheat_abs1);
-      #endif
-      #if TEMP_SENSOR_2 != 0
-        MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H3, lcd_preheat_abs2);
-      #endif
-      #if TEMP_SENSOR_3 != 0
-        MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H4, lcd_preheat_abs3);
-      #endif
-      MENU_ITEM(function, MSG_PREHEAT_ABS_ALL, lcd_preheat_abs0123);
-      #if TEMP_SENSOR_BED != 0
-        MENU_ITEM(function, MSG_PREHEAT_ABS_BEDONLY, lcd_preheat_abs_bedonly);
-      #endif
-      END_MENU();
-    }
+    #endif
+    MENU_ITEM(function, MSG_PREHEAT_PLA_ALL, lcd_preheat_pla0123);
   #endif
+  #if TEMP_SENSOR_BED != 0
+    MENU_ITEM(function, MSG_PREHEAT_PLA_BEDONLY, lcd_preheat_pla_bedonly);
+  #endif
+  END_MENU();
+}
 
-#endif // more than one temperature sensor present
+static void lcd_preheat_abs_menu() {
+  START_MENU();
+  MENU_ITEM(back, MSG_PREPARE, lcd_prepare_menu);
+  #if EXTRUDERS == 1
+    MENU_ITEM(function, MSG_PREHEAT_ABS, lcd_preheat_abs0);
+  #else
+    MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H1, lcd_preheat_abs0);
+    #if EXTRUDERS > 1
+      MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H2, lcd_preheat_abs1);
+      #if EXTRUDERS > 2
+        MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H3, lcd_preheat_abs2);
+        #if EXTRUDERS > 3
+          MENU_ITEM(function, MSG_PREHEAT_ABS_N MSG_H4, lcd_preheat_abs3);
+        #endif
+      #endif
+    #endif
+    MENU_ITEM(function, MSG_PREHEAT_ABS_ALL, lcd_preheat_abs0123);
+  #endif
+  #if TEMP_SENSOR_BED != 0
+    MENU_ITEM(function, MSG_PREHEAT_ABS_BEDONLY, lcd_preheat_abs_bedonly);
+  #endif
+  END_MENU();
+}
 
 void lcd_cooldown() {
   disable_all_heaters();


### PR DESCRIPTION
@MagoKimbra @Wackerbarth @thinkyhead
Can you take a look at this PR? It's just my version of what I think should be the DRYRUN behavior. With the extruders option `EXTRUDER_X_DRYRUN_ENABLE`, you can make a regular dry run "à la Repetier", or make it more compliant to a "real" test run. The code can be refined, or simply rewriten. I just wanted to know if it's worth an inclusion in Marlin.
