### PR TITLE
Complete M200 output with M503

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -605,7 +605,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 // M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
 // M502 - reverts to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
 //define this to enable EEPROM support
-//#define EEPROM_SETTINGS
+#define EEPROM_SETTINGS
 
 #ifdef EEPROM_SETTINGS
   // To disable EEPROM Serial responses and decrease program space by ~1700 byte: comment this out:

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3047,7 +3047,7 @@ inline void gcode_M42() {
     if (code_seen('P') && pin_status >= 0 && pin_status <= 255)
       pin_number = code_value_short();
 
-    for (int8_t i = 0; i < COUNT(sensitive_pins); i++) {
+    for (uint8_t i = 0; i < COUNT(sensitive_pins); i++) {
       if (sensitive_pins[i] == pin_number) {
         pin_number = -1;
         break;
@@ -4187,7 +4187,7 @@ inline void gcode_M226() {
 
     if (pin_state >= -1 && pin_state <= 1) {
 
-      for (int8_t i = 0; i < COUNT(sensitive_pins); i++) {
+      for (uint8_t i = 0; i < COUNT(sensitive_pins); i++) {
         if (sensitive_pins[i] == pin_number) {
           pin_number = -1;
           break;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -826,39 +826,43 @@ void Config_PrintSettings(bool forReplay) {
 
   #endif // FWRETRACT
 
-  if (volumetric_enabled) {
-    if (!forReplay) {
-      CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Filament settings:");
-    }
-
+  /**
+   * Volumetric extrusion M200
+   */
+  if (!forReplay) {
     CONFIG_ECHO_START;
-    SERIAL_ECHOPAIR("  M200 D", filament_size[0]);
-    SERIAL_EOL;
-
-    #if EXTRUDERS > 1
-      CONFIG_ECHO_START;
-      SERIAL_ECHOPAIR("  M200 T1 D", filament_size[1]);
-      SERIAL_EOL;
-      #if EXTRUDERS > 2
-        CONFIG_ECHO_START;
-        SERIAL_ECHOPAIR("  M200 T2 D", filament_size[2]);
-        SERIAL_EOL;
-        #if EXTRUDERS > 3
-          CONFIG_ECHO_START;
-          SERIAL_ECHOPAIR("  M200 T3 D", filament_size[3]);
-          SERIAL_EOL;
-        #endif
-      #endif
-    #endif
-
-  } else {
-    if (!forReplay) {
-      CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Filament settings: Disabled");
-    }
+    SERIAL_ECHOPGM("Filament settings:");
+    SERIAL_ECHOLNPGM(volumetric_enabled ? "" : " Disabled");
   }
 
+  CONFIG_ECHO_START;
+  SERIAL_ECHOPAIR("  M200 D", filament_size[0]);
+  SERIAL_EOL;
+  #if EXTRUDERS > 1
+    CONFIG_ECHO_START;
+    SERIAL_ECHOPAIR("  M200 T1 D", filament_size[1]);
+    SERIAL_EOL;
+    #if EXTRUDERS > 2
+      CONFIG_ECHO_START;
+      SERIAL_ECHOPAIR("  M200 T2 D", filament_size[2]);
+      SERIAL_EOL;
+      #if EXTRUDERS > 3
+        CONFIG_ECHO_START;
+        SERIAL_ECHOPAIR("  M200 T3 D", filament_size[3]);
+        SERIAL_EOL;
+      #endif
+    #endif
+  #endif
+
+  if (!volumetric_enabled) {
+    CONFIG_ECHO_START;
+    SERIAL_ECHOPAIR("  M200 D0");
+    SERIAL_EOL;
+  }
+
+  /**
+   * Auto Bed Leveling
+   */
   #ifdef ENABLE_AUTO_BED_LEVELING
     #ifdef CUSTOM_M_CODES
       if (!forReplay) {

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -832,7 +832,10 @@ void Config_PrintSettings(bool forReplay) {
   if (!forReplay) {
     CONFIG_ECHO_START;
     SERIAL_ECHOPGM("Filament settings:");
-    SERIAL_ECHOLNPGM(volumetric_enabled ? "" : " Disabled");
+    if (volumetric_enabled)
+      SERIAL_EOL;
+    else
+      SERIAL_ECHOLNPGM(" Disabled");
   }
 
   CONFIG_ECHO_START;
@@ -856,8 +859,7 @@ void Config_PrintSettings(bool forReplay) {
 
   if (!volumetric_enabled) {
     CONFIG_ECHO_START;
-    SERIAL_ECHOPAIR("  M200 D0");
-    SERIAL_EOL;
+    SERIAL_ECHOLNPGM("  M200 D0");
   }
 
   /**


### PR DESCRIPTION
- The contents of EEPROM include filament diameters even with Volumetric disabled. This change makes `M503` display the full volumetric settings so that playing back the output of `M503 S0` will fully restore them.
