### PR TITLE
Custom name when the motherboard is known

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -48,14 +48,13 @@
   #define MACHINE_NAME "SAV MkI"
   #define FIRMWARE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
 #else
-  #ifdef CUSTOM_MENDEL_NAME
-    #define MACHINE_NAME CUSTOM_MENDEL_NAME
-  #else
-    #define MACHINE_NAME "Mendel"
-  #endif
-
+  #define MACHINE_NAME "Mendel"
 // Default firmware set to Mendel
   #define FIRMWARE_URL "https://github.com/MarlinFirmware/Marlin"
+#endif
+
+#ifdef CUSTOM_MENDEL_NAME
+  #define MACHINE_NAME CUSTOM_MENDEL_NAME
 #endif
 
 


### PR DESCRIPTION
I have an oddball Delta that's using a cheap ebay board that is compatible with the Ultimaker board and is therefore set as 
# define MOTHERBOARD BOARD_ULTIMAKER

in configuration.h.

The result is that if I set CUSTOM_MENDEL_NAME to what my machine actually is (or what I want it to be named as), it's overwritten by the name Ultimaker.

This is a change to allow the changing of a machine name regardless if the motherboard is one of the common types in the list. This allows me to name my Ultimaker board based machine, and allows me to rename my Ultimaker if I need to.
