### PR TITLE
More complete M206

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4012,7 +4012,7 @@ inline void gcode_M205() {
   if (code_seen('E')) max_e_jerk = code_value();
 }
 
-void set_home_offset(AxisEnum axis, float offs) {
+void set_home_offset(uint8_t axis, float offs) {
   if (axis_known_position[axis]) {
     float diff = offs - home_offset[axis];
     current_position[axis] += diff;
@@ -4696,8 +4696,8 @@ inline void gcode_M428() {
   for (int8_t i = X_AXIS; i <= Z_AXIS; i++) {
     if (axis_known_position[i]) {
       float mid = (min_pos[i] + max_pos[i]) / 2,
-            base = (new_pos[i] > mid) ? base_home_pos(i) : 0,
-            diff = new_pos[i] - base;
+            base = (current_position[i] > mid) ? base_home_pos(i) : 0,
+            diff = current_position[i] - base;
       if (diff > -20 && diff < 20) {
         new_offs[i] -= diff;
       }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4019,7 +4019,7 @@ void set_home_offset(AxisEnum axis, float offs) {
     min_pos[axis] += diff;
     max_pos[axis] += diff;
   }
-  home_offset[i] = offs;
+  home_offset[axis] = offs;
 }
 
 /**


### PR DESCRIPTION
When `M206` is applied it needs to recalculate axis information that was set based on `home_offset`. This includes the `current_position`, `min_pos`, and `max_pos` arrays. All need to shift by the difference between the old and new home_offset. This only applies to known positions.
