### PR TITLE
Kc is also a multi-PID parameter

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -518,7 +518,7 @@ float get_pid_output(int e) {
               lpq[lpq_ptr++] = 0;
             }
             if (lpq_ptr >= lpq_len) lpq_ptr = 0;
-            cTerm[e] = (lpq[lpq_ptr] / axis_steps_per_unit[E_AXIS]) * Kc;
+            cTerm[e] = (lpq[lpq_ptr] / axis_steps_per_unit[E_AXIS]) * PID_PARAM(Kc, e);
             pid_output += cTerm[e];
           }
         #endif //PID_ADD_EXTRUSION_RATE


### PR DESCRIPTION
This corrects the case of multiple PID loops with extrusion rate compensation #2793
