### PR TITLE
Further cleanup of comments, partial Doxygen-style

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Conditionals.h
  * Defines that depend on configuration but are not editable.
  */

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/Default_Version.h
+++ b/Marlin/Default_Version.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * This file is a placeholder for a file which could be distributed in an archive
  * It takes the place of an automatically created "_Version.h" which is generated during the build process
  */

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,28 +20,25 @@
  *
  */
 
+/**
+ * M100 Free Memory Watcher
+ * 
+ * This code watches the free memory block between the bottom of the heap and the top of the stack.
+ * This memory block is initialized and watched via the M100 command.
+ * 
+ * M100 I Initializes the free memory block and prints vitals statistics about the area
+ * M100 F Identifies how much of the free memory block remains free and unused.  It also
+ *    detects and reports any corruption within the free memory block that may have
+ *    happened due to errant firmware.
+ * M100 D Does a hex display of the free memory block along with a flag for any errant
+ *    data that does not match the expected value.
+ * M100 C x Corrupts x locations within the free memory block.   This is useful to check the
+ *    correctness of the M100 F and M100 D commands.
+ * 
+ * Initial version by Roxy-3DPrintBoard
+ */
 #define M100_FREE_MEMORY_DUMPER     // Comment out to remove Dump sub-command
 #define M100_FREE_MEMORY_CORRUPTOR    // Comment out to remove Corrupt sub-command
-
-
-// M100 Free Memory Watcher
-//
-// This code watches the free memory block between the bottom of the heap and the top of the stack.
-// This memory block is initialized and watched via the M100 command.
-//
-// M100 I Initializes the free memory block and prints vitals statistics about the area
-// M100 F Identifies how much of the free memory block remains free and unused.  It also
-//    detects and reports any corruption within the free memory block that may have
-//    happened due to errant firmware.
-// M100 D Does a hex display of the free memory block along with a flag for any errant
-//    data that does not match the expected value.
-// M100 C x Corrupts x locations within the free memory block.   This is useful to check the
-//    correctness of the M100 F and M100 D commands.
-//
-// Initial version by Roxy-3DPrintBoard
-//
-//
-
 
 #include "Marlin.h"
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/Marlin.ino
+++ b/Marlin/Marlin.ino
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * About Marlin
  *
  * This firmware is a mashup between Sprinter and grbl.

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   HardwareSerial.cpp - Hardware serial library for Wiring
   Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
 

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   HardwareSerial.h - Hardware serial library for Wiring
   Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  *
  * About Marlin
  *
@@ -6618,7 +6618,7 @@ void clamp_to_software_endstops(float target[3]) {
                           - sq(delta_tower3_x - cartesian[X_AXIS])
                           - sq(delta_tower3_y - cartesian[Y_AXIS])
                          ) + cartesian[Z_AXIS];
-    /*
+    /**
     SERIAL_ECHOPGM("cartesian x="); SERIAL_ECHO(cartesian[X_AXIS]);
     SERIAL_ECHOPGM(" y="); SERIAL_ECHO(cartesian[Y_AXIS]);
     SERIAL_ECHOPGM(" z="); SERIAL_ECHOLN(cartesian[Z_AXIS]);
@@ -6653,7 +6653,7 @@ void clamp_to_software_endstops(float target[3]) {
       delta[Y_AXIS] += offset;
       delta[Z_AXIS] += offset;
 
-      /*
+      /**
       SERIAL_ECHOPGM("grid_x="); SERIAL_ECHO(grid_x);
       SERIAL_ECHOPGM(" grid_y="); SERIAL_ECHO(grid_y);
       SERIAL_ECHOPGM(" floor_x="); SERIAL_ECHO(floor_x);
@@ -7145,7 +7145,7 @@ void plan_arc(
     delta[Y_AXIS] = (SCARA_theta + SCARA_psi) * SCARA_RAD2DEG;  //       -  equal to sub arm angle (inverted motor)
     delta[Z_AXIS] = cartesian[Z_AXIS];
 
-    /*
+    /**
     SERIAL_ECHOPGM("cartesian x="); SERIAL_ECHO(cartesian[X_AXIS]);
     SERIAL_ECHOPGM(" y="); SERIAL_ECHO(cartesian[Y_AXIS]);
     SERIAL_ECHOPGM(" z="); SERIAL_ECHOLN(cartesian[Z_AXIS]);

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/Sd2Card.cpp
+++ b/Marlin/Sd2Card.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino Sd2Card Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/Sd2Card.h
+++ b/Marlin/Sd2Card.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino Sd2Card Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/Sd2PinMap.h
+++ b/Marlin/Sd2PinMap.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2010 by William Greiman
  *

--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdBaseFile.h
+++ b/Marlin/SdBaseFile.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdFatConfig.h
+++ b/Marlin/SdFatConfig.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdFatStructs.h
+++ b/Marlin/SdFatStructs.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *
@@ -37,7 +37,7 @@
  * \file
  * \brief FAT file structures
  */
