### PR TITLE
Add Menu Items to initiate M303

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -718,7 +718,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5 // Set according to ENCODER_PULSES_PER_STEP or your liking
 //#define REVERSE_MENU_DIRECTION // When enabled CLOCKWISE moves UP in the LCD menu
 //#define ULTIMAKERCONTROLLER //as available from the Ultimaker online store.
-#define ULTIPANEL  //the UltiPanel as on Thingiverse
+//#define ULTIPANEL  //the UltiPanel as on Thingiverse
 //#define SPEAKER // The sound device is a speaker - not a buzzer. A buzzer resonates with his own frequency.
 //#define LCD_FEEDBACK_FREQUENCY_DURATION_MS 100 // the duration the buzzer plays the UI feedback sound. ie Screen Click
 //#define LCD_FEEDBACK_FREQUENCY_HZ 1000         // this is the tone frequency the buzzer plays when on UI feedback. ie Screen Click

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -718,7 +718,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5 // Set according to ENCODER_PULSES_PER_STEP or your liking
 //#define REVERSE_MENU_DIRECTION // When enabled CLOCKWISE moves UP in the LCD menu
 //#define ULTIMAKERCONTROLLER //as available from the Ultimaker online store.
-//#define ULTIPANEL  //the UltiPanel as on Thingiverse
+#define ULTIPANEL  //the UltiPanel as on Thingiverse
 //#define SPEAKER // The sound device is a speaker - not a buzzer. A buzzer resonates with his own frequency.
 //#define LCD_FEEDBACK_FREQUENCY_DURATION_MS 100 // the duration the buzzer plays the UI feedback sound. ie Screen Click
 //#define LCD_FEEDBACK_FREQUENCY_HZ 1000         // this is the tone frequency the buzzer plays when on UI feedback. ie Screen Click

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -228,6 +228,7 @@ inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }
 
 bool enqueue_and_echo_command(const char* cmd, bool say_ok=false); //put a single ASCII command at the end of the current buffer or return false when it is full
