### PR TITLE
Fix home_offset handling and account for it in G29

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -568,7 +568,7 @@ float junction_deviation = 0.1;
   while (block_buffer_tail == next_buffer_head) idle();
 
   #if ENABLED(MESH_BED_LEVELING)
-    if (mbl.active) z += mbl.get_z(x, y);
+    if (mbl.active) z += mbl.get_z(x - home_offset[X_AXIS], y - home_offset[Y_AXIS]);
   #elif ENABLED(AUTO_BED_LEVELING_FEATURE)
     apply_rotation_xyz(plan_bed_level_matrix, x, y, z);
   #endif
@@ -1111,7 +1111,7 @@ float junction_deviation = 0.1;
 #endif // AUTO_BED_LEVELING_FEATURE || MESH_BED_LEVELING
   {
     #if ENABLED(MESH_BED_LEVELING)
-      if (mbl.active) z += mbl.get_z(x, y);
+      if (mbl.active) z += mbl.get_z(x - home_offset[X_AXIS], y - home_offset[Y_AXIS]);
     #elif ENABLED(AUTO_BED_LEVELING_FEATURE)
       apply_rotation_xyz(plan_bed_level_matrix, x, y, z);
     #endif


### PR DESCRIPTION
Addressing #3444…
1. Whenever `home_offset` is altered, the `current_position` should be altered by the same amount, otherwise the current position no longer applies to the altered geometry. Without this PR, you must home with `G28` after `M206` or `M428` or else disparities will occur in positioning.
2. The `G29` handlers fail to include `home_offset` when moving to the probe points.

The alternative is to clear `axis_homed` for any axis that has its `home_offset` altered, forcing it to be re-homed to get the correct position. That's not a very good solution.

Note that this has implications for `G92` as well, which sets the `current_position` directly. In my view, the `min_pos` and `max_pos` values should retain their relative positions from `current_position` after `G92`. This would prevent the software endstops from improperly limiting movement after a `G92`. See PR #3227 for that patch and discussion.
