### PR TITLE
Rename SDCARDDETECT to SD_DETECT_PIN

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -321,7 +321,7 @@
   #endif
 
   #if ENABLED(ULTIPANEL) && DISABLED(ELB_FULL_GRAPHIC_CONTROLLER)
-    #undef SDCARDDETECTINVERTED
+    #undef SD_DETECT_INVERTED
   #endif
 
   // Power Signal Control Definitions

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -674,7 +674,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -291,13 +291,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #ifndef ELB_FULL_GRAPHIC_CONTROLLER
-    #define SDCARDDETECTINVERTED
-  #endif
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -366,4 +366,12 @@
     #error BEEPER has been replaced with BEEPER_PIN. Please update your pins definitions.
   #endif
 
+  #ifdef SDCARDDETECT
+    #error SDCARDDETECT is now SD_DETECT_PIN. Please update your pins definitions.
+  #endif
+
+  #ifdef SDCARDDETECTINVERTED
+    #error SDCARDDETECTINVERTED is now SD_DETECT_INVERTED. Please update your configuration.
+  #endif
+
 #endif //SANITYCHECK_H

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -81,11 +81,11 @@ extern CardReader card;
 
 #define IS_SD_PRINTING (card.sdprinting)
 
-#if (SDCARDDETECT > -1)
+#if PIN_EXISTS(SDCARDDETECT)
   #if ENABLED(SDCARDDETECTINVERTED)
-    #define IS_SD_INSERTED (READ(SDCARDDETECT) != 0)
+    #define IS_SD_INSERTED (READ(SDCARDDETECT_PIN) != 0)
   #else
-    #define IS_SD_INSERTED (READ(SDCARDDETECT) == 0)
+    #define IS_SD_INSERTED (READ(SDCARDDETECT_PIN) == 0)
   #endif
 #else
   //No card detect line? Assume the card is inserted.

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -81,11 +81,11 @@ extern CardReader card;
 
 #define IS_SD_PRINTING (card.sdprinting)
 
-#if PIN_EXISTS(SDCARDDETECT)
-  #if ENABLED(SDCARDDETECTINVERTED)
-    #define IS_SD_INSERTED (READ(SDCARDDETECT_PIN) != 0)
+#if PIN_EXISTS(SD_DETECT)
+  #if ENABLED(SD_DETECT_INVERTED)
+    #define IS_SD_INSERTED (READ(SD_DETECT_PIN) != 0)
   #else
-    #define IS_SD_INSERTED (READ(SDCARDDETECT_PIN) == 0)
+    #define IS_SD_INSERTED (READ(SD_DETECT_PIN) == 0)
   #endif
 #else
   //No card detect line? Assume the card is inserted.

--- a/Marlin/configurator/config/Configuration.h
+++ b/Marlin/configurator/config/Configuration.h
@@ -674,7 +674,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -291,13 +291,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #ifndef ELB_FULL_GRAPHIC_CONTROLLER
-    #define SDCARDDETECTINVERTED
-  #endif
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -652,7 +652,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -610,7 +610,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -661,7 +661,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic 
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -657,7 +657,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -669,7 +669,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -649,7 +649,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -292,11 +292,11 @@
 #if ENABLED(SDSUPPORT)
 
   // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
+  // You can get round this by connecting a push button or single throw switch to the pin defined as SD_DETECT_PIN
   // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
   // be commented out otherwise
   #ifndef ELB_FULL_GRAPHIC_CONTROLLER
-    #define SDCARDDETECTINVERTED
+    #define SD_DETECT_INVERTED
   #endif
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -677,7 +677,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -661,7 +661,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic 
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -669,7 +669,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 #define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -789,7 +789,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic 
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -300,11 +300,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -789,7 +789,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic 
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -300,11 +300,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -793,7 +793,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -788,7 +788,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -340,11 +340,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
@@ -452,7 +453,7 @@
 const unsigned int dropsegments=5; //everything with less than this number of steps will be ignored as move and joined with the next movement
 
 #if ENABLED(ULTIPANEL)
- #undef SDCARDDETECTINVERTED
+ #undef SD_DETECT_INVERTED
 #endif
 
 // Power Signal Control Definitions

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -672,7 +672,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the logic
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -300,10 +300,10 @@
 #if ENABLED(SDSUPPORT)
 
   // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
+  // You can get round this by connecting a push button or single throw switch to the pin defined as SD_DETECT_PIN
   // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
   // be commented out otherwise
-  //#define SDCARDDETECTINVERTED
+  //#define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -663,7 +663,7 @@ const bool Z_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the logic 
 //
 // ==> REMEMBER TO INSTALL U8glib to your ARDUINO library folder: http://code.google.com/p/u8glib/wiki/u8glib
 //#define ELB_FULL_GRAPHIC_CONTROLLER
