### PR TITLE
Support for multiple PWM fans

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -465,7 +465,9 @@
   #define HAS_AUTO_FAN_2 (PIN_EXISTS(EXTRUDER_2_AUTO_FAN))
   #define HAS_AUTO_FAN_3 (PIN_EXISTS(EXTRUDER_3_AUTO_FAN))
   #define HAS_AUTO_FAN (HAS_AUTO_FAN_0 || HAS_AUTO_FAN_1 || HAS_AUTO_FAN_2 || HAS_AUTO_FAN_3)
-  #define HAS_FAN (PIN_EXISTS(FAN))
+  #define HAS_FAN0 (PIN_EXISTS(FAN))
+  #define HAS_FAN1 (PIN_EXISTS(FAN1) && CONTROLLERFAN_PIN != FAN1_PIN && EXTRUDER_0_AUTO_FAN_PIN != FAN1_PIN && EXTRUDER_1_AUTO_FAN_PIN != FAN1_PIN && EXTRUDER_2_AUTO_FAN_PIN != FAN1_PIN)
+  #define HAS_FAN2 (PIN_EXISTS(FAN2) && CONTROLLERFAN_PIN != FAN2_PIN && EXTRUDER_0_AUTO_FAN_PIN != FAN2_PIN && EXTRUDER_1_AUTO_FAN_PIN != FAN2_PIN && EXTRUDER_2_AUTO_FAN_PIN != FAN2_PIN)
   #define HAS_CONTROLLERFAN (PIN_EXISTS(CONTROLLERFAN))
   #define HAS_SERVOS (defined(NUM_SERVOS) && NUM_SERVOS > 0)
   #define HAS_SERVO_0 (PIN_EXISTS(SERVO0))
@@ -550,9 +552,31 @@
   #if HAS_HEATER_BED
     #define WRITE_HEATER_BED(v) WRITE(HEATER_BED_PIN, v)
   #endif
-  #if HAS_FAN
-    #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+
+  /**
+   * Up to 3 PWM fans
+   */
+  #if HAS_FAN2
+    #define FAN_COUNT 3
+  #elif HAS_FAN1
+    #define FAN_COUNT 2
+  #elif HAS_FAN0
+    #define FAN_COUNT 1
+  #else
+    #define FAN_COUNT 0
   #endif
+
+  #if HAS_FAN0
+    #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+    #define WRITE_FAN0(v) WRITE_FAN(v)
+  #endif
+  #if HAS_FAN1
+    #define WRITE_FAN1(v) WRITE(FAN1_PIN, v)
+  #endif
+  #if HAS_FAN2
+    #define WRITE_FAN2(v) WRITE(FAN2_PIN, v)
+  #endif
+  #define WRITE_FAN_N(n, v) WRITE_FAN##n(v)
 
   #define HAS_BUZZER (PIN_EXISTS(BEEPER) || defined(LCD_USE_I2C_BUZZER))
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -306,15 +306,13 @@ extern bool axis_homed[3]; // axis[n].is_homed
   extern float extrude_min_temp;
 #endif
 
-extern int fanSpeed;
+#if FAN_COUNT > 0
+  extern int fanSpeeds[FAN_COUNT];
+#endif
 
 #if ENABLED(BARICUDA)
   extern int ValvePressure;
   extern int EtoPPressure;
-#endif
-
-#if ENABLED(FAN_SOFT_PWM)
-  extern unsigned char fanSpeedSoftPwm;
 #endif
 
 #if ENABLED(FILAMENT_SENSOR)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4047,7 +4047,7 @@ inline void gcode_M109() {
         }
       #else
         SERIAL_EOL;
-      #endif //TEMP_RESIDENCY_TIME
+      #endif
     }
 
     idle();

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -264,20 +264,34 @@
 /**
  * Make sure auto fan pins don't conflict with the fan pin
  */
-#if HAS_AUTO_FAN && HAS_FAN
-  #if EXTRUDER_0_AUTO_FAN_PIN == FAN_PIN
-    #error You cannot set EXTRUDER_0_AUTO_FAN_PIN equal to FAN_PIN.
-  #elif EXTRUDER_1_AUTO_FAN_PIN == FAN_PIN
-    #error You cannot set EXTRUDER_1_AUTO_FAN_PIN equal to FAN_PIN.
-  #elif EXTRUDER_2_AUTO_FAN_PIN == FAN_PIN
-    #error You cannot set EXTRUDER_2_AUTO_FAN_PIN equal to FAN_PIN.
-  #elif EXTRUDER_3_AUTO_FAN_PIN == FAN_PIN
-    #error You cannot set EXTRUDER_3_AUTO_FAN_PIN equal to FAN_PIN.
+#if HAS_AUTO_FAN
+  #if HAS_FAN0
+    #if EXTRUDER_0_AUTO_FAN_PIN == FAN_PIN
+      #error You cannot set EXTRUDER_0_AUTO_FAN_PIN equal to FAN_PIN.
+    #elif EXTRUDER_1_AUTO_FAN_PIN == FAN_PIN
+      #error You cannot set EXTRUDER_1_AUTO_FAN_PIN equal to FAN_PIN.
+    #elif EXTRUDER_2_AUTO_FAN_PIN == FAN_PIN
+      #error You cannot set EXTRUDER_2_AUTO_FAN_PIN equal to FAN_PIN.
+    #elif EXTRUDER_3_AUTO_FAN_PIN == FAN_PIN
+      #error You cannot set EXTRUDER_3_AUTO_FAN_PIN equal to FAN_PIN.
+    #endif
   #endif
 #endif
 
