### PR TITLE
deleted double used comments

### DIFF
--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -126,10 +126,6 @@ void MarlinSerial::flush() {
   // occurs after reading the value of rx_buffer_head but before writing
   // the value to rx_buffer_tail; the previous value of rx_buffer_head
   // may be written to rx_buffer_tail, making it appear as if the buffer
-  // don't reverse this or there may be problems if the RX interrupt
-  // occurs after reading the value of rx_buffer_head but before writing
-  // the value to rx_buffer_tail; the previous value of rx_buffer_head
-  // may be written to rx_buffer_tail, making it appear as if the buffer
   // were full, not empty.
   rx_buffer.head = rx_buffer.tail;
 }


### PR DESCRIPTION
Deleting double used comments in the File MarlinSerial.cpp for nicer reading. 
