### PR TITLE
Renamed stopwatch::status to stopwatch::state

### DIFF
--- a/Marlin/stopwatch.cpp
+++ b/Marlin/stopwatch.cpp
@@ -34,7 +34,7 @@ void Stopwatch::stop() {
 
   if (!this->isRunning()) return;
 
-  this->status = STPWTCH_STOPPED;
+  this->state = STPWTCH_STOPPED;
   this->stopTimestamp = millis();
 }
 
@@ -45,7 +45,7 @@ void Stopwatch::pause() {
 
   if (!this->isRunning()) return;
 
-  this->status = STPWTCH_PAUSED;
+  this->state = STPWTCH_PAUSED;
   this->stopTimestamp = millis();
 }
 
@@ -59,7 +59,7 @@ void Stopwatch::start() {
   if (this->isPaused()) this->accumulator = this->duration();
   else this->reset();
 
-  this->status = STPWTCH_RUNNING;
+  this->state = STPWTCH_RUNNING;
   this->startTimestamp = millis();
 }
 
@@ -68,18 +68,18 @@ void Stopwatch::reset() {
     debug(PSTR("reset"));
   #endif
 
-  this->status = STPWTCH_STOPPED;
+  this->state = STPWTCH_STOPPED;
   this->startTimestamp = 0;
   this->stopTimestamp = 0;
   this->accumulator = 0;
 }
 
 bool Stopwatch::isRunning() {
-  return (this->status == STPWTCH_RUNNING) ? true : false;
+  return (this->state == STPWTCH_RUNNING) ? true : false;
 }
 
 bool Stopwatch::isPaused() {
-  return (this->status == STPWTCH_PAUSED) ? true : false;
+  return (this->state == STPWTCH_PAUSED) ? true : false;
 }
 
 uint16_t Stopwatch::duration() {

--- a/Marlin/stopwatch.h
+++ b/Marlin/stopwatch.h
@@ -28,7 +28,7 @@
 // Print debug messages with M111 S2 (Uses 156 bytes of PROGMEM)
 //#define DEBUG_STOPWATCH
 
-enum StopwatchStatus {
+enum StopwatchState {
   STPWTCH_STOPPED,
   STPWTCH_RUNNING,
   STPWTCH_PAUSED
@@ -41,7 +41,7 @@ enum StopwatchStatus {
  */
 class Stopwatch {
   private:
-    StopwatchStatus status;
+    StopwatchState state;
     uint16_t accumulator;
     uint32_t startTimestamp;
     uint32_t stopTimestamp;


### PR DESCRIPTION
Using `state` instead of `status` for the `StopWatch` state machine as suggested by @CONSULitAS.
