### PR TITLE
Minor cleanup to filament sensor code

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -338,7 +338,7 @@ extern bool axis_homed[3]; // axis[n].is_homed
   extern float filament_width_nominal;  //holds the theoretical filament diameter i.e., 3.00 or 1.75
   extern bool filament_sensor;  //indicates that filament sensor readings should control extrusion
   extern float filament_width_meas; //holds the filament diameter as accurately measured
-  extern signed char measurement_delay[];  //ring buffer to delay measurement
+  extern int8_t measurement_delay[];  //ring buffer to delay measurement
   extern int delay_index1, delay_index2;  //ring buffer index. used by planner, temperature, and main code
   extern float delay_dist; //delay distance counter
   extern int meas_delay_cm; //delay distance

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -410,7 +410,7 @@ static uint8_t target_extruder;
   float filament_width_nominal = DEFAULT_NOMINAL_FILAMENT_DIA;  //Set nominal filament width, can be changed with M404
   bool filament_sensor = false;  //M405 turns on filament_sensor control, M406 turns it off
   float filament_width_meas = DEFAULT_MEASURED_FILAMENT_DIA; //Stores the measured filament diameter
-  signed char measurement_delay[MAX_MEASUREMENT_DELAY + 1]; //ring buffer to delay measurement  store extruder factor after subtracting 100
+  int8_t measurement_delay[MAX_MEASUREMENT_DELAY + 1]; //ring buffer to delay measurement  store extruder factor after subtracting 100
   int delay_index1 = 0;  //index into ring buffer
   int delay_index2 = -1;  //index into ring buffer - set to -1 on startup to indicate ring buffer needs to be initialized
   float delay_dist = 0; //delay distance counter
@@ -5464,7 +5464,7 @@ inline void gcode_M400() { st_synchronize(); }
     if (delay_index2 == -1) { //initialize the ring buffer if it has not been done since startup
       int temp_ratio = widthFil_to_size_ratio();
 
-      for (delay_index1 = 0; delay_index1 < MAX_MEASUREMENT_DELAY + 1; ++delay_index1)
+      for (delay_index1 = 0; delay_index1 < COUNT(measurement_delay); ++delay_index1)
         measurement_delay[delay_index1] = temp_ratio - 100;  //subtract 100 to scale within a signed byte
 
       delay_index1 = delay_index2 = 0;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -147,10 +147,6 @@ uint8_t g_uc_extruder_last_move[EXTRUDERS] = { 0 };
   static long axis_segment_time[2][3] = { {MAX_FREQ_TIME + 1, 0, 0}, {MAX_FREQ_TIME + 1, 0, 0} };
 #endif
 
-#if ENABLED(FILAMENT_SENSOR)
-  static char meas_sample; //temporary variable to hold filament measurement sample
-#endif
-
 #if ENABLED(DUAL_X_CARRIAGE)
   extern bool extruder_duplication_enabled;
 #endif
@@ -857,7 +853,6 @@ float junction_deviation = 0.1;
 
   #if ENABLED(FILAMENT_SENSOR)
     //FMM update ring buffer used for delay with filament measurements
-
     if (extruder == FILAMENT_SENSOR_EXTRUDER_NUM && delay_index2 > -1) {  //only for extruder with filament sensor and if ring buffer is initialized
 
       const int MMD = MAX_MEASUREMENT_DELAY + 1, MMD10 = MMD * 10;
@@ -870,7 +865,7 @@ float junction_deviation = 0.1;
       delay_index1 = constrain(delay_index1, 0, MAX_MEASUREMENT_DELAY); // (already constrained above)
 
       if (delay_index1 != delay_index2) { // moved index
-        meas_sample = widthFil_to_size_ratio() - 100;  // Subtract 100 to reduce magnitude - to store in a signed char
+        int8_t meas_sample = widthFil_to_size_ratio() - 100;  // Subtract 100 to reduce magnitude - to store in a signed char
         while (delay_index1 != delay_index2) {
           // Increment and loop around buffer
           if (++delay_index2 >= MMD) delay_index2 -= MMD;


### PR DESCRIPTION
Use `int8_t` instead of `char`, remove global static `meas_sample`, use `COUNT()` for array iteration.