-//#define SDCARDDETECTINVERTED
+//#define SD_DETECT_INVERTED
 
 // The RepRapDiscount Smart Controller (white PCB)
 // http://reprap.org/wiki/RepRapDiscount_Smart_Controller

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -299,11 +299,12 @@
 
 #if ENABLED(SDSUPPORT)
 
-  // If you are using a RAMPS board or cheap E-bay purchased boards that do not detect when an SD card is inserted
-  // You can get round this by connecting a push button or single throw switch to the pin defined as SDCARDCARDDETECT
-  // in the pins.h file.  When using a push button pulling the pin to ground this will need inverted.  This setting should
-  // be commented out otherwise
-  #define SDCARDDETECTINVERTED
+  // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
+  // around this by connecting a push button or single throw switch to the pin defined
+  // as SD_DETECT_PIN in your board's pins definitions.
+  // This setting should be disabled unless you are using a push button, pulling the pin to ground.
+  // Note: This is always disabled for ULTIPANEL (except ELB_FULL_GRAPHIC_CONTROLLER).
+  #define SD_DETECT_INVERTED
 
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -21,7 +21,7 @@
   #define BTN_ENC           12  //the click switch
 
   #define SDSS              53
-  #define SDCARDDETECT      -1  // Pin 49 if using display sd interface
+  #define SD_DETECT      -1  // Pin 49 if using display sd interface
 
   #if ENABLED(TEMP_STAT_LEDS)
     #define STAT_LED_RED    64

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -109,7 +109,7 @@
   #define BTN_ENC          39  //the click switch
  
   #define SDSS             53
-  #define SDCARDDETECT_PIN 49
+  #define SD_DETECT_PIN 49
   
   #define KILL_PIN         31
  #endif

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -109,7 +109,7 @@
   #define BTN_ENC          39  //the click switch
  
   #define SDSS             53
-  #define SDCARDDETECT     49
+  #define SDCARDDETECT_PIN 49
   
   #define KILL_PIN         31
  #endif

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -54,7 +54,7 @@
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
 #define ALARM_PIN          -1
-#define SDCARDDETECT_PIN   12
+#define SD_DETECT_PIN      12
 
 #if DISABLED(SDSUPPORT)
 // these pins are defined in the SD library if building with SD support

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -54,7 +54,7 @@
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
 #define ALARM_PIN          -1
-#define SDCARDDETECT       12
+#define SDCARDDETECT_PIN   12
 
 #if DISABLED(SDSUPPORT)
 // these pins are defined in the SD library if building with SD support

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -86,4 +86,4 @@
 #define BLEN_A 0
 
 // Cheaptronic v1.0 doesn't use this
-#define SDCARDDETECT_PIN -1
+#define SD_DETECT_PIN -1

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -86,4 +86,4 @@
 #define BLEN_A 0
 
 // Cheaptronic v1.0 does not use this port
-#define SDCARDDETECT -1
+#define SDCARDDETECT_PIN -1

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -85,5 +85,5 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-// Cheaptronic v1.0 does not use this port
+// Cheaptronic v1.0 doesn't use this
 #define SDCARDDETECT_PIN -1

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -64,7 +64,7 @@
 #if ENABLED(RA_CONTROL_PANEL)
 
   #define SDSS             53
-  #define SDCARDDETECT     28
+  #define SDCARDDETECT_PIN 28
 
   #define BTN_EN1          14
   #define BTN_EN2          39

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -64,7 +64,7 @@
 #if ENABLED(RA_CONTROL_PANEL)
 
   #define SDSS             53
-  #define SDCARDDETECT_PIN 28
+  #define SD_DETECT_PIN    28
 
   #define BTN_EN1          14
   #define BTN_EN2          39

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -19,6 +19,6 @@
   #define BLEN_C 2
   #define BLEN_B 1
   #define BLEN_A 0
-  #define SDCARDDETECT 6
+  #define SDCARDDETECT_PIN 6
 
 #endif // NEWPANEL && ULTRA_LCD

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -19,6 +19,6 @@
   #define BLEN_C 2
   #define BLEN_B 1
   #define BLEN_A 0
-  #define SDCARDDETECT_PIN 6
+  #define SD_DETECT_PIN 6
 
 #endif // NEWPANEL && ULTRA_LCD

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -57,7 +57,7 @@
 //#define RX_ENABLE_PIN       13
 
 #define BEEPER_PIN -1
-#define SDCARDDETECT_PIN -1
+#define SD_DETECT_PIN -1
 #define SUICIDE_PIN -1    //has to be defined; otherwise Power_off doesn't work
 
 #define KILL_PIN -1

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -57,7 +57,7 @@
 //#define RX_ENABLE_PIN       13
 
 #define BEEPER_PIN -1
