### PR TITLE
Fix: menu edit items saving position twice

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1778,8 +1778,6 @@ static void lcd_control_volumetric_menu() {
   void menu_edit_ ## _name () { _menu_edit_ ## _name(); } \
   void menu_edit_callback_ ## _name () { if (_menu_edit_ ## _name ()) (*callbackFunc)(); } \
   static void _menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
-    lcd_save_previous_menu(); \
-    \
     lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW; \
     currentMenu = menu_edit_ ## _name; \
     \


### PR DESCRIPTION
The menu system got some updates recently to make it easier to go back to the previous position. As a result, menu **edit items** no longer need to save the previous menu position, but this change was not included in the recent patch. This PR removes the extra `lcd_save_previous_menu` to fix the issue.

This should fix #3382 and maybe #3375.
