### PR TITLE
Split DEFAULT_MACHINE_NAME from DEFAULT_SOURCE_URL

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -71,38 +71,18 @@
 
 #define PROTOCOL_VERSION "1.0"
 
-#if MB(ULTIMAKER)|| MB(ULTIMAKER_OLD)|| MB(ULTIMAIN_2)
-  #define DEFAULT_MACHINE_NAME "Ultimaker"
-#elif MB(RUMBA)
-  #define DEFAULT_MACHINE_NAME "Rumba"
-#elif MB(3DRAG)
-  #define DEFAULT_MACHINE_NAME "3Drag"
-#elif MB(K8200)
-  #define DEFAULT_MACHINE_NAME "K8200"
-#elif MB(5DPRINT)
-  #define DEFAULT_MACHINE_NAME "Makibox"
-#elif MB(SAV_MKI)
-  #define DEFAULT_MACHINE_NAME "SAV MkI"
-#else
+#ifndef DEFAULT_MACHINE_NAME
   #define DEFAULT_MACHINE_NAME "3D Printer"
-#endif
-
-#if MB(ULTIMAKER)|| MB(ULTIMAKER_OLD)|| MB(ULTIMAIN_2)
-  #define DEFAULT_SOURCE_URL "https://github.com/Ultimaker/Marlin"
-#elif MB(3DRAG)
-  #define DEFAULT_SOURCE_URL "http://3dprint.elettronicain.it/"
-#elif MB(K8200)
-  #define DEFAULT_SOURCE_URL "https://github.com/CONSULitAS/Marlin-K8200"
-#elif MB(SAV_MKI)
-  #define DEFAULT_SOURCE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
-#else
-  #define DEFAULT_SOURCE_URL "https://github.com/MarlinFirmware/Marlin"
 #endif
 
 #ifdef CUSTOM_MACHINE_NAME
   #define MACHINE_NAME CUSTOM_MACHINE_NAME
 #else
   #define MACHINE_NAME DEFAULT_MACHINE_NAME
+#endif
+
+#ifndef DEFAULT_SOURCE_URL
+  #define DEFAULT_SOURCE_URL "https://github.com/MarlinFirmware/Marlin"
 #endif
 
 #ifndef SOURCE_CODE_URL

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -73,22 +73,29 @@
 
 #if MB(ULTIMAKER)|| MB(ULTIMAKER_OLD)|| MB(ULTIMAIN_2)
   #define DEFAULT_MACHINE_NAME "Ultimaker"
-  #define DEFAULT_SOURCE_URL "https://github.com/Ultimaker/Marlin"
 #elif MB(RUMBA)
   #define DEFAULT_MACHINE_NAME "Rumba"
 #elif MB(3DRAG)
   #define DEFAULT_MACHINE_NAME "3Drag"
-  #define DEFAULT_SOURCE_URL "http://3dprint.elettronicain.it/"
 #elif MB(K8200)
   #define DEFAULT_MACHINE_NAME "K8200"
-  #define DEFAULT_SOURCE_URL "https://github.com/CONSULitAS/Marlin-K8200"
 #elif MB(5DPRINT)
   #define DEFAULT_MACHINE_NAME "Makibox"
 #elif MB(SAV_MKI)
   #define DEFAULT_MACHINE_NAME "SAV MkI"
-  #define DEFAULT_SOURCE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
 #else
   #define DEFAULT_MACHINE_NAME "3D Printer"
+#endif
+
+#if MB(ULTIMAKER)|| MB(ULTIMAKER_OLD)|| MB(ULTIMAIN_2)
+  #define DEFAULT_SOURCE_URL "https://github.com/Ultimaker/Marlin"
+#elif MB(3DRAG)
+  #define DEFAULT_SOURCE_URL "http://3dprint.elettronicain.it/"
+#elif MB(K8200)
+  #define DEFAULT_SOURCE_URL "https://github.com/CONSULitAS/Marlin-K8200"
+#elif MB(SAV_MKI)
+  #define DEFAULT_SOURCE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
+#else
   #define DEFAULT_SOURCE_URL "https://github.com/MarlinFirmware/Marlin"
 #endif
 

--- a/Marlin/pins_3DRAG.h
+++ b/Marlin/pins_3DRAG.h
@@ -26,6 +26,9 @@
 
 #include "pins_RAMPS_14.h"
 
+#define DEFAULT_MACHINE_NAME "3Drag"
+#define DEFAULT_SOURCE_URL   "http://3dprint.elettronicain.it/"
+
 #undef Z_ENABLE_PIN
 #define Z_ENABLE_PIN       63
 

--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -30,6 +30,8 @@
   #error Oops!  Make sure you have 'Teensy++ 2.0' selected from the 'Tools -> Boards' menu.
 #endif
 
+#define DEFAULT_MACHINE_NAME "Makibox"
+
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN          0

--- a/Marlin/pins_K8200.h
+++ b/Marlin/pins_K8200.h
@@ -26,3 +26,9 @@
  */
 
 #include "pins_3DRAG.h"
+
+#undef DEFAULT_MACHINE_NAME
+#define DEFAULT_MACHINE_NAME "K8200"
+
+#undef DEFAULT_SOURCE_URL
+#define DEFAULT_SOURCE_URL   "https://github.com/CONSULitAS/Marlin-K8200"

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -32,6 +32,8 @@
   #error RUMBA supports up to 3 extruders. Comment this line to keep going.
 #endif
 
+#define DEFAULT_MACHINE_NAME "Rumba"
+
 #define X_STEP_PIN         17
 #define X_DIR_PIN          16
 #define X_ENABLE_PIN       48

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -31,6 +31,9 @@
   #error Oops!  Make sure you have 'Teensy++ 2.0' selected from the 'Tools -> Boards' menu.
 #endif
 
+#define DEFAULT_MACHINE_NAME "SAV MkI"
+#define DEFAULT_SOURCE_URL   "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
+
 #define LARGE_FLASH        true
 
 #define X_STEP_PIN         0

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -28,6 +28,9 @@
   #error Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu.
 #endif
 
+#define DEFAULT_MACHINE_NAME "Ultimaker"
+#define DEFAULT_SOURCE_URL   "https://github.com/Ultimaker/Marlin"
+
 #define X_STEP_PIN 25
 #define X_DIR_PIN 23
 #define X_STOP_PIN 22

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -28,6 +28,9 @@
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
 #endif
 
+#define DEFAULT_MACHINE_NAME "Ultimaker"
+#define DEFAULT_SOURCE_URL   "https://github.com/Ultimaker/Marlin"
+
 #define LARGE_FLASH true
 
 #define SERVO0_PIN 13 // untested

--- a/Marlin/pins_ULTIMAKER_OLD.h
+++ b/Marlin/pins_ULTIMAKER_OLD.h
@@ -28,6 +28,9 @@
   #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
 #endif
 
+#define DEFAULT_MACHINE_NAME "Ultimaker"
+#define DEFAULT_SOURCE_URL   "https://github.com/Ultimaker/Marlin"
+
 #define LARGE_FLASH true
 
 #define X_STEP_PIN 25


### PR DESCRIPTION
Addressing #3325 – Avoid undefined symbol errors in the compiler.
