### PR TITLE
Cleanup the DEBUG FLAG section

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -232,6 +232,7 @@ void Stop();
  * Debug flags - not yet widely applied
  */
 enum DebugFlags {
+  DEBUG_NONE          = 0,
   DEBUG_ECHO          = _BV(0),
   DEBUG_INFO          = _BV(1),
   DEBUG_ERRORS        = _BV(2),

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -250,7 +250,7 @@
 
 bool Running = true;
 
-uint8_t marlin_debug_flags = DEBUG_INFO | DEBUG_ERRORS;
+uint8_t marlin_debug_flags = DEBUG_NONE;
 
 static float feedrate = 1500.0, saved_feedrate;
 float current_position[NUM_AXIS] = { 0.0 };
@@ -4333,22 +4333,41 @@ inline void gcode_M110() {
  * M111: Set the debug level
  */
 inline void gcode_M111() {
-  marlin_debug_flags = code_seen('S') ? code_value_short() : DEBUG_INFO | DEBUG_COMMUNICATION;
+  marlin_debug_flags = code_seen('S') ? code_value_short() : DEBUG_NONE;
 
+  // Use "M111 S1" to activate DEBUG_ECHO
   if (marlin_debug_flags & DEBUG_ECHO) {
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPGM(MSG_DEBUG_ECHO);
   }
-  // FOR MOMENT NOT ACTIVE
-  //if (marlin_debug_flags & DEBUG_INFO) SERIAL_ECHOLNPGM(MSG_DEBUG_INFO);
-  //if (marlin_debug_flags & DEBUG_ERRORS) SERIAL_ECHOLNPGM(MSG_DEBUG_ERRORS);
+
+  // Use "M111 S2" to activate DEBUG_INFO
+  if (marlin_debug_flags & DEBUG_INFO) {
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM(MSG_DEBUG_INFO);
+  }
+
+  // Use "M111 S4" to activate DEBUG_ERRORS
+  if (marlin_debug_flags & DEBUG_ERRORS) {
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM(MSG_DEBUG_ERRORS);
+  }
+
+  // Use "M111 S8" to activate DEBUG_DRYRUN
   if (marlin_debug_flags & DEBUG_DRYRUN) {
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPGM(MSG_DEBUG_DRYRUN);
     disable_all_heaters();
   }
 
+  // Use "M111 S16" to activate DEBUG_COMMUNICATION
+  if (marlin_debug_flags & DEBUG_COMMUNICATION) {
+    SERIAL_ECHO_START;
+    SERIAL_ECHOLNPGM(MSG_DEBUG_COMMUNICATION);
+  }
+
   #if ENABLED(DEBUG_LEVELING_FEATURE)
+    // Use "M111 S32" to activate DEBUG_LEVELING
     if (marlin_debug_flags & DEBUG_LEVELING) {
       SERIAL_ECHO_START;
       SERIAL_ECHOLNPGM(MSG_DEBUG_LEVELING);

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -242,6 +242,7 @@
 #define MSG_DEBUG_INFO                      "DEBUG INFO ENABLED"
 #define MSG_DEBUG_ERRORS                    "DEBUG ERRORS ENABLED"
 #define MSG_DEBUG_DRYRUN                    "DEBUG DRYRUN ENABLED"
+#define MSG_DEBUG_COMMUNICATION             "DEBUG COMMUNICATION ENABLED"
 #define MSG_DEBUG_LEVELING                  "DEBUG LEVELING ENABLED"
 
 // LCD Menu Messages


### PR DESCRIPTION
Marlin defines multiple `DebugFlags`:

``` cpp
enum DebugFlags {
  DEBUG_ECHO          = _BV(0),
  DEBUG_INFO          = _BV(1),
  DEBUG_ERRORS        = _BV(2),
  DEBUG_DRYRUN        = _BV(3),
  DEBUG_COMMUNICATION = _BV(4),
  DEBUG_LEVELING      = _BV(5)
};
```

Currently the only used flag is `DEBUG_ECHO`, `DEBUG_DRYRUN` and `DEBUG_LEVELING` when `ENABLED(DEBUG_LEVELING_FEATURE)` but to have consistency with the `enum` the commented sections for `DEBUG_INFO` and `DEBUG_ERRORS` in `gcode_M111()` were activated, being the only side effect the following messages to appear on the serial line when the flags are activated.

```
>>> M111 S2
SENDING:M111 S2
echo:DEBUG INFO ENABLED

>>> M111 S4
SENDING:M111 S4
echo:DEBUG ERRORS ENABLED
```

Since `DEBUG_COMMUNICATION` was not defined anywhere the following changes were applied:
- Add `MSG_DEBUG_COMMUNICATION` to `language.h`
- Add the required code to confirm the activation of the debug mode in `gcode_M111()`

``` cpp
 >>> M111 S16
SENDING:M111 S16
echo:DEBUG COMMUNICATION ENABLED
```

At runtime the default `marlin_debug_flags` i.e. the default _DEBUG LEVEL_, was being set to `DEBUG_INFO | DEBUG_ERRORS` which was inconsistent with the default value of `M111`.

Default `marlin_debug_flags` for `M111` without the `S` argument or using `S0`:

``` cpp
marlin_debug_flags = code_seen('S') ? code_value_short() : DEBUG_INFO | DEBUG_COMMUNICATION
```

Default runtime `marlin_debug_flags`:

``` cpp
uint8_t marlin_debug_flags = DEBUG_INFO | DEBUG_ERRORS;
```

As the behavior of Marlin is to have no _DEBUG FLAG_ active by default, a new `DEBUG_NONE` flag was added to the `DebugFlags` enum and `marlin_debug_flags` is now defaulting to this flag as well as `M111`.
