### PR TITLE
Fix M111 output using pgm_read_word, as required

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4373,7 +4373,7 @@ inline void gcode_M111() {
     for (uint8_t i = 0; i < COUNT(debug_strings); i++) {
       if (TEST(marlin_debug_flags, i)) {
         if (comma++) SERIAL_CHAR('|');
-        serialprintPGM(debug_strings[i]);
+        serialprintPGM((char*)pgm_read_word(&(debug_strings[i])));
       }
     }
   }


### PR DESCRIPTION
As noted by @taratata2016 in https://github.com/MarlinFirmware/Marlin/issues/3300#issuecomment-204687275
