### PR TITLE
Various patches for LCD menu issues

### DIFF
--- a/Marlin/Default_Version.h
+++ b/Marlin/Default_Version.h
@@ -28,9 +28,9 @@
 // #error "You must specify the following parameters related to your distribution"
 
 #if true
-#define SHORT_BUILD_VERSION "1.1.0-RC4"
-#define DETAILED_BUILD_VERSION "1.1.0-RC4 From Archive"
-#define STRING_DISTRIBUTION_DATE "2016-03-24 12:00"
+#define SHORT_BUILD_VERSION "1.1.0-RCBugFix"
+#define DETAILED_BUILD_VERSION "1.1.0-RCBugFix From Archive"
+#define STRING_DISTRIBUTION_DATE "2016-04-01 12:00"
 // It might also be appropriate to define a location where additional information can be found
 // #define SOURCE_CODE_URL  "http:// ..."
 #endif

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -378,7 +378,7 @@ static void lcd_implementation_status_screen() {
   u8g.setColorIndex(0); // white on black
   u8g.setPrintPos(2, XYZ_BASELINE);
   if (blink)
-    lcd_printPGM(PSTR("X"));
+    lcd_printPGM(PSTR(MSG_X));
   else {
     if (!axis_homed[X_AXIS])
       lcd_printPGM(PSTR("?"));
@@ -388,7 +388,7 @@ static void lcd_implementation_status_screen() {
           lcd_printPGM(PSTR(" "));
         else
       #endif
-      lcd_printPGM(PSTR("X"));
+      lcd_printPGM(PSTR(MSG_X));
     }
   }
   u8g.drawPixel(8, XYZ_BASELINE - 5);
@@ -398,7 +398,7 @@ static void lcd_implementation_status_screen() {
 
   u8g.setPrintPos(43, XYZ_BASELINE);
   if (blink)
-    lcd_printPGM(PSTR("Y"));
+    lcd_printPGM(PSTR(MSG_Y));
   else {
     if (!axis_homed[Y_AXIS])
       lcd_printPGM(PSTR("?"));
@@ -408,7 +408,7 @@ static void lcd_implementation_status_screen() {
           lcd_printPGM(PSTR(" "));
         else
       #endif
-      lcd_printPGM(PSTR("Y"));
+      lcd_printPGM(PSTR(MSG_Y));
     }
   }
   u8g.drawPixel(49, XYZ_BASELINE - 5);
@@ -418,7 +418,7 @@ static void lcd_implementation_status_screen() {
 
   u8g.setPrintPos(83, XYZ_BASELINE);
   if (blink)
-    lcd_printPGM(PSTR("Z"));
+    lcd_printPGM(PSTR(MSG_Z));
   else {
     if (!axis_homed[Z_AXIS])
       lcd_printPGM(PSTR("?"));
@@ -428,7 +428,7 @@ static void lcd_implementation_status_screen() {
           lcd_printPGM(PSTR(" "));
         else
       #endif
-      lcd_printPGM(PSTR("Z"));
+      lcd_printPGM(PSTR(MSG_Z));
     }
   }
   u8g.drawPixel(89, XYZ_BASELINE - 5);

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -562,9 +562,11 @@ void lcd_implementation_drawedit(const char* pstr, const char* value) {
 
   u8g.setPrintPos(0, rowHeight + kHalfChar);
   lcd_printPGM(pstr);
-  lcd_print(':');
-  u8g.setPrintPos((lcd_width - 1 - vallen) * char_width, rows * rowHeight + kHalfChar);
-  lcd_print(value);
+  if (value != NULL) {
+    lcd_print(':');
+    u8g.setPrintPos((lcd_width - 1 - vallen) * char_width, rows * rowHeight + kHalfChar);
+    lcd_print(value);
+  }
 }
 
 #if ENABLED(SDSUPPORT)

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       " Autostart"
 #define MSG_DISABLE_STEPPERS                "Amortar motors"
 #define MSG_AUTO_HOME                       "Levar a l'orichen"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Establir zero"
 #define MSG_PREHEAT_PLA                     "Precalentar PLA"

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Автостарт"
 #define MSG_DISABLE_STEPPERS                "Изкл. двигатели"
 #define MSG_AUTO_HOME                       "Паркиране"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Задай Начало"
 #define MSG_SET_ORIGIN                      "Изходна точка"
 #define MSG_PREHEAT_PLA                     "Подгряване PLA"

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -43,7 +43,7 @@
 #define MSG_AUTOSTART                       "Inici automatic"
 #define MSG_DISABLE_STEPPERS                "Apagar motors"
 #define MSG_AUTO_HOME                       "Home global"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Establir origen"
 #define MSG_PREHEAT_PLA                     "Preescalfar PLA"

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -40,7 +40,7 @@
 #define MSG_AUTOSTART                       "\xb1\xb2\xb3\xb4"
 #define MSG_DISABLE_STEPPERS                "\xb5\xb6\xb7\xb8\xb9\xba"
 #define MSG_AUTO_HOME                       "\xbb\xbc\xbd"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "\xbe\xbf\xbb\xbc\xbd\xc0\xc1"
 #define MSG_SET_ORIGIN                      "\xbe\xbf\xbc\xbd"
 #define MSG_PREHEAT_PLA                     "\xc3\xc4 PLA"

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -43,7 +43,7 @@
 #define MSG_AUTO_HOME                       "Home" // G28
 #define MSG_COOLDOWN                        "Afkøl"
 #define MSG_DISABLE_STEPPERS                "Slå stepper fra"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Sæt home offsets"
 #define MSG_SET_ORIGIN                      "Sæt origin"
 #define MSG_SWITCH_PS_ON                    "Slå strøm til"

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Autostart"
 #define MSG_DISABLE_STEPPERS                "Motoren Aus" // M84
 #define MSG_AUTO_HOME                       "Home" // G28
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Setze Home hier"
 #define MSG_SET_ORIGIN                      "Setze Null hier" //"G92 X0 Y0 Z0" commented out in ultralcd.cpp
 #define MSG_PREHEAT_PLA                     "Vorwärmen PLA"

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -62,7 +62,7 @@
   #define MSG_AUTO_HOME                       "Auto home"
 #endif
 #ifndef MSG_LEVEL_BED_HOMING
-  #define MSG_LEVEL_BED_HOMING                "Homing"
+  #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #endif
 #ifndef MSG_SET_HOME_OFFSETS
   #define MSG_SET_HOME_OFFSETS                "Set home offsets"

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Autostart"
 #define MSG_DISABLE_STEPPERS                "Apagar motores"
 #define MSG_AUTO_HOME                       "Llevar al origen"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Ajustar offsets"
 #define MSG_SET_ORIGIN                      "Establecer cero"
 #define MSG_PREHEAT_PLA                     "Precalentar PLA"

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Auto hasiera"
 #define MSG_DISABLE_STEPPERS                "Itzali motoreak"
 #define MSG_AUTO_HOME                       "Hasierara joan"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Hasiera ipini"
 #define MSG_PREHEAT_PLA                     "Aurreberotu PLA"

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Automaatti"
 #define MSG_DISABLE_STEPPERS                "Vapauta moottorit"
 #define MSG_AUTO_HOME                       "Aja referenssiin"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Aseta origo"
 #define MSG_PREHEAT_PLA                     "Esilämmitä PLA"

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -43,7 +43,7 @@
 #define MSG_AUTOSTART                       "Demarrage auto"
 #define MSG_DISABLE_STEPPERS                "Arreter moteurs"
 #define MSG_AUTO_HOME                       "Home auto."
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Regler origine"
 #define MSG_PREHEAT_PLA                     "Prechauffage PLA"

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Autostart"
 #define MSG_DISABLE_STEPPERS                "Disabilita Motori"
 #define MSG_AUTO_HOME                       "Auto Home"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Setta offset home"
 #define MSG_SET_ORIGIN                      "Imposta Origine"
 #define MSG_PREHEAT_PLA                     "Preriscalda PLA"

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -44,7 +44,7 @@
 #define MSG_AUTOSTART                       "\xbc\xde\xc4\xde\xb3\xb6\xb2\xbc"                             // "Autostart"
 #define MSG_DISABLE_STEPPERS                "\xd3\xb0\xc0\xb0\xc3\xde\xdd\xb9\xde\xdd\x20\xb5\xcc"         // "Disable steppers"
 #define MSG_AUTO_HOME                       "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Auto home"
-#define MSG_LEVEL_BED_HOMING                "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Homing"
+#define MSG_LEVEL_BED_HOMING                "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "\xb7\xbc\xde\xad\xdd\xb5\xcc\xbe\xaf\xc4\xbe\xaf\xc3\xb2"     // "Set home offsets"
 #define MSG_SET_ORIGIN                      "\xb7\xbc\xde\xad\xdd\xbe\xaf\xc4"                             // "Set origin"
 #define MSG_PREHEAT_PLA                     "PLA \xd6\xc8\xc2"                                             // "Preheat PLA"

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Autostart"
 #define MSG_DISABLE_STEPPERS                "Motoren uit"
 #define MSG_AUTO_HOME                       "Auto home"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Nulpunt instellen"
 #define MSG_PREHEAT_PLA                     "PLA voorverwarmen"

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Autostart"
 #define MSG_DISABLE_STEPPERS                "Wylacz silniki"
 #define MSG_AUTO_HOME                       "Auto. poz. zerowa"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_SET_ORIGIN                      "Ustaw punkt zero"
 #define MSG_PREHEAT_PLA                     "Rozgrzej PLA"

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Autostart"
 #define MSG_DISABLE_STEPPERS                "Desabi. motores"
 #define MSG_AUTO_HOME                       "Ir para origen"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Ajustar Jogo"
 #define MSG_SET_ORIGIN                      "Ajustar orig."
 #define MSG_PREHEAT_PLA                     "Pre-aquecer PLA"

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -42,7 +42,7 @@
 #define MSG_AUTOSTART                       "Автостарт"
 #define MSG_DISABLE_STEPPERS                "Выкл. двигатели"
 #define MSG_AUTO_HOME                       "Парковка"
-#define MSG_LEVEL_BED_HOMING                "Homing"
+#define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Запомнить парковку"
 #define MSG_SET_ORIGIN                      "Запомнить ноль"
 #define MSG_PREHEAT_PLA                     "Преднагрев PLA"

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2449,9 +2449,12 @@ char* ftostr52(const float& x) {
       if (max_software_endstops) NOMORE(current_position[Z_AXIS], Z_MAX_POS);
       encoderPosition = 0;
       line_to_current(Z_AXIS);
-      lcdDrawUpdate = 2;
+      lcdDrawUpdate = 1;
     }
-    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Z"), ftostr43(current_position[Z_AXIS]));
+    if (lcdDrawUpdate) {
+      float v = current_position[Z_AXIS] - MESH_HOME_SEARCH_Z;
+      lcd_implementation_drawedit(PSTR(MSG_MOVE_Z), ftostr43(v + (v < 0 ? -0.0001 : 0.0001)));
+    }
     static bool debounce_click = false;
     if (LCD_CLICKED) {
       if (!debounce_click) {

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -267,7 +267,7 @@ static void lcd_status_screen();
   uint8_t currentMenuViewOffset;              /* scroll offset in the current menu */
   millis_t next_button_update_ms;
   uint8_t lastEncoderBits;
-  uint32_t encoderPosition;
+  uint32_t encoderPosition, prevEncoderPosition;
   #if PIN_EXISTS(SD_DETECT)
     uint8_t lcd_sd_status;
   #endif
@@ -281,14 +281,12 @@ bool ignore_click = false;
 bool wait_for_unclick;
 uint8_t lcdDrawUpdate = 2;                  /* Set to none-zero when the LCD needs to draw, decreased after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial) */
 
-//prevMenu and prevEncoderPosition are used to store the previous menu location when editing settings.
-menuFunc_t prevMenu = NULL;
-uint16_t prevEncoderPosition;
-//Variables used when editing values.
+// Variables used when editing values.
 const char* editLabel;
 void* editValue;
 int32_t minEditValue, maxEditValue;
-menuFunc_t callbackFunc;
+menuFunc_t prevMenu = NULL;           // return here after editing (also prevEncoderPosition)
+menuFunc_t callbackFunc;              // call this after editing
 
 // place-holders for Ki and Kd edits
 float raw_Ki, raw_Kd;
@@ -310,9 +308,20 @@ static void lcd_goto_menu(menuFunc_t menu, const bool feedback = false, const ui
   }
 }
 
-inline void lcd_save_previous_menu() { prevMenu = currentMenu; prevEncoderPosition = encoderPosition; }
+inline void lcd_save_previous_menu() {
+  prevMenu = currentMenu;
+  #if ENABLED(ULTIPANEL)
+    prevEncoderPosition = encoderPosition;
+  #endif
+}
 
-static void lcd_goto_previous_menu() { lcd_goto_menu(prevMenu, true, prevEncoderPosition); }
+static void lcd_goto_previous_menu() {
+  lcd_goto_menu(prevMenu, true
+    #if ENABLED(ULTIPANEL)
+      , prevEncoderPosition
+    #endif
+  );
+}
 
 /**
  *

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -536,7 +536,7 @@ void lcd_set_home_offsets() {
         babystepsTodo[axis] += distance;
       #endif
     }
-    if (lcdDrawUpdate) lcd_implementation_drawedit(msg, "");
+    if (lcdDrawUpdate) lcd_implementation_drawedit(msg, NULL);
     if (LCD_CLICKED) lcd_goto_previous_menu();
   }
 
@@ -2482,7 +2482,7 @@ char* ftostr52(const float& x) {
    * MBL Move to mesh starting point
    */
   static void _lcd_level_bed_homing() {
-    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ"), MSG_LEVEL_BED_HOMING);
+    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ " MSG_LEVEL_BED_HOMING), NULL);
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2494,7 +2494,7 @@ char* ftostr52(const float& x) {
    * MBL Move to mesh starting point
    */
   static void _lcd_level_bed_homing() {
-    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ " MSG_LEVEL_BED_HOMING), NULL);
+    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_HOMING), NULL);
     lcdDrawUpdate = 1;
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1822,9 +1822,10 @@ int lcd_strlen_P(const char* s) {
 bool lcd_blink() {
   static uint8_t blink = 0;
   static millis_t next_blink_ms = 0;
-  if (millis() >= next_blink_ms) {
+  millis_t ms = millis();
+  if (ms >= next_blink_ms) {
     blink ^= 0xFF;
-    next_blink_ms = millis() + LCD_UPDATE_INTERVAL - 50;
+    next_blink_ms = ms + 1000 - LCD_UPDATE_INTERVAL / 2;
   }
   return blink != 0;
 }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -298,6 +298,7 @@ float raw_Ki, raw_Kd;
 static void lcd_goto_menu(menuFunc_t menu, const bool feedback = false, const uint32_t encoder = 0) {
   if (currentMenu != menu) {
     currentMenu = menu;
+    lcdDrawUpdate = 2;
     #if ENABLED(NEWPANEL)
       encoderPosition = encoder;
       if (feedback) lcd_quick_feedback();
@@ -2476,7 +2477,7 @@ char* ftostr52(const float& x) {
           current_position[X_AXIS] = mbl.get_x(ix);
           current_position[Y_AXIS] = mbl.get_y(iy);
           line_to_current(manual_feedrate[X_AXIS] <= manual_feedrate[Y_AXIS] ? X_AXIS : Y_AXIS);
-          lcdDrawUpdate = 2;
+          lcdDrawUpdate = 1;
         }
       }
     }
@@ -2490,6 +2491,7 @@ char* ftostr52(const float& x) {
    */
   static void _lcd_level_bed_homing() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("XYZ " MSG_LEVEL_BED_HOMING), NULL);
+    lcdDrawUpdate = 1;
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
@@ -2499,7 +2501,6 @@ char* ftostr52(const float& x) {
       _lcd_level_bed_position = 0;
       lcd_goto_menu(_lcd_level_bed);
     }
-    lcdDrawUpdate = 2;
   }
 
   /**
@@ -2510,7 +2511,6 @@ char* ftostr52(const float& x) {
     axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
     mbl.reset();
     enqueue_and_echo_commands_P(PSTR("G28"));
-    lcdDrawUpdate = 2;
     lcd_goto_menu(_lcd_level_bed_homing);
   }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2228,11 +2228,11 @@ char* ftostr43(const float& x) {
   long xx = x * 1000;
   char *conv_ptr = conv;
   if (xx >= 0) {
-    *conv_ptr++ = ' ';
+    conv_ptr++;
   }
   else {
-    conv[0] = '-';
     xx = -xx;
+    conv[0] = '-';
   }
   conv[1] = (xx / 1000) % 10 + '0';
   conv[2] = '.';

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1154,7 +1154,7 @@ static void lcd_control_menu() {
       _PIDTEMP_BASE_FUNCTIONS(eindex); \
       void lcd_autotune_callback_E ## eindex() { _lcd_autotune(eindex); }
   #else
-    #define _PIDTEMP_FUNCTIONS(eindex) _PIDTEMP_BASE_FUNCTIONS(eindex);
+    #define _PIDTEMP_FUNCTIONS(eindex) _PIDTEMP_BASE_FUNCTIONS(eindex)
   #endif
 
   _PIDTEMP_FUNCTIONS(0);

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -863,9 +863,11 @@ static void lcd_implementation_drawmenu_setting_edit_generic_P(bool sel, uint8_t
 void lcd_implementation_drawedit(const char* pstr, const char* value) {
   lcd.setCursor(1, 1);
   lcd_printPGM(pstr);
-  lcd.print(':');
-  lcd.setCursor(LCD_WIDTH - lcd_strlen(value), 1);
-  lcd_print(value);
+  if (value != NULL) {
+    lcd.print(':');
+    lcd.setCursor(LCD_WIDTH - lcd_strlen(value), 1);
+    lcd_print(value);
+  }
 }
 
 #if ENABLED(SDSUPPORT)


### PR DESCRIPTION
- Pin and button macros fixes
- `RCBugFix` version string
- Allow `lcd_implementation_drawedit` to draw a message (with a `NULL` `value` pointer)
- Use `BUTTON` macros
- Clarify local var in `lcd_implementation_read_slow_buttons`
- Use XYZ translated strings in dogm
- Patch `prevEncoderPosition` compile issue as with #3301
- Use a flag to defer lcd return-to-status (instead of looking for certain menus)
