### PR TITLE
Fix MELZI_MAKR3D to use correct motherboard

### DIFF
--- a/Marlin/pins_MELZI_MAKR3D.h
+++ b/Marlin/pins_MELZI_MAKR3D.h
@@ -3,7 +3,7 @@
  */
 
 #undef MOTHERBOARD
-#define MOTHERBOARD MELZI
+#define MOTHERBOARD BOARD_MELZI
 #define SANGUINOLOLU_V_1_2
 
 #if defined(__AVR_ATmega1284P__)


### PR DESCRIPTION
Signed-off-by: Jaroslav Škarvada jskarvad@redhat.com
