### PR TITLE
Fix Printrboard with LCD

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -631,6 +631,11 @@ void servo_init() {
  *    • status LEDs
  */
 void setup() {
+#ifdef DISABLE_JTAG
+  // Disable JTAG on AT90USB chips to free up pins for IO
+  MCUCR = 0x80;
+  MCUCR = 0x80;
+#endif
   setup_killpin();
   setup_filrunoutpin();
   setup_powerhold();

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -15,6 +15,9 @@
 
 #define LARGE_FLASH        true
 
+//Disable JTAG pins so they can be used for the Extrudrboard
+#define DISABLE_JTAG       true
+
 #define X_STEP_PIN          0
 #define X_DIR_PIN           1
 #define X_ENABLE_PIN       39
@@ -64,7 +67,7 @@
 ////LCD Pin Setup////
 
 #define SDPOWER            -1
-#define SDSS                8
+#define SDSS               26
 #define LED_PIN            -1
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
@@ -89,6 +92,18 @@
   #endif // LCD_I2C_PANELOLU2
   //not connected to a pin
   #define SD_DETECT_PIN -1
+  
+  #define LCD_PINS_RS 9
+  #define LCD_PINS_ENABLE 8
+  #define LCD_PINS_D4 7
+  #define LCD_PINS_D5 6
+  #define LCD_PINS_D6 5
+  #define LCD_PINS_D7 4
+
+  #define BTN_EN1   16
+  #define BTN_EN2   17
+  #define BTN_ENC   18//the click
+
 #endif // ULTRA_LCD && NEWPANEL
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -896,11 +896,12 @@ void tp_init() {
     SET_OUTPUT(HEATER_BED_PIN);
   #endif
   #if HAS_FAN
-    SET_OUTPUT(FAN_PIN);
     #if ENABLED(FAST_PWM_FAN)
+      SET_OUTPUT(FAN_PIN);
       setPwmFrequency(FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
     #endif
     #if ENABLED(FAN_SOFT_PWM)
+      SET_OUTPUT(FAN_PIN);
       soft_pwm_fan = fanSpeedSoftPwm / 2;
     #endif
   #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1533,7 +1533,7 @@ void lcd_init() {
   #endif//!NEWPANEL
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
-    pinMode(SD_DETECT_PIN, INPUT);
+    SET_INPUT(SD_DETECT_PIN);
     WRITE(SD_DETECT_PIN, HIGH);
     lcd_sd_status = 2; // UNKNOWN
   #endif


### PR DESCRIPTION
The printrbot/printrboard fork of marlin has working LCD support and fixed some some fastio / teensy pin issues not in trunk. This PR includes those changes (commits listed below), but not as a proper merge commit.

I've spent enough time today fucking with finding the commits that fix the problems I was having. Please let me know how to go about making these "real" merge commits or how I can help you merge these (or more?) changes from the printrbot branch.

---

The commits fixing the LCD problems I had are listed below:

Commit: 1f17c434755917b098576572fe91c44095738ad8 [1f17c43]
Parents: 5d58fe0d3a
Author: Laine Walker-Avina lwalkera@ieee.org
Date: Thursday, April 18, 2013 10:55:16 PM
Commit Date: Saturday, January 18, 2014 2:09:00 PM
Marlin_main: Disable JTAG in setup() if DISABLE_JTAG is defined

Allows use of JTAG pins as IO

Commit: a2b97c3dc112c263fd29007289cfd9009791ef83 [a2b97c3]
Parents: cc992f0a76
Author: Laine Walker-Avina lwalkera@ieee.org
Date: Thursday, July 11, 2013 11:39:12 AM
Commit Date: Sunday, January 19, 2014 3:42:04 PM
Printrboard: Disable JTAG

Commit: ebe5f4b64ca77e1576db72337c4b470c289b696c [ebe5f4b]
Parents: a2b97c3dc1
Author: Laine Walker-Avina lwalkera@ieee.org
Date: Wednesday, July 24, 2013 10:20:47 PM
Commit Date: Sunday, January 19, 2014 3:42:04 PM
Fix fan pin from conflicting with other pins on Teensyduino based platforms

Commit: b02e8bd71a6087a76d884488c95ad66c64e75a74 [b02e8bd]
Parents: ebe5f4b64c
Author: Laine Walker-Avina lwalkera@ieee.org
Date: Wednesday, July 24, 2013 10:25:42 PM
Commit Date: Sunday, January 19, 2014 3:42:04 PM
Fix pins for Printrboard

Commit: cc41b4405c7390ac2870501513aa3ecfaa493ebe [cc41b44]
Parents: 875a39cefe
Author: Laine Walker-Avina lwalkera@ieee.org
Date: Friday, August 2, 2013 2:37:32 PM
Commit Date: Sunday, January 19, 2014 3:42:04 PM
ultralcd: Use SET_{OUTPUT|INPUT}() instead of pinMode() to set pin direction
