### PR TITLE
Remove references to marlinfirmware.org

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -74,7 +74,7 @@
  *  - http://objects.reprap.org/wiki/Mendel_User_Manual:_RepRapGCodes
  *
  * Help us document these G-codes online:
- *  - http://marlinfirmware.org/index.php/G-Code
+ *  - https://github.com/MarlinFirmware/Marlin/wiki/G-Code-in-Marlin
  *  - http://reprap.org/wiki/G-code
  *
  * -----------------

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -414,6 +414,7 @@ char lcd_print(char* str) {
 unsigned lcd_print(char c) { return charset_mapper(c); }
 
 #if ENABLED(SHOW_BOOTSCREEN)
+
   void lcd_erase_line(int line) {
     lcd.setCursor(0, 3);
     for (int i = 0; i < LCD_WIDTH; i++)
@@ -486,18 +487,21 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
     lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 1);                    lcd_printPGM(PSTR("|Marlin|"));
     lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 2); lcd.print('\x02'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x03');
 
-    lcd_scroll(0, 3, PSTR("marlinfirmware.org"), LCD_WIDTH, 3000);
+    delay(2000);
 
     #ifdef STRING_SPLASH_LINE1
       lcd_erase_line(3);
       lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE1), LCD_WIDTH, 1000);
     #endif
+
     #ifdef STRING_SPLASH_LINE2
       lcd_erase_line(3);
       lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 1000);
     #endif
   }
+
 #endif // SHOW_BOOTSCREEN
+
 /*
 Possible status screens:
 16x2   |000/000 B000/000|


### PR DESCRIPTION
The domain is gone and doesn’t redirect, so for now show no URL on the boot screen.
