### PR TITLE
PWM_MOTOR_CURRENT Flag

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -268,6 +268,9 @@
 // Motor Current setting (Only functional when motor driver current ref pins are connected to a digital trimpot on supported boards)
 #define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
 
+// Motor Current controlled via PWM (Only functional when motor driver current is driven by PWM on supported boards)
+#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
+   
 // uncomment to enable an I2C based DIGIPOT like on the Azteeg X3 Pro
 //#define DIGIPOT_I2C
 // Number of channels available for I2C digipot, For Azteeg X3 Pro we have 8

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -88,7 +88,10 @@ static volatile char endstop_hit_bits = 0; // use X_MIN, Y_MIN, Z_MIN and Z_MIN_
 #endif
 
 #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
-  int motor_current_setting[3] = DEFAULT_PWM_MOTOR_CURRENT;
+  #ifndef PWM_MOTOR_CURRENT
+    #define PWM_MOTOR_CURRENT DEFAULT_PWM_MOTOR_CURRENT
+  #endif
+  int motor_current_setting[3] = PWM_MOTOR_CURRENT;
 #endif
 
 static bool check_endstops = true;


### PR DESCRIPTION
Adding PWM_MOTOR_CURRENT flag to help expose PWM_MOTOR_CURRENTS in Configuration_adv.h similar to DIGIPOT_MOTOR_CURRENT.

I haven't received any feedback from this change in the Dev branch and it seems useful in the latest RC as a bug fix.  Feedback is appreciated.
