### PR TITLE
Reduce PROGMEM usage by TWIBus, stopwatch

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -233,12 +233,12 @@ void kill(const char*);
  */
 enum DebugFlags {
   DEBUG_NONE          = 0,
-  DEBUG_ECHO          = _BV(0),
-  DEBUG_INFO          = _BV(1),
-  DEBUG_ERRORS        = _BV(2),
-  DEBUG_DRYRUN        = _BV(3),
-  DEBUG_COMMUNICATION = _BV(4),
-  DEBUG_LEVELING      = _BV(5)
+  DEBUG_ECHO          = _BV(0), ///< Echo commands in order as they are processed
+  DEBUG_INFO          = _BV(1), ///< Print messages for code that has debug output
+  DEBUG_ERRORS        = _BV(2), ///< Not implemented
+  DEBUG_DRYRUN        = _BV(3), ///< Ignore temperature setting and E movement commands
+  DEBUG_COMMUNICATION = _BV(4), ///< Not implemented
+  DEBUG_LEVELING      = _BV(5)  ///< Print detailed output for homing and leveling
 };
 extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (DEBUG_## F))

--- a/Marlin/stopwatch.cpp
+++ b/Marlin/stopwatch.cpp
@@ -24,11 +24,14 @@
 #include "stopwatch.h"
 
 Stopwatch::Stopwatch() {
-   this->reset();
- }
+  this->reset();
+}
 
 void Stopwatch::stop() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::stop()");
+  #if ENABLED(DEBUG_STOPWATCH)
+    debug(PSTR("stop"));
+  #endif
+
   if (!this->isRunning()) return;
 
   this->status = STPWTCH_STOPPED;
@@ -36,7 +39,10 @@ void Stopwatch::stop() {
 }
 
 void Stopwatch::pause() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::pause()");
+  #if ENABLED(DEBUG_STOPWATCH)
+    debug(PSTR("pause"));
+  #endif
+
   if (!this->isRunning()) return;
 
   this->status = STPWTCH_PAUSED;
@@ -44,7 +50,10 @@ void Stopwatch::pause() {
 }
 
 void Stopwatch::start() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::start()");
+  #if ENABLED(DEBUG_STOPWATCH)
+    debug(PSTR("start"));
+  #endif
+
   if (this->isRunning()) return;
 
   if (this->isPaused()) this->accumulator = this->duration();
@@ -55,7 +64,9 @@ void Stopwatch::start() {
 }
 
 void Stopwatch::reset() {
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("Stopwatch::reset()");
+  #if ENABLED(DEBUG_STOPWATCH)
+    debug(PSTR("reset"));
+  #endif
 
   this->status = STPWTCH_STOPPED;
   this->startTimestamp = 0;
@@ -75,3 +86,15 @@ uint16_t Stopwatch::duration() {
   return (((this->isRunning()) ? millis() : this->stopTimestamp)
           - this->startTimestamp) / 1000 + this->accumulator;
 }
+
+#if ENABLED(DEBUG_STOPWATCH)
+
+  void Stopwatch::debug(const char func[]) {
+    if (DEBUGGING(INFO)) {
+      SERIAL_ECHOPGM("Stopwatch::");
+      serialprintPGM(func);
+      SERIAL_ECHOLNPGM("()");
+    }
+  }
+
+#endif

--- a/Marlin/stopwatch.h
+++ b/Marlin/stopwatch.h
@@ -23,10 +23,15 @@
 #ifndef STOPWATCH_H
 #define STOPWATCH_H
 
+#include "macros.h"
+
+// Print debug messages with M111 S2 (Uses 156 bytes of PROGMEM)
+//#define DEBUG_STOPWATCH
+
 enum StopwatchStatus {
-  STPWTCH_STOPPED = 0x0,
-  STPWTCH_RUNNING = 0x1,
-  STPWTCH_PAUSED  = 0x2
+  STPWTCH_STOPPED,
+  STPWTCH_RUNNING,
+  STPWTCH_PAUSED
 };
 
 /**
@@ -94,6 +99,16 @@ class Stopwatch {
      * @return uint16_t
      */
     uint16_t duration();
+
+    #if ENABLED(DEBUG_STOPWATCH)
+
+      /**
+       * @brief Prints a debug message
+       * @details Prints a simple debug message "Stopwatch::function"
+       */
+      static void debug(const char func[]);
+
+    #endif
 };
 
 #endif //STOPWATCH_H

