### PR TITLE
Stop print timer with M105/M109

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -351,4 +351,9 @@ extern uint8_t active_extruder;
 
 extern void calculate_volumetric_multipliers();
 
+// Print job timer related functions
+millis_t print_job_timer();
+bool print_job_start(millis_t t = 0);
+bool print_job_stop(bool force = false);
+
 #endif //MARLIN_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3837,7 +3837,7 @@ inline void gcode_M104() {
   // Detect if a print job has finished.
   // When the target temperature for all extruders is zero then we must have
   // finished printing.
-  if( print_job_start_ms != 0 ) {
+  if (print_job_start_ms) {
     bool all_extruders_cooling = true;
     for (int i = 0; i < EXTRUDERS; i++) if( degTargetHotend(i) > 0 ) {
       all_extruders_cooling = false;
@@ -3957,7 +3957,6 @@ inline void gcode_M105() {
  *       Rxxx Wait for extruder(s) to reach temperature. Waits when heating and cooling.
  */
 inline void gcode_M109() {
-  float temp;
   bool no_wait_for_cooling = true;
 
   if (setTargetedHotend(109)) return;
@@ -3965,16 +3964,16 @@ inline void gcode_M109() {
 
   no_wait_for_cooling = code_seen('S');
   if (no_wait_for_cooling || code_seen('R')) {
-    temp = code_value();
+    float temp = code_value();
     setTargetHotend(temp, target_extruder);
     #if ENABLED(DUAL_X_CARRIAGE)
       if (dual_x_carriage_mode == DXC_DUPLICATION_MODE && target_extruder == 0)
         setTargetHotend1(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset);
     #endif
-  }
 
-  // Only makes sense to show the heating message if we're in fact heating.
-  if( temp > 0 ) LCD_MESSAGEPGM(MSG_HEATING);
+    // Only makes sense to show the heating message if we're in fact heating.
+    if (temp > 0) LCD_MESSAGEPGM(MSG_HEATING);
+  }
 
   #if ENABLED(AUTOTEMP)
     autotemp_enabled = code_seen('F');

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -306,8 +306,8 @@ static void lcd_implementation_status_screen() {
 
     u8g.setPrintPos(80,48);
     if (print_job_start_ms != 0) {
-      uint16_t time = ((print_job_stop_ms > print_job_start_ms)
-                       ? print_job_stop_ms : millis()) / 60000 - print_job_start_ms / 60000;
+      uint16_t time = (((print_job_stop_ms > print_job_start_ms)
+                       ? print_job_stop_ms : millis()) - print_job_start_ms) / 60000;
       lcd_print(itostr2(time/60));
       lcd_print(':');
       lcd_print(itostr2(time%60));

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -306,7 +306,8 @@ static void lcd_implementation_status_screen() {
 
     u8g.setPrintPos(80,48);
     if (print_job_start_ms != 0) {
-      uint16_t time = (millis() - print_job_start_ms) / 60000;
+      uint16_t time = ((print_job_stop_ms > print_job_start_ms)
+                       ? print_job_stop_ms : millis()) / 60000 - print_job_start_ms / 60000;
       lcd_print(itostr2(time/60));
       lcd_print(':');
       lcd_print(itostr2(time%60));

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1112,7 +1112,7 @@ void disable_all_heaters() {
   setTargetBed(0);
 
   // If all heaters go down then for sure our print job has stopped
-  if( print_job_start_ms != 0 ) print_job_stop_ms = millis();
+  print_job_stop(true);
 
   #define DISABLE_HEATER(NR) { \
     target_temperature[NR] = 0; \

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1111,6 +1111,9 @@ void disable_all_heaters() {
   for (int i = 0; i < EXTRUDERS; i++) setTargetHotend(0, i);
   setTargetBed(0);
 
+  // If all heaters go down then for sure our print job has stopped
+  if( print_job_start_ms != 0 ) print_job_stop_ms = millis();
+
   #define DISABLE_HEATER(NR) { \
     target_temperature[NR] = 0; \
     soft_pwm[NR] = 0; \

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -707,8 +707,8 @@ static void lcd_implementation_status_screen() {
     lcd.setCursor(LCD_WIDTH - 6, 2);
     lcd.print(LCD_STR_CLOCK[0]);
     if (print_job_start_ms != 0) {
-      uint16_t time = ((print_job_stop_ms > print_job_start_ms)
-                       ? print_job_stop_ms : millis()) / 60000 - print_job_start_ms / 60000;
+      uint16_t time = (((print_job_stop_ms > print_job_start_ms)
+                       ? print_job_stop_ms : millis()) - print_job_start_ms) / 60000;
       lcd.print(itostr2(time / 60));
       lcd.print(':');
       lcd.print(itostr2(time % 60));

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -137,7 +137,7 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
   #define LCD_I2C_PIN_D5  5
   #define LCD_I2C_PIN_D6  6
   #define LCD_I2C_PIN_D7  7
-  
+
   #include <Wire.h>
   #include <LCD.h>
   #include <LiquidCrystal_I2C.h>
@@ -632,7 +632,7 @@ static void lcd_implementation_status_screen() {
         else {
           if (!axis_homed[X_AXIS])
             lcd_printPGM(PSTR("?"));
-          else 
+          else
             #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
               if (!axis_known_position[X_AXIS])
                 lcd_printPGM(PSTR(" "));
@@ -649,7 +649,7 @@ static void lcd_implementation_status_screen() {
         else {
           if (!axis_homed[Y_AXIS])
             lcd_printPGM(PSTR("?"));
-          else 
+          else
             #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
               if (!axis_known_position[Y_AXIS])
                 lcd_printPGM(PSTR(" "));
@@ -669,7 +669,7 @@ static void lcd_implementation_status_screen() {
     else {
       if (!axis_homed[Z_AXIS])
         lcd_printPGM(PSTR("?"));
-      else 
+      else
         #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
           if (!axis_known_position[Z_AXIS])
             lcd_printPGM(PSTR(" "));
@@ -707,7 +707,8 @@ static void lcd_implementation_status_screen() {
     lcd.setCursor(LCD_WIDTH - 6, 2);
     lcd.print(LCD_STR_CLOCK[0]);
     if (print_job_start_ms != 0) {
-      uint16_t time = millis() / 60000 - print_job_start_ms / 60000;
+      uint16_t time = ((print_job_stop_ms > print_job_start_ms)
+                       ? print_job_stop_ms : millis()) / 60000 - print_job_start_ms / 60000;
       lcd.print(itostr2(time / 60));
       lcd.print(':');
       lcd.print(itostr2(time % 60));


### PR DESCRIPTION
This is a proposed fix for #3061.
Three hooks have been set in order to stop the print timer:
1. `M105`
2. `M109`
3. `disable_all_heaters()`

Note: `M105/M109` hooks only stop the print timer when the temperature of the last extruder is set to zero.
