### PR TITLE
Print job statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -139,7 +139,7 @@ script:
   ### I2C PANELS ###
   #
   # LCD_I2C_SAINSMART_YWROBOT
-  # Failing at the moment needs different library 
+  # Failing at the moment needs different library
   #- restore_configs
   #- opt_enable LCD_I2C_SAINSMART_YWROBOT
   #- build_marlin
@@ -197,6 +197,12 @@ script:
   - opt_enable_adv Z_DUAL_STEPPER_DRIVERS Z_DUAL_ENDSTOPS
   - pins_set RAMPS_14 X_MAX_PIN -1
   - opt_set_adv Z2_MAX_PIN 2
+  - build_marlin
+  #
+  # Test PRINTCOUNTER
+  #
+  - restore_configs
+  - opt_enable PRINTCOUNTER
   - build_marlin
   #
   #

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -763,7 +763,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -757,6 +757,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -65,7 +65,11 @@ typedef unsigned long millis_t;
 
 #include "WString.h"
 
-#include "stopwatch.h"
+#if ENABLED(PRINTCOUNTER)
+  #include "printcounter.h"
+#else
+  #include "stopwatch.h"
+#endif
 
 #ifdef USBCON
   #if ENABLED(BLUETOOTH)
@@ -364,7 +368,11 @@ extern bool axis_homed[3]; // axis[n].is_homed
 #endif
 
 // Print job timer
