### PR TITLE
Code cleanup around MOTOR_CURRENT_PWM options

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -570,6 +570,8 @@
   #define HAS_E3_STEP (PIN_EXISTS(E3_STEP))
   #define HAS_E4_STEP (PIN_EXISTS(E4_STEP))
 
+  #define HAS_MOTOR_CURRENT_PWM (PIN_EXISTS(MOTOR_CURRENT_PWM_XY) || PIN_EXISTS(MOTOR_CURRENT_PWM_Z) || PIN_EXISTS(MOTOR_CURRENT_PWM_E))
+
   /**
    * Helper Macros for heaters and extruder fan
    */

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5729,13 +5729,13 @@ inline void gcode_M907() {
     if (code_seen('B')) digipot_current(4, code_value());
     if (code_seen('S')) for (int i = 0; i <= 4; i++) digipot_current(i, code_value());
   #endif
-  #ifdef MOTOR_CURRENT_PWM_XY_PIN
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
     if (code_seen('X')) digipot_current(0, code_value());
   #endif
-  #ifdef MOTOR_CURRENT_PWM_Z_PIN
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
     if (code_seen('Z')) digipot_current(1, code_value());
   #endif
-  #ifdef MOTOR_CURRENT_PWM_E_PIN
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
     if (code_seen('E')) digipot_current(2, code_value());
   #endif
   #if ENABLED(DIGIPOT_I2C)

--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -85,39 +85,35 @@
   //#define _useTimer1
   #define _useTimer3
   #define _useTimer4
-  #ifndef MOTOR_CURRENT_PWM_XY_PIN
-    //Timer 5 is used for motor current PWM and can't be used for servos.
-    #define _useTimer5
-    //typedef enum { _timer5, _timer1, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
-    typedef enum { _timer5, _timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
-  #else
-    typedef enum {_timer3, _timer4, _Nbr_16timers } timer16_Sequence_t ;
+  #if !HAS_MOTOR_CURRENT_PWM
+    #define _useTimer5 // Timer 5 is used for motor current PWM and can't be used for servos.
   #endif
-
 #elif defined(__AVR_ATmega32U4__)
-  //#define _useTimer1
   #define _useTimer3
-  //typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t ;
-  typedef enum { _timer3, _Nbr_16timers } timer16_Sequence_t ;
-
 #elif defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB1286__)
   #define _useTimer3
-  //#define _useTimer1
-  //typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;
-  typedef enum { _timer3, _Nbr_16timers } timer16_Sequence_t ;
-
-#elif defined(__AVR_ATmega128__) ||defined(__AVR_ATmega1281__) || defined(__AVR_ATmega1284P__) ||defined(__AVR_ATmega2561__)
+#elif defined(__AVR_ATmega128__) || defined(__AVR_ATmega1281__) || defined(__AVR_ATmega1284P__) || defined(__AVR_ATmega2561__)
   #define _useTimer3
-  //#define _useTimer1
-  //typedef enum { _timer3, _timer1, _Nbr_16timers } timer16_Sequence_t ;
-  typedef enum { _timer3, _Nbr_16timers } timer16_Sequence_t ;
-
-#else  // everything else
-  //#define _useTimer1
-  //typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t ;
-  typedef enum { _Nbr_16timers } timer16_Sequence_t ;
-
+#else
+  // everything else
 #endif
+
+typedef enum {
+  #if ENABLED(_useTimer1)
+    _timer1,
+  #endif
+  #if ENABLED(_useTimer3)
+    _timer3,
+  #endif
+  #if ENABLED(_useTimer4)
+    _timer4,
+  #endif
+  #if ENABLED(_useTimer5)
+    _timer5,
+  #endif
+  _Nbr_16timers
+} timer16_Sequence_t;
+
 
 #define Servo_VERSION           2     // software version of this library
 


### PR DESCRIPTION
Understandably, contributors are not always familiar with the helpful macros available in Marlin, or the types of tricks we encourage through `Conditionals.h` and `SanityCheck.h`. This patch takes advantage of the macro `PIN_EXISTS` and adds an alias in `Conditionals.h` for the existence of any `MOTOR_CURRENT_PWM...` pins.

The code allows for the enabling of the current-PWM feature for the individual drivers (even though, true enough, this is unlikely to ever be the case).

Finally –to reduce redundancy of expression– I altered the servo code so that the only the `_useTimer` flags need to be set (according to your hardware), and then the definition of `typedef enum timer16_Sequence_t` is handled automatically.
