### PR TITLE
Move slow_buttons_update into the LCD_UPDATE_INTERVAL block

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1571,10 +1571,6 @@ void lcd_update() {
     static millis_t return_to_status_ms = 0;
   #endif
 
-  #if ENABLED(LCD_HAS_SLOW_BUTTONS)
-    slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
-  #endif
-
   lcd_buttons_update();
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
@@ -1604,6 +1600,10 @@ void lcd_update() {
 
   millis_t ms = millis();
   if (ms > next_lcd_update_ms) {
+
+    #if ENABLED(LCD_HAS_SLOW_BUTTONS)
+      slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
+    #endif
 
     #if ENABLED(ULTIPANEL)
 


### PR DESCRIPTION
Move slow_buttons_update into the LCD_UPDATE_INTERVAL block.
lcd_implementation_read_slow_buttons() will then be executed ~10 times a
second.

Fix for #2681
