### PR TITLE
language.h: SOURCE_CODE_URL - suppress redefinition warnings

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -50,19 +50,23 @@
 
 #if MB(ULTIMAKER)|| MB(ULTIMAKER_OLD)|| MB(ULTIMAIN_2)
   #define MACHINE_NAME "Ultimaker"
+  #undef SOURCE_CODE_URL
   #define SOURCE_CODE_URL "https://github.com/Ultimaker/Marlin"
 #elif MB(RUMBA)
   #define MACHINE_NAME "Rumba"
 #elif MB(3DRAG)
   #define MACHINE_NAME "3Drag"
+  #undef SOURCE_CODE_URL
   #define SOURCE_CODE_URL "http://3dprint.elettronicain.it/"
 #elif MB(K8200)
   #define MACHINE_NAME "K8200"
+  #undef SOURCE_CODE_URL
   #define SOURCE_CODE_URL "https://github.com/CONSULitAS/Marlin-K8200"
 #elif MB(5DPRINT)
   #define MACHINE_NAME "Makibox"
 #elif MB(SAV_MKI)
   #define MACHINE_NAME "SAV MkI"
+  #undef SOURCE_CODE_URL
   #define SOURCE_CODE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
 #elif !defined(MACHINE_NAME)
   #define MACHINE_NAME "3D Printer"


### PR DESCRIPTION
if you define Motherboard e.g. „K8200“ you get a lot of warnings:

```
In file included from sketch/Marlin_main.cpp:49:0:
sketch/language.h:62:0: warning: "SOURCE_CODE_URL" redefined [enabled
by default]
   #define SOURCE_CODE_URL "https://github.com/CONSULitAS/Marlin-K8200"
 ^
In file included from sketch/language.h:46:0,
                 from sketch/Marlin_main.cpp:49:
sketch/Default_Version.h:13:0: note: this is the location of the
previous definition
 #define SOURCE_CODE_URL  "http:// ..."
 ^
```

the `#undef` suppresses the warnings