+void enqueue_and_echo_command_now(const char* cmd); // enqueue now, only return when the command has been enqueued
 void enqueue_and_echo_commands_P(const char* cmd); //put one or many ASCII commands at the end of the current buffer, read from flash
 
 void prepare_arc_move(char isclockwise);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5142,7 +5142,7 @@ inline void gcode_M226() {
 inline void gcode_M303() {
   int e = code_seen('E') ? code_value_short() : 0;
   int c = code_seen('C') ? code_value_short() : 5;
-  bool u = code_seen('U') && code_value_short() == 1;
+  bool u = code_seen('U') && code_value_short() != 0;
   
   float temp = code_seen('S') ? code_value() : (e < 0 ? 70.0 : 150.0);
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5142,13 +5142,15 @@ inline void gcode_M226() {
 inline void gcode_M303() {
   int e = code_seen('E') ? code_value_short() : 0;
   int c = code_seen('C') ? code_value_short() : 5;
+  bool u = code_seen('U') && code_value_short() == 1;
+  
   float temp = code_seen('S') ? code_value() : (e < 0 ? 70.0 : 150.0);
 
   if (e >=0 && e < EXTRUDERS)
     target_extruder = e;
 
   KEEPALIVE_STATE(NOT_BUSY);
-  PID_autotune(temp, e, c);
+  PID_autotune(temp, e, c, u);
 }
 
 #if ENABLED(SCARA)

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -247,7 +247,7 @@ void CardReader::openAndPrintFile(const char *name) {
   char cmd[4 + (FILENAME_LENGTH + 1) * MAX_DIR_DEPTH + 2]; // Room for "M23 ", names with slashes, a null, and one extra
   sprintf_P(cmd, PSTR("M23 %s"), name);
   for (char *c = &cmd[4]; *c; c++) *c = tolower(*c);
-  enqueue_and_echo_command(cmd);
+  enqueue_and_echo_command_now(cmd);
   enqueue_and_echo_commands_P(PSTR("M24"));
 }
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -199,7 +199,7 @@ static void updateTemperaturesFromRawValues();
 //================================ Functions ================================
 //===========================================================================
 
-void PID_autotune(float temp, int extruder, int ncycles, bool set_result /* = false */) {
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false*/) {
   float input = 0.0;
   int cycles = 0;
   bool heating = true;
@@ -346,7 +346,8 @@ void PID_autotune(float temp, int extruder, int ncycles, bool set_result /* = fa
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Kp "); SERIAL_PROTOCOLLN(Kp);
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Ki "); SERIAL_PROTOCOLLN(Ki);
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Kd "); SERIAL_PROTOCOLLN(Kd);
-      //Uses the result if set_result is true
+
+      // Use the result? (As with "M303 U1")
       if (set_result) {
         if (extruder < 0) {
           #if ENABLED(PIDTEMPBED)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -199,7 +199,7 @@ static void updateTemperaturesFromRawValues();
 //================================ Functions ================================
 //===========================================================================
 
-void PID_autotune(float temp, int extruder, int ncycles) {
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result) {
   float input = 0.0;
   int cycles = 0;
   bool heating = true;
@@ -346,6 +346,23 @@ void PID_autotune(float temp, int extruder, int ncycles) {
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Kp "); SERIAL_PROTOCOLLN(Kp);
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Ki "); SERIAL_PROTOCOLLN(Ki);
       SERIAL_PROTOCOLPGM("#define  DEFAULT_"); SERIAL_PROTOCOL(estring); SERIAL_PROTOCOLPGM("Kd "); SERIAL_PROTOCOLLN(Kd);
+      //Uses the result if set_result is true
+      if (set_result) {
+        if (extruder < 0) {
+          #if ENABLED(PIDTEMPBED)
+            bedKp = Kp;
+            bedKi = scalePID_i(Ki);
+            bedKd = scalePID_d(Kd);
+            updatePID();
+          #endif
+        }
+        else {
+          PID_PARAM(Kp, extruder) = Kp;
+          PID_PARAM(Ki, e) = scalePID_i(Ki);
+          PID_PARAM(Kd, e) = scalePID_d(Kd);
+          updatePID();
+        }
+      }
       return;
     }
     lcd_update();

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -199,7 +199,7 @@ static void updateTemperaturesFromRawValues();
 //================================ Functions ================================
 //===========================================================================
 
-void PID_autotune(float temp, int extruder, int ncycles, bool set_result) {
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result /* = false */) {
   float input = 0.0;
   int cycles = 0;
   bool heating = true;

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -141,7 +141,7 @@ int getHeaterPower(int heater);
 void disable_all_heaters();
 void updatePID();
 
-void PID_autotune(float temp, int extruder, int ncycles);
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -141,7 +141,7 @@ int getHeaterPower(int heater);
 void disable_all_heaters();
 void updatePID();
 
-void PID_autotune(float temp, int extruder, int ncycles, bool set_result = false);
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result=false);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -141,7 +141,7 @@ int getHeaterPower(int heater);
 void disable_all_heaters();
 void updatePID();
 
-void PID_autotune(float temp, int extruder, int ncycles, bool set_result);
+void PID_autotune(float temp, int extruder, int ncycles, bool set_result = false);
 
 void setExtruderAutoFanState(int pin, bool state);
 void checkExtruderAutoFans();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1189,39 +1189,30 @@ static void lcd_control_temperature_menu() {
       raw_Kd = unscalePID_d(PID_PARAM(Kd, eindex)); \
       MENU_ITEM_EDIT(float52, MSG_PID_P ELABEL, &PID_PARAM(Kp, eindex), 1, 9990); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I ELABEL, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E ## eindex); \
-      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex); \
-      if (eindex == 0) { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1")); \
-      } \
-      else if (eindex == 1) { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E1")); \
-      } \
-      else if (eindex == 2) { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E2")); \
-      } \
-      else { \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E3")); \
-      }
+      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex)
       
     #if ENABLED(PID_ADD_EXTRUSION_RATE)
