### PR TITLE
Versions of Arduino IDE prior to 1.6.0 are no longer supported

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -34,8 +34,8 @@
  * release we will stop supporting old IDE versions and will require user
  * action to proceed with compilation in such environments.
  */
-#if !defined(ARDUINO) || ARDUINO < 10500
-  #warning Versions of Arduino IDE prior to 1.5 are no longer supported, please update your toolkit.
+#if !defined(ARDUINO) || ARDUINO < 10600
+  #error Versions of Arduino IDE prior to 1.6.0 are no longer supported, please update your toolkit.
 #endif
 
 /**


### PR DESCRIPTION
Followup of #3259, #3229 #3460.

The following Arduino IDE version were tested, this PR raised an `#error` for the versions marked as "not working".
- `arduino-1.0.5-r2`: Not working
- `arduino-1.5.8`: Not working
- `arduino-1.6.0`: Working
- `arduino-1.6.8`: Working
