### PR TITLE
Release 1.1.0-RC4

### DIFF
--- a/Marlin/Default_Version.h
+++ b/Marlin/Default_Version.h
@@ -6,9 +6,9 @@
 // #error "You must specify the following parameters related to your distribution"
 
 #if true
-#define SHORT_BUILD_VERSION "1.1.0-RC3"
-#define DETAILED_BUILD_VERSION "1.1.0-RC3 From Archive"
-#define STRING_DISTRIBUTION_DATE "2015-12-01 12:00"
+#define SHORT_BUILD_VERSION "1.1.0-RC4"
+#define DETAILED_BUILD_VERSION "1.1.0-RC4 From Archive"
+#define STRING_DISTRIBUTION_DATE "2016-03-07 12:00"
 // It might also be appropriate to define a location where additional information can be found
 // #define SOURCE_CODE_URL  "http:// ..."
 #endif


### PR DESCRIPTION
Over the weekend I integrated the most high-confidence patches with `RCBugFix` for RC4. This may not be the final release candidate, but it takes care of several longstanding and nagging bugs that exist in RC3. I feel pretty confident in the changes between RC3 and the current RC4, but if there are any side-effects of these patches I'm sure we'll know about them soon.

Issues to consider for RC5, or for the following release 1.1.1:
- Improved feedback to hosts during busy periods, while pausing, and while awaiting input
- I would like see #3012 (or equivalent) merged to prevent serial buffer corruption
- Roxy's updated M48 for DELTA needs testing, and would be good to see updated also
