### PR TITLE
Throw an error if ENCODER_PULSES_PER_STEP < 0

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -290,6 +290,10 @@
   #error ULTIPANEL requires some kind of encoder.
 #endif
 
+#if ENCODER_PULSES_PER_STEP < 0
+  #error ENCODER_PULSES_PER_STEP should not be negative, use REVERSE_MENU_DIRECTION instead
+#endif
+
 /**
  * Delta has limited bed leveling options
  */


### PR DESCRIPTION
This PR is a follow up of #3485, before the existence of `REVERSE_MENU_DIRECTION` people were using `ENCODER_PULSES_PER_STEP` to obtain the same result. This change triggers an error to force them to use the correct `REVERSE_MENU_DIRECTION` option.
