### PR TITLE
Make RAMPS 1.3 the special case, default to RAMPS 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,20 +49,20 @@ script:
   # backup configuration.h
   - cp Marlin/Configuration.h Marlin/Configuration.h.backup
   - cp Marlin/Configuration_adv.h Marlin/Configuration_adv.h.backup
-  - cp Marlin/pins_RAMPS_13.h Marlin/pins_RAMPS_13.h.backup
+  - cp Marlin/pins_RAMPS_14.h Marlin/pins_RAMPS_14.h.backup
   # add sensor for bed
   - sed -i 's/#define TEMP_SENSOR_BED 0/#define TEMP_SENSOR_BED 1/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # change extruder numbers from 1 to 2
-  - sed -i 's/#define MOTHERBOARD BOARD_RAMPS_13_EFB/#define MOTHERBOARD BOARD_RAMPS_13_EEB/g' Marlin/Configuration.h
+  - sed -i 's/#define MOTHERBOARD BOARD_RAMPS_14_EFB/#define MOTHERBOARD BOARD_RAMPS_14_EEB/g' Marlin/Configuration.h
   - sed -i 's/#define EXTRUDERS 1/#define EXTRUDERS 2/g' Marlin/Configuration.h
   - sed -i 's/#define TEMP_SENSOR_1 0/#define TEMP_SENSOR_1 1/g' Marlin/Configuration.h
   #- cat Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # change extruder numbers from 2 to 3, needs to be a board with 3 extruders defined in pins.h 
-  - sed -i 's/#define MOTHERBOARD BOARD_RAMPS_13_EEB/#define MOTHERBOARD BOARD_RUMBA/g' Marlin/Configuration.h
+  - sed -i 's/#define MOTHERBOARD BOARD_RAMPS_14_EEB/#define MOTHERBOARD BOARD_RUMBA/g' Marlin/Configuration.h
   - sed -i 's/#define EXTRUDERS 2/#define EXTRUDERS 3/g' Marlin/Configuration.h
   - sed -i 's/#define TEMP_SENSOR_2 0/#define TEMP_SENSOR_2 1/g' Marlin/Configuration.h
   - rm -rf .build/
@@ -175,13 +175,13 @@ script:
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define Z_DUAL_STEPPER_DRIVERS/#define Z_DUAL_STEPPER_DRIVERS/g' Marlin/Configuration_adv.h
   - sed -i 's/\ \ \/\/\ \#define Z_DUAL_ENDSTOPS/#define Z_DUAL_ENDSTOPS/g' Marlin/Configuration_adv.h
-  - sed -i 's/#define X_MAX_PIN           2/#define X_MAX_PIN          -1/g' Marlin/pins_RAMPS_13.h
+  - sed -i 's/#define X_MAX_PIN           2/#define X_MAX_PIN          -1/g' Marlin/pins_RAMPS_14.h
   - sed -i 's/\ \ \ \ \#define Z2_MAX_PIN 36/#define Z2_MAX_PIN  2/g' Marlin/Configuration_adv.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - cp Marlin/Configuration_adv.h.backup Marlin/Configuration_adv.h
-  - cp Marlin/pins_RAMPS_13.h.backup Marlin/pins_RAMPS_13.h
+  - cp Marlin/pins_RAMPS_14.h.backup Marlin/pins_RAMPS_14.h
   ######## Example Configurations ##############
   # Delta Config (generic)
   - cp Marlin/example_configurations/delta/generic/Configuration* Marlin/

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -70,7 +70,7 @@ Here are some standard links for getting your machine calibrated:
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_13_EFB
+  #define MOTHERBOARD BOARD_RAMPS_14_EFB
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -54,6 +54,7 @@
 #define BOARD_OMCA              91   // Final OMCA board
 #define BOARD_RAMBO             301  // Rambo
 #define BOARD_MINIRAMBO         302  // Mini-Rambo
