### PR TITLE
Wrong Pin Assignment Megatronics 3

### DIFF
--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -39,7 +39,7 @@
 #define SERVO0_PIN         46 //AUX3-6
 #define SERVO1_PIN         47 //AUX3-5
 #define SERVO2_PIN         48 //AUX3-4
-#define SERVO2_PIN         49 //AUX3-3
+#define SERVO3_PIN         49 //AUX3-3
 
 #define X_STEP_PIN         58
 #define X_DIR_PIN          57


### PR DESCRIPTION
SERVO2 is doubled defined and causes compiler errors
