### PR TITLE
Auto Filament Change Reworked: finally working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,10 +162,10 @@ script:
   - opt_enable LCM1602
   - build_marlin
   #
-  # Enable FILAMENTCHANGEENABLE
+  # Enable FILAMENT_CHANGE_ENABLE
   #
   - restore_configs
-  - opt_enable FILAMENTCHANGEENABLE ULTIMAKERCONTROLLER
+  - opt_enable FILAMENT_CHANGE_ENABLE ULTIMAKERCONTROLLER
   - build_marlin
   #
   # Enable filament sensor

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -506,16 +506,30 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 
 // Add support for experimental filament exchange support M600; requires display
 #if ENABLED(ULTIPANEL)
-  //#define FILAMENTCHANGEENABLE
-  #if ENABLED(FILAMENTCHANGEENABLE)
-    #define FILAMENTCHANGE_XPOS 3
-    #define FILAMENTCHANGE_YPOS 3
-    #define FILAMENTCHANGE_ZADD 10
-    #define FILAMENTCHANGE_FIRSTRETRACT -2
-    #define FILAMENTCHANGE_FINALRETRACT -100
-    #define AUTO_FILAMENT_CHANGE                //This extrude filament until you press the button on LCD
-    #define AUTO_FILAMENT_CHANGE_LENGTH 0.04    //Extrusion length on automatic extrusion loop
-    #define AUTO_FILAMENT_CHANGE_FEEDRATE 300   //Extrusion feedrate (mm/min) on automatic extrusion loop
+  #define FILAMENT_CHANGE_ENABLE                // Enable filament exchange menu and M600 g-code (used for runout sensor too)
+  #if ENABLED(FILAMENT_CHANGE_ENABLE)
+    #define FILAMENT_CHANGE_X_POS 3             // X position of hotend
+    #define FILAMENT_CHANGE_Y_POS 3             // Y position of hotend
+    #define FILAMENT_CHANGE_Z_ADD 10            // Z addition of hotend (lift)
+    #define FILAMENT_CHANGE_XY_FEEDRATE 100     // X and Y axes feedrate in mm/s (also used for delta printers Z axis)
+    #define FILAMENT_CHANGE_Z_FEEDRATE 5        // Z axis feedrate in mm/s (not used for delta printers)
+    #define FILAMENT_CHANGE_RETRACT_LENGTH 2    // Initial retract in mm
+                                                // It is a short retract used immediately after print interrupt before move to filament exchange position
+    #define FILAMENT_CHANGE_RETRACT_FEEDRATE 60 // Initial retract feedrate in mm/s
+    #define FILAMENT_CHANGE_UNLOAD_LENGTH 100   // Unload filament length from hotend in mm
+                                                // Longer length for bowden printers to unload filament from whole bowden tube,
+                                                // shorter lenght for printers without bowden to unload filament from extruder only,
+                                                // 0 to disable unloading for manual unloading
+    #define FILAMENT_CHANGE_UNLOAD_FEEDRATE 10  // Unload filament feedrate in mm/s - filament unloading can be fast
+    #define FILAMENT_CHANGE_LOAD_LENGTH 0       // Load filament length over hotend in mm
+                                                // Longer length for bowden printers to fast load filament into whole bowden tube over the hotend,
+                                                // Short or zero length for printers without bowden where loading is not used
+    #define FILAMENT_CHANGE_LOAD_FEEDRATE 10    // Load filament feedrate in mm/s - filament loading into the bowden tube can be fast
+    #define FILAMENT_CHANGE_EXTRUDE_LENGTH 50   // Extrude filament length in mm after filament is load over the hotend,
+                                                // 0 to disable for manual extrusion
+                                                // Filament can be extruded repeatedly from the filament exchange menu to fill the hotend,
+                                                // or until outcoming filament color is not clear for filament color change
+    #define FILAMENT_CHANGE_EXTRUDE_FEEDRATE 3  // Extrude filament feedrate in mm/s - must be slower than load feedrate
   #endif
 #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -506,7 +506,7 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 
 // Add support for experimental filament exchange support M600; requires display
 #if ENABLED(ULTIPANEL)
