### PR TITLE
Version RC6 for general release

### DIFF
--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -29,7 +29,7 @@
 /**
  * Marlin release version identifier
  */
-#define SHORT_BUILD_VERSION "1.1.0-RCBugFix"
+#define SHORT_BUILD_VERSION "1.1.0-RC6"
 
 /**
  * Verbose version identifier which should contain a reference to the location
@@ -42,7 +42,7 @@
  * here we define this default string as the date where the latest release
  * version was tagged.
  */
-#define STRING_DISTRIBUTION_DATE "2016-04-16 12:00"
+#define STRING_DISTRIBUTION_DATE "2016-04-24 12:00"
 
 /**
  * @todo: Missing documentation block

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Marlin 3D Printer Firmware
 <img align="top" width=175 src="Documentation/Logo/Marlin%20Logo%20GitHub.png" />
- Additional documentation can be found in [The Marlin Wiki](https://github.com/MarlinFirmware/Marlin/wiki/Main-Page).
+ Additional documentation can be found in [The Marlin Wiki](https://github.com/MarlinFirmware/Marlin/wiki).
 
-## Release Candidate -- Marlin 1.1.0-RC4 - 24 March 2016
+## Release Candidate -- Marlin 1.1.0-RC6 - 24 April 2016
 
 __Not for production use – use with caution!__
 
@@ -13,6 +13,28 @@ You'll always find the latest Release Candidate in the ["RC" branch](https://git
 Future development (Marlin 1.2 and beyond) takes place in the [MarlinDev repository](https://github.com/MarlinFirmware/MarlinDev/).
 
 ## Recent Changes
+- RCBugFix
+  - Throw error if compiling with older versions (<1.60) of Arduino due to serious problems with outdated Arduino versions
+  - Please upgrade your IDE at least to Arduino 1.6.0. Thanks.
+
+- RC6 - 23 Apr 2016
+  - Completed support for CoreXY / CoreXZ in planner
+  - Changes to positioning behavior
+  - Various issues fixed. More details pending.
+
+- RC5 - 01 Apr 2016
+  - Warn if compiling with older versions (<1.50) of Arduino
+  - Fix various LCD menu issues
+  - Add formal support for MKSv1.3 and Sainsmart (RAMPS variants)
+  - Fix bugs in M104, M109, and M190
+  - Fix broken M404 command
+  - Fix issues with M23 and "Start SD Print"
+  - More output for M111
+  - Rename FILAMENT_SENSOR to FILAMENT_WIDTH_SENSOR
+  - Fix SD card bugs
+  - and a lot more
+  - see https://github.com/MarlinFirmware/Marlin/releases/tag/1.1.0-RC5 for details
+
 - RC4 - 24 Mar 2016
   - Many lingering bugs and nagging issues addressed
   - Improvements to LCD menus, CoreXY/CoreXZ, Delta, Bed Leveling, and more…
@@ -52,7 +74,7 @@ The current Marlin dev team consists of:
  - Scott Lahteine [@thinkyhead] - English
  - [@Wurstnase] - Deutsch, English
  - F. Malpartida [@fmalpartida] - English, Spanish
- - [@CONSULitAS] - Deutsch, English
+ - Jochen Groppe [@CONSULitAS] - Deutsch, English
  - [@maverikou]
  - Chris Palmer [@nophead]
  - [@paclema]


### PR DESCRIPTION
Applying the RC6 version label here, migrating to RC soon, and then `RCBugFix` will be reverted back to `RCBugFix` version.

Waiting on resolution of #3368, ~~#3511~~, ~~#3517~~, #3520, ~~#3521~~, and #3523, #3533, #3562 before doing this release candidate.