-/*
+/**
  * mostly from Microsoft document fatgen103.doc
  * http://www.microsoft.com/whdc/system/platform/firmware/fatgen.mspx
  */

--- a/Marlin/SdFatUtil.cpp
+++ b/Marlin/SdFatUtil.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2008 by William Greiman
  *

--- a/Marlin/SdFatUtil.h
+++ b/Marlin/SdFatUtil.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2008 by William Greiman
  *

--- a/Marlin/SdFile.cpp
+++ b/Marlin/SdFile.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdFile.h
+++ b/Marlin/SdFile.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdInfo.h
+++ b/Marlin/SdInfo.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino Sd2Card Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdVolume.cpp
+++ b/Marlin/SdVolume.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/SdVolume.h
+++ b/Marlin/SdVolume.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino SdFat Library
  * Copyright (C) 2009 by William Greiman
  *

--- a/Marlin/blinkm.cpp
+++ b/Marlin/blinkm.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * blinkm.cpp - Library for controlling a BlinkM over i2c
  * Created by Tim Koster, August 21 2013.
  */

--- a/Marlin/blinkm.h
+++ b/Marlin/blinkm.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * blinkm.h - Library for controlling a BlinkM over i2c
  * Created by Tim Koster, August 21 2013.
  */

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/buzzer.cpp
+++ b/Marlin/buzzer.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/buzzer.h
+++ b/Marlin/buzzer.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -245,7 +245,7 @@ void CardReader::initsd() {
   }
   workDir = root;
   curDir = &root;
-  /*
+  /**
   if (!workDir.openRoot(&volume)) {
     SERIAL_ECHOLNPGM(MSG_SD_WORKDIR_FAIL);
   }

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * configuration_store.cpp
  *
  * Configuration and EEPROM storage

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/dac_mcp4728.cpp
+++ b/Marlin/dac_mcp4728.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * mcp4728.cpp - Arduino library for MicroChip MCP4728 I2C D/A converter
  *
  * For implementation details, please take a look at the datasheet:
@@ -30,18 +30,15 @@
  * http://arduino.cc/forum/index.php/topic,51842.0.html
  */
 
-
-/* _____PROJECT INCLUDES_____________________________________________________ */
 #include "dac_mcp4728.h"
 
 #if ENABLED(DAC_STEPPER_CURRENT)
 
-// Used Global variables
 uint16_t     mcp4728_values[4];
 
-/*
-Begin I2C, get current values (input register and eeprom) of mcp4728
-*/
+/**
+ * Begin I2C, get current values (input register and eeprom) of mcp4728
+ */
 void mcp4728_init() {
   Wire.begin();
   Wire.requestFrom(int(DAC_DEV_ADDRESS), 24);
@@ -58,19 +55,19 @@ void mcp4728_init() {
   }
 }
 
-/*
-Write input resister value to specified channel using fastwrite method.
-Channel : 0-3, Values : 0-4095
-*/
+/**
+ * Write input resister value to specified channel using fastwrite method.
+ * Channel : 0-3, Values : 0-4095
+ */
 uint8_t mcp4728_analogWrite(uint8_t channel, uint16_t value) {
   mcp4728_values[channel] = value;
   return mcp4728_fastWrite();
 }
