### PR TITLE
Print job timer rework

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -65,6 +65,8 @@ typedef unsigned long millis_t;
 
 #include "WString.h"
 
+#include "stopwatch.h"
+
 #ifdef USBCON
   #if ENABLED(BLUETOOTH)
     #define MYSERIAL bluetoothSerial
@@ -357,8 +359,8 @@ extern bool axis_homed[3]; // axis[n].is_homed
   extern float retract_recover_length, retract_recover_length_swap, retract_recover_feedrate;
 #endif
 
-extern millis_t print_job_start_ms;
-extern millis_t print_job_stop_ms;
+// Print job timer
+extern stopwatch print_job_timer;
 
 // Handling multiple extruders pins
 extern uint8_t active_extruder;
@@ -373,10 +375,5 @@ extern uint8_t active_extruder;
 #endif
 
 extern void calculate_volumetric_multipliers();
-
-// Print job timer related functions
-millis_t print_job_timer();
-bool print_job_start(millis_t t = 0);
-bool print_job_stop(bool force = false);
 
 #endif //MARLIN_H

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -360,7 +360,7 @@ extern bool axis_homed[3]; // axis[n].is_homed
 #endif
 
 // Print job timer
-extern stopwatch print_job_timer;
+extern Stopwatch print_job_timer;
 
 // Handling multiple extruders pins
 extern uint8_t active_extruder;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3715,7 +3715,7 @@ inline void gcode_M31() {
       card.startFileprint();
 
       // Procedure calls count as normal print time.
-      if (!call_procedure) print_job_start();
+      if (!call_procedure) print_job_timer.start();
     }
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4083,6 +4083,27 @@ inline void gcode_M42() {
 #endif // AUTO_BED_LEVELING_FEATURE && Z_MIN_PROBE_REPEATABILITY_TEST
 
 /**
+ * M75: Start print timer
+ */
+inline void gcode_M75() {
+  print_job_timer.start();
+}
+
+/**
+ * M76: Pause print timer
+ */
+inline void gcode_M76() {
+  print_job_timer.pause();
+}
+
+/**
+ * M77: Stop print timer
+ */
+inline void gcode_M77() {
+  print_job_timer.stop();
+}
+
+/**
  * M104: Set hot end temperature
  */
 inline void gcode_M104() {
@@ -6296,6 +6317,18 @@ void process_next_command() {
           gcode_M48();
           break;
       #endif // AUTO_BED_LEVELING_FEATURE && Z_MIN_PROBE_REPEATABILITY_TEST
+
+      case 75: // Start print timer
+        gcode_M75();
+        break;
+
+      case 76: // Pause print timer
+        gcode_M76();
+        break;
+
+      case 77: // Stop print timer
+        gcode_M77();
+        break;
 
       #if ENABLED(M100_FREE_MEMORY_WATCHER)
         case 100:

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -298,8 +298,7 @@ const int sensitive_pins[] = SENSITIVE_PINS; ///< Sensitive pin list for M42
 millis_t previous_cmd_ms = 0;
 static millis_t max_inactive_time = 0;
 static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000L;
-millis_t print_job_start_ms = 0; ///< Print job start time
-millis_t print_job_stop_ms = 0;  ///< Print job stop time
+stopwatch print_job_timer = stopwatch();
 static uint8_t target_extruder;
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)
@@ -1012,9 +1011,9 @@ inline void get_serial_commands() {
       ) {
         if (card_eof) {
           SERIAL_PROTOCOLLNPGM(MSG_FILE_PRINTED);
-          print_job_stop(true);
+          print_job_timer.stop();
           char time[30];
-          millis_t t = print_job_timer();
+          millis_t t = print_job_timer.duration();
           int hours = t / 60 / 60, minutes = (t / 60) % 60;
           sprintf_P(time, PSTR("%i " MSG_END_HOUR " %i " MSG_END_MINUTE), hours, minutes);
           SERIAL_ECHO_START;
@@ -3624,7 +3623,7 @@ inline void gcode_M17() {
    */
   inline void gcode_M24() {
     card.startFileprint();
-    print_job_start();
+    print_job_timer.start();
   }
 
   /**
@@ -3680,7 +3679,7 @@ inline void gcode_M17() {
  * M31: Get the time since the start of SD Print (or last M109)
  */
 inline void gcode_M31() {
-  millis_t t = print_job_timer();
+  millis_t t = print_job_timer.duration();
   int min = t / 60, sec = t % 60;
   char time[30];
   sprintf_P(time, PSTR("%i min, %i sec"), min, sec);
@@ -4090,9 +4089,6 @@ inline void gcode_M104() {
   if (setTargetedHotend(104)) return;
   if (DEBUGGING(DRYRUN)) return;
 
-  // Start hook must happen before setTargetHotend()
-  print_job_start();
-
   if (code_seen('S')) {
     float temp = code_value();
     setTargetHotend(temp, target_extruder);
@@ -4101,10 +4097,24 @@ inline void gcode_M104() {
         setTargetHotend1(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset);
     #endif
 
+    /**
+     * We use halve EXTRUDE_MINTEMP here to allow nozzles to be put into hot
+     * stand by mode, for instance in a dual extruder setup, without affecting
+     * the running print timer.
+     */
+    if (temp <= (EXTRUDE_MINTEMP/2)) {
+      print_job_timer.stop();
+      LCD_MESSAGEPGM(WELCOME_MSG);
+    }
+    /**
+     * We do not check if the timer is already running because this check will
+     * be done for us inside the stopwatch::start() method thus a running timer
+     * will not restart.
+     */
+    else print_job_timer.start();
+
     if (temp > degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
   }
-
-  if (print_job_stop()) LCD_MESSAGEPGM(WELCOME_MSG);
 }
 
 #if HAS_TEMP_HOTEND || HAS_TEMP_BED
@@ -4232,9 +4242,6 @@ inline void gcode_M109() {
   if (setTargetedHotend(109)) return;
   if (DEBUGGING(DRYRUN)) return;
 
-  // Start hook must happen before setTargetHotend()
-  print_job_start();
-
   no_wait_for_cooling = code_seen('S');
   if (no_wait_for_cooling || code_seen('R')) {
     float temp = code_value();
@@ -4244,10 +4251,24 @@ inline void gcode_M109() {
         setTargetHotend1(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset);
     #endif
 
+    /**
+     * We use halve EXTRUDE_MINTEMP here to allow nozzles to be put into hot
+     * stand by mode, for instance in a dual extruder setup, without affecting
+     * the running print timer.
+     */
+    if (temp <= (EXTRUDE_MINTEMP/2)) {
+      print_job_timer.stop();
+      LCD_MESSAGEPGM(WELCOME_MSG);
+    }
+    /**
+     * We do not check if the timer is already running because this check will
+     * be done for us inside the stopwatch::start() method thus a running timer
+     * will not restart.
+     */
+    else print_job_timer.start();
+
     if (temp > degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
   }
-
-  if (print_job_stop()) LCD_MESSAGEPGM(WELCOME_MSG);
 
   #if ENABLED(AUTOTEMP)
     autotemp_enabled = code_seen('F');
@@ -7691,51 +7712,4 @@ float calculate_volumetric_multiplier(float diameter) {
 void calculate_volumetric_multipliers() {
   for (int i = 0; i < EXTRUDERS; i++)
     volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
-}
-
-/**
- * Start the print job timer
- *
- * The print job is only started if all extruders have their target temp at zero
- * otherwise the print job timew would be reset everytime a M109 is received.
- *
- * @param t start timer timestamp
- *
- * @return true if the timer was started at function call
- */
-bool print_job_start(millis_t t /* = 0 */) {
-  for (int i = 0; i < EXTRUDERS; i++) if (degTargetHotend(i) > 0) return false;
-  print_job_start_ms = (t) ? t : millis();
-  print_job_stop_ms = 0;
-  return true;
-}
-
-/**
- * Check if the running print job has finished and stop the timer
- *
- * When the target temperature for all extruders is zero then we assume that the
- * print job has finished printing. There are some special conditions under which
- * this assumption may not be valid: If during a print job for some reason the
- * user decides to bring a nozzle temp down and only then heat the other afterwards.
- *
- * @param force stops the timer ignoring all pre-checks
- *
- * @return boolean true if the print job has finished printing
- */
-bool print_job_stop(bool force /* = false */) {
-  if (!print_job_start_ms) return false;
-  if (!force) for (int i = 0; i < EXTRUDERS; i++) if (degTargetHotend(i) > 0) return false;
-  print_job_stop_ms = millis();
-  return true;
-}
-
-/**
- * Output the print job timer in seconds
- *
- * @return the number of seconds
- */
-millis_t print_job_timer() {
-  if (!print_job_start_ms) return 0;
-  return (((print_job_stop_ms > print_job_start_ms)
-    ? print_job_stop_ms : millis()) - print_job_start_ms) / 1000;
 }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -298,7 +298,7 @@ const int sensitive_pins[] = SENSITIVE_PINS; ///< Sensitive pin list for M42
 millis_t previous_cmd_ms = 0;
 static millis_t max_inactive_time = 0;
 static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000L;
-stopwatch print_job_timer = stopwatch();
+Stopwatch print_job_timer = Stopwatch();
 static uint8_t target_extruder;
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)
@@ -4119,17 +4119,17 @@ inline void gcode_M104() {
     #endif
 
     /**
-     * We use halve EXTRUDE_MINTEMP here to allow nozzles to be put into hot
+     * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
      * stand by mode, for instance in a dual extruder setup, without affecting
      * the running print timer.
      */
-    if (temp <= (EXTRUDE_MINTEMP/2)) {
+    if (temp <= (EXTRUDE_MINTEMP)/2) {
       print_job_timer.stop();
       LCD_MESSAGEPGM(WELCOME_MSG);
     }
     /**
      * We do not check if the timer is already running because this check will
-     * be done for us inside the stopwatch::start() method thus a running timer
+     * be done for us inside the Stopwatch::start() method thus a running timer
      * will not restart.
      */
     else print_job_timer.start();
@@ -4273,17 +4273,17 @@ inline void gcode_M109() {
     #endif
 
     /**
-     * We use halve EXTRUDE_MINTEMP here to allow nozzles to be put into hot
+     * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
      * stand by mode, for instance in a dual extruder setup, without affecting
      * the running print timer.
      */
-    if (temp <= (EXTRUDE_MINTEMP/2)) {
+    if (temp <= (EXTRUDE_MINTEMP)/2) {
       print_job_timer.stop();
       LCD_MESSAGEPGM(WELCOME_MSG);
     }
     /**
      * We do not check if the timer is already running because this check will
-     * be done for us inside the stopwatch::start() method thus a running timer
+     * be done for us inside the Stopwatch::start() method thus a running timer
      * will not restart.
      */
     else print_job_timer.start();

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -334,9 +334,8 @@ static void lcd_implementation_status_screen() {
     }
 
     u8g.setPrintPos(80,48);
-    if (print_job_start_ms != 0) {
-      uint16_t time = (((print_job_stop_ms > print_job_start_ms)
-                       ? print_job_stop_ms : millis()) - print_job_start_ms) / 60000;
+    uint16_t time = print_job_timer.duration() / 60;
+    if (time != 0) {
       lcd_print(itostr2(time/60));
       lcd_print(':');
       lcd_print(itostr2(time%60));

--- a/Marlin/stopwatch.cpp
+++ b/Marlin/stopwatch.cpp
@@ -23,28 +23,28 @@
 #include "Marlin.h"
 #include "stopwatch.h"
 
-stopwatch::stopwatch() {
+Stopwatch::Stopwatch() {
    this->reset();
  }
 
-void stopwatch::stop() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::stop()");
+void Stopwatch::stop() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::stop()");
   if (!this->isRunning()) return;
 
   this->status = STPWTCH_STOPPED;
   this->stopTimestamp = millis();
 }
 
-void stopwatch::pause() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::pause()");
+void Stopwatch::pause() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::pause()");
   if (!this->isRunning()) return;
 
   this->status = STPWTCH_PAUSED;
   this->stopTimestamp = millis();
 }
 
-void stopwatch::start() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::start()");
+void Stopwatch::start() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::start()");
   if (this->isRunning()) return;
 
   if (this->isPaused()) this->accumulator = this->duration();
@@ -54,8 +54,8 @@ void stopwatch::start() {
   this->startTimestamp = millis();
 }
 
-void stopwatch::reset() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::reset()");
+void Stopwatch::reset() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::reset()");
 
   this->status = STPWTCH_STOPPED;
   this->startTimestamp = 0;
@@ -63,15 +63,15 @@ void stopwatch::reset() {
   this->accumulator = 0;
 }
 
-bool stopwatch::isRunning() {
+bool Stopwatch::isRunning() {
   return (this->status == STPWTCH_RUNNING) ? true : false;
 }
 
-bool stopwatch::isPaused() {
+bool Stopwatch::isPaused() {
   return (this->status == STPWTCH_PAUSED) ? true : false;
 }
 
-uint16_t stopwatch::duration() {
+uint16_t Stopwatch::duration() {
   return (((this->isRunning()) ? millis() : this->stopTimestamp)
           - this->startTimestamp) / 1000 + this->accumulator;
 }

--- a/Marlin/stopwatch.cpp
+++ b/Marlin/stopwatch.cpp
@@ -1,0 +1,77 @@
+/*
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Marlin.h"
+#include "stopwatch.h"
+
+stopwatch::stopwatch() {
+   this->reset();
+ }
+
+void stopwatch::stop() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::stop()");
+  if (!this->isRunning()) return;
+
+  this->status = STPWTCH_STOPPED;
+  this->stopTimestamp = millis();
+}
+
+void stopwatch::pause() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::pause()");
+  if (!this->isRunning()) return;
+
+  this->status = STPWTCH_PAUSED;
+  this->stopTimestamp = millis();
+}
+
+void stopwatch::start() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::start()");
+  if (this->isRunning()) return;
+
+  if (this->isPaused()) this->accumulator = this->duration();
+  else this->reset();
+
+  this->status = STPWTCH_RUNNING;
+  this->startTimestamp = millis();
+}
+
+void stopwatch::reset() {
+  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("stopwatch::reset()");
+
+  this->status = STPWTCH_STOPPED;
+  this->startTimestamp = 0;
+  this->stopTimestamp = 0;
+  this->accumulator = 0;
+}
+
+bool stopwatch::isRunning() {
+  return (this->status == STPWTCH_RUNNING) ? true : false;
+}
+
+bool stopwatch::isPaused() {
+  return (this->status == STPWTCH_PAUSED) ? true : false;
+}
+
+uint16_t stopwatch::duration() {
+  return (((this->isRunning()) ? millis() : this->stopTimestamp)
+          - this->startTimestamp) / 1000 + this->accumulator;
+}

--- a/Marlin/stopwatch.h
+++ b/Marlin/stopwatch.h
@@ -1,0 +1,99 @@
+/*
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef STOPWATCH_H
+#define STOPWATCH_H
+
+enum stopwatch_s {
+  STPWTCH_STOPPED = 0x0,
+  STPWTCH_RUNNING = 0x1,
+  STPWTCH_PAUSED  = 0x2
+};
+
+/**
+ * @brief Stopwatch class
+ * @details This class acts as a timer proving stopwatch functionality including
+ * the ability to pause the running time counter.
+ */
+class stopwatch {
+  private:
+    stopwatch_s status;
+    uint16_t accumulator;
+    uint32_t startTimestamp;
+    uint32_t stopTimestamp;
+
+  public:
+    /**
+     * @brief Class constructor
+     */
+    stopwatch();
+
+    /**
+     * @brief Stops the stopwatch
+     * @details Stops the running timer, it will silently ignore the request if
+     * no timer is currently running.
+     */
+    void stop();
+
+    /**
+     * @brief Pauses the stopwatch
+     * @details Pauses the running timer, it will silently ignore the request if
+     * no timer is currently running.
+     */
+    void pause();
+
+    /**
+     * @brief Starts the stopwatch
+     * @details Starts the timer, it will silently ignore the request if the
+     * timer is already running.
+     */
+    void start();
+
+    /**
+     * @brief Resets the stopwatch
+     * @details Resets all settings to their default values.
+     */
+    void reset();
+
+    /**
+     * @brief Checks if the timer is running
+     * @details Returns true if the timer is currently running, false otherwise.
+     * @return bool
+     */
+    bool isRunning();
+
+    /**
+     * @brief Checks if the timer is paused
+     * @details Returns true if the timer is currently paused, false otherwise.
+     * @return bool
+     */
+    bool isPaused();
+
+    /**
+     * @brief Gets the running time
+     * @details Returns the total number of seconds the timer has been running.
+     * @return uint16_t
+     */
+    uint16_t duration();
+};
+
+#endif //STOPWATCH_H

--- a/Marlin/stopwatch.h
+++ b/Marlin/stopwatch.h
@@ -23,7 +23,7 @@
 #ifndef STOPWATCH_H
 #define STOPWATCH_H
 
-enum stopwatch_s {
+enum StopwatchStatus {
   STPWTCH_STOPPED = 0x0,
   STPWTCH_RUNNING = 0x1,
   STPWTCH_PAUSED  = 0x2
@@ -34,9 +34,9 @@ enum stopwatch_s {
  * @details This class acts as a timer proving stopwatch functionality including
  * the ability to pause the running time counter.
  */
-class stopwatch {
+class Stopwatch {
   private:
-    stopwatch_s status;
+    StopwatchStatus status;
     uint16_t accumulator;
     uint32_t startTimestamp;
     uint32_t stopTimestamp;
@@ -45,7 +45,7 @@ class stopwatch {
     /**
      * @brief Class constructor
      */
-    stopwatch();
+    Stopwatch();
 
     /**
      * @brief Stops the stopwatch

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1175,7 +1175,7 @@ void disable_all_heaters() {
   setTargetBed(0);
 
   // If all heaters go down then for sure our print job has stopped
-  print_job_stop(true);
+  print_job_timer.stop();
 
   #define DISABLE_HEATER(NR) { \
     setTargetHotend(NR, 0); \

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -739,9 +739,9 @@ static void lcd_implementation_status_screen() {
 
     lcd.setCursor(LCD_WIDTH - 6, 2);
     lcd.print(LCD_STR_CLOCK[0]);
-    if (print_job_start_ms != 0) {
-      uint16_t time = (((print_job_stop_ms > print_job_start_ms)
-                       ? print_job_stop_ms : millis()) - print_job_start_ms) / 60000;
+
+    uint16_t time = print_job_timer.duration() / 60;
+    if (time != 0) {
       lcd.print(itostr2(time / 60));
       lcd.print(':');
       lcd.print(itostr2(time % 60));


### PR DESCRIPTION
As discussed on #3275 this PR implements a better way to handle the print timer which is no longer dependent on nozzle temperature.

This is the current logic:
- `M104`/`M109` with a temperature above `EXTRUDE_MINTEMP/2` will start the print job timer
- Any consequent `M104`/`M109` above `EXTRUDE_MINTEMP/2` will not reset the timer
- Print job timer will be stopped when `M104`/`M109` sets temperature bellow `EXTRUDE_MINTEMP/2`

Three new G-Code commands have been implemented:
- `M75` to start/unpause the print job timer
- `M76` to pause the print job timer
- `M77` to stop the print job timer

**Open to discussion**: With the current logic in a multi-extruder configuration is possible to stop the print job timer in mid-print if the user pulls just one of the nozzles bellow `EXTRUDE_MINTEMP/2`. Should the `stop()` function revert to the old behavior of _only_ stopping the timer if all nozzles are with their setpoints cold ?
