### PR TITLE
Show a warning message when Arduino IDE is prior to 1.5

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -29,6 +29,16 @@
 #define SANITYCHECK_H
 
 /**
+ * Due to the high number of issues related with old versions of Arduino IDE
+ * we are now warning our users to update their toolkits. In a future Marlin
+ * release we will stop supporting old IDE versions and will require user
+ * action to proceed with compilation in such environments.
+ */
+#if !defined(ARDUINO) || ARDUINO < 10500
+  #warning Versions of Arduino IDE prior to 1.5 are no longer supported, please update your toolkit.
+#endif
+
+/**
  * Dual Stepper Drivers
  */
 #if ENABLED(Z_DUAL_STEPPER_DRIVERS) && ENABLED(Y_DUAL_STEPPER_DRIVERS)


### PR DESCRIPTION
The idea for this came out in #3229, @thinkyhead suggested to mark it as an `#error` in the Makefile for RC5. I suggest to implement now (RC4 included) to give an heads up to the users, in the future we can opt-in to force this as an `#error`.

I also did the check in `SanityCheck.h`, this will produce the following message (multiple times) on Arduino IDE status window:

``` cpp
In file included from sketch\Configuration_adv.h:659:0,

                 from sketch\Configuration.h:941,

                 from sketch\Marlin.h:44,

                 from sketch\M100_Free_Mem_Chk.cpp:43:

sketch\SanityCheck.h:38:4: warning: #warning Versions of Arduino IDE prior to 1.5 are no longer supported, please update your toolkit. [-Wcpp]

   #warning Versions of Arduino IDE prior to 1.5 are no longer supported, please update your toolkit.

    ^
```

I also left the following comment near the `#warning` statement:

``` cpp
/**
* Due to the high number of issues related with old versions of Arduino IDE
* we are now warning our users to update their toolkits. In a future Marlin
* release we will stop supporting old IDE versions and will require user
* action to proceed with the compilation on such environment.
*/
```
