### PR TITLE
Host Keepalive: Reduce frequency of "busy" messages

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2224,13 +2224,15 @@ void unknown_command_error() {
 
 #if ENABLED(HOST_KEEPALIVE_FEATURE)
 
+  /**
+   * Output a "busy" message at regular intervals
+   * while the machine is not accepting commands.
+   */
   void host_keepalive() {
     millis_t ms = millis();
     if (busy_state != NOT_BUSY) {
       if (ms < next_busy_signal_ms) return;
       switch (busy_state) {
-        case NOT_BUSY:
-          break;
         case IN_HANDLER:
         case IN_PROCESS:
           SERIAL_ECHO_START;
@@ -2246,7 +2248,7 @@ void unknown_command_error() {
           break;
       }
     }
-    next_busy_signal_ms = ms + 2000UL;
+    next_busy_signal_ms = ms + 10000UL; // "busy: ..." message every 10s
   }
 
 #endif //HOST_KEEPALIVE_FEATURE


### PR DESCRIPTION
It's not unusual for a some print moves to take more than 2 seconds, sometimes blocking a full input queue. So currently this feature will produce a fair number of busy messages during normal printing. Since hosts don't seem to get worried about a non-responsive printer until a much longer period of time has elapsed, this PR relaxes the timeout period for "busy" messages to 4 seconds. Perhaps we can even go as long as 10 seconds…
