### PR TITLE
8.3-filenames second try

### DIFF
--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -405,7 +405,7 @@ bool SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
       uint8_t b;
       while ((b = pgm_read_byte(p++))) if (b == c) goto fail;
       // check size and only allow ASCII printable characters
-      if (i > n || c < 0x21 || c > 0x7E) goto fail;
+      if (i > n || c < 0x21 || c == 0x7F) goto fail;
       // only upper case allowed in 8.3 names - convert lower to upper
       name[i++] = (c < 'a' || c > 'z') ? (c) : (c + ('A' - 'a'));
     }


### PR DESCRIPTION
Fix for #3593, #3648
this time excluding 'DEL' instead of accidentally '~'.
