### PR TITLE
Improve condition for SERVO_LEVELING

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -287,7 +287,7 @@
     #define MAX_PROBE_Y (min(Y_MAX_POS, Y_MAX_POS + Y_PROBE_OFFSET_FROM_EXTRUDER))
   #endif
 
-  #define SERVO_LEVELING (defined(ENABLE_AUTO_BED_LEVELING) && defined(DEACTIVATE_SERVOS_AFTER_MOVE))
+  #define SERVO_LEVELING (defined(ENABLE_AUTO_BED_LEVELING) && defined(Z_ENDSTOP_SERVO_NR))
 
    /**
     * Sled Options


### PR DESCRIPTION
Addressing a regression mentioned in #1769 and several other issues.

`DEACTIVATE_SERVOS_AFTER_MOVE` is only for anti-jitter.
When the original code line was written the better define was not available.