+#define BOARD_AJ4P              303  // AJ4P
 #define BOARD_MEGACONTROLLER    310  // Mega controller
 #define BOARD_ELEFU_3           21   // Elefu Ra Board (v3)
 #define BOARD_5DPRINT           88   // 5DPrint D8 Driver Board

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -95,7 +95,7 @@ Here are some standard links for getting your machine calibrated:
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_13_EFB
+  #define MOTHERBOARD BOARD_RAMPS_14_EFB
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -70,7 +70,7 @@ Here are some standard links for getting your machine calibrated:
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_13_EFB
+  #define MOTHERBOARD BOARD_RAMPS_14_EFB
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -70,7 +70,7 @@ Here are some standard links for getting your machine calibrated:
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_13_EFB
+  #define MOTHERBOARD BOARD_RAMPS_14_EFB
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -70,7 +70,7 @@ Here are some standard links for getting your machine calibrated:
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_13_EFB
+  #define MOTHERBOARD BOARD_RAMPS_14_EFB
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -70,7 +70,7 @@ Here are some standard links for getting your machine calibrated:
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_13_EFB
+  #define MOTHERBOARD BOARD_RAMPS_14_EFB
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -127,6 +127,8 @@
   #include "pins_BQ_ZUM_MEGA_3D.h"
 #elif MB(99)
   #include "pins_99.h"
+#elif MB(AJ4P)
+  #include "pins_AJ4P.h"
 #else
   #error Unknown MOTHERBOARD value set in Configuration.h
 #endif

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -38,11 +38,9 @@
 #elif MB(RAMPS_13_EEB) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
   #include "pins_RAMPS_13.h"
 #elif MB(RAMPS_14_EFB)
-  #define IS_RAMPS_14
-  #include "pins_RAMPS_13_EFB.h"
+  #include "pins_RAMPS_14_EFB.h"
 #elif MB(RAMPS_14_EEB) || MB(RAMPS_14_EFF) || MB(RAMPS_14_EEF) || MB(RAMPS_14_SF)
-  #define IS_RAMPS_14
-  #include "pins_RAMPS_13.h"
+  #include "pins_RAMPS_14.h"
 #elif MB(GEN6)
   #include "pins_GEN6.h"
 #elif MB(GEN6_DELUXE)
@@ -114,7 +112,7 @@
 #elif MB(LEAPFROG)
   #include "pins_LEAPFROG.h"
 #elif MB(BAM_DICE)
-  #include "pins_RAMPS_13.h"
+  #include "pins_RAMPS_14.h"
 #elif MB(BAM_DICE_DUE)
   #include "pins_BAM_DICE_DUE.h"
 #elif MB(FELIX2)

--- a/Marlin/pins_3DRAG.h
+++ b/Marlin/pins_3DRAG.h
@@ -1,8 +1,8 @@
 /**
- * 3DRAG (and K8200) Arduino Mega with RAMPS v1.3 pin assignments
+ * 3DRAG (and K8200) Arduino Mega with RAMPS v1.4 pin assignments
  */
 
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_14.h"
 
 #undef Z_ENABLE_PIN
 #define Z_ENABLE_PIN       63