-#define SDCARDDETECT -1
+#define SDCARDDETECT_PIN -1
 #define SUICIDE_PIN -1    //has to be defined; otherwise Power_off doesn't work
 
 #define KILL_PIN -1

--- a/Marlin/pins_LEAPFROG.h
+++ b/Marlin/pins_LEAPFROG.h
@@ -42,7 +42,7 @@
 
 #define SDPOWER            -1
 #define SDSS               11
-#define SDCARDDETECT       -1 // 10 optional also used as mode pin
+#define SDCARDDETECT_PIN   -1 // 10 optional also used as mode pin
 #define LED_PIN            13
 #define FAN_PIN            7
 #define PS_ON_PIN          -1

--- a/Marlin/pins_LEAPFROG.h
+++ b/Marlin/pins_LEAPFROG.h
@@ -42,7 +42,7 @@
 
 #define SDPOWER            -1
 #define SDSS               11
-#define SDCARDDETECT_PIN   -1 // 10 optional also used as mode pin
+#define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
 #define LED_PIN            13
 #define FAN_PIN            7
 #define PS_ON_PIN          -1

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -107,6 +107,6 @@
     #define BTN_EN2 11
     #define BTN_ENC 10  //the click switch
     //not connected to a pin
-    #define SDCARDDETECT_PIN 49
+    #define SD_DETECT_PIN 49
 #endif //Minipanel
 

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -107,6 +107,6 @@
     #define BTN_EN2 11
     #define BTN_ENC 10  //the click switch
     //not connected to a pin
-    #define SDCARDDETECT 49
+    #define SDCARDDETECT_PIN 49
 #endif //Minipanel
 

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -78,6 +78,6 @@
   #define BLEN_B           1
   #define BLEN_A           0
 
-  #define SDCARDDETECT    -1   // RAMPS doesn't use this
+  #define SDCARDDETECT_PIN -1   // RAMPS doesn't use this
 
 #endif // ULTRA_LCD && NEWPANEL

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -78,6 +78,6 @@
   #define BLEN_B           1
   #define BLEN_A           0
 
-  #define SDCARDDETECT_PIN -1   // RAMPS doesn't use this
+  #define SD_DETECT_PIN   -1   // RAMPS doesn't use this
 
 #endif // ULTRA_LCD && NEWPANEL

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -94,4 +94,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN -1  // Megatronics does not use this port
+#define SDCARDDETECT_PIN -1  // Megatronics doesn't use this

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -94,4 +94,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT -1  // Megatronics does not use this port
+#define SDCARDDETECT_PIN -1  // Megatronics does not use this port

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -94,4 +94,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN -1  // Megatronics doesn't use this
+#define SD_DETECT_PIN -1  // Megatronics doesn't use this

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -99,4 +99,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN -1	// Megatronics doesn't use this
+#define SD_DETECT_PIN -1	// Megatronics doesn't use this

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -99,4 +99,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN -1	// Megatronics does not use this port
+#define SDCARDDETECT_PIN -1	// Megatronics doesn't use this

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -99,4 +99,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT -1	// Megatronics does not use this port
+#define SDCARDDETECT_PIN -1	// Megatronics does not use this port

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -107,7 +107,7 @@
     #define BTN_EN2         72
     #define BTN_ENC          9  // the click
 
-    #define SDCARDDETECT_PIN 15
+    #define SD_DETECT_PIN   15
 
   #endif //NEWPANEL
 #endif //ULTRA_LCD

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -107,7 +107,7 @@
     #define BTN_EN2         72
     #define BTN_ENC          9  // the click
 
-    #define SDCARDDETECT    15
+    #define SDCARDDETECT_PIN 15
 
   #endif //NEWPANEL
 #endif //ULTRA_LCD

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -78,4 +78,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN -1  // Minitronics doesn't use this
+#define SD_DETECT_PIN -1  // Minitronics doesn't use this

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -78,4 +78,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN -1  // Minitronics does not use this port
+#define SDCARDDETECT_PIN -1  // Minitronics doesn't use this

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -78,4 +78,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT -1  // Megatronics does not use this port
+#define SDCARDDETECT_PIN -1  // Minitronics does not use this port

--- a/Marlin/pins_OMCA.h
+++ b/Marlin/pins_OMCA.h
@@ -70,7 +70,7 @@
 
 #define SDPOWER            -1
 #define SDSS               11
-#define SDCARDDETECT       -1 // 10 optional also used as mode pin
+#define SDCARDDETECT_PIN   -1 // 10 optional also used as mode pin
 #define LED_PIN            -1
 #define FAN_PIN            14 // PWM on MIDDLE connector
 #define PS_ON_PIN          -1

--- a/Marlin/pins_OMCA.h
+++ b/Marlin/pins_OMCA.h
@@ -70,7 +70,7 @@
 
 #define SDPOWER            -1
 #define SDSS               11
