### PR TITLE
Make DISABLE_INACTIVE_X, etc., true if missing

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -360,6 +360,22 @@
     #undef SD_DETECT_INVERTED
   #endif
 
+  /**
+   * Set defaults for missing (newer) options
+   */
+  #ifndef DISABLE_INACTIVE_X
+    #define DISABLE_INACTIVE_X DISABLE_X
+  #endif
+  #ifndef DISABLE_INACTIVE_Y
+    #define DISABLE_INACTIVE_Y DISABLE_Y
+  #endif
+  #ifndef DISABLE_INACTIVE_Z
+    #define DISABLE_INACTIVE_Z DISABLE_Z
+  #endif
+  #ifndef DISABLE_INACTIVE_E
+    #define DISABLE_INACTIVE_E DISABLE_E
+  #endif
+
   // Power Signal Control Definitions
   // By default use ATX definition
   #ifndef POWER_SUPPLY

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6986,11 +6986,11 @@ void plan_arc(
 #if HAS_CONTROLLERFAN
 
   void controllerFan() {
-    static millis_t lastMotor = 0;      // Last time a motor was turned on
-    static millis_t lastMotorCheck = 0; // Last time the state was checked
+    static millis_t lastMotorOn = 0; // Last time a motor was turned on
+    static millis_t nextMotorCheck = 0; // Last time the state was checked
     millis_t ms = millis();
-    if (ms >= lastMotorCheck + 2500) { // Not a time critical function, so we only check every 2500ms
-      lastMotorCheck = ms;
+    if (ms >= nextMotorCheck) {
+      nextMotorCheck = ms + 2500; // Not a time critical function, so only check every 2.5s
       if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON || soft_pwm_bed > 0
           || E0_ENABLE_READ == E_ENABLE_ON // If any of the drivers are enabled...
           #if EXTRUDERS > 1
@@ -7006,9 +7006,12 @@ void plan_arc(
             #endif
           #endif
       ) {
-        lastMotor = ms; //... set time to NOW so the fan will turn on
+        lastMotorOn = ms; //... set time to NOW so the fan will turn on
       }
-      uint8_t speed = (lastMotor == 0 || ms >= lastMotor + ((CONTROLLERFAN_SECS) * 1000UL)) ? 0 : CONTROLLERFAN_SPEED;
+
+      // Fan off if no steppers have been enabled for CONTROLLERFAN_SECS seconds
+      uint8_t speed = (lastMotorOn == 0 || ms >= lastMotorOn + (CONTROLLERFAN_SECS) * 1000UL) ? 0 : CONTROLLERFAN_SPEED;
+
       // allows digital or PWM fan output to be used (see M42 handling)
       digitalWrite(CONTROLLERFAN_PIN, speed);
       analogWrite(CONTROLLERFAN_PIN, speed);


### PR DESCRIPTION
When new defines are added, users may use their older configs expecting the same results. Sometimes we throw an error if a setting is missing. In this case a default is set in `Conditionals.h`, setting `DISABLE_INACTIVE_[XYZE]` to the value of `DISABLE_[XYZE]`, which will produce consistent behavior to previous versions of Marlin, if users fail to fully update their config files.

Perhaps it would be better to have them all set to `true` by default, as a safety measure. But presumably long-time Marlin users already have their in-print timeouts set appropriate to the type of machine they are using. Setting `true` by default may cause some deltas to sag unexpectedly.

This PR also includes a commit tweaking `controllerFan`, as the original issue that led to this change pointed to this function. Nothing seems amiss with the function, but it never hurts to extend the comments.
