### PR TITLE
Advance extrusion algorithm – LIN_ADVANCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,10 +76,12 @@ script:
   - build_marlin
   #
   # Test 3 extruders on RUMBA (can use any board with >=3 extruders defined)
+  # Include a test for LIN_ADVANCE here also
   #
   - opt_set MOTHERBOARD BOARD_RUMBA
   - opt_set EXTRUDERS 3
   - opt_set TEMP_SENSOR_2 1
+  - opt_enable_adv LIN_ADVANCE
   - build_marlin
   #
   # Test PIDTEMPBED

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -457,6 +457,15 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+//Implementation of a linear pressure control
+//Assumption: advance = k * (delta velocity)
+//K=0 means advance disabled. A good value for a gregs wade extruder will be around K=75
+#define LIN_ADVANCE
+
+#if ENABLED(LIN_ADVANCE)
+  #define LIN_K 75
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -445,6 +445,15 @@
   #define D_FILAMENT 2.85
 #endif
 
+// Implementation of a linear pressure control
+// Assumption: advance = k * (delta velocity)
+// K=0 means advance disabled. A good value for a gregs wade extruder will be around K=75
+//#define LIN_ADVANCE
+
+#if ENABLED(LIN_ADVANCE)
+  #define LIN_ADVANCE_K 75
+#endif
+
 // @section leveling
 
 // Default mesh area is an area with an inset margin on the print area.
