### PR TITLE
Fixed Makefile to work with Melzi2 boards on arduino-1.6.x

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -41,17 +41,17 @@ HARDWARE_MOTHERBOARD ?= 11
 
 # Arduino source install directory, and version number
 # On most linuxes this will be /usr/share/arduino
-ARDUINO_INSTALL_DIR  ?= /usr/share/arduino
-ARDUINO_VERSION      ?= 105
+ARDUINO_INSTALL_DIR  ?= ${HOME}/Arduino
+ARDUINO_VERSION      ?= 106
 
 # You can optionally set a path to the avr-gcc tools. Requires a trailing slash. (ex: /usr/local/avr-gcc/bin)
 AVR_TOOLS_PATH ?=
 
 #Programmer configuration
-UPLOAD_RATE        ?= 115200
-AVRDUDE_PROGRAMMER ?= wiring
+UPLOAD_RATE        ?= 57600
+AVRDUDE_PROGRAMMER ?= arduino
 # on most linuxes this will be /dev/ttyACM0 or /dev/ttyACM1 
-UPLOAD_PORT        ?= /dev/arduino
+UPLOAD_PORT        ?= /dev/ttyUSB0
 
 #Directory used to build files in, contains all the build files, from object files to the final hex file
 #on linux it is best to put an absolute path like /home/username/tmp .
@@ -147,6 +147,9 @@ MCU              ?= atmega1284p
 else ifeq  ($(HARDWARE_MOTHERBOARD),66)
 HARDWARE_VARIANT ?= Sanguino
 MCU              ?= atmega1284p
+else ifeq  ($(HARDWARE_MOTHERBOARD),69)
+HARDWARE_VARIANT ?= Sanguino
+MCU              ?= atmega1284p
 
 #Ultimaker
 else ifeq  ($(HARDWARE_MOTHERBOARD),7)
@@ -222,7 +225,7 @@ F_CPU ?= 16000000
 # Libraries, the "hardware variant" are for boards
 # that derives from that, and their source are present in
 # the main Marlin source directory
-ifeq ($(HARDWARE_VARIANT), arduino)
+ifeq ($(HARDWARE_VARIANT), $(filter $(HARDWARE_VARIANT),arduino Sanguino))
 HARDWARE_DIR = $(ARDUINO_INSTALL_DIR)/hardware
 else
 ifeq ($(shell [ $(ARDUINO_VERSION) -ge 100 ] && echo true), true)
@@ -231,7 +234,7 @@ else
 HARDWARE_DIR = ../ArduinoAddons/Arduino_0.xx
 endif
 endif
-HARDWARE_SRC = $(HARDWARE_DIR)/$(HARDWARE_VARIANT)/cores/arduino
+HARDWARE_SRC = $(HARDWARE_DIR)/marlin/avr/cores/arduino
 
 TARGET = $(notdir $(CURDIR))
 
@@ -242,9 +245,9 @@ TARGET = $(notdir $(CURDIR))
 VPATH = .
 VPATH += $(BUILD_DIR)
 VPATH += $(HARDWARE_SRC)
-ifeq ($(HARDWARE_VARIANT), $(filter $(HARDWARE_VARIANT),arduino Teensy))
-VPATH += $(ARDUINO_INSTALL_DIR)/libraries/LiquidCrystal
-VPATH += $(ARDUINO_INSTALL_DIR)/libraries/SPI
+ifeq ($(HARDWARE_VARIANT), $(filter $(HARDWARE_VARIANT),arduino Teensy Sanguino))
+VPATH += $(HARDWARE_DIR)/marlin/avr/libraries/LiquidCrystal/src
+VPATH += $(HARDWARE_DIR)/marlin/avr/libraries/SPI
 ifeq ($(LIQUID_TWI2), 1)
 VPATH += $(ARDUINO_INSTALL_DIR)/libraries/Wire
 VPATH += $(ARDUINO_INSTALL_DIR)/libraries/Wire/utility
@@ -271,13 +274,17 @@ ifeq ($(HARDWARE_VARIANT), arduino)
 HARDWARE_SUB_VARIANT ?= mega
 VPATH += $(ARDUINO_INSTALL_DIR)/hardware/arduino/variants/$(HARDWARE_SUB_VARIANT)
 else
+ifeq ($(HARDWARE_VARIANT), Sanguino)
+VPATH += $(HARDWARE_DIR)/marlin/avr/variants/sanguino
+else
 HARDWARE_SUB_VARIANT ?= standard
 VPATH += $(HARDWARE_DIR)/$(HARDWARE_VARIANT)/variants/$(HARDWARE_SUB_VARIANT)
+endif
 endif
 SRC = wiring.c \
 	wiring_analog.c wiring_digital.c \
 	wiring_pulse.c \
-	wiring_shift.c WInterrupts.c
+	wiring_shift.c WInterrupts.c hooks.c
 ifeq ($(HARDWARE_VARIANT), Teensy)
 SRC = wiring.c
 VPATH += $(ARDUINO_INSTALL_DIR)/hardware/teensy/cores/teensy


### PR DESCRIPTION
This is an attempt to fix Makefile to work with Melzi2 boards on arduino-1.6.x
- also by default use ${HOME}/Arduino as install directory which may be more sane, especially with arduino packages provided by distributions
- bump arduino version to 106 (this seems to be useless)
- program firmware through the USB serial which is more comfortable way how to program the firmware
- use 57600 programing speed by default which seems to be more reliable with arduino bootloaders (at least with those shipped with the Melzi2 boards)

This may break Makefile compatibility with older arduinos (but to be honest the Makefile never worked for me out of the box). Let me know in such case and I will try to patch it different way, but support for arduino-1.6.x is needed.
