### PR TITLE
Fix initial extruder direction for second/third/fourth extruder if they run inverted to the first

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -574,8 +574,11 @@ void set_stepper_direction() {
 // block begins.
 FORCE_INLINE void trapezoid_generator_reset() {
 
-  if (current_block->direction_bits != out_bits) {
+  static int8_t last_extruder = -1;
+
+  if (current_block->direction_bits != out_bits || current_block->active_extruder != last_extruder) {
     out_bits = current_block->direction_bits;
+    last_extruder = current_block->active_extruder;
     set_stepper_direction();
   }
 


### PR DESCRIPTION
In #3144 I described my problem and here is my solution.

To sum up the problem:
The current implementation does not have any possibility to initialise the stepper interrupt for every extruder. So the interrupt uses the direction for the E axis of the first extruder.
If you now do not change the directions but use a second/third/fourth extruder which is inverted then this extruder runs the wrong direction initially until you send a command to do a negative extraction. Then the routine to set the stepper directions is called again and the direction of the extruder is set to the right value.

My fix just lets the interrupt remember the last used extruder initialised with zero and checks that last_extruder against the active_extruder of the current_block.
That way the set_stepper_directions routine is called a bit more frequently (but not so often like what I describe in #3144 where I proposed just to disable the whole condition and let the routine run every time) but the direction of other extruder is correct right from the beginning without any need to have some negative extrusion set in startup script or something else.