@@ -455,15 +464,6 @@
   #define MESH_MAX_X (X_MAX_POS - (MESH_INSET))
   #define MESH_MIN_Y (Y_MIN_POS + MESH_INSET)
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
-#endif
-
-//Implementation of a linear pressure control
-//Assumption: advance = k * (delta velocity)
-//K=0 means advance disabled. A good value for a gregs wade extruder will be around K=75
-#define LIN_ADVANCE
-
-#if ENABLED(LIN_ADVANCE)
-  #define LIN_K 75
 #endif
 
 // @section extras

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6469,13 +6469,13 @@ inline void gcode_M503() {
 #endif // DUAL_X_CARRIAGE
 
 #if ENABLED(LIN_ADVANCE)
-/**
- * M905: Set advance factor
- */
-inline void gcode_M905() {
-  stepper.synchronize();
-  stepper.advance_M905();
-}
+  /**
+   * M905: Set advance factor
+   */
+  inline void gcode_M905() {
+    stepper.synchronize();
+    stepper.advance_M905();
+  }
 #endif
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6468,6 +6468,16 @@ inline void gcode_M503() {
 
 #endif // DUAL_X_CARRIAGE
 
+#if ENABLED(LIN_ADVANCE)
+/**
+ * M905: Set advance factor
+ */
+inline void gcode_M905() {
+  stepper.synchronize();
+  stepper.advance_M905();
+}
+#endif
+
 /**
  * M907: Set digital trimpot motor current using axis codes X, Y, Z, E, B, S
  */
@@ -7339,6 +7349,12 @@ void process_next_command() {
           gcode_M605();
           break;
       #endif // DUAL_X_CARRIAGE
+      
+      #if ENABLED(LIN_ADVANCE)
+        case 905: // M905 Set advance factor.
+          gcode_M905();
+          break;
+      #endif
 
       case 907: // M907 Set digital trimpot motor current using axis codes.
         gcode_M907();

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -352,12 +352,18 @@
 #endif // AUTO_BED_LEVELING_FEATURE
 
 /**
+ * Advance Extrusion
+ */
+#if ENABLED(ADVANCE) && ENABLED(LIN_ADVANCE)
+  #error You can enable ADVANCE or LIN_ADVANCE, but not both.
+#endif
+
+/**
  * Filament Width Sensor
  */
 #if ENABLED(FILAMENT_WIDTH_SENSOR) && !HAS_FILAMENT_WIDTH_SENSOR
   #error "FILAMENT_WIDTH_SENSOR requires a FILWIDTH_PIN to be defined."
 #endif
-
 
 /**
  * ULTIPANEL encoder

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1045,6 +1045,18 @@ void Planner::check_axes_activity() {
   // the maximum junction speed and may always be ignored for any speed reduction checks.
   block->nominal_length_flag = (block->nominal_speed <= v_allowable);
   block->recalculate_flag = true; // Always calculate trapezoid for new block
+  
+  #ifdef LIN_ADVANCE
+    //bse = allsteps: A problem occures if there is a very tiny move before a retract.
+    //In this case, the retract and the move will be executed together. This leads to an enormus amount advance steps due to a hughe e_acceleration.
+    //The math is correct, but you don't want a retract move done with advance! This situation has to be filtered out.
+    if ((!bse || (!bsx && !bsy && !bsz)) || (stepper.get_advance_k() == 0) || (bse == allsteps)) {
+      block->use_advance_lead = false;
+    } else {
+      block->use_advance_lead = true;
+      block->e_speed_multiplier8 = (block->steps[E_AXIS] << 8) / block->step_event_count;
+    }
+  #endif
 
   // Update previous path unit_vector and nominal speed
   for (int i = 0; i < NUM_AXIS; i++) previous_speed[i] = current_speed[i];

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1045,24 +1045,28 @@ void Planner::check_axes_activity() {
   // the maximum junction speed and may always be ignored for any speed reduction checks.
   block->nominal_length_flag = (block->nominal_speed <= v_allowable);
   block->recalculate_flag = true; // Always calculate trapezoid for new block
-  
-  #ifdef LIN_ADVANCE
-    //bse = allsteps: A problem occures if there is a very tiny move before a retract.
-    //In this case, the retract and the move will be executed together. This leads to an enormus amount advance steps due to a hughe e_acceleration.
-    //The math is correct, but you don't want a retract move done with advance! This situation has to be filtered out.
-    if ((!bse || (!bsx && !bsy && !bsz)) || (stepper.get_advance_k() == 0) || (bse == allsteps)) {
-      block->use_advance_lead = false;
-    } else {
-      block->use_advance_lead = true;
-      block->e_speed_multiplier8 = (block->steps[E_AXIS] << 8) / block->step_event_count;
-    }
-  #endif
 
   // Update previous path unit_vector and nominal speed
   for (int i = 0; i < NUM_AXIS; i++) previous_speed[i] = current_speed[i];
   previous_nominal_speed = block->nominal_speed;
 
-  #if ENABLED(ADVANCE)
+  #if ENABLED(LIN_ADVANCE)
+
+    // bse == allsteps: A problem occurs when there's a very tiny move before a retract.
+    // In this case, the retract and the move will be executed together.
+    // This leads to an enormous number of advance steps due to a huge e_acceleration.
+    // The math is correct, but you don't want a retract move done with advance!
+    // So this situation is filtered out here.
+    if (!bse || (!bsx && !bsy && !bsz) || stepper.get_advance_k() == 0 || bse == allsteps) {
+      block->use_advance_lead = false;
+    }
+    else {
+      block->use_advance_lead = true;
+      block->e_speed_multiplier8 = (block->steps[E_AXIS] << 8) / block->step_event_count;
+    }
+
+  #elif ENABLED(ADVANCE)
+
     // Calculate advance rate
     if (!bse || (!bsx && !bsy && !bsz)) {
       block->advance_rate = 0;
@@ -1081,7 +1085,8 @@ void Planner::check_axes_activity() {
      SERIAL_ECHOPGM("advance rate :");
      SERIAL_ECHOLN(block->advance_rate/256.0);
      */
-  #endif // ADVANCE
+
+  #endif // ADVANCE or LIN_ADVANCE
 
   calculate_trapezoid_for_block(block, block->entry_speed / block->nominal_speed, safe_speed / block->nominal_speed);
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -64,15 +64,15 @@ typedef struct {
 
   unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
 
-  #if ENABLED(ADVANCE)
+  // Advance extrusion
+  #if ENABLED(LIN_ADVANCE)
+    bool use_advance_lead;
+    int e_speed_multiplier8; // Factorised by 2^8 to avoid float
+  #elif ENABLED(ADVANCE)
     long advance_rate;
     volatile long initial_advance;
     volatile long final_advance;
     float advance;
-  #endif
-  #ifdef LIN_ADVANCE
-    bool use_advance_lead;
-    int e_speed_multiplier8; //factorised by 2^8 to avoid float
   #endif
 
   // Fields used by the motion planner to manage acceleration

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -70,6 +70,10 @@ typedef struct {
     volatile long final_advance;
     float advance;
   #endif
+  #ifdef LIN_ADVANCE
+    bool use_advance_lead;
+    int e_speed_multiplier8; //factorised by 2^8 to avoid float
+  #endif
 
   // Fields used by the motion planner to manage acceleration
   float nominal_speed,                               // The nominal speed for this block in mm/sec

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -22,7 +22,7 @@
 
 /**
  * stepper.h - stepper motor driver: executes motion plans of planner.c using the stepper motors
- * Part of Grbl
+ * Derived from Grbl
  *
  * Copyright (c) 2009-2011 Simen Svale Skogsrud
  *

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -90,14 +90,6 @@ class Stepper {
       static bool performing_homing;
     #endif
 
-    #if ENABLED(ADVANCE)
-      static long e_steps[EXTRUDERS];
-    #endif
-    
-    #if ENABLED(LIN_ADVANCE)
-      int extruder_advance_k = LIN_K;
-    #endif
-
   private:
 
     static unsigned char last_direction_bits;        // The next stepping-bits to be output
@@ -111,18 +103,23 @@ class Stepper {
     static long counter_X, counter_Y, counter_Z, counter_E;
     static volatile unsigned long step_events_completed; // The number of step events executed in the current block
 
-    #if ENABLED(ADVANCE)
+    #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
       static unsigned char old_OCR0A;
-      static long advance_rate, advance, old_advance, final_advance;
-    #endif
-    
-    #if ENABLED(LIN_ADVANCE)
-      unsigned char old_OCR0A;
-      volatile int e_steps[EXTRUDERS];
-      int final_estep_rate;
-      int current_estep_rate[EXTRUDERS]; //Actual extruder speed [steps/s]
-      int current_adv_steps[EXTRUDERS]; //The amount of current added esteps due to advance. Think of it as the current amount of pressure applied to the spring (=filament).
-    #endif
+      static volatile unsigned char eISR_Rate;
+      #if ENABLED(LIN_ADVANCE)
+        static volatile int e_steps[EXTRUDERS];
+        static int extruder_advance_k;
+        static int final_estep_rate;
+        static int current_estep_rate[EXTRUDERS]; // Actual extruder speed [steps/s]
+        static int current_adv_steps[EXTRUDERS];  // The amount of current added esteps due to advance.
+                                                  // i.e., the current amount of pressure applied
+                                                  // to the spring (=filament).
+      #else
+        static long e_steps[EXTRUDERS];
+        static long advance_rate, advance, final_advance;
+        static long old_advance;
+      #endif
+    #endif // ADVANCE or LIN_ADVANCE
 
     static long acceleration_time, deceleration_time;
     //unsigned long accelerate_until, decelerate_after, acceleration_rate, initial_rate, final_rate, nominal_rate;
@@ -168,14 +165,8 @@ class Stepper {
 
     static void isr();
 
-    #if ENABLED(ADVANCE)
+    #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
       static void advance_isr();
-    #endif
-    
-    #if ENABLED(LIN_ADVANCE)
-      void advance_isr();
-      void advance_M905();
-      int get_advance_k();
     #endif
 
     //
@@ -264,6 +255,11 @@ class Stepper {
       return endstops_trigsteps[axis] / planner.axis_steps_per_mm[axis];
     }
 
+    #if ENABLED(LIN_ADVANCE)
+      void advance_M905();
+      FORCE_INLINE int get_advance_k() { return extruder_advance_k; }
+    #endif
+
   private:
 
     static FORCE_INLINE unsigned short calc_timer(unsigned short step_rate) {
@@ -335,7 +331,7 @@ class Stepper {
       OCR1A = acceleration_time;
       
       #if ENABLED(LIN_ADVANCE)
-        if (current_block->use_advance_lead){
+        if (current_block->use_advance_lead) {
           current_estep_rate[current_block->active_extruder] = ((unsigned long)acc_step_rate * current_block->e_speed_multiplier8) >> 8;
           final_estep_rate = (current_block->nominal_rate * current_block->e_speed_multiplier8) >> 8;
         }


### PR DESCRIPTION
@Sebastianv650 has been working on this over on his fork. This is a patched up PR for compatibility with `stepper_indirection.h` which already handles multiple steppers for different features. This also keeps `Stepper::advance_isr` compatible with the upcoming Mixing Extruder feature.
- Disable `LIN_ADVANCE` by default
- Added a sanity check to prevent enabling both `ADVANCE` and `LIN_ADVANCE`
- Blocks use `ENABLED(LIN_ADVANCE)`
- Blocks use `#if ... #elif ... #endif` to group `LIN_ADVANCE` with `ADVANCE`
- The `advance_isr` can be simplified due to macros in `stepper_indirection.h`

References: MarlinFirmware/MarlinDev#402 #3655
