### PR TITLE
Lift the 1.0.x branch to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Release Branch
 
-The Release branch contains the latest tagged version of Marlin (currently 1.0.2-1 – January 2015). It also includes a version 1.0.1 (December 2014). Any version of Marlin before 1.0.1 (when we started tagging versions) can be collectively referred to as Marlin 1.0.0.
+The Release branch contains the latest tagged version of Marlin (currently 1.0.2-2 – 26 September 2015). It also includes a version 1.0.1 (December 2014). Any version of Marlin before 1.0.1 (when we started tagging versions) can be collectively referred to as Marlin 1.0.0.
 
 ## Patches - 1.0.x Branch
 


### PR DESCRIPTION
When you download the default (release) branch you get now a unpatched 1.0.2-1.
1.0.x is some bug-fixes ahead. Let's commit this little patch for the README.md file, tag the current 1.0.x with `1.0.1-2` and merge with release. Then i'll update https://github.com/MarlinFirmware/Marlin/releases/tag/1.0.2-1 to point to the new tag.

Because of the already in PR#2266 and PR#2284  the proposed PR#2627 will be obsolete.
