### PR TITLE
Add array size to servo_endstop_angles

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -316,7 +316,7 @@ bool target_direction;
 
 #ifdef SERVO_ENDSTOPS
   const int servo_endstops[] = SERVO_ENDSTOPS;
-  const int servo_endstop_angles[][] = SERVO_ENDSTOP_ANGLES;
+  const int servo_endstop_angles[][2] = SERVO_ENDSTOP_ANGLES;
 #endif
 
 #ifdef BARICUDA


### PR DESCRIPTION
Fix compile bug introduced by #2543, as reported in #2551.
