### PR TITLE
Alternative impl. of LCD-based manual movement

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -213,7 +213,7 @@ void manage_inactivity(bool ignore_stepper_queue = false);
  * A_AXIS and B_AXIS are used by COREXY printers
  * X_HEAD and Y_HEAD is used for systems that don't have a 1:1 relationship between X_AXIS and X Head movement, like CoreXY bots.
  */
-enum AxisEnum {X_AXIS = 0, A_AXIS = 0, Y_AXIS = 1, B_AXIS = 1, Z_AXIS = 2, C_AXIS = 2, E_AXIS = 3, X_HEAD = 4, Y_HEAD = 5, Z_HEAD = 5};
+enum AxisEnum {NO_AXIS = -1, X_AXIS = 0, A_AXIS = 0, Y_AXIS = 1, B_AXIS = 1, Z_AXIS = 2, C_AXIS = 2, E_AXIS = 3, X_HEAD = 4, Y_HEAD = 5, Z_HEAD = 5};
 
 #define _AXIS(AXIS) AXIS ##_AXIS
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -189,6 +189,8 @@ class Planner {
      */
     static uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block_buffer_tail + BLOCK_BUFFER_SIZE); }
 
+    static bool is_full() { return (block_buffer_tail == BLOCK_MOD(block_buffer_head + 1)); }
+
     #if ENABLED(AUTO_BED_LEVELING_FEATURE) || ENABLED(MESH_BED_LEVELING)
 
       #if ENABLED(AUTO_BED_LEVELING_FEATURE)


### PR DESCRIPTION
Recently we found that LCD-based movement can cause a stack overflow if the planner buffer gets full. This is because `plan_buffer_line()` calls `idle()` in a loop. Since `idle()` calls `lcd_update()` which in turn may call `plan_buffer_line()` again, if you do a lot of manual moves with a slow axis (like Z), the stack quickly overflows due to nested calls to `plan_buffer_line()`.

The previous workaround was to skip calling `plan_buffer_line()` if the buffer had some moves already queued up. Unfortunately this may cause `current_position` to be different from the last place moved, because any moves that can't be added are just dropped!

This workaround changes the way that manual moves are applied, so moves won't be dropped, while at the same ensuring that `lcd_update()` will never call `plan_buffer_line()` if it would result in recursion.

The key is to simply set a flag that a manual move has been applied to one of the axes. Whenever `lcd_update()` is called (for example, from `idle()`) it will check to see if any manual move was applied but postponed. If so, and there's room in the planner, the move is added to the planner.

A helpful feature of this change is that in the case of a long delay only the most recent destination set will be added to the planner. So if a single Z move takes a long time while there's a full planner buffer, fewer additional Z moves will end up being buffered.

This change also opens up the potential for interruptible manual moves, which could be achieved by setting a separate manual move destination, then adding smaller moves to the planner until the destination is reached. In this way, if the destination ends up being in the opposite direction from a previous destination, the direction change can happen more quickly.
