### PR TITLE
Fix#2661 Pre home display - Stepper release

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -354,7 +354,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately  when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -360,7 +360,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -354,11 +354,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis stepper immediately  when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -234,7 +234,7 @@
 // Default stepper release if idle. Set to 0 to deactivate.
 // Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
 // Time can be set by M18 and M84.
-#define DEFAULT_STEPPER_DEACTIVE_TIME 120
+#define DEFAULT_STEPPER_DEACTIVE_TIME 60
 #define DISABLE_INACTIV_X true
 #define DISABLE_INACTIV_Y true
 #define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -52,7 +52,7 @@
  * The maximum buffered steps/sec of the extruder motor is called "se".
  * Start autotemp mode with M109 S<mintemp> B<maxtemp> F<factor>
  * The target temperature is set to mintemp+factor*se[steps/sec] and is limited by
- * mintemp and maxtemp. Turn this off by excuting M109 without F*
+ * mintemp and maxtemp. Turn this off by executing M109 without F*
  * Also, if the temperature is set to a value below mintemp, it will not be changed by autotemp.
  * On an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
  */
@@ -232,7 +232,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
-#define DEFAULT_STEPPER_DEACTIVE_TIME 60
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
+#define DEFAULT_STEPPER_DEACTIVE_TIME 120
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -259,6 +259,7 @@ extern float home_offset[3]; // axis[n].home_offset
 extern float min_pos[3]; // axis[n].min_pos
 extern float max_pos[3]; // axis[n].max_pos
 extern bool axis_known_position[3]; // axis[n].is_known
+extern bool axis_homed[3]; // axis[n].is_homed
 
 #if ENABLED(DELTA)
   extern float delta[3];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -245,6 +245,7 @@ static float feedrate = 1500.0, saved_feedrate;
 float current_position[NUM_AXIS] = { 0.0 };
 static float destination[NUM_AXIS] = { 0.0 };
 bool axis_known_position[3] = { false };
+bool axis_homed[3] = { false };
 
 static long gcode_N, gcode_LastN, Stopped_gcode_LastN = 0;
 
