### PR TITLE
Fix an acceleration anomaly by making block->steps unsigned

### DIFF
--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -52,7 +52,7 @@
 // the source g-code and may never actually be reached if acceleration management is active.
 typedef struct {
   // Fields used by the bresenham algorithm for tracing the line
-  long steps[NUM_AXIS];                     // Step count along each axis
+  unsigned long steps[NUM_AXIS];            // Step count along each axis
   unsigned long step_event_count;           // The number of step events required to complete this block
   long accelerate_until;                    // The index of the step event on which to stop acceleration
   long decelerate_after;                    // The index of the step event on which to start decelerating


### PR DESCRIPTION
An acceleration issue appears to be caused by conflicting signedness of `block->steps` and locals used in the acceleration handler. Can `block-steps[]` simply be made `unsigned long`? Why is it signed?
#3613 proposed an alternate solution.
