### PR TITLE
Catch a TEMP_SENSOR error before a pins issue

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -368,27 +368,29 @@
  * Test Heater, Temp Sensor, and Extruder Pins; Sensor Type must also be set.
  */
 #if EXTRUDERS > 3
-  #if !HAS_HEATER_3
+  #if TEMP_SENSOR_3 == 0
+    #error TEMP_SENSOR_3 is required with 4 EXTRUDERS.
+  #elif !HAS_HEATER_3
     #error HEATER_3_PIN not defined for this board.
   #elif !PIN_EXISTS(TEMP_3)
     #error TEMP_3_PIN not defined for this board.
   #elif !PIN_EXISTS(E3_STEP) || !PIN_EXISTS(E3_DIR) || !PIN_EXISTS(E3_ENABLE)
     #error E3_STEP_PIN, E3_DIR_PIN, or E3_ENABLE_PIN not defined for this board.
-  #elif TEMP_SENSOR_3 == 0
-    #error TEMP_SENSOR_3 is required with 4 EXTRUDERS.
   #endif
 #elif EXTRUDERS > 2
-  #if !HAS_HEATER_2
+  #if TEMP_SENSOR_2 == 0
+    #error TEMP_SENSOR_2 is required with 3 or more EXTRUDERS.
+  #elif !HAS_HEATER_2
     #error HEATER_2_PIN not defined for this board.
   #elif !PIN_EXISTS(TEMP_2)
     #error TEMP_2_PIN not defined for this board.
   #elif !PIN_EXISTS(E2_STEP) || !PIN_EXISTS(E2_DIR) || !PIN_EXISTS(E2_ENABLE)
     #error E2_STEP_PIN, E2_DIR_PIN, or E2_ENABLE_PIN not defined for this board.
-  #elif TEMP_SENSOR_2 == 0
-    #error TEMP_SENSOR_2 is required with 3 or more EXTRUDERS.
   #endif
 #elif EXTRUDERS > 1
-  #if !PIN_EXISTS(TEMP_1)
+  #if TEMP_SENSOR_1 == 0
+    #error TEMP_SENSOR_1 is required with 2 or more EXTRUDERS.
+  #elif !PIN_EXISTS(TEMP_1)
     #error TEMP_1_PIN not defined for this board.
   #elif !PIN_EXISTS(E1_STEP) || !PIN_EXISTS(E1_DIR) || !PIN_EXISTS(E1_ENABLE)
     #error E1_STEP_PIN, E1_DIR_PIN, or E1_ENABLE_PIN not defined for this board.
@@ -401,12 +403,8 @@
   #endif
 #endif
 
-#if TEMP_SENSOR_1 == 0
-  #if EXTRUDERS > 1
-    #error TEMP_SENSOR_1 is required with 2 or more EXTRUDERS.
-  #elif ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-    #error TEMP_SENSOR_1 is required with TEMP_SENSOR_1_AS_REDUNDANT.
-  #endif
+#if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT) && TEMP_SENSOR_1 == 0
+  #error TEMP_SENSOR_1 is required with TEMP_SENSOR_1_AS_REDUNDANT.
 #endif
 
 #if !HAS_HEATER_0


### PR DESCRIPTION
Addressing #2599…

We should warn users about failing to set a temp sensor before checking other issues with multiple extruders, since this is a common mistake. This will prevent incorrect errors like "heater pin not defined for this board" which is caused by **improper conditional pin definition** in the board pin files.

In the long run we should fix up the pins files, because they should not use `#if ENABLED(...)` to decide whether or not to define pins. They should simply define the pins. The code should decide whether or not to enable features based on configuration, not based on the mere existence of pins. (PWM fans are a minor exception.)
