### PR TITLE
Drop obsolete test for leading "N"

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -870,7 +870,7 @@ void get_command() {
           }
           // if no errors, continue parsing
         }
-        else if (npos == command) {
+        else {
           gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM));
           return;
         }


### PR DESCRIPTION
The test for `npos == command` is no longer needed here because we already know at this point that there was a leading `N` parameter.
