### PR TITLE
Makefile avrdude

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -350,7 +350,7 @@ LDFLAGS = -lm
 AVRDUDE_PORT = $(UPLOAD_PORT)
 AVRDUDE_WRITE_FLASH = -Uflash:w:$(BUILD_DIR)/$(TARGET).hex:i
 ifeq ($(shell uname -s), Linux)
-AVRDUDE_CONF = $(ARDUINO_INSTALL_DIR)/hardware/tools/avrdude.conf
+AVRDUDE_CONF = /etc/avrdude/avrdude.conf
 else
 AVRDUDE_CONF = $(ARDUINO_INSTALL_DIR)/hardware/tools/avr/etc/avrdude.conf
 endif

--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -354,7 +354,7 @@ AVRDUDE_CONF = /etc/avrdude/avrdude.conf
 else
 AVRDUDE_CONF = $(ARDUINO_INSTALL_DIR)/hardware/tools/avr/etc/avrdude.conf
 endif
-AVRDUDE_FLAGS = -q -q -D -C$(AVRDUDE_CONF) \
+AVRDUDE_FLAGS = -D -C$(AVRDUDE_CONF) \
 	-p$(MCU) -P$(AVRDUDE_PORT) -c$(AVRDUDE_PROGRAMMER) \
 	-b$(UPLOAD_RATE)
 


### PR DESCRIPTION
```
makefile: use /etc/avrdude/avrdude.conf on linux

No need to look for arduino specific avrdude configuration
as distributions ship their own avrdude.conf file that
is compatible with arduino.

makefile: drop -q -q (much quiet) from avrdude flags

Annoying when trying to figure out if uploading
actually does something.
```