--- a/Marlin/pins_A4JP.h
+++ b/Marlin/pins_A4JP.h
@@ -1,0 +1,138 @@
+/************************************************
+ * Rambo pin assignments MODIFIED FOR A4JP
+ ************************************************/
+
+#ifndef __AVR_ATmega2560__
+  #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
+#endif
+
+// Servo support
+#define SERVO0_PIN 22 // Motor header MX1
+#define SERVO1_PIN 23 // Motor header MX2
+#define SERVO2_PIN 24 // Motor header MX3
+#define SERVO3_PIN  5 // PWM header pin 5
+
+#if ENABLED(Z_PROBE_SLED)
+  #define SLED_PIN -1
+#endif
+
+#undef X_MS1_PIN
+#undef X_MS2_PIN
+#undef Y_MS1_PIN
+#undef Y_MS2_PIN
+#undef Z_MS1_PIN
+#undef Z_MS2_PIN
+#undef E0_MS1_PIN
+#undef E0_MS2_PIN
+#undef E1_MS1_PIN
+#undef E1_MS2_PIN
+
+#undef DIGIPOTSS_PIN
+//Fan_2 2
+
+/*****************
+#if ENABLED(ULTRA_LCD)
+
+  #define KILL_PIN -1 //was 80 Glen maybe a mistake
+
+#endif // ULTRA_LCD */
+
+#if ENABLED(VIKI2) || ENABLED(miniVIKI)
+  #define BEEPER_PIN 44
+  // Pins for DOGM SPI LCD Support
+  #define DOGLCD_A0  70
+  #define DOGLCD_CS  71
+  #define LCD_SCREEN_ROT_180
+
+  #define SD_DETECT_PIN -1 // Pin 72 if using easy adapter board
+
+  #if ENABLED(TEMP_STAT_LEDS)
+    #define STAT_LED_RED      22
+    #define STAT_LED_BLUE     32
+  #endif
+#endif // VIKI2/miniVIKI
+
+#if ENABLED(FILAMENT_SENSOR)
+  //Filip added pin for Filament sensor analog input
+  #define FILWIDTH_PIN        3
+#endif
+
+/************************************************
+ * Rambo pin assignments old
+ ************************************************/
+
+#define LARGE_FLASH true
+#define X_STEP_PIN    37
+#define X_DIR_PIN     48
+#define X_MIN_PIN     12
+#define X_MAX_PIN     24
+#define X_ENABLE_PIN  29
+#define X_MS1_PIN     40
+#define X_MS2_PIN     41
+#define Y_STEP_PIN    36
+#define Y_DIR_PIN     49
+#define Y_MIN_PIN     11
+#define Y_MAX_PIN     23
+#define Y_ENABLE_PIN  28
+#define Y_MS1_PIN     69
+#define Y_MS2_PIN     39
+#define Z_STEP_PIN    35
+#define Z_DIR_PIN     47
+#define Z_MIN_PIN     10
+#define Z_MAX_PIN     30
+#define Z_ENABLE_PIN  27
+#define Z_MS1_PIN     68
+#define Z_MS2_PIN     67
+
+#define HEATER_BED_PIN 3
+#define TEMP_BED_PIN   7 //2014/02/04  0:T0 / 1:T1 / 2:T2 / 7:T3
+#define HEATER_0_PIN   9
+#define TEMP_0_PIN     0
+#define HEATER_1_PIN   7
+#define TEMP_1_PIN    -1
+#define HEATER_2_PIN  -1
+#define TEMP_2_PIN    -1
+
+#define E0_STEP_PIN   34
+#define E0_DIR_PIN    43
+#define E0_ENABLE_PIN 26
+#define E0_MS1_PIN    65
+#define E0_MS2_PIN    66
+#define E1_STEP_PIN   33
+#define E1_DIR_PIN    42
+#define E1_ENABLE_PIN 25
+#define E1_MS1_PIN    63
+#define E1_MS2_PIN    64
+
+#define DIGIPOTSS_PIN 38
+#define DIGIPOT_CHANNELS {4,5,3,0,1} // X Y Z E0 E1 digipot channels to stepper driver mapping
+
+#define SDPOWER       -1
+#define SDSS          53
+#define LED_PIN       13
+#define FAN_PIN        8
+#define PS_ON_PIN      4
+#define KILL_PIN      -1
+#define SUICIDE_PIN   -1 //PIN that has to be turned on right after start, to keep power flowing.
+#define FAN_0_PIN      6 //Glen
+#define FAN_1_PIN      2 //Glen
+
+// 2015/12/23
+
+#define LCD_PINS_RS     70 //ext2_5
+#define LCD_PINS_ENABLE 71 //ext2_7
+#define LCD_PINS_D4     72 ///////Ext2 9 ?
+#define LCD_PINS_D5     73 ///////Ext2 11 ?
+#define LCD_PINS_D6     74 //ext2_13
+#define LCD_PINS_D7     75 ///////Ext2 15 ?
+#define BEEPER_PIN      -1
+
+#define BTN_HOME        80 //ext_16
+#define BTN_CENTER      81 //ext_14
+#define BTN_ENC         BTN_CENTER
+#define BTN_RIGHT       82 //ext_12
+#define BTN_LEFT        83 //ext_10
+#define BTN_UP          84 //ext2_8
+#define BTN_DOWN        85 //ext2_6
+
+#define HOME_PIN        BTN_HOME

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -1,8 +1,8 @@
 /**
- * AZTEEG_X3 Arduino Mega with RAMPS v1.3 pin assignments
+ * AZTEEG_X3 Arduino Mega with RAMPS v1.4 pin assignments
  */
 
