### PR TITLE
Rename BTENABLED to BLUETOOTH

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -51,11 +51,11 @@ typedef unsigned long millis_t;
 #include "WString.h"
 
 #ifdef USBCON
-  #if ENABLED(BTENABLED)
+  #if ENABLED(BLUETOOTH)
     #define MYSERIAL bt
   #else
     #define MYSERIAL Serial
-  #endif // BTENABLED
+  #endif // BLUETOOTH
 #else
   #define MYSERIAL MSerial
 #endif

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -287,6 +287,6 @@ MarlinSerial MSerial;
 #endif // !USBCON
 
 // For AT90USB targets use the UART for BT interfacing
-#if defined(USBCON) && ENABLED(BTENABLED)
+#if defined(USBCON) && ENABLED(BLUETOOTH)
   HardwareSerial bt;
 #endif

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -153,7 +153,7 @@ extern MarlinSerial MSerial;
 #endif // !USBCON
 
 // Use the UART for BT in AT90USB configurations
-#if defined(USBCON) && ENABLED(BTENABLED)
+#if defined(USBCON) && ENABLED(BLUETOOTH)
   extern HardwareSerial bt;
 #endif
 

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -366,4 +366,8 @@
     #error BEEPER has been replaced with BEEPER_PIN. Please update your pins definitions.
   #endif
 
+  #ifdef BTENABLED
+    #error BTENABLED has been replaced with BLUETOOTH. Please update your configuration.
+  #endif
+
 #endif //SANITYCHECK_H

--- a/Marlin/configurator/config/Configuration.h
+++ b/Marlin/configurator/config/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/configurator/index.html
+++ b/Marlin/configurator/index.html
@@ -42,7 +42,7 @@
           <label>Baud Rate:</label><select name="BAUDRATE"></select>
 
           <label>AT90USB BT IF:</label>
-            <input name="BTENABLED" type="checkbox" value="1" checked />
+            <input name="BLUETOOTH" type="checkbox" value="1" checked />
 
           <label class="newline">Motherboard:</label><select name="MOTHERBOARD"></select>
 

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -62,8 +62,8 @@ Here are some standard links for getting your machine calibrated:
 // This determines the communication speed of the printer
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 115200
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -68,8 +68,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 115200
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -88,8 +88,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 115200
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -67,8 +67,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -63,8 +63,8 @@ Here are some standard links for getting your machine calibrated:
 // :[2400,9600,19200,38400,57600,115200,250000]
 #define BAUDRATE 250000
 
-// This enables the serial port associated to the Bluetooth interface
-//#define BTENABLED              // Enable BT interface on AT90USB devices
+// Enable the Bluetooth serial interface on AT90USB devices
+//#define BLUETOOTH
 
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup


### PR DESCRIPTION
- For some reason I keep forgetting what "BT" stands for, but it doesn’t need an abbreviation.
