### PR TITLE
Git helper shell scripts for MarlinFirmware

### DIFF
--- a/Marlin/scripts/firstpush
+++ b/Marlin/scripts/firstpush
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+git push --set-upstream origin `git branch | grep \* | sed 's/\* //g'`

--- a/Marlin/scripts/mfinfo
+++ b/Marlin/scripts/mfinfo
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# mfinfo
+#
+# Get the following helpful git info about the working directory:
+#
+#   - Remote (upstream) Org name (MarlinFirmware)
+#   - Remote (origin) Org name (your Github username)
+#   - Repo Name (Marlin or MarlinDev)
+#   - Marlin Target branch (RCBugFix or dev)
+#   - Branch Name (the current branch or the one that was passed)
+#
+
+REPO=$(git remote get-url upstream 2>/dev/null | sed -E 's/.*\/(.*)\.git/\1/')
+
+if [[ -z $REPO ]]; then
+  echo "`basename $0`: No 'upstream' remote found." 1>&2 ; exit 1
+fi
+
+ORG=$(git remote get-url upstream 2>/dev/null | sed -E 's/.*[\/:](.*)\/.*$/\1/')
+
+if [[ $ORG != MarlinFirmware ]]; then
+  echo "`basename $0`: Not a Marlin repository."
+  exit 1
+fi
+
+case "$REPO" in
+  Marlin    ) TARG=RCBugFix ;;
+  MarlinDev ) TARG=dev ;;
+esac
+
+FORK=$(git remote get-url origin 2>/dev/null | sed -E 's/.*[\/:](.*)\/.*$/\1/')
+
+case "$#" in
+  0 ) BRANCH=$(git branch 2>/dev/null | grep ^* | sed 's/\* //g') ;;
+  1 ) BRANCH=$1 ;;
+  * ) echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1 ;;
+esac
+
+echo "$ORG $FORK $REPO $TARG $BRANCH"

--- a/Marlin/scripts/mfnew
+++ b/Marlin/scripts/mfnew
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# mfnew
+#
+# Create a new branch based on RCBugFix or dev a given branch name
+#
+
+MFINFO=$(mfinfo) || exit
+IFS=' ' read -a INFO <<< "$MFINFO"
+TARG=${INFO[3]}
+
+if [[ ${INFO[4]} == "(no" ]]; then
+  echo "Branch is unavailable!"
+  exit 1
+fi
+
+case "$#" in
+  0 ) BRANCH=pr_for_$TARG-$(date +"%G-%d-%m|%H:%M:%S") ;;
+  1 ) BRANCH=$1 ;;
+  * ) echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1 ;;
+esac
+
+git checkout $TARG -b $BRANCH

--- a/Marlin/scripts/mfpr
+++ b/Marlin/scripts/mfpr
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# mfpr
+#
+# Make a PR of the current branch against RCBugFix or dev
+#
+
+MFINFO=$(mfinfo "$@") || exit
+
+IFS=' ' read -a INFO <<< "$MFINFO"
+
+ORG=${INFO[0]}
+FORK=${INFO[1]}
+REPO=${INFO[2]}
+TARG=${INFO[3]}
+BRANCH=${INFO[4]}
+
+if [[ $BRANCH == "(no" ]]; then
+  echo "Git is busy with merge, rebase, etc."
+  exit 1
+fi
+
+if [[ ! -z "$1" ]]; then { BRANCH=$1 ; git checkout $1 || exit 1; } fi
+
+if [[ $BRANCH == $TARG ]]; then
+  echo "Can't make a PR from $BRANCH" ; exit
+fi
+
+if [ -z "$(git branch -vv | grep ^\* | grep \\[origin)" ]; then firstpush; fi
+
+TOOL=$(which gnome-open xdg-open open | awk '{ print $1 }')
+URL="https://github.com/$ORG/$REPO/compare/$TARG...$FORK:$BRANCH?expand=1"
+
+if [ -z "$TOOL" ]; then
+  echo "Can't find a tool to open the URL:"
+  echo $URL
+else
+  echo "Opening a New PR Form..."
+  "$TOOL" "$URL"
+fi

--- a/Marlin/scripts/mfprune
+++ b/Marlin/scripts/mfprune
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# mfprune
+#
+# Prune all your merged branches and any branches whose remotes are gone
+# Great way to clean up your branches after messing around a lot
+#
+
+echo "Pruning Merged Branches..."
+git branch --merged | egrep -v "^\*|RC|RCBugFix|dev" | xargs -n 1 git branch -d
+echo
+
+echo "Pruning Remotely-deleted Branches..."
+git branch -vv | egrep -v "^\*|RC|RCBugFix|dev" | grep ': gone]' | gawk '{print $1}' | xargs -n 1 git branch -D
+echo
+
+echo "You may want to remove these remote tracking references..."
+comm -23 \
+  <(git branch --all | sed 's/^[\* ] //' | grep origin/ | grep -v "\->" | awk '{ print $1; }' | sed 's/remotes\/origin\///') \
+  <(git branch --all | sed 's/^[\* ] //' | grep -v remotes/ | awk '{ print $1; }') \
+  | awk '{ print "git branch -d -r origin/" $1; }'
+echo