-  #define FILAMENT_CHANGE_ENABLE                // Enable filament exchange menu and M600 g-code (used for runout sensor too)
+  // #define FILAMENT_CHANGE_ENABLE             // Enable filament exchange menu and M600 g-code (used for runout sensor too)
   #if ENABLED(FILAMENT_CHANGE_ENABLE)
     #define FILAMENT_CHANGE_X_POS 3             // X position of hotend
     #define FILAMENT_CHANGE_Y_POS 3             // Y position of hotend

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -354,9 +354,9 @@ extern bool axis_homed[3]; // axis[n].is_homed
 
 #if ENABLED(FILAMENT_CHANGE_ENABLE)
   enum FilamentChangeMenuResponse {
-    FILAMENT_CHANGE_RESPONSE_WAIT_FOR = 0,
-    FILAMENT_CHANGE_RESPONSE_EXTRUDE_MORE = 1,
-    FILAMENT_CHANGE_RESPONSE_RESUME_PRINT = 2
+    FILAMENT_CHANGE_RESPONSE_WAIT_FOR,
+    FILAMENT_CHANGE_RESPONSE_EXTRUDE_MORE,
+    FILAMENT_CHANGE_RESPONSE_RESUME_PRINT
   };
   extern FilamentChangeMenuResponse filament_change_menu_response;
 #endif

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -123,8 +123,8 @@ FORCE_INLINE void serialprintPGM(const char* str) {
 }
 
 void idle(
-  #if ENABLED(FILAMENTCHANGEENABLE)
-    bool no_stepper_sleep=false  // pass true to keep steppers from disabling on timeout
+  #if ENABLED(FILAMENT_CHANGE_ENABLE)
+    bool no_stepper_sleep = false  // pass true to keep steppers from disabling on timeout
   #endif
 );
 
@@ -350,6 +350,15 @@ extern bool axis_homed[3]; // axis[n].is_homed
   extern int8_t measurement_delay[];  //ring buffer to delay measurement
   extern int filwidth_delay_index1, filwidth_delay_index2;  //ring buffer index. used by planner, temperature, and main code
   extern int meas_delay_cm; //delay distance
+#endif
+
+#if ENABLED(FILAMENT_CHANGE_ENABLE)
+  enum FilamentChangeMenuResponse {
+    FILAMENT_CHANGE_RESPONSE_WAIT_FOR = 0,
+    FILAMENT_CHANGE_RESPONSE_EXTRUDE_MORE = 1,
+    FILAMENT_CHANGE_RESPONSE_RESUME_PRINT = 2
+  };
+  extern FilamentChangeMenuResponse filament_change_menu_response;
 #endif
 
 #if ENABLED(PID_ADD_EXTRUSION_RATE)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6100,13 +6100,13 @@ inline void gcode_M503() {
     lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INSERT);
   
     while (!lcd_clicked()) {
-      millis_t ms = millis();
-      if (ms >= next_tick) {
-        #if HAS_BUZZER
+      #if HAS_BUZZER
+        millis_t ms = millis();
+        if (ms >= next_tick) {
           buzz(300, 2000);
-        #endif
-        next_tick = ms + 2500; // Beep every 2.5s while waiting
-      }
+          next_tick = ms + 2500; // Beep every 2.5s while waiting
+        }
+      #endif
       idle(true);
     }
     delay(100);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1,4 +1,4 @@
-filasme/**
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -449,6 +449,10 @@ static uint8_t target_extruder;
   static bool filament_ran_out = false;
 #endif
 
+#if ENABLED(FILAMENT_CHANGE_ENABLE)
+  FilamentChangeMenuResponse filament_change_menu_response;
+#endif
+
 static bool send_ok[BUFSIZE];
 
 #if HAS_SERVOS
@@ -5997,7 +6001,7 @@ inline void gcode_M503() {
 
 #endif // CUSTOM_M_CODE_SET_Z_PROBE_OFFSET
 
-#if ENABLED(FILAMENTCHANGEENABLE)
+#if ENABLED(FILAMENT_CHANGE_ENABLE)
 
   /**
    * M600: Pause for filament change
@@ -6013,135 +6017,164 @@ inline void gcode_M503() {
    */
   inline void gcode_M600() {
 
+    // Show initial message and wait for synchronize steppers
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INIT);
+    st_synchronize();
+  
     if (degHotend(active_extruder) < extrude_min_temp) {
       SERIAL_ERROR_START;
       SERIAL_ERRORLNPGM(MSG_TOO_COLD_FOR_M600);
       return;
     }
-
+  
     float lastpos[NUM_AXIS];
-    #if ENABLED(DELTA)
-      float fr60 = feedrate / 60;
-    #endif
-
+  
+    // Save current position of all axes
     for (int i = 0; i < NUM_AXIS; i++)
       lastpos[i] = destination[i] = current_position[i];
-
+  
+    // Define runplan for move axes
     #if ENABLED(DELTA)
       #define RUNPLAN calculate_delta(destination); \
-                      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], fr60, active_extruder);
+        plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], FILAMENT_CHANGE_XY_FEEDRATE * 60, active_extruder);
     #else
