### PR TITLE
Differentiate Axis Homed from Axis Unknown

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -116,10 +116,10 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 
 #if ENABLED(DUAL_X_CARRIAGE) && HAS_X_ENABLE && HAS_X2_ENABLE
   #define  enable_x() do { X_ENABLE_WRITE( X_ENABLE_ON); X2_ENABLE_WRITE( X_ENABLE_ON); } while (0)
-  #define disable_x() do { X_ENABLE_WRITE(!X_ENABLE_ON); X2_ENABLE_WRITE(!X_ENABLE_ON); axis_known_position[X_AXIS] = false; } while (0)
+  #define disable_x() do { X_ENABLE_WRITE(!X_ENABLE_ON); X2_ENABLE_WRITE(!X_ENABLE_ON); BITCLR(axis_known_position, X_AXIS); } while (0)
 #elif HAS_X_ENABLE
   #define  enable_x() X_ENABLE_WRITE( X_ENABLE_ON)
-  #define disable_x() { X_ENABLE_WRITE(!X_ENABLE_ON); axis_known_position[X_AXIS] = false; }
+  #define disable_x() { X_ENABLE_WRITE(!X_ENABLE_ON); BITCLR(axis_known_position, X_AXIS); }
 #else
   #define enable_x() ;
   #define disable_x() ;
@@ -128,10 +128,10 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 #if HAS_Y_ENABLE
   #if ENABLED(Y_DUAL_STEPPER_DRIVERS)
     #define  enable_y() { Y_ENABLE_WRITE( Y_ENABLE_ON); Y2_ENABLE_WRITE(Y_ENABLE_ON); }
-    #define disable_y() { Y_ENABLE_WRITE(!Y_ENABLE_ON); Y2_ENABLE_WRITE(!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
+    #define disable_y() { Y_ENABLE_WRITE(!Y_ENABLE_ON); Y2_ENABLE_WRITE(!Y_ENABLE_ON); BITCLR(axis_known_position, Y_AXIS); }
   #else
     #define  enable_y() Y_ENABLE_WRITE( Y_ENABLE_ON)
-    #define disable_y() { Y_ENABLE_WRITE(!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }
+    #define disable_y() { Y_ENABLE_WRITE(!Y_ENABLE_ON); BITCLR(axis_known_position, Y_AXIS); }
   #endif
 #else
   #define enable_y() ;
@@ -141,10 +141,10 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 #if HAS_Z_ENABLE
   #if ENABLED(Z_DUAL_STEPPER_DRIVERS)
     #define  enable_z() { Z_ENABLE_WRITE( Z_ENABLE_ON); Z2_ENABLE_WRITE(Z_ENABLE_ON); }
-    #define disable_z() { Z_ENABLE_WRITE(!Z_ENABLE_ON); Z2_ENABLE_WRITE(!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
+    #define disable_z() { Z_ENABLE_WRITE(!Z_ENABLE_ON); Z2_ENABLE_WRITE(!Z_ENABLE_ON); BITCLR(axis_known_position, Z_AXIS); }
   #else
     #define  enable_z() Z_ENABLE_WRITE( Z_ENABLE_ON)
-    #define disable_z() { Z_ENABLE_WRITE(!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }
+    #define disable_z() { Z_ENABLE_WRITE(!Z_ENABLE_ON); BITCLR(axis_known_position, Z_AXIS); }
   #endif
 #else
   #define enable_z() ;
@@ -255,10 +255,11 @@ extern int extruder_multiplier[EXTRUDERS]; // sets extrude multiply factor (in p
 extern float filament_size[EXTRUDERS]; // cross-sectional area of filament (in millimeters), typically around 1.75 or 2.85, 0 disables the volumetric calculations for the extruder.
 extern float volumetric_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
 extern float current_position[NUM_AXIS];
-extern float home_offset[3]; // axis[n].home_offset
-extern float min_pos[3]; // axis[n].min_pos
-extern float max_pos[3]; // axis[n].max_pos
-extern bool axis_known_position[3]; // axis[n].is_known
+extern float home_offset[3];
+extern float min_pos[3];
+extern float max_pos[3];
+extern uint8_t axis_known_position;
+extern uint8_t axis_was_homed;
 
 #if ENABLED(DELTA)
   extern float delta[3];

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -337,7 +337,11 @@ static void lcd_implementation_status_screen() {
       lcd_printPGM(PSTR("---"));
     }
 
-  // X, Y, Z-Coordinates
+  //
+  // Print XYZ Coordinates
+  // If the axis was not homed, show "---"
+  // If the position is untrusted, show "?"
+  //
   #define XYZ_BASELINE 38
   lcd_setFont(FONT_STATUSMENU);
 
