### PR TITLE
ELAPSED / PENDING for rollover-safe time checking

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -306,7 +306,7 @@ const int sensitive_pins[] = SENSITIVE_PINS; ///< Sensitive pin list for M42
 // Inactivity shutdown
 millis_t previous_cmd_ms = 0;
 static millis_t max_inactive_time = 0;
-static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000L;
+static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
 Stopwatch print_job_timer = Stopwatch();
 static uint8_t target_extruder;
 
@@ -435,7 +435,7 @@ static bool send_ok[BUFSIZE];
 #endif
 
 #ifdef CHDK
-  unsigned long chdkHigh = 0;
+  millis_t chdkHigh = 0;
   boolean chdkActive = false;
 #endif
 
@@ -456,7 +456,7 @@ static bool send_ok[BUFSIZE];
   };
 
   static MarlinBusyState busy_state = NOT_BUSY;
-  static millis_t prev_busy_signal_ms = -1;
+  static millis_t next_busy_signal_ms = 0;
   uint8_t host_keepalive_interval = DEFAULT_KEEPALIVE_INTERVAL;
   #define KEEPALIVE_STATE(n) do{ busy_state = n; }while(0)
 #else
@@ -874,7 +874,7 @@ inline void get_serial_commands() {
   #if defined(NO_TIMEOUTS) && NO_TIMEOUTS > 0
     static millis_t last_command_time = 0;
     millis_t ms = millis();
-    if (commands_in_queue == 0 && !MYSERIAL.available() && ms > last_command_time + NO_TIMEOUTS) {
+    if (commands_in_queue == 0 && !MYSERIAL.available() && ELAPSED(ms, last_command_time + NO_TIMEOUTS)) {
       SERIAL_ECHOLNPGM(MSG_WAIT);
       last_command_time = ms;
     }
@@ -2280,7 +2280,7 @@ void unknown_command_error() {
   void host_keepalive() {
     millis_t ms = millis();
     if (host_keepalive_interval && busy_state != NOT_BUSY) {
-      if (ms - prev_busy_signal_ms < 1000UL * host_keepalive_interval) return;
+      if (PENDING(ms, next_busy_signal_ms)) return;
       switch (busy_state) {
         case IN_HANDLER:
         case IN_PROCESS:
@@ -2299,7 +2299,7 @@ void unknown_command_error() {
           break;
       }
     }
-    prev_busy_signal_ms = ms;
+    next_busy_signal_ms = ms + host_keepalive_interval * 1000UL;
   }
 
 #endif //HOST_KEEPALIVE_FEATURE
@@ -2368,7 +2368,7 @@ inline void gcode_G4() {
   millis_t codenum = 0;
 
   if (code_seen('P')) codenum = code_value_long(); // milliseconds to wait
-  if (code_seen('S')) codenum = code_value() * 1000; // seconds to wait
+  if (code_seen('S')) codenum = code_value() * 1000UL; // seconds to wait
 
   st_synchronize();
   refresh_cmd_timeout();
@@ -2376,7 +2376,7 @@ inline void gcode_G4() {
 
   if (!lcd_hasstatus()) LCD_MESSAGEPGM(MSG_DWELL);
 
-  while (millis() < codenum) idle();
+  while (PENDING(millis(), codenum)) idle();
 }
 
 #if ENABLED(FWRETRACT)
@@ -3525,7 +3525,7 @@ inline void gcode_G92() {
       hasP = codenum > 0;
     }
     if (code_seen('S')) {
-      codenum = code_value() * 1000; // seconds to wait
+      codenum = code_value() * 1000UL; // seconds to wait
       hasS = codenum > 0;
     }
 
@@ -3544,7 +3544,7 @@ inline void gcode_G92() {
     if (codenum > 0) {
       codenum += previous_cmd_ms;  // wait until this time for a click
       KEEPALIVE_STATE(PAUSED_FOR_USER);
-      while (millis() < codenum && !lcd_clicked()) idle();
+      while (PENDING(millis(), codenum) && !lcd_clicked()) idle();
       KEEPALIVE_STATE(IN_HANDLER);
       lcd_ignore_click(false);
     }
@@ -4290,9 +4290,9 @@ inline void gcode_M109() {
   if (degTargetHotend(target_extruder) < (EXTRUDE_MINTEMP)/2) return;
 
   #ifdef TEMP_RESIDENCY_TIME
-    long residency_start_ms = -1;
+    millis_t residency_start_ms = 0;
     // Loop until the temperature has stabilized
-    #define TEMP_CONDITIONS (residency_start_ms == -1 || now < residency_start_ms + (TEMP_RESIDENCY_TIME) * 1000UL)
+    #define TEMP_CONDITIONS (!residency_start_ms || PENDING(now, residency_start_ms + (TEMP_RESIDENCY_TIME) * 1000UL))
   #else
     // Loop until the temperature is very close target
     #define TEMP_CONDITIONS (isHeatingHotend(target_extruder))
@@ -4302,14 +4302,14 @@ inline void gcode_M109() {
   millis_t now = millis(), next_temp_ms = now + 1000UL;
   while (!cancel_heatup && TEMP_CONDITIONS) {
     now = millis();
-    if (now > next_temp_ms) { //Print temp & remaining time every 1s while waiting
+    if (ELAPSED(now, next_temp_ms)) { //Print temp & remaining time every 1s while waiting
       next_temp_ms = now + 1000UL;
       #if HAS_TEMP_HOTEND || HAS_TEMP_BED
         print_heaterstates();
       #endif
       #ifdef TEMP_RESIDENCY_TIME
         SERIAL_PROTOCOLPGM(" W:");
-        if (residency_start_ms != -1) {
+        if (residency_start_ms) {
           long rem = (((TEMP_RESIDENCY_TIME) * 1000UL) - (now - residency_start_ms)) / 1000UL;
           SERIAL_PROTOCOLLN(rem);
         }
@@ -4328,7 +4328,7 @@ inline void gcode_M109() {
 
       float temp_diff = labs(degHotend(target_extruder) - degTargetHotend(target_extruder));
 
-      if (residency_start_ms == -1) {
+      if (!residency_start_ms) {
         // Start the TEMP_RESIDENCY_TIME timer when we reach target temp for the first time.
         if (temp_diff < TEMP_WINDOW) residency_start_ms = millis();
       }
@@ -4365,7 +4365,7 @@ inline void gcode_M109() {
     millis_t now = millis(), next_temp_ms = now + 1000UL;
     while (!cancel_heatup && isHeatingBed()) {
       millis_t now = millis();
-      if (now > next_temp_ms) { //Print Temp Reading every 1 second while heating up.
+      if (ELAPSED(now, next_temp_ms)) { //Print Temp Reading every 1 second while heating up.
         next_temp_ms = now + 1000UL;
         print_heaterstates();
         SERIAL_EOL;
@@ -4613,7 +4613,7 @@ inline void gcode_M83() { axis_relative_modes[E_AXIS] = true; }
  */
 inline void gcode_M18_M84() {
   if (code_seen('S')) {
-    stepper_inactive_time = code_value() * 1000;
+    stepper_inactive_time = code_value() * 1000UL;
   }
   else {
     bool all_axis = !((code_seen(axis_codes[X_AXIS])) || (code_seen(axis_codes[Y_AXIS])) || (code_seen(axis_codes[Z_AXIS])) || (code_seen(axis_codes[E_AXIS])));
@@ -4641,7 +4641,7 @@ inline void gcode_M18_M84() {
  * M85: Set inactivity shutdown timer with parameter S<seconds>. To disable set zero (default)
  */
 inline void gcode_M85() {
-  if (code_seen('S')) max_inactive_time = code_value() * 1000;
+  if (code_seen('S')) max_inactive_time = code_value() * 1000UL;
 }
 
 /**
@@ -5868,9 +5868,9 @@ inline void gcode_M503() {
     while (!lcd_clicked()) {
       #if DISABLED(AUTO_FILAMENT_CHANGE)
         millis_t ms = millis();
-        if (ms >= next_tick) {
+        if (ELAPSED(ms, next_tick)) {
           lcd_quick_feedback();
-          next_tick = ms + 2500; // feedback every 2.5s while waiting
+          next_tick = ms + 2500UL; // feedback every 2.5s while waiting
         }
         idle(true);
       #else
@@ -6109,7 +6109,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
         set_destination_to_current();
         #if ENABLED(DUAL_X_CARRIAGE)
           if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE && IsRunning() &&
-              (delayed_move_time != 0 || current_position[X_AXIS] != x_home_pos(active_extruder))) {
+              (delayed_move_time || current_position[X_AXIS] != x_home_pos(active_extruder))) {
             // Park old head: 1) raise 2) move to park position 3) lower
             plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] + TOOLCHANGE_PARK_ZLIFT,
                              current_position[E_AXIS], max_feedrate[Z_AXIS], active_extruder);
@@ -7337,8 +7337,8 @@ void plan_arc(
     static millis_t lastMotorOn = 0; // Last time a motor was turned on
     static millis_t nextMotorCheck = 0; // Last time the state was checked
     millis_t ms = millis();
-    if (ms >= nextMotorCheck) {
-      nextMotorCheck = ms + 2500; // Not a time critical function, so only check every 2.5s
+    if (ELAPSED(ms, nextMotorCheck)) {
+      nextMotorCheck = ms + 2500UL; // Not a time critical function, so only check every 2.5s
       if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON || soft_pwm_bed > 0
           || E0_ENABLE_READ == E_ENABLE_ON // If any of the drivers are enabled...
           #if EXTRUDERS > 1
@@ -7358,7 +7358,7 @@ void plan_arc(
       }
 
       // Fan off if no steppers have been enabled for CONTROLLERFAN_SECS seconds
-      uint8_t speed = (lastMotorOn == 0 || ms >= lastMotorOn + (CONTROLLERFAN_SECS) * 1000UL) ? 0 : CONTROLLERFAN_SPEED;
+      uint8_t speed = (!lastMotorOn || ELAPSED(ms, lastMotorOn + (CONTROLLERFAN_SECS) * 1000UL)) ? 0 : CONTROLLERFAN_SPEED;
 
       // allows digital or PWM fan output to be used (see M42 handling)
       digitalWrite(CONTROLLERFAN_PIN, speed);
@@ -7454,7 +7454,7 @@ void plan_arc(
 
   void handle_status_leds(void) {
     float max_temp = 0.0;
-    if (millis() > next_status_led_update_ms) {
+    if (ELAPSED(millis(), next_status_led_update_ms)) {
       next_status_led_update_ms += 500; // Update every 0.5s
       for (int8_t cur_extruder = 0; cur_extruder < EXTRUDERS; ++cur_extruder)
         max_temp = max(max(max_temp, degHotend(cur_extruder)), degTargetHotend(cur_extruder));
@@ -7533,9 +7533,9 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   millis_t ms = millis();
 
-  if (max_inactive_time && ms > previous_cmd_ms + max_inactive_time) kill(PSTR(MSG_KILLED));
+  if (max_inactive_time && ELAPSED(ms, previous_cmd_ms + max_inactive_time)) kill(PSTR(MSG_KILLED));
 
-  if (stepper_inactive_time && ms > previous_cmd_ms + stepper_inactive_time
+  if (stepper_inactive_time && ELAPSED(ms, previous_cmd_ms + stepper_inactive_time)
       && !ignore_stepper_queue && !blocks_queued()) {
     #if ENABLED(DISABLE_INACTIVE_X)
       disable_x();
@@ -7555,7 +7555,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
   }
 
   #ifdef CHDK // Check if pin should be set to LOW after M240 set it to HIGH
-    if (chdkActive && ms > chdkHigh + CHDK_DELAY) {
+    if (chdkActive && PENDING(ms, chdkHigh + CHDK_DELAY)) {
       chdkActive = false;
       WRITE(CHDK, LOW);
     }
@@ -7601,7 +7601,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
   #endif
 
   #if ENABLED(EXTRUDER_RUNOUT_PREVENT)
-    if (ms > previous_cmd_ms + (EXTRUDER_RUNOUT_SECONDS) * 1000)
+    if (ELAPSED(ms, previous_cmd_ms + (EXTRUDER_RUNOUT_SECONDS) * 1000UL))
       if (degHotend(active_extruder) > EXTRUDER_RUNOUT_MINTEMP) {
         bool oldstatus;
         switch (active_extruder) {
@@ -7662,7 +7662,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   #if ENABLED(DUAL_X_CARRIAGE)
     // handle delayed move timeout
-    if (delayed_move_time && ms > delayed_move_time + 1000 && IsRunning()) {
+    if (delayed_move_time && ELAPSED(ms, delayed_move_time + 1000UL) && IsRunning()) {
       // travel moves have been received so enact them
       delayed_move_time = 0xFFFFFFFFUL; // force moves to be done
       set_destination_to_current();

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -508,7 +508,7 @@ void CardReader::write_command(char *buf) {
 }
 
 void CardReader::checkautostart(bool force) {
-  if (!force && (!autostart_stilltocheck || next_autostart_ms < millis()))
+  if (!force && (!autostart_stilltocheck || ELAPSED(millis(), next_autostart_ms)))
     return;
 
   autostart_stilltocheck = false;

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -459,7 +459,7 @@ static void lcd_implementation_status_screen() {
   #if DISABLED(FILAMENT_LCD_DISPLAY)
     lcd_print(lcd_status_message);
   #else
-    if (millis() < previous_lcd_status_ms + 5000) {  //Display both Status message line and Filament display on the last line
+    if (PENDING(millis(), previous_lcd_status_ms + 5000)) {  //Display both Status message line and Filament display on the last line
       lcd_print(lcd_status_message);
     }
     else {

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -57,4 +57,7 @@
 
 #define PIN_EXISTS(PN) (defined(PN ##_PIN) && PN ##_PIN >= 0)
 
+#define PENDING(NOW,SOON) ((long)(NOW-(SOON))<0)
+#define ELAPSED(NOW,SOON) (!PENDING(NOW,SOON))
+
 #endif //__MACROS_H

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -491,7 +491,7 @@ void check_axes_activity() {
             fan_kick_end[f] = ms + FAN_KICKSTART_TIME; \
             tail_fan_speed[f] = 255; \
           } else { \
-            if (fan_kick_end[f] > ms) { \
+            if (PENDING(ms, fan_kick_end[f])) { \
               tail_fan_speed[f] = 255; \
             } \
           } \

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -235,7 +235,7 @@ void PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false
   float max = 0, min = 10000;
 
   #if HAS_AUTO_FAN
-    millis_t next_auto_fan_check_ms = temp_ms + 2500;
+    millis_t next_auto_fan_check_ms = temp_ms + 2500UL;
   #endif
 
   if (extruder >= EXTRUDERS
@@ -270,14 +270,14 @@ void PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false
       min = min(min, input);
 
       #if HAS_AUTO_FAN
-        if (ms > next_auto_fan_check_ms) {
+        if (ELAPSED(ms, next_auto_fan_check_ms)) {
           checkExtruderAutoFans();
-          next_auto_fan_check_ms = ms + 2500;
+          next_auto_fan_check_ms = ms + 2500UL;
         }
       #endif
 
       if (heating && input > temp) {
-        if (ms > t2 + 5000) {
+        if (ELAPSED(ms, t2 + 5000UL)) {
           heating = false;
           if (extruder < 0)
             soft_pwm_bed = (bias - d) >> 1;
@@ -290,7 +290,7 @@ void PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false
       }
 
       if (!heating && input < temp) {
-        if (ms > t1 + 5000) {
+        if (ELAPSED(ms, t1 + 5000UL)) {
           heating = true;
           t2 = ms;
           t_low = t2 - t1;
@@ -349,7 +349,7 @@ void PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false
       return;
     }
     // Every 2 seconds...
-    if (ms > temp_ms + 2000) {
+    if (ELAPSED(ms, temp_ms + 2000UL)) {
       #if HAS_TEMP_HOTEND || HAS_TEMP_BED
         print_heaterstates();
         SERIAL_EOL;
@@ -673,7 +673,7 @@ void manage_heater() {
     #if ENABLED(THERMAL_PROTECTION_HOTENDS)
 
       // Is it time to check this extruder's heater?
-      if (watch_heater_next_ms[e] && ms > watch_heater_next_ms[e]) {
+      if (watch_heater_next_ms[e] && ELAPSED(ms, watch_heater_next_ms[e])) {
         // Has it failed to increase enough?
         if (degHotend(e) < watch_target_temp[e]) {
           // Stop!
@@ -696,9 +696,9 @@ void manage_heater() {
   } // Extruders Loop
 
   #if HAS_AUTO_FAN
-    if (ms > next_auto_fan_check_ms) { // only need to check fan state very infrequently
+    if (ELAPSED(ms > next_auto_fan_check_ms)) { // only need to check fan state very infrequently
       checkExtruderAutoFans();
-      next_auto_fan_check_ms = ms + 2500;
+      next_auto_fan_check_ms = ms + 2500UL;
     }
   #endif
 
@@ -718,7 +718,7 @@ void manage_heater() {
   #endif //FILAMENT_WIDTH_SENSOR
 
   #if DISABLED(PIDTEMPBED)
-    if (ms < next_bed_check_ms) return;
+    if (PENDING(ms, next_bed_check_ms)) return;
     next_bed_check_ms = ms + BED_CHECK_INTERVAL;
   #endif
 
@@ -1105,7 +1105,7 @@ void tp_init() {
   void start_watching_heater(int e) {
     if (degHotend(e) < degTargetHotend(e) - (WATCH_TEMP_INCREASE + TEMP_HYSTERESIS + 1)) {
       watch_target_temp[e] = degHotend(e) + WATCH_TEMP_INCREASE;
-      watch_heater_next_ms[e] = millis() + (WATCH_TEMP_PERIOD) * 1000UL;
+      watch_heater_next_ms[e] = millis() + (WATCH_TEMP_PERIOD) * 1000;
     }
     else
       watch_heater_next_ms[e] = 0;
@@ -1160,7 +1160,7 @@ void tp_init() {
         if (temperature >= tr_target_temperature[heater_index] - hysteresis_degc)
           *timer = millis();
         // If the timer goes too long without a reset, trigger shutdown
-        else if (millis() > *timer + period_seconds * 1000UL)
+        else if (ELAPSED(millis(), *timer + period_seconds * 1000UL))
           *state = TRRunaway;
         break;
       case TRRunaway:
@@ -1232,7 +1232,7 @@ void disable_all_heaters() {
 
     millis_t ms = millis();
 
-    if (ms < next_max6675_ms) return (int)max6675_temp;
+    if (PENDING(ms, next_max6675_ms)) return (int)max6675_temp;
 
     next_max6675_ms = ms + MAX6675_HEAT_INTERVAL;
 

--- a/Marlin/twibus.cpp
+++ b/Marlin/twibus.cpp
@@ -77,12 +77,12 @@ void TWIBus::reqbytes(uint8_t bytes) {
     SERIAL_EOL;
   }
 
-  millis_t t = millis();
+  millis_t t = millis() + this->timeout;
   Wire.requestFrom(this->addr, bytes);
 
     // requestFrom() is a blocking function
   while (Wire.available() < bytes) {
-    if (millis() - t >= this->timeout) break;
+    if (ELAPSED(millis(), t)) break;
     else continue;
   }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -369,7 +369,7 @@ static void lcd_status_screen() {
   #if ENABLED(LCD_PROGRESS_BAR)
     millis_t ms = millis();
     #if DISABLED(PROGRESS_MSG_ONCE)
-      if (ms > progress_bar_ms + PROGRESS_BAR_MSG_TIME + PROGRESS_BAR_BAR_TIME) {
+      if (ELAPSED(ms, progress_bar_ms + PROGRESS_BAR_MSG_TIME + PROGRESS_BAR_BAR_TIME)) {
         progress_bar_ms = ms;
       }
     #endif
@@ -380,7 +380,7 @@ static void lcd_status_screen() {
           if (card.isFileOpen()) {
             // Expire the message when printing is active
             if (IS_SD_PRINTING) {
-              if (ms >= expire_status_ms) {
+              if (ELAPSED(ms, expire_status_ms)) {
                 lcd_status_message[0] = '\0';
                 expire_status_ms = 0;
               }
@@ -2025,7 +2025,7 @@ bool lcd_blink() {
   static uint8_t blink = 0;
   static millis_t next_blink_ms = 0;
   millis_t ms = millis();
-  if (ms >= next_blink_ms) {
+  if (ELAPSED(ms, next_blink_ms)) {
     blink ^= 0xFF;
     next_blink_ms = ms + 1000 - LCD_UPDATE_INTERVAL / 2;
   }
@@ -2094,7 +2094,7 @@ void lcd_update() {
   #endif //SDSUPPORT && SD_DETECT_PIN
 
   millis_t ms = millis();
-  if (ms > next_lcd_update_ms) {
+  if (ELAPSED(ms, next_lcd_update_ms)) {
 
     #if ENABLED(LCD_HAS_SLOW_BUTTONS)
       slow_buttons = lcd_implementation_read_slow_buttons(); // buttons which take too long to read in interrupt context
@@ -2343,7 +2343,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
         millis_t now = millis();
       #endif
       #if ENABLED(RIGIDBOT_PANEL)
-        if (now > next_button_update_ms) {
+        if (ELAPSED(now, next_button_update_ms)) {
           if (BUTTON_PRESSED(UP)) {
             encoderDiff = -1 * (ENCODER_STEPS_PER_MENU_ITEM);
             next_button_update_ms = now + 300;
@@ -2363,7 +2363,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
         }
       #endif
       #if BUTTON_EXISTS(ENC)
-        if (now > next_button_update_ms && BUTTON_PRESSED(ENC)) newbutton |= EN_C;
+        if (ELAPSED(now, next_button_update_ms) && BUTTON_PRESSED(ENC)) newbutton |= EN_C;
       #endif
       buttons = newbutton;
       #if ENABLED(LCD_HAS_SLOW_BUTTONS)

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -741,7 +741,7 @@ static void lcd_implementation_status_screen() {
     if (card.isFileOpen()) {
       // Draw the progress bar if the message has shown long enough
       // or if there is no message set.
-      if (millis() >= progress_bar_ms + PROGRESS_BAR_MSG_TIME || !lcd_status_message[0]) {
+      if (ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0]) {
         int tix = (int)(card.percentDone() * (LCD_WIDTH) * 3) / 100,
           cel = tix / 3, rem = tix % 3, i = LCD_WIDTH;
         char msg[LCD_WIDTH + 1], b = ' ';
@@ -762,7 +762,7 @@ static void lcd_implementation_status_screen() {
 
     // Show Filament Diameter and Volumetric Multiplier %
     // After allowing lcd_status_message to show for 5 seconds
-    if (millis() >= previous_lcd_status_ms + 5000) {
+    if (ELAPSED(millis(), previous_lcd_status_ms + 5000)) {
       lcd_printPGM(PSTR("Dia "));
       lcd.print(ftostr12ns(filament_width_meas));
       lcd_printPGM(PSTR(" V"));
@@ -930,7 +930,7 @@ void lcd_implementation_drawedit(const char* pstr, const char* value) {
       // so they are called during normal lcd_update
       uint8_t slow_bits = lcd.readButtons() << B_I2C_BTN_OFFSET;
       #if ENABLED(LCD_I2C_VIKI)
-        if ((slow_bits & (B_MI | B_RI)) && millis() < next_button_update_ms) // LCD clicked
+        if ((slow_bits & (B_MI | B_RI)) && PENDING(millis(), next_button_update_ms)) // LCD clicked
           slow_bits &= ~(B_MI | B_RI); // Disable LCD clicked buttons if screen is updated
       #endif // LCD_I2C_VIKI
       return slow_bits;


### PR DESCRIPTION
Do time comparison based on advice from @repetier to **always use subtraction-and-comparison** to prevent `millis` rollover from giving the opposite result (which may happen after 49 days of continuous power-on without a reset).
- Add `ELAPSED` and `PENDING` macros to compare two time values
- Use `UL` suffix to cue the compiler (better than `(millis_t)1000` amirite?)

Another thing that may happen extremely rarely is that `my_next_ms = millis() + 1000UL` could produce a zero, so time values that use zero for a disabled state might hit this edge once every few years. The fix would be to employ another macro:

``` cpp
#define NEXT_TIME(VAR,VAL) (VAR = VAL; if (VAR == 0) VAR = 1;)
```

…to be used when updating a timeout that shouldn't be zero.

``` cpp
NEXT_TIME(next_temp_ms, now + 1000);
```
