### PR TITLE
Extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ applet/
 *.bak
 *.DS_Store
 *.idea
+*.s
+*.i
+*.ii


### PR DESCRIPTION
Extend .gitignore to avoid *.s, *.i, *.ii files in the changed-files-list and to accidentally commit them.

See #3212 how to get them.
