### PR TITLE
Fix: Blinking is accelerated by the controller wheel.

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -304,9 +304,11 @@ static void _draw_heater_status(int x, int heater) {
 static void lcd_implementation_status_screen() {
   u8g.setColorIndex(1); // black on white
 
+  millis_t ms = millis();
+
   #if HAS_FAN0
     // Symbols menu graphics, animated fan
-    u8g.drawBitmapP(9, 1, STATUS_SCREENBYTEWIDTH, STATUS_SCREENHEIGHT, (blink % 2) && fanSpeeds[0] ? status_screen0_bmp : status_screen1_bmp);
+    u8g.drawBitmapP(9, 1, STATUS_SCREENBYTEWIDTH, STATUS_SCREENHEIGHT, TEST(ms, 11) && fanSpeeds[0] ? status_screen0_bmp : status_screen1_bmp);
   #endif
 
   #if ENABLED(SDSUPPORT)
@@ -330,7 +332,7 @@ static void lcd_implementation_status_screen() {
     u8g.setPrintPos(80,48);
     if (print_job_start_ms != 0) {
       uint16_t time = (((print_job_stop_ms > print_job_start_ms)
-                       ? print_job_stop_ms : millis()) - print_job_start_ms) / 60000;
+                       ? print_job_stop_ms : ms) - print_job_start_ms) / 60000;
       lcd_print(itostr2(time/60));
       lcd_print(':');
       lcd_print(itostr2(time%60));
@@ -373,9 +375,13 @@ static void lcd_implementation_status_screen() {
   #else
     u8g.drawBox(0, 30, LCD_PIXEL_WIDTH, 9);
   #endif
+
   u8g.setColorIndex(0); // white on black
   u8g.setPrintPos(2, XYZ_BASELINE);
-  if (blink & 1)
+
+  bool blink_on = TEST(ms, 10);
+
+  if (blink_on)
     lcd_printPGM(PSTR("X"));
   else {
     if (!axis_homed[X_AXIS])
@@ -394,7 +400,7 @@ static void lcd_implementation_status_screen() {
   lcd_print(ftostr31ns(current_position[X_AXIS]));
 
   u8g.setPrintPos(43, XYZ_BASELINE);
-  if (blink & 1)
+  if (blink_on)
     lcd_printPGM(PSTR("Y"));
   else {
     if (!axis_homed[Y_AXIS])
@@ -413,7 +419,7 @@ static void lcd_implementation_status_screen() {
   lcd_print(ftostr31ns(current_position[Y_AXIS]));
 
   u8g.setPrintPos(83, XYZ_BASELINE);
-  if (blink & 1)
+  if (blink_on)
     lcd_printPGM(PSTR("Z"));
   else {
     if (!axis_homed[Z_AXIS])
@@ -451,7 +457,7 @@ static void lcd_implementation_status_screen() {
   #if DISABLED(FILAMENT_LCD_DISPLAY)
     lcd_print(lcd_status_message);
   #else
-    if (millis() < previous_lcd_status_ms + 5000) {  //Display both Status message line and Filament display on the last line
+    if (ms < previous_lcd_status_ms + 5000) {  //Display both Status message line and Filament display on the last line
       lcd_print(lcd_status_message);
     }
     else {

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -48,8 +48,6 @@
   #define ENCODER_DIRECTION_MENUS() ;
 #endif
 
-uint8_t blink = 0; // Variable for animation
-
 int8_t encoderDiff; // updated from interrupt context and added to encoderPosition every LCD update
 
 bool encoderRateMultiplierEnabled;
@@ -1923,25 +1921,22 @@ void lcd_update() {
         lcd_status_update_delay--;
       }
     }
-    #if ENABLED(DOGLCD)  // Changes due to different driver architecture of the DOGM display
-        if (lcdDrawUpdate) {
-          blink++;     // Variable for animation and alive dot
-          u8g.firstPage();
-          do {
-            lcd_setFont(FONT_MENU);
-            u8g.setPrintPos(125, 0);
-            if (blink & 1) u8g.setColorIndex(1); else u8g.setColorIndex(0); // Set color for the alive dot
-            u8g.drawPixel(127, 63); // draw alive dot
-            u8g.setColorIndex(1); // black on white
-            (*currentMenu)();
-          } while (u8g.nextPage());
-        }
-    #else
-      if (lcdDrawUpdate) {
-        blink++;     // Variable for animation
+
+    if (lcdDrawUpdate) {
+      #if ENABLED(DOGLCD)  // Changes due to different driver architecture of the DOGM display
+        u8g.firstPage();
+        do {
+          lcd_setFont(FONT_MENU);
+          u8g.setPrintPos(125, 0);
+          u8g.setColorIndex(TEST(ms, 10) ? 1 : 0); // Set color for the alive dot
+          u8g.drawPixel(127, 63); // draw alive dot
+          u8g.setColorIndex(1); // black on white
+          (*currentMenu)();
+        } while (u8g.nextPage());
+      #else
         (*currentMenu)();
-      }
-    #endif
+      #endif
+    }
 
     #if ENABLED(LCD_HAS_STATUS_INDICATORS)
       lcd_implementation_update_indicators();
@@ -1963,8 +1958,7 @@ void lcd_update() {
 
     #endif // ULTIPANEL
 
-    if (lcdDrawUpdate == 2) lcd_implementation_clear();
-    if (lcdDrawUpdate) lcdDrawUpdate--;
+    if (lcdDrawUpdate && --lcdDrawUpdate) lcd_implementation_clear();
     next_lcd_update_ms = ms + LCD_UPDATE_INTERVAL;
   }
 }

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -76,8 +76,6 @@
 
   extern bool cancel_heatup;
 
-  extern uint8_t blink; // Variable for animation
-
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     extern millis_t previous_lcd_status_ms;
   #endif

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -624,7 +624,13 @@ static void lcd_implementation_status_screen() {
   // Line 2
   //
 
+  #if LCD_HEIGHT > 2 || ENABLED(LCD_PROGRESS_BAR) || ENABLED(FILAMENT_LCD_DISPLAY)
+    millis_t ms = millis();
+  #endif
+
   #if LCD_HEIGHT > 2
+
+    bool blink_on = TEST(ms, 10);
 
     #if LCD_WIDTH < 20
 
@@ -654,7 +660,7 @@ static void lcd_implementation_status_screen() {
         // When axis is homed but axis_known_position is false the axis letters are blinking 'X' <-> ' '.
         // When everything is ok you see a constant 'X'.
 
-        if (blink & 1)
+        if (blink_on)
           lcd_printPGM(PSTR("X"));
         else {
           if (!axis_homed[X_AXIS])
@@ -671,7 +677,7 @@ static void lcd_implementation_status_screen() {
         lcd.print(ftostr4sign(current_position[X_AXIS]));
 
         lcd_printPGM(PSTR(" "));
-        if (blink & 1)
+        if (blink_on)
           lcd_printPGM(PSTR("Y"));
         else {
           if (!axis_homed[Y_AXIS])
@@ -691,7 +697,7 @@ static void lcd_implementation_status_screen() {
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    if (blink & 1)
+    if (blink_on)
       lcd_printPGM(PSTR("Z"));
     else {
       if (!axis_homed[Z_AXIS])
@@ -735,7 +741,7 @@ static void lcd_implementation_status_screen() {
     lcd.print(LCD_STR_CLOCK[0]);
     if (print_job_start_ms != 0) {
       uint16_t time = (((print_job_stop_ms > print_job_start_ms)
-                       ? print_job_stop_ms : millis()) - print_job_start_ms) / 60000;
+                       ? print_job_stop_ms : ms) - print_job_start_ms) / 60000;
       lcd.print(itostr2(time / 60));
       lcd.print(':');
       lcd.print(itostr2(time % 60));
@@ -758,7 +764,7 @@ static void lcd_implementation_status_screen() {
     if (card.isFileOpen()) {
       // Draw the progress bar if the message has shown long enough
       // or if there is no message set.
-      if (millis() >= progress_bar_ms + PROGRESS_BAR_MSG_TIME || !lcd_status_message[0]) {
+      if (ms >= progress_bar_ms + PROGRESS_BAR_MSG_TIME || !lcd_status_message[0]) {
         int tix = (int)(card.percentDone() * (LCD_WIDTH) * 3) / 100,
           cel = tix / 3, rem = tix % 3, i = LCD_WIDTH;
         char msg[LCD_WIDTH + 1], b = ' ';
@@ -779,7 +785,7 @@ static void lcd_implementation_status_screen() {
 
     // Show Filament Diameter and Volumetric Multiplier %
     // After allowing lcd_status_message to show for 5 seconds
-    if (millis() >= previous_lcd_status_ms + 5000) {
+    if (ms >= previous_lcd_status_ms + 5000) {
       lcd_printPGM(PSTR("Dia "));
       lcd.print(ftostr12ns(filament_width_meas));
       lcd_printPGM(PSTR(" V"));


### PR DESCRIPTION
The blink variable counts up on every display update, so when the display updates a lot, as when adjusting feedrate with the controller wheel, blinking accelerates. This patch drops the `blink` variable and syncs up blinking at an interval of about 1 second (by testing bit 10 of `millis()`).