-extern Stopwatch print_job_timer;
+#if ENABLED(PRINTCOUNTER)
+  extern PrintCounter print_job_timer;
+#else
+  extern Stopwatch print_job_timer;
+#endif
 
 // Handling multiple extruders pins
 extern uint8_t active_extruder;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -137,6 +137,10 @@
  * M33  - Get the longname version of a path
  * M42  - Change pin status via gcode Use M42 Px Sy to set pin x to value y, when omitting Px the onboard led will be used.
  * M48  - Measure Z_Probe repeatability. M48 [P # of points] [X position] [Y position] [V_erboseness #] [E_ngage Probe] [L # of legs of travel]
+ * M75  - Start the print job timer
+ * M76  - Pause the print job timer
+ * M77  - Stop the print job timer
+ * M78  - Show statistical information about the print jobs
  * M80  - Turn on Power Supply
  * M81  - Turn off Power Supply
  * M82  - Set E codes absolute (default)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -327,7 +327,11 @@ static millis_t max_inactive_time = 0;
 static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
 
 // Print Job Timer
-Stopwatch print_job_timer = Stopwatch();
+#if ENABLED(PRINTCOUNTER)
+  PrintCounter print_job_timer = PrintCounter();
+#else
+  Stopwatch print_job_timer = Stopwatch();
+#endif
 
 static uint8_t target_extruder;
 
@@ -4252,6 +4256,15 @@ inline void gcode_M77() {
   print_job_timer.stop();
 }
 
+#if ENABLED(PRINTCOUNTER)
+  /*+
+   * M78: Show print statistics
+   */
+  inline void gcode_M78() {
+    print_job_timer.showStats();
+  }
+#endif
+
 /**
  * M104: Set hot end temperature
  */
@@ -6636,6 +6649,12 @@ void process_next_command() {
         gcode_M77();
         break;
 
+      #if ENABLED(PRINTCOUNTER)
+        case 78: // Show print statistics
+          gcode_M78();
+          break;
+      #endif
+
       #if ENABLED(M100_FREE_MEMORY_WATCHER)
         case 100:
           gcode_M100();
@@ -7750,6 +7769,9 @@ void idle(
   );
   host_keepalive();
   lcd_update();
+  #if ENABLED(PRINTCOUNTER)
+      print_job_timer.tick();
+  #endif
 }
 
 /**

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -739,6 +739,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -745,7 +745,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -748,6 +748,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -754,7 +754,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -756,7 +756,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -750,6 +750,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP    110
 #define ABS_PREHEAT_FAN_SPEED   0   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -779,7 +779,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -773,6 +773,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 60 // K8200: set back to 110 if you have an upgraded heatbed power supply
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -762,7 +762,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -756,6 +756,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -757,7 +757,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1,4 +1,4 @@
-/**
+f/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -750,6 +750,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HOTEND_TEMP 240
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
+
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
 
 //=============================================================================
 //============================= LCD and SD support ============================

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -764,6 +764,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -770,7 +770,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -777,6 +777,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -783,7 +783,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -748,6 +748,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -754,7 +754,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -762,7 +762,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -756,6 +756,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -885,6 +885,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -891,7 +891,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -885,6 +885,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -891,7 +891,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -889,6 +889,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -895,7 +895,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -882,6 +882,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -888,7 +888,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -896,7 +896,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -890,6 +890,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -765,7 +765,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -759,6 +759,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -750,6 +750,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+
+//
+// Print Counter
+//
+// When enabled Marlin will keep track of some print statistical data such as:
+//  - Total print jobs
+//  - Total successfull print jobs
+//  - Total failed print jobs
+//  - Total time printing
+//
+// This information can be viewed by the M78 command.
+//#define PRINTCOUNTER
+
 //=============================================================================
 //============================= LCD and SD support ============================
 //=============================================================================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -756,7 +756,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // When enabled Marlin will keep track of some print statistical data such as:
 //  - Total print jobs
-//  - Total successfull print jobs
+//  - Total successful print jobs
 //  - Total failed print jobs
 //  - Total time printing
 //

--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -1,0 +1,109 @@
+/*
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Marlin.h"
+#include "printcounter.h"
+#include <avr/eeprom.h>
+
+PrintCounter::PrintCounter(): super() {}
+
+void PrintCounter::tick() {
+  if (!this->isRunning()) return;
+
+  static uint32_t update_before = millis(),
+                  eeprom_before = millis();
+
+  uint32_t now = millis();
+
+  // Trying to get the amount of calculations down to the bare min
+  const static uint16_t i = this->updateInterval * 1000;
+
+  if (now - update_before >= i) {
+    //this->addToTimeCounter((uint16_t) (now - update_before) / 1000);
+    update_before = now;
+    PrintCounter::debug(PSTR("tick1"));
+  }
+
+  // Trying to get the amount of calculations down to the bare min
+  const static uint16_t j = this->saveInterval * 1000;
+
+  if (now - eeprom_before >= j) {
+    eeprom_before = now;
+    this->save();
+  }
+}
+
+void PrintCounter::load() {
+  uint16_t pos = this->addr;
+
+  this->data.successPrints= eeprom_read_word ((uint16_t*) pos);
+  this->data.failedPrints = eeprom_read_word ((uint16_t*) pos);
+  this->data.printTime    = eeprom_read_dword((uint32_t*) pos);
+  this->data.longestPrint = eeprom_read_dword((uint32_t*) pos);
+
+  SERIAL_ECHOPGM("successPrints: ");
+  SERIAL_ECHOLN(this->data.successPrints);
+
+  SERIAL_ECHOPGM("failedPrints: ");
+  SERIAL_ECHOLN(this->data.failedPrints);
+
+  SERIAL_ECHOPGM("printTime: ");
+  SERIAL_ECHOLN(this->data.printTime);
+
+  SERIAL_ECHOPGM("longestPrint: ");
+  SERIAL_ECHOLN(this->data.longestPrint);
+}
+
+void PrintCounter::save() {
+  #if ENABLED(DEBUG_PRINTCOUNTER)
+    PrintCounter::debug(PSTR("save"));
+  #endif
+
+  uint16_t pos = this->addr;
+
+  eeprom_write_word ((uint16_t*) pos, this->data.successPrints);
+  eeprom_write_word ((uint16_t*) pos, this->data.failedPrints);
+  eeprom_write_dword((uint32_t*) pos, this->data.printTime);
+  eeprom_write_dword((uint32_t*) pos, this->data.longestPrint);
+}
+
+void PrintCounter::start() {
+  super::start();
+  this->load();
+}
+
+void PrintCounter::stop() {
+  super::stop();
+  this->save();
+}
+
+#if ENABLED(DEBUG_PRINTCOUNTER)
+
+  void PrintCounter::debug(const char func[]) {
+    if (DEBUGGING(INFO)) {
+      SERIAL_ECHOPGM("PrintCounter::");
+      serialprintPGM(func);
+      SERIAL_ECHOLNPGM("()");
+    }
+  }
+
+#endif

--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -51,7 +51,7 @@ void PrintCounter::initStats() {
   this->data = { 0, 0, 0, 0 };
 
   this->saveStats();
-  eeprom_write_byte((uint8_t*) this->addr, 0x16);
+  eeprom_write_byte((uint8_t *) this->address, 0x16);
 }
 
 void PrintCounter::loadStats() {
@@ -60,8 +60,8 @@ void PrintCounter::loadStats() {
   #endif
 
   // Checks if the EEPROM block is initialized
-  if (eeprom_read_byte((uint8_t*) this->addr) != 0x16) this->initStats();
-  else eeprom_read_block(&this->data, (void *)(this->addr + sizeof(uint8_t)), sizeof(printStatistics));
+  if (eeprom_read_byte((uint8_t *) this->address) != 0x16) this->initStats();
+  else eeprom_read_block(&this->data, (void *)(this->address + sizeof(uint8_t)), sizeof(printStatistics));
 
   this->loaded = true;
 }
@@ -74,7 +74,7 @@ void PrintCounter::saveStats() {
   // Refuses to save data is object is not loaded
   if (!this->isLoaded()) return;
 
-  eeprom_write_block(&this->data, (void *)(this->addr + sizeof(uint8_t)), sizeof(printStatistics));
+  eeprom_update_block(&this->data, (void *)(this->address + sizeof(uint8_t)), sizeof(printStatistics));
 }
 
 void PrintCounter::showStats() {

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -71,7 +71,7 @@ class PrintCounter: public Stopwatch {
      * EEPROM save cycle, the development team recommends to set this value
      * no lower than 3600 secs (1 hour).
      */
-    const uint16_t saveInterval = PRINTCOUNTER_SAVE_INTERVAL;
+    const uint16_t saveInterval = 3600;
 
     /**
      * @brief Stats were loaded from EERPROM

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -47,13 +47,12 @@ class PrintCounter: public Stopwatch {
      * @brief EEPROM address
      * @details Defines the start offset address where the data is stored.
      */
-    const uint16_t addr = 50;
+    const uint16_t address = 0x32;
 
     /**
      * @brief Interval in seconds between counter updates
      * @details This const value defines what will be the time between each
-     * accumulator update. This is different from the EEPROM save interval
-     * which is user defined at the Configuration.h file.
+     * accumulator update. This is different from the EEPROM save interval.
      */
     const uint16_t updateInterval = 10;
 

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -27,7 +27,7 @@
 #include "stopwatch.h"
 
 // Print debug messages with M111 S2
-#define DEBUG_PRINTCOUNTER
+//#define DEBUG_PRINTCOUNTER
 
 struct printStatistics {    // 13 bytes
   //uint8_t  magic;         // Magic header, it will always be 0x16

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -1,0 +1,93 @@
+/*
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef PRINTCOUNTER_H
+#define PRINTCOUNTER_H
+
+#include "macros.h"
+#include "stopwatch.h"
+
+// Print debug messages with M111 S2
+#define DEBUG_PRINTCOUNTER
+
+struct printStatistics {  // 12 bytes
+  uint16_t successPrints; // Total number of prints
+  uint16_t failedPrints;  // Total number of aborted prints - not in use
+  uint32_t printTime;     // Total time printing
+  uint32_t longestPrint;  // Longest print job - not in use
+};
+
+class PrintCounter: public Stopwatch {
+  private:
+    typedef Stopwatch super;
+
+    printStatistics data;
+
+    /**
+     * @brief EEPROM address
+     * @details Defines the start offset address where the data is stored.
+     */
+    const uint16_t addr = 60;
+
+    /**
+     * @brief Interval in seconds between counter updates
+     * @details This const value defines what will be the time between each
+     * accumulator update. This is different from the EEPROM save interval
+     * which is user defined at the Configuration.h file.
+     */
+    const uint16_t updateInterval = 2;
+
+    /**
+     * @brief Interval in seconds between EEPROM saves
+     * @details This const value defines what will be the time between each
+     * EEPROM save cycle, the development team recommends to set this value
+     * no lower than 3600 secs (1 hour).
+     */
+    const uint16_t saveInterval = PRINTCOUNTER_SAVE_INTERVAL;
+
+  public:
+    /**
+     * @brief Class constructor
+     */
+    PrintCounter();
+
+    void tick();
+    void save();
+    void load();
+    void addToTimeCounter(uint16_t const &minutes);
+    void addToPrintCounter(uint8_t const &prints);
+
+    void start();
+    void stop();
+
+    #if ENABLED(DEBUG_PRINTCOUNTER)
+
+      /**
+       * @brief Prints a debug message
+       * @details Prints a simple debug message "PrintCounter::function"
+       */
+      static void debug(const char func[]);
+
+    #endif
+};
+
+#endif // PRINTCOUNTER_H

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -30,7 +30,7 @@
 //#define DEBUG_PRINTCOUNTER
 
 struct printStatistics {    // 13 bytes
-  //uint8_t  magic;         // Magic header, it will always be 0x16
+  //const uint8_t magic;    // Magic header, it will always be 0x16
   uint16_t totalPrints;     // Number of prints
   uint16_t finishedPrints;  // Number of complete prints
   uint32_t printTime;       // Total printing time
@@ -42,14 +42,6 @@ class PrintCounter: public Stopwatch {
     typedef Stopwatch super;
 
     printStatistics data;
-
-    /**
-     * @brief Timestamp of the last update
-     * @details Stores the timestamp of the last data.pritnTime update, when the
-     * print job finishes, this will be used to calculate the exact time elapsed,
-     * this is required due to the updateInterval cycle.
-     */
-    uint16_t lastUpdate;
 
     /**
      * @brief EEPROM address
@@ -74,11 +66,27 @@ class PrintCounter: public Stopwatch {
     const uint16_t saveInterval = 3600;
 
     /**
+     * @brief Timestamp of the last call to deltaDuration()
+     * @details Stores the timestamp of the last deltaDuration(), this is
+     * required due to the updateInterval cycle.
+     */
+    uint16_t lastDuration;
+
+    /**
      * @brief Stats were loaded from EERPROM
      * @details If set to true it indicates if the statistical data was already
      * loaded from the EEPROM.
      */
     bool loaded = false;
+
+  protected:
+    /**
+     * @brief dT since the last call
+     * @details Returns the elapsed time in seconds since the last call, this is
+     * used internally for print statistics accounting is not intended to be a
+     * user callable function.
+     */
+    uint16_t deltaDuration();
 
   public:
     /**

--- a/Marlin/stopwatch.cpp
+++ b/Marlin/stopwatch.cpp
@@ -29,7 +29,7 @@ Stopwatch::Stopwatch() {
 
 void Stopwatch::stop() {
   #if ENABLED(DEBUG_STOPWATCH)
-    debug(PSTR("stop"));
+    Stopwatch::debug(PSTR("stop"));
   #endif
 
   if (!this->isRunning()) return;
@@ -40,7 +40,7 @@ void Stopwatch::stop() {
 
 void Stopwatch::pause() {
   #if ENABLED(DEBUG_STOPWATCH)
-    debug(PSTR("pause"));
+    Stopwatch::debug(PSTR("pause"));
   #endif
 
   if (!this->isRunning()) return;
@@ -51,7 +51,7 @@ void Stopwatch::pause() {
 
 void Stopwatch::start() {
   #if ENABLED(DEBUG_STOPWATCH)
-    debug(PSTR("start"));
+    Stopwatch::debug(PSTR("start"));
   #endif
 
   if (this->isRunning()) return;
@@ -65,7 +65,7 @@ void Stopwatch::start() {
 
 void Stopwatch::reset() {
   #if ENABLED(DEBUG_STOPWATCH)
-    debug(PSTR("reset"));
+    Stopwatch::debug(PSTR("reset"));
   #endif
 
   this->state = STPWTCH_STOPPED;


### PR DESCRIPTION
Fixes #1971

This PR introduces Print Statistics, by default they are disabled, to turn them on the user must `#define PRINTCOUNTER` in `Configuration.h`.

``` cpp
//
// Print Counter
//
// When enabled Marlin will keep track of some print statistical data such as:
//  - Total print jobs
//  - Total successful print jobs
//  - Total failed print jobs
//  - Total time printing
//
// This information can be viewed by the M78 command.
```

A sample output of the M78 command:

```
M78
Print statistics: Total: 3, Finished: 2, Failed: 1, Total print time: 3h 2min
ok
```

~~Note: Still pending the update of the example configuration files.~~
