### PR TITLE
Added autotune PID on LCD

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -694,7 +694,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5 // Set according to ENCODER_PULSES_PER_STEP or your liking
 //#define REVERSE_MENU_DIRECTION // When enabled CLOCKWISE moves UP in the LCD menu
 //#define ULTIMAKERCONTROLLER //as available from the Ultimaker online store.
-#define ULTIPANEL  //the UltiPanel as on Thingiverse
+//#define ULTIPANEL  //the UltiPanel as on Thingiverse
 //#define SPEAKER // The sound device is a speaker - not a buzzer. A buzzer resonates with his own frequency.
 //#define LCD_FEEDBACK_FREQUENCY_DURATION_MS 100 // the duration the buzzer plays the UI feedback sound. ie Screen Click
 //#define LCD_FEEDBACK_FREQUENCY_HZ 1000         // this is the tone frequency the buzzer plays when on UI feedback. ie Screen Click

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -694,7 +694,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5 // Set according to ENCODER_PULSES_PER_STEP or your liking
 //#define REVERSE_MENU_DIRECTION // When enabled CLOCKWISE moves UP in the LCD menu
 //#define ULTIMAKERCONTROLLER //as available from the Ultimaker online store.
-//#define ULTIPANEL  //the UltiPanel as on Thingiverse
+#define ULTIPANEL  //the UltiPanel as on Thingiverse
 //#define SPEAKER // The sound device is a speaker - not a buzzer. A buzzer resonates with his own frequency.
 //#define LCD_FEEDBACK_FREQUENCY_DURATION_MS 100 // the duration the buzzer plays the UI feedback sound. ie Screen Click
 //#define LCD_FEEDBACK_FREQUENCY_HZ 1000         // this is the tone frequency the buzzer plays when on UI feedback. ie Screen Click

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5053,13 +5053,15 @@ inline void gcode_M226() {
 inline void gcode_M303() {
   int e = code_seen('E') ? code_value_short() : 0;
   int c = code_seen('C') ? code_value_short() : 5;
+  bool u = code_seen('U') && code_value_short() == 1;
+  
   float temp = code_seen('S') ? code_value() : (e < 0 ? 70.0 : 150.0);
 
   if (e >=0 && e < EXTRUDERS)
     target_extruder = e;
 
   KEEPALIVE_STATE(NOT_BUSY);
-  PID_autotune(temp, e, c);
+  PID_autotune(temp, e, c, u);
 }
 
 #if ENABLED(SCARA)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5053,7 +5053,7 @@ inline void gcode_M226() {
 inline void gcode_M303() {
   int e = code_seen('E') ? code_value_short() : 0;
   int c = code_seen('C') ? code_value_short() : 5;
-  bool u = code_seen('U') && code_value_short() == 1;
+  bool u = code_seen('U') && code_value_short() != 0;
   
   float temp = code_seen('S') ? code_value() : (e < 0 ? 70.0 : 150.0);
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -199,7 +199,7 @@ static void updateTemperaturesFromRawValues();
 //================================ Functions ================================
 //===========================================================================
 
-void PID_autotune(float temp, int extruder, int ncycles) {
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result) {
   float input = 0.0;
   int cycles = 0;
   bool heating = true;
@@ -346,6 +346,23 @@ void PID_autotune(float temp, int extruder, int ncycles) {
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Kp "); SERIAL_PROTOCOLLN(Kp);
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Ki "); SERIAL_PROTOCOLLN(Ki);
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Kd "); SERIAL_PROTOCOLLN(Kd);
+      //Uses the result if set_result is true
+      if (set_result) {
+        if (extruder < 0) {
+          #if ENABLED(PIDTEMPBED)
+            bedKp = Kp;
+            bedKi = scalePID_i(Ki);
+            bedKd = scalePID_d(Kd);
+            updatePID();
+          #endif
+        }
+        else {
+          PID_PARAM(Kp, extruder) = Kp;
+          PID_PARAM(Ki, e) = scalePID_i(Ki);
+          PID_PARAM(Kd, e) = scalePID_d(Kd);
+          updatePID();
+        }
+      }
       return;
     }
     lcd_update();

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -199,7 +199,7 @@ static void updateTemperaturesFromRawValues();
 //================================ Functions ================================
 //===========================================================================
 
-void PID_autotune(float temp, int extruder, int ncycles, bool set_result) {
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result /* = false */) {
   float input = 0.0;
   int cycles = 0;
   bool heating = true;

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -141,7 +141,7 @@ int getHeaterPower(int heater);
 void disable_all_heaters();
 void updatePID();
 
-void PID_autotune(float temp, int extruder, int ncycles);
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -141,7 +141,7 @@ int getHeaterPower(int heater);
 void disable_all_heaters();
 void updatePID();
 
-void PID_autotune(float temp, int extruder, int ncycles, bool set_result);
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result = false);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1189,10 +1189,20 @@ static void lcd_control_temperature_menu() {
       raw_Kd = unscalePID_d(PID_PARAM(Kd, eindex)); \
       MENU_ITEM_EDIT(float52, MSG_PID_P ELABEL, &PID_PARAM(Kp, eindex), 1, 9990); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I ELABEL, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E ## eindex); \
-      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex)
-      MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E" + eindex));
+      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex); \
+      if (eindex == 0) { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1")); \
+      } \
+      else if (eindex == 1) { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E1")); \
+      } \
+      else if (eindex == 2) { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E2")); \
+      } \
+      else { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E3")); \
+      }
       
