### PR TITLE
Fix MELZI_MAKR3D to use correct motherboard

### DIFF
--- a/Marlin/pins_MELZI_MAKR3D.h
+++ b/Marlin/pins_MELZI_MAKR3D.h
@@ -3,7 +3,7 @@
  */
 
 #undef MOTHERBOARD
-#define MOTHERBOARD MELZI
+#define MOTHERBOARD BOARD_MELZI
 #define SANGUINOLOLU_V_1_2
 
 #if defined(__AVR_ATmega1284P__)


### PR DESCRIPTION
This is an attempt to fix MELZI_MAKR3D to use correct motherboard. The motherboard should be BOARD_MELZI, not MELZI.
