### PR TITLE
Marlin v1.1 RC2 would not compile in Arduino IDE v1.6.6

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -275,6 +275,12 @@
   /**
    * Auto Bed Leveling
    */
+
+  #ifndef min
+    #define min(a,b) (a<b?a:b)
+    #define max(a,b) (a>b?a:b)
+  #endif
+
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     // Boundaries for probing based on set limits
     #define MIN_PROBE_X (max(X_MIN_POS, X_MIN_POS + X_PROBE_OFFSET_FROM_EXTRUDER))

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7056,6 +7056,8 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 void kill(const char* lcd_msg) {
   #if ENABLED(ULTRA_LCD)
     lcd_setalertstatuspgm(lcd_msg);
+  #else
+    UNUSED(lcd_msg);
   #endif
 
   cli(); // Stop interrupts

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -796,6 +796,7 @@ static float analog2tempBed(int raw) {
 
   #else
 
+    UNUSED(raw);
     return 0;
 
   #endif


### PR DESCRIPTION
... This fixes that. 

My min/max defines should probably go into a more general .h file. But this works, for now.
