### PR TITLE
Better splash screen consolidation

### DIFF
--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -445,7 +445,7 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
     }
   }
 
-  inline void logo_lines(const char *extra) {
+  static void logo_lines(const char *extra) {
     int indent = (LCD_WIDTH - 8 - lcd_strlen_P(extra)) / 2;
     lcd.setCursor(indent, 0); lcd.print('\x00'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x01');
     lcd.setCursor(indent, 1);                    lcd_printPGM(PSTR("|Marlin|"));  lcd_printPGM(extra);
@@ -503,38 +503,64 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
 
     #define LCD_EXTRA_SPACE (LCD_WIDTH-8)
 
+    #define CENTER_OR_SCROLL(STRING,DELAY) \
+      lcd_erase_line(3); \
+      if (strlen(STRING) <= LCD_WIDTH) { \
+        lcd.setCursor((LCD_WIDTH - lcd_strlen_P(PSTR(STRING))) / 2, 3); \
+        lcd_printPGM(PSTR(STRING)); \
+        delay(DELAY); \
+      } \
+      else { \
+        lcd_scroll(0, 3, PSTR(STRING), LCD_WIDTH, DELAY); \
+      }
+
     #ifdef STRING_SPLASH_LINE1
-      // Combine into a single splash screen if possible
+      //
+      // Show the Marlin logo with splash line 1
+      //
       if (LCD_EXTRA_SPACE >= strlen(STRING_SPLASH_LINE1) + 1) {
+        //
+        // Show the Marlin logo, splash line1, and splash line 2
+        //
         logo_lines(PSTR(" " STRING_SPLASH_LINE1));
         #ifdef STRING_SPLASH_LINE2
-          lcd_erase_line(3);
-          lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 2000);
+          CENTER_OR_SCROLL(STRING_SPLASH_LINE2, 2000);
         #else
           delay(2000);
         #endif
       }
       else {
-        logo_lines(PSTR(""));
-        lcd_erase_line(3);
-        lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE1), LCD_WIDTH, 1500);
+        //
+        // Show the Marlin logo with splash line 1
+        // After a delay show splash line 2, if it exists
+        //
         #ifdef STRING_SPLASH_LINE2
-          lcd_erase_line(3);
-          lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 1500);
+          #define _SPLASH_WAIT_1 1500
+        #else
+          #define _SPLASH_WAIT_1 2000
+        #endif
+        logo_lines(PSTR(""));
+        CENTER_OR_SCROLL(STRING_SPLASH_LINE1, _SPLASH_WAIT_1);
+        #ifdef STRING_SPLASH_LINE2
+          CENTER_OR_SCROLL(STRING_SPLASH_LINE2, 1500);
         #endif
       }
     #elif defined(STRING_SPLASH_LINE2)
-      // Combine into a single splash screen if possible
+      //
+      // Show splash line 2 only, alongside the logo if possible
+      //
       if (LCD_EXTRA_SPACE >= strlen(STRING_SPLASH_LINE2) + 1) {
         logo_lines(PSTR(" " STRING_SPLASH_LINE2));
         delay(2000);
       }
       else {
         logo_lines(PSTR(""));
-        lcd_erase_line(3);
-        lcd_scroll(0, 3, PSTR(STRING_SPLASH_LINE2), LCD_WIDTH, 2000);
+        CENTER_OR_SCROLL(STRING_SPLASH_LINE2, 2000);
       }
     #else
+      //
+      // Show only the Marlin logo
+      //
       logo_lines(PSTR(""));
       delay(2000);
     #endif


### PR DESCRIPTION
The splash screen will be displayed in the most minimal manner possible. In order of preference:
- Show the Marlin logo, splash line1, and splash line 2 all together on one screen
- Show the Marlin logo with splash line1, then splash line 2 after a delay
- Show the Marlin logo with splash line2 (if there is no splash line 1)
- Show the Marlin logo only (if there is no splash line 1 or 2)

The `CENTER_OR_SCROLL` macro produces code to either center or scroll the splash line depending on its length.

The compiler optimizes this down to minimal code, including pre-evaluating `strlen()` on the splash line strings. Test with and without `SHOW_BOOTSCREEN` to see the size difference for your splash strings.
- **76,236** : `SHOW_BOOTSCREEN` off
- **76,614** : `SHOW_BOOTSCREEN` only (+378 (321+32+25) bytes)
- **76,624** : Short `STRING_SPLASH_LINE1` ("`1.1.0-RC5`") (+10 (0+10) bytes)
  - **76,752** : (Add medium `STRING_SPLASH_LINE2` ("`2016-04-16 12:00`") (+128 (111+17) bytes)
- **76,738** : Medium `STRING_SPLASH_LINE1` ("`1.1.0-RCBugFix`") (+114 (109+5) bytes)
  - **76,836** : (Add medium `STRING_SPLASH_LINE2` ("`2016-04-16 12:00`") (+98 (81+17) bytes)
- **76,946** : Longer `STRING_SPLASH_LINE1` ("`123456789012345678901`") (+208 (202+6) bytes)
  - **77,044** : (Add medium `STRING_SPLASH_LINE2` ("`2016-04-16 12:00`") (+98 (81+17) bytes)

For most users the `SHOW_BOOTSCREEN` feature adds from 388 to 502 bytes to the binary size. At the extreme, it might add ~800 bytes.
