### PR TITLE
More complete M206

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4051,8 +4051,8 @@ inline void gcode_M206() {
       set_home_offset(i, code_value());
 
   #ifdef SCARA
-    if (code_seen('T')) home_offset[X_AXIS] = code_value(); // Theta
-    if (code_seen('P')) home_offset[Y_AXIS] = code_value(); // Psi
+    if (code_seen('T')) set_home_offset(X_AXIS, code_value()); // Theta
+    if (code_seen('P')) set_home_offset(Y_AXIS, code_value()); // Psi
   #endif
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3067,7 +3067,7 @@ inline void gcode_M42() {
     if (code_seen('P') && pin_status >= 0 && pin_status <= 255)
       pin_number = code_value_short();
 
-    for (int8_t i = 0; i < COUNT(sensitive_pins); i++) {
+    for (uint8_t i = 0; i < COUNT(sensitive_pins); i++) {
       if (sensitive_pins[i] == pin_number) {
         pin_number = -1;
         break;


### PR DESCRIPTION
When `M206` is applied it needs to recalculate axis information that was set based on `home_offset`. This includes the `current_position`, `min_pos`, and `max_pos` arrays. All need to shift by the difference between the old and new home_offset. This only applies to known positions.
