### PR TITLE
Rename BEEPER to BEEPER_PIN

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -512,7 +512,7 @@
     #define WRITE_FAN(v) WRITE(FAN_PIN, v)
   #endif
 
-  #define HAS_BUZZER ((defined(BEEPER) && BEEPER >= 0) || defined(LCD_USE_I2C_BUZZER))
+  #define HAS_BUZZER (PIN_EXISTS(BEEPER) || defined(LCD_USE_I2C_BUZZER))
 
   #if defined(NUM_SERVOS) && NUM_SERVOS > 0
     #ifndef X_ENDSTOP_SERVO_NR

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -362,4 +362,8 @@
     #error "Z_LATE_ENABLE can't be used with COREXZ."
   #endif
 
+  #ifdef BEEPER
+    #error BEEPER has been replaced with BEEPER_PIN. Please update your pins definitions.
+  #endif
+
 #endif //SANITYCHECK_H

--- a/Marlin/buzzer.cpp
+++ b/Marlin/buzzer.cpp
@@ -7,22 +7,22 @@
     if (freq > 0) {
       #ifdef LCD_USE_I2C_BUZZER
         lcd_buzz(duration, freq);
-      #elif defined(BEEPER) && BEEPER >= 0 // on-board buzzers have no further condition
-        SET_OUTPUT(BEEPER);
+      #elif PIN_EXISTS(BEEPER) // on-board buzzers have no further condition
+        SET_OUTPUT(BEEPER_PIN);
         #ifdef SPEAKER // a speaker needs a AC ore a pulsed DC
-          //tone(BEEPER, freq, duration); // needs a PWMable pin
+          //tone(BEEPER_PIN, freq, duration); // needs a PWMable pin
           unsigned int delay = 1000000 / freq / 2;
           int i = duration * freq / 1000;
           while (i--) {
-            WRITE(BEEPER,HIGH);
+            WRITE(BEEPER_PIN, HIGH);
             delayMicroseconds(delay);
-            WRITE(BEEPER,LOW);
+            WRITE(BEEPER_PIN, LOW);
             delayMicroseconds(delay);
            }
         #else // buzzer has its own resonator - needs a DC
-          WRITE(BEEPER, HIGH);
+          WRITE(BEEPER_PIN, HIGH);
           delay(duration);
-          WRITE(BEEPER, LOW);
+          WRITE(BEEPER_PIN, LOW);
         #endif
       #else
         delay(duration);

--- a/Marlin/pins_3DRAG.h
+++ b/Marlin/pins_3DRAG.h
@@ -30,8 +30,8 @@
 #define HEATER_BED_PIN     9    // BED
 
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
-  #undef BEEPER
-  #define BEEPER -1
+  #undef BEEPER_PIN
+  #define BEEPER_PIN -1
 
   #undef LCD_PINS_RS
   #undef LCD_PINS_ENABLE
@@ -56,6 +56,6 @@
 
 #else
 
-  #define BEEPER 33
+  #define BEEPER_PIN 33
 
 #endif // ULTRA_LCD && NEWPANEL

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -24,8 +24,8 @@
  #define SDCARDDETECT -1 // Pin 49 if using display sd interface   
  
   #if ENABLED(TEMP_STAT_LEDS)
-   #define STAT_LED_RED 64
-   #define STAT_LED_BLUE 63
+    #define STAT_LED_RED 64
+    #define STAT_LED_BLUE 63
   #endif
 
 #elif ENABLED(TEMP_STAT_LEDS)

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -8,7 +8,8 @@
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
 
- #define BEEPER 33
+ #define BEEPER_PIN 33
+
  // Pins for DOGM SPI LCD Support
  #define DOGLCD_A0  31 
  #define DOGLCD_CS  32 

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -8,24 +8,24 @@
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
 
- #define BEEPER_PIN 33
+  #define BEEPER_PIN        33
 
  // Pins for DOGM SPI LCD Support
- #define DOGLCD_A0  31 
- #define DOGLCD_CS  32 
- #define LCD_SCREEN_ROT_180
- 
- //The encoder and click button 
- #define BTN_EN1 22 
- #define BTN_EN2 7
- #define BTN_ENC 12  //the click switch
- 
- #define SDSS 53
- #define SDCARDDETECT -1 // Pin 49 if using display sd interface   
- 
+  #define DOGLCD_A0         31
+  #define DOGLCD_CS         32
+  #define LCD_SCREEN_ROT_180
+
+ //The encoder and click button
+  #define BTN_EN1           22
+  #define BTN_EN2            7
+  #define BTN_ENC           12  //the click switch
+
+  #define SDSS              53
+  #define SDCARDDETECT      -1  // Pin 49 if using display sd interface
+
   #if ENABLED(TEMP_STAT_LEDS)
-    #define STAT_LED_RED 64
-    #define STAT_LED_BLUE 63
+    #define STAT_LED_RED    64
+    #define STAT_LED_BLUE   63
   #endif
 
 #elif ENABLED(TEMP_STAT_LEDS)

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -6,7 +6,7 @@
 
 #undef FAN_PIN
 #define FAN_PIN             6 //Part Cooling System
-#define BEEPER             33
+#define BEEPER_PIN         33
 #define CONTROLLERFAN_PIN   4 //Pin used for the fan to cool motherboard (-1 to disable)
 //Fans/Water Pump to cool the hotend cool side.
 #define EXTRUDER_0_AUTO_FAN_PIN   5
@@ -97,7 +97,7 @@
 //LCD Pins//
 
  #if ENABLED(VIKI2) || ENABLED(miniVIKI)
-  #define BEEPER           33
+  #define BEEPER_PIN       33
  // Pins for DOGM SPI LCD Support
   #define DOGLCD_A0        44
   #define DOGLCD_CS        45

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -13,14 +13,14 @@
 #define X_MAX_PIN          34
 
 #define Y_STEP_PIN         11
-#define Y_DIR_PIN          9
+#define Y_DIR_PIN           9
 #define Y_ENABLE_PIN       12
 #define Y_MIN_PIN          33
 #define Y_MAX_PIN          32
 
-#define Z_STEP_PIN         7
-#define Z_DIR_PIN          6
-#define Z_ENABLE_PIN       8
+#define Z_STEP_PIN          7
+#define Z_DIR_PIN           6
+#define Z_ENABLE_PIN        8
 #define Z_MIN_PIN          31
 #define Z_MAX_PIN          30
 
@@ -48,10 +48,10 @@
 #define HEATER_1_PIN       46 //12V PWM2
 #define HEATER_2_PIN       17 //12V PWM3
 #define HEATER_BED_PIN     44 //DOUBLE 12V PWM
-#define TEMP_0_PIN         3  //ANALOG NUMBERING
-#define TEMP_1_PIN         2  //ANALOG NUMBERING
-#define TEMP_2_PIN         1  //ANALOG NUMBERING
-#define TEMP_BED_PIN       0  //ANALOG NUMBERING
+#define TEMP_0_PIN          3 //ANALOG NUMBERING
+#define TEMP_1_PIN          2 //ANALOG NUMBERING
+#define TEMP_2_PIN          1 //ANALOG NUMBERING
+#define TEMP_BED_PIN        0 //ANALOG NUMBERING
 
 #define BEEPER_PIN         36
 
@@ -70,9 +70,9 @@
   #define BTN_EN2          39
   #define BTN_ENC          15  //the click
 
-  #define BLEN_C           2
-  #define BLEN_B           1
-  #define BLEN_A           0
+  #define BLEN_C            2
+  #define BLEN_B            1
+  #define BLEN_A            0
 
 #endif // RA_CONTROL_PANEL
 

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -53,7 +53,7 @@
 #define TEMP_2_PIN         1  //ANALOG NUMBERING
 #define TEMP_BED_PIN       0  //ANALOG NUMBERING
 
-#define BEEPER             36
+#define BEEPER_PIN         36
 
 #define KILL_PIN           -1
 

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -56,7 +56,7 @@
 //#define TX_ENABLE_PIN       12
 //#define RX_ENABLE_PIN       13
 
-#define BEEPER -1
+#define BEEPER_PIN -1
 #define SDCARDDETECT -1
 #define SUICIDE_PIN -1    //has to be defined; otherwise Power_off doesn't work
 

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -89,7 +89,7 @@
 #endif
 
 #ifdef MINIPANEL
-    #define BEEPER 46
+    #define BEEPER_PIN 46
     // Pins for DOGM SPI LCD Support
     #define DOGLCD_A0  47
     #define DOGLCD_CS  45

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -58,7 +58,7 @@
 #define HEATER_BED_PIN     10   // BED
 #define TEMP_BED_PIN       14   // ANALOG NUMBERING
 
-#define BEEPER             33   // AUX-4
+#define BEEPER_PIN         33   // AUX-4
 
 #if defined(ULTRA_LCD) && defined(NEWPANEL)
 

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -74,7 +74,7 @@
   #define TEMP_BED_PIN 14 // ANALOG NUMBERING
 #endif
 
-#define BEEPER 64
+#define BEEPER_PIN 64
 
 
 #define LCD_PINS_RS 14

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -76,7 +76,7 @@
 #define TEMP_2_PIN   (TEMP_SENSOR_2 == -1 ?   9 : 12) // ANALOG NUMBERING
 #define TEMP_BED_PIN (TEMP_SENSOR_BED == -1 ? 8 : 14) // ANALOG NUMBERING
 
-#define BEEPER 61
+#define BEEPER_PIN 61
 
 #define LCD_PINS_RS 32
 #define LCD_PINS_ENABLE 31

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -91,8 +91,8 @@
 #if ENABLED(ULTRA_LCD)
   #define KILL_PIN 32
   #if ENABLED(NEWPANEL)
-   //arduino pin which triggers an piezzo beeper
-    #define BEEPER 84      // Beeper on AUX-4
+
+    #define BEEPER_PIN 84      // Beeper on AUX-4
     #define LCD_PINS_RS 82
     #define LCD_PINS_ENABLE 18
     #define LCD_PINS_D4 19

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -89,7 +89,9 @@
 #define SUICIDE_PIN        -1  //PIN that has to be turned on right after start, to keep power flowing.
 
 #if ENABLED(ULTRA_LCD)
+
   #define KILL_PIN 32
+
   #if ENABLED(NEWPANEL)
 
     #define BEEPER_PIN 84      // Beeper on AUX-4
@@ -107,5 +109,5 @@
 
     #define SDCARDDETECT 15
 
-  #endif
+  #endif //NEWPANEL
 #endif //ULTRA_LCD

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -3,10 +3,10 @@
  */
 
 #ifndef __AVR_ATmega2560__
-#error Oops!  Make sure you have 'Arduino Mega 2560 or Rambo' selected from the 'Tools -> Boards' menu.
+  #error Oops!  Make sure you have 'Arduino Mega 2560 or Rambo' selected from the 'Tools -> Boards' menu.
 #endif
 
-#define LARGE_FLASH true
+#define LARGE_FLASH         true
 
 
 #undef X_MS1_PIN
@@ -20,94 +20,94 @@
 #undef E1_MS1_PIN
 #undef E1_MS2_PIN
  
-#define X_STEP_PIN 37
-#define X_DIR_PIN 48
-#define X_MIN_PIN 12
-#define X_MAX_PIN 30
-#define X_ENABLE_PIN 29
-#define X_MS1_PIN 40
-#define X_MS2_PIN 41
+#define X_STEP_PIN          37
+#define X_DIR_PIN           48
+#define X_MIN_PIN           12
+#define X_MAX_PIN           30
+#define X_ENABLE_PIN        29
+#define X_MS1_PIN           40
+#define X_MS2_PIN           41
 
-#define Y_STEP_PIN 36
-#define Y_DIR_PIN 49
-#define Y_MIN_PIN 11
-#define Y_MAX_PIN 24
-#define Y_ENABLE_PIN 28
-#define Y_MS1_PIN 69
-#define Y_MS2_PIN 39
+#define Y_STEP_PIN          36
+#define Y_DIR_PIN           49
+#define Y_MIN_PIN           11
+#define Y_MAX_PIN           24
+#define Y_ENABLE_PIN        28
+#define Y_MS1_PIN           69
+#define Y_MS2_PIN           39
 
-#define Z_STEP_PIN 35
-#define Z_DIR_PIN 47
-#define Z_MIN_PIN 10
-#define Z_MAX_PIN 23
-#define Z_ENABLE_PIN 27
-#define Z_MS1_PIN 68
-#define Z_MS2_PIN 67
+#define Z_STEP_PIN          35
+#define Z_DIR_PIN           47
+#define Z_MIN_PIN           10
+#define Z_MAX_PIN           23
+#define Z_ENABLE_PIN        27
+#define Z_MS1_PIN           68
+#define Z_MS2_PIN           67
 
-#define HEATER_BED_PIN 4
-#define TEMP_BED_PIN 2
+#define HEATER_BED_PIN       4
+#define TEMP_BED_PIN         2
 
-#define HEATER_0_PIN 3
-#define TEMP_0_PIN 0
+#define HEATER_0_PIN         3
+#define TEMP_0_PIN           0
 
-#define HEATER_1_PIN 7
-#define TEMP_1_PIN 1
+#define HEATER_1_PIN         7
+#define TEMP_1_PIN           1
 
 #if ENABLED(BARICUDA)
-  #define HEATER_2_PIN 6
+  #define HEATER_2_PIN       6
 #else
-  #define HEATER_2_PIN -1
+  #define HEATER_2_PIN      -1
 #endif
 
-#define TEMP_2_PIN -1
+#define TEMP_2_PIN          -1
 
 #define E0_STEP_PIN         34
 #define E0_DIR_PIN          43
 #define E0_ENABLE_PIN       26
-#define E0_MS1_PIN 65
-#define E0_MS2_PIN 66
+#define E0_MS1_PIN          65
+#define E0_MS2_PIN          66
 
 #define E1_STEP_PIN         -1
 #define E1_DIR_PIN          -1
 #define E1_ENABLE_PIN       -1
-#define E1_MS1_PIN -1
-#define E1_MS2_PIN -1
+#define E1_MS1_PIN          -1
+#define E1_MS2_PIN          -1
 
 #define MOTOR_CURRENT_PWM_XY_PIN 46
-#define MOTOR_CURRENT_PWM_Z_PIN 45
-#define MOTOR_CURRENT_PWM_E_PIN 44
+#define MOTOR_CURRENT_PWM_Z_PIN  45
+#define MOTOR_CURRENT_PWM_E_PIN  44
 //Motor current PWM conversion, PWM value = MotorCurrentSetting * 255 / range
 #define MOTOR_CURRENT_PWM_RANGE 2000
 #define DEFAULT_PWM_MOTOR_CURRENT  {1300, 1300, 1250}
-#define SDPOWER            -1
-#define SDSS               53
-#define LED_PIN            13
-#define FAN_PIN            8
-#define FAN_1_PIN 6
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1 //80 with Smart Controller LCD
-#define SUICIDE_PIN        -1  //PIN that has to be turned on right after start, to keep power flowing.
+#define SDPOWER             -1
+#define SDSS                53
+#define LED_PIN             13
+#define FAN_PIN              8
+#define FAN_1_PIN            6
+#define PS_ON_PIN           -1
+#define KILL_PIN            -1  // 80 with Smart Controller LCD
+#define SUICIDE_PIN         -1  // PIN that has to be turned on right after start, to keep power flowing.
 
 #if ENABLED(ULTRA_LCD)
 
-  #define KILL_PIN 32
+  #define KILL_PIN          32
 
   #if ENABLED(NEWPANEL)
 
-    #define BEEPER_PIN 84      // Beeper on AUX-4
-    #define LCD_PINS_RS 82
+    #define BEEPER_PIN      84  // Beeper on AUX-4
+    #define LCD_PINS_RS     82
     #define LCD_PINS_ENABLE 18
-    #define LCD_PINS_D4 19
-    #define LCD_PINS_D5 70
-    #define LCD_PINS_D6 85
-    #define LCD_PINS_D7 71
+    #define LCD_PINS_D4     19
+    #define LCD_PINS_D5     70
+    #define LCD_PINS_D6     85
+    #define LCD_PINS_D7     71
 
     //buttons are directly attached using AUX-2
-    #define BTN_EN1 14
-    #define BTN_EN2 72
-    #define BTN_ENC 9  //the click
+    #define BTN_EN1         14
+    #define BTN_EN2         72
+    #define BTN_ENC          9  // the click
 
-    #define SDCARDDETECT 15
+    #define SDCARDDETECT    15
 
   #endif //NEWPANEL
 #endif //ULTRA_LCD

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -59,8 +59,7 @@
 #define HEATER_BED_PIN 3 // BED
 #define TEMP_BED_PIN 6 // ANALOG NUMBERING
 
-#define BEEPER -1
-
+#define BEEPER_PIN -1
 
 #define LCD_PINS_RS -1
 #define LCD_PINS_ENABLE -1

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -79,7 +79,7 @@
 
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
   //we have no buzzer installed
-  #define BEEPER -1
+  #define BEEPER_PIN -1
   //LCD Pins
   #if ENABLED(LCD_I2C_PANELOLU2)
     #define BTN_EN1 27  //RX1 - fastio.h pin mapping 27
@@ -92,7 +92,7 @@
 #endif // ULTRA_LCD && NEWPANEL
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
- #define BEEPER 32 //FastIO
+ #define BEEPER_PIN 32 //FastIO
  // Pins for DOGM SPI LCD Support
  #define DOGLCD_A0  42 //Non-FastIO
  #define DOGLCD_CS  43 //Non-FastIO

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -110,7 +110,9 @@
 #define SUICIDE_PIN        -1  //PIN that has to be turned on right after start, to keep power flowing.
 
 #if ENABLED(ULTRA_LCD)
+
   #define KILL_PIN 80
+
   #if ENABLED(NEWPANEL)
 
     #define BEEPER_PIN 79      // Beeper on AUX-4
@@ -138,7 +140,7 @@
     #define BEEPER_PIN 33    // No Beeper added
 
     //buttons are attached to a shift register
-    // Not wired this yet
+    // Not wired yet
     // #define SHIFT_CLK 38
     // #define SHIFT_LD 42
     // #define SHIFT_OUT 40

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -112,8 +112,9 @@
 #if ENABLED(ULTRA_LCD)
   #define KILL_PIN 80
   #if ENABLED(NEWPANEL)
-   //arduino pin which triggers an piezzo beeper
-    #define BEEPER 79      // Beeper on AUX-4
+
+    #define BEEPER_PIN 79      // Beeper on AUX-4
+
     #define LCD_PINS_RS 70
     #define LCD_PINS_ENABLE 71
     #define LCD_PINS_D4 72
@@ -133,8 +134,9 @@
     #define SDCARDDETECT 81    // Ramps does not use this port
 
   #else //!NEWPANEL - old style panel with shift register
-    //arduino pin witch triggers an piezzo beeper
-    #define BEEPER 33    No Beeper added
+
+    #define BEEPER_PIN 33    // No Beeper added
+
     //buttons are attached to a shift register
     // Not wired this yet
     // #define SHIFT_CLK 38
@@ -165,7 +167,7 @@
 #endif // ULTRA_LCD
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
- #define BEEPER 44
+ #define BEEPER_PIN 44
  // Pins for DOGM SPI LCD Support
  #define DOGLCD_A0  70 
  #define DOGLCD_CS  71 

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -159,7 +159,7 @@
     #endif
 
     #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
-      #define BEEPER 37
+      #define BEEPER_PIN 37
 
       #define BTN_EN1 31
       #define BTN_EN2 33
@@ -186,12 +186,12 @@
       #define SDCARDDETECT 49
       #define LCD_SDSS 53
       #define KILL_PIN 41
-      #define BEEPER 23
+      #define BEEPER_PIN 23
       #define DOGLCD_CS 29
       #define DOGLCD_A0 27
       #define LCD_PIN_BL 33
     #elif defined(MINIPANEL)
-       #define BEEPER 42
+       #define BEEPER_PIN 42
        // Pins for DOGM SPI LCD Support
        #define DOGLCD_A0  44
        #define DOGLCD_CS  66
@@ -211,9 +211,10 @@
        #define BTN_ENC 59  //the click switch
        //not connected to a pin
        #define SDCARDDETECT 49
+
     #else
-      // arduino pin which triggers an piezzo beeper
-      #define BEEPER 33  // Beeper on AUX-4
+
+      #define BEEPER_PIN 33  // Beeper on AUX-4
 
       // buttons are directly attached using AUX-2
       #if ENABLED(REPRAPWORLD_KEYPAD)
@@ -241,8 +242,8 @@
 
     #endif
   #else // !NEWPANEL (Old-style panel with shift register)
-    // Arduino pin to trigger a piezzo beeper
-    #define BEEPER 33   // No Beeper added
+
+    #define BEEPER_PIN 33   // No Beeper added
 
     // Buttons are attached to a shift register
     // Not wired yet

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -22,8 +22,8 @@
 
 #if ENABLED(RIGIDBOT_PANEL)
 
-  #undef BEEPER
-  #define BEEPER -1
+  #undef BEEPER_PIN
+  #define BEEPER_PIN -1
 
   #undef SDCARDDETECT
   #define SDCARDDETECT 22
@@ -48,8 +48,8 @@
 
 #elif defined(REPRAP_DISCOUNT_SMART_CONTROLLER)
 
-  #undef BEEPER
-  #define BEEPER -1
+  #undef BEEPER_PIN
+  #define BEEPER_PIN -1
 
   #undef  SDCARDDETECT
   #define SDCARDDETECT 22

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -102,7 +102,7 @@
 #define SDPOWER            -1
 #define SDSS               53
 #define SDCARDDETECT       49
-#define BEEPER             44
+#define BEEPER_PIN         44
 #define LCD_PINS_RS        19
 #define LCD_PINS_ENABLE    42
 #define LCD_PINS_D4        18

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -95,7 +95,7 @@
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
 
   // No buzzer installed
-  #define BEEPER -1
+  #define BEEPER_PIN -1
 
   // LCD Pins
   #if ENABLED(DOGLCD)
@@ -106,7 +106,7 @@
         #define LCD_PINS_RS     30 //CS chip select /SS chip slave select
         #define LCD_PINS_ENABLE 29 //SID (MOSI)
         #define LCD_PINS_D4     17 //SCK (CLK) clock
-        #define BEEPER          27 // Pin 27 is take by LED_Pin, but Melzi LED do nothing with Marlin and I take this pin for BEEPER.... See here > [github.com] , If you want use this pin with Gcode M42 instead BEEPER
+        #define BEEPER_PIN      27 // Pin 27 is taken by LED_PIN, but Melzi LED does nothing with Marlin so this can be used for BEEPER_PIN. You can use this pin with M42 instead of BEEPER_PIN.
       #else         // Sanguinololu 1.3
         #define LCD_PINS_RS      4 
         #define LCD_PINS_ENABLE 17 
@@ -160,7 +160,7 @@
 
 #elif ENABLED(MAKRPANEL)
 
-  #define BEEPER                29
+  #define BEEPER_PIN            29
 
   // Pins for DOGM SPI LCD Support
   #define DOGLCD_A0             30

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -85,7 +85,7 @@
 #define ALARM_PIN          -1
 #define SDCARDDETECT       -1
 
-#define BEEPER             -1
+#define BEEPER_PIN         -1
 #define LCD_PINS_RS        -1
 #define LCD_PINS_ENABLE    -1
 #define LCD_PINS_D4        -1

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -68,7 +68,6 @@
 #endif
 
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
-  //LCD Pins
 
   #define BEEPER_PIN -1
 
@@ -78,7 +77,8 @@
     #define BTN_ENC 43 //A3 - fastio.h pin mapping 43
     #define SDSS   40 //use SD card on Panelolu2 (Teensyduino pin mapping)
   #endif // LCD_I2C_PANELOLU2
-  //not connected to a pin
+
   #define SDCARDDETECT -1    
+
 #endif // ULTRA_LCD && NEWPANEL
 

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -69,16 +69,16 @@
 
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
 
-  #define BEEPER_PIN -1
+  #define BEEPER_PIN       -1
 
   #if ENABLED(LCD_I2C_PANELOLU2)
-    #define BTN_EN1 27  //RX1 - fastio.h pin mapping 27
-    #define BTN_EN2 26  //TX1 - fastio.h pin mapping 26
-    #define BTN_ENC 43 //A3 - fastio.h pin mapping 43
-    #define SDSS   40 //use SD card on Panelolu2 (Teensyduino pin mapping)
+    #define BTN_EN1        27  //RX1 - fastio.h pin mapping 27
+    #define BTN_EN2        26  //TX1 - fastio.h pin mapping 26
+    #define BTN_ENC        43  //A3 - fastio.h pin mapping 43
+    #define SDSS           40  //use SD card on Panelolu2 (Teensyduino pin mapping)
   #endif // LCD_I2C_PANELOLU2
 
-  #define SDCARDDETECT -1    
+  #define SDCARDDETECT     -1
 
 #endif // ULTRA_LCD && NEWPANEL
 

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -68,9 +68,10 @@
 #endif
 
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
-  //we have no buzzer installed
-  #define BEEPER -1
   //LCD Pins
+
+  #define BEEPER_PIN -1
+
   #if ENABLED(LCD_I2C_PANELOLU2)
     #define BTN_EN1 27  //RX1 - fastio.h pin mapping 27
     #define BTN_EN2 26  //TX1 - fastio.h pin mapping 26

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -58,8 +58,7 @@
 #define MOTOR_CURRENT_PWM_RANGE 2000
 #define DEFAULT_PWM_MOTOR_CURRENT  {1300, 1300, 1250}
 
-//arduino pin witch triggers an piezzo beeper
-#define BEEPER 18
+#define BEEPER_PIN 18
 
 #define LCD_PINS_RS 20
 #define LCD_PINS_ENABLE 15

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -57,9 +57,9 @@
 
 #if ENABLED(ULTRA_LCD)
 
+  #define BEEPER_PIN 18
+
   #if ENABLED(NEWPANEL)
-  //arduino pin witch triggers an piezzo beeper
-    #define BEEPER 18
 
     #define LCD_PINS_RS 20
     #define LCD_PINS_ENABLE 17
@@ -71,14 +71,11 @@
     //buttons are directly attached
     #define BTN_EN1 40
     #define BTN_EN2 42
-    #define BTN_ENC 19  //the click
+    #define BTN_ENC 19
 
     #define SDCARDDETECT 38
 
   #else //!NEWPANEL - Old style panel with shift register
-
-    //arduino pin witch triggers an piezzo beeper
-    #define BEEPER 18
 
     //buttons are attached to a shift register
     #define SHIFT_CLK 38

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1325,7 +1325,7 @@ void lcd_quick_feedback() {
       #define LCD_FEEDBACK_FREQUENCY_DURATION_MS (1000/6)
     #endif    
     lcd.buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
-  #elif defined(BEEPER) && BEEPER >= 0
+  #elif PIN_EXISTS(BEEPER)
     #ifndef LCD_FEEDBACK_FREQUENCY_HZ
       #define LCD_FEEDBACK_FREQUENCY_HZ 5000
     #endif


### PR DESCRIPTION
For consistency with other pins, allowing use of `PIN_EXISTS` macro.