-#include "pins_RAMPS_13_EFB.h"
+#include "pins_RAMPS_14_EFB.h"
 
 //LCD Pins//
 

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -2,7 +2,7 @@
  * AZTEEG_X3_PRO (Arduino Mega) pin assignments
  */
 
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_14.h"
 
 #undef FAN_PIN
 #define FAN_PIN             6 //Part Cooling System

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -2,7 +2,7 @@
  * BAM&DICE Due (Arduino Mega) pin assignments
  */
 
-#include "pins_RAMPS_13_EFB.h"
+#include "pins_RAMPS_14_EFB.h"
 
 #undef TEMP_0_PIN
 #undef TEMP_1_PIN

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -1,8 +1,8 @@
 /**
- * FELIXprinters v2.0/3.0 (RAMPS v1.3) pin assignments
+ * FELIXprinters v2.0/3.0 (RAMPS v1.4) pin assignments
  */
 
-#include "pins_RAMPS_13_EFB.h"
+#include "pins_RAMPS_14_EFB.h"
 
 #undef HEATER_1_PIN
 #define HEATER_1_PIN        7 // EXTRUDER 2

--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -2,7 +2,7 @@
  * MKS BASE 1.0 – Arduino Mega2560 with RAMPS v1.4 pin assignments
  */
 
-#include "pins_RAMPS_13_EFB.h"
+#include "pins_RAMPS_14_EFB.h"
 
 #undef HEATER_1_PIN
 #define HEATER_1_PIN        7

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -12,7 +12,7 @@
 #define SERVO0_PIN 22 // Motor header MX1
 #define SERVO1_PIN 23 // Motor header MX2
 #define SERVO2_PIN 24 // Motor header MX3
-#define SERVO2_PIN  5 // PWM header pin 5
+#define SERVO3_PIN  5 // PWM header pin 5
 
 #if ENABLED(Z_PROBE_SLED)
   #define SLED_PIN         -1

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -1,0 +1,16 @@
+/**
+ * Arduino Mega with RAMPS v1.3 pin assignments
+ *
+ * Applies to the following boards:
+ *
+ *  RAMPS_13_EFB (Extruder, Fan, Bed)
+ *  RAMPS_13_EEB (Extruder, Extruder, Bed)
+ *  RAMPS_13_EFF (Extruder, Fan, Fan)
+ *  RAMPS_13_EEF (Extruder, Extruder, Fan)
+ *  RAMPS_13_SF  (Spindle, Controller Fan)
+ * 
+ */
+
+#define IS_RAMPS_13
+
+#include "pins_RAMPS_14.h"

--- a/Marlin/pins_RAMPS_13_EFB.h
+++ b/Marlin/pins_RAMPS_13_EFB.h
@@ -1,9 +1,0 @@
-/**
- * Arduino Mega with RAMPS v1.3 pin assignments
- *
- *  RAMPS_13_EFB (Extruder, Fan, Bed)
- */
-
-#define IS_RAMPS_EFB
-
-#include "pins_RAMPS_13.h"

--- a/Marlin/pins_RAMPS_13_EFB.h
+++ b/Marlin/pins_RAMPS_13_EFB.h
@@ -1,0 +1,9 @@
+/**
+ * Arduino Mega with RAMPS v1.3 pin assignments
+ *
+ *  RAMPS_13_EFB (Extruder, Fan, Bed)
+ */
+
+#define IS_RAMPS_13
+
+#include "pins_RAMPS_14_EFB.h"

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -85,12 +85,12 @@
   #define FILRUNOUT_PIN     4
 #endif
 
-#if MB(RAMPS_13_EFF) || ENABLED(IS_RAMPS_EFB)
+#if MB(RAMPS_14_EFF) || MB(RAMPS_13_EFF) || ENABLED(IS_RAMPS_EFB)
   #define FAN_PIN           9 // (Sprinter config)
-  #if MB(RAMPS_13_EFF)
+  #if MB(RAMPS_14_EFF) || MB(RAMPS_13_EFF)
     #define CONTROLLERFAN_PIN  -1 // Pin used for the fan to cool controller
   #endif
-#elif MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
+#elif MB(RAMPS_14_EEF) || MB(RAMPS_14_SF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
   #define FAN_PIN           8
 #else
   #define FAN_PIN           4 // IO pin. Buffer needed
