### PR TITLE
Correct an error in lang_de

### DIFF
--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -102,8 +102,8 @@
 #define MSG_VMIN                            "V min"
 #define MSG_VTRAV_MIN                       "VTrav min"
 #define MSG_AMAX                            "A max " // space by purpose
-#define MSG_A_RETRACT                       "A Retract"
-#define MSG_A_TRAVEL                        "A Rückzug"
+#define MSG_A_RETRACT                       "A Rückzug"
+#define MSG_A_TRAVEL                        "A Reise"
 #define MSG_XSTEPS                          "X steps/mm"
 #define MSG_YSTEPS                          "Y steps/mm"
 #define MSG_ZSTEPS                          "Z steps/mm"


### PR DESCRIPTION
There is no way to translate "A-travel" to "A Rückzug". That's simply wrong.

Für mich ist die deutsche Übersetzung, zur Zeit, völlig unbrauchbar.
- Sie ist inconsistent.
- Sie ist völlig über-übersetz. Fachworte wie "jerk" oder "retract" mit "Ruck" oder "Rückzug" zu übersetzen halte ich für fahrlässig. Habt ihr schon mal versucht nach "Ruck" zu googeln und eine vernünftige, 3D-Drucker bezogene, Antwort gefunden? Oder "Rückzug", oder ...
- Fehlermeldungen sollten ins Auge springen.

So wie es zur Zeit ist, würde ich jedem deutschen Anfänger empfehlen die Englische Version zu benutzen.
Solange thinkyhead jeden Scheiß, ohne Diskussion, merged (Entschuldigung einpflegt) bin ich aber nicht bereit mehr Arbeit in die Übersetzung zu stecken.
