### PR TITLE
Fix an acceleration anomaly by making locals signed

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -941,7 +941,7 @@ float junction_deviation = 0.1;
 
   // Compute and limit the acceleration rate for the trapezoid generator.
   float steps_per_mm = block->step_event_count / block->millimeters;
-  unsigned long bsx = block->steps[X_AXIS], bsy = block->steps[Y_AXIS], bsz = block->steps[Z_AXIS], bse = block->steps[E_AXIS];
+  long bsx = block->steps[X_AXIS], bsy = block->steps[Y_AXIS], bsz = block->steps[Z_AXIS], bse = block->steps[E_AXIS];
   if (bsx == 0 && bsy == 0 && bsz == 0) {
     block->acceleration_st = ceil(retract_acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
   }


### PR DESCRIPTION
Since `block->steps[]` is signed, this should be signed too, apparently. #3614 proposed an alternate solution.