@@ -102,13 +102,13 @@
   #define KILL_PIN         41
 #endif
 
-#if MB(RAMPS_13_EFF)
+#if MB(RAMPS_14_EFF) || MB(RAMPS_13_EFF)
   #define HEATER_0_PIN      8
 #else
   #define HEATER_0_PIN     10   // EXTRUDER 1
 #endif
 
-#if MB(RAMPS_13_SF) || ENABLED(IS_RAMPS_EFB)
+#if MB(RAMPS_14_SF) || MB(RAMPS_13_SF) || ENABLED(IS_RAMPS_EFB)
   #define HEATER_1_PIN     -1
 #else
   #define HEATER_1_PIN      9   // EXTRUDER 2 (FAN On Sprinter)
@@ -120,7 +120,7 @@
 #define TEMP_1_PIN         15   // ANALOG NUMBERING
 #define TEMP_2_PIN         -1   // ANALOG NUMBERING
 
-#if MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
+#if MB(RAMPS_14_EFF) || MB(RAMPS_14_EEF) || MB(RAMPS_14_SF) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
   #define HEATER_BED_PIN   -1    // NO BED
 #else
   #define HEATER_BED_PIN    8    // BED

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -1,13 +1,7 @@
 /**
- * Arduino Mega with RAMPS v1.3 v1.4 pin assignments
+ * Arduino Mega with RAMPS v1.4 (or v1.3) pin assignments
  *
  * Applies to the following boards:
- *
- *  RAMPS_13_EFB (Extruder, Fan, Bed)
- *  RAMPS_13_EEB (Extruder, Extruder, Bed)
- *  RAMPS_13_EFF (Extruder, Fan, Fan)
- *  RAMPS_13_EEF (Extruder, Extruder, Fan)
- *  RAMPS_13_SF  (Spindle, Controller Fan)
  *
  *  RAMPS_14_EFB (Extruder, Fan, Bed)
  *  RAMPS_14_EEB (Extruder, Extruder, Bed)
@@ -15,6 +9,12 @@
  *  RAMPS_14_EEF (Extruder, Extruder, Fan)
  *  RAMPS_14_SF  (Spindle, Controller Fan)
  *
+ *  RAMPS_13_EFB (Extruder, Fan, Bed)
+ *  RAMPS_13_EEB (Extruder, Extruder, Bed)
+ *  RAMPS_13_EFF (Extruder, Fan, Fan)
+ *  RAMPS_13_EEF (Extruder, Extruder, Fan)
+ *  RAMPS_13_SF  (Spindle, Controller Fan)
+ * 
  *  Other pins_MYBOARD.h files may override these defaults
  *
  *  Differences between
@@ -28,10 +28,10 @@
 
 #define LARGE_FLASH true
 
-#ifdef IS_RAMPS_14
-  #define SERVO0_PIN       11
-#else
+#ifdef IS_RAMPS_13
   #define SERVO0_PIN        7 // RAMPS_13 // Will conflict with BTN_EN2 on LCD_I2C_VIKI
+#else
+  #define SERVO0_PIN       11
 #endif
 #define SERVO1_PIN          6
 #define SERVO2_PIN          5

--- a/Marlin/pins_RAMPS_14_EFB.h
+++ b/Marlin/pins_RAMPS_14_EFB.h
@@ -1,0 +1,9 @@
+/**
+ * Arduino Mega with RAMPS v1.4 pin assignments
+ *
+ *  RAMPS_14_EFB (Extruder, Fan, Bed)
+ */
+
+#define IS_RAMPS_EFB
+
+#include "pins_RAMPS_14.h"

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -1,8 +1,8 @@
 /**
- * RIGIDBOARD Arduino Mega with RAMPS v1.3 pin assignments
+ * RIGIDBOARD Arduino Mega with RAMPS v1.4 pin assignments
  */
 
-#include "pins_RAMPS_13.h"
+#include "pins_RAMPS_14.h"
 
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
   #undef Z_MAX_PIN


### PR DESCRIPTION
Boards should assume RAMPS 1.4 pin assignments, with RAMPS 1.3 as the exception. The only affected pin is `SERVO0_PIN`. See also MarlinFirmware/MarlinDev#375
