### PR TITLE
Fixed path to generate_version_header_for_marlin

### DIFF
--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/platform.local.txt
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/platform.local.txt
@@ -1,7 +1,7 @@
 compiler.cpp.extra_flags=-DUSE_AUTOMATIC_VERSIONING
 compiler.cpp.extra_flags.windows=
 build.custom_bin.path.macosx=/usr/local/bin/
-build.custom_bin.path.linux=
+build.custom_bin.path.linux={build.source.path}/../LinuxAddons/bin/
 recipe.hooks.prebuild0.pattern={build.custom_bin.path}generate_version_header_for_marlin "{build.source.path}" "{build.path}/_Version.h"
 # Please help -- We need an implementation on Windows
 recipe.hooks.prebuild0.pattern.windows=


### PR DESCRIPTION
Travis seems not to like this commit, but I don't know what's wrong. What I got after clone:

```
./Marlin/LinuxAddons/bin/generate_version_header_for_marlin
```

and firmware sources:

```
./Marlin/Marlin
```

Thus doing:

```
./Marlin/Marlin/../LinuxAddons/bin/generate_version_header_for_marlin
```

results in correct path as I checked on several my boxes and it worked correctly for me. So there must be something 'non-standard' in Travis configuration.

Could anybody check?