@@ -1981,6 +1982,7 @@ static void homeaxis(AxisEnum axis) {
     feedrate = 0.0;
     endstops_hit_on_purpose(); // clear endstop hit flags
     axis_known_position[axis] = true;
+    axis_homed[axis] = true;
 
     #if ENABLED(Z_PROBE_SLED)
       // bring Z probe back

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1281,6 +1281,8 @@ static void setup_for_endstop_move() {
 
   static void run_z_probe() {
 
+    refresh_cmd_timeout(); // to prevent stepper_inactive_time from running out and EXTRUDER_RUNOUT_PREVENT from extruding
+
     #if ENABLED(DELTA)
 
       float start_z = current_position[Z_AXIS];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3953,6 +3953,7 @@ inline void gcode_M109() {
     }
 
     idle();
+    refresh_cmd_timeout(); // to prevent stepper_inactive_time from running out
 
     #ifdef TEMP_RESIDENCY_TIME
       // start/restart the TEMP_RESIDENCY_TIME timer whenever we reach target temp for the first time
@@ -3967,7 +3968,6 @@ inline void gcode_M109() {
   }
 
   LCD_MESSAGEPGM(MSG_HEATING_COMPLETE);
-  refresh_cmd_timeout();
   print_job_start_ms = previous_cmd_ms;
 }
 
@@ -4004,9 +4004,9 @@ inline void gcode_M109() {
         SERIAL_EOL;
       }
       idle();
+      refresh_cmd_timeout(); // to prevent stepper_inactive_time from running out
     }
     LCD_MESSAGEPGM(MSG_BED_DONE);
-    refresh_cmd_timeout();
   }
 
 #endif // HAS_TEMP_BED

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6927,16 +6927,16 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   if (stepper_inactive_time && ms > previous_cmd_ms + stepper_inactive_time
       && !ignore_stepper_queue && !blocks_queued()) {
-    #if DISABLE_X == true
+    #if DISABLE_INACTIV_X == true
       disable_x();
     #endif
-    #if DISABLE_Y == true
+    #if DISABLE_INACTIV_Y == true
       disable_y();
     #endif
-    #if DISABLE_Z == true
+    #if DISABLE_INACTIV_Z == true
       disable_z();
     #endif
-    #if DISABLE_E == true
+    #if DISABLE_INACTIV_E == true
       disable_e0();
       disable_e1();
       disable_e2();

--- a/Marlin/configurator/config/Configuration.h
+++ b/Marlin/configurator/config/Configuration.h
@@ -354,11 +354,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/configurator/config/Configuration.h
+++ b/Marlin/configurator/config/Configuration.h
@@ -360,7 +360,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/configurator/config/Configuration_adv.h
+++ b/Marlin/configurator/config/Configuration_adv.h
@@ -232,7 +232,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -348,32 +348,61 @@ static void lcd_implementation_status_screen() {
   #endif
   u8g.setColorIndex(0); // white on black
   u8g.setPrintPos(2, XYZ_BASELINE);
-  lcd_print('X');
+  if ((axis_homed[X_AXIS] && axis_known_position[X_AXIS]) || (blink & 1))
+    lcd_printPGM(PSTR("X"));
+  else {
+    if (!axis_homed[X_AXIS])
+      lcd_printPGM(PSTR("?"));
+    else
+      #if ENABLED(WARN_REDUCED_ACCURACY)
+        if (!axis_known_position[X_AXIS])
+          lcd_printPGM(PSTR("~"));
+        else
+      #endif
+      lcd_printPGM(PSTR("X"));
+  }
   u8g.drawPixel(8, XYZ_BASELINE - 5);
   u8g.drawPixel(8, XYZ_BASELINE - 3);
   u8g.setPrintPos(10, XYZ_BASELINE);
-  if (axis_homed[X_AXIS] || (blink & 1))
-    lcd_print(ftostr31ns(current_position[X_AXIS]));
-  else
-    lcd_printPGM(PSTR("---"));
+  lcd_print(ftostr31ns(current_position[X_AXIS]));
+
   u8g.setPrintPos(43, XYZ_BASELINE);
-  lcd_print('Y');
+  if ((axis_homed[Y_AXIS] && axis_known_position[Y_AXIS]) || (blink & 1))
+    lcd_printPGM(PSTR("Y"));
+  else {
+    if (!axis_homed[Y_AXIS])
+      lcd_printPGM(PSTR("?"));
+    else
+      #if ENABLED(WARN_REDUCED_ACCURACY)
+        if (!axis_known_position[Y_AXIS])
+          lcd_printPGM(PSTR("~"));
+        else
+      #endif
+      lcd_printPGM(PSTR("Y"));
+  }
   u8g.drawPixel(49, XYZ_BASELINE - 5);
   u8g.drawPixel(49, XYZ_BASELINE - 3);
   u8g.setPrintPos(51, XYZ_BASELINE);
-  if (axis_homed[Y_AXIS] || (blink & 1))
-    lcd_print(ftostr31ns(current_position[Y_AXIS]));
-  else
-    lcd_printPGM(PSTR("---"));
+  lcd_print(ftostr31ns(current_position[Y_AXIS]));
+
   u8g.setPrintPos(83, XYZ_BASELINE);
-  lcd_print('Z');
+  if ((axis_homed[Z_AXIS] && axis_known_position[Z_AXIS]) || (blink & 1))
+    lcd_printPGM(PSTR("Z"));
+  else {
+    if (!axis_homed[Z_AXIS])
+      lcd_printPGM(PSTR("?"));
+    else
+      #if ENABLED(WARN_REDUCED_ACCURACY)
+        if (!axis_known_position[Z_AXIS])
+          lcd_printPGM(PSTR("~"));
+        else
+      #endif
+      lcd_printPGM(PSTR("Z"));
+  }
   u8g.drawPixel(89, XYZ_BASELINE - 5);
   u8g.drawPixel(89, XYZ_BASELINE - 3);
   u8g.setPrintPos(91, XYZ_BASELINE);
-  if (axis_homed[Z_AXIS] || (blink & 1))
-    lcd_print(ftostr32sp(current_position[Z_AXIS]));
-  else
-    lcd_printPGM(PSTR("---.--"));
+  lcd_print(ftostr32sp(current_position[Z_AXIS]));
   u8g.setColorIndex(1); // black on white
 
   // Feedrate

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -352,7 +352,7 @@ static void lcd_implementation_status_screen() {
   u8g.drawPixel(8, XYZ_BASELINE - 5);
   u8g.drawPixel(8, XYZ_BASELINE - 3);
   u8g.setPrintPos(10, XYZ_BASELINE);
-  if (axis_known_position[X_AXIS])
+  if (axis_known_position[X_AXIS] || (blink & 1))
     lcd_print(ftostr31ns(current_position[X_AXIS]));
   else
     lcd_printPGM(PSTR("---"));
@@ -361,7 +361,7 @@ static void lcd_implementation_status_screen() {
   u8g.drawPixel(49, XYZ_BASELINE - 5);
   u8g.drawPixel(49, XYZ_BASELINE - 3);
   u8g.setPrintPos(51, XYZ_BASELINE);
-  if (axis_known_position[Y_AXIS])
+  if (axis_known_position[Y_AXIS] || (blink & 1))
     lcd_print(ftostr31ns(current_position[Y_AXIS]));
   else
     lcd_printPGM(PSTR("---"));
@@ -370,7 +370,7 @@ static void lcd_implementation_status_screen() {
   u8g.drawPixel(89, XYZ_BASELINE - 5);
   u8g.drawPixel(89, XYZ_BASELINE - 3);
   u8g.setPrintPos(91, XYZ_BASELINE);
-  if (axis_known_position[Z_AXIS])
+  if (axis_known_position[Z_AXIS] || (blink & 1))
     lcd_print(ftostr32sp(current_position[Z_AXIS]));
   else
     lcd_printPGM(PSTR("---.--"));

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -356,7 +356,7 @@ static void lcd_implementation_status_screen() {
     else
       #if ENABLED(WARN_REDUCED_ACCURACY)
         if (!axis_known_position[X_AXIS])
-          lcd_printPGM(PSTR("~"));
+          lcd_printPGM(PSTR(" "));
         else
       #endif
       lcd_printPGM(PSTR("X"));
@@ -375,7 +375,7 @@ static void lcd_implementation_status_screen() {
     else
       #if ENABLED(WARN_REDUCED_ACCURACY)
         if (!axis_known_position[Y_AXIS])
-          lcd_printPGM(PSTR("~"));
+          lcd_printPGM(PSTR(" "));
         else
       #endif
       lcd_printPGM(PSTR("Y"));
@@ -394,7 +394,7 @@ static void lcd_implementation_status_screen() {
     else
       #if ENABLED(WARN_REDUCED_ACCURACY)
         if (!axis_known_position[Z_AXIS])
-          lcd_printPGM(PSTR("~"));
+          lcd_printPGM(PSTR(" "));
         else
       #endif
       lcd_printPGM(PSTR("Z"));

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -354,7 +354,7 @@ static void lcd_implementation_status_screen() {
     if (!axis_homed[X_AXIS])
       lcd_printPGM(PSTR("?"));
     else
-      #if ENABLED(WARN_REDUCED_ACCURACY)
+      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[X_AXIS])
           lcd_printPGM(PSTR(" "));
         else
@@ -373,7 +373,7 @@ static void lcd_implementation_status_screen() {
     if (!axis_homed[Y_AXIS])
       lcd_printPGM(PSTR("?"));
     else
-      #if ENABLED(WARN_REDUCED_ACCURACY)
+      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[Y_AXIS])
           lcd_printPGM(PSTR(" "));
         else
@@ -392,7 +392,7 @@ static void lcd_implementation_status_screen() {
     if (!axis_homed[Z_AXIS])
       lcd_printPGM(PSTR("?"));
     else
-      #if ENABLED(WARN_REDUCED_ACCURACY)
+      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[Z_AXIS])
           lcd_printPGM(PSTR(" "));
         else

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -352,7 +352,7 @@ static void lcd_implementation_status_screen() {
   u8g.drawPixel(8, XYZ_BASELINE - 5);
   u8g.drawPixel(8, XYZ_BASELINE - 3);
   u8g.setPrintPos(10, XYZ_BASELINE);
-  if (axis_known_position[X_AXIS] || (blink & 1))
+  if (axis_homed[X_AXIS] || (blink & 1))
     lcd_print(ftostr31ns(current_position[X_AXIS]));
   else
     lcd_printPGM(PSTR("---"));
@@ -361,7 +361,7 @@ static void lcd_implementation_status_screen() {
   u8g.drawPixel(49, XYZ_BASELINE - 5);
   u8g.drawPixel(49, XYZ_BASELINE - 3);
   u8g.setPrintPos(51, XYZ_BASELINE);
-  if (axis_known_position[Y_AXIS] || (blink & 1))
+  if (axis_homed[Y_AXIS] || (blink & 1))
     lcd_print(ftostr31ns(current_position[Y_AXIS]));
   else
     lcd_printPGM(PSTR("---"));
@@ -370,7 +370,7 @@ static void lcd_implementation_status_screen() {
   u8g.drawPixel(89, XYZ_BASELINE - 5);
   u8g.drawPixel(89, XYZ_BASELINE - 3);
   u8g.setPrintPos(91, XYZ_BASELINE);
-  if (axis_known_position[Z_AXIS] || (blink & 1))
+  if (axis_homed[Z_AXIS] || (blink & 1))
     lcd_print(ftostr32sp(current_position[Z_AXIS]));
   else
     lcd_printPGM(PSTR("---.--"));

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -336,11 +336,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -342,7 +342,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -326,7 +326,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 #define DISABLE_E false // For all extruders
 #define DISABLE_INACTIVE_EXTRUDER true //disable only inactive extruders and keep active extruder enabled
 

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -320,11 +320,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 #define DISABLE_E false // For all extruders
 #define DISABLE_INACTIVE_EXTRUDER true //disable only inactive extruders and keep active extruder enabled
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -346,11 +346,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -352,7 +352,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -342,11 +342,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z true
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -348,7 +348,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z true
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -354,11 +354,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -360,7 +360,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -340,11 +340,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -346,7 +346,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -232,7 +232,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -362,11 +362,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -368,7 +368,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 240
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -374,11 +374,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -380,7 +380,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -346,11 +346,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z true
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -352,7 +352,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define DISABLE_Y false
 #define DISABLE_Z true
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -354,11 +354,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -360,7 +360,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -389,11 +389,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -395,7 +395,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 0
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -389,11 +389,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -395,7 +395,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -395,7 +395,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -389,11 +389,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -382,7 +382,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -376,11 +376,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -244,7 +244,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -363,7 +363,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -357,11 +357,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define Z_ENABLE_ON 0
 #define E_ENABLE_ON 0 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -350,7 +350,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define DISABLE_Y false
 #define DISABLE_Z false
 // Warn on display about possibly reduced accuracy
-//#define WARN_REDUCED_ACCURACY
+//#define DISABLE_REDUCED_ACCURACY_WARNING
 
 // @section extruder
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -344,11 +344,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define Z_ENABLE_ON 1
 #define E_ENABLE_ON 1 // For all extruders
 
-// Disables axis when it's not being used.
+// Disables axis stepper immediately when it's not being used.
 // WARNING: When motors turn off there is a chance of losing position accuracy!
 #define DISABLE_X false
 #define DISABLE_Y false
 #define DISABLE_Z false
+// Warn on display about possibly reduced accuracy
+//#define WARN_REDUCED_ACCURACY
 
 // @section extruder
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -240,7 +240,13 @@
 #define INVERT_E_STEP_PIN false
 
 // Default stepper release if idle. Set to 0 to deactivate.
+// Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIV_? is true.
+// Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 60
+#define DISABLE_INACTIV_X true
+#define DISABLE_INACTIV_Y true
+#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIV_E true
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1671,21 +1671,23 @@ void lcd_update() {
     }
     #if ENABLED(DOGLCD)  // Changes due to different driver architecture of the DOGM display
         if (lcdDrawUpdate) {
-          blink++;     // Variable for fan animation and alive dot
+          blink++;     // Variable for animation and alive dot
           u8g.firstPage();
           do {
             lcd_setFont(FONT_MENU);
             u8g.setPrintPos(125, 0);
-            if (blink % 2) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
+            if (blink & 1) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
             u8g.drawPixel(127, 63); // draw alive dot
             u8g.setColorIndex(1); // black on white
             (*currentMenu)();
           } while (u8g.nextPage());
         }
     #else
-      if (lcdDrawUpdate)
+      if (lcdDrawUpdate) {
+        blink++;     // Variable for animation
         (*currentMenu)();
-    #endif
+      }
+      #endif
 
     #if ENABLED(LCD_HAS_STATUS_INDICATORS)
       lcd_implementation_update_indicators();

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -618,7 +618,7 @@ static void lcd_implementation_status_screen() {
           if (!axis_homed[X_AXIS])
             lcd_printPGM(PSTR("?"));
           else 
-            #if ENABLED(WARN_REDUCED_ACCURACY)  
+            #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)  
               if (!axis_known_position[X_AXIS])
                 lcd_printPGM(PSTR(" "));
               else
@@ -635,7 +635,7 @@ static void lcd_implementation_status_screen() {
           if (!axis_homed[Y_AXIS])
             lcd_printPGM(PSTR("?"));
           else 
-            #if ENABLED(WARN_REDUCED_ACCURACY)  
+            #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)  
               if (!axis_known_position[Y_AXIS])
                 lcd_printPGM(PSTR(" "));
               else
@@ -655,7 +655,7 @@ static void lcd_implementation_status_screen() {
       if (!axis_homed[Z_AXIS])
         lcd_printPGM(PSTR("?"));
       else 
-        #if ENABLED(WARN_REDUCED_ACCURACY)  
+        #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)  
           if (!axis_known_position[Z_AXIS])
             lcd_printPGM(PSTR(" "));
           else

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -620,7 +620,7 @@ static void lcd_implementation_status_screen() {
           else 
             #if ENABLED(WARN_REDUCED_ACCURACY)  
               if (!axis_known_position[X_AXIS])
-                lcd_printPGM(PSTR("~"));
+                lcd_printPGM(PSTR(" "));
               else
             #endif  
             lcd_printPGM(PSTR("X"));
@@ -637,7 +637,7 @@ static void lcd_implementation_status_screen() {
           else 
             #if ENABLED(WARN_REDUCED_ACCURACY)  
               if (!axis_known_position[Y_AXIS])
-                lcd_printPGM(PSTR("~"));
+                lcd_printPGM(PSTR(" "));
               else
             #endif
             lcd_printPGM(PSTR("Y"));
@@ -657,7 +657,7 @@ static void lcd_implementation_status_screen() {
       else 
         #if ENABLED(WARN_REDUCED_ACCURACY)  
           if (!axis_known_position[Z_AXIS])
-            lcd_printPGM(PSTR("~"));
+            lcd_printPGM(PSTR(" "));
           else
         #endif
         lcd_printPGM(PSTR("Z"));

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -3,14 +3,10 @@
 
 /**
 * Implementation of the LCD display routines for a Hitachi HD44780 display. These are common LCD character displays.
-* When selecting the Russian language, a slightly different LCD implementation is used to handle UTF8 characters.
 **/
 
-//#if DISABLED(REPRAPWORLD_KEYPAD)
-//  extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
-//#else
-  extern volatile uint8_t buttons;  //an extended version of the last checked buttons in a bit array.
-//#endif
+static unsigned char blink = 0; // Variable for animation
+extern volatile uint8_t buttons;  //an extended version of the last checked buttons in a bit array.
 
 ////////////////////////////////////
 // Setup button and encode mappings for each panel (into 'buttons' variable
@@ -617,13 +613,13 @@ static void lcd_implementation_status_screen() {
       #else
 
         lcd.print('X');
-        if (axis_known_position[X_AXIS])
+        if (axis_known_position[X_AXIS] || (blink & 1))
           lcd.print(ftostr3(current_position[X_AXIS]));
         else
           lcd_printPGM(PSTR("---"));
 
         lcd_printPGM(PSTR("  Y"));
-        if (axis_known_position[Y_AXIS])
+        if (axis_known_position[Y_AXIS] || (blink & 1))
           lcd.print(ftostr3(current_position[Y_AXIS]));
         else
           lcd_printPGM(PSTR("---"));
@@ -634,7 +630,7 @@ static void lcd_implementation_status_screen() {
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
     lcd.print('Z');
-    if (axis_known_position[Z_AXIS])
+    if (axis_known_position[Z_AXIS] || (blink & 1))
       lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
     else
       lcd_printPGM(PSTR("---.--"));

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -613,13 +613,13 @@ static void lcd_implementation_status_screen() {
       #else
 
         lcd.print('X');
-        if (axis_known_position[X_AXIS] || (blink & 1))
+        if (axis_homed[X_AXIS] || (blink & 1))
           lcd.print(ftostr3(current_position[X_AXIS]));
         else
           lcd_printPGM(PSTR("---"));
 
         lcd_printPGM(PSTR("  Y"));
-        if (axis_known_position[Y_AXIS] || (blink & 1))
+        if (axis_homed[Y_AXIS] || (blink & 1))
           lcd.print(ftostr3(current_position[Y_AXIS]));
         else
           lcd_printPGM(PSTR("---"));
@@ -630,7 +630,7 @@ static void lcd_implementation_status_screen() {
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
     lcd.print('Z');
-    if (axis_known_position[Z_AXIS] || (blink & 1))
+    if (axis_homed[Z_AXIS] || (blink & 1))
       lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
     else
       lcd_printPGM(PSTR("---.--"));

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -612,28 +612,57 @@ static void lcd_implementation_status_screen() {
 
       #else
 
-        lcd.print('X');
-        if (axis_homed[X_AXIS] || (blink & 1))
-          lcd.print(ftostr3(current_position[X_AXIS]));
-        else
-          lcd_printPGM(PSTR("---"));
+        if ((axis_homed[X_AXIS] && axis_known_position[X_AXIS]) || (blink & 1))
+          lcd_printPGM(PSTR("X"));
+        else {
+          if (!axis_homed[X_AXIS])
+            lcd_printPGM(PSTR("?"));
+          else 
+            #if ENABLED(WARN_REDUCED_ACCURACY)  
+              if (!axis_known_position[X_AXIS])
+                lcd_printPGM(PSTR("~"));
+              else
+            #endif  
+            lcd_printPGM(PSTR("X"));
+        }
 
-        lcd_printPGM(PSTR("  Y"));
-        if (axis_homed[Y_AXIS] || (blink & 1))
-          lcd.print(ftostr3(current_position[Y_AXIS]));
-        else
-          lcd_printPGM(PSTR("---"));
+        lcd.print(ftostr3(current_position[X_AXIS]));
+
+        lcd_printPGM(PSTR("  "));
+        if ((axis_homed[Y_AXIS] && axis_known_position[Y_AXIS]) || (blink & 1))
+          lcd_printPGM(PSTR("Y"));
+        else {
+          if (!axis_homed[Y_AXIS])
+            lcd_printPGM(PSTR("?"));
+          else 
+            #if ENABLED(WARN_REDUCED_ACCURACY)  
+              if (!axis_known_position[Y_AXIS])
+                lcd_printPGM(PSTR("~"));
+              else
+            #endif
+            lcd_printPGM(PSTR("Y"));
+        }
+        lcd.print(ftostr3(current_position[Y_AXIS]));
 
       #endif // EXTRUDERS > 1 || TEMP_SENSOR_BED != 0
 
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    lcd.print('Z');
-    if (axis_homed[Z_AXIS] || (blink & 1))
-      lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
-    else
-      lcd_printPGM(PSTR("---.--"));
+    if ((axis_homed[Z_AXIS] && axis_known_position[Z_AXIS]) || (blink & 1))
+      lcd_printPGM(PSTR("Z"));
+    else {
+      if (!axis_homed[Z_AXIS])
+        lcd_printPGM(PSTR("?"));
+      else 
+        #if ENABLED(WARN_REDUCED_ACCURACY)  
+          if (!axis_known_position[Z_AXIS])
+            lcd_printPGM(PSTR("~"));
+          else
+        #endif
+        lcd_printPGM(PSTR("Z"));
+    }
+    lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
 
   #endif // LCD_HEIGHT > 2
 


### PR DESCRIPTION
This PR is a cleaned version of #2676
- enables the character-displays to blink,
- shows again the relative to boot position coordinates on the displays - instead of "---",
- indicates an unhomed axis with a blinking '?' on the place of the axis letters 'X', 'Y','Z'
- indicates an axis where the stepper was disabled after homing with a blinking ' ' on the position of the axis letter, when the new configuration option `//#define WARN_REDUCED_ACCURACY` is uncommented.
- introduces a new set of configuration options 

```
#define DISABLE_INACTIV_X true
#define DISABLE_INACTIV_Y true
#define DISABLE_INACTIV_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
#define DISABLE_INACTIV_E true
```

what are used in conjunction with `DEFAULT_STEPPER_DEACTIVE_TIME`. Disabling the steppers after `DEFAULT_STEPPER_DEACTIVE_TIME` is then independent from the `DISABLE_?` settings.
- the `DISABLE_?` configurations then will be used only for the immediate disabling of the steppers when they are not used (buffer empty).

Option names can be discussed.
Moving the `DISABLE_?` block from 'Configuration.h' to 'Configuration_adv.h'  should be considered.

You can find some optical examples in #2661

Happy testing.
