### PR TITLE
Fix: current_command_args contains command

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5714,7 +5714,7 @@ void process_next_command() {
 
   // Args pointer optimizes code_seen, especially those taking XYZEF
   // This wastes a little cpu on commands that expect no arguments.
-  current_command_args = current_command;
+  current_command_args = current_command+2; // skip two chars for command code and first digit
   while (*current_command_args >= '0' && *current_command_args <= '9') ++current_command_args;
   while (*current_command_args == ' ') ++current_command_args;
 


### PR DESCRIPTION
@thinkyhead
Hi Scott,
your code from a0f362c@thinkyhead is great, but you forgot to skip the
command.
Symptom `M117 Test`shows `M117 Test` on LCD instead of `Test`.

see also
https://github.com/MarlinFirmware/Marlin/commit/a0f362c735401ebbcd95de3f
6f8e3c2f17ecc770 lines 941, 2851 and so on

Greetings and welcome back

Jochen
