### PR TITLE
Remove redundant text from MSG_ERR_REDUNDANT_TEMP

### DIFF
--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -149,7 +149,7 @@
 #define MSG_BABYSTEP_Z                      "Babystep Z"
 #define MSG_ENDSTOP_ABORT                   "Endstop abort"
 #define MSG_HEATING_FAILED_LCD              "Heating failed"
-#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "Err: MAXTEMP"
 #define MSG_ERR_MINTEMP                     "Err: MINTEMP"

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -452,7 +452,7 @@
   #define MSG_HEATING_FAILED_LCD              "Heating failed"
 #endif
 #ifndef MSG_ERR_REDUNDANT_TEMP
-  #define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP ERROR"
+  #define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP"
 #endif
 #ifndef MSG_THERMAL_RUNAWAY
   #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -154,7 +154,7 @@
 #define MSG_BABYSTEP_Z                      "Z\xbc\xde\xb8\x20\xcb\xde\xc4\xde\xb3"                         // "Babystep Z"
 #define MSG_ENDSTOP_ABORT                   "\xb4\xdd\xc4\xde\xbd\xc4\xaf\xcc\xdf\x20\xbb\xc4\xde\xb3"      // "Endstop abort"
 #define MSG_HEATING_FAILED_LCD              "\xb6\xc8\xc2\xbc\xaf\xca\xde\xb2"                              // "Heating failed"
-#define MSG_ERR_REDUNDANT_TEMP              "\xb4\xd7\xb0:\xbc\xde\xae\xb3\xc1\xae\xb3\xbb\xb0\xd0\xbd\xc0\xb0\xb7\xc9\xb3" // "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "\xb4\xd7\xb0:\xbc\xde\xae\xb3\xc1\xae\xb3\xbb\xb0\xd0\xbd\xc0\xb0\xb7\xc9\xb3" // "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "\xc8\xc2\xce\xde\xb3\xbf\xb3"                                                  // "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "\xb4\xd7\xb0:\xbb\xb2\xba\xb3\xb5\xdd\xc1\xae\xb3\xb6"                         // "Err: MAXTEMP"
 #define MSG_ERR_MINTEMP                     "\xb4\xd7\xb0:\xbb\xb2\xc3\xb2\xb5\xdd\xd0\xcf\xdd"                             // "Err: MINTEMP"

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -158,7 +158,7 @@
 #define MSG_BABYSTEP_Z                      "Zジク ビドウ"                  // "Babystep Z"
 #define MSG_ENDSTOP_ABORT                   "エンドストップ サドウ"            // "Endstop abort"
 #define MSG_HEATING_FAILED_LCD              "カネツシッパイ"                 // "Heating failed"
-#define MSG_ERR_REDUNDANT_TEMP              "エラー:ジョウチョウサーミスターキノウ"  // "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "エラー:ジョウチョウサーミスターキノウ"  // "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "ネツボウソウ"                   // "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "エラー:サイコウオンチョウカ"         // "Err: MAXTEMP"
 #define MSG_ERR_MINTEMP                     "エラー:サイテイオンミマン"          // "Err: MINTEMP"

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -154,7 +154,7 @@
 #define MSG_BED_Z                           "Base Z"
 #define MSG_A_TRAVEL                        "A-movimento"
 #define MSG_HEATING_FAILED_LCD              "Aquecimento falhou"
-#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "Err: T Maxima"
 #define MSG_ERR_MINTEMP                     "Err: T Minima"

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -154,7 +154,7 @@
 #define MSG_BED_Z                           "Base Z"
 #define MSG_A_TRAVEL                        "A-movimento"
 #define MSG_HEATING_FAILED_LCD              "Aquecimento falhou"
-#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "Err: T Máxima"
 #define MSG_ERR_MINTEMP                     "Err: T Mínima"

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -155,7 +155,7 @@
 #define MSG_BABYSTEP_Z                      "Babystep Z"
 #define MSG_ENDSTOP_ABORT                   "Fim de curso"
 #define MSG_HEATING_FAILED_LCD              "Aquecimento falhou"
-#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "Err: T Maxima"
 #define MSG_ERR_MINTEMP                     "Err: T Minima"

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -155,7 +155,7 @@
 #define MSG_BABYSTEP_Z                      "Babystep Z"
 #define MSG_ENDSTOP_ABORT                   "Fim de curso"
 #define MSG_HEATING_FAILED_LCD              "Aquecimento falhou"
-#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP ERROR"
+#define MSG_ERR_REDUNDANT_TEMP              "Err: REDUNDANT TEMP"
 #define MSG_THERMAL_RUNAWAY                 "THERMAL RUNAWAY"
 #define MSG_ERR_MAXTEMP                     "Err: T Máxima"
 #define MSG_ERR_MINTEMP                     "Err: T Mínima"


### PR DESCRIPTION
This rarely-used LCD error string is not just over-long, but redundant. So this PR shortens it.