--- a/Marlin/scripts/mfrb
+++ b/Marlin/scripts/mfrb
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# mfrb
+#
+# Do "git rebase -i" against the "target" branch (RCBugFix or dev)
+#
+
+MFINFO=$(mfinfo) || exit
+IFS=' ' read -a INFO <<< "$MFINFO"
+
+if [[ ${INFO[4]} == "(no" ]]; then
+  echo "Branch is unavailable!"
+  exit 1
+fi
+
+case "$#" in
+  0 ) ;;
+  * ) echo "Usage: `basename $0`" 1>&2 ; exit 1 ;;
+esac
+
+git rebase -i ${INFO[3]}

--- a/Marlin/scripts/mfup
+++ b/Marlin/scripts/mfup
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# mfup
+#
+# Fetch and merge upstream changes, optionally with a branch
+#
+
+MFINFO=$(mfinfo) || exit
+
+IFS=' ' read -a INFO <<< "$MFINFO"
+
+ORG=${INFO[0]}
+FORK=${INFO[1]}
+REPO=${INFO[2]}
+TARG=${INFO[3]}
+OLDBRANCH=${INFO[4]}
+
+if [[ $OLDBRANCH == "(no" ]]; then
+  echo "Branch is unavailable!"
+  exit 1
+fi
+
+case "$#" in
+  0 ) BRANCH=$OLDBRANCH ;;
+  1 ) BRANCH=$1 ;;
+  * ) echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1 ;;
+esac
+
+set -e
+
+echo "Fetching upstream ($ORG/$REPO)..."
+git fetch upstream
+
+echo ; echo "Bringing $TARG up to date..."
+git checkout -q $TARG || git branch checkout upstream/$TARG -b $TARG && git push --set-upstream origin $TARG
+git merge upstream/$TARG
+git push origin
+
+if [[ $BRANCH != $TARG ]]; then
+  echo ; echo "Rebasing $BRANCH on $TARG..."
+  if git checkout $BRANCH; then
+    echo
+    if git rebase $TARG; then
+      git push -f ; echo
+      [[ $BRANCH != $OLDBRANCH ]] && git checkout $OLDBRANCH
+    else
+      echo "Looks like merge conflicts. Stopping here."
+    fi
+  else
+    echo "No such branch!" ; echo
+    git checkout $OLDBRANCH
+  fi
+fi


### PR DESCRIPTION
Do PR submissions for Marlin directly from your BASH command line with these helpful scripts specifically tailored to make your Marlin workflow go more smoothly.

> #### `mfinfo [branch]`
> 
> Get the following helpful Marlin-Github info about the repo of your working directory:
> - Remote (upstream) Org name (MarlinFirmware)
> - Remote (origin) Org name (your Github username)
> - Repo Name (Marlin or MarlinDev)
> - Marlin Target branch (RCBugFix or dev)
> - Branch Name (the current branch or the one that was passed)
> ##### Example:
> 
> ```
> [/Projects/Firmware/Marlin] $ mfinfo
> MarlinFirmware thinkyhead Marlin RCBugFix rc_slow_buttons
> ```

---

> #### `mfup [branch]`
> 
> Fetch and merge upstream changes, optionally with a branch
> ##### Example:
> 
> ```
> [/Projects/Firmware/Marlin] $ mfup rc_doc_tweaks
> Fetching upstream (MarlinFirmware)...
> 
> Bringing RCBugFix up to date...
> Branch RCBugFix set up to track remote branch RCBugFix from origin.
> Everything up-to-date
> Already up-to-date.
> Everything up-to-date
> 
> Rebasing rc_doc_tweaks on RCBugFix...
> Switched to branch 'rc_doc_tweaks'
> Your branch is up-to-date with 'origin/rc_doc_tweaks'.
> First, rewinding head to replay your work on top of it...
> Applying: Move STRINGIFY to macros.h, use in language.h
> Applying: Drop DISABLE_M(IN|AX)_ENDSTOPS, replace with individual endstop flags
> Applying: Simplify configuration of Z2 endstops
> Applying: Account for Z_DUAL_ENDSTOPS in sanity checking of endstops
> Applying: Adjust SanityCheck messages
> Auto packing the repository in background for optimum performance.
> See "git help gc" for manual housekeeping.
> 
> Switched to branch 'i3_millie_RCBugFix'
> Your branch is up-to-date with 'origin/i3_millie_RCBugFix'.
> ```

---

> #### `mfpr [branch]`
> 
> Start a PR of the current branch against `RCBugFix` or `dev`. Pushes your branch to `origin` if you forgot. This script may need to be adjusted to your particular environment. In particular, if you don't have a `gnome-open`, `xdg-open`, or `open` command to open a URL in a browser, you will need to use your system's equivalent.
> ##### Example:
> 
> ```
> [/Projects/Firmware/Marlin] $ mfpr
> Opening a New PR Form...
> (opens the "New PR" page in the browser, set to the current branch)
> ```

---

> #### `mfprune`
> 
> Prune all your merged branches and any branches whose remotes are gone.
> A great way to clean up your branches after messing around a lot.
> ##### Example:
> 
> ``` sh
> [/Projects/Firmware/Marlin] $ mfprune
> Pruning Merged Branches...
> Deleted branch rc_epatel_mesh_fixes (was 14afe1a).
> Deleted branch rc_fix_numeric_filenames (was f423716).
> Deleted branch rc_general_clean (was 5d8036e).
> Deleted branch rc_keepalive_less (was cd4c3e9).
> 
> Pruning Remotely-deleted Branches...
> 
> ```

---

> #### `mfrb`
> 
> Start an interactive rebase of the current branch against `RCBugFix` or `dev`.
> ##### Example:
> 
> ``` sh
> [/Projects/Firmware/Marlin] $ mfrb
> ```
