### PR TITLE
Missing bracket issue Dev#248

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7148,6 +7148,7 @@ void kill(const char* lcd_msg) {
           TCCR5B |= val;
           break;
       #endif
+    }
   }
 
 #endif // FAST_PWM_FAN


### PR DESCRIPTION
Add the Missing bracket of FAST_PWM_FAN

like https://github.com/MarlinFirmware/MarlinDev/pull/251
with corrected indendation.
