### PR TITLE
Fix an error when EXTRUDE_MINTEMP is not defined

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -27,8 +27,19 @@
 
 #ifndef CONDITIONALS_H
 
+/**
+* Miscellaneous
+*/
 #ifndef M_PI
   #define M_PI 3.1415926536
+#endif
+
+/**
+ * This value is used by M109 when tying to calculate a ballpark safe margin
+ * to prevent wait-forever situation.
+ */
+#ifndef EXTRUDE_MINTEMP
+ #define EXTRUDE_MINTEMP 170
 #endif
 
 #ifndef CONFIGURATION_LCD // Get the LCD defines which are needed first


### PR DESCRIPTION
Followup 1981e53d68734e69d16cb3d1a33705eec32aed90
Fixes #3291
