### PR TITLE
Use a serial line buffer to prevent queue corruption

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -223,8 +223,8 @@ extern bool Running;
 inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }
 
-bool enqueuecommand(const char* cmd); //put a single ASCII command at the end of the current buffer or return false when it is full
-void enqueuecommands_P(const char* cmd); //put one or many ASCII commands at the end of the current buffer, read from flash
+bool enqueue_and_echo_command(const char* cmd, bool say_ok=false); //put a single ASCII command at the end of the current buffer or return false when it is full
+void enqueue_and_echo_commands_P(const char* cmd); //put one or many ASCII commands at the end of the current buffer, read from flash
 
 void prepare_arc_move(char isclockwise);
 void clamp_to_software_endstops(float target[3]);

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -23,6 +23,7 @@ public:
   void removeFile(char* name);
   void closefile(bool store_location=false);
   void release();
+  void openAndPrintFile(const char *name);
   void startFileprint();
   void pauseSDPrint();
   void getStatus();

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -617,7 +617,7 @@ ISR(TIMER1_COMPA_vect) {
     current_block = NULL;
     plan_discard_current_block();
     #ifdef SD_FINISHED_RELEASECOMMAND
-      if ((cleaning_buffer_counter == 1) && (SD_FINISHED_STEPPERRELEASE)) enqueuecommands_P(PSTR(SD_FINISHED_RELEASECOMMAND));
+      if ((cleaning_buffer_counter == 1) && (SD_FINISHED_STEPPERRELEASE)) enqueue_and_echo_commands_P(PSTR(SD_FINISHED_RELEASECOMMAND));
     #endif
     cleaning_buffer_counter--;
     OCR1A = 200;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -479,7 +479,7 @@ static void lcd_main_menu() {
  */
 void lcd_set_home_offsets() {
   // M428 Command
-  enqueuecommands_P(PSTR("M428"));
+  enqueue_and_echo_commands_P(PSTR("M428"));
   lcd_return_to_status();
 }
 
@@ -1504,7 +1504,7 @@ menu_edit_type(unsigned long, long5, ftostr5, 0.01)
     lcd_move_y();
   }
   static void reprapworld_keypad_move_home() {
-    enqueuecommands_P((PSTR("G28"))); // move all axis home
+    enqueue_and_echo_commands_P((PSTR("G28"))); // move all axis home
   }
 #endif // REPRAPWORLD_KEYPAD
 
@@ -1556,18 +1556,13 @@ void lcd_quick_feedback() {
  */
 static void menu_action_back(menuFunc_t func) { lcd_goto_menu(func); }
 static void menu_action_submenu(menuFunc_t func) { lcd_save_previous_menu(); lcd_goto_menu(func); }
-static void menu_action_gcode(const char* pgcode) { enqueuecommands_P(pgcode); }
+static void menu_action_gcode(const char* pgcode) { enqueue_and_echo_commands_P(pgcode); }
 static void menu_action_function(menuFunc_t func) { (*func)(); }
 
 #if ENABLED(SDSUPPORT)
 
   static void menu_action_sdfile(const char* filename, char* longFilename) {
-    char cmd[30];
-    char* c;
-    sprintf_P(cmd, PSTR("M23 %s"), filename);
-    for (c = &cmd[4]; *c; c++) *c = tolower(*c);
-    enqueuecommand(cmd);
-    enqueuecommands_P(PSTR("M24"));
+    card.openAndPrintFile(filename);
     lcd_return_to_status();
   }
 
@@ -2313,7 +2308,7 @@ char* ftostr52(const float& x) {
           current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
           line_to_current(Z_AXIS);
           mbl.active = 1;
-          enqueuecommands_P(PSTR("G28"));
+          enqueue_and_echo_commands_P(PSTR("G28"));
           lcd_return_to_status();
         }
         else {
@@ -2357,7 +2352,7 @@ char* ftostr52(const float& x) {
   static void lcd_level_bed() {
     axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
     mbl.reset();
-    enqueuecommands_P(PSTR("G28"));
+    enqueue_and_echo_commands_P(PSTR("G28"));
     lcdDrawUpdate = 2;
     lcd_goto_menu(_lcd_level_bed_homing);
   }


### PR DESCRIPTION
In addition to getting rid of "ok" messages for all non-serial commands...

This PR takes another approach to fix the issue where `enqueuecommand` causes the command queue to become corrupted. To sum up the bug, if any code uses `enqueuecommand` or `enqueuecommands_P` while there's a serial stream (as with an active print job), if there is an incomplete command in the buffer, the injected command will first overwrite the current buffer slot, then the next buffer slot will get only a partial serial command written into it, causing unpredictable results due to stale data in the ring buffer.

This approach adds an intermediate buffer to cache a single line of serial input. This ensures that only complete commands are ever injected into the queue. So there's no incomplete writing state, and calls to `enqueuecommand` can't corrupt some serial command in-progress.

As a result, code doesn't need to worry about whether `serial_count` is zero or not, and the SD buffer continues to process in the middle of an incomplete serial command.
- To prevent spurious re-running of dead commands in the queue, one additional trick would be to write `null` to the first byte of the command slot immediately after processing it.

References: #2911 #2951 #2984