-#define SDCARDDETECT_PIN   -1 // 10 optional also used as mode pin
+#define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
 #define LED_PIN            -1
 #define FAN_PIN            14 // PWM on MIDDLE connector
 #define PS_ON_PIN          -1

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -61,7 +61,7 @@
 
 #define SDPOWER            -1
 #define SDSS               11
-#define SDCARDDETECT_PIN   -1 // 10 optional also used as mode pin
+#define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
 #define LED_PIN            -1
 #define FAN_PIN            3
 #define PS_ON_PIN          -1

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -35,39 +35,39 @@
 #define X_STEP_PIN         21
 #define X_DIR_PIN          20
 #define X_ENABLE_PIN       24
-#define X_STOP_PIN         0
+#define X_STOP_PIN          0
 
 #define Y_STEP_PIN         23
 #define Y_DIR_PIN          22
 #define Y_ENABLE_PIN       24
-#define Y_STOP_PIN         1
+#define Y_STOP_PIN          1
 
 #define Z_STEP_PIN         26
 #define Z_DIR_PIN          25
 #define Z_ENABLE_PIN       24
-#define Z_STOP_PIN         2
+#define Z_STOP_PIN          2
 
-#define E0_STEP_PIN         28
-#define E0_DIR_PIN          27
-#define E0_ENABLE_PIN       24
+#define E0_STEP_PIN        28
+#define E0_DIR_PIN         27
+#define E0_ENABLE_PIN      24
 
-#define E1_STEP_PIN         -1 // 19
-#define E1_DIR_PIN          -1 // 18
-#define E1_ENABLE_PIN       24
+#define E1_STEP_PIN        -1 // 19
+#define E1_DIR_PIN         -1 // 18
+#define E1_ENABLE_PIN      24
 
-#define E2_STEP_PIN         -1 // 17
-#define E2_DIR_PIN          -1 // 16
-#define E2_ENABLE_PIN       24
+#define E2_STEP_PIN        -1 // 17
+#define E2_DIR_PIN         -1 // 16
+#define E2_ENABLE_PIN      24
 
 #define SDPOWER            -1
 #define SDSS               11
 #define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
 #define LED_PIN            -1
-#define FAN_PIN            3
+#define FAN_PIN             3
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
 
-#define HEATER_0_PIN       4
+#define HEATER_0_PIN        4
 #define HEATER_1_PIN       -1 // 12
 #define HEATER_2_PIN       -1 // 13
 #define TEMP_0_PIN          0 //D27   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -61,7 +61,7 @@
 
 #define SDPOWER            -1
 #define SDSS               11
-#define SDCARDDETECT       -1 // 10 optional also used as mode pin
+#define SDCARDDETECT_PIN   -1 // 10 optional also used as mode pin
 #define LED_PIN            -1
 #define FAN_PIN            3
 #define PS_ON_PIN          -1

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -88,7 +88,7 @@
     #define SDSS   40 //use SD card on Panelolu2 (Teensyduino pin mapping)
   #endif // LCD_I2C_PANELOLU2
   //not connected to a pin
-  #define SDCARDDETECT_PIN -1    
+  #define SD_DETECT_PIN -1    
 #endif // ULTRA_LCD && NEWPANEL
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
@@ -104,7 +104,7 @@
  #define BTN_ENC 47  //the click switch
 
  #define SDSS 45
- #define SDCARDDETECT_PIN -1 // FastIO (Manual says 72 I'm not certain cause I can't test) 
+ #define SD_DETECT_PIN -1 // FastIO (Manual says 72 I'm not certain cause I can't test) 
 
  #if ENABLED(TEMP_STAT_LEDS)
   #define STAT_LED_RED      12 //Non-FastIO

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -88,7 +88,7 @@
     #define SDSS   40 //use SD card on Panelolu2 (Teensyduino pin mapping)
   #endif // LCD_I2C_PANELOLU2
   //not connected to a pin
-  #define SDCARDDETECT -1    
+  #define SDCARDDETECT_PIN -1    
 #endif // ULTRA_LCD && NEWPANEL
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
@@ -104,7 +104,7 @@
  #define BTN_ENC 47  //the click switch
 
  #define SDSS 45
- #define SDCARDDETECT -1 // FastIO (Manual says 72 I'm not certain cause I can't test) 
+ #define SDCARDDETECT_PIN -1 // FastIO (Manual says 72 I'm not certain cause I can't test) 
 
  #if ENABLED(TEMP_STAT_LEDS)
   #define STAT_LED_RED      12 //Non-FastIO

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -133,7 +133,7 @@
     #define BLEN_B 1
     #define BLEN_A 0
 
