### PR TITLE
Cleanup, simplification of command dispatcher code

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -109,7 +109,6 @@ void serial_echopair_P(const char* s_P, float v);
 void serial_echopair_P(const char* s_P, double v);
 void serial_echopair_P(const char* s_P, unsigned long v);
 
-
 // Things to write to serial from Program memory. Saves 400 to 2k of RAM.
 FORCE_INLINE void serialprintPGM(const char* str) {
   char ch;
@@ -118,8 +117,6 @@ FORCE_INLINE void serialprintPGM(const char* str) {
     str++;
   }
 }
-
-void get_command();
 
 void idle(
   #if ENABLED(FILAMENTCHANGEENABLE)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -893,7 +893,7 @@ void get_command() {
 
       serial_comment_mode = false; // end of line == end of comment
 
-      if (!serial_count) return; // empty lines just exit
+      if (!serial_count) continue; // skip empty lines
 
       serial_line_buffer[serial_count] = 0; // terminate string
       serial_count = 0; //reset buffer

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -978,7 +978,7 @@ void get_command() {
       if (MYSERIAL.available() > 0) {
         // if we have one more character, copy it over
         serial_char = MYSERIAL.read();
-        serial_line_buffer[serial_count++] = serial_char;
+        if (!serial_comment_mode) serial_line_buffer[serial_count++] = serial_char;
       }
       // otherwise do nothing
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6082,25 +6082,22 @@ void process_next_command() {
   // Skip spaces to get the numeric part
   while (*cmd_ptr == ' ') cmd_ptr++;
 
-  // The code must have a numeric value
-  bool code_is_good = false;
-
-  int codenum = 0; // define ahead of goto
-
-  // Get and skip the code number
-  while (*cmd_ptr >= '0' && *cmd_ptr <= '9') {
-    code_is_good = true;
-    codenum = codenum * 10 + *cmd_ptr - '0';
-    cmd_ptr++;
-  }
+  uint16_t codenum = 0; // define ahead of goto
 
   // Bail early if there's no code
+  bool code_is_good = NUMERIC(*cmd_ptr);
   if (!code_is_good) goto ExitUnknownCommand;
 
-  // Skip all spaces to get to the first argument
+  // Get and skip the code number
+  do {
+    codenum = (codenum * 10) + (*cmd_ptr - '0');
+    cmd_ptr++;
+  } while (NUMERIC(*cmd_ptr));
+
+  // Skip all spaces to get to the first argument, or nul
   while (*cmd_ptr == ' ') cmd_ptr++;
 
-  // The command's arguments start here, for sure!
+  // The command's arguments (if any) start here, for sure!
   current_command_args = cmd_ptr;
 
   KEEPALIVE_STATE(IN_HANDLER);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1060,7 +1060,7 @@ bool code_has_value() {
   while (c == ' ') c = seen_pointer[++i];
   if (c == '-' || c == '+') c = seen_pointer[++i];
   if (c == '.') c = seen_pointer[++i];
-  return (c >= '0' && c <= '9');
+  return NUMERIC(c);
 }
 
 float code_value() {
@@ -6066,9 +6066,9 @@ void process_next_command() {
   //  - Bypass N[-0-9][0-9]*[ ]*
   //  - Overwrite * with nul to mark the end
   while (*current_command == ' ') ++current_command;
-  if (*current_command == 'N' && ((current_command[1] >= '0' && current_command[1] <= '9') || current_command[1] == '-')) {
+  if (*current_command == 'N' && NUMERIC_SIGNED(current_command[1])) {
     current_command += 2; // skip N[-0-9]
-    while (*current_command >= '0' && *current_command <= '9') ++current_command; // skip [0-9]*
+    while (NUMERIC(*current_command)) ++current_command; // skip [0-9]*
     while (*current_command == ' ') ++current_command; // skip [ ]*
   }
   char* starpos = strchr(current_command, '*');  // * should always be the last parameter
@@ -6668,7 +6668,7 @@ void ok_to_send() {
     if (*p == 'N') {
       SERIAL_PROTOCOL(' ');
       SERIAL_ECHO(*p++);
-      while ((*p >= '0' && *p <= '9') || *p == '-')
+      while (NUMERIC_SIGNED(*p))
         SERIAL_ECHO(*p++);
     }
     SERIAL_PROTOCOLPGM(" P"); SERIAL_PROTOCOL(int(BLOCK_BUFFER_SIZE - movesplanned() - 1));

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -51,6 +51,8 @@
 #define ENABLED(b) _CAT(SWITCH_ENABLED_, b)
 #define DISABLED(b) (!_CAT(SWITCH_ENABLED_, b))
 
+#define NUMERIC(a) ((a) >= '0' && '9' >= (a))
+#define NUMERIC_SIGNED(a) (NUMERIC(a) || (a) == '-')
 #define COUNT(a) (sizeof(a)/sizeof(*a))
 
 #endif //__MACROS_H


### PR DESCRIPTION
In the process of scrubbing through the code looking for errors, I found no huge errors, but a few opportunities to clean up the code.
- Bug: Escaped serial chars were stored in serial comment mode – patched
- Macros to test a character for numeracy
- More academic code in the command dispatcher
- Move serial / SD processing from `get_command` to their own functions