-      #define PID_MENU_ITEMS(ELABEL, eindex) \
+      #define PID_MENU_ITEMS(ELABEL, eindex, AUTOTUNE_CMD) \
         _PID_MENU_ITEMS(ELABEL, eindex); \
-        MENU_ITEM_EDIT(float3, MSG_PID_C ELABEL, &PID_PARAM(Kc, eindex), 1, 9990)
+        MENU_ITEM_EDIT(float3, MSG_PID_C ELABEL, &PID_PARAM(Kc, eindex), 1, 9990); \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR(AUTOTUNE_CMD))
     #else
-      #define PID_MENU_ITEMS(ELABEL, eindex) _PID_MENU_ITEMS(ELABEL, eindex)
+      #define PID_MENU_ITEMS(ELABEL, eindex, AUTOTUNE_CMD) \
+        _PID_MENU_ITEMS(ELABEL, eindex); \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR(AUTOTUNE_CMD))
     #endif
 
     #if ENABLED(PID_PARAMS_PER_EXTRUDER) && EXTRUDERS > 1
-      PID_MENU_ITEMS(MSG_E1, 0);
-      PID_MENU_ITEMS(MSG_E2, 1);
+      PID_MENU_ITEMS(MSG_E1, 0, "M303 U1");
+      PID_MENU_ITEMS(MSG_E2, 1, "M303 U1 E1");
       #if EXTRUDERS > 2
-        PID_MENU_ITEMS(MSG_E3, 2);
+        PID_MENU_ITEMS(MSG_E3, 2, "M303 U1 E2");
         #if EXTRUDERS > 3
-          PID_MENU_ITEMS(MSG_E4, 3);
+          PID_MENU_ITEMS(MSG_E4, 3, "M303 U1 E3");
         #endif //EXTRUDERS > 3
       #endif //EXTRUDERS > 2
     #else //!PID_PARAMS_PER_EXTRUDER || EXTRUDERS == 1
-      PID_MENU_ITEMS("", 0);
+      PID_MENU_ITEMS("", 0, "M303 U1");
     #endif //!PID_PARAMS_PER_EXTRUDER || EXTRUDERS == 1
 
   #endif //PIDTEMP

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1067,6 +1067,33 @@ static void lcd_control_menu() {
  *
  */
 
+#if ENABLED(PIDTEMP) || ENABLED(PIDTEMPBED)
+
+  #if ENABLED(PIDTEMP)
+    int autotune_temp[EXTRUDERS] = { 150 };
+    const int heater_maxtemp[EXTRUDERS] = ARRAY_BY_EXTRUDERS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP);
+  #endif
+
+  #if ENABLED(PIDTEMPBED)
+    int autotune_temp_bed = 70;
+  #endif
+
+  static void _lcd_autotune(int e) {
+    char cmd[30];
+    sprintf_P(cmd, PSTR("M303 U1 E%d S%d"), e,
+      #if ENABLED(PIDTEMP) && ENABLED(PIDTEMPBED)
+        e < 0 ? autotune_temp_bed : autotune_temp[e]
+      #elif ENABLED(PIDTEMPBED)
+        autotune_temp_bed
+      #else
+        autotune_temp[e]
+      #endif
+    );
+    enqueue_and_echo_command_now(cmd);
+  }
+
+#endif PIDTEMP || PIDTEMPBED
+
 #if ENABLED(PIDTEMP)
 
   // Helpers for editing PID Ki & Kd values
@@ -1079,18 +1106,19 @@ static void lcd_control_menu() {
     PID_PARAM(Kd, e) = scalePID_d(raw_Kd);
     updatePID();
   }
-  #define COPY_AND_SCALE(eindex) \
+  #define _PIDTEMP_FUNCTIONS(eindex) \
     void copy_and_scalePID_i_E ## eindex() { copy_and_scalePID_i(eindex); } \
