### PR TITLE
Support for MKS v1.3/1.4 and Sainsmart RAMPS 1.4 variants

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -83,6 +83,8 @@
 #define BOARD_5DPRINT           88   // 5DPrint D8 Driver Board
 #define BOARD_LEAPFROG          999  // Leapfrog
 #define BOARD_MKS_BASE          40   // MKS BASE 1.0
+#define BOARD_MKS_13            47   // MKS v1.3 or 1.4 (maybe higher)
+#define BOARD_SAINSMART_2IN1    49   // Sainsmart 2-in-1 board
 #define BOARD_BAM_DICE          401  // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402  // 2PrintBeta BAM&DICE Due with STK drivers
 #define BOARD_BQ_ZUM_MEGA_3D    503  // bq ZUM Mega 3D

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -149,6 +149,10 @@
   #include "pins_99.h"
 #elif MB(AJ4P)
   #include "pins_AJ4P.h"
+#elif MB(MKS_13)
+  #include "pins_MKS_13.h"
+#elif MB(BOARD_SAINSMART_2IN1)
+  #include "pins_SAINSMART_2IN1.h"
 #else
   #error Unknown MOTHERBOARD value set in Configuration.h
 #endif

--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -1,0 +1,35 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Arduino Mega with RAMPS v1.4 adjusted pin assignments
+ *
+ *  MKS v1.3  (Extruder, Fan, Bed)
+ *  MKS v1.3  (Extruder, Extruder, Fan, Bed)
+ *  MKS v1.4  (Extruder, Fan, Bed)
+ *  MKS v1.4  (Extruder, Extruder, Fan, Bed)
+ */
+
+#include "pins_RAMPS_14_EFB.h"
+
+#undef HEATER_1_PIN
+#define HEATER_1_PIN        7 // EXTRUDER 2 (-1 on RAMPS 1.4)

--- a/Marlin/pins_SAINSMART_2IN1.h
+++ b/Marlin/pins_SAINSMART_2IN1.h
@@ -1,0 +1,36 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ *  Sainsmart 2-in-1 pin assignments
+ */
+
+#include "pins_RAMPS_14_EFB.h"
+
+#undef FAN_PIN
+#define FAN_PIN             7 // PART FAN in front of board next to Extruder heat
+
+#undef HEATER_0_PIN
+#define HEATER_0_PIN        9   // EXTRUDER 1
+
+#undef HEATER_1_PIN
+#define HEATER_1_PIN       10   // EXTRUDER 2


### PR DESCRIPTION
Redo of #3297, adding pins definitions and board defines for MKS 1.3/1.4 and Sainsmart 2-in-1, which are basic RAMPS 1.4 variants.
