### PR TITLE
Don't reject 8.3-filenames with chars > 0x7f

### DIFF
--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -405,7 +405,7 @@ bool SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
       uint8_t b;
       while ((b = pgm_read_byte(p++))) if (b == c) goto fail;
       // check size and only allow ASCII printable characters
-      if (i > n || c < 0X21 || c > 0X7E)goto fail;
+      if (i > n || c < 0X21 || c == 0X7E)goto fail;
       // only upper case allowed in 8.3 names - convert lower to upper
       name[i++] = (c < 'a' || c > 'z') ? (c) : (c + ('A' - 'a'));
     }


### PR DESCRIPTION
Don't reject 8.3-filenames with chars > 0x7f

Windows produces 8.3-filenames with chars > 0x7f. Those have been rejected
by Marlin until now.

With these 'malformed' filenames can now be worked: 
- In the LCD menu. If Marlin has not the same charset as the used OS, when creating the file, the 'strange' chars are displyed wrong - but you can work with.
- With RepetierHost (V1.6.1 tested) - full support. Characters are
  displayed as '?' 
## 
- With Octoprint (1.2.10 tested) the files do not appear in the files
  area. At the console, listed with M20 they appear with a '�'.
- With Pronterface the files appear in the sd-window but you can't start
  them. They are mangled by Pronterface. The names are altered and than
  rejected by Marlin. In the console they appear with different but not the
  correct characters.

All in all, a little step forward.

Fix for #3593