-    void copy_and_scalePID_d_E ## eindex() { copy_and_scalePID_d(eindex); }
+    void copy_and_scalePID_d_E ## eindex() { copy_and_scalePID_d(eindex); } \
+    void lcd_autotune_callback_E ## eindex() { _lcd_autotune(eindex); }
 
-  COPY_AND_SCALE(0);
+  _PIDTEMP_FUNCTIONS(0);
   #if ENABLED(PID_PARAMS_PER_EXTRUDER)
     #if EXTRUDERS > 1
-      COPY_AND_SCALE(1);
+      _PIDTEMP_FUNCTIONS(1);
       #if EXTRUDERS > 2
-        COPY_AND_SCALE(2);
+        _PIDTEMP_FUNCTIONS(2);
         #if EXTRUDERS > 3
-          COPY_AND_SCALE(3);
+          _PIDTEMP_FUNCTIONS(3);
         #endif //EXTRUDERS > 3
       #endif //EXTRUDERS > 2
     #endif //EXTRUDERS > 1
@@ -1184,35 +1212,36 @@ static void lcd_control_temperature_menu() {
   //
   #if ENABLED(PIDTEMP)
 
-    #define _PID_MENU_ITEMS(ELABEL, eindex) \
+    #define _PID_BASE_MENU_ITEMS(ELABEL, eindex) \
       raw_Ki = unscalePID_i(PID_PARAM(Ki, eindex)); \
       raw_Kd = unscalePID_d(PID_PARAM(Kd, eindex)); \
       MENU_ITEM_EDIT(float52, MSG_PID_P ELABEL, &PID_PARAM(Kp, eindex), 1, 9990); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I ELABEL, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E ## eindex); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex)
-      
+
     #if ENABLED(PID_ADD_EXTRUSION_RATE)
-      #define PID_MENU_ITEMS(ELABEL, eindex, AUTOTUNE_CMD) \
-        _PID_MENU_ITEMS(ELABEL, eindex); \
-        MENU_ITEM_EDIT(float3, MSG_PID_C ELABEL, &PID_PARAM(Kc, eindex), 1, 9990); \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR(AUTOTUNE_CMD))
+      #define _PID_MENU_ITEMS(ELABEL, eindex) \
+        _PID_BASE_MENU_ITEMS(ELABEL, eindex); \
+        MENU_ITEM_EDIT(float3, MSG_PID_C ELABEL, &PID_PARAM(Kc, eindex), 1, 9990)
     #else
-      #define PID_MENU_ITEMS(ELABEL, eindex, AUTOTUNE_CMD) \
-        _PID_MENU_ITEMS(ELABEL, eindex); \
-        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR(AUTOTUNE_CMD))
+      #define _PID_MENU_ITEMS(ELABEL, eindex) _PID_BASE_MENU_ITEMS(ELABEL, eindex)
     #endif
 
+    #define PID_MENU_ITEMS(ELABEL, eindex) \
+      _PID_MENU_ITEMS(ELABEL, eindex); \
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int3, MSG_PID_AUTOTUNE ELABEL, &autotune_temp[eindex], 150, heater_maxtemp[eindex] - 15, lcd_autotune_callback_E ## eindex)
+
     #if ENABLED(PID_PARAMS_PER_EXTRUDER) && EXTRUDERS > 1
-      PID_MENU_ITEMS(MSG_E1, 0, "M303 U1");
-      PID_MENU_ITEMS(MSG_E2, 1, "M303 U1 E1");
+      PID_MENU_ITEMS(MSG_E1, 0);
+      PID_MENU_ITEMS(MSG_E2, 1);
       #if EXTRUDERS > 2
-        PID_MENU_ITEMS(MSG_E3, 2, "M303 U1 E2");
+        PID_MENU_ITEMS(MSG_E3, 2);
         #if EXTRUDERS > 3
-          PID_MENU_ITEMS(MSG_E4, 3, "M303 U1 E3");
+          PID_MENU_ITEMS(MSG_E4, 3);
         #endif //EXTRUDERS > 3
       #endif //EXTRUDERS > 2
     #else //!PID_PARAMS_PER_EXTRUDER || EXTRUDERS == 1
