### PR TITLE
Fix compile bug with DEBUG_LEVELING_FEATURE

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1523,7 +1523,7 @@ static void setup_for_endstop_move() {
               if (marlin_debug_flags & DEBUG_LEVELING) {
                 SERIAL_ECHOPAIR("Raise Z (after) by ", (float)Z_RAISE_AFTER_PROBING);
                 SERIAL_EOL;
-                SERIAL_ECHOPAIR("> SERVO_ENDSTOPS > raise_z_after_probing()");
+                SERIAL_ECHO("> SERVO_ENDSTOPS > raise_z_after_probing()");
                 SERIAL_EOL;
               }
             #endif


### PR DESCRIPTION
This fixes a compile bug caused by mis-use of `SERIAL_ECHOPAIR`.
