### PR TITLE
Use arduino programming protocol by default for sanguino

### DIFF
--- a/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/boards.txt
+++ b/ArduinoAddons/Arduino_1.6.x/hardware/marlin/avr/boards.txt
@@ -95,7 +95,7 @@ rambo.build.variant=rambo
 sanguino.name=Sanguino
 
 sanguino.upload.tool=arduino:avrdude
-sanguino.upload.protocol=stk500
+sanguino.upload.protocol=arduino
 sanguino.upload.maximum_size=131072
 sanguino.upload.speed=57600
 


### PR DESCRIPTION
This is usually more handy, just plug&play, because most of the boards sold today already have usable bootloader.
