### PR TITLE
Fix bug which can cause an infinite M109 loop

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4279,7 +4279,9 @@ inline void gcode_M109() {
     #ifdef TEMP_RESIDENCY_TIME
       // Start the TEMP_RESIDENCY_TIME timer when we reach target temp for the first time.
       // Restart the timer whenever the temperature falls outside the hysteresis.
-      if (labs(degHotend(target_extruder) - degTargetHotend(target_extruder)) > ((residency_start_ms < 0) ? TEMP_WINDOW : TEMP_HYSTERESIS))
+      if ((residency_start_ms <= 0 && (degHotend(target_extruder) >= degTargetHotend(target_extruder)-TEMP_WINDOW)
+                                   && (degHotend(target_extruder) <= degTargetHotend(target_extruder)+TEMP_WINDOW)) ||
+          (labs(degHotend(target_extruder) - degTargetHotend(target_extruder)) > ((residency_start_ms < 0) ? TEMP_WINDOW : TEMP_HYSTERESIS)))
         residency_start_ms = millis();
     #endif //TEMP_RESIDENCY_TIME
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4279,7 +4279,7 @@ inline void gcode_M109() {
     #ifdef TEMP_RESIDENCY_TIME
       // Start the TEMP_RESIDENCY_TIME timer when we reach target temp for the first time.
       // Restart the timer whenever the temperature falls outside the hysteresis.
-      if ((residency_start_ms <= 0 && labs(degHotend(target_extruder) - degTargetHotend(target_extruder) < TEMP_WINDOW)) ||
+      if ((residency_start_ms <= 0 && labs(degHotend(target_extruder) - degTargetHotend(target_extruder)) < TEMP_WINDOW) ||
           (labs(degHotend(target_extruder) - degTargetHotend(target_extruder)) > ((residency_start_ms < 0) ? TEMP_WINDOW : TEMP_HYSTERESIS)))
         residency_start_ms = millis();
     #endif //TEMP_RESIDENCY_TIME

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4279,8 +4279,7 @@ inline void gcode_M109() {
     #ifdef TEMP_RESIDENCY_TIME
       // Start the TEMP_RESIDENCY_TIME timer when we reach target temp for the first time.
       // Restart the timer whenever the temperature falls outside the hysteresis.
-      if ((residency_start_ms <= 0 && (degHotend(target_extruder) >= degTargetHotend(target_extruder)-TEMP_WINDOW)
-                                   && (degHotend(target_extruder) <= degTargetHotend(target_extruder)+TEMP_WINDOW)) ||
+      if ((residency_start_ms <= 0 && labs(degHotend(target_extruder) - degTargetHotend(target_extruder) < TEMP_WINDOW)) ||
           (labs(degHotend(target_extruder) - degTargetHotend(target_extruder)) > ((residency_start_ms < 0) ? TEMP_WINDOW : TEMP_HYSTERESIS)))
         residency_start_ms = millis();
     #endif //TEMP_RESIDENCY_TIME


### PR DESCRIPTION
Since residency_start_ms is -1 when entering the heatup while loop whilst the hotend temp is close to the target them already then it may not escape.

Hence "Start the TEMP_RESIDENCY_TIME timer when we reach target temp for the first time."