-      #define RUNPLAN line_to_destination();
+      #define RUNPLAN line_to_destination(FILAMENT_CHANGE_XY_FEEDRATE * 60);
     #endif
-
-    //retract by E
+  
+    KEEPALIVE_STATE(IN_HANDLER);
+  
+    // Initial retract before move to filament change position
     if (code_seen('E')) destination[E_AXIS] += code_value();
-    #ifdef FILAMENTCHANGE_FIRSTRETRACT
-      else destination[E_AXIS] += FILAMENTCHANGE_FIRSTRETRACT;
-    #endif
-
-    RUNPLAN;
-
-    //lift Z
+      #ifdef FILAMENT_CHANGE_RETRACT_LENGTH
+        else destination[E_AXIS] -= FILAMENT_CHANGE_RETRACT_LENGTH;
+      #endif
+    line_to_destination(FILAMENT_CHANGE_RETRACT_FEEDRATE * 60);
+  
+    // Lift Z axis
     if (code_seen('Z')) destination[Z_AXIS] += code_value();
-    #ifdef FILAMENTCHANGE_ZADD
-      else destination[Z_AXIS] += FILAMENTCHANGE_ZADD;
+      #ifdef FILAMENT_CHANGE_Z_ADD
+        else destination[Z_AXIS] += FILAMENT_CHANGE_Z_ADD;
+      #endif
+    // RUNPLAN;
+    #if ENABLED(DELTA)
+      // calculate_delta(destination);
+      // plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], FILAMENT_CHANGE_XY_FEEDRATE * 60, active_extruder);
+      RUNPLAN;
+    #else
+      line_to_destination(FILAMENT_CHANGE_Z_FEEDRATE * 60);
     #endif
-
-    RUNPLAN;
-
-    //move xy
+  
+    // Move XY axes to filament exchange position
     if (code_seen('X')) destination[X_AXIS] = code_value();
-    #ifdef FILAMENTCHANGE_XPOS
-      else destination[X_AXIS] = FILAMENTCHANGE_XPOS;
-    #endif
-
+      #ifdef FILAMENT_CHANGE_X_POS
+        else destination[X_AXIS] = FILAMENT_CHANGE_X_POS;
+      #endif
     if (code_seen('Y')) destination[Y_AXIS] = code_value();
-    #ifdef FILAMENTCHANGE_YPOS
-      else destination[Y_AXIS] = FILAMENTCHANGE_YPOS;
-    #endif
-
+      #ifdef FILAMENT_CHANGE_Y_POS
+        else destination[Y_AXIS] = FILAMENT_CHANGE_Y_POS;
+      #endif
     RUNPLAN;
-
-    if (code_seen('L')) destination[E_AXIS] += code_value();
-    #ifdef FILAMENTCHANGE_FINALRETRACT
-      else destination[E_AXIS] += FILAMENTCHANGE_FINALRETRACT;
-    #endif
-
-    RUNPLAN;
-
-    //finish moves
+  
+    // Synchronize steppers and show unload message
     st_synchronize();
-    //disable extruder steppers so filament can be removed
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_UNLOAD);
+  
+    // Unload filament
+    if (code_seen('L')) destination[E_AXIS] += code_value();
+      #ifdef FILAMENT_CHANGE_UNLOAD_LENGTH
+        else destination[E_AXIS] -= FILAMENT_CHANGE_UNLOAD_LENGTH;
+      #endif
+    line_to_destination(FILAMENT_CHANGE_UNLOAD_FEEDRATE * 60);
+  
+    // Synchronize steppers and then disable extruders steppers for manual filament changing
+    st_synchronize();
     disable_e0();
     disable_e1();
     disable_e2();
     disable_e3();
     delay(100);
-    LCD_ALERTMESSAGEPGM(MSG_FILAMENTCHANGE);
-    #if DISABLED(AUTO_FILAMENT_CHANGE)
-      millis_t next_tick = 0;
-    #endif
-    KEEPALIVE_STATE(PAUSED_FOR_USER);
+  
+    millis_t next_tick = 0;
+  
+    // Wait for filament insert by user and press button
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INSERT);
+  
     while (!lcd_clicked()) {
-      #if DISABLED(AUTO_FILAMENT_CHANGE)
-        millis_t ms = millis();
-        if (ELAPSED(ms, next_tick)) {
-          lcd_quick_feedback();
-          next_tick = ms + 2500UL; // feedback every 2.5s while waiting
-        }
-        idle(true);
-      #else
-        current_position[E_AXIS] += AUTO_FILAMENT_CHANGE_LENGTH;
-        destination[E_AXIS] = current_position[E_AXIS];
-        line_to_destination(AUTO_FILAMENT_CHANGE_FEEDRATE);
-        st_synchronize();
-      #endif
-    } // while(!lcd_clicked)
-    KEEPALIVE_STATE(IN_HANDLER);
-    lcd_quick_feedback(); // click sound feedback
-
-    #if ENABLED(AUTO_FILAMENT_CHANGE)
-      current_position[E_AXIS] = 0;
-      st_synchronize();
-    #endif
-
-    //return to normal
+      millis_t ms = millis();
+      if (ms >= next_tick) {
+        buzz(300, 2000);
+        next_tick = ms + 2500; // Beep every 2.5s while waiting
+      }
+      idle(true);
+    }
+    delay(100);
+    while (lcd_clicked()) {
+      idle(true);
+    }
+    delay(100);
+  
+    // Show load message
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_LOAD);
+  
+    // Load filament
     if (code_seen('L')) destination[E_AXIS] -= code_value();
