### PR TITLE
Fix GCode handling of spaces between command letter and first digit

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5704,8 +5704,12 @@ void process_next_command() {
   // Get the command code, which must be G, M, or T
   char command_code = *current_command;
 
+  // Skip the letter-code and spaces to get the numeric part
+  current_command_args = current_command + 1;
+  while (*current_command_args == ' ') ++current_command_args;
+
   // The code must have a numeric value
-  bool code_is_good = (current_command[1] >= '0' && current_command[1] <= '9');
+  bool code_is_good = (*current_command_args >= '0' && *current_command_args <= '9');
 
   int codenum; // define ahead of goto
 
@@ -5714,9 +5718,7 @@ void process_next_command() {
 
   // Args pointer optimizes code_seen, especially those taking XYZEF
   // This wastes a little cpu on commands that expect no arguments.
-  current_command_args = current_command+2; // skip two chars for command code and first digit
-  while (*current_command_args >= '0' && *current_command_args <= '9') ++current_command_args;
-  while (*current_command_args == ' ') ++current_command_args;
+  while (*current_command_args == ' ' || (*current_command_args >= '0' && *current_command_args <= '9')) ++current_command_args;
 
   // Interpret the code int
   seen_pointer = current_command;


### PR DESCRIPTION
This fixes a bug #2715 where the command argument pointer was not being properly set. In addition it makes the GCode parser tolerant of a space after the initial command letter. See also MarlinFirmware/MarlinDev#352 and #3027
