### PR TITLE
Support "true" and "false" in the ENABLED macro

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6999,16 +6999,16 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   if (stepper_inactive_time && ms > previous_cmd_ms + stepper_inactive_time
       && !ignore_stepper_queue && !blocks_queued()) {
-    #if DISABLE_INACTIVE_X == true
+    #if ENABLED(DISABLE_INACTIVE_X)
       disable_x();
     #endif
-    #if DISABLE_INACTIVE_Y == true
+    #if ENABLED(DISABLE_INACTIVE_Y)
       disable_y();
     #endif
-    #if DISABLE_INACTIVE_Z == true
+    #if ENABLED(DISABLE_INACTIVE_Z)
       disable_z();
     #endif
-    #if DISABLE_INACTIVE_E == true
+    #if ENABLED(DISABLE_INACTIVE_E)
       disable_e0();
       disable_e1();
       disable_e2();

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -17,9 +17,11 @@
 
 // Macros to support option testing
 #define _CAT(a, ...) a ## __VA_ARGS__
-#define SWITCH_ENABLED_0 0
-#define SWITCH_ENABLED_1 1
-#define SWITCH_ENABLED_  1
+#define SWITCH_ENABLED_false 0
+#define SWITCH_ENABLED_true  1
+#define SWITCH_ENABLED_0     0
+#define SWITCH_ENABLED_1     1
+#define SWITCH_ENABLED_      1
 #define ENABLED(b) _CAT(SWITCH_ENABLED_, b)
 #define DISABLED(b) (!_CAT(SWITCH_ENABLED_, b))
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -421,15 +421,23 @@ void check_axes_activity() {
       block_index = next_block_index(block_index);
     }
   }
-  if (DISABLE_X && !axis_active[X_AXIS]) disable_x();
-  if (DISABLE_Y && !axis_active[Y_AXIS]) disable_y();
-  if (DISABLE_Z && !axis_active[Z_AXIS]) disable_z();
-  if (DISABLE_E && !axis_active[E_AXIS]) {
-    disable_e0();
-    disable_e1();
-    disable_e2();
-    disable_e3();
-  }
+  #if ENABLED(DISABLE_X)
+    if (!axis_active[X_AXIS]) disable_x();
+  #endif
+  #if ENABLED(DISABLE_Y)
+    if (!axis_active[Y_AXIS]) disable_y();
+  #endif
+  #if ENABLED(DISABLE_Z)
+    if (!axis_active[Z_AXIS]) disable_z();
+  #endif
+  #if ENABLED(DISABLE_E)
+    if (!axis_active[E_AXIS]) {
+      disable_e0();
+      disable_e1();
+      disable_e2();
+      disable_e3();
+    }
+  #endif
 
   #if HAS_FAN
     #ifdef FAN_KICKSTART_TIME


### PR DESCRIPTION
The `ENABLED` macro needs to support "true" and "false" so it can be applied for settings that use those values, either in a configuration or a Makefile. This PR also applies `ENABLED` to the two settings which currently use "true" and "false" – the `DISABLE_[XYZE]` and `DISABLE_INACTIVE_[XYZE]` settings.
