### PR TITLE
Mesh Bed Leveling – Add lift between probes, comments, cleanup

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2465,7 +2465,7 @@ inline void gcode_G28() {
    */
   #if ENABLED(MESH_BED_LEVELING)
     uint8_t mbl_was_active = mbl.active;
-    mbl.active = 0;
+    mbl.active = false;
   #endif
 
   setup_for_endstop_move();
@@ -2896,7 +2896,7 @@ inline void gcode_G28() {
           // After recording the last point, activate the mbl and home
           SERIAL_PROTOCOLLNPGM("Mesh probing done.");
           probe_point = -1;
-          mbl.active = 1;
+          mbl.active = true;
           enqueue_and_echo_commands_P(PSTR("G28"));
         }
         break;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2799,6 +2799,28 @@ inline void gcode_G28() {
 
   enum MeshLevelingState { MeshReport, MeshStart, MeshNext, MeshSet, MeshSetZOffset };
 
+  inline void _mbl_goto_xy(float x, float y) {
+    saved_feedrate = feedrate;
+    feedrate = homing_feedrate[X_AXIS];
+
+    #if MIN_Z_HEIGHT_FOR_HOMING > 0
+      current_position[Z_AXIS] = MESH_HOME_SEARCH_Z + MIN_Z_HEIGHT_FOR_HOMING;
+      line_to_current_position();
+    #endif
+
+    current_position[X_AXIS] = x + home_offset[X_AXIS];
+    current_position[Y_AXIS] = y + home_offset[Y_AXIS];
+    line_to_current_position();
+
+    #if MIN_Z_HEIGHT_FOR_HOMING > 0
+      current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
+      line_to_current_position();
+    #endif
+
+    feedrate = saved_feedrate;
+    st_synchronize();
+  }
+
   /**
    * G29: Mesh-based Z probe, probes a grid and produces a
    *      mesh to compensate for variable bed height
@@ -2866,33 +2888,28 @@ inline void gcode_G28() {
           SERIAL_PROTOCOLLNPGM("Start mesh probing with \"G29 S1\" first.");
           return;
         }
+        // For each G29 S2...
         if (probe_point == 0) {
-          // Set Z to a positive value before recording the first Z.
-          current_position[Z_AXIS] = MESH_HOME_SEARCH_Z + home_offset[Z_AXIS];
+          // For the intial G29 S2 make Z a positive value (e.g., 4.0)
+          current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
           sync_plan_position();
         }
         else {
-          // For others, save the Z of the previous point, then raise Z again.
-          ix = (probe_point - 1) % (MESH_NUM_X_POINTS);
-          iy = (probe_point - 1) / (MESH_NUM_X_POINTS);
-          if (iy & 1) ix = (MESH_NUM_X_POINTS - 1) - ix; // zig-zag
-          mbl.set_z(ix, iy, current_position[Z_AXIS]);
-          current_position[Z_AXIS] = MESH_HOME_SEARCH_Z + home_offset[Z_AXIS];
-          plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], homing_feedrate[X_AXIS] / 60, active_extruder);
-          st_synchronize();
+          // For G29 S2 after adjusting Z.
+          mbl.set_zigzag_z(probe_point - 1, current_position[Z_AXIS]);
         }
-        // Is there another point to sample? Move there.
+        // If there's another point to sample, move there with optional lift.
         if (probe_point < (MESH_NUM_X_POINTS) * (MESH_NUM_Y_POINTS)) {
-          ix = probe_point % (MESH_NUM_X_POINTS);
-          iy = probe_point / (MESH_NUM_X_POINTS);
-          if (iy & 1) ix = (MESH_NUM_X_POINTS - 1) - ix; // zig-zag
-          current_position[X_AXIS] = mbl.get_x(ix) + home_offset[X_AXIS];
-          current_position[Y_AXIS] = mbl.get_y(iy) + home_offset[Y_AXIS];
-          plan_buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], homing_feedrate[X_AXIS] / 60, active_extruder);
-          st_synchronize();
+          mbl.zigzag(probe_point, ix, iy);
+          _mbl_goto_xy(mbl.get_x(ix), mbl.get_y(iy));
           probe_point++;
         }
         else {
+          // One last "return to the bed" (as originally coded) at completion
+          current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
+          line_to_current_position();
+          st_synchronize();
+
           // After recording the last point, activate the mbl and home
           SERIAL_PROTOCOLLNPGM("Mesh probing done.");
           probe_point = -1;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -551,7 +551,7 @@ void Config_ResetDefault() {
   home_offset[X_AXIS] = home_offset[Y_AXIS] = home_offset[Z_AXIS] = 0;
 
   #if ENABLED(MESH_BED_LEVELING)
-    mbl.active = 0;
+    mbl.active = false;
   #endif
 
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -29,7 +29,7 @@
 
   class mesh_bed_leveling {
   public:
-    uint8_t active;
+    bool active;
     float z_offset;
     float z_values[MESH_NUM_Y_POINTS][MESH_NUM_X_POINTS];
 

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -41,6 +41,18 @@
     float get_y(int i) { return MESH_MIN_Y + (MESH_Y_DIST) * i; }
     void set_z(int ix, int iy, float z) { z_values[iy][ix] = z; }
 
+    inline void zigzag(int index, int &ix, int &iy) {
+      ix = index % (MESH_NUM_X_POINTS);
+      iy = index / (MESH_NUM_X_POINTS);
+      if (iy & 1) ix = (MESH_NUM_X_POINTS - 1) - ix; // Zig zag
+    }
+
+    void set_zigzag_z(int index, float z) {
+      int ix, iy;
+      zigzag(index, ix, iy);
+      set_z(ix, iy, z);
+    }
+
     int select_x_index(float x) {
       int i = 1;
       while (x > get_x(i) && i < MESH_NUM_X_POINTS - 1) i++;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -889,9 +889,9 @@ void lcd_cooldown() {
   static int _lcd_level_bed_position;
 
   /**
-   * MBL Wait for controller movement and clicks:
-   *   - Movement adjusts the Z axis
-   *   - Click saves the Z and goes to the next mesh point
+   * 5. MBL Wait for controller movement and clicks:
+   *        - Movement adjusts the Z axis
+   *        - Click saves the Z, goes to the next mesh point
    */
   static void _lcd_level_bed_procedure() {
     static bool mbl_wait_for_move = false;
@@ -973,6 +973,10 @@ void lcd_cooldown() {
     }
   }
 
+  /**
+   * 4. MBL Display "Click to Begin", wait for click
+   *        Move to the first probe position
+   */
   static void _lcd_level_bed_homing_done() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_WAITING), NULL);
     lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