-    #define SDCARDDETECT_PIN 81 // Ramps doesn't use this
+    #define SD_DETECT_PIN 81 // Ramps doesn't use this
 
   #else //!NEWPANEL - old style panel with shift register
 
@@ -180,7 +180,7 @@
  #define BTN_EN2 84
  #define BTN_ENC 83  //the click switch
 
- #define SDCARDDETECT_PIN -1 // Pin 72 if using easy adapter board   
+ #define SD_DETECT_PIN -1 // Pin 72 if using easy adapter board   
 
   #if ENABLED(TEMP_STAT_LEDS)
    #define STAT_LED_RED      22

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -133,7 +133,7 @@
     #define BLEN_B 1
     #define BLEN_A 0
 
-    #define SDCARDDETECT_PIN 81 // Ramps doesn't use this port
+    #define SDCARDDETECT_PIN 81 // Ramps doesn't use this
 
   #else //!NEWPANEL - old style panel with shift register
 

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -133,7 +133,7 @@
     #define BLEN_B 1
     #define BLEN_A 0
 
-    #define SDCARDDETECT 81    // Ramps does not use this port
+    #define SDCARDDETECT_PIN 81 // Ramps doesn't use this port
 
   #else //!NEWPANEL - old style panel with shift register
 
@@ -180,7 +180,7 @@
  #define BTN_EN2 84
  #define BTN_ENC 83  //the click switch
 
- #define SDCARDDETECT -1 // Pin 72 if using easy adapter board   
+ #define SDCARDDETECT_PIN -1 // Pin 72 if using easy adapter board   
 
   #if ENABLED(TEMP_STAT_LEDS)
    #define STAT_LED_RED      22

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -165,25 +165,25 @@
       #define BTN_EN2 33
       #define BTN_ENC 35
 
-      #define SDCARDDETECT 49
+      #define SDCARDDETECT_PIN 49
     #elif ENABLED(LCD_I2C_PANELOLU2)
       #define BTN_EN1 47  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 43
       #define BTN_ENC 32
       #define LCD_SDSS 53
-      #define SDCARDDETECT -1
+      #define SDCARDDETECT_PIN -1
       #define KILL_PIN 41
     #elif ENABLED(LCD_I2C_VIKI)
       #define BTN_EN1 22  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 7
       #define BTN_ENC -1
       #define LCD_SDSS 53
-      #define SDCARDDETECT 49
+      #define SDCARDDETECT_PIN 49
     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
       #define BTN_EN1 35  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 37
       #define BTN_ENC 31
-      #define SDCARDDETECT 49
+      #define SDCARDDETECT_PIN 49
       #define LCD_SDSS 53
       #define KILL_PIN 41
       #define BEEPER_PIN 23
@@ -210,7 +210,7 @@
        #define BTN_EN2 63
        #define BTN_ENC 59  //the click switch
        //not connected to a pin
-       #define SDCARDDETECT 49
+       #define SDCARDDETECT_PIN 49
 
     #else
 
@@ -235,9 +235,9 @@
       #endif
 
       #if ENABLED(G3D_PANEL)
-        #define SDCARDDETECT 49
+        #define SDCARDDETECT_PIN 49
       #else
-        #define SDCARDDETECT -1  // Ramps does not use this port
+        #define SDCARDDETECT_PIN -1  // Ramps does not use this port
       #endif
 
     #endif

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -165,25 +165,25 @@
       #define BTN_EN2 33
       #define BTN_ENC 35
 
-      #define SDCARDDETECT_PIN 49
+      #define SD_DETECT_PIN 49
     #elif ENABLED(LCD_I2C_PANELOLU2)
       #define BTN_EN1 47  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 43
       #define BTN_ENC 32
       #define LCD_SDSS 53
-      #define SDCARDDETECT_PIN -1
+      #define SD_DETECT_PIN -1
       #define KILL_PIN 41
     #elif ENABLED(LCD_I2C_VIKI)
       #define BTN_EN1 22  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 7
       #define BTN_ENC -1
       #define LCD_SDSS 53
-      #define SDCARDDETECT_PIN 49
+      #define SD_DETECT_PIN 49
     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
       #define BTN_EN1 35  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 37
       #define BTN_ENC 31
-      #define SDCARDDETECT_PIN 49
+      #define SD_DETECT_PIN 49
       #define LCD_SDSS 53
       #define KILL_PIN 41
       #define BEEPER_PIN 23
@@ -210,7 +210,7 @@
        #define BTN_EN2 63
        #define BTN_ENC 59  //the click switch
        //not connected to a pin
-       #define SDCARDDETECT_PIN 49
+       #define SD_DETECT_PIN 49
 
     #else
 
@@ -235,9 +235,9 @@
       #endif
 
       #if ENABLED(G3D_PANEL)
