### PR TITLE
On wider screens show a wider splash page, if possible

### DIFF
--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -445,6 +445,13 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
     }
   }
 
+  inline void logo_lines(const char *extra) {
+    int indent = (LCD_WIDTH - 8 - lcd_strlen_P(extra)) / 2;
+    lcd.setCursor(indent, 0); lcd.print('\x00'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x01');
+    lcd.setCursor(indent, 1);                    lcd_printPGM(PSTR("|Marlin|"));  lcd_printPGM(extra);
+    lcd.setCursor(indent, 2); lcd.print('\x02'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x03');
+  }
+
   static void bootscreen() {
     show_bootscreen = false;
     byte top_left[8] = {
@@ -494,22 +501,44 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
 
     lcd.clear();
 
-    #define TEXT_SCREEN_LOGO_SHIFT ((LCD_WIDTH/2) - 4)
-    lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 0); lcd.print('\x00'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x01');
-    lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 1);                    lcd_printPGM(PSTR("|Marlin|"));
-    lcd.setCursor(TEXT_SCREEN_LOGO_SHIFT, 2); lcd.print('\x02'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x03');
-
-    delay(2000);
+    #define LCD_EXTRA_SPACE (LCD_WIDTH-8)
 
     #ifdef STRING_SPLASH_LINE1
-      lcd_erase_line(3);
-      lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE1), LCD_WIDTH, 1000);
+      // Combine into a single splash screen if possible
+      if (LCD_EXTRA_SPACE >= strlen(STRING_SPLASH_LINE1) + 1) {
+        logo_lines(PSTR(" " STRING_SPLASH_LINE1));
+        #ifdef STRING_SPLASH_LINE2
+          lcd_erase_line(3);
+          lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 2000);
+        #else
+          delay(2000);
+        #endif
+      }
+      else {
+        logo_lines(PSTR(""));
+        lcd_erase_line(3);
+        lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE1), LCD_WIDTH, 1500);
+        #ifdef STRING_SPLASH_LINE2
+          lcd_erase_line(3);
+          lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 1500);
+        #endif
+      }
+    #elif defined(STRING_SPLASH_LINE2)
+      // Combine into a single splash screen if possible
+      if (LCD_EXTRA_SPACE >= strlen(STRING_SPLASH_LINE2) + 1) {
+        logo_lines(PSTR(" " STRING_SPLASH_LINE2));
+        delay(2000);
+      }
+      else {
+        logo_lines(PSTR(""));
+        lcd_erase_line(3);
+        lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 2000);
+      }
+    #else
+      logo_lines(PSTR(""));
+      delay(2000);
     #endif
 
-    #ifdef STRING_SPLASH_LINE2
-      lcd_erase_line(3);
-      lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 1000);
-    #endif
   }
 
 #endif // SHOW_BOOTSCREEN


### PR DESCRIPTION
When possible show the version (splash line 1) next to the Marlin logo.

If `SPLASH_LINE_1` is defined, and is short enough, show this for 2 seconds:

```
./------\...........
.|Marlin| 1.1.0-RC3.
.\------/...........
...Splash Line 2....
```

The logo and splash line are centered:

```
.../------\.........
...|Marlin| 1.1.0...
...\------/.........
...Splash Line 2....
```

In the case of a long `SPLASH_LINE_1` it will show for 2 seconds (1.5 if there is a second splash line).

```
....../------\......
......|Marlin|......
......\------/......
...Splash Line 1....
```

…and if there's a `SPLASH_LINE_2` will show for 1.5 seconds:

```
....../------\......
......|Marlin|......
......\------/......
...Splash Line 2....
```

Note that the compiler will evaluate `strlen("LITERAL STRING")` in advance and optimize out code blocks when a test like `if (strlen("LITERAL") < 10)` evaluates to `false`.