@@ -988,7 +992,7 @@ void lcd_cooldown() {
   }
 
   /**
-   * MBL Move to mesh starting point
+   * 3. MBL Display "Hoing XYZ" - Wait for homing to finish
    */
   static void _lcd_level_bed_homing() {
     if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_HOMING), NULL);
@@ -998,7 +1002,7 @@ void lcd_cooldown() {
   }
 
   /**
-   * MBL Continue Bed Leveling...
+   * 2. MBL Continue Bed Leveling...
    */
   static void _lcd_level_bed_continue() {
     defer_return_to_status = true;
@@ -1009,7 +1013,7 @@ void lcd_cooldown() {
   }
 
   /**
-   * MBL entry-point
+   * 1. MBL entry-point: "Cancel" or "Level Bed"
    */
   static void lcd_level_bed() {
     START_MENU();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -946,7 +946,7 @@ void lcd_cooldown() {
           current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
           line_to_current(Z_AXIS);
           st_synchronize();
-          mbl.active = 1;
+          mbl.active = true;
           enqueue_and_echo_commands_P(PSTR("G28"));
         }
         else {


### PR DESCRIPTION
Mesh bed leveling has a few redundancies and some minor deficits in operation. In my own experience the behavior is such that the nozzle tends to drag on the bed. So this PR takes advantage of the `MIN_Z_HEIGHT_FOR_HOMING` value to add a raise between probes. Other cleanup also…
- Make `mbl.active` into a `bool` so it may be used (in future) in a menu edit item
- Add helper functions to the MBL object for doing zigzag points
- Use `_mbl_goto_xy` functions to consolidate MBL code in both `G29` and LCD menu
- Raise by `MIN_Z_HEIGHT_FOR_HOMING` between points in MBL `G29` and LCD-based leveling
- Remove `+ home_offset[axis]` where it doesn't apply (i.e., `MESH_HOME_SEARCH_Z` is arbitrary)
- Expand comments on Manual Bed Leveling options

Since `Marlin_main.cpp` and `ultralcd.cpp` each have their own convenience functions for moving to `current_position`, there is still some duplication of effort in the probing functions. This PR points the way to merge these movement functions and consolidate more of the MBL code in `mesh_bed_leveling.cpp`.
