### PR TITLE
Fix KEEPALIVE_STATE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,11 @@ script:
   - sed -i 's/\/\/#define LCM1602/#define LCM1602/g' Marlin/Configuration.h
   - rm -rf .build/
   - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
+  # Enable FILAMENTCHANGEENABLE
+  - cp Marlin/Configuration.h.backup Marlin/Configuration.h
+  - sed -i 's/\/\/#define FILAMENTCHANGEENABLE/#define FILAMENTCHANGEENABLE/g' Marlin/Configuration.h
+  - rm -rf .build/
+  - DISPLAY=:1.0 ~/bin/arduino --verify --board marlin:avr:mega  Marlin/Marlin.ino
   # Enable filament sensor
   - cp Marlin/Configuration.h.backup Marlin/Configuration.h
   - sed -i 's/\/\/#define FILAMENT_SENSOR/#define FILAMENT_SENSOR/g' Marlin/Configuration.h

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5508,7 +5508,7 @@ inline void gcode_M503() {
     delay(100);
     LCD_ALERTMESSAGEPGM(MSG_FILAMENTCHANGE);
     millis_t next_tick = 0;
-    KEEPALIVE_STATE(WAIT_FOR_USER);
+    KEEPALIVE_STATE(PAUSED_FOR_USER);
     while (!lcd_clicked()) {
       #if DISABLED(AUTO_FILAMENT_CHANGE)
         millis_t ms = millis();
@@ -6028,6 +6028,7 @@ void process_next_command() {
 
       case 105: // M105: Read current temperature
         gcode_M105();
+        KEEPALIVE_STATE(NOT_BUSY);
         return; // "ok" already printed
 
       case 109: // M109: Wait for temperature


### PR DESCRIPTION
Add return to `NOT_BUSY` for `M105` (because it returns right away).
Replace WAIT_FOR_USER with PAUSED_FOR_USER

Add Travis test for FILAMENTCHANGEENABLE

Fixing #3179 https://github.com/MarlinFirmware/Marlin/pull/3109#issuecomment-198708577
