### PR TITLE
Revert PR 3648 to fix SD printing

### DIFF
--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -405,7 +405,7 @@ bool SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
       uint8_t b;
       while ((b = pgm_read_byte(p++))) if (b == c) goto fail;
       // check size and only allow ASCII printable characters
-      if (i > n || c < 0X21 || c == 0X7E)goto fail;
+      if (i > n || c < 0x21 || c > 0x7E) goto fail;
       // only upper case allowed in 8.3 names - convert lower to upper
       name[i++] = (c < 'a' || c > 'z') ? (c) : (c + ('A' - 'a'));
     }


### PR DESCRIPTION
Reverting #3648 which rejects `~`.

@Blue-Marlin The character 0x7E is rather common in 8.3 filenames. In fact, it's the tilde `~` character. Maybe the last condition should be removed completely instead.
