### PR TITLE
Complete M200 output with M503

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3047,7 +3047,7 @@ inline void gcode_M42() {
     if (code_seen('P') && pin_status >= 0 && pin_status <= 255)
       pin_number = code_value_short();
 
-    for (int8_t i = 0; i < COUNT(sensitive_pins); i++) {
+    for (uint8_t i = 0; i < COUNT(sensitive_pins); i++) {
       if (sensitive_pins[i] == pin_number) {
         pin_number = -1;
         break;
@@ -4187,7 +4187,7 @@ inline void gcode_M226() {
 
     if (pin_state >= -1 && pin_state <= 1) {
 
-      for (int8_t i = 0; i < COUNT(sensitive_pins); i++) {
+      for (uint8_t i = 0; i < COUNT(sensitive_pins); i++) {
         if (sensitive_pins[i] == pin_number) {
           pin_number = -1;
           break;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -826,39 +826,45 @@ void Config_PrintSettings(bool forReplay) {
 
   #endif // FWRETRACT
 
-  if (volumetric_enabled) {
-    if (!forReplay) {
-      CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Filament settings:");
-    }
-
+  /**
+   * Volumetric extrusion M200
+   */
+  if (!forReplay) {
     CONFIG_ECHO_START;
-    SERIAL_ECHOPAIR("  M200 D", filament_size[0]);
-    SERIAL_EOL;
-
-    #if EXTRUDERS > 1
-      CONFIG_ECHO_START;
-      SERIAL_ECHOPAIR("  M200 T1 D", filament_size[1]);
+    SERIAL_ECHOPGM("Filament settings:");
+    if (volumetric_enabled)
       SERIAL_EOL;
-      #if EXTRUDERS > 2
-        CONFIG_ECHO_START;
-        SERIAL_ECHOPAIR("  M200 T2 D", filament_size[2]);
-        SERIAL_EOL;
-        #if EXTRUDERS > 3
-          CONFIG_ECHO_START;
-          SERIAL_ECHOPAIR("  M200 T3 D", filament_size[3]);
-          SERIAL_EOL;
-        #endif
-      #endif
-    #endif
-
-  } else {
-    if (!forReplay) {
-      CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Filament settings: Disabled");
-    }
+    else
+      SERIAL_ECHOLNPGM(" Disabled");
   }
 
+  CONFIG_ECHO_START;
+  SERIAL_ECHOPAIR("  M200 D", filament_size[0]);
+  SERIAL_EOL;
+  #if EXTRUDERS > 1
+    CONFIG_ECHO_START;
+    SERIAL_ECHOPAIR("  M200 T1 D", filament_size[1]);
+    SERIAL_EOL;
+    #if EXTRUDERS > 2
+      CONFIG_ECHO_START;
+      SERIAL_ECHOPAIR("  M200 T2 D", filament_size[2]);
+      SERIAL_EOL;
+      #if EXTRUDERS > 3
+        CONFIG_ECHO_START;
+        SERIAL_ECHOPAIR("  M200 T3 D", filament_size[3]);
+        SERIAL_EOL;
+      #endif
+    #endif
+  #endif
+
+  if (!volumetric_enabled) {
+    CONFIG_ECHO_START;
+    SERIAL_ECHOLNPGM("  M200 D0");
+  }
+
+  /**
+   * Auto Bed Leveling
+   */
   #ifdef ENABLE_AUTO_BED_LEVELING
     #ifdef CUSTOM_M_CODES
       if (!forReplay) {

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -565,16 +565,8 @@ void Config_ResetDefault() {
   #endif
 
   volumetric_enabled = false;
-  filament_size[0] = DEFAULT_NOMINAL_FILAMENT_DIA;
-  #if EXTRUDERS > 1
-    filament_size[1] = DEFAULT_NOMINAL_FILAMENT_DIA;
-    #if EXTRUDERS > 2
-      filament_size[2] = DEFAULT_NOMINAL_FILAMENT_DIA;
-      #if EXTRUDERS > 3
-        filament_size[3] = DEFAULT_NOMINAL_FILAMENT_DIA;
-      #endif
-    #endif
-  #endif
+  for (int q=0; q<COUNT(filament_size); q++)
+    filament_size[q] = DEFAULT_NOMINAL_FILAMENT_DIA;
   calculate_volumetric_multipliers();
 
   SERIAL_ECHO_START;


### PR DESCRIPTION
- The contents of EEPROM include filament diameters even with Volumetric disabled. This change makes `M503` display the full volumetric settings so that playing back the output of `M503 S0` will fully restore them.
