### PR TITLE
Mark unchanging arrays as const

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -249,7 +249,6 @@ inline void refresh_cmd_timeout() { previous_cmd_ms = millis(); }
   #define CRITICAL_SECTION_END    SREG = _sreg;
 #endif
 
-extern float homing_feedrate[];
 extern bool axis_relative_modes[];
 extern int feedrate_multiplier;
 extern bool volumetric_enabled;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -246,7 +246,7 @@ static int cmd_queue_index_w = 0;
 static int commands_in_queue = 0;
 static char command_queue[BUFSIZE][MAX_CMD_SIZE];
 
-float homing_feedrate[] = HOMING_FEEDRATE;
+const float homing_feedrate[] = HOMING_FEEDRATE;
 bool axis_relative_modes[] = AXIS_RELATIVE_MODES;
 int feedrate_multiplier = 100; //100->1 200->2
 int saved_feedrate_multiplier;
@@ -310,8 +310,8 @@ bool target_direction;
 #endif
 
 #ifdef SERVO_ENDSTOPS
-  int servo_endstops[] = SERVO_ENDSTOPS;
-  int servo_endstop_angles[] = SERVO_ENDSTOP_ANGLES;
+  const int servo_endstops[] = SERVO_ENDSTOPS;
+  const int servo_endstop_angles[] = SERVO_ENDSTOP_ANGLES;
 #endif
 
 #ifdef BARICUDA

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -44,7 +44,7 @@ static void lcd_status_screen();
   #if HAS_POWER_SWITCH
     extern bool powersupply;
   #endif
-  static float manual_feedrate[] = MANUAL_FEEDRATE;
+  const float manual_feedrate[] = MANUAL_FEEDRATE;
   static void lcd_main_menu();
   static void lcd_tune_menu();
   static void lcd_prepare_menu();


### PR DESCRIPTION
The compiler may be able to optimize if it knows an array won’t be changing.