--- a/Marlin/twibus.cpp
+++ b/Marlin/twibus.cpp
@@ -28,7 +28,7 @@
 
 #include <Wire.h>
 
-TWIBus::twibus() {
+TWIBus::TWIBus() {
   Wire.begin(); // We use no address so we will join the BUS as the master
   this->reset();
 }

--- a/Marlin/twibus.cpp
+++ b/Marlin/twibus.cpp
@@ -42,25 +42,26 @@ void TWIBus::reset() {
 void TWIBus::address(uint8_t addr) {
   this->addr = addr;
 
-  if (DEBUGGING(INFO)) {
-    SERIAL_ECHOPAIR("TWIBus::sendto: ", this->addr);
-    SERIAL_EOL;
-  }
+  #if ENABLED(DEBUG_TWIBUS)
+    debug(PSTR("sendto"), this->addr);
+  #endif
 }
 
 void TWIBus::addbyte(char c) {
   if (buffer_s >= sizeof(this->buffer)) return;
   this->buffer[this->buffer_s++] = c;
 
-  if (DEBUGGING(INFO)) {
-    SERIAL_ECHOPAIR("TWIBus::addbyte: ", this->buffer[this->buffer_s -1]);
-    SERIAL_EOL;
-  }
+  #if ENABLED(DEBUG_TWIBUS)
+    debug(PSTR("addbyte"), this->buffer[this->buffer_s - 1]);
+  #endif
 }
 
 void TWIBus::send() {
   if (!this->addr) return;
-  if (DEBUGGING(INFO)) SERIAL_ECHOLNPGM("TWIBus::send()");
+
+  #if ENABLED(DEBUG_TWIBUS)
+    debug(PSTR("send()"));
+  #endif
 
   Wire.beginTransmission(this->addr);
   Wire.write(this->buffer, this->buffer_s);
@@ -72,10 +73,10 @@ void TWIBus::send() {
 
 void TWIBus::reqbytes(uint8_t bytes) {
   if (!this->addr) return;
-  if (DEBUGGING(INFO)) {
-    SERIAL_ECHOPAIR("TWIBus::reqbytes(): ", bytes);
-    SERIAL_EOL;
-  }
+
+  #if ENABLED(DEBUG_TWIBUS)
+    debug(PSTR("reqbytes"), bytes);
+  #endif
 
   millis_t t = millis() + this->timeout;
   Wire.requestFrom(this->addr, bytes);
@@ -100,5 +101,18 @@ void TWIBus::reqbytes(uint8_t bytes) {
   // Reset the buffer after sending the data
   this->reset();
 }
+
+#if ENABLED(DEBUG_TWIBUS)
+
+  void TWIBus::debug(const char func[], int32_t val/*=-1*/) {
+    if (DEBUGGING(INFO)) {
+      SERIAL_ECHOPGM("TWIBus::");
+      serialprintPGM(func);
+      if (val >= 0) SERIAL_ECHOPAIR(": ", val);
+      SERIAL_EOL;
+    }
+  }
+
+#endif
 
 #endif //EXPERIMENTAL_I2CBUS

--- a/Marlin/twibus.h
+++ b/Marlin/twibus.h
@@ -23,6 +23,11 @@
 #ifndef TWIBUS_H
 #define TWIBUS_H
 
+#include "macros.h"
+
+// Print debug messages with M111 S2 (Uses 236 bytes of PROGMEM)
+//#define DEBUG_TWIBUS
+
 /**
  * TWIBUS class
  *
@@ -117,6 +122,16 @@ class TWIBus {
      * @param bytes the number of bytes to request
      */
     void reqbytes(uint8_t bytes);
+
+    #if ENABLED(DEBUG_TWIBUS)
+
+      /**
+       * @brief Prints a debug message
+       * @details Prints a simple debug message "TWIBus::function: value"
+       */
+      static void debug(const char func[], int32_t val = -1);
+
+    #endif
 };
 
 #endif //TWIBUS_H


### PR DESCRIPTION
- Fix a typo in the `TWIBus` constructor name so `TWIBus` can compile
- Reduce PROGMEM usage with static `debug` methods that reduce redundancies
- Make debug output an optional feature of these classes and disable by default
