### PR TITLE
Fix lost undef Y_MAX_PIN in pins.h

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -219,6 +219,7 @@
 #endif
 
 #if ENABLED(DISABLE_YMAX_ENDSTOP)
+  #undef Y_MAX_PIN
   #define Y_MAX_PIN          -1
 #endif
 


### PR DESCRIPTION
All other endstops are undefined before redefined to -1 when disabling.