-        #define SDCARDDETECT_PIN 49
+        #define SD_DETECT_PIN 49
       #else
-        #define SDCARDDETECT_PIN -1  // Ramps doesn't use this
+        #define SD_DETECT_PIN -1  // Ramps doesn't use this
       #endif
 
     #endif

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -237,7 +237,7 @@
       #if ENABLED(G3D_PANEL)
         #define SDCARDDETECT_PIN 49
       #else
-        #define SDCARDDETECT_PIN -1  // Ramps does not use this port
+        #define SDCARDDETECT_PIN -1  // Ramps doesn't use this
       #endif
 
     #endif

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -25,8 +25,8 @@
   #undef BEEPER_PIN
   #define BEEPER_PIN -1
 
-  #undef SDCARDDETECT_PIN
-  #define SDCARDDETECT_PIN 22
+  #undef SD_DETECT_PIN
+  #define SD_DETECT_PIN 22
 
   // Extra button definitions, substitute for EN1 / EN2
   #define BTN_UP  37 // BTN_EN1
@@ -43,16 +43,16 @@
   #undef  BTN_ENC
   #define BTN_ENC 31
 
-  #undef  SDCARDDETECT_PIN
-  #define SDCARDDETECT_PIN 22
+  #undef  SD_DETECT_PIN
+  #define SD_DETECT_PIN 22
 
 #elif defined(REPRAP_DISCOUNT_SMART_CONTROLLER)
 
   #undef BEEPER_PIN
   #define BEEPER_PIN -1
 
-  #undef  SDCARDDETECT_PIN
-  #define SDCARDDETECT_PIN 22
+  #undef  SD_DETECT_PIN
+  #define SD_DETECT_PIN 22
 
   #undef  KILL_PIN
   #define KILL_PIN 32

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -25,8 +25,8 @@
   #undef BEEPER_PIN
   #define BEEPER_PIN -1
 
-  #undef SDCARDDETECT
-  #define SDCARDDETECT 22
+  #undef SDCARDDETECT_PIN
+  #define SDCARDDETECT_PIN 22
 
   // Extra button definitions, substitute for EN1 / EN2
   #define BTN_UP  37 // BTN_EN1
@@ -43,16 +43,16 @@
   #undef  BTN_ENC
   #define BTN_ENC 31
 
-  #undef  SDCARDDETECT
-  #define SDCARDDETECT 22
+  #undef  SDCARDDETECT_PIN
+  #define SDCARDDETECT_PIN 22
 
 #elif defined(REPRAP_DISCOUNT_SMART_CONTROLLER)
 
   #undef BEEPER_PIN
   #define BEEPER_PIN -1
 
-  #undef  SDCARDDETECT
-  #define SDCARDDETECT 22
+  #undef  SDCARDDETECT_PIN
+  #define SDCARDDETECT_PIN 22
 
   #undef  KILL_PIN
   #define KILL_PIN 32

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -101,7 +101,7 @@
 
 #define SDPOWER            -1
 #define SDSS               53
-#define SDCARDDETECT_PIN   49
+#define SD_DETECT_PIN      49
 #define BEEPER_PIN         44
 #define LCD_PINS_RS        19
 #define LCD_PINS_ENABLE    42

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -101,7 +101,7 @@
 
 #define SDPOWER            -1
 #define SDSS               53
-#define SDCARDDETECT       49
+#define SDCARDDETECT_PIN   49
 #define BEEPER_PIN         44
 #define LCD_PINS_RS        19
 #define LCD_PINS_ENABLE    42

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -156,7 +156,7 @@
     #define LCD_SDSS            28 // Smart Controller SD card reader rather than the Melzi
   #endif //Panelolu2
 
-  #define SDCARDDETECT          -1
+  #define SDCARDDETECT_PIN      -1
 
 #elif ENABLED(MAKRPANEL)
 
@@ -178,7 +178,7 @@
   #define BTN_EN2               10
   #define BTN_ENC               16
 
-  #define SDCARDDETECT          -1
+  #define SDCARDDETECT_PIN      -1
 
 #endif // MAKRPANEL
 

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -156,7 +156,7 @@
     #define LCD_SDSS            28 // Smart Controller SD card reader rather than the Melzi
   #endif //Panelolu2
 
-  #define SDCARDDETECT_PIN      -1
+  #define SD_DETECT_PIN         -1
 
 #elif ENABLED(MAKRPANEL)
 
@@ -178,7 +178,7 @@
   #define BTN_EN2               10
   #define BTN_ENC               16
 
-  #define SDCARDDETECT_PIN      -1
+  #define SD_DETECT_PIN         -1
 
 #endif // MAKRPANEL
 

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -83,7 +83,7 @@
 #define LED_PIN            -1
 #define PS_ON_PIN          -1
 #define ALARM_PIN          -1
