### PR TITLE
Enabling servo usage on boards with PWM current control

### DIFF
--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -60,12 +60,17 @@
 
 // Say which 16 bit timers can be used and in what order
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
-  #define _useTimer5
   //#define _useTimer1
   #define _useTimer3
   #define _useTimer4
-  //typedef enum { _timer5, _timer1, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
-  typedef enum { _timer5, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
+  #ifndef MOTOR_CURRENT_PWM_XY_PIN
+	//Timer 5 is used for motor current PWM and can't be used for servos.
+    #define _useTimer5
+	//typedef enum { _timer5, _timer1, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
+	typedef enum { _timer5, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
+  #else
+	typedef enum {_timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
+  #endif
 
 #elif defined(__AVR_ATmega32U4__)
   //#define _useTimer1


### PR DESCRIPTION
timer5 is used by some boards like the Mini Rambo for controlling motor current via PWM, see stepper.cpp.

``` cpp
  #ifdef MOTOR_CURRENT_PWM_XY_PIN
    pinMode(MOTOR_CURRENT_PWM_XY_PIN, OUTPUT);
    pinMode(MOTOR_CURRENT_PWM_Z_PIN, OUTPUT);
    pinMode(MOTOR_CURRENT_PWM_E_PIN, OUTPUT);
    digipot_current(0, motor_current_setting[0]);
    digipot_current(1, motor_current_setting[1]);
    digipot_current(2, motor_current_setting[2]);
    //Set timer5 to 31khz so the PWM of the motor power is as constant as possible. (removes a buzzing noise)
    TCCR5B = (TCCR5B & ~(_BV(CS50) | _BV(CS51) | _BV(CS52))) | _BV(CS50);
  #endif
}
```

Using the same timer for controlling servos results in loss of motor control. So use timer4/3 for those boards instead.
[See discussion here.](http://shop.prusa3d.com/forum/software-f13/enabling-auto-leveling-in-firmware-t416-s40.html)
