### PR TITLE
M110 and M29 rework

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -756,6 +756,7 @@ void loop() {
           // M29 closes the file
           card.closefile();
           SERIAL_PROTOCOLLNPGM(MSG_FILE_SAVED);
+          ok_to_send();
         }
         else {
           // Write the string from the read buffer to SD
@@ -763,7 +764,7 @@ void loop() {
           if (card.logging)
             process_next_command(); // The card is saving because it's logging
           else
-            SERIAL_PROTOCOLLNPGM(MSG_OK);
+            ok_to_send();
         }
       }
       else
@@ -4053,6 +4054,13 @@ inline void gcode_M109() {
 #endif // HAS_TEMP_BED
 
 /**
+ * M110: Set Current Line Number
+ */
+inline void gcode_M110() {
+  if (code_seen('N')) gcode_N = code_value_long();
+}
+
+/**
  * M111: Set the debug level
  */
 inline void gcode_M111() {
@@ -5926,6 +5934,10 @@ void process_next_command() {
         gcode_M104();
         break;
 
+      case 110: // M110: Set Current Line Number
+        gcode_M110();
+        break;
+
       case 111: // M111: Set debug level
         gcode_M111();
         break;
@@ -7173,9 +7185,9 @@ void kill(const char* lcd_msg) {
   cli();   // disable interrupts
   suicide();
   while (1) {
-	#if ENABLED(USE_WATCHDOG)
-	  watchdog_reset();
-	#endif
+    #if ENABLED(USE_WATCHDOG)
+      watchdog_reset();
+    #endif
   } // Wait for reset
 }
 


### PR DESCRIPTION
Add 'ok' output for M29 actually closing the file.
M29 now with ADVANCED_OK, if defined.
Handle `M110` when received without linenumber/checksum.

Tested with Octoprint 1.2.9, RH V1.6.1, Pronterface 03-Feb-2015.

Proposal for a fix of #3055