-#define SDCARDDETECT_PIN   -1
+#define SD_DETECT_PIN      -1
 
 #define BEEPER_PIN         -1
 #define LCD_PINS_RS        -1

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -83,7 +83,7 @@
 #define LED_PIN            -1
 #define PS_ON_PIN          -1
 #define ALARM_PIN          -1
-#define SDCARDDETECT       -1
+#define SDCARDDETECT_PIN   -1
 
 #define BEEPER_PIN         -1
 #define LCD_PINS_RS        -1

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -86,7 +86,7 @@
 #define TEMP_2_PIN         -1
 
 #define SDPOWER            -1
-#define SDCARDDETECT       -1   
+#define SDCARDDETECT_PIN   -1   
 #define SDSS               20 // 8
 #define LED_PIN             6
 #define PS_ON_PIN          27

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -86,7 +86,7 @@
 #define TEMP_2_PIN         -1
 
 #define SDPOWER            -1
-#define SDCARDDETECT_PIN   -1   
+#define SD_DETECT_PIN      -1   
 #define SDSS               20 // 8
 #define LED_PIN             6
 #define PS_ON_PIN          27

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -78,7 +78,7 @@
     #define SDSS           40  //use SD card on Panelolu2 (Teensyduino pin mapping)
   #endif // LCD_I2C_PANELOLU2
 
-  #define SDCARDDETECT     -1
+  #define SDCARDDETECT_PIN -1    
 
 #endif // ULTRA_LCD && NEWPANEL
 

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -78,7 +78,7 @@
     #define SDSS           40  //use SD card on Panelolu2 (Teensyduino pin mapping)
   #endif // LCD_I2C_PANELOLU2
 
-  #define SDCARDDETECT_PIN -1    
+  #define SD_DETECT_PIN    -1    
 
 #endif // ULTRA_LCD && NEWPANEL
 

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -76,4 +76,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT 39
+#define SDCARDDETECT_PIN 39

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -76,4 +76,4 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SDCARDDETECT_PIN 39
+#define SD_DETECT_PIN 39

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -73,7 +73,7 @@
     #define BTN_EN2 42
     #define BTN_ENC 19
 
-    #define SDCARDDETECT_PIN 38
+    #define SD_DETECT_PIN 38
 
   #else //!NEWPANEL - Old style panel with shift register
 
@@ -90,7 +90,7 @@
     #define LCD_PINS_D6 20
     #define LCD_PINS_D7 19
 
-    #define SDCARDDETECT_PIN -1
+    #define SD_DETECT_PIN -1
 
   #endif // !NEWPANEL
 

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -73,7 +73,7 @@
     #define BTN_EN2 42
     #define BTN_ENC 19
 
-    #define SDCARDDETECT 38
+    #define SDCARDDETECT_PIN 38
 
   #else //!NEWPANEL - Old style panel with shift register
 
@@ -90,7 +90,7 @@
     #define LCD_PINS_D6 20
     #define LCD_PINS_D7 19
 
-    #define SDCARDDETECT -1
+    #define SDCARDDETECT_PIN -1
 
   #endif // !NEWPANEL
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -221,7 +221,7 @@ static void lcd_status_screen();
   millis_t next_button_update_ms;
   uint8_t lastEncoderBits;
   uint32_t encoderPosition;
-  #if (SDCARDDETECT > 0)
+  #if PIN_EXISTS(SDCARDDETECT)
     bool lcd_oldcardstatus;
   #endif
 
@@ -411,14 +411,14 @@ static void lcd_main_menu() {
       }
       else {
         MENU_ITEM(submenu, MSG_CARD_MENU, lcd_sdcard_menu);
-        #if SDCARDDETECT < 1
+        #if !PIN_EXISTS(SDCARDDETECT)
           MENU_ITEM(gcode, MSG_CNG_SDCARD, PSTR("M21"));  // SD-card changed by user
         #endif
       }
     }
     else {
       MENU_ITEM(submenu, MSG_NO_CARD, lcd_sdcard_menu);
-      #if SDCARDDETECT < 1
+      #if !PIN_EXISTS(SDCARDDETECT)
         MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21")); // Manually initialize the SD-card via user interface
       #endif
     }
@@ -1156,7 +1156,7 @@ static void lcd_control_volumetric_menu() {
   }
 #endif // FWRETRACT
 
