### PR TITLE
Change XY formatting on LCD

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1882,10 +1882,11 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
 char conv[8];
 
-// Convert float to string with +123.4 format
-char* ftostr3(const float& x) {
-  return itostr3((int)x);
-}
+// Convert float to rj string with 123 or -12 format
+char *ftostr3(const float& x) { return itostr3((int)x); }
+
+// Convert float to rj string with _123, -123, _-12, or __-1 format
+char *ftostr4sign(const float& x) { return itostr4sign((int)x); }
 
 // Convert int to string with 12 format
 char* itostr2(const uint8_t& x) {
@@ -1922,8 +1923,8 @@ char* ftostr31ns(const float& x) {
   return conv;
 }
 
-// Convert float to string with 123.4 format
-char* ftostr32(const float& x) {
+// Convert float to string with 123.45 format
+char *ftostr32(const float& x) {
   long xx = abs(x * 100);
   conv[0] = x >= 0 ? (xx / 10000) % 10 + '0' : '-';
   conv[1] = (xx / 1000) % 10 + '0';
@@ -2062,6 +2063,30 @@ char* itostr4(const int& xx) {
   conv[0] = xx >= 1000 ? (xx / 1000) % 10 + '0' : ' ';
   conv[1] = xx >= 100 ? (xx / 100) % 10 + '0' : ' ';
   conv[2] = xx >= 10 ? (xx / 10) % 10 + '0' : ' ';
+  conv[3] = xx % 10 + '0';
+  conv[4] = 0;
+  return conv;
+}
+
+// Convert int to rj string with _123, -123, _-12, or __-1 format
+char *itostr4sign(const int& x) {
+  int xx = abs(x);
+  int sign = 0;
+  if (xx >= 100) {
+    conv[1] = (xx / 100) % 10 + '0';
+    conv[2] = (xx / 10) % 10 + '0';
+  }
+  else if (xx >= 10) {
+    conv[0] = ' ';
+    sign = 1;
+    conv[2] = (xx / 10) % 10 + '0';
+  }
+  else {
+    conv[0] = ' ';
+    conv[1] = ' ';
+    sign = 2;
+  }
+  conv[sign] = x < 0 ? '-' : ' ';
   conv[3] = xx % 10 + '0';
   conv[4] = 0;
   return conv;

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -121,8 +121,10 @@ char* itostr31(const int& xx);
 char* itostr3(const int& xx);
 char* itostr3left(const int& xx);
 char* itostr4(const int& xx);
+char* itostr4sign(const int& x);
 
 char* ftostr3(const float& x);
+char* ftostr4sign(const float& x);
 char* ftostr31ns(const float& x); // float to string without sign character
 char* ftostr31(const float& x);
 char* ftostr32(const float& x);

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -504,7 +504,7 @@ Possible status screens:
        |0123456789012345|
 
 16x4   |000/000 B000/000|
-       |SD100%  Z000.00 |
+       |SD100%  Z 000.00|
        |F100%     T--:--|
        |0123456789012345|
 
@@ -512,12 +512,12 @@ Possible status screens:
        |01234567890123456789|
 
 20x4   |T000/000D B000/000D |
-       |X000  Y000  Z000.00 |
+       |X 000 Y 000 Z 000.00|
        |F100%  SD100% T--:--|
        |01234567890123456789|
 
 20x4   |T000/000D B000/000D |
-       |T000/000D   Z000.00 |
+       |T000/000D   Z 000.00|
        |F100%  SD100% T--:--|
        |01234567890123456789|
 */
@@ -618,22 +618,22 @@ static void lcd_implementation_status_screen() {
 
         lcd.print('X');
         if (axis_known_position[X_AXIS])
-          lcd.print(ftostr3(current_position[X_AXIS]));
+          lcd.print(ftostr4sign(current_position[X_AXIS]));
         else
-          lcd_printPGM(PSTR("---"));
+          lcd_printPGM(PSTR(" ---"));
 
-        lcd_printPGM(PSTR("  Y"));
+        lcd_printPGM(PSTR(" Y"));
         if (axis_known_position[Y_AXIS])
-          lcd.print(ftostr3(current_position[Y_AXIS]));
+          lcd.print(ftostr4sign(current_position[Y_AXIS]));
         else
-          lcd_printPGM(PSTR("---"));
+          lcd_printPGM(PSTR(" ---"));
 
       #endif // EXTRUDERS > 1 || TEMP_SENSOR_BED != 0
 
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    lcd.print('Z');
+    lcd_printPGM(PSTR("Z "));
     if (axis_known_position[Z_AXIS])
       lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
     else


### PR DESCRIPTION
According to MarlinFirmware/MarlinDev#123 negative values for XY at or below -100 are displaying incorrectly, dropping the first digit. Deltas can easily have XY values in this range. This PR adds a function to display floats/ints formatted like _123, -123, _-12, or __-1 as appropriate and applies it to the XY coordinates on Hitachi displays. It also moves the Z value to the right to be consistent with the XY formatting.

Originally by @thinkyhead (MarlinFirmware/MarlinDev#181)
with some minor improvements.