-
     #if ENABLED(PID_ADD_EXTRUSION_RATE)
       #define PID_MENU_ITEMS(ELABEL, eindex) \
         _PID_MENU_ITEMS(ELABEL, eindex); \

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1176,11 +1176,11 @@ static void lcd_control_temperature_menu() {
   #endif
 
   //
-  // PID-P, PID-I, PID-D, PID-C
-  // PID-P E1, PID-I E1, PID-D E1, PID-C E1
-  // PID-P E2, PID-I E2, PID-D E2, PID-C E2
-  // PID-P E3, PID-I E3, PID-D E3, PID-C E3
-  // PID-P E4, PID-I E4, PID-D E4, PID-C E4
+  // PID-P, PID-I, PID-D, PID-C, PID Autotune
+  // PID-P E1, PID-I E1, PID-D E1, PID-C E1, PID Autotune E1
+  // PID-P E2, PID-I E2, PID-D E2, PID-C E2, PID Autotune E2
+  // PID-P E3, PID-I E3, PID-D E3, PID-C E3, PID Autotune E3
+  // PID-P E4, PID-I E4, PID-D E4, PID-C E4, PID Autotune E4
   //
   #if ENABLED(PIDTEMP)
 
@@ -1190,6 +1190,8 @@ static void lcd_control_temperature_menu() {
       MENU_ITEM_EDIT(float52, MSG_PID_P ELABEL, &PID_PARAM(Kp, eindex), 1, 9990); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I ELABEL, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E ## eindex); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex)
+      MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E" + eindex));
+      
 
     #if ENABLED(PID_ADD_EXTRUSION_RATE)
       #define PID_MENU_ITEMS(ELABEL, eindex) \

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1189,39 +1189,30 @@ static void lcd_control_temperature_menu() {
       raw_Kd = unscalePID_d(PID_PARAM(Kd, eindex)); \
       MENU_ITEM_EDIT(float52, MSG_PID_P ELABEL, &PID_PARAM(Kp, eindex), 1, 9990); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I ELABEL, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E ## eindex); \
-      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex); \
-      if (eindex == 0) { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1")); \
-      } \
-      else if (eindex == 1) { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E1")); \
-      } \
-      else if (eindex == 2) { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E2")); \
-      } \
-      else { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E3")); \
-      }
+      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex)
       
     #if ENABLED(PID_ADD_EXTRUSION_RATE)
-      #define PID_MENU_ITEMS(ELABEL, eindex) \
+      #define PID_MENU_ITEMS(ELABEL, eindex, AUTOTUNE_CMD) \
         _PID_MENU_ITEMS(ELABEL, eindex); \
-        MENU_ITEM_EDIT(float3, MSG_PID_C ELABEL, &PID_PARAM(Kc, eindex), 1, 9990)
+        MENU_ITEM_EDIT(float3, MSG_PID_C ELABEL, &PID_PARAM(Kc, eindex), 1, 9990); \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR(AUTOTUNE_CMD))
     #else
-      #define PID_MENU_ITEMS(ELABEL, eindex) _PID_MENU_ITEMS(ELABEL, eindex)
+      #define PID_MENU_ITEMS(ELABEL, eindex, AUTOTUNE_CMD) \
+        _PID_MENU_ITEMS(ELABEL, eindex); \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR(AUTOTUNE_CMD))
     #endif
 
     #if ENABLED(PID_PARAMS_PER_EXTRUDER) && EXTRUDERS > 1
-      PID_MENU_ITEMS(MSG_E1, 0);
-      PID_MENU_ITEMS(MSG_E2, 1);
+      PID_MENU_ITEMS(MSG_E1, 0, "M303 U1");
+      PID_MENU_ITEMS(MSG_E2, 1, "M303 U1 E1");
       #if EXTRUDERS > 2
-        PID_MENU_ITEMS(MSG_E3, 2);
+        PID_MENU_ITEMS(MSG_E3, 2, "M303 U1 E2");
         #if EXTRUDERS > 3
-          PID_MENU_ITEMS(MSG_E4, 3);
+          PID_MENU_ITEMS(MSG_E4, 3, "M303 U1 E3");
         #endif //EXTRUDERS > 3
       #endif //EXTRUDERS > 2
     #else //!PID_PARAMS_PER_EXTRUDER || EXTRUDERS == 1
-      PID_MENU_ITEMS("", 0);
+      PID_MENU_ITEMS("", 0, "M303 U1");
     #endif //!PID_PARAMS_PER_EXTRUDER || EXTRUDERS == 1
 
   #endif //PIDTEMP


### PR DESCRIPTION
According to Issue #3135

Added the parameter `U` to `M303` so that if you send it with `U1` it will use the Kp, Ki and Kd values from the autotune. Also added a menu-item under the Temperature-menu to start the autotuning-process and use the generated values.

The menu could probably be done much better, since you now don't see what is happening, and you can't choose the times to run the autotune, or the temperature. I couldn't understand the menu-system enough to make this though.

This code is also not tested, since I'm not able to access my printer in a while, but it compiles without errors, and i don't think it can break anything else.
