### PR TITLE
Correct Kossel Pro Configuration_adv

### DIFF
--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -19,16 +19,11 @@
 #define BED_CHECK_INTERVAL 5000 //ms between checks in bang-bang control
 
 /**
- * Heating Sanity Check
- *
- * Whenever an M104 or M109 increases the target temperature this will wait for WATCH_TEMP_PERIOD milliseconds,
- * and if the temperature hasn't increased by WATCH_TEMP_INCREASE degrees, the machine is halted, requiring a
- * hard reset. This test restarts with any M104/M109, but only if the current temperature is below the target
- * by at least 2 * WATCH_TEMP_INCREASE degrees celsius.
+ * Thermal Protection parameters
  */
-#ifdef THERMAL_RUNAWAY_PROTECTION_HOTENDS
-  #define THERMAL_RUNAWAY_PROTECTION_PERIOD 40        // Seconds
-  #define THERMAL_RUNAWAY_PROTECTION_HYSTERESIS 4     // Degrees Celsius
+#ifdef THERMAL_PROTECTION_HOTENDS
+  #define THERMAL_PROTECTION_PERIOD 40        // Seconds
+  #define THERMAL_PROTECTION_HYSTERESIS 4     // Degrees Celsius
 
   /**
    * Whenever an M104 or M109 increases the target temperature the firmware will wait for the
@@ -40,9 +35,9 @@
   #define WATCH_TEMP_INCREASE 4               // Degrees Celsius
 #endif
 
-#ifdef THERMAL_RUNAWAY_PROTECTION_BED
-  #define THERMAL_RUNAWAY_PROTECTION_BED_PERIOD 20    // Seconds
-  #define THERMAL_RUNAWAY_PROTECTION_BED_HYSTERESIS 2 // Degrees Celsius
+#ifdef THERMAL_PROTECTION_BED
+  #define THERMAL_PROTECTION_BED_PERIOD 20    // Seconds
+  #define THERMAL_PROTECTION_BED_HYSTERESIS 2 // Degrees Celsius
 #endif
 
 #ifdef PIDTEMP
@@ -54,14 +49,16 @@
   #endif
 #endif
 
-
-//automatic temperature: The hot end target temperature is calculated by all the buffered lines of gcode.
-//The maximum buffered steps/sec of the extruder motor are called "se".
-//You enter the autotemp mode by a M109 S<mintemp> B<maxtemp> F<factor>
-// the target temperature is set to mintemp+factor*se[steps/sec] and limited by mintemp and maxtemp
-// you exit the value by any M109 without F*
-// Also, if the temperature is set to a value <mintemp, it is not changed by autotemp.
-// on an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
+/**
+ * Automatic Temperature:
+ * The hotend target temperature is calculated by all the buffered lines of gcode.
+ * The maximum buffered steps/sec of the extruder motor is called "se".
+ * Start autotemp mode with M109 S<mintemp> B<maxtemp> F<factor>
+ * The target temperature is set to mintemp+factor*se[steps/sec] and is limited by
+ * mintemp and maxtemp. Turn this off by excuting M109 without F*
+ * Also, if the temperature is set to a value below mintemp, it will not be changed by autotemp.
+ * On an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
+ */
 #define AUTOTEMP
 #ifdef AUTOTEMP
   #define AUTOTEMP_OLDWEIGHT 0.98
@@ -100,6 +97,11 @@
 // given number of milliseconds.  This gets the fan spinning reliably
 // before setting a PWM value. (Does not work with software PWM for fan on Sanguinololu)
 //#define FAN_KICKSTART_TIME 100
+
+// This defines the minimal speed for the main fan, run in PWM mode
+// to enable uncomment and set minimal PWM speed for reliable running (1-255)
+// if fan speed is [1 - (FAN_MIN_PWM-1)] it is set to FAN_MIN_PWM
+//#define FAN_MIN_PWM 50
 
 // @section extruder
 
@@ -365,6 +367,9 @@
     // Enable this to show messages for MSG_TIME then hide them
     //#define PROGRESS_MSG_ONCE
   #endif
+
+  // This allows hosts to request long names for files and folders with M33
+  //#define LONG_FILENAME_HOST_SUPPORT
 
 #endif // SDSUPPORT
 


### PR DESCRIPTION
This got missed when Thermal Runaway Defines were renamed