-/*
-Write all input resistor values to EEPROM using SequencialWrite method.
-This will update both input register and EEPROM value
-This will also write current Vref, PowerDown, Gain settings to EEPROM
-*/
+/**
+ * Write all input resistor values to EEPROM using SequencialWrite method.
+ * This will update both input register and EEPROM value
+ * This will also write current Vref, PowerDown, Gain settings to EEPROM
+ */
 uint8_t mcp4728_eepromWrite() {
   Wire.beginTransmission(DAC_DEV_ADDRESS);
   Wire.send(SEQWRITE);
@@ -81,31 +78,32 @@ uint8_t mcp4728_eepromWrite() {
   return Wire.endTransmission();
 }
 
-/*
-  Write Voltage reference setting to all input regiters
-*/
+/**
+ * Write Voltage reference setting to all input regiters
+ */
 uint8_t mcp4728_setVref_all(uint8_t value) {
   Wire.beginTransmission(DAC_DEV_ADDRESS);
   Wire.send(VREFWRITE | value << 3 | value << 2 | value << 1 | value);
   return Wire.endTransmission();
 }
-/*
-  Write Gain setting to all input regiters
-*/
+/**
+ * Write Gain setting to all input regiters
+ */
 uint8_t mcp4728_setGain_all(uint8_t value) {
   Wire.beginTransmission(DAC_DEV_ADDRESS);
   Wire.send(GAINWRITE | value << 3 | value << 2 | value << 1 | value);
   return Wire.endTransmission();
 }
 
-/*
-  Return Input Regiter value
-*/
+/**
+ * Return Input Regiter value
+ */
 uint16_t mcp4728_getValue(uint8_t channel) { return mcp4728_values[channel]; }
 
-/*
-// Steph: Might be useful in the future
-// Return Vout
+/**
+ * Steph: Might be useful in the future
+ * Return Vout
+ *
 uint16_t mcp4728_getVout(uint8_t channel) {
   uint32_t vref = 2048;
   uint32_t vOut = (vref * mcp4728_values[channel] * (_DAC_STEPPER_GAIN + 1)) / 4096;
@@ -114,11 +112,11 @@ uint16_t mcp4728_getVout(uint8_t channel) {
 }
 */
 
-/*
-FastWrite input register values - All DAC ouput update. refer to DATASHEET 5.6.1
-DAC Input and PowerDown bits update.
-No EEPROM update
-*/
+/**
+ * FastWrite input register values - All DAC ouput update. refer to DATASHEET 5.6.1
+ * DAC Input and PowerDown bits update.
+ * No EEPROM update
+ */
 uint8_t mcp4728_fastWrite() {
   Wire.beginTransmission(DAC_DEV_ADDRESS);
   for (uint8_t channel=0; channel <= 3; channel++) {
@@ -128,9 +126,9 @@ uint8_t mcp4728_fastWrite() {
   return Wire.endTransmission();
 }
 
-/*
-Common function for simple general commands
-*/
+/**
+ * Common function for simple general commands
+ */
 uint8_t mcp4728_simpleCommand(byte simpleCommand) {
   Wire.beginTransmission(GENERALCALL);
   Wire.send(simpleCommand);

--- a/Marlin/dac_mcp4728.h
+++ b/Marlin/dac_mcp4728.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * Arduino library for MicroChip MCP4728 I2C D/A converter.
  */
 

--- a/Marlin/digipot_mcp4451.cpp
+++ b/Marlin/digipot_mcp4451.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/dogm_bitmaps.h
+++ b/Marlin/dogm_bitmaps.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  * BitMap for splashscreen
  * Generated with: http://www.digole.com/tools/PicturetoC_Hex_converter.php
  * Please note that using the high-res version takes 402Bytes of PROGMEM.

--- a/Marlin/dogm_font_data_6x9_marlin.h
+++ b/Marlin/dogm_font_data_6x9_marlin.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: -Misc-Fixed-Medium-R-Normal--9-90-75-75-C-60-ISO10646-1
   Copyright: Public domain font.  Share and enjoy.
   Capital A Height: 6, '1' Height: 6

--- a/Marlin/dogm_font_data_HD44780_C.h
+++ b/Marlin/dogm_font_data_HD44780_C.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: HD44780_C v1.2
   Copyright: A. Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_HD44780_J.h
+++ b/Marlin/dogm_font_data_HD44780_J.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: HD44780_J
   Copyright: A. Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_HD44780_W.h
+++ b/Marlin/dogm_font_data_HD44780_W.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: HD44780_W
   Copyright: A.Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_ISO10646_1.h
+++ b/Marlin/dogm_font_data_ISO10646_1.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: ISO10646-1
   Copyright: A.Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_ISO10646_5_Cyrillic.h
+++ b/Marlin/dogm_font_data_ISO10646_5_Cyrillic.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: ISO10646_5_Cyrillic
   Copyright: A. Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_ISO10646_CN.h
+++ b/Marlin/dogm_font_data_ISO10646_CN.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: ISO10646_CN
   Copyright: A. Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_ISO10646_Kana.h
+++ b/Marlin/dogm_font_data_ISO10646_Kana.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: ISO10646_Kana
   Copyright: A. Hardtung, public domain
   Capital A Height: 7, '1' Height: 7

--- a/Marlin/dogm_font_data_Marlin_symbols.h
+++ b/Marlin/dogm_font_data_Marlin_symbols.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   Fontname: Marlin_symbols
   Copyright: Created with Fony 1.4.7
   Capital A Height: 0, '1' Height: 0

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1,4 +1,4 @@
-﻿/*
+﻿/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,11 +20,28 @@
  *
  */
 
-// Sample configuration file for Vellemann K8200
-// tested on K8200 with VM8201 (Display)
-// and Arduino 1.6.8 (Mac) by @CONSULitAS, 2016-02-21
-// https://github.com/CONSULitAS/Marlin-K8200/archive/K8200_stable_2016-02-21.zip
+/**
+ * Sample configuration file for Vellemann K8200
+ * tested on K8200 with VM8201 (Display)
+ * and Arduino 1.6.8 (Mac) by @CONSULitAS, 2016-02-21
+ * https://github.com/CONSULitAS/Marlin-K8200/archive/K8200_stable_2016-02-21.zip
+ */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -34,8 +51,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -43,11 +62,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -25,6 +25,17 @@
 // and Arduino 1.6.8 (Mac) by @CONSULitAS, 2016-02-21
 // https://github.com/CONSULitAS/Marlin-K8200/archive/K8200_stable_2016-02-21.zip
 
+
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,10 +20,27 @@
  *
  */
 
-// Example configuration file for OpenBeam Kossel Pro
-// tested on 2015-05-19 by @Wackerbarth
-// using Arduino 1.6.5 (Mac)
+/**
+ * Example configuration file for OpenBeam Kossel Pro
+ * tested on 2015-05-19 by @Wackerbarth
+ * using Arduino 1.6.5 (Mac)
+ */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -33,8 +50,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -42,11 +61,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -24,6 +24,17 @@
 // tested on 2015-05-19 by @Wackerbarth
 // using Arduino 1.6.5 (Mac)
 
+
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,21 @@
  *
  */
 
+/**
+ * Configuration.h
+ *
+ * Basic settings such as:
+ *
+ * - Type of electronics
+ * - Type of temperature sensor
+ * - Printer geometry
+ * - Endstop configuration
+ * - LCD controller
+ * - Extra features
+ *
+ * Advanced settings can be found in Configuration_adv.h
+ *
+ */
 #ifndef CONFIGURATION_H
 #define CONFIGURATION_H
 
@@ -29,8 +44,10 @@
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================
-/*
-Here are some standard links for getting your machine calibrated:
+
+/**
+ * Here are some standard links for getting your machine calibrated:
+ *
  * http://reprap.org/wiki/Calibration
  * http://youtu.be/wAL9d7FgInk
  * http://calculator.josefprusa.cz
@@ -38,11 +55,7 @@ Here are some standard links for getting your machine calibrated:
  * http://www.thingiverse.com/thing:5573
  * https://sites.google.com/site/repraplogphase/calibration-of-your-reprap
  * http://www.thingiverse.com/thing:298812
-*/
-
-// This configuration file contains the basic settings.
-// Advanced settings can be found in Configuration_adv.h
-// BASIC SETTINGS: select your board type, temperature sensor type, axis scaling, and endstop configuration
+ */
 
 //===========================================================================
 //============================= DELTA Printer ===============================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,6 +20,16 @@
  *
  */
 
+/**
+ * Configuration_adv.h
+ *
+ * Advanced settings.
+ * Only change these if you know exactly what you're doing.
+ * Some of these settings can damage your printer if improperly set!
+ *
+ * Basic settings can be found in Configuration.h
+ *
+ */
 #ifndef CONFIGURATION_ADV_H
 #define CONFIGURATION_ADV_H
 

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   This code contributed by Triffid_Hunter and modified by Kliment
   why double up on these macros? see http://gcc.gnu.org/onlinedocs/cpp/Stringification.html
 */
@@ -30,7 +30,7 @@
 
 #include <avr/io.h>
 
-/*
+/**
   utility functions
 */
 
@@ -38,7 +38,7 @@
   #define MASK(PIN)  (1 << PIN)
 #endif
 
-/*
+/**
   magic I/O routines
   now you can simply SET_OUTPUT(STEP); WRITE(STEP, 1); WRITE(STEP, 0);
 */
@@ -107,7 +107,7 @@
 // Shorthand
 #define OUT_WRITE(IO, v) { SET_OUTPUT(IO); WRITE(IO, v); }
 
-/*
+/**
   ports and functions
 
   added as necessary or if I feel like it- not a comprehensive list!
@@ -138,7 +138,7 @@
 
   #define DEBUG_LED   AIO5
 
-  /*
+  /**
   pins
   */
 
@@ -477,7 +477,7 @@
   #define OC2B        DIO14
 
   #define DEBUG_LED   DIO0
-  /*
+  /**
   pins
   */
 
@@ -986,7 +986,7 @@
   // change for your board
   #define DEBUG_LED   DIO21
 
-  /*
+  /**
   pins
   */
   #define DIO0_PIN    PINE0
@@ -2056,7 +2056,7 @@
   // change for your board
   #define DEBUG_LED   DIO31 /* led D5 red */
 
-  /*
+  /**
   pins
   */
 
@@ -2698,7 +2698,7 @@
 
   #else // AT90USBxx_TEENSYPP_ASSIGNMENTS -- Use Teensyduino Teensy++2.0 assignments.
 
-    /*
+    /**
 
     AT90USB  51 50 49 48 47 46 45 44 10 11 12 13 14 15 16 17 35 36 37 38 39 40 41 42 25 26 27 28 29 30 31 32 33 34 43 09 18 19 01 02 61 60 59 58 57 56 55 54
     Port     A0 A1 A2 A3 A4 A5 A6 A7 B0 B1 B2 B3 B4 B5 B6 B7 C0 C1 C2 C3 C4 C5 C6 C7 D0 D1 D2 D3 D4 D5 D6 D7 E0 E1 E2 E3 E4 E5 E6 E7 F0 F1 F2 F3 F4 F5 F6 F7
@@ -3373,7 +3373,7 @@
   // change for your board
   #define DEBUG_LED   DIO46
 
-  /*
+  /**
   pins
   */
   #define DIO0_PIN    PINE0

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -1,4 +1,4 @@
-﻿/*
+﻿/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_gl.h
+++ b/Marlin/language_gl.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -1,4 +1,4 @@
-﻿/*
+﻿/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/language_test.h
+++ b/Marlin/language_test.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/mesh_bed_leveling.cpp
+++ b/Marlin/mesh_bed_leveling.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_3DRAG.h
+++ b/Marlin/pins_3DRAG.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_99.h
+++ b/Marlin/pins_99.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_A4JP.h
+++ b/Marlin/pins_A4JP.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_AZTEEG_X1.h
+++ b/Marlin/pins_AZTEEG_X1.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_BQ_ZUM_MEGA_3D.h
+++ b/Marlin/pins_BQ_ZUM_MEGA_3D.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_BRAINWAVE.h
+++ b/Marlin/pins_BRAINWAVE.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN3_MONOLITHIC.h
+++ b/Marlin/pins_GEN3_MONOLITHIC.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN3_PLUS.h
+++ b/Marlin/pins_GEN3_PLUS.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN6.h
+++ b/Marlin/pins_GEN6.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN6_DELUXE.h
+++ b/Marlin/pins_GEN6_DELUXE.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN7_12.h
+++ b/Marlin/pins_GEN7_12.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN7_13.h
+++ b/Marlin/pins_GEN7_13.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN7_14.h
+++ b/Marlin/pins_GEN7_14.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_K8200.h
+++ b/Marlin/pins_K8200.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_LEAPFROG.h
+++ b/Marlin/pins_LEAPFROG.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MELZI.h
+++ b/Marlin/pins_MELZI.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MELZI_MAKR3D.h
+++ b/Marlin/pins_MELZI_MAKR3D.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_OMCA.h
+++ b/Marlin/pins_OMCA.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RAMPS_13.h
+++ b/Marlin/pins_RAMPS_13.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RAMPS_13_EFB.h
+++ b/Marlin/pins_RAMPS_13_EFB.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RAMPS_14_EFB.h
+++ b/Marlin/pins_RAMPS_14_EFB.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RAMPS_OLD.h
+++ b/Marlin/pins_RAMPS_OLD.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_SANGUINOLOLU_12.h
+++ b/Marlin/pins_SANGUINOLOLU_12.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_SETHI.h
+++ b/Marlin/pins_SETHI.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_STB_11.h
+++ b/Marlin/pins_STB_11.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/pins_ULTIMAKER_OLD.h
+++ b/Marlin/pins_ULTIMAKER_OLD.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -1062,7 +1062,7 @@ float junction_deviation = 0.1;
       block->advance = advance;
       block->advance_rate = acc_dist ? advance / (float)acc_dist : 0;
     }
-    /*
+    /**
       SERIAL_ECHO_START;
      SERIAL_ECHOPGM("advance :");
      SERIAL_ECHO(block->advance/256.0);

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   planner.h - buffers movement commands and manages the acceleration profile plan
   Part of Grbl
 

--- a/Marlin/qr_solve.cpp
+++ b/Marlin/qr_solve.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -32,7 +32,7 @@
 int i4_min(int i1, int i2)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     I4_MIN returns the smaller of two I4's.
@@ -62,7 +62,7 @@ int i4_min(int i1, int i2)
 double r8_epsilon(void)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     R8_EPSILON returns the R8 round off unit.
@@ -99,7 +99,7 @@ double r8_epsilon(void)
 double r8_max(double x, double y)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     R8_MAX returns the maximum of two R8's.
@@ -129,7 +129,7 @@ double r8_max(double x, double y)
 double r8_abs(double x)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     R8_ABS returns the absolute value of an R8.
@@ -159,7 +159,7 @@ double r8_abs(double x)
 double r8_sign(double x)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     R8_SIGN returns the sign of an R8.
@@ -189,7 +189,7 @@ double r8_sign(double x)
 double r8mat_amax(int m, int n, double a[])
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     R8MAT_AMAX returns the maximum absolute value entry of an R8MAT.
@@ -234,7 +234,7 @@ double r8mat_amax(int m, int n, double a[])
 void r8mat_copy(double a2[], int m, int n, double a1[])
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     R8MAT_COPY_NEW copies one R8MAT to a "new" R8MAT.
@@ -276,7 +276,7 @@ void r8mat_copy(double a2[], int m, int n, double a1[])
 void daxpy(int n, double da, double dx[], int incx, double dy[], int incy)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DAXPY computes constant times a vector plus a vector.
@@ -328,7 +328,7 @@ void daxpy(int n, double da, double dx[], int incx, double dy[], int incy)
   if (n <= 0 || da == 0.0) return;
 
   int i, ix, iy, m;
-  /*
+  /**
     Code for unequal increments or equal increments
     not equal to 1.
   */
@@ -347,7 +347,7 @@ void daxpy(int n, double da, double dx[], int incx, double dy[], int incy)
       iy = iy + incy;
     }
   }
-  /*
+  /**
     Code for both increments equal to 1.
   */
   else {
@@ -367,7 +367,7 @@ void daxpy(int n, double da, double dx[], int incx, double dy[], int incy)
 double ddot(int n, double dx[], int incx, double dy[], int incy)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DDOT forms the dot product of two vectors.
@@ -422,7 +422,7 @@ double ddot(int n, double dx[], int incx, double dy[], int incy)
   int i, m;
   double dtemp = 0.0;
 
-  /*
+  /**
     Code for unequal increments or equal increments
     not equal to 1.
   */
@@ -435,7 +435,7 @@ double ddot(int n, double dx[], int incx, double dy[], int incy)
       iy = iy + incy;
     }
   }
-  /*
+  /**
     Code for both increments equal to 1.
   */
   else {
@@ -457,7 +457,7 @@ double ddot(int n, double dx[], int incx, double dy[], int incy)
 double dnrm2(int n, double x[], int incx)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DNRM2 returns the euclidean norm of a vector.
@@ -531,7 +531,7 @@ void dqrank(double a[], int lda, int m, int n, double tol, int* kr,
             int jpvt[], double qraux[])
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DQRANK computes the QR factorization of a rectangular matrix.
@@ -625,7 +625,7 @@ void dqrdc(double a[], int lda, int n, int p, double qraux[], int jpvt[],
            double work[], int job)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DQRDC computes the QR factorization of a real rectangular matrix.
@@ -709,7 +709,7 @@ void dqrdc(double a[], int lda, int n, int p, double qraux[], int jpvt[],
   double maxnrm, nrmxl, t, tt;
 
   int pl = 1, pu = 0;
-  /*
+  /**
     If pivoting is requested, rearrange the columns.
   */
   if (job != 0) {
@@ -738,19 +738,19 @@ void dqrdc(double a[], int lda, int n, int p, double qraux[], int jpvt[],
       }
     }
   }
-  /*
+  /**
     Compute the norms of the free columns.
   */
   for (j = pl; j <= pu; j++)
     qraux[j - 1] = dnrm2(n, a + 0 + (j - 1) * lda, 1);
   for (j = pl; j <= pu; j++)
     work[j - 1] = qraux[j - 1];
-  /*
+  /**
     Perform the Householder reduction of A.
   */
   lup = i4_min(n, p);
   for (int l = 1; l <= lup; l++) {
-    /*
+    /**
       Bring the column of largest norm into the pivot position.
     */
     if (pl <= l && l < pu) {
@@ -771,7 +771,7 @@ void dqrdc(double a[], int lda, int n, int p, double qraux[], int jpvt[],
         jpvt[l - 1] = jp;
       }
     }
-    /*
+    /**
       Compute the Householder transformation for column L.
     */
     qraux[l - 1] = 0.0;
@@ -782,7 +782,7 @@ void dqrdc(double a[], int lda, int n, int p, double qraux[], int jpvt[],
           nrmxl = nrmxl * r8_sign(a[l - 1 + (l - 1) * lda]);
         dscal(n - l + 1, 1.0 / nrmxl, a + l - 1 + (l - 1)*lda, 1);
         a[l - 1 + (l - 1)*lda] = 1.0 + a[l - 1 + (l - 1) * lda];
-        /*
+        /**
           Apply the transformation to the remaining columns, updating the norms.
         */
         for (j = l + 1; j <= p; j++) {
@@ -804,7 +804,7 @@ void dqrdc(double a[], int lda, int n, int p, double qraux[], int jpvt[],
             }
           }
         }
-        /*
+        /**
           Save the transformation.
         */
         qraux[l - 1] = a[l - 1 + (l - 1) * lda];
@@ -819,7 +819,7 @@ int dqrls(double a[], int lda, int m, int n, double tol, int* kr, double b[],
           double x[], double rsd[], int jpvt[], double qraux[], int itask)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DQRLS factors and solves a linear system in the least squares sense.
@@ -949,12 +949,12 @@ int dqrls(double a[], int lda, int m, int n, double tol, int* kr, double b[],
   }
 
   ind = 0;
-  /*
+  /**
     Factor the matrix.
   */
   if (itask == 1)
     dqrank(a, lda, m, n, tol, kr, jpvt, qraux);
-  /*
+  /**
     Solve the least-squares problem.
   */
   dqrlss(a, lda, m, n, *kr, b, x, rsd, jpvt, qraux);
@@ -966,7 +966,7 @@ void dqrlss(double a[], int lda, int m, int n, int kr, double b[], double x[],
             double rsd[], int jpvt[], double qraux[])
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DQRLSS solves a linear system in a least squares sense.
@@ -1075,7 +1075,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
           double qy[], double qty[], double b[], double rsd[], double ab[], int job)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DQRSL computes transformations, projections, and least squares solutions.
@@ -1222,12 +1222,12 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
   int ju;
   double t;
   double temp;
-  /*
+  /**
     Set INFO flag.
   */
   info = 0;
 
-  /*
+  /**
     Determine what is to be computed.
   */
   cqy  = ( job / 10000        != 0);
@@ -1237,7 +1237,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
   cab  = ((job %    10)       != 0);
   ju = i4_min(k, n - 1);
 
-  /*
+  /**
     Special action when N = 1.
   */
   if (ju == 0) {
@@ -1257,7 +1257,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
       rsd[0] = 0.0;
     return info;
   }
-  /*
+  /**
     Set up to compute QY or QTY.
   */
   if (cqy) {
@@ -1268,7 +1268,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
     for (i = 1; i <= n; i++)
       qty[i - 1] = y[i - 1];
   }
-  /*
+  /**
     Compute QY.
   */
   if (cqy) {
@@ -1283,7 +1283,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
       }
     }
   }