@@ -347,33 +351,37 @@ static void lcd_implementation_status_screen() {
     u8g.drawBox(0, 30, LCD_PIXEL_WIDTH, 9);
   #endif
   u8g.setColorIndex(0); // white on black
+
   u8g.setPrintPos(2, XYZ_BASELINE);
-  lcd_print('X');
+  lcd_print(TEST(axis_known_position, X_AXIS) || !TEST(axis_was_homed, X_AXIS) ? 'X' : '?');
   u8g.drawPixel(8, XYZ_BASELINE - 5);
   u8g.drawPixel(8, XYZ_BASELINE - 3);
   u8g.setPrintPos(10, XYZ_BASELINE);
-  if (axis_known_position[X_AXIS])
+  if (TEST(axis_was_homed, X_AXIS))
     lcd_print(ftostr31ns(current_position[X_AXIS]));
   else
     lcd_printPGM(PSTR("---"));
+
   u8g.setPrintPos(43, XYZ_BASELINE);
-  lcd_print('Y');
+  lcd_print(TEST(axis_known_position, Y_AXIS) || !TEST(axis_was_homed, Y_AXIS) ? 'Y' : '?');
   u8g.drawPixel(49, XYZ_BASELINE - 5);
   u8g.drawPixel(49, XYZ_BASELINE - 3);
   u8g.setPrintPos(51, XYZ_BASELINE);
-  if (axis_known_position[Y_AXIS])
+  if (TEST(axis_was_homed, Y_AXIS))
     lcd_print(ftostr31ns(current_position[Y_AXIS]));
   else
     lcd_printPGM(PSTR("---"));
+
   u8g.setPrintPos(83, XYZ_BASELINE);
-  lcd_print('Z');
+  lcd_print(TEST(axis_known_position, Z_AXIS) || !TEST(axis_was_homed, Z_AXIS) ? 'Z' : '?');
   u8g.drawPixel(89, XYZ_BASELINE - 5);
   u8g.drawPixel(89, XYZ_BASELINE - 3);
   u8g.setPrintPos(91, XYZ_BASELINE);
-  if (axis_known_position[Z_AXIS])
+  if (TEST(axis_was_homed, Z_AXIS))
     lcd_print(ftostr32sp(current_position[Z_AXIS]));
   else
     lcd_printPGM(PSTR("---.--"));
+
   u8g.setColorIndex(1); // black on white
 
   // Feedrate

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -4,6 +4,8 @@
 // Macros for bit masks
 #define BIT(b) (1<<(b))
 #define TEST(n,b) (((n)&BIT(b))!=0)
+#define BITSET(n,b) n |= BIT(b)
+#define BITCLR(n,b) n &= ~BIT(b)
 #define SET_BIT(n,b,value) (n) ^= ((-value)^(n)) & (BIT(b))
 
 // Macros for maths shortcuts

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -735,7 +735,7 @@ static void lcd_prepare_menu() {
   // Level Bed
   //
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
-    if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS])
+    if (axis_known_position & (BIT(X_AXIS)|BIT(Y_AXIS)) == BIT(X_AXIS)|BIT(Y_AXIS)) {
       MENU_ITEM(gcode, MSG_LEVEL_BED, PSTR("G29"));
   #elif ENABLED(MANUAL_BED_LEVELING)
     MENU_ITEM(submenu, MSG_LEVEL_BED, lcd_level_bed);
@@ -2271,7 +2271,7 @@ char* ftostr52(const float& x) {
    */
   static void _lcd_level_bed_homing() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ"), "Homing");
-    if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
+    if (axis_known_position & (BIT(X_AXIS)|BIT(Y_AXIS)|BIT(Z_AXIS)) == BIT(X_AXIS)|BIT(Y_AXIS)|BIT(Z_AXIS)) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
       current_position[X_AXIS] = MESH_MIN_X;
@@ -2287,7 +2287,7 @@ char* ftostr52(const float& x) {
    * MBL entry-point
    */
   static void lcd_level_bed() {
-    axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
+    axis_was_homed = axis_known_position = 0;
     mbl.reset();
     enqueuecommands_P(PSTR("G28"));
     lcdDrawUpdate = 2;

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -607,6 +607,12 @@ static void lcd_implementation_status_screen() {
 
       lcd.setCursor(0, 1);
 
+      //
+      // Print XYZ Coordinates
+      // If the axis was not homed, show "---"
+      // If the position is untrusted, show "?"
+      //
+
       #if EXTRUDERS > 1 && TEMP_SENSOR_BED != 0
 
         // If we both have a 2nd extruder and a heated bed,
@@ -616,14 +622,14 @@ static void lcd_implementation_status_screen() {
 
       #else
 
-        lcd.print('X');
-        if (axis_known_position[X_AXIS])
+        lcd.print(TEST(axis_known_position, X_AXIS) || !TEST(axis_was_homed, X_AXIS) ? 'X' : '?');
+        if (TEST(axis_was_homed, X_AXIS))
           lcd.print(ftostr4sign(current_position[X_AXIS]));
         else
           lcd_printPGM(PSTR(" ---"));
 
-        lcd_printPGM(PSTR(" Y"));
-        if (axis_known_position[Y_AXIS])
+        lcd_printPGM(TEST(axis_known_position, Y_AXIS) || !TEST(axis_was_homed, Y_AXIS) ? PSTR(" Y") : PSTR(" ?"));
+        if (TEST(axis_was_homed, Y_AXIS))
           lcd.print(ftostr4sign(current_position[Y_AXIS]));
         else
           lcd_printPGM(PSTR(" ---"));
@@ -633,8 +639,8 @@ static void lcd_implementation_status_screen() {
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    lcd_printPGM(PSTR("Z "));
-    if (axis_known_position[Z_AXIS])
+    lcd_printPGM(TEST(axis_known_position, Z_AXIS) || !TEST(axis_was_homed, Z_AXIS) ? PSTR("Z ") : PSTR("? "));
+    if (TEST(axis_was_homed, Z_AXIS))
       lcd.print(ftostr32sp(current_position[Z_AXIS] + 0.00001));
     else
       lcd_printPGM(PSTR("---.--"));


### PR DESCRIPTION
Corresponds to MarlinFirmware/MarlinDev#356 addressing issue #2661
- Convert `axis_known_position` to a bit-mask
- Add a new flag `axis_was_homed` and use it to decide how to display LCD coordinates:

Axis not homed: `X:---`
Axis homed and known: `X:123.4`
Axis homed but unknown: `?:123.4`

Note that the XY coordinates on graphical displays are still missing the sign when negative. That will need to be patched separately.