-    #ifdef FILAMENTCHANGE_FINALRETRACT
-      else destination[E_AXIS] -= FILAMENTCHANGE_FINALRETRACT;
+      #ifdef FILAMENT_CHANGE_LOAD_LENGTH
+        else destination[E_AXIS] += FILAMENT_CHANGE_LOAD_LENGTH;
+      #endif
+    line_to_destination(FILAMENT_CHANGE_LOAD_FEEDRATE * 60);
+    st_synchronize();
+  
+    #ifdef FILAMENT_CHANGE_EXTRUDE_LENGTH
+      do {
+        // Extrude filament to get into hotend
+        KEEPALIVE_STATE(IN_HANDLER);
+        lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_EXTRUDE);
+        destination[E_AXIS] += FILAMENT_CHANGE_EXTRUDE_LENGTH;
+        line_to_destination(FILAMENT_CHANGE_EXTRUDE_FEEDRATE * 60);
+        st_synchronize();
+        // Ask user if more filament should be extruded
+        KEEPALIVE_STATE(PAUSED_FOR_USER);
+        lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_OPTION);
+        while (filament_change_menu_response == FILAMENT_CHANGE_RESPONSE_WAIT_FOR) {
+          idle(true);
+        }
+      } while (filament_change_menu_response != FILAMENT_CHANGE_RESPONSE_RESUME_PRINT);
     #endif
-
-    current_position[E_AXIS] = destination[E_AXIS]; //the long retract of L is compensated by manual filament feeding
-    sync_plan_position_e();
-
-    RUNPLAN; //should do nothing
-
-    lcd_reset_alert_level();
-
+  
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_RESUME);
+  
+    KEEPALIVE_STATE(IN_HANDLER);
+  
+    // Set extruder to saved position
+    current_position[E_AXIS] = lastpos[E_AXIS];
+    destination[E_AXIS] = lastpos[E_AXIS];
+    plan_set_e_position(current_position[E_AXIS]);
+  
     #if ENABLED(DELTA)
       // Move XYZ to starting position, then E
       calculate_delta(lastpos);
-      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], fr60, active_extruder);
-      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], lastpos[E_AXIS], fr60, active_extruder);
+      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], FILAMENT_CHANGE_XY_FEEDRATE * 60, active_extruder);
+      plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], lastpos[E_AXIS], FILAMENT_CHANGE_XY_FEEDRATE * 60, active_extruder);
     #else
       // Move XY to starting position, then Z, then E
       destination[X_AXIS] = lastpos[X_AXIS];
       destination[Y_AXIS] = lastpos[Y_AXIS];
-      line_to_destination();
+      line_to_destination(FILAMENT_CHANGE_XY_FEEDRATE * 60);
       destination[Z_AXIS] = lastpos[Z_AXIS];
-      line_to_destination();
-      destination[E_AXIS] = lastpos[E_AXIS];
-      line_to_destination();
+      line_to_destination(FILAMENT_CHANGE_Z_FEEDRATE * 60);
     #endif
-
+    st_synchronize();
+  
     #if ENABLED(FILAMENT_RUNOUT_SENSOR)
       filament_ran_out = false;
     #endif
-
+  
+    // Show status screen
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_STATUS);
+    KEEPALIVE_STATE(NOT_BUSY);
   }
 
-#endif // FILAMENTCHANGEENABLE
+#endif // FILAMENT_CHANGE_ENABLE
 
 #if ENABLED(DUAL_X_CARRIAGE)
 