-      PID_MENU_ITEMS("", 0, "M303 U1");
+      PID_MENU_ITEMS("", 0);
     #endif //!PID_PARAMS_PER_EXTRUDER || EXTRUDERS == 1
 
   #endif //PIDTEMP

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1176,11 +1176,11 @@ static void lcd_control_temperature_menu() {
   #endif
 
   //
-  // PID-P, PID-I, PID-D, PID-C
-  // PID-P E1, PID-I E1, PID-D E1, PID-C E1
-  // PID-P E2, PID-I E2, PID-D E2, PID-C E2
-  // PID-P E3, PID-I E3, PID-D E3, PID-C E3
-  // PID-P E4, PID-I E4, PID-D E4, PID-C E4
+  // PID-P, PID-I, PID-D, PID-C, PID Autotune
+  // PID-P E1, PID-I E1, PID-D E1, PID-C E1, PID Autotune E1
+  // PID-P E2, PID-I E2, PID-D E2, PID-C E2, PID Autotune E2
+  // PID-P E3, PID-I E3, PID-D E3, PID-C E3, PID Autotune E3
+  // PID-P E4, PID-I E4, PID-D E4, PID-C E4, PID Autotune E4
   //
   #if ENABLED(PIDTEMP)
 
@@ -1189,8 +1189,20 @@ static void lcd_control_temperature_menu() {
       raw_Kd = unscalePID_d(PID_PARAM(Kd, eindex)); \
       MENU_ITEM_EDIT(float52, MSG_PID_P ELABEL, &PID_PARAM(Kp, eindex), 1, 9990); \
       MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_I ELABEL, &raw_Ki, 0.01, 9990, copy_and_scalePID_i_E ## eindex); \
-      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex)
-
+      MENU_ITEM_EDIT_CALLBACK(float52, MSG_PID_D ELABEL, &raw_Kd, 1, 9990, copy_and_scalePID_d_E ## eindex); \
+      if (eindex == 0) { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1")); \
+      } \
+      else if (eindex == 1) { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E1")); \
+      } \
+      else if (eindex == 2) { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E2")); \
+      } \
+      else { \
+        MENU_ITEM(gcode, MSG_PID_AUTOTUNE ELABEL, PSTR("M303 U1 E3")); \
+      }
+      
     #if ENABLED(PID_ADD_EXTRUSION_RATE)
       #define PID_MENU_ITEMS(ELABEL, eindex) \
         _PID_MENU_ITEMS(ELABEL, eindex); \


### PR DESCRIPTION
This is a patch on top of the earlier PR #3189 by @WPBack. This PR adds onto the original by making the Autotune items into edit items so a target temperature can be selected. When the click-wheel is pressed, the selected value will be used as the "`S`" parameter to `M303`.

Additional changes were needed.
- Added an array to store the temperatures being edited in the menus. As with `M303` they default to `150`. (Perhaps they would all be better to default to `EXTRUDE_MINTEMP`, but that's another topic.)
- Added a `const` array to store the heater max temps so that these values can be picked up by the macro. (This is necessary because the pre-processor cannot recurse. _I.e._, you cannot compose a macro name from substitution parts [like the `e` here in `HEATER_## e ##_MAXTEMP`] and then get the value of that macro – it's just too "meta"). A `const` array gets around this limitation.
- The `U` parameter is now documented in the comment to `gcode_M303` and takes any non-zero value as "true".
- Opened up the option to add bed PID and autotune options as well. The functions are ready if menu items should be added.
- The function `enqueue_and_echo_command_now` was added as a way to always enqueue a command now, only returning to the caller once the command is enqueued, whereas the function `enqueue_and_echo_command` may return immediately without success. The new function was applied to a point in `cardreader.cpp` where `enqueue_and_echo_command` might (extremely rarely) cause a failure to enqueue the `M23` command.
- Renamed the `COPY_AND_SCALE` internal macro to the more appropriate `_PIDTEMP_FUNCTIONS` since it now defines more menu functions.
