### PR TITLE
Toshiba Flash Air Wifi SD card support

### DIFF
--- a/Marlin/Sd2Card.cpp
+++ b/Marlin/Sd2Card.cpp
@@ -498,9 +498,13 @@ bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
   spiRec();
 #endif
   chipSelectHigh();
+  // Send an additional dummy byte, required by Toshiba Flash Air SD Card
+  spiSend(0XFF);
   return true;
 fail:
   chipSelectHigh();
+  // Send an additional dummy byte, required by Toshiba Flash Air SD Card
+  spiSend(0XFF);
   return false;
 }
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes a bug with the SD card: when Marlin reads the SD card it turns off the card's builtin WiFi function.
Original patch can be found [here](http://www.rc-cam.com/forum/index.php?/topic/4058-marlin-reprap-with-toshiba-flashair-wifi-firmware-patch/).
