### PR TITLE
Fix value edit click bug

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -268,6 +268,10 @@ static void lcd_goto_menu(menuFunc_t menu, const bool feedback = false, const ui
   }
 }
 
+inline void lcd_save_previous_menu() { prevMenu = currentMenu; prevEncoderPosition = encoderPosition; }
+
+static void lcd_goto_previous_menu() { lcd_goto_menu(prevMenu, true, prevEncoderPosition); }
+
 /**
  *
  * "Info Screen"
@@ -466,7 +470,7 @@ void lcd_set_home_offsets() {
       lcdDrawUpdate = 1;
     }
     if (lcdDrawUpdate) lcd_implementation_drawedit(msg, "");
-    if (LCD_CLICKED) lcd_goto_menu(lcd_tune_menu);
+    if (LCD_CLICKED) lcd_goto_previous_menu();
   }
   static void lcd_babystep_x() { _lcd_babystep(X_AXIS, PSTR(MSG_BABYSTEPPING_X)); }
   static void lcd_babystep_y() { _lcd_babystep(Y_AXIS, PSTR(MSG_BABYSTEPPING_Y)); }
@@ -837,7 +841,7 @@ static void _lcd_move(const char* name, AxisEnum axis, int min, int max) {
   if (lcdDrawUpdate) lcd_implementation_drawedit(name, ftostr31(current_position[axis]));
   if (LCD_CLICKED) {
       line_to_current(axis);
-      lcd_goto_menu(lcd_move_menu_axis);
+      lcd_goto_previous_menu();
   }
 }
 #if ENABLED(DELTA)
@@ -883,7 +887,7 @@ static void lcd_move_e(
     #endif //EXTRUDERS > 1
     lcd_implementation_drawedit(pos_label, ftostr31(current_position[E_AXIS]));
   }
-  if (LCD_CLICKED) lcd_goto_menu(lcd_move_menu_axis);
+  if (LCD_CLICKED) lcd_goto_previous_menu();
   #if EXTRUDERS > 1
     active_extruder = original_active_extruder;
   #endif
@@ -1282,7 +1286,7 @@ static void lcd_control_volumetric_menu() {
         lcd_implementation_drawedit(PSTR(MSG_CONTRAST), itostr2(lcd_contrast));
       #endif
     }
-    if (LCD_CLICKED) lcd_goto_menu(lcd_control_menu);
+    if (LCD_CLICKED) lcd_goto_previous_menu();
   }
 #endif // HAS_LCD_CONTRAST
 
@@ -1381,15 +1385,14 @@ static void lcd_control_volumetric_menu() {
       lcd_implementation_drawedit(editLabel, _strFunc(((_type)((int32_t)encoderPosition + minEditValue)) / scale)); \
     if (isClicked) { \
       *((_type*)editValue) = ((_type)((int32_t)encoderPosition + minEditValue)) / scale; \
-      lcd_goto_menu(prevMenu, prevEncoderPosition); \
+      lcd_goto_previous_menu(); \
     } \
     return isClicked; \
   } \
   void menu_edit_ ## _name () { _menu_edit_ ## _name(); } \
   void menu_edit_callback_ ## _name () { if (_menu_edit_ ## _name ()) (*callbackFunc)(); } \
   static void _menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
-    prevMenu = currentMenu; \
-    prevEncoderPosition = encoderPosition; \
+    lcd_save_previous_menu(); \
     \
     lcdDrawUpdate = 2; \
     currentMenu = menu_edit_ ## _name; \
@@ -1506,7 +1509,7 @@ void lcd_quick_feedback() {
  *
  */
 static void menu_action_back(menuFunc_t func) { lcd_goto_menu(func); }
-static void menu_action_submenu(menuFunc_t func) { lcd_goto_menu(func); }
+static void menu_action_submenu(menuFunc_t func) { lcd_save_previous_menu(); lcd_goto_menu(func); }
 static void menu_action_gcode(const char* pgcode) { enqueuecommands_P(pgcode); }
 static void menu_action_function(menuFunc_t func) { (*func)(); }
 


### PR DESCRIPTION
Expected behavior: After editing a value the menu should return to the previous point with the same item previously selected.

Actual behavior: Either the top (back) item is selected, or the menu jumps up another level.

Causes: (1) Wrong arguments are being passed to `lcd_goto_menu` on click when editing a value. (2) Menus are just exiting with `lcd_goto_menu`.

Solution: (1) Pass the correct arguments to `lcd_goto_menu(prevMenu, ...)` to get feedback and set the encoder position. (2) Allow submenu (leaf) items to go back to origin. (3) Have all edit items go back to origin.

Future considerations: It should be possible, adding a small array, to make a more general paging system, so a page can just go "up a level" when exiting and doesn't need an explicit `lcd_goto_menu` call. Also, the "back" label on a page could be determined by its parent, allowing more than one entry- and exit-point for a page.

Naming conventions: It would be good to rename "menu" to "screen" or "page" and use that term in place of "menu" for those pages which aren't menu pages. This way we can think more generally about other kinds of pages, such as wizards, status screens, value editing pages, etc.
