### PR TITLE
Don't use LCD alert unless error or alert level is reset later

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5851,7 +5851,7 @@ inline void gcode_M428() {
 
   if (!err) {
     sync_plan_position();
-    LCD_ALERTMESSAGEPGM(MSG_HOME_OFFSETS_APPLIED);
+    LCD_MESSAGEPGM(MSG_HOME_OFFSETS_APPLIED);
     #if HAS_BUZZER
       buzz(200, 659);
       buzz(200, 698);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -953,7 +953,7 @@ void lcd_cooldown() {
         mbl.set_zigzag_z(_lcd_level_bed_position++, current_position[Z_AXIS]);
         if (_lcd_level_bed_position == (MESH_NUM_X_POINTS) * (MESH_NUM_Y_POINTS)) {
           lcd_return_to_status();
-          LCD_ALERTMESSAGEPGM(MSG_LEVEL_BED_DONE);
+          LCD_MESSAGEPGM(MSG_LEVEL_BED_DONE);
           #if HAS_BUZZER
             buzz(200, 659);
             buzz(200, 698);


### PR DESCRIPTION
Addressing #3510 

The messages `MSG_HOME_OFFSETS_APPLIED` and `MSG_LEVEL_BED_DONE` should use `LCD_MESSAGEPGM` so they can be overridden by `M117`. Code that uses `LCD_ALERTMESSAGEPGM` must either call `stop()` to halt the machine, or call `lcd_reset_alert_level` to unblock the LCD status message.