-#if HAS_FAN && CONTROLLERFAN_PIN == FAN_PIN
+#if HAS_FAN0 && CONTROLLERFAN_PIN == FAN_PIN
   #error You cannot set CONTROLLERFAN_PIN equal to FAN_PIN.
+#endif
+
+#if HAS_CONTROLLERFAN
+  #if EXTRUDER_0_AUTO_FAN_PIN == CONTROLLERFAN_PIN
+    #error You cannot set EXTRUDER_0_AUTO_FAN_PIN equal to CONTROLLERFAN_PIN.
+  #elif EXTRUDER_1_AUTO_FAN_PIN == CONTROLLERFAN_PIN
+    #error You cannot set EXTRUDER_1_AUTO_FAN_PIN equal to CONTROLLERFAN_PIN.
+  #elif EXTRUDER_2_AUTO_FAN_PIN == CONTROLLERFAN_PIN
+    #error You cannot set EXTRUDER_2_AUTO_FAN_PIN equal to CONTROLLERFAN_PIN.
+  #elif EXTRUDER_3_AUTO_FAN_PIN == CONTROLLERFAN_PIN
+    #error You cannot set EXTRUDER_3_AUTO_FAN_PIN equal to CONTROLLERFAN_PIN.
+  #endif
 #endif
 
 /**

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -283,7 +283,7 @@ static void lcd_implementation_status_screen() {
   u8g.setColorIndex(1); // black on white
 
   // Symbols menu graphics, animated fan
-  u8g.drawBitmapP(9,1,STATUS_SCREENBYTEWIDTH,STATUS_SCREENHEIGHT, (blink % 2) && fanSpeed ? status_screen0_bmp : status_screen1_bmp);
+  u8g.drawBitmapP(9,1,STATUS_SCREENBYTEWIDTH,STATUS_SCREENHEIGHT, (blink % 2) && fanSpeeds[0] ? status_screen0_bmp : status_screen1_bmp);
 
   #if ENABLED(SDSUPPORT)
     // SD Card Symbol
@@ -324,8 +324,8 @@ static void lcd_implementation_status_screen() {
   // Fan
   lcd_setFont(FONT_STATUSMENU);
   u8g.setPrintPos(104, 27);
-  #if HAS_FAN
-    int per = ((fanSpeed + 1) * 100) / 256;
+  #if HAS_FAN0
+    int per = ((fanSpeeds[0] + 1) * 100) / 256;
     if (per) {
       lcd_print(itostr3(per));
       lcd_print('%');

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -49,7 +49,7 @@
 #define FAN1_PIN 35
 #define FAN2_PIN 36
 #define FAN_SOFT_PWM
-#define CONTROLLERFAN_PIN 36
+#define CONTROLLERFAN_PIN FAN2_PIN
 #define PS_ON_PIN -1
 #define KILL_PIN -1
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -59,12 +59,18 @@ typedef struct {
   unsigned long initial_rate;                        // The jerk-adjusted step rate at start of block
   unsigned long final_rate;                          // The minimal rate at exit
   unsigned long acceleration_st;                     // acceleration steps/sec^2
-  unsigned long fan_speed;
+
+  #if FAN_COUNT > 0
+    unsigned long fan_speed[FAN_COUNT];
+  #endif
+
   #if ENABLED(BARICUDA)
     unsigned long valve_pressure;
     unsigned long e_to_p_pressure;
   #endif
+
   volatile char busy;
+
 } block_t;
 
 #define BLOCK_MOD(n) ((n)&(BLOCK_BUFFER_SIZE-1))

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -614,7 +614,22 @@ static void lcd_tune_menu() {
   //
   // Fan Speed:
   //
-  MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED, &fanSpeed, 0, 255);
+  #if FAN_COUNT > 0
+    #if HAS_FAN0
+      #if FAN_COUNT > 1
+        #define MSG_1ST_FAN_SPEED MSG_FAN_SPEED " 1"
+      #else
+        #define MSG_1ST_FAN_SPEED MSG_FAN_SPEED
+      #endif
+      MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_1ST_FAN_SPEED, &fanSpeeds[0], 0, 255);
+    #endif
+    #if HAS_FAN1
+      MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 2", &fanSpeeds[1], 0, 255);
+    #endif
+    #if HAS_FAN2
+      MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 3", &fanSpeeds[2], 0, 255);
+    #endif
+  #endif // FAN_COUNT > 0
 
   //
   // Flow:
@@ -665,7 +680,13 @@ void _lcd_preheat(int endnum, const float temph, const float tempb, const int fa
   #if TEMP_SENSOR_BED != 0
     setTargetBed(tempb);
   #endif
-  fanSpeed = fan;
+  #if FAN_COUNT > 0
+    #if FAN_COUNT > 1
+      fanSpeeds[active_extruder < FAN_COUNT ? active_extruder : 0] = fan;
+    #else
+      fanSpeeds[0] = fan;
+    #endif
+  #endif
   lcd_return_to_status();
 }
 
@@ -755,8 +776,10 @@ void _lcd_preheat(int endnum, const float temph, const float tempb, const int fa
 #endif // TEMP_SENSOR_0 && (TEMP_SENSOR_1 || TEMP_SENSOR_2 || TEMP_SENSOR_3 || TEMP_SENSOR_BED)
 
 void lcd_cooldown() {
+  #if FAN_COUNT > 0
+    for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+  #endif
   disable_all_heaters();
-  fanSpeed = 0;
   lcd_return_to_status();
 }
 
@@ -1125,7 +1148,22 @@ static void lcd_control_temperature_menu() {
   //
   // Fan Speed:
   //
-  MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED, &fanSpeed, 0, 255);
+  #if FAN_COUNT > 0
+    #if HAS_FAN0
+      #if FAN_COUNT > 1
+        #define MSG_1ST_FAN_SPEED MSG_FAN_SPEED " 1"
+      #else
+        #define MSG_1ST_FAN_SPEED MSG_FAN_SPEED
+      #endif
+      MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_1ST_FAN_SPEED, &fanSpeeds[0], 0, 255);
+    #endif
+    #if HAS_FAN1
+      MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 2", &fanSpeeds[1], 0, 255);
+    #endif
+    #if HAS_FAN2
+      MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 3", &fanSpeeds[2], 0, 255);
+    #endif
+  #endif // FAN_COUNT > 0
 
   //
   // Autotemp, Min, Max, Fact

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -873,16 +873,34 @@ void lcd_implementation_drawedit(const char* pstr, char* value) {
     // Set the LEDS - referred to as backlights by the LiquidTWI2 library
     static uint8_t ledsprev = 0;
     uint8_t leds = 0;
+
     if (target_temperature_bed > 0) leds |= LED_A;
+
     if (target_temperature[0] > 0) leds |= LED_B;
-    if (fanSpeed) leds |= LED_C;
+
+    #if FAN_COUNT > 0
+      if (0
+        #if HAS_FAN0
+          || fanSpeeds[0]
+        #endif
+        #if HAS_FAN1
+          || fanSpeeds[1]
+        #endif
+        #if HAS_FAN2
+          || fanSpeeds[2]
+        #endif
+      ) leds |= LED_C;
+    #endif // FAN_COUNT > 0
+
     #if EXTRUDERS > 1
       if (target_temperature[1] > 0) leds |= LED_C;
     #endif
+
     if (leds != ledsprev) {
       lcd.setBacklight(leds);
       ledsprev = leds;
     }
+
   }
 
 #endif // LCD_HAS_STATUS_INDICATORS


### PR DESCRIPTION
See #3075 for feature request.

Some pins files specify `FAN1_PIN` and `FAN2_PIN` as alternative places to attach a fan. Marlin has supported the use of these pins for `CONTROLLERFAN_PIN` since no other code would conflict. But it also makes sense to make fans independently controllable, in some cases associated with `active_extruder` so that the fan speed specified in GCode could apply to the active nozzle. (This implies a somewhat different approach from the `EXTRUDER_n_AUTO_FAN_PIN` stuff currently in the code, which I presume exists for the benefit of one or more specific printer models.)

This PR demonstrates how to implement support for multiple fans within the 1.1.x codebase as a jumping-off point. This gives low-level support so commands like `M106 P1 S100` and `M107 P1` can control multiple fans.

By default this PR exposes all fan pins on a board in `M106`, `M107`, and the LCD menus (even if no fan is attached to those pins). If some fan pins are being used as `CONTROLLERFAN_PIN` or `EXTRUDER_n_AUTO_FAN_PIN` then they are not exposed as plain `FAN1` and `FAN2` pins.
