### PR TITLE
Fix a "Heating failed" error

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1112,13 +1112,13 @@ void disable_all_heaters() {
   setTargetBed(0);
 
   #define DISABLE_HEATER(NR) { \
-    target_temperature[NR] = 0; \
+    setTargetHotend(NR, 0); \
     soft_pwm[NR] = 0; \
     WRITE_HEATER_ ## NR (LOW); \
   }
 
-#if HAS_TEMP_0 || ENABLED(HEATER_0_USES_MAX6675)
-    target_temperature[0] = 0;
+  #if HAS_TEMP_0 || ENABLED(HEATER_0_USES_MAX6675)
+    setTargetHotend(0, 0);
     soft_pwm[0] = 0;
     WRITE_HEATER_0P(LOW); // Should HEATERS_PARALLEL apply here? Then change to DISABLE_HEATER(0)
   #endif


### PR DESCRIPTION
Addressing #3085. If the `target_temperature` is set directly it never invokes or disables the timer set in `start_watching_heater`, so after _stopping a print_ or turning off _all heaters_ you could get a “Heating failed” error.

This fixes the issue by using `setTargetHotend(n, 0)` in `disable_all_heaters` instead of setting `target_temperature[n] = 0` directly.
