### PR TITLE
Don't override SOURCE_CODE_URL in Default_Version.h

### DIFF
--- a/Marlin/Default_Version.h
+++ b/Marlin/Default_Version.h
@@ -10,5 +10,5 @@
 #define DETAILED_BUILD_VERSION "1.1.0-RC3 From Archive"
 #define STRING_DISTRIBUTION_DATE "2015-12-01 12:00"
 // It might also be appropriate to define a location where additional information can be found
-#define SOURCE_CODE_URL  "http:// ..."
+// #define SOURCE_CODE_URL  "http:// ..."
 #endif

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -49,32 +49,34 @@
 #define PROTOCOL_VERSION "1.0"
 
 #if MB(ULTIMAKER)|| MB(ULTIMAKER_OLD)|| MB(ULTIMAIN_2)
-  #define MACHINE_NAME "Ultimaker"
-  #define SOURCE_CODE_URL "https://github.com/Ultimaker/Marlin"
+  #define DEFAULT_MACHINE_NAME "Ultimaker"
+  #define DEFAULT_SOURCE_URL "https://github.com/Ultimaker/Marlin"
 #elif MB(RUMBA)
-  #define MACHINE_NAME "Rumba"
+  #define DEFAULT_MACHINE_NAME "Rumba"
 #elif MB(3DRAG)
-  #define MACHINE_NAME "3Drag"
-  #define SOURCE_CODE_URL "http://3dprint.elettronicain.it/"
+  #define DEFAULT_MACHINE_NAME "3Drag"
+  #define DEFAULT_SOURCE_URL "http://3dprint.elettronicain.it/"
 #elif MB(K8200)
-  #define MACHINE_NAME "K8200"
-  #define SOURCE_CODE_URL "https://github.com/CONSULitAS/Marlin-K8200"
+  #define DEFAULT_MACHINE_NAME "K8200"
+  #define DEFAULT_SOURCE_URL "https://github.com/CONSULitAS/Marlin-K8200"
 #elif MB(5DPRINT)
-  #define MACHINE_NAME "Makibox"
+  #define DEFAULT_MACHINE_NAME "Makibox"
 #elif MB(SAV_MKI)
-  #define MACHINE_NAME "SAV MkI"
-  #define SOURCE_CODE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
-#elif !defined(MACHINE_NAME)
-  #define MACHINE_NAME "3D Printer"
+  #define DEFAULT_MACHINE_NAME "SAV MkI"
+  #define DEFAULT_SOURCE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
+#else
+  #define DEFAULT_MACHINE_NAME "3D Printer"
+  #define DEFAULT_SOURCE_URL "https://github.com/MarlinFirmware/Marlin"
 #endif
 
 #ifdef CUSTOM_MACHINE_NAME
-  #undef MACHINE_NAME
   #define MACHINE_NAME CUSTOM_MACHINE_NAME
+#else
+  #define MACHINE_NAME DEFAULT_MACHINE_NAME
 #endif
 
 #ifndef SOURCE_CODE_URL
-  #define SOURCE_CODE_URL "https://github.com/MarlinFirmware/Marlin"
+  #define SOURCE_CODE_URL DEFAULT_SOURCE_URL
 #endif
 
 #ifndef DETAILED_BUILD_VERSION


### PR DESCRIPTION
Rework of #3017
- Defining `SOURCE_CODE_URL` in `Default_Version.h` overrides it elsewhere. So comment it out.
- Fix up `language.h` so no `#undef` is needed.
