### PR TITLE
Can't use the ENABLED macro as a boolean

### DIFF
--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -37,7 +37,13 @@
 Endstops endstops;
 
 Endstops::Endstops() {
-  enable_globally(ENABLED(ENDSTOPS_ONLY_FOR_HOMING));
+  enable_globally(
+    #if ENABLED(ENDSTOPS_ONLY_FOR_HOMING)
+      true
+    #else
+      false
+    #endif
+  );
   enable(true);
   #if ENABLED(HAS_Z_MIN_PROBE)
     enable_z_probe(false);


### PR DESCRIPTION
Addressing #3677 – allow compilation with `ENDSTOPS_ONLY_FOR_HOMING`.
