### PR TITLE
Define dependencies for Z_SAFE_HOMING if left out

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -368,6 +368,24 @@
   #endif
 
   /**
+   * Z Safe Homing dependencies
+   */
+  #if ENABLED(Z_SAFE_HOMING)
+    #ifndef X_PROBE_OFFSET_FROM_EXTRUDER
+      #define X_PROBE_OFFSET_FROM_EXTRUDER 0
+    #endif
+    #ifndef Y_PROBE_OFFSET_FROM_EXTRUDER
+      #define Y_PROBE_OFFSET_FROM_EXTRUDER 0
+    #endif
+    #ifndef Z_PROBE_OFFSET_FROM_EXTRUDER
+      #define Z_PROBE_OFFSET_FROM_EXTRUDER 0
+    #endif
+    #ifndef XY_TRAVEL_SPEED
+      #define XY_TRAVEL_SPEED 4000
+    #endif
+  #endif
+
+  /**
    * Enable MECHANICAL_PROBE for Z_PROBE_ALLEN_KEY, for older configs
    */
   #if ENABLED(Z_PROBE_ALLEN_KEY)


### PR DESCRIPTION
Followup to #3576 to allow compiling with `Z_SAFE_HOMING` but no ABL.
