### PR TITLE
Fixed Positional_Shift array overrun

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3598,13 +3598,14 @@ inline void gcode_G92() {
 
       current_position[i] = v;
 
-      position_shift[i] += v - p; // Offset the coordinate space
-      update_software_endstops((AxisEnum)i);
-
       if (i == E_AXIS)
         plan_set_e_position(v);
-      else
+      else {
+        position_shift[i] += v - p; // Offset the coordinate space
+        update_software_endstops((AxisEnum)i);
+		  
         didXYZ = true;
+	  }
     }
   }
   if (didXYZ) {


### PR DESCRIPTION
Addressing #3539 – I found the G92 command software endstop / position_shift updating wrote past the array size, causing bad behavior (in my case messing up X motor step counts)
