### PR TITLE
Refinements, fixes, reduced stack usage in CardReader

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3704,7 +3704,7 @@ inline void gcode_M31() {
     bool call_procedure = code_seen('P') && (seen_pointer < namestartpos);
 
     if (card.cardOK) {
-      card.openFile(namestartpos, true, !call_procedure);
+      card.openFile(namestartpos, true, call_procedure);
 
       if (code_seen('S') && seen_pointer < namestartpos) // "S" (must occur _before_ the filename!)
         card.setIndex(code_value_short());

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -584,22 +584,15 @@ void CardReader::chdir(const char * relpath) {
     SERIAL_ECHOLN(relpath);
   }
   else {
-    if (workDirDepth < MAX_DIR_DEPTH) {
-      ++workDirDepth;
-      for (int d = workDirDepth; d--;) workDirParents[d + 1] = workDirParents[d];
-      workDirParents[0] = *parent;
-    }
+    if (workDirDepth < MAX_DIR_DEPTH)
+      workDirParents[workDirDepth++] = *parent;
     workDir = newfile;
   }
 }
 
 void CardReader::updir() {
-  if (workDirDepth > 0) {
-    --workDirDepth;
-    workDir = workDirParents[0];
-    for (uint16_t d = 0; d < workDirDepth; d++)
-      workDirParents[d] = workDirParents[d+1];
-  }
+  if (workDirDepth > 0)
+    workDir = workDirParents[--workDirDepth];
 }
 
 void CardReader::printingHasFinished() {

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -318,9 +318,9 @@ void CardReader::openFile(char* name, bool read, bool replace_current/*=true*/) 
       SERIAL_ECHOPGM("\" parent:\"");
 
       //store current filename and position
-      getAbsFilename(filenames[file_subcall_ctr]);
+      getAbsFilename(proc_filenames[file_subcall_ctr]);
 
-      SERIAL_ECHO(filenames[file_subcall_ctr]);
+      SERIAL_ECHO(proc_filenames[file_subcall_ctr]);
       SERIAL_ECHOPGM("\" pos");
       SERIAL_ECHOLN(sdpos);
       filespos[file_subcall_ctr] = sdpos;
@@ -607,7 +607,7 @@ void CardReader::printingHasFinished() {
   if (file_subcall_ctr > 0) { // Heading up to a parent file that called current as a procedure.
     file.close();
     file_subcall_ctr--;
-    openFile(filenames[file_subcall_ctr], true, true);
+    openFile(proc_filenames[file_subcall_ctr], true, true);
     setIndex(filespos[file_subcall_ctr]);
     startFileprint();
   }
@@ -617,7 +617,6 @@ void CardReader::printingHasFinished() {
     if (SD_FINISHED_STEPPERRELEASE) {
       //finishAndDisableSteppers();
       enqueue_and_echo_commands_P(PSTR(SD_FINISHED_RELEASECOMMAND));
-    }
     autotempShutdown();
   }
 }

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -269,7 +269,7 @@ void CardReader::openAndPrintFile(const char *name) {
   char cmd[4 + strlen(name) + 1]; // Room for "M23 ", filename, and null
   sprintf_P(cmd, PSTR("M23 %s"), name);
   for (char *c = &cmd[4]; *c; c++) *c = tolower(*c);
-  enqueue_and_echo_command_now(cmd);
+  enqueue_and_echo_command(cmd);
   enqueue_and_echo_commands_P(PSTR("M24"));
 }
 

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -300,10 +300,10 @@ void CardReader::getAbsFilename(char *t) {
     t[0] = 0;
 }
 
-void CardReader::openFile(char* name, bool read, bool replace_current/*=true*/) {
+void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
   if (!cardOK) return;
   if (file.isOpen()) { //replacing current file by new file, or subfile call
-    if (!replace_current) {
+    if (push_current) {
       if (file_subcall_ctr > SD_PROCEDURE_DEPTH - 1) {
         SERIAL_ERROR_START;
         SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -607,8 +607,7 @@ void CardReader::printingHasFinished() {
   else {
     file.close();
     sdprinting = false;
-    if (SD_FINISHED_STEPPERRELEASE) {
-      //finishAndDisableSteppers();
+    if (SD_FINISHED_STEPPERRELEASE)
       enqueue_and_echo_commands_P(PSTR(SD_FINISHED_RELEASECOMMAND));
     autotempShutdown();
   }

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -266,7 +266,7 @@ void CardReader::release() {
 }
 
 void CardReader::openAndPrintFile(const char *name) {
-  char cmd[4 + (FILENAME_LENGTH + 1) * MAX_DIR_DEPTH + 2]; // Room for "M23 ", names with slashes, a null, and one extra
+  char cmd[4 + strlen(name) + 1]; // Room for "M23 ", filename, and null
   sprintf_P(cmd, PSTR("M23 %s"), name);
   for (char *c = &cmd[4]; *c; c++) *c = tolower(*c);
   enqueue_and_echo_command_now(cmd);

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -325,13 +325,13 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
       SERIAL_ECHOLN(sdpos);
       filespos[file_subcall_ctr] = sdpos;
       file_subcall_ctr++;
-     }
-     else {
-      SERIAL_ECHO_START;
-      SERIAL_ECHOPGM("Now doing file: ");
-      SERIAL_ECHOLN(name);
-     }
-     file.close();
+    }
+    else {
+     SERIAL_ECHO_START;
+     SERIAL_ECHOPGM("Now doing file: ");
+     SERIAL_ECHOLN(name);
+    }
+    file.close();
   }
   else { //opening fresh file
     file_subcall_ctr = 0; //resetting procedure depth in case user cancels print while in procedure

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -79,7 +79,7 @@ public:
   int autostart_index;
 private:
   SdFile root, *curDir, workDir, workDirParents[MAX_DIR_DEPTH];
-  uint16_t workDirDepth;
+  uint8_t workDirDepth;
   Sd2Card card;
   SdVolume volume;
   SdFile file;

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -40,7 +40,7 @@ public:
   //this is to delay autostart and hence the initialisaiton of the sd card to some seconds after the normal init, so the device is available quick after a reset
 
   void checkautostart(bool x);
-  void openFile(char* name,bool read,bool replace_current=true);
+  void openFile(char* name, bool read, bool push_current=false);
   void openLogFile(char* name);
   void removeFile(char* name);
   void closefile(bool store_location=false);

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -65,7 +65,6 @@ public:
   void updir();
   void setroot();
 
-
   FORCE_INLINE bool isFileOpen() { return file.isOpen(); }
   FORCE_INLINE bool eof() { return sdpos >= filesize; }
   FORCE_INLINE int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
@@ -90,9 +89,9 @@ private:
   uint32_t filespos[SD_PROCEDURE_DEPTH];
   char proc_filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH];
   uint32_t filesize;
-  millis_t next_autostart_ms;
   uint32_t sdpos;
 
+  millis_t next_autostart_ms;
   bool autostart_stilltocheck; //the sd start is delayed, because otherwise the serial cannot answer fast enought to make contact with the hostsoftware.
 
   LsAction lsAction; //stored for recursion.

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -83,11 +83,12 @@ private:
   Sd2Card card;
   SdVolume volume;
   SdFile file;
+
   #define SD_PROCEDURE_DEPTH 1
   #define MAXPATHNAMELENGTH (FILENAME_LENGTH*MAX_DIR_DEPTH + MAX_DIR_DEPTH + 1)
   uint8_t file_subcall_ctr;
   uint32_t filespos[SD_PROCEDURE_DEPTH];
-  char filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH];
+  char proc_filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH];
   uint32_t filesize;
   millis_t next_autostart_ms;
   uint32_t sdpos;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1116,7 +1116,7 @@ static void lcd_control_menu() {
         autotune_temp[e]
       #endif
     );
-    enqueue_and_echo_command_now(cmd);
+    enqueue_and_echo_command(cmd);
   }
 
 #endif //PID_AUTOTUNE_MENU


### PR DESCRIPTION
This includes a small reversion to skip the use of `enqueue_and_echo_command_now` for immediate injected `M23` commands. In addition, it reduces the amount of stack used for `M23` commands, clarifies some variable naming in `CardReader`, makes the working directory stack `workDirParents` simpler (pushing to the end instead of the front), and as a result of that fixes a bug in `getAbsFileName` (the parent order was reversed).

This PR may just possibly, hopefully, address issues with printing from SD.
