### PR TITLE
Keep blinking limited to LCD_UPDATE_INTERVAL

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -304,9 +304,11 @@ static void _draw_heater_status(int x, int heater) {
 static void lcd_implementation_status_screen() {
   u8g.setColorIndex(1); // black on white
 
+  bool blink = lcd_blink();
+
   #if HAS_FAN0
     // Symbols menu graphics, animated fan
-    u8g.drawBitmapP(9, 1, STATUS_SCREENBYTEWIDTH, STATUS_SCREENHEIGHT, (blink % 2) && fanSpeeds[0] ? status_screen0_bmp : status_screen1_bmp);
+    u8g.drawBitmapP(9, 1, STATUS_SCREENBYTEWIDTH, STATUS_SCREENHEIGHT, blink && fanSpeeds[0] ? status_screen0_bmp : status_screen1_bmp);
   #endif
 
   #if ENABLED(SDSUPPORT)
@@ -375,18 +377,19 @@ static void lcd_implementation_status_screen() {
   #endif
   u8g.setColorIndex(0); // white on black
   u8g.setPrintPos(2, XYZ_BASELINE);
-  if (blink & 1)
+  if (blink)
     lcd_printPGM(PSTR("X"));
   else {
     if (!axis_homed[X_AXIS])
       lcd_printPGM(PSTR("?"));
-    else
+    else {
       #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[X_AXIS])
           lcd_printPGM(PSTR(" "));
         else
       #endif
       lcd_printPGM(PSTR("X"));
+    }
   }
   u8g.drawPixel(8, XYZ_BASELINE - 5);
   u8g.drawPixel(8, XYZ_BASELINE - 3);
@@ -394,18 +397,19 @@ static void lcd_implementation_status_screen() {
   lcd_print(ftostr31ns(current_position[X_AXIS]));
 
   u8g.setPrintPos(43, XYZ_BASELINE);
-  if (blink & 1)
+  if (blink)
     lcd_printPGM(PSTR("Y"));
   else {
     if (!axis_homed[Y_AXIS])
       lcd_printPGM(PSTR("?"));
-    else
+    else {
       #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[Y_AXIS])
           lcd_printPGM(PSTR(" "));
         else
       #endif
       lcd_printPGM(PSTR("Y"));
+    }
   }
   u8g.drawPixel(49, XYZ_BASELINE - 5);
   u8g.drawPixel(49, XYZ_BASELINE - 3);
@@ -413,18 +417,19 @@ static void lcd_implementation_status_screen() {
   lcd_print(ftostr31ns(current_position[Y_AXIS]));
 
   u8g.setPrintPos(83, XYZ_BASELINE);
-  if (blink & 1)
+  if (blink)
     lcd_printPGM(PSTR("Z"));
   else {
     if (!axis_homed[Z_AXIS])
       lcd_printPGM(PSTR("?"));
-    else
+    else {
       #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[Z_AXIS])
           lcd_printPGM(PSTR(" "));
         else
       #endif
       lcd_printPGM(PSTR("Z"));
+    }
   }
   u8g.drawPixel(89, XYZ_BASELINE - 5);
   u8g.drawPixel(89, XYZ_BASELINE - 3);

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -76,15 +76,13 @@
 
   extern bool cancel_heatup;
 
-  extern uint8_t blink; // Variable for animation
-
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     extern millis_t previous_lcd_status_ms;
   #endif
   void lcd_quick_feedback(); // Audible feedback for a button click - could also be visual
   bool lcd_clicked();
-
   void lcd_ignore_click(bool b=true);
+  bool lcd_blink();
 
   #if ENABLED(NEWPANEL)
     #define EN_C (_BV(BLEN_C))

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -626,6 +626,8 @@ static void lcd_implementation_status_screen() {
 
   #if LCD_HEIGHT > 2
 
+    bool blink = lcd_blink();
+
     #if LCD_WIDTH < 20
 
       #if ENABLED(SDSUPPORT)
@@ -654,7 +656,7 @@ static void lcd_implementation_status_screen() {
         // When axis is homed but axis_known_position is false the axis letters are blinking 'X' <-> ' '.
         // When everything is ok you see a constant 'X'.
 
-        if (blink & 1)
+        if (blink)
           lcd_printPGM(PSTR("X"));
         else {
           if (!axis_homed[X_AXIS])
@@ -671,7 +673,7 @@ static void lcd_implementation_status_screen() {
         lcd.print(ftostr4sign(current_position[X_AXIS]));
 
         lcd_printPGM(PSTR(" "));
-        if (blink & 1)
+        if (blink)
           lcd_printPGM(PSTR("Y"));
         else {
           if (!axis_homed[Y_AXIS])
@@ -691,7 +693,7 @@ static void lcd_implementation_status_screen() {
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    if (blink & 1)
+    if (blink)
       lcd_printPGM(PSTR("Z"));
     else {
       if (!axis_homed[Z_AXIS])


### PR DESCRIPTION
Replaces #3263

The blink variable counts up on every display update, so when the display updates a lot, as when adjusting feedrate with the controller wheel, blinking accelerates. This patch adds an `lcd_blink` function to limit blinking frequency to no more than 2 blinks per second.
