### PR TITLE
使用SD卡打印时,初始化风扇速度为0

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6224,6 +6224,7 @@ void process_next_command() {
         case 23: //M23 - Select file
           gcode_M23(); break;
         case 24: //M24 - Start SD print
+          gcode_M107();//SD PRINT FAN off
           gcode_M24(); break;
         case 25: //M25 - Pause SD print
           gcode_M25(); break;


### PR DESCRIPTION
因为很多切片软件不能定义GCODE加热前把风扇关闭.如果打印前风扇是打开的,那么加热的时候风扇还是打开状态,影响打印头加热,极端情况下打印头温度永远达不到预设温度,造成打印失败
