### PR TITLE
don't pass integer by reference, inefficient.

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -473,9 +473,9 @@ float junction_deviation = 0.1;
 // mm. Microseconds specify how many microseconds the move should take to perform. To aid acceleration
 // calculation the caller must also provide the physical length of the line in millimeters.
 #if defined(ENABLE_AUTO_BED_LEVELING) || defined(MESH_BED_LEVELING)
-  void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate, const uint8_t &extruder)
+  void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate, const uint8_t extruder)
 #else
-  void plan_buffer_line(const float &x, const float &y, const float &z, const float &e, float feed_rate, const uint8_t &extruder)
+  void plan_buffer_line(const float &x, const float &y, const float &z, const float &e, float feed_rate, const uint8_t extruder)
 #endif  // ENABLE_AUTO_BED_LEVELING
 {
   // Calculate the buffer head after we push this byte

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -97,7 +97,7 @@ FORCE_INLINE uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block
    * Add a new linear movement to the buffer. x, y, z are the signed, absolute target position in
    * millimeters. Feed rate specifies the (target) speed of the motion.
    */
-  void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate, const uint8_t &extruder);
+  void plan_buffer_line(float x, float y, float z, const float &e, float feed_rate, const uint8_t extruder);
 
   /**
    * Set the planner positions. Used for G92 instructions.
@@ -108,7 +108,7 @@ FORCE_INLINE uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block
 
 #else
 
-  void plan_buffer_line(const float &x, const float &y, const float &z, const float &e, float feed_rate, const uint8_t &extruder);
+  void plan_buffer_line(const float &x, const float &y, const float &z, const float &e, float feed_rate, const uint8_t extruder);
   void plan_set_position(const float &x, const float &y, const float &z, const float &e);
 
 #endif // ENABLE_AUTO_BED_LEVELING || MESH_BED_LEVELING


### PR DESCRIPTION
Saves a handful of bytes both in the target function and the callers.  Semantically, there is no change.

``` diff
+0000003e W line_to_destination(float)
-00000046 W line_to_destination(float)
+00000054 W line_to_current(AxisEnum)
-0000005c W line_to_current(AxisEnum)
+0000066e T plan_arc(float*, float*, unsigned char)
-00000676 T plan_arc(float*, float*, unsigned char)
+000015b2 T plan_buffer_line(float const&, float const&, float const&, float const&, float, unsigned char)
-000015f2 T plan_buffer_line(float const&, float const&, float const&, float const&, float, unsigned char const&)
```
