### PR TITLE
More fine-grained control of LCD redraw

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -249,7 +249,7 @@ static void lcd_status_screen();
   #endif //!ENCODER_RATE_MULTIPLIER
   #define END_MENU() \
       if (encoderLine >= _menuItemNr) { encoderPosition = _menuItemNr * (ENCODER_STEPS_PER_MENU_ITEM) - 1; encoderLine = _menuItemNr - 1; }\
-      if (encoderLine >= currentMenuViewOffset + LCD_HEIGHT) { currentMenuViewOffset = encoderLine - (LCD_HEIGHT) + 1; lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW; _lineNr = currentMenuViewOffset - 1; _drawLineNr = -1; } \
+      if (encoderLine >= currentMenuViewOffset + LCD_HEIGHT) { currentMenuViewOffset = encoderLine - (LCD_HEIGHT) + 1; lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT; _lineNr = currentMenuViewOffset - 1; _drawLineNr = -1; } \
       } } while(0)
 
   /** Used variables to keep track of the menu */
@@ -289,14 +289,15 @@ bool ignore_click = false;
 bool wait_for_unclick;
 bool defer_return_to_status = false;
 
-enum LCDHandlerAction {
-  LCD_DRAW_UPDATE_NONE,
-  LCD_DRAW_UPDATE_CALL_REDRAW,
-  LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW,
-  LCD_DRAW_UPDATE_CALL_NO_REDRAW
+enum LCDViewAction {
+  LCDVIEW_NONE,
+  LCDVIEW_REDRAW_NOW,
+  LCDVIEW_CALL_REDRAW_NEXT,
+  LCDVIEW_CLEAR_CALL_REDRAW,
+  LCDVIEW_CALL_NO_REDRAW
 };
 
-uint8_t lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW; // Set 1 or 2 when the LCD needs to draw, decrements after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
+uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to draw, decrements after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
 
 // Variables used when editing values.
 const char* editLabel;
@@ -314,7 +315,7 @@ float raw_Ki, raw_Kd;
 static void lcd_goto_menu(menuFunc_t menu, const bool feedback = false, const uint32_t encoder = 0) {
   if (currentMenu != menu) {
     currentMenu = menu;
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
+    lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
     #if ENABLED(NEWPANEL)
       encoderPosition = encoder;
       if (feedback) lcd_quick_feedback();
@@ -556,7 +557,7 @@ void lcd_set_home_offsets() {
     if (encoderPosition) {
       int distance =  (int32_t)encoderPosition * BABYSTEP_MULTIPLICATOR;
       encoderPosition = 0;
-      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+      lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
       #if ENABLED(COREXY) || ENABLED(COREXZ)
         #if ENABLED(BABYSTEP_XY)
           switch(axis) {
@@ -894,7 +895,7 @@ void lcd_cooldown() {
     // if they call st_synchronize or plan_buffer_line. So
     // while waiting for a move we just ignore new input.
     if (mbl_wait_for_move) {
-      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+      lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
       return;
     }
 
@@ -908,7 +909,7 @@ void lcd_cooldown() {
       if (max_software_endstops) NOMORE(current_position[Z_AXIS], Z_MAX_POS);
       encoderPosition = 0;
       line_to_current(Z_AXIS);
-      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+      lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
     }
 
     // Update on first display, then only on updates to Z position
@@ -919,7 +920,7 @@ void lcd_cooldown() {
 
     // We want subsequent calls, but don't force redraw
     // Set here so it can be overridden by lcd_return_to_status below
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+    lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
 
     // Click sets the current Z and moves to the next position
     static bool debounce_click = false;
@@ -970,7 +971,7 @@ void lcd_cooldown() {
 
   static void _lcd_level_bed_homing_done() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_WAITING), NULL);
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+    lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
     if (LCD_CLICKED) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       plan_set_position(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
@@ -987,7 +988,7 @@ void lcd_cooldown() {
    */
   static void _lcd_level_bed_homing() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_HOMING), NULL);
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_NO_REDRAW;
+    lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
     if (axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS])
       lcd_goto_menu(_lcd_level_bed_homing_done);
   }
@@ -1131,7 +1132,7 @@ static void _lcd_move(const char* name, AxisEnum axis, float min, float max) {
     if (max_software_endstops) NOMORE(current_position[axis], max);
     encoderPosition = 0;
     line_to_current(axis);
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+    lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
   }
   if (lcdDrawUpdate) lcd_implementation_drawedit(name, ftostr31(current_position[axis]));
   if (LCD_CLICKED) lcd_goto_previous_menu(true);
@@ -1160,7 +1161,7 @@ static void lcd_move_e(
     current_position[E_AXIS] += float((int32_t)encoderPosition) * move_menu_scale;
     encoderPosition = 0;
     line_to_current(E_AXIS);
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+    lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
   }
   if (lcdDrawUpdate) {
     PGM_P pos_label;
@@ -1650,7 +1651,7 @@ static void lcd_control_volumetric_menu() {
         lcd_contrast &= 0x3F;
       #endif
       encoderPosition = 0;
-      lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+      lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
       u8g.setContrast(lcd_contrast);
     }
     if (lcdDrawUpdate) {
@@ -1791,7 +1792,7 @@ static void lcd_control_volumetric_menu() {
   static void _menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
     lcd_save_previous_menu(); \
     \
-    lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW; \
+    lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; \
     \
     editLabel = pstr; \
     editValue = ptr; \
@@ -1872,7 +1873,7 @@ menu_edit_type(unsigned long, long5, ftostr5, 0.01);
 #endif
 
 void lcd_quick_feedback() {
-  lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
+  lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
   next_button_update_ms = millis() + 500;
 
   #if ENABLED(LCD_USE_I2C_BUZZER)
@@ -2039,24 +2040,24 @@ bool lcd_blink() {
  *   - Act on RepRap World keypad input
  *   - Update the encoder position
  *   - Apply acceleration to the encoder position
- *   - Set lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW on controller events
+ *   - Set lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT on controller events
  *   - Reset the Info Screen timeout if there's any input
  *   - Update status indicators, if any
  *
  *   Run the current LCD menu handler callback function:
- *   - Call the handler only if lcdDrawUpdate != LCD_DRAW_UPDATE_NONE
- *   - Before calling the handler, LCD_DRAW_UPDATE_CALL_NO_REDRAW => LCD_DRAW_UPDATE_NONE
+ *   - Call the handler only if lcdDrawUpdate != LCDVIEW_NONE
+ *   - Before calling the handler, LCDVIEW_CALL_NO_REDRAW => LCDVIEW_NONE
  *   - Call the menu handler. Menu handlers should do the following:
- *     - If a value changes, set lcdDrawUpdate to LCD_DRAW_UPDATE_CALL_REDRAW
+ *     - If a value changes, set lcdDrawUpdate to LCDVIEW_REDRAW_NOW
  *     - if (lcdDrawUpdate) { redraw }
  *     - Before exiting the handler set lcdDrawUpdate to:
- *       - LCD_DRAW_UPDATE_CALL_REDRAW or LCD_DRAW_UPDATE_NONE for no callbacks until the next controller event.
- *       - LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW to clear screen, LCD_DRAW_UPDATE_CALL_REDRAW on the next loop.
- *       - LCD_DRAW_UPDATE_CALL_NO_REDRAW for a callback with no forced redraw on the next loop.
+ *       - LCDVIEW_REDRAW_NOW or LCDVIEW_NONE for no callbacks until the next controller event.
+ *       - LCDVIEW_CLEAR_CALL_REDRAW to clear screen and set LCDVIEW_CALL_REDRAW_NEXT.
+ *       - LCDVIEW_CALL_NO_REDRAW for a callback with no forced redraw on the next loop.
  *     - NOTE: For some displays, the menu handler may be called 2 or more times per loop.
  *
  *   After the menu handler callback runs (or not):
- *   - Clear the LCD if lcdDrawUpdate == LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW
+ *   - Clear the LCD if lcdDrawUpdate == LCDVIEW_CLEAR_CALL_REDRAW
  *   - Update lcdDrawUpdate for the next loop (i.e., move one state down, usually)
  *
  * No worries. This function is only called from the main thread.
@@ -2072,7 +2073,7 @@ void lcd_update() {
 
     bool sd_status = IS_SD_INSERTED;
     if (sd_status != lcd_sd_status && lcd_detected()) {
-      lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
+      lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
         #if ENABLED(LCD_PROGRESS_BAR)
           currentMenu == lcd_status_screen
@@ -2095,6 +2096,12 @@ void lcd_update() {
 
   millis_t ms = millis();
   if (ELAPSED(ms, next_lcd_update_ms)) {
+
+    next_lcd_update_ms = ms + LCD_UPDATE_INTERVAL;
+
+    #if ENABLED(LCD_HAS_STATUS_INDICATORS)
+      lcd_implementation_update_indicators();
+    #endif
 
     #if ENABLED(LCD_HAS_SLOW_BUTTONS)
       slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
@@ -2160,23 +2167,27 @@ void lcd_update() {
           encoderDiff = 0;
         }
         return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;
-        lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+        lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
       }
     #endif //ULTIPANEL
 
-    if (currentMenu == lcd_status_screen) {
-      if (!lcd_status_update_delay) {
-        lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
-        lcd_status_update_delay = 10;   /* redraw the main screen every second. This is easier then trying keep track of all things that change on the screen */
-      }
-      else {
-        lcd_status_update_delay--;
-      }
-    }
+    // Simply redraw the Info Screen 10 times a second
+    if (currentMenu == lcd_status_screen && !(++lcd_status_update_delay % 10))
+      lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
 
     if (lcdDrawUpdate) {
 
-      if (lcdDrawUpdate == LCD_DRAW_UPDATE_CALL_NO_REDRAW) lcdDrawUpdate = LCD_DRAW_UPDATE_NONE;
+      switch (lcdDrawUpdate) {
+        case LCDVIEW_CALL_NO_REDRAW:
+          lcdDrawUpdate = LCDVIEW_NONE;
+          break;
+        case LCDVIEW_CLEAR_CALL_REDRAW: // set by handlers, then altered after (rarely occurs here)
+        case LCDVIEW_CALL_REDRAW_NEXT:  // set by handlers, then altered after (never occurs here?)
+          lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
+        case LCDVIEW_REDRAW_NOW:        // set above, or by a handler through LCDVIEW_CALL_REDRAW_NEXT
+        case LCDVIEW_NONE:
+          break;
+      }
 
       #if ENABLED(DOGLCD)  // Changes due to different driver architecture of the DOGM display
         bool blink = lcd_blink();
@@ -2194,37 +2205,29 @@ void lcd_update() {
       #endif
     }
 
-    #if ENABLED(LCD_HAS_STATUS_INDICATORS)
-      lcd_implementation_update_indicators();
-    #endif
-
     #if ENABLED(ULTIPANEL)
 
       // Return to Status Screen after a timeout
-      if (defer_return_to_status)
+      if (currentMenu == lcd_status_screen || defer_return_to_status)
         return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;
-      else if (currentMenu != lcd_status_screen && ms > return_to_status_ms) {
+      else if (ELAPSED(ms, return_to_status_ms))
         lcd_return_to_status();
-      }
 
     #endif // ULTIPANEL
 
     switch (lcdDrawUpdate) {
-      case LCD_DRAW_UPDATE_NONE:
-        // do nothing
-      case LCD_DRAW_UPDATE_CALL_NO_REDRAW:
-        // changes to LCD_DRAW_UPDATE_NONE before call
-        break;
-      case LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW:
+      case LCDVIEW_CLEAR_CALL_REDRAW:
         lcd_implementation_clear();
-        lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW;
+      case LCDVIEW_CALL_REDRAW_NEXT:
+        lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
         break;
-      case LCD_DRAW_UPDATE_CALL_REDRAW:
-        lcdDrawUpdate = LCD_DRAW_UPDATE_NONE;
+      case LCDVIEW_REDRAW_NOW:
+        lcdDrawUpdate = LCDVIEW_NONE;
+        break;
+      case LCDVIEW_NONE:
         break;
     }
 
-    next_lcd_update_ms = ms + LCD_UPDATE_INTERVAL;
   }
 }
 
@@ -2244,7 +2247,7 @@ void lcd_finishstatus(bool persist=false) {
       expire_status_ms = persist ? 0 : progress_bar_ms + PROGRESS_MSG_EXPIRE;
     #endif
   #endif
-  lcdDrawUpdate = LCD_DRAW_UPDATE_CLEAR_CALL_REDRAW;
+  lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
 
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     previous_lcd_status_ms = millis();  //get status message to show up for a while


### PR DESCRIPTION
In response to #3373…

Allow more fine-grained control of LCD redraw, and handle redraws set by both handlers or encoder events in one place, ahead of the menu handler call. This may or may not have a helpful effect on #3373, and will need some testing to see if it improves the behavior. If it doesn't, then it may be enough to simply set `lcdDrawUpdate = LCD_DRAW_UPDATE_CALL_REDRAW_NEXT` instead of `LCD_DRAW_UPDATE_CALL_REDRAW_NOW`, which will give one extra redraw after a value has been altered (or basically, whenever any characters on the LCD have been changed).