@@ -6994,11 +7027,11 @@ void process_next_command() {
           break;
       #endif // CUSTOM_M_CODE_SET_Z_PROBE_OFFSET
 
-      #if ENABLED(FILAMENTCHANGEENABLE)
+      #if ENABLED(FILAMENT_CHANGE_ENABLE)
         case 600: //Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
           gcode_M600();
           break;
-      #endif // FILAMENTCHANGEENABLE
+      #endif // FILAMENT_CHANGE_ENABLE
 
       #if ENABLED(DUAL_X_CARRIAGE)
         case 605:
@@ -7738,13 +7771,13 @@ void disable_all_steppers() {
  * Standard idle routine keeps the machine alive
  */
 void idle(
-  #if ENABLED(FILAMENTCHANGEENABLE)
+  #if ENABLED(FILAMENT_CHANGE_ENABLE)
     bool no_stepper_sleep/*=false*/
   #endif
 ) {
   manage_heater();
   manage_inactivity(
-    #if ENABLED(FILAMENTCHANGEENABLE)
+    #if ENABLED(FILAMENT_CHANGE_ENABLE)
       no_stepper_sleep
     #endif
   );

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1,4 +1,4 @@
-/**
+filasme/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -6017,15 +6017,15 @@ inline void gcode_M503() {
    */
   inline void gcode_M600() {
 
-    // Show initial message and wait for synchronize steppers
-    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INIT);
-    st_synchronize();
-  
     if (degHotend(active_extruder) < extrude_min_temp) {
       SERIAL_ERROR_START;
       SERIAL_ERRORLNPGM(MSG_TOO_COLD_FOR_M600);
       return;
     }
+  
+    // Show initial message and wait for synchronize steppers
+    lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INIT);
+    st_synchronize();
   
     float lastpos[NUM_AXIS];
   
@@ -6102,7 +6102,9 @@ inline void gcode_M503() {
     while (!lcd_clicked()) {
       millis_t ms = millis();
       if (ms >= next_tick) {
-        buzz(300, 2000);
+        #if HAS_BUZZER
+          buzz(300, 2000);
+        #endif
         next_tick = ms + 2500; // Beep every 2.5s while waiting
       }
       idle(true);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6053,12 +6053,14 @@ inline void gcode_M503() {
     // Lift Z axis
     if (code_seen('Z')) destination[Z_AXIS] += code_value();
       #ifdef FILAMENT_CHANGE_Z_ADD
-        else destination[Z_AXIS] += FILAMENT_CHANGE_Z_ADD;
+        else {
+          if (destination[Z_AXIS] + FILAMENT_CHANGE_Z_ADD > Z_MAX_POS)
+            destination[Z_AXIS] = Z_MAX_POS;
+          else
+            destination[Z_AXIS] += FILAMENT_CHANGE_Z_ADD;
+        }
       #endif
-    // RUNPLAN;
     #if ENABLED(DELTA)
-      // calculate_delta(destination);
-      // plan_buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], destination[E_AXIS], FILAMENT_CHANGE_XY_FEEDRATE * 60, active_extruder);
       RUNPLAN;
     #else
       line_to_destination(FILAMENT_CHANGE_Z_FEEDRATE * 60);

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -113,8 +113,8 @@
 /**
  * Filament Change with Extruder Runout Prevention
  */
-#if ENABLED(FILAMENTCHANGEENABLE) && ENABLED(EXTRUDER_RUNOUT_PREVENT)
-  #error EXTRUDER_RUNOUT_PREVENT currently incompatible with FILAMENTCHANGE.
+#if ENABLED(FILAMENT_CHANGE_ENABLE) && ENABLED(EXTRUDER_RUNOUT_PREVENT)
+  #error EXTRUDER_RUNOUT_PREVENT currently incompatible with FILAMENT_CHANGE.
 #endif
 
 /**
@@ -506,6 +506,8 @@
   #error DISABLE_MAX_ENDSTOPS and DISABLE_MIN_ENDSTOPS deprecated. Use individual USE_*_PLUG options instead.
 #elif ENABLED(Z_DUAL_ENDSTOPS) && !defined(Z2_USE_ENDSTOP)
   #error Z_DUAL_ENDSTOPS settings are simplified. Just set Z2_USE_ENDSTOP to the endstop you want to repurpose for Z2
+#elif ENABLED(FILAMENTCHANGEENABLE)
+  #error FILAMENTCHANGEENABLE was renamed to FILAMENT_CHANGE_ENABLE
 #endif
 
 #endif //SANITYCHECK_H

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -192,7 +192,7 @@
   #define MSG_FILAMENT_CHANGE_EXTRUDE_1       "Cekejte prosim"
   #define MSG_FILAMENT_CHANGE_EXTRUDE_2       "na vytlaceni"
   #define MSG_FILAMENT_CHANGE_EXTRUDE_3       "filamentu"
-  #define MSG_FILAMENT_CHANGE_OPTION_HEADER   "Co dal?"
+  #define MSG_FILAMENT_CHANGE_OPTION_HEADER   "CO DAL?"
   #define MSG_FILAMENT_CHANGE_OPTION_EXTRUDE  "Jeste vytlacit"
   #define MSG_FILAMENT_CHANGE_OPTION_RESUME   "Obnovit tisk"
   #define MSG_FILAMENT_CHANGE_RESUME_1        "Cekejte prosim"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -175,4 +175,29 @@
 #define MSG_DELTA_CALIBRATE_Z               "Kalibrovat Z"
 #define MSG_DELTA_CALIBRATE_CENTER          "Kalibrovat Stred"
 
+#if ENABLED(FILAMENT_CHANGE_ENABLE)
+  #define MSG_FILAMENT_CHANGE_HEADER          "VYMENA FILAMENTU"
+  #define MSG_FILAMENT_CHANGE_INIT_1          "Cekejte prosim"
+  #define MSG_FILAMENT_CHANGE_INIT_2          "na zahajeni"
+  #define MSG_FILAMENT_CHANGE_INIT_3          "vymeny filamentu"
+  #define MSG_FILAMENT_CHANGE_UNLOAD_1        "Cekejte prosim"
+  #define MSG_FILAMENT_CHANGE_UNLOAD_2        "na vysunuti"
+  #define MSG_FILAMENT_CHANGE_UNLOAD_3        "filamentu"
+  #define MSG_FILAMENT_CHANGE_INSERT_1        "Vlozte filament"
+  #define MSG_FILAMENT_CHANGE_INSERT_2        "a stisknete"
+  #define MSG_FILAMENT_CHANGE_INSERT_3        "tlacitko..."
+  #define MSG_FILAMENT_CHANGE_LOAD_1          "Cekejte prosim"
+  #define MSG_FILAMENT_CHANGE_LOAD_2          "na zavedeni"
+  #define MSG_FILAMENT_CHANGE_LOAD_3          "filamentu"
+  #define MSG_FILAMENT_CHANGE_EXTRUDE_1       "Cekejte prosim"
+  #define MSG_FILAMENT_CHANGE_EXTRUDE_2       "na vytlaceni"
+  #define MSG_FILAMENT_CHANGE_EXTRUDE_3       "filamentu"
+  #define MSG_FILAMENT_CHANGE_OPTION_HEADER   "Co dal?"
+  #define MSG_FILAMENT_CHANGE_OPTION_EXTRUDE  "Jeste vytlacit"
+  #define MSG_FILAMENT_CHANGE_OPTION_RESUME   "Obnovit tisk"
+  #define MSG_FILAMENT_CHANGE_RESUME_1        "Cekejte prosim"
+  #define MSG_FILAMENT_CHANGE_RESUME_2        "na pokracovani"
+  #define MSG_FILAMENT_CHANGE_RESUME_3        "tisku"
+#endif
+
 #endif // LANGUAGE_CZ_H

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -509,4 +509,73 @@
   #define MSG_DELTA_CALIBRATE_CENTER          "Calibrate Center"
 #endif
 
+#if ENABLED(FILAMENT_CHANGE_ENABLE)
+  #ifndef MSG_FILAMENT_CHANGE_HEADER
+    #define MSG_FILAMENT_CHANGE_HEADER "FILAMENT CHANGING"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_INIT_1
+    #define MSG_FILAMENT_CHANGE_INIT_1 "Wait for start"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_INIT_2
+    #define MSG_FILAMENT_CHANGE_INIT_2 "of the filament"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_INIT_3
+    #define MSG_FILAMENT_CHANGE_INIT_3 "change"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_UNLOAD_1
+    #define MSG_FILAMENT_CHANGE_UNLOAD_1 "Wait for filament"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_UNLOAD_2
+    #define MSG_FILAMENT_CHANGE_UNLOAD_2 "unload"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_UNLOAD_3
+    #define MSG_FILAMENT_CHANGE_UNLOAD_3 ""
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_INSERT_1
+    #define MSG_FILAMENT_CHANGE_INSERT_1 "Insert filament"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_INSERT_2
+    #define MSG_FILAMENT_CHANGE_INSERT_2 "and press button"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_INSERT_3
+    #define MSG_FILAMENT_CHANGE_INSERT_3 "to continue..."
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_LOAD_1
+    #define MSG_FILAMENT_CHANGE_LOAD_1 "Wait for filament"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_LOAD_2
+    #define MSG_FILAMENT_CHANGE_LOAD_2 "load"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_LOAD_3
+    #define MSG_FILAMENT_CHANGE_LOAD_3 ""
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_EXTRUDE_1
+    #define MSG_FILAMENT_CHANGE_EXTRUDE_1 "Wait for filament"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_EXTRUDE_2
+    #define MSG_FILAMENT_CHANGE_EXTRUDE_2 "extrude"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_EXTRUDE_3
+    #define MSG_FILAMENT_CHANGE_EXTRUDE_3 ""
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_OPTION_HEADER
+    #define MSG_FILAMENT_CHANGE_OPTION_HEADER "WHAT NEXT?"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_OPTION_EXTRUDE
+    #define MSG_FILAMENT_CHANGE_OPTION_EXTRUDE "Extrude more"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_OPTION_RESUME
+    #define MSG_FILAMENT_CHANGE_OPTION_RESUME "Resume print"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_RESUME_1
+    #define MSG_FILAMENT_CHANGE_RESUME_1 "Wait for printing"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_RESUME_2
+    #define MSG_FILAMENT_CHANGE_RESUME_2 "resume"
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_RESUME_3
+    #define MSG_FILAMENT_CHANGE_RESUME_3 ""
+  #endif
+#endif 
+ 
 #endif // LANGUAGE_EN_H

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -97,6 +97,16 @@ static void lcd_status_screen();
   static void lcd_control_motion_menu();
   static void lcd_control_volumetric_menu();
 
+  #if ENABLED(FILAMENT_CHANGE_ENABLE)
+    static void lcd_filament_change_option_menu();
+    static void lcd_filament_change_init_message();
+    static void lcd_filament_change_unload_message();
+    static void lcd_filament_change_insert_message();
+    static void lcd_filament_change_load_message();
+    static void lcd_filament_change_extrude_message();
+    static void lcd_filament_change_resume_message();
+  #endif 
+
   #if ENABLED(HAS_LCD_CONTRAST)
     static void lcd_set_contrast();
   #endif
@@ -745,7 +755,7 @@ static void lcd_tune_menu() {
   //
   // Change filament
   //
-  #if ENABLED(FILAMENTCHANGEENABLE)
+  #if ENABLED(FILAMENT_CHANGE_ENABLE)
      MENU_ITEM(gcode, MSG_FILAMENTCHANGE, PSTR("M600"));
   #endif
 
@@ -1813,6 +1823,120 @@ static void lcd_control_volumetric_menu() {
   }
 
 #endif //SDSUPPORT
+
+#if ENABLED(FILAMENT_CHANGE_ENABLE)
+
+  static void lcd_filament_change_nothing() {
+  }
+  
+  static void lcd_filament_change_resume_print() {
+    filament_change_menu_response = FILAMENT_CHANGE_RESPONSE_RESUME_PRINT;
+    lcdDrawUpdate = 2;
+    lcd_goto_menu(lcd_status_screen);
+  }
+  
+  static void lcd_filament_change_extrude_more() {
+    filament_change_menu_response = FILAMENT_CHANGE_RESPONSE_EXTRUDE_MORE;
+  }
+  
+  static void lcd_filament_change_option_menu() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_RESUME, lcd_filament_change_resume_print);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_EXTRUDE, lcd_filament_change_extrude_more);
+    END_MENU();
+  }
+  
+  static void lcd_filament_change_init_message() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_INIT_1, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_INIT_2, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_INIT_3, lcd_filament_change_nothing);
+    END_MENU();
+  }
+  
+  static void lcd_filament_change_unload_message() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_UNLOAD_1, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_UNLOAD_2, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_UNLOAD_3, lcd_filament_change_nothing);
+    END_MENU();
+  }
+  
+  static void lcd_filament_change_insert_message() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_INSERT_1, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_INSERT_2, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_INSERT_3, lcd_filament_change_nothing);
+    END_MENU();
+  }
+  
+  static void lcd_filament_change_load_message() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_LOAD_1, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_LOAD_2, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_LOAD_3, lcd_filament_change_nothing);
+    END_MENU();
+  }
+  
+  static void lcd_filament_change_extrude_message() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_EXTRUDE_1, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_EXTRUDE_2, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_EXTRUDE_3, lcd_filament_change_nothing);
+    END_MENU();
+  }
+  
+  static void lcd_filament_change_resume_message() {
+    START_MENU();
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_HEADER, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_RESUME_1, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_RESUME_2, lcd_filament_change_nothing);
+    MENU_ITEM(function, MSG_FILAMENT_CHANGE_RESUME_3, lcd_filament_change_nothing);
+    END_MENU();
+  }
+  
+  void lcd_filament_change_show_message(FilamentChangeMessage message) {
+    lcdDrawUpdate = 2;
+    switch (message) {
+      case FILAMENT_CHANGE_MESSAGE_INIT:
+        defer_return_to_status = true;
+        lcd_goto_menu(lcd_filament_change_init_message, false);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_UNLOAD:
+        lcd_goto_menu(lcd_filament_change_unload_message, false);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_INSERT:
+        lcd_goto_menu(lcd_filament_change_insert_message, false);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_LOAD:
+        lcd_goto_menu(lcd_filament_change_load_message, false);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_EXTRUDE:
+        lcd_goto_menu(lcd_filament_change_extrude_message, false);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_OPTION:
+        while (lcd_clicked()) {
+          idle(true);
+        }
+        filament_change_menu_response = FILAMENT_CHANGE_RESPONSE_WAIT_FOR;
+        lcd_goto_menu(lcd_filament_change_option_menu, false);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_RESUME:
+        lcd_goto_menu(lcd_filament_change_resume_message);
+        break;
+      case FILAMENT_CHANGE_MESSAGE_STATUS:
+        lcd_return_to_status();
+        break;
+    }
+  }
+
+#endif // FILAMENT_CHANGE_ENABLE
 
 /**
  *

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -65,6 +65,19 @@
   #if ENABLED(ULTIPANEL)
     void lcd_buttons_update();
     extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
+    #if ENABLED(FILAMENT_CHANGE_ENABLE)
+      enum FilamentChangeMessage {
+        FILAMENT_CHANGE_MESSAGE_INIT = 0,
+        FILAMENT_CHANGE_MESSAGE_UNLOAD = 1,
+        FILAMENT_CHANGE_MESSAGE_INSERT = 2,
+        FILAMENT_CHANGE_MESSAGE_LOAD = 3,
+        FILAMENT_CHANGE_MESSAGE_EXTRUDE = 4,
+        FILAMENT_CHANGE_MESSAGE_OPTION = 5,
+        FILAMENT_CHANGE_MESSAGE_RESUME = 6,
+        FILAMENT_CHANGE_MESSAGE_STATUS = 7
+      };
+      void lcd_filament_change_show_message(FilamentChangeMessage message);
+    #endif     
   #else
     FORCE_INLINE void lcd_buttons_update() {}
   #endif

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -67,14 +67,14 @@
     extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
     #if ENABLED(FILAMENT_CHANGE_ENABLE)
       enum FilamentChangeMessage {
-        FILAMENT_CHANGE_MESSAGE_INIT = 0,
-        FILAMENT_CHANGE_MESSAGE_UNLOAD = 1,
-        FILAMENT_CHANGE_MESSAGE_INSERT = 2,
-        FILAMENT_CHANGE_MESSAGE_LOAD = 3,
-        FILAMENT_CHANGE_MESSAGE_EXTRUDE = 4,
-        FILAMENT_CHANGE_MESSAGE_OPTION = 5,
-        FILAMENT_CHANGE_MESSAGE_RESUME = 6,
-        FILAMENT_CHANGE_MESSAGE_STATUS = 7
+        FILAMENT_CHANGE_MESSAGE_INIT,
+        FILAMENT_CHANGE_MESSAGE_UNLOAD,
+        FILAMENT_CHANGE_MESSAGE_INSERT,
+        FILAMENT_CHANGE_MESSAGE_LOAD,
+        FILAMENT_CHANGE_MESSAGE_EXTRUDE,
+        FILAMENT_CHANGE_MESSAGE_OPTION,
+        FILAMENT_CHANGE_MESSAGE_RESUME,
+        FILAMENT_CHANGE_MESSAGE_STATUS
       };
       void lcd_filament_change_show_message(FilamentChangeMessage message);
     #endif     


### PR DESCRIPTION
_(Don't mix up with Manual filament change #3605)_
# Background

Months ago, someone suggested reworking (or at leats make existing function work) Auto filament change in #2926 and #2933. This function is working (as mentioned there) in Prusa's firmware and many other closed-source 3D printer. But neither of them is sufficient to be publicated for community of most used 3D firmware, with variety of printers, extruders and displays. So we started working on complete rewrite of filament change function, to make it work for us and then make it open to everyone here on GitHub.
# Functions

This change rewrites Auto Filament Change controlled by G-Code M600.
The procedure of change is:
- Retract a bit and move axis to position set by Configuration or by G-Code parameters
- Unload filament
- Keep beeping and wait for user to insert filament and click on button (encoder)
- Load filament through bowden (see Configuration for details)
- Extrude some filament and ask user either to extrude more or to resume print
- Move axis back and continue printing
  Every step is clearly documented with information messages displayed on the display. As suggested by others, KEEP_ALIVE is also used. Simple working procedure makes it easy to change filament for everyone.
# TODO list for community
- [ ] Check behaviour on DELTA printers
- [ ] Choose load and extrude distances for all example printers
- [ ] Translate messages
