### PR TITLE
Fix string issues in ultralcd.cpp

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -536,7 +536,7 @@ void lcd_set_home_offsets() {
         babystepsTodo[axis] += distance;
       #endif
     }
-    if (lcdDrawUpdate) lcd_implementation_drawedit(msg, PSTR(""));
+    if (lcdDrawUpdate) lcd_implementation_drawedit(msg, "");
     if (LCD_CLICKED) lcd_goto_previous_menu();
   }
 
@@ -2477,7 +2477,7 @@ char* ftostr52(const float& x) {
    * MBL Move to mesh starting point
    */
   static void _lcd_level_bed_homing() {
-    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ"), PSTR(MSG_LEVEL_BED_HOMING));
+    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ"), MSG_LEVEL_BED_HOMING);
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);


### PR DESCRIPTION
Addressing #3273 — String literals being passed to `lcd_implementation_drawedit` were incorrectly wrapped in `PSTR` (do to conflation of `const` with `PROGMEM` magic). The string `MSG_LEVEL_BED_HOMING` won't be stored in `PROGMEM`. But it could be, using this code:

``` cpp
const char msg_level_bed_homing[] PROGMEM = MSG_LEVEL_BED_HOMING;
if (lcdDrawUpdate) {
  char homing_str[strlen_P(msg_level_bed_homing) + 1];
  strcpy_P(homing_str, (char*)pgm_read_word(&(msg_level_bed_homing)));
  lcd_implementation_drawedit(PSTR("XYZ"), homing_str);
}
```
