### PR TITLE
added menu item to reset BLTouch sensor alarm

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -884,6 +884,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // leaving it undefined or defining as 0 will disable the servo subsystem
 // If unsure, leave commented / disabled
 //
+//#define BLTOUCH_MENU // uncomment if you want the reset BLTouch menu item
 //#define NUM_SERVOS 3 // Servo index starts with 0 for M280 command
 
 // Servo Endstops

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -491,7 +491,7 @@
   #define MSG_DELTA_CALIBRATE_CENTER          "Calibrate Center"
 #endif
 #ifndef MSG_RESET_BLT
-  #define MSG_RESET_BLT                        "Reset BLTouch"  
+  #define MSG_RESET_BLT                        "Reset BLTouch alarm"  
 #endif
 
 

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -490,5 +490,9 @@
 #ifndef MSG_DELTA_CALIBRATE_CENTER
   #define MSG_DELTA_CALIBRATE_CENTER          "Calibrate Center"
 #endif
+#ifndef MSG_RESET_BLT
+  #define MSG_RESET_BLT                        "Reset BLTouch"  
+#endif
+
 
 #endif // LANGUAGE_EN_H

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -888,7 +888,7 @@ static void lcd_prepare_menu() {
   
   //
   // BLTouch installed so allow reset menu option to reset alarm mode
-  #if BLTOUCH_MENU 
+  #if ENABLED(BLTOUCH_MENU)
     MENU_ITEM(gcode, MSG_RESET_BLT, PSTR("M280 P0 S160"));
   #endif // BLTOUCH_MENU
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -885,6 +885,13 @@ static void lcd_prepare_menu() {
   // Cooldown
   //
   MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
+  
+  //
+  // BLTouch installed so allow reset menu option to reset alarm mode
+  #if BLTOUCH_MENU 
+    MENU_ITEM(gcode, MSG_RESET_BLT, PSTR("M280 P0 S160"));
+  #endif // BLTOUCH_MENU
+
 
   //
   // Switch power on/off


### PR DESCRIPTION
On power up the BLTouch auto levelling sensor does a self test and just halts and flashes its LED if there is any obstruction on the probe pin.  A common problem is if the printer is turned on and the probe is too close to the bed it goes into the alarm mode and the only way to reset it is a power on/off or send the code `M280 P0 S160`.
