### PR TITLE
Patch for slow_buttons to read in every lcd_update

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1875,12 +1875,12 @@ void lcd_update() {
 
   #endif //SDSUPPORT && SD_DETECT_PIN
 
+  #if ENABLED(LCD_HAS_SLOW_BUTTONS)
+    slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
+  #endif
+
   millis_t ms = millis();
   if (ms > next_lcd_update_ms) {
-
-    #if ENABLED(LCD_HAS_SLOW_BUTTONS)
-      slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
-    #endif
 
     #if ENABLED(ULTIPANEL)
 


### PR DESCRIPTION
Potential fix for #3007. Instead of waiting 100ms between lcd "slow button" tests, check on every loop.
