### PR TITLE
Fix a compiler warning in ultralcd.cpp

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -486,7 +486,7 @@ void lcd_set_home_offsets() {
 #if ENABLED(BABYSTEPPING)
 
   static void _lcd_babystep(const int axis, const char* msg) {
-    ENCODER_DIRECTION_NORMAL(); 
+    ENCODER_DIRECTION_NORMAL();
     if (encoderPosition != 0) {
       encoderPosition = 0;
       lcdDrawUpdate = 1;
@@ -901,7 +901,7 @@ float move_menu_scale;
 static void lcd_move_menu_axis();
 
 static void _lcd_move(const char* name, AxisEnum axis, int min, int max) {
-  ENCODER_DIRECTION_NORMAL(); 
+  ENCODER_DIRECTION_NORMAL();
   if ((encoderPosition != 0) && (movesplanned() <= 3)) {
     refresh_cmd_timeout();
     current_position[axis] += float((int)encoderPosition) * move_menu_scale;
@@ -929,7 +929,7 @@ static void lcd_move_e(
     uint8_t e
   #endif
 ) {
-  ENCODER_DIRECTION_NORMAL(); 
+  ENCODER_DIRECTION_NORMAL();
   #if EXTRUDERS > 1
     unsigned short original_active_extruder = active_extruder;
     active_extruder = e;
@@ -1092,7 +1092,7 @@ static void lcd_control_menu() {
     enqueue_and_echo_command_now(cmd);
   }
 
-#endif PIDTEMP || PIDTEMPBED
+#endif //PIDTEMP || PIDTEMPBED
 
 #if ENABLED(PIDTEMP)
 
@@ -1514,7 +1514,7 @@ static void lcd_control_volumetric_menu() {
  *
  *
  * Also: MENU_MULTIPLIER_ITEM_EDIT, MENU_ITEM_EDIT_CALLBACK, and MENU_MULTIPLIER_ITEM_EDIT_CALLBACK
- *     
+ *
  *       menu_action_setting_edit_int3(PSTR(MSG_SPEED), &feedrate_multiplier, 10, 999)
  */
 #define menu_edit_type(_type, _name, _strFunc, scale) \
@@ -2380,7 +2380,7 @@ char* ftostr52(const float& x) {
    *   - Click saves the Z and goes to the next mesh point
    */
   static void _lcd_level_bed() {
-    ENCODER_DIRECTION_NORMAL(); 
+    ENCODER_DIRECTION_NORMAL();
     if ((encoderPosition != 0) && (movesplanned() <= 3)) {
       refresh_cmd_timeout();
       current_position[Z_AXIS] += float((int)encoderPosition) * (MBL_Z_STEP);


### PR DESCRIPTION
```
ultralcd.cpp:1095:8: warning: extra tokens at end of #endif directive [enabled by default]
#endif PIDTEMP || PIDTEMPBED
```
