### PR TITLE
Rc bug fix - Fix for issue #2931

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2308,7 +2308,8 @@ inline void gcode_G28() {
           }
         #endif
 
-      #elif DISABLED(Z_SAFE_HOMING) && defined(Z_RAISE_BEFORE_HOMING) && Z_RAISE_BEFORE_HOMING > 0
+      #elif defined(Z_RAISE_BEFORE_HOMING) && Z_RAISE_BEFORE_HOMING > 0
+//      #elif DISABLED(Z_SAFE_HOMING) && defined(Z_RAISE_BEFORE_HOMING) && Z_RAISE_BEFORE_HOMING > 0
 
         // Raise Z before homing any other axes
         // (Does this need to be "negative home direction?" Why not just use Z_RAISE_BEFORE_HOMING?)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2309,7 +2309,6 @@ inline void gcode_G28() {
         #endif
 
       #elif defined(Z_RAISE_BEFORE_HOMING) && Z_RAISE_BEFORE_HOMING > 0
-//      #elif DISABLED(Z_SAFE_HOMING) && defined(Z_RAISE_BEFORE_HOMING) && Z_RAISE_BEFORE_HOMING > 0
 
         // Raise Z before homing any other axes
         // (Does this need to be "negative home direction?" Why not just use Z_RAISE_BEFORE_HOMING?)


### PR DESCRIPTION
This change should fix issue #2931 

If Z_SAFE_HOMING is set, then Z_RAISE_BEFORE_HOMING doesn't happen until after X and Y have been homed.  This is actually unsafe on many printers.  Disabling Z_SAFE_HOMING is also undesirable, because of the many benefits when using a head mounted Z probe, such as not probing when the probe isn't over the bed. 

This change allows the Z raise before X and Y are homed, even if Z_SAFE_HOMING is set.  The risk of raising Z before homing, is that if Z is already near max, and the Z_MAX_POS is too high, then it could be a problem.  This is noted on the comment for Z_RAISE_BEFORE_HOMING.  The risk of not raising Z before homing X and Y, is that the Z probe and head may be crashed through bed leveling knobs, screws, clips, etc. on the way to X and Y home if the head was already at 0, or the head was out of bounds.

I believe that raising Z before homing X & Y (when that is set) is better than homing X and Y first, then raising Z anyway, which is how it works with Z_SAFE_HOMING set in the current RcBugFix branch.
