### PR TITLE
Extend ABORT_ON_ENDSTOP_HIT to USB-printing

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -322,13 +322,15 @@
   // This allows hosts to request long names for files and folders with M33
   //#define LONG_FILENAME_HOST_SUPPORT
 
-  // This option allows you to abort SD printing when any endstop is triggered.
-  // This feature must be enabled with "M540 S1" or from the LCD menu.
-  // To have any effect, endstops must be enabled during SD printing.
-  // With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
-  //#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
-
 #endif // SDSUPPORT
+
+// This option allows you to abort printing when any endstop is triggered.
+// This feature must be enabled with "M540 S1" or from the LCD menu
+// or by #define ABORT_ON_ENDSTOP_HIT_INIT true.
+// To have any effect, endstops must be enabled during printing.
+// With ENDSTOPS_ONLY_FOR_HOMING you must send "M120" to enable endstops.
+//#define ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
+//#define ABORT_ON_ENDSTOP_HIT_INIT true
 
 // for dogm lcd displays you can choose some additional fonts:
 #if ENABLED(DOGLCD)


### PR DESCRIPTION
Added configurable option ABORT_ON_ENDSTOP_HIT_INIT to activate the feature at boot time.
Changes some descriptive text.
Cleaned up the use of enable_endstops() in homeaxis().
Changed the initialisation of abort_on_endstop_hit to relate on ABORT_ON_ENDSTOP_HIT_INIT.
Changed checkHitEndstops() to
throw an ERROR instead of an ECHO when ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED.
Send "X=" instead of "X:" also for Y,Z and probe to make the output not readable by Repetier Host.

Abort all printing when ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED. Therefor the already existent feature for sd-printing was extended.

To come out of the look send M999.
