### PR TITLE
Improvements to MBL, general LCD menu handling

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5589,7 +5589,7 @@ inline void gcode_M428() {
     memcpy(current_position, new_pos, sizeof(new_pos));
     memcpy(home_offset, new_offs, sizeof(new_offs));
     sync_plan_position();
-    LCD_ALERTMESSAGEPGM("Offset applied.");
+    LCD_ALERTMESSAGEPGM(MSG_HOME_OFFSETS_APPLIED);
     #if HAS_BUZZER
       buzz(200, 659);
       buzz(200, 698);

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Amortar motors"
 #define MSG_AUTO_HOME                       "Levar a l'orichen"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Establir zero"

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Levar a l'orichen"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Establir zero"
 #define MSG_PREHEAT_PLA                     "Precalentar PLA"
 #define MSG_PREHEAT_PLA_N                   "Precalentar PLA "

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Изкл. двигатели"
 #define MSG_AUTO_HOME                       "Паркиране"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Задай Начало"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Изходна точка"

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Паркиране"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Задай Начало"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Изходна точка"
 #define MSG_PREHEAT_PLA                     "Подгряване PLA"
 #define MSG_PREHEAT_PLA_N                   "Подгряване PLA"

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -44,6 +44,8 @@
 #define MSG_DISABLE_STEPPERS                "Apagar motors"
 #define MSG_AUTO_HOME                       "Home global"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Establir origen"

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -45,6 +45,7 @@
 #define MSG_AUTO_HOME                       "Home global"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Establir origen"
 #define MSG_PREHEAT_PLA                     "Preescalfar PLA"
 #define MSG_PREHEAT_PLA_N                   "Preescalfar PLA "

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -42,6 +42,7 @@
 #define MSG_AUTO_HOME                       "\xbb\xbc\xbd"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "\xbe\xbf\xbb\xbc\xbd\xc0\xc1"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "\xbe\xbf\xbc\xbd"
 #define MSG_PREHEAT_PLA                     "\xc3\xc4 PLA"
 #define MSG_PREHEAT_PLA_N                   MSG_PREHEAT_PLA " "

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -41,6 +41,8 @@
 #define MSG_DISABLE_STEPPERS                "\xb5\xb6\xb7\xb8\xb9\xba"
 #define MSG_AUTO_HOME                       "\xbb\xbc\xbd"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "\xbe\xbf\xbb\xbc\xbd\xc0\xc1"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "\xbe\xbf\xbc\xbd"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -47,6 +47,8 @@
 #define MSG_DISABLE_STEPPERS                "Uvolnit motory"
 #define MSG_AUTO_HOME                       "Domovska pozice"
 #define MSG_LEVEL_BED_HOMING                "Mereni podlozky"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Nastavit ofsety"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Nastavit pocatek"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -48,6 +48,7 @@
 #define MSG_AUTO_HOME                       "Domovska pozice"
 #define MSG_LEVEL_BED_HOMING                "Mereni podlozky"
 #define MSG_SET_HOME_OFFSETS                "Nastavit ofsety"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Nastavit pocatek"
 #define MSG_PREHEAT_PLA                     "Zahrat PLA"
 #define MSG_PREHEAT_PLA_N                   MSG_PREHEAT_PLA " "

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -44,6 +44,8 @@
 #define MSG_COOLDOWN                        "Afkøl"
 #define MSG_DISABLE_STEPPERS                "Slå stepper fra"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Sæt home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Sæt origin"

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -45,6 +45,7 @@
 #define MSG_DISABLE_STEPPERS                "Slå stepper fra"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Sæt home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Sæt origin"
 #define MSG_SWITCH_PS_ON                    "Slå strøm til"
 #define MSG_SWITCH_PS_OFF                   "Slå strøm fra"

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Home" // G28
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Setze Home hier"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Setze Null hier" //"G92 X0 Y0 Z0" commented out in ultralcd.cpp
 #define MSG_PREHEAT_PLA                     "Vorwärmen PLA"
 #define MSG_PREHEAT_PLA_N                   "Vorwärmen PLA "

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Motoren Aus" // M84
 #define MSG_AUTO_HOME                       "Home" // G28
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Setze Home hier"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Setze Null hier" //"G92 X0 Y0 Z0" commented out in ultralcd.cpp

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -67,6 +67,9 @@
 #ifndef MSG_SET_HOME_OFFSETS
   #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #endif
+#ifndef MSG_HOME_OFFSETS_APPLIED
+  #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
+#endif
 #ifndef MSG_SET_ORIGIN
   #define MSG_SET_ORIGIN                      "Set origin"
 #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -64,6 +64,12 @@
 #ifndef MSG_LEVEL_BED_HOMING
   #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #endif
+#ifndef MSG_LEVEL_BED_WAITING
+  #define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#endif
+#ifndef MSG_LEVEL_BED_DONE
+  #define MSG_LEVEL_BED_DONE                  "Leveling Done!"
+#endif
 #ifndef MSG_SET_HOME_OFFSETS
   #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #endif

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Llevar al origen"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Ajustar offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Establecer cero"
 #define MSG_PREHEAT_PLA                     "Precalentar PLA"
 #define MSG_PREHEAT_PLA_N                   "Precalentar PLA "

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Apagar motores"
 #define MSG_AUTO_HOME                       "Llevar al origen"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Ajustar offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Establecer cero"

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Hasierara joan"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Hasiera ipini"
 #define MSG_PREHEAT_PLA                     "Aurreberotu PLA"
 #define MSG_PREHEAT_PLA_N                   "Aurreberotu PLA "

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Itzali motoreak"
 #define MSG_AUTO_HOME                       "Hasierara joan"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Hasiera ipini"

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Aja referenssiin"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Aseta origo"
 #define MSG_PREHEAT_PLA                     "Esilämmitä PLA"
 #define MSG_PREHEAT_PLA_N                   "Esilämmitä PLA "

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Vapauta moottorit"
 #define MSG_AUTO_HOME                       "Aja referenssiin"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Aseta origo"

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -44,6 +44,8 @@
 #define MSG_DISABLE_STEPPERS                "Arreter moteurs"
 #define MSG_AUTO_HOME                       "Home auto."
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Regler origine"

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -45,6 +45,7 @@
 #define MSG_AUTO_HOME                       "Home auto."
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Regler origine"
 #define MSG_PREHEAT_PLA                     "Prechauffage PLA"
 #define MSG_PREHEAT_PLA_N                   "Prechauff. PLA "

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Disabilita Motori"
 #define MSG_AUTO_HOME                       "Auto Home"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Setta offset home"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Imposta Origine"

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Auto Home"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Setta offset home"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Imposta Origine"
 #define MSG_PREHEAT_PLA                     "Preriscalda PLA"
 #define MSG_PREHEAT_PLA_N                   "Preriscalda PLA "

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -45,6 +45,8 @@
 #define MSG_DISABLE_STEPPERS                "\xd3\xb0\xc0\xb0\xc3\xde\xdd\xb9\xde\xdd\x20\xb5\xcc"         // "Disable steppers"
 #define MSG_AUTO_HOME                       "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Auto home"
 #define MSG_LEVEL_BED_HOMING                "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "\xb7\xbc\xde\xad\xdd\xb5\xcc\xbe\xaf\xc4\xbe\xaf\xc3\xb2"     // "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "\xb7\xbc\xde\xad\xdd\xbe\xaf\xc4"                             // "Set origin"

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -46,6 +46,7 @@
 #define MSG_AUTO_HOME                       "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Auto home"
 #define MSG_LEVEL_BED_HOMING                "\xb9\xde\xdd\xc3\xdd\xc6\xb2\xc4\xde\xb3"                     // "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "\xb7\xbc\xde\xad\xdd\xb5\xcc\xbe\xaf\xc4\xbe\xaf\xc3\xb2"     // "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "\xb7\xbc\xde\xad\xdd\xbe\xaf\xc4"                             // "Set origin"
 #define MSG_PREHEAT_PLA                     "PLA \xd6\xc8\xc2"                                             // "Preheat PLA"
 #define MSG_PREHEAT_PLA_N                   MSG_PREHEAT_PLA " "

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -49,6 +49,8 @@
 #define MSG_DISABLE_STEPPERS                "モーターデンゲン オフ"            // "Disable steppers"
 #define MSG_AUTO_HOME                       "ゲンテンニイドウ"                // "Auto home"
 #define MSG_LEVEL_BED_HOMING                "ゲンテンニイドウ"                // "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "キジュンオフセットセッテイ"         // "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "キジュンセット"                 // "Set origin"

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -50,6 +50,7 @@
 #define MSG_AUTO_HOME                       "ゲンテンニイドウ"                // "Auto home"
 #define MSG_LEVEL_BED_HOMING                "ゲンテンニイドウ"                // "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "キジュンオフセットセッテイ"         // "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "キジュンセット"                 // "Set origin"
 #define MSG_PREHEAT_PLA                     "PLA ヨネツ"                   // "Preheat PLA"
 #define MSG_PREHEAT_PLA_N                   MSG_PREHEAT_PLA " "

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Motoren uit"
 #define MSG_AUTO_HOME                       "Auto home"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Nulpunt instellen"

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Auto home"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Nulpunt instellen"
 #define MSG_PREHEAT_PLA                     "PLA voorverwarmen"
 #define MSG_PREHEAT_PLA_N                   "PLA voorverw. "

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Wylacz silniki"
 #define MSG_AUTO_HOME                       "Auto. poz. zerowa"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Ustaw punkt zero"

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Auto. poz. zerowa"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Set home offsets"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Ustaw punkt zero"
 #define MSG_PREHEAT_PLA                     "Rozgrzej PLA"
 #define MSG_PREHEAT_PLA_N                   "Rozgrzej PLA "

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Desabi. motores"
 #define MSG_AUTO_HOME                       "Ir para origen"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Ajustar Jogo"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Ajustar orig."

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Ir para origen"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Ajustar Jogo"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Ajustar orig."
 #define MSG_PREHEAT_PLA                     "Pre-aquecer PLA"
 #define MSG_PREHEAT_PLA_N                   "Pre-aquecer PLA"

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Ir para origen"
 #define MSG_LEVEL_BED_HOMING                "Indo para origem"
 #define MSG_SET_HOME_OFFSETS                "Ajustar Jogo"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Ajustar orig."
 #define MSG_PREHEAT_PLA                     "Pre-aquecer PLA"
 #define MSG_PREHEAT_PLA_N                   "Pre-aquecer PLA"

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Desabi. motores"
 #define MSG_AUTO_HOME                       "Ir para origen"
 #define MSG_LEVEL_BED_HOMING                "Indo para origem"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Ajustar Jogo"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Ajustar orig."

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Ir para origem"
 #define MSG_LEVEL_BED_HOMING                "Indo para origem"
 #define MSG_SET_HOME_OFFSETS                "Definir desvio"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Definir origem"
 #define MSG_PREHEAT_PLA                     "Pre-aquecer PLA"
 #define MSG_PREHEAT_PLA_N                   "Pre-aquecer PLA"

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Desactivar motores"
 #define MSG_AUTO_HOME                       "Ir para origem"
 #define MSG_LEVEL_BED_HOMING                "Indo para origem"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Definir desvio"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Definir origem"

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Ir para origem"
 #define MSG_LEVEL_BED_HOMING                "Indo para origem"
 #define MSG_SET_HOME_OFFSETS                "Definir desvio"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Definir origem"
 #define MSG_PREHEAT_PLA                     "Pre-aquecer PLA"
 #define MSG_PREHEAT_PLA_N                   "Pre-aquecer PLA"

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Desactivar motores"
 #define MSG_AUTO_HOME                       "Ir para origem"
 #define MSG_LEVEL_BED_HOMING                "Indo para origem"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Definir desvio"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Definir origem"

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -43,6 +43,8 @@
 #define MSG_DISABLE_STEPPERS                "Выкл. двигатели"
 #define MSG_AUTO_HOME                       "Парковка"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
+#define MSG_LEVEL_BED_WAITING               "Click to Begin"
+#define MSG_LEVEL_BED_DONE                  "Leveling Done!"
 #define MSG_SET_HOME_OFFSETS                "Запомнить парковку"
 #define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Запомнить ноль"

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -44,6 +44,7 @@
 #define MSG_AUTO_HOME                       "Парковка"
 #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #define MSG_SET_HOME_OFFSETS                "Запомнить парковку"
+#define MSG_HOME_OFFSETS_APPLIED            "Offsets applied"
 #define MSG_SET_ORIGIN                      "Запомнить ноль"
 #define MSG_PREHEAT_PLA                     "Преднагрев PLA"
 #define MSG_PREHEAT_PLA_N                   "Греть PLA Сопло "

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2223,13 +2223,13 @@ char *ftostr32(const float& x) {
   return conv;
 }
 
-// Convert signed float to string (len 5 or 6) with 1.234 / -1.234 format
-char* ftostr43(const float& x) {
+// Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
+char* ftostr43(const float& x, char plus/*=' '*/) {
   long xx = x * 1000;
-  char *conv_ptr = conv;
-  if (xx >= 0) {
-    conv_ptr++;
-  }
+  if (xx == 0)
+    conv[0] = ' ';
+  else if (xx > 0)
+    conv[0] = plus;
   else {
     xx = -xx;
     conv[0] = '-';
@@ -2240,7 +2240,7 @@ char* ftostr43(const float& x) {
   conv[4] = (xx / 10) % 10 + '0';
   conv[5] = (xx) % 10 + '0';
   conv[6] = 0;
-  return conv_ptr;
+  return conv;
 }
 
 // Convert unsigned float to string with 1.23 format
@@ -2453,7 +2453,7 @@ char* ftostr52(const float& x) {
     }
     if (lcdDrawUpdate) {
       float v = current_position[Z_AXIS] - MESH_HOME_SEARCH_Z;
-      lcd_implementation_drawedit(PSTR(MSG_MOVE_Z), ftostr43(v + (v < 0 ? -0.0001 : 0.0001)));
+      lcd_implementation_drawedit(PSTR(MSG_MOVE_Z), ftostr43(v + (v < 0 ? -0.0001 : 0.0001), '+'));
     }
     static bool debounce_click = false;
     if (LCD_CLICKED) {

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2482,7 +2482,7 @@ char* ftostr52(const float& x) {
    *   - Movement adjusts the Z axis
    *   - Click saves the Z and goes to the next mesh point
    */
-  static void _lcd_level_bed() {
+  static void _lcd_level_bed_procedure() {
     static bool mbl_wait_for_move = false;
     // Menu handlers may be called in a re-entrant fashion
     // if they call st_synchronize or plan_buffer_line. So
@@ -2570,7 +2570,7 @@ char* ftostr52(const float& x) {
       current_position[Y_AXIS] = MESH_MIN_Y;
       line_to_current(manual_feedrate[X_AXIS] <= manual_feedrate[Y_AXIS] ? X_AXIS : Y_AXIS);
       _lcd_level_bed_position = 0;
-      lcd_goto_menu(_lcd_level_bed, true);
+      lcd_goto_menu(_lcd_level_bed_procedure, true);
     }
   }
 
@@ -2587,7 +2587,7 @@ char* ftostr52(const float& x) {
   /**
    * MBL Continue Bed Leveling...
    */
-  static void lcd_level_bed_continue() {
+  static void _lcd_level_bed_continue() {
     defer_return_to_status = true;
     axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
     mbl.reset();
@@ -2601,7 +2601,7 @@ char* ftostr52(const float& x) {
   static void lcd_level_bed() {
     START_MENU();
     MENU_ITEM(back, "Cancel", lcd_prepare_menu);
-    MENU_ITEM(submenu, MSG_LEVEL_BED, lcd_level_bed_continue);
+    MENU_ITEM(submenu, MSG_LEVEL_BED, _lcd_level_bed_continue);
     END_MENU();
   }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2471,6 +2471,14 @@ char* ftostr52(const float& x) {
           mbl.active = 1;
           enqueue_and_echo_commands_P(PSTR("G28"));
           lcd_return_to_status();
+          #if ENABLED(NEWPANEL)
+            lcd_quick_feedback();
+          #endif
+          LCD_ALERTMESSAGEPGM("Leveling Done!");
+          #if HAS_BUZZER
+            buzz(200, 659);
+            buzz(200, 698);
+          #endif
         }
         else {
           current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
@@ -2503,7 +2511,7 @@ char* ftostr52(const float& x) {
       current_position[Y_AXIS] = MESH_MIN_Y;
       line_to_current(manual_feedrate[X_AXIS] <= manual_feedrate[Y_AXIS] ? X_AXIS : Y_AXIS);
       _lcd_level_bed_position = 0;
-      lcd_goto_menu(_lcd_level_bed);
+      lcd_goto_menu(_lcd_level_bed, true);
     }
   }
 
@@ -2515,7 +2523,7 @@ char* ftostr52(const float& x) {
     axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
     mbl.reset();
     enqueue_and_echo_commands_P(PSTR("G28"));
-    lcd_goto_menu(_lcd_level_bed_homing);
+    lcd_goto_menu(_lcd_level_bed_homing, true);
   }
 
 #endif  // MANUAL_BED_LEVELING

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2516,7 +2516,7 @@ char* ftostr52(const float& x) {
           #if ENABLED(NEWPANEL)
             lcd_quick_feedback();
           #endif
-          LCD_ALERTMESSAGEPGM("Leveling Done!");
+          LCD_ALERTMESSAGEPGM(MSG_LEVEL_BED_DONE);
           #if HAS_BUZZER
             buzz(200, 659);
             buzz(200, 698);
@@ -2541,7 +2541,7 @@ char* ftostr52(const float& x) {
   }
 
   static void _lcd_level_bed_homing_done() {
-    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Click to Begin"), NULL);
+    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_WAITING), NULL);
     lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
     if (LCD_CLICKED) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -252,7 +252,7 @@ static void lcd_status_screen();
   #endif //!ENCODER_RATE_MULTIPLIER
   #define END_MENU() \
       if (encoderLine >= _menuItemNr) { encoderPosition = _menuItemNr * (ENCODER_STEPS_PER_MENU_ITEM) - 1; encoderLine = _menuItemNr - 1; }\
-      if (encoderLine >= currentMenuViewOffset + LCD_HEIGHT) { currentMenuViewOffset = encoderLine - (LCD_HEIGHT) + 1; lcdDrawUpdate = 1; _lineNr = currentMenuViewOffset - 1; _drawLineNr = -1; } \
+      if (encoderLine >= currentMenuViewOffset + LCD_HEIGHT) { currentMenuViewOffset = encoderLine - (LCD_HEIGHT) + 1; lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW; _lineNr = currentMenuViewOffset - 1; _drawLineNr = -1; } \
       } } while(0)
 
   /** Used variables to keep track of the menu */
@@ -280,7 +280,15 @@ uint8_t lcd_status_update_delay;
 bool ignore_click = false;
 bool wait_for_unclick;
 bool defer_return_to_status = false;
-uint8_t lcdDrawUpdate = 2;                  /* Set to none-zero when the LCD needs to draw, decreased after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial) */
+
+enum LCDHandlerAction {
+  LCD_DRAW_UPDATE_NONE,
+  LCD_DRAW_UPDATE_CALL_REDRAW,
+  LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW,
+  LCD_DRAW_UPDATE_CALL_NO_REDRAW,
+};
+
+uint8_t lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW; // Set 1 or 2 when the LCD needs to draw, decrements after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
 
 // Variables used when editing values.
 const char* editLabel;
@@ -298,7 +306,7 @@ float raw_Ki, raw_Kd;
 static void lcd_goto_menu(menuFunc_t menu, const bool feedback = false, const uint32_t encoder = 0) {
   if (currentMenu != menu) {
     currentMenu = menu;
-    lcdDrawUpdate = 2;
+    lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
     #if ENABLED(NEWPANEL)
       encoderPosition = encoder;
       if (feedback) lcd_quick_feedback();
@@ -524,7 +532,7 @@ void lcd_set_home_offsets() {
     if (encoderPosition != 0) {
       int distance =  (int)encoderPosition * BABYSTEP_MULTIPLICATOR;
       encoderPosition = 0;
-      lcdDrawUpdate = 1;
+      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
       #if ENABLED(COREXY) || ENABLED(COREXZ)
         #if ENABLED(BABYSTEP_XY)
           switch(axis) {
@@ -948,7 +956,7 @@ static void _lcd_move(const char* name, AxisEnum axis, int min, int max) {
     if (max_software_endstops) NOMORE(current_position[axis], max);
     encoderPosition = 0;
     line_to_current(axis);
-    lcdDrawUpdate = 1;
+    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
   }
   if (lcdDrawUpdate) lcd_implementation_drawedit(name, ftostr31(current_position[axis]));
   if (LCD_CLICKED) lcd_goto_previous_menu();
@@ -977,7 +985,7 @@ static void lcd_move_e(
     current_position[E_AXIS] += float((int)encoderPosition) * move_menu_scale;
     encoderPosition = 0;
     line_to_current(E_AXIS);
-    lcdDrawUpdate = 1;
+    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
   }
   if (lcdDrawUpdate) {
     PGM_P pos_label;
@@ -1449,7 +1457,7 @@ static void lcd_control_volumetric_menu() {
         lcd_contrast &= 0x3F;
       #endif
       encoderPosition = 0;
-      lcdDrawUpdate = 1;
+      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
       u8g.setContrast(lcd_contrast);
     }
     if (lcdDrawUpdate) {
@@ -1590,7 +1598,7 @@ static void lcd_control_volumetric_menu() {
   static void _menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
     lcd_save_previous_menu(); \
     \
-    lcdDrawUpdate = 2; \
+    lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW; \
     currentMenu = menu_edit_ ## _name; \
     \
     editLabel = pstr; \
@@ -1672,7 +1680,7 @@ menu_edit_type(unsigned long, long5, ftostr5, 0.01)
 #endif
 
 void lcd_quick_feedback() {
-  lcdDrawUpdate = 2;
+  lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
   next_button_update_ms = millis() + 500;
 
   #if ENABLED(LCD_USE_I2C_BUZZER)
@@ -1837,11 +1845,27 @@ bool lcd_blink() {
  *   - Act on RepRap World keypad input
  *   - Update the encoder position
  *   - Apply acceleration to the encoder position
+ *   - Set lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW on controller events
  *   - Reset the Info Screen timeout if there's any input
  *   - Update status indicators, if any
- *   - Clear the LCD if lcdDrawUpdate == 2
  *
- * Warning: This function is called from interrupt context!
+ *   Run the current LCD menu handler callback function:
+ *   - Call the handler only if lcdDrawUpdate != LCD_DRAW_UPDATE_NONE
+ *   - Before calling the handler, LCD_DRAW_UPDATE_CALL_NO_REDRAW => LCD_DRAW_UPDATE_NONE
+ *   - Call the menu handler. Menu handlers should do the following:
+ *     - If a value changes, set lcdDrawUpdate to LCD_DRAW_UPDATE_CALL_REDRAW
+ *     - if (lcdDrawUpdate) { redraw }
+ *     - Before exiting the handler set lcdDrawUpdate to:
+ *       - LCD_DRAW_UPDATE_CALL_REDRAW or LCD_DRAW_UPDATE_NONE for no callbacks until the next controller event.
+ *       - LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW to clear screen, LCD_DRAW_UPDATE_CALL_REDRAW on the next loop.
+ *       - LCD_DRAW_UPDATE_CALL_NO_REDRAW for a callback with no forced redraw on the next loop.
+ *     - NOTE: For some displays, the menu handler may be called 2 or more times per loop.
+ *
+ *   After the menu handler callback runs (or not):
+ *   - Clear the LCD if lcdDrawUpdate == LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW
+ *   - Update lcdDrawUpdate for the next loop (i.e., move one state down, usually)
+ *
+ * No worries. This function is only called from the main thread.
  */
 void lcd_update() {
   #if ENABLED(ULTIPANEL)
@@ -1854,7 +1878,7 @@ void lcd_update() {
 
     bool sd_status = IS_SD_INSERTED;
     if (sd_status != lcd_sd_status && lcd_detected()) {
-      lcdDrawUpdate = 2;
+      lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
         #if ENABLED(LCD_PROGRESS_BAR)
           currentMenu == lcd_status_screen
@@ -1933,13 +1957,13 @@ void lcd_update() {
           encoderDiff = 0;
         }
         return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;
-        lcdDrawUpdate = 1;
+        lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
       }
     #endif //ULTIPANEL
 
     if (currentMenu == lcd_status_screen) {
       if (!lcd_status_update_delay) {
-        lcdDrawUpdate = 1;
+        lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
         lcd_status_update_delay = 10;   /* redraw the main screen every second. This is easier then trying keep track of all things that change on the screen */
       }
       else {
@@ -1948,6 +1972,9 @@ void lcd_update() {
     }
 
     if (lcdDrawUpdate) {
+
+      if (lcdDrawUpdate == LCD_DRAW_UPDATE_CALL_NO_REDRAW) lcdDrawUpdate = LCD_DRAW_UPDATE_NONE;
+
       #if ENABLED(DOGLCD)  // Changes due to different driver architecture of the DOGM display
         bool blink = lcd_blink();
         u8g.firstPage();
@@ -1971,14 +1998,29 @@ void lcd_update() {
     #if ENABLED(ULTIPANEL)
 
       // Return to Status Screen after a timeout
-      if (!defer_return_to_status && currentMenu != lcd_status_screen && millis() > return_to_status_ms) {
+      if (defer_return_to_status)
+        return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;
+      else if (currentMenu != lcd_status_screen && millis() > return_to_status_ms) {
         lcd_return_to_status();
-        lcdDrawUpdate = 2;
       }
 
     #endif // ULTIPANEL
 
-    if (lcdDrawUpdate && --lcdDrawUpdate) lcd_implementation_clear();
+    switch (lcdDrawUpdate) {
+      case LCD_DRAW_UPDATE_NONE:
+        // do nothing
+      case LCD_DRAW_UPDATE_CALL_NO_REDRAW:
+        // changes to LCD_DRAW_UPDATE_NONE before call
+        break;
+      case LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW:
+        lcd_implementation_clear();
+        lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+        break;
+      case LCD_DRAW_UPDATE_CALL_REDRAW:
+        lcdDrawUpdate = LCD_DRAW_UPDATE_NONE;
+        break;
+    }
+
     next_lcd_update_ms = ms + LCD_UPDATE_INTERVAL;
   }
 }
@@ -1995,7 +2037,7 @@ void lcd_finishstatus(bool persist=false) {
       expire_status_ms = persist ? 0 : progress_bar_ms + PROGRESS_MSG_EXPIRE;
     #endif
   #endif
-  lcdDrawUpdate = 2;
+  lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
 
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     previous_lcd_status_ms = millis();  //get status message to show up for a while
@@ -2449,7 +2491,7 @@ char* ftostr52(const float& x) {
       if (max_software_endstops) NOMORE(current_position[Z_AXIS], Z_MAX_POS);
       encoderPosition = 0;
       line_to_current(Z_AXIS);
-      lcdDrawUpdate = 1;
+      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
     }
     if (lcdDrawUpdate) {
       float v = current_position[Z_AXIS] - MESH_HOME_SEARCH_Z;
@@ -2458,7 +2500,7 @@ char* ftostr52(const float& x) {
     static bool debounce_click = false;
     if (LCD_CLICKED) {
       if (!debounce_click) {
-        debounce_click = true;
+        debounce_click = true; // ignore multiple "clicks" in a row
         int ix = _lcd_level_bed_position % (MESH_NUM_X_POINTS),
             iy = _lcd_level_bed_position / (MESH_NUM_X_POINTS);
         if (iy & 1) ix = (MESH_NUM_X_POINTS - 1) - ix; // Zig zag
@@ -2489,7 +2531,7 @@ char* ftostr52(const float& x) {
           current_position[X_AXIS] = mbl.get_x(ix);
           current_position[Y_AXIS] = mbl.get_y(iy);
           line_to_current(manual_feedrate[X_AXIS] <= manual_feedrate[Y_AXIS] ? X_AXIS : Y_AXIS);
-          lcdDrawUpdate = 1;
+          lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
         }
       }
     }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2540,13 +2540,10 @@ char* ftostr52(const float& x) {
     }
   }
 
-  /**
-   * MBL Move to mesh starting point
-   */
-  static void _lcd_level_bed_homing() {
-    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_HOMING), NULL);
-    lcdDrawUpdate = 1;
-    if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) {
+  static void _lcd_level_bed_homing_done() {
+    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR("Click to Begin"), NULL);
+    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+    if (LCD_CLICKED) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
       current_position[X_AXIS] = MESH_MIN_X;
@@ -2558,14 +2555,34 @@ char* ftostr52(const float& x) {
   }
 
   /**
-   * MBL entry-point
+   * MBL Move to mesh starting point
    */
-  static void lcd_level_bed() {
+  static void _lcd_level_bed_homing() {
+    if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_HOMING), NULL);
+    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+    if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS])
+      lcd_goto_menu(_lcd_level_bed_homing_done);
+  }
+
+  /**
+   * MBL Continue Bed Leveling...
+   */
+  static void lcd_level_bed_continue() {
     defer_return_to_status = true;
     axis_known_position[X_AXIS] = axis_known_position[Y_AXIS] = axis_known_position[Z_AXIS] = false;
     mbl.reset();
     enqueue_and_echo_commands_P(PSTR("G28"));
     lcd_goto_menu(_lcd_level_bed_homing, true);
+  }
+
+  /**
+   * MBL entry-point
+   */
+  static void lcd_level_bed() {
+    START_MENU();
+    MENU_ITEM(back, "Cancel", lcd_prepare_menu);
+    MENU_ITEM(submenu, MSG_LEVEL_BED, lcd_level_bed_continue);
+    END_MENU();
   }
 
 #endif  // MANUAL_BED_LEVELING

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -156,7 +156,7 @@ char* ftostr4sign(const float& x);
 char* ftostr31ns(const float& x); // float to string without sign character
 char* ftostr31(const float& x);
 char* ftostr32(const float& x);
-char* ftostr43(const float& x);
+char* ftostr43(const float& x, char plus=' ');
 char* ftostr12ns(const float& x);
 char* ftostr32sp(const float& x); // remove zero-padding from ftostr32
 char* ftostr5(const float& x);


### PR DESCRIPTION
This PR fixes up Manual Bed Leveling to give it a better workflow, patching up code in `ultralcd.cpp` so that MBL can do its magic without abusing the menu manager.

Currently (in 1.1.0-RC5) the Manual Bed Leveling menus are a little off as a result of trying to eliminate the bad flickering. Sorry about that! The current "menu manager" system has some constraints, so the "menu manager" needed a minor rework to get the desired behavior.

Background: In Marlin the menu manager is responsible for deciding when the active "menu handler" function is called. Menu handler functions both draw and handle input. The LCD menu manager tries to be smart, only calling the handler when it needs to handle input and therefore redraw. There's no _supported_ way to have the menu manager call the handler continuously, so handlers can't be used to wait for some state or time to pass.

MBL worked around this limitation by setting `lcdDrawUpdate = 2`. This causes the "menu manager" to Clear the Screen and decrement `lcdDrawUpdate`, so the next time in the loop the "menu handler" function will be called again. If a handler sets `lcdDrawUpdate` to `1` it has no effect, because `lcdDrawUpdate` is decremented immediately after the handler. (I'm talking to you, `END_MENU`.) So developers were stuck – either clear the screen or get no extra callback.

This PR adds a mechanism so menu handlers can get a callback without being forced to clear the screen. In the process, it applies `enum` names to the values given to `lcdDrawUpdate` so we don't have too many "mystery numbers" in the code.
