### PR TITLE
Fixed path to generate_version_header_for_marlin

### DIFF
--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/platform.local.txt
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/platform.local.txt
@@ -1,7 +1,7 @@
 compiler.cpp.extra_flags=-DUSE_AUTOMATIC_VERSIONING
 compiler.cpp.extra_flags.windows=
 build.custom_bin.path.macosx=/usr/local/bin/
-build.custom_bin.path.linux=
+build.custom_bin.path.linux={build.source.path}/../LinuxAddons/bin/
 recipe.hooks.prebuild0.pattern={build.custom_bin.path}generate_version_header_for_marlin "{build.source.path}" "{build.path}/_Version.h"
 # Please help -- We need an implementation on Windows
 recipe.hooks.prebuild0.pattern.windows=


### PR DESCRIPTION
This is an attempt to fix failure to locate 'generate_version_header_for_marlin' script with arduino-1.6.x.