-#if SDCARDDETECT == -1
+#if !PIN_EXISTS(SDCARDDETECT)
   static void lcd_sd_refresh() {
     card.initsd();
     currentMenuViewOffset = 0;
@@ -1180,7 +1180,7 @@ void lcd_sdcard_menu() {
   MENU_ITEM(back, MSG_MAIN, lcd_main_menu);
   card.getWorkDirName();
   if (card.filename[0] == '/') {
-    #if SDCARDDETECT == -1
+    #if !PIN_EXISTS(SDCARDDETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);
     #endif
   }
@@ -1407,11 +1407,11 @@ void lcd_init() {
   #endif // SR_LCD_2W_NL
 #endif//!NEWPANEL
 
-  #if ENABLED(SDSUPPORT) && defined(SDCARDDETECT) && (SDCARDDETECT > 0)
-    pinMode(SDCARDDETECT, INPUT);
-    WRITE(SDCARDDETECT, HIGH);
+  #if ENABLED(SDSUPPORT) && PIN_EXISTS(SDCARDDETECT)
+    pinMode(SDCARDDETECT_PIN, INPUT);
+    WRITE(SDCARDDETECT_PIN, HIGH);
     lcd_oldcardstatus = IS_SD_INSERTED;
-  #endif //(SDCARDDETECT > 0)
+  #endif
 
   #if ENABLED(LCD_HAS_SLOW_BUTTONS)
     slow_buttons = 0;
@@ -1466,7 +1466,7 @@ void lcd_update() {
 
   lcd_buttons_update();
 
-  #if (SDCARDDETECT > 0)
+  #if PIN_EXISTS(SDCARDDETECT)
     if (IS_SD_INSERTED != lcd_oldcardstatus && lcd_detected()) {
       lcdDrawUpdate = 2;
       lcd_oldcardstatus = IS_SD_INSERTED;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -221,7 +221,7 @@ static void lcd_status_screen();
   millis_t next_button_update_ms;
   uint8_t lastEncoderBits;
   uint32_t encoderPosition;
-  #if PIN_EXISTS(SDCARDDETECT)
+  #if PIN_EXISTS(SD_DETECT)
     bool lcd_oldcardstatus;
   #endif
 
@@ -411,14 +411,14 @@ static void lcd_main_menu() {
       }
       else {
         MENU_ITEM(submenu, MSG_CARD_MENU, lcd_sdcard_menu);
-        #if !PIN_EXISTS(SDCARDDETECT)
+        #if !PIN_EXISTS(SD_DETECT)
           MENU_ITEM(gcode, MSG_CNG_SDCARD, PSTR("M21"));  // SD-card changed by user
         #endif
       }
     }
     else {
       MENU_ITEM(submenu, MSG_NO_CARD, lcd_sdcard_menu);
-      #if !PIN_EXISTS(SDCARDDETECT)
+      #if !PIN_EXISTS(SD_DETECT)
         MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21")); // Manually initialize the SD-card via user interface
       #endif
     }
@@ -1156,7 +1156,7 @@ static void lcd_control_volumetric_menu() {
   }
 #endif // FWRETRACT
 
-#if !PIN_EXISTS(SDCARDDETECT)
+#if !PIN_EXISTS(SD_DETECT)
   static void lcd_sd_refresh() {
     card.initsd();
     currentMenuViewOffset = 0;
@@ -1180,7 +1180,7 @@ void lcd_sdcard_menu() {
   MENU_ITEM(back, MSG_MAIN, lcd_main_menu);
   card.getWorkDirName();
   if (card.filename[0] == '/') {
-    #if !PIN_EXISTS(SDCARDDETECT)
+    #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);
     #endif
   }
@@ -1407,9 +1407,9 @@ void lcd_init() {
   #endif // SR_LCD_2W_NL
 #endif//!NEWPANEL
 
-  #if ENABLED(SDSUPPORT) && PIN_EXISTS(SDCARDDETECT)
-    pinMode(SDCARDDETECT_PIN, INPUT);
-    WRITE(SDCARDDETECT_PIN, HIGH);
+  #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
+    pinMode(SD_DETECT_PIN, INPUT);
+    WRITE(SD_DETECT_PIN, HIGH);
     lcd_oldcardstatus = IS_SD_INSERTED;
   #endif
 
@@ -1466,7 +1466,7 @@ void lcd_update() {
 
   lcd_buttons_update();
 
-  #if PIN_EXISTS(SDCARDDETECT)
+  #if PIN_EXISTS(SD_DETECT)
     if (IS_SD_INSERTED != lcd_oldcardstatus && lcd_detected()) {
       lcdDrawUpdate = 2;
       lcd_oldcardstatus = IS_SD_INSERTED;


### PR DESCRIPTION
- Rename the pin so it can be tested with `PIN_EXISTS`
- Fix some incorrect tests for `SDCARDDETECT`

Also:
- `SD_DETECT_PIN` replaces `SDCARDDETECT_PIN`
- `SD_DETECT_INVERTED` replaces `SDCARDDETECTINVERTED`
- Revise the description of `SD_DETECT_INVERTED`
- Add a note about the override of `SD_DETECT_INVERTED` by `ULTIPANEL`.
- Add sanity checks for the name changes.
