### PR TITLE
Add Watchdog timer reset in kill()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7115,7 +7115,11 @@ void kill(const char* lcd_msg) {
   for (int i = 5; i--; lcd_update()) delay(200); // Wait a short time
   cli();   // disable interrupts
   suicide();
-  while (1) { /* Intentionally left empty */ } // Wait for reset
+  while (1) {
+	#if ENABLED(USE_WATCHDOG)
+	  watchdog_reset();
+	#endif
+  } // Wait for reset
 }
 
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)


### PR DESCRIPTION
Add watchdog reset in the kill loop to simplify recovering with Arduino Mega based boards..

Fix for #3076 
