### PR TITLE
Ultimate followup to Stepper/Planner patch

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -21,24 +21,12 @@
  */
 
 /**
- * planner.cpp - Buffer movement commands and manage the acceleration profile plan
- * Part of Grbl
+ * planner.cpp
  *
+ * Buffer movement commands and manage the acceleration profile plan
+ *
+ * Derived from Grbl
  * Copyright (c) 2009-2011 Simen Svale Skogsrud
- *
- * Grbl is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * Grbl is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
- *
  *
  * The ring buffer implementation gleaned from the wiring_serial library by David A. Mellis.
  *

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -21,27 +21,13 @@
  */
 
 /**
-  planner.h - buffers movement commands and manages the acceleration profile plan
-  Part of Grbl
-
-  Copyright (c) 2009-2011 Simen Svale Skogsrud
-
-  Grbl is free software: you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation, either version 3 of the License, or
-  (at your option) any later version.
-
-  Grbl is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
-*/
-
-// This module is to be considered a sub-module of stepper.c. Please don't include
-// this file from any other module.
+ * planner.h
+ *
+ * Buffer movement commands and manage the acceleration profile plan
+ *
+ * Derived from Grbl
+ * Copyright (c) 2009-2011 Simen Svale Skogsrud
+ */
 
 #ifndef PLANNER_H
 #define PLANNER_H
@@ -268,6 +254,17 @@ class Planner {
         return NULL;
     }
 
+    #if ENABLED(AUTOTEMP)
+      float autotemp_max = 250;
+      float autotemp_min = 210;
+      float autotemp_factor = 0.1;
+      bool autotemp_enabled = false;
+      void getHighESpeed();
+      void autotemp_M109();
+    #endif
+
+  private:
+
     /**
      * Get the index of the next / previous block in the ring buffer
      */
@@ -304,18 +301,6 @@ class Planner {
     FORCE_INLINE float max_allowable_speed(float acceleration, float target_velocity, float distance) {
       return sqrt(target_velocity * target_velocity - 2 * acceleration * distance);
     }
-
-
-    #if ENABLED(AUTOTEMP)
-      float autotemp_max = 250;
-      float autotemp_min = 210;
-      float autotemp_factor = 0.1;
-      bool autotemp_enabled = false;
-      void getHighESpeed();
-      void autotemp_M109();
-    #endif
-
-  private:
 
     void calculate_trapezoid_for_block(block_t* block, float entry_factor, float exit_factor);
 

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -979,9 +979,3 @@ void Stepper::microstep_readings() {
     SERIAL_PROTOCOLLN(digitalRead(E1_MS2_PIN));
   #endif
 }
-
-#if ENABLED(Z_DUAL_ENDSTOPS)
-  void Stepper::set_homing_flag(bool state) { performing_homing = state; }
-  void Stepper::set_z_lock(bool state) { locked_z_motor = state; }
-  void Stepper::set_z2_lock(bool state) { locked_z2_motor = state; }
-#endif

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -224,9 +224,9 @@ class Stepper {
     void microstep_readings();
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      void set_homing_flag(bool state);
-      void set_z_lock(bool state);
-      void set_z2_lock(bool state);
+      FORCE_INLINE void set_homing_flag(bool state) { performing_homing = state; }
+      FORCE_INLINE void set_z_lock(bool state) { locked_z_motor = state; }
+      FORCE_INLINE void set_z2_lock(bool state) { locked_z2_motor = state; }
     #endif
 
     #if ENABLED(BABYSTEPPING)
@@ -248,6 +248,8 @@ class Stepper {
     FORCE_INLINE float triggered_position_mm(AxisEnum axis) {
       return endstops_trigsteps[axis] / planner.axis_steps_per_unit[axis];
     }
+
+  private:
 
     FORCE_INLINE unsigned short calc_timer(unsigned short step_rate) {
       unsigned short timer;
@@ -324,7 +326,6 @@ class Stepper {
       // SERIAL_ECHOLN(current_block->final_advance/256.0);
     }
 
-  private:
     void digipot_init();
     void microstep_init();
 


### PR DESCRIPTION
Methodically go through symbols in the recent `Stepper`/`Planner` patch, because science!
- Search all `Stepper`/`Planner` symbols and apply prefixes
  - (Oops! @esenapaj beat me to it with his _penultimate_ patch #3667.)
- Make `Stepper::microstep_mode()` a public method
  - (Oops! @esenapaj beat me to it again.)
- Encapsulate some private methods in `Stepper` / `Planner`
- Inline some setters
