### PR TITLE
Suppress Compiler Warnings

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7056,6 +7056,8 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 void kill(const char* lcd_msg) {
   #if ENABLED(ULTRA_LCD)
     lcd_setalertstatuspgm(lcd_msg);
+  #else
+    UNUSED(lcd_msg);
   #endif
 
   cli(); // Stop interrupts

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -796,6 +796,7 @@ static float analog2tempBed(int raw) {
 
   #else
 
+    UNUSED(raw);
     return 0;
 
   #endif


### PR DESCRIPTION
Just suppressing some unused argument warnings when there is no LCD display
