### PR TITLE
Correct bracketing for COREXY-XZ

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -142,12 +142,12 @@ script:
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Enable COREXY
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
-  - sed -i 's/\/\/ #define COREXY/#define COREXY/g' Marlin/Configuration.h
+  - sed -i 's/\/\/#define COREXY/#define COREXY/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Enable COREXZ
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
-  - sed -i 's/\/\/ #define COREXZ/#define COREXZ/g' Marlin/Configuration.h
+  - sed -i 's/\/\/#define COREXZ/#define COREXZ/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ######## Example Configurations ##############

--- a/.travis.yml
+++ b/.travis.yml
@@ -142,12 +142,12 @@ script:
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Enable COREXY
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
-  - sed -i 's/\/\/  #define COREXY/#define COREXY/g' Marlin/Configuration.h
+  - sed -i 's/\/\/ #define COREXY/#define COREXY/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Enable COREXZ
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
-  - sed -i 's/\/\/  #define COREXZ/#define COREXZ/g' Marlin/Configuration.h
+  - sed -i 's/\/\/ #define COREXZ/#define COREXZ/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ######## Example Configurations ##############

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,16 @@ script:
   - sed -i 's/\/\/#define FILAMENT_LCD_DISPLAY/#define FILAMENT_LCD_DISPLAY/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
+  # Enable COREXY
+  - cp Marlin/Configuration.h.backup Marlin/Configuration.h
+  - sed -i 's/\/\/  #define COREXY/#define COREXY/g' Marlin/Configuration.h
+  - rm -rf .build/
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
+  # Enable COREXZ
+  - cp Marlin/Configuration.h.backup Marlin/Configuration.h
+  - sed -i 's/\/\/  #define COREXZ/#define COREXZ/g' Marlin/Configuration.h
+  - rm -rf .build/
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   ######## Example Configurations ##############
   # Delta Config (generic)
   - cp Marlin/example_configurations/delta/generic/Configuration* Marlin/

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -304,10 +304,10 @@ Here are some standard links for getting your machine calibrated:
 // @section machine
 
 // Uncomment this option to enable CoreXY kinematics
-// #define COREXY
+//#define COREXY
 
 // Uncomment this option to enable CoreXZ kinematics
-// #define COREXZ
+//#define COREXZ
 
 // Enable this option for Toshiba steppers
 //#define CONFIG_STEPPERS_TOSHIBA

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -374,7 +374,7 @@ inline void update_endstops() {
           UPDATE_ENDSTOP(Y, MAX);
         #endif
       }
-  #if defined(COREXY) || defined(COREXZ)
+  #if defined(COREXY)
     }
   #endif
 
@@ -459,6 +459,9 @@ inline void update_endstops() {
           }
         #endif
       }
+  #if defined(COREXZ)
+    }
+  #endif  
   old_endstop_bits = current_endstop_bits;
 }
 


### PR DESCRIPTION
as proposed by @grytole in #2502.
At least compiles now.

Added Travis tests for `COREXY` and `COREXZ`.