-  /*
+  /**
     Compute Q'*Y.
   */
   if (cqty) {
@@ -1297,7 +1297,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
       }
     }
   }
-  /*
+  /**
     Set up to compute B, RSD, or AB.
   */
   if (cb) {
@@ -1320,7 +1320,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
     for (i = 1; i <= k; i++)
       rsd[i - 1] = 0.0;
   }
-  /*
+  /**
     Compute B.
   */
   if (cb) {
@@ -1337,7 +1337,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
       }
     }
   }
-  /*
+  /**
     Compute RSD or AB as required.
   */
   if (cr || cab) {
@@ -1369,7 +1369,7 @@ int dqrsl(double a[], int lda, int n, int k, double qraux[], double y[],
 void dscal(int n, double sa, double x[], int incx)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DSCAL scales a vector by a constant.
@@ -1444,7 +1444,7 @@ void dscal(int n, double sa, double x[], int incx)
 void dswap(int n, double x[], int incx, double y[], int incy)
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     DSWAP interchanges two vectors.
@@ -1529,7 +1529,7 @@ void dswap(int n, double x[], int incx, double y[], int incy)
 void qr_solve(double x[], int m, int n, double a[], double b[])
 
 /******************************************************************************/
-/*
+/**
   Purpose:
 
     QR_SOLVE solves a linear system in the least squares sense.

--- a/Marlin/qr_solve.h
+++ b/Marlin/qr_solve.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/servo.cpp
+++ b/Marlin/servo.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
  servo.cpp - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
  Copyright (c) 2009 Michael Margolis.  All right reserved.
 
@@ -39,7 +39,7 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-/*
+/**
 
  A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
  The servos are pulsed in the background using the value most recently written using the write() method

--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   servo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
   Copyright (c) 2009 Michael Margolis.  All right reserved.
 
@@ -39,7 +39,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/*
+/**
 
   A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
   The servos are pulsed in the background using the value most recently written using the write() method
@@ -71,7 +71,7 @@
 
 #include <inttypes.h>
 
-/*
+/**
  * Defines for 16 bit timers used with  Servo library
  *
  * If _useTimerX is defined then TimerX is a 16 bit timer on the current board

--- a/Marlin/speed_lookuptable.h
+++ b/Marlin/speed_lookuptable.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   stepper.h - stepper motor driver: executes motion plans of planner.c using the stepper motors
   Part of Grbl
 

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   stepper_dac.cpp - To set stepper current via DAC
 
   Part of Marlin

--- a/Marlin/stepper_dac.h
+++ b/Marlin/stepper_dac.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   stepper_dac.h   - To set stepper current via DAC
 
   Part of Marlin

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   stepper_indirection.c - stepper motor driver indirection
   to allow some stepper functions to be done via SPI/I2c instead of direct pin manipulation
   Part of Marlin

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   stepper_indirection.h - stepper motor driver indirection macros
   to allow some stepper functions to be done via SPI/I2c instead of direct pin manipulation
   Part of Marlin

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   temperature.cpp - temperature control
   Part of Marlin
 
@@ -316,7 +316,7 @@ void PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false
               SERIAL_PROTOCOLPGM(MSG_KP); SERIAL_PROTOCOLLN(Kp);
               SERIAL_PROTOCOLPGM(MSG_KI); SERIAL_PROTOCOLLN(Ki);
               SERIAL_PROTOCOLPGM(MSG_KD); SERIAL_PROTOCOLLN(Kd);
-              /*
+              /**
               Kp = 0.33*Ku;
               Ki = Kp/Tu;
               Kd = Kp*Tu/3;
@@ -1118,7 +1118,7 @@ void tp_init() {
 
     static float tr_target_temperature[EXTRUDERS + 1] = { 0.0 };
 
-    /*
+    /**
         SERIAL_ECHO_START;
         SERIAL_ECHOPGM("Thermal Thermal Runaway Running. Heater ID: ");
         if (heater_id < 0) SERIAL_ECHOPGM("bed"); else SERIAL_ECHOPGM(heater_id);
@@ -1435,7 +1435,7 @@ ISR(TIMER0_COMPB_vect) {
 
   #else // SLOW_PWM_HEATERS
 
-    /*
+    /**
      * SLOW PWM HEATERS
      *
      * for heaters drived by relay

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   temperature.h - temperature controller
   Part of Marlin
 

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -533,7 +533,7 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
 
 #endif // SHOW_BOOTSCREEN
 
-/*
+/**
 Possible status screens:
 16x2   |000/000 B000/000|
        |0123456789012345|

--- a/Marlin/ultralcd_st7920_u8glib_rrd.h
+++ b/Marlin/ultralcd_st7920_u8glib_rrd.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/utf_mapper.h
+++ b/Marlin/utf_mapper.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/vector_3.cpp
+++ b/Marlin/vector_3.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   vector_3.cpp - Vector library for bed leveling
   Copyright (c) 2012 Lars Brubaker.  All right reserved.
 

--- a/Marlin/vector_3.h
+++ b/Marlin/vector_3.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -20,7 +20,7 @@
  *
  */
 
-/*
+/**
   vector_3.cpp - Vector library for bed leveling
   Copyright (c) 2012 Lars Brubaker.  All right reserved.
 

--- a/Marlin/watchdog.cpp
+++ b/Marlin/watchdog.cpp
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/watchdog.h
+++ b/Marlin/watchdog.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *


### PR DESCRIPTION
Following up on #3231 with `/**` opening header comments, configuration headings, and some other basic comment cleanup.
