### PR TITLE
Added warning for number of axis limit

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -474,6 +474,8 @@ const bool Z_MAX_ENDSTOP_INVERTING = true; // set to true to invert the logic of
 //#define MANUAL_Z_HOME_POS 402 // For delta: Distance between nozzle and print surface after homing.
 
 //// MOVEMENT SETTINGS
+// 4 is maximum number of axis supported.
+// Increasing number of axis value and adding more than 4 values to arrays below, will have NO effect.
 #define NUM_AXIS 4 // The axis order in all axis related arrays is X, Y, Z, E
 #define HOMING_FEEDRATE {50*60, 50*60, 4*60, 0}  // set the homing speeds (mm/min)
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -312,7 +312,7 @@
 #endif
 
 // The hardware watchdog should reset the microcontroller disabling all outputs, in case the firmware gets stuck and doesn't do temperature regulation.
-//#define USE_WATCHDOG
+#define USE_WATCHDOG
 
 #ifdef USE_WATCHDOG
 // If you have a watchdog reboot in an ArduinoMega2560 then the device will hang forever, as a watchdog reset will leave the watchdog on.


### PR DESCRIPTION
In regards to following issue;
https://github.com/MarlinFirmware/Marlin/issues/2743

I also saw people on forums, trying to adjust seperate extruders by changing values here.

It is good to have this warning here.
