### PR TITLE
Remove need to define unused pins as -1 in pins files

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -52,11 +52,6 @@
 
 typedef unsigned long millis_t;
 
-// Arduino < 1.0.0 does not define this, so we need to do it ourselves
-#ifndef analogInputToDigitalPin
-  #define analogInputToDigitalPin(p) ((p) + 0xA0)
-#endif
-
 #ifdef USBCON
   #include "HardwareSerial.h"
 #endif

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -23,20 +23,6 @@
 #ifndef PINS_H
 #define PINS_H
 
-// Preset optional pins
-#define X_MS1_PIN -1
-#define X_MS2_PIN -1
-#define Y_MS1_PIN -1
-#define Y_MS2_PIN -1
-#define Z_MS1_PIN -1
-#define Z_MS2_PIN -1
-#define E0_MS1_PIN -1
-#define E0_MS2_PIN -1
-#define E1_MS1_PIN -1
-#define E1_MS2_PIN -1
-#define HEATER_3_PIN -1
-#define TEMP_3_PIN -1
-
 #if MB(GEN7_CUSTOM)
   #include "pins_GEN7_CUSTOM.h"
 #elif MB(GEN7_12)
@@ -157,21 +143,120 @@
   #error Unknown MOTHERBOARD value set in Configuration.h
 #endif
 
+// Define certain undefined pins
+#ifndef X_MS1_PIN
+  #define X_MS1_PIN -1
+#endif
+#ifndef X_MS2_PIN
+  #define X_MS2_PIN -1
+#endif
+#ifndef Y_MS1_PIN
+  #define Y_MS1_PIN -1
+#endif
+#ifndef Y_MS2_PIN
+  #define Y_MS2_PIN -1
+#endif
+#ifndef Z_MS1_PIN
+  #define Z_MS1_PIN -1
+#endif
+#ifndef Z_MS2_PIN
+  #define Z_MS2_PIN -1
+#endif
+#ifndef E0_MS1_PIN
+  #define E0_MS1_PIN -1
+#endif
+#ifndef E0_MS2_PIN
+  #define E0_MS2_PIN -1
+#endif
+#ifndef E1_MS1_PIN
+  #define E1_MS1_PIN -1
+#endif
+#ifndef E1_MS2_PIN
+  #define E1_MS2_PIN -1
+#endif
+
+#ifndef FAN_PIN
+  #define FAN_PIN -1
+#endif
+#ifndef FAN1_PIN
+  #define FAN1_PIN -1
+#endif
+#ifndef FAN2_PIN
+  #define FAN2_PIN -1
+#endif
+
+#ifndef HEATER_0_PIN
+  #define HEATER_0_PIN -1
+#endif
+#ifndef HEATER_1_PIN
+  #define HEATER_1_PIN -1
+#endif
+#ifndef HEATER_2_PIN
+  #define HEATER_2_PIN -1
+#endif
+#ifndef HEATER_3_PIN
+  #define HEATER_3_PIN -1
+#endif
+#ifndef HEATER_BED_PIN
+  #define HEATER_BED_PIN -1
+#endif
+
+#ifndef TEMP_0_PIN
+  #define TEMP_0_PIN -1
+#endif
+#ifndef TEMP_1_PIN
+  #define TEMP_1_PIN -1
+#endif
+#ifndef TEMP_2_PIN
+  #define TEMP_2_PIN -1
+#endif
+#ifndef TEMP_3_PIN
+  #define TEMP_3_PIN -1
+#endif
+#ifndef TEMP_BED_PIN
+  #define TEMP_BED_PIN -1
+#endif
+
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN -1
+#endif
+#ifndef SDPOWER
+  #define SDPOWER -1
+#endif
+#ifndef SDSS
+  #define SDSS -1
+#endif
+#ifndef LED_PIN
+  #define LED_PIN -1
+#endif
+#ifndef PS_ON_PIN
+  #define PS_ON_PIN -1
+#endif
+#ifndef KILL_PIN
+  #define KILL_PIN -1
+#endif
+#ifndef SUICIDE_PIN
+  #define SUICIDE_PIN -1
+#endif
+
+// Marlin needs to account for pins that equal -1
+#define marlinAnalogInputToDigitalPin(p) ((p) == -1 ? -1 : (p) + 0xA0)
+
 // List of pins which to ignore when asked to change by gcode, 0 and 1 are RX and TX, do not mess with those!
-#define _E0_PINS E0_STEP_PIN, E0_DIR_PIN, E0_ENABLE_PIN, HEATER_0_PIN, analogInputToDigitalPin(TEMP_0_PIN),
+#define _E0_PINS E0_STEP_PIN, E0_DIR_PIN, E0_ENABLE_PIN, E0_MS1_PIN, E0_MS2_PIN, HEATER_0_PIN, EXTRUDER_0_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_0_PIN),
 #define _E1_PINS
 #define _E2_PINS
 #define _E3_PINS
 
 #if EXTRUDERS > 1
   #undef _E1_PINS
-  #define _E1_PINS E1_STEP_PIN, E1_DIR_PIN, E1_ENABLE_PIN, HEATER_1_PIN, analogInputToDigitalPin(TEMP_1_PIN),
+  #define _E1_PINS E1_STEP_PIN, E1_DIR_PIN, E1_ENABLE_PIN, HEATER_1_PIN, E1_MS1_PIN, E1_MS2_PIN, EXTRUDER_1_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_1_PIN),
   #if EXTRUDERS > 2
     #undef _E2_PINS
-    #define _E2_PINS E2_STEP_PIN, E2_DIR_PIN, E2_ENABLE_PIN, HEATER_2_PIN, analogInputToDigitalPin(TEMP_2_PIN),
+    #define _E2_PINS E2_STEP_PIN, E2_DIR_PIN, E2_ENABLE_PIN, HEATER_2_PIN, EXTRUDER_2_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_2_PIN),
     #if EXTRUDERS > 3
       #undef _E3_PINS
-      #define _E3_PINS E3_STEP_PIN, E3_DIR_PIN, E3_ENABLE_PIN, HEATER_3_PIN, analogInputToDigitalPin(TEMP_3_PIN),
+      #define _E3_PINS E3_STEP_PIN, E3_DIR_PIN, E3_ENABLE_PIN, HEATER_3_PIN, EXTRUDER_3_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_3_PIN),
     #endif
   #endif
 #elif ENABLED(Y_DUAL_STEPPER_DRIVERS) || ENABLED(Z_DUAL_STEPPER_DRIVERS)
@@ -179,6 +264,11 @@
   #define _E1_PINS E1_STEP_PIN, E1_DIR_PIN, E1_ENABLE_PIN,
 #endif
 
+#define BED_PINS HEATER_BED_PIN, marlinAnalogInputToDigitalPin(TEMP_BED_PIN),
+
+//
+// Assign endstop pins for boards with only 3 connectors
+//
 #ifdef X_STOP_PIN
   #if X_HOME_DIR < 0
     #define X_MIN_PIN X_STOP_PIN
@@ -209,6 +299,9 @@
   #endif
 #endif
 
+//
+// Disable unused endstop / probe pins
+//
 #if ENABLED(DISABLE_Z_MIN_PROBE_ENDSTOP) || DISABLED(Z_MIN_PROBE_ENDSTOP) // Allow code to compile regardless of Z_MIN_PROBE_ENDSTOP setting.
   #undef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN    -1
@@ -270,10 +363,9 @@
     X_STEP_PIN, X_DIR_PIN, X_ENABLE_PIN, X_MIN_PIN, X_MAX_PIN, \
     Y_STEP_PIN, Y_DIR_PIN, Y_ENABLE_PIN, Y_MIN_PIN, Y_MAX_PIN, \
     Z_STEP_PIN, Z_DIR_PIN, Z_ENABLE_PIN, Z_MIN_PIN, Z_MAX_PIN, Z_MIN_PROBE_PIN, \
-    PS_ON_PIN, HEATER_BED_PIN, FAN_PIN, CONTROLLERFAN_PIN, \
-    EXTRUDER_0_AUTO_FAN_PIN, EXTRUDER_1_AUTO_FAN_PIN, EXTRUDER_2_AUTO_FAN_PIN, EXTRUDER_3_AUTO_FAN_PIN, \
-    _E0_PINS _E1_PINS _E2_PINS _E3_PINS \
-    analogInputToDigitalPin(TEMP_BED_PIN) \
+    PS_ON_PIN, HEATER_BED_PIN, FAN_PIN, FAN1_PIN, FAN2_PIN, CONTROLLERFAN_PIN, \
+    _E0_PINS _E1_PINS _E2_PINS _E3_PINS BED_PINS \
+    X_MS1_PIN, X_MS2_PIN, Y_MS1_PIN, Y_MS2_PIN, Z_MS1_PIN, Z_MS2_PIN \
   }
 
 #define HAS_DIGIPOTSS (PIN_EXISTS(DIGIPOTSS))

--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -54,8 +54,6 @@
 #define E0_ENABLE_PIN      17
 
 #define HEATER_0_PIN       21  // Extruder
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 #define HEATER_BED_PIN     20  // Bed
 // You may need to change FAN_PIN to 16 because Marlin isn't using fastio.h
 // for the fan and Teensyduino uses a different pin mapping.
@@ -63,14 +61,6 @@
 
 #define TEMP_0_PIN          1  // Extruder / Analog pin numbering
 #define TEMP_BED_PIN        0  // Bed / Analog pin numbering
-
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
-
-#define SDPOWER            -1
-#define LED_PIN            -1
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 // The SDSS pin uses a different pin mapping from file Sd2PinMap.h
 #define SDSS               20
@@ -85,15 +75,6 @@
 // Microstepping pins
 // Note that the pin mapping is not from fastio.h
 // See Sd2PinMap.h for the pin configurations
-
-#undef X_MS1_PIN
-#undef X_MS2_PIN
-#undef Y_MS1_PIN
-#undef Y_MS2_PIN
-#undef Z_MS1_PIN
-#undef Z_MS2_PIN
-#undef E0_MS1_PIN
-#undef E0_MS2_PIN
 #define X_MS1_PIN 25
 #define X_MS2_PIN 26
 #define Y_MS1_PIN 9
@@ -102,4 +83,3 @@
 #define Z_MS2_PIN 6
 #define E0_MS1_PIN 5
 #define E0_MS2_PIN 4
-

--- a/Marlin/pins_99.h
+++ b/Marlin/pins_99.h
@@ -43,18 +43,10 @@
 #define E0_DIR_PIN          66
 #define E0_ENABLE_PIN      -1
 
-#define SDPOWER            -1
 #define SDSS               53
-#define LED_PIN            -1
-#define FAN_PIN            -1
 #define PS_ON_PIN           9
-#define KILL_PIN           -1
 
 #define HEATER_0_PIN        13
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 #define TEMP_0_PIN          6   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
-#define TEMP_1_PIN         -1   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
-#define TEMP_2_PIN         -1   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
 #define HEATER_BED_PIN      4
 #define TEMP_BED_PIN       10

--- a/Marlin/pins_A4JP.h
+++ b/Marlin/pins_A4JP.h
@@ -38,18 +38,6 @@
   #define SLED_PIN -1
 #endif
 
-#undef X_MS1_PIN
-#undef X_MS2_PIN
-#undef Y_MS1_PIN
-#undef Y_MS2_PIN
-#undef Z_MS1_PIN
-#undef Z_MS2_PIN
-#undef E0_MS1_PIN
-#undef E0_MS2_PIN
-#undef E1_MS1_PIN
-#undef E1_MS2_PIN
-
-#undef DIGIPOTSS_PIN
 //Fan_2 2
 
 /*****************
@@ -108,9 +96,6 @@
 #define HEATER_0_PIN   9
 #define TEMP_0_PIN     0
 #define HEATER_1_PIN   7
-#define TEMP_1_PIN    -1
-#define HEATER_2_PIN  -1
-#define TEMP_2_PIN    -1
 
 #define E0_STEP_PIN   34
 #define E0_DIR_PIN    43
@@ -126,13 +111,10 @@
 #define DIGIPOTSS_PIN 38
 #define DIGIPOT_CHANNELS {4,5,3,0,1} // X Y Z E0 E1 digipot channels to stepper driver mapping
 
-#define SDPOWER       -1
 #define SDSS          53
 #define LED_PIN       13
 #define FAN_PIN        8
 #define PS_ON_PIN      4
-#define KILL_PIN      -1
-#define SUICIDE_PIN   -1 //PIN that has to be turned on right after start, to keep power flowing.
 #define FAN_0_PIN      6 //Glen
 #define FAN_1_PIN      2 //Glen
 

--- a/Marlin/pins_BRAINWAVE.h
+++ b/Marlin/pins_BRAINWAVE.h
@@ -55,21 +55,13 @@
 #define E0_ATT_PIN         20
 
 #define HEATER_0_PIN        4  // Extruder
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 #define HEATER_BED_PIN     38  // Bed
 #define FAN_PIN             3  // Fan
 
 #define TEMP_0_PIN          7  // Extruder / Analog pin numbering
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
 #define TEMP_BED_PIN        6  // Bed / Analog pin numbering
 
-#define SDPOWER            -1
-#define SDSS               -1
 #define LED_PIN            39
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 #if DISABLED(SDSUPPORT)
   // these pins are defined in the SD library if building with SD support

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -60,21 +60,15 @@
 #define E0_ENABLE_PIN      13
 
 #define HEATER_0_PIN       15
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 #define HEATER_BED_PIN     14  // Bed
 #define FAN_PIN            16  // Fan, PWM
 
 #define TEMP_0_PIN          2  // Extruder / Analog pin numbering
 #define TEMP_1_PIN          1  // Spare / Analog pin numbering
-#define TEMP_2_PIN         -1
 #define TEMP_BED_PIN        0  // Bed / Analog pin numbering
 
-#define SDPOWER            -1
 #define SDSS               20
 #define LED_PIN            19
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 #define SD_DETECT_PIN      12
 
 #if DISABLED(SDSUPPORT)

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -35,27 +35,20 @@
 #define X_DIR_PIN 15
 #define X_ENABLE_PIN 24
 
-// X endstop
-#define X_MIN_PIN 3
-#define X_MAX_PIN -1
-
 // Y motor stepper
 #define Y_STEP_PIN 35
 #define Y_DIR_PIN 36
 #define Y_ENABLE_PIN 31
-
-// Y endstop
-#define Y_MIN_PIN 2
-#define Y_MAX_PIN -1
 
 // Z motor stepper
 #define Z_STEP_PIN 40
 #define Z_DIR_PIN 41
 #define Z_ENABLE_PIN 37
 
-// Z endstop
-#define Z_MIN_PIN 5
-#define Z_MAX_PIN -1
+// XYZ endstops
+#define X_STOP_PIN 3
+#define Y_STOP_PIN 2
+#define Z_STOP_PIN 5
 
 // Extruder 0 stepper
 #define E0_STEP_PIN 26
@@ -67,27 +60,14 @@
 #define E1_DIR_PIN 34
 #define E1_ENABLE_PIN 30
 
-#define SDPOWER -1
-#define SDSS -1
-#define LED_PIN -1
-
-// FAN
-#define FAN_PIN -1
-
-#define PS_ON_PIN -1
-#define KILL_PIN -1
 
 #define HEATER_0_PIN 19 // EXTRUDER 1
 #define HEATER_1_PIN 23 // EXTRUDER 2
-// HeatedBad
 #define HEATER_BED_PIN 22
-// Cheaptronic v1.0 hasent EXTRUDER 3
-#define HEATER_2_PIN -1
 
 // Temperature sensors
 #define TEMP_0_PIN 15
 #define TEMP_1_PIN 14
-#define TEMP_2_PIN -1
 #define TEMP_BED_PIN 13
 
 // Cheaptronic v1.0 doesn't support LCD
@@ -108,4 +88,3 @@
 #define BLEN_A 0
 
 // Cheaptronic v1.0 doesn't use this
-#define SD_DETECT_PIN -1

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -58,9 +58,6 @@
 #define E0_DIR_PIN         41
 #define E0_ENABLE_PIN      37
 
-#define SDPOWER            -1
-#define LED_PIN            -1 //Use +12V Aux port for LED Ring
-
 #define FAN_PIN            16 //5V PWM
 
 #define PS_ON_PIN          10 //Set to -1 if using a manual switch on the PWRSW Connector
@@ -76,8 +73,6 @@
 #define TEMP_BED_PIN        0 //ANALOG NUMBERING
 
 #define BEEPER_PIN         36
-
-#define KILL_PIN           -1
 
 // M240  Triggers a camera by emulating a Canon RC-1 Remote
 // Data from: http://www.doc-diy.net/photo/rc-1_hacked/

--- a/Marlin/pins_GEN3_MONOLITHIC.h
+++ b/Marlin/pins_GEN3_MONOLITHIC.h
@@ -62,22 +62,7 @@
 #define HEATER_0_PIN 16
 #define TEMP_0_PIN 0
 
-#define FAN_PIN -1
-
-// bed pins
-#define HEATER_BED_PIN -1
-#define TEMP_BED_PIN -1
-
-
-#define SDSS     -1
-#define SDPOWER          -1
-#define LED_PIN          -1
-
 // pin for controlling the PSU.
 #define PS_ON_PIN       14  // Alex, Do this work on the card?
 
 // Alex extras from Gen3+
-#define KILL_PIN           -1
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
-#define HEATER_2_PIN       -1

--- a/Marlin/pins_GEN3_PLUS.h
+++ b/Marlin/pins_GEN3_PLUS.h
@@ -43,12 +43,7 @@
 #define E0_STEP_PIN        17
 #define E0_DIR_PIN         21
 
-#define LED_PIN            -1
-
-#define FAN_PIN            -1
-
 #define PS_ON_PIN         14
-#define KILL_PIN           -1
 
 #define HEATER_0_PIN       12 // (extruder)
 
@@ -59,9 +54,5 @@
 #define E0_ENABLE_PIN      13
 
 #define TEMP_0_PIN          0   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 33 extruder)
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
 #define TEMP_BED_PIN        5   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
-#define SDPOWER            -1
 #define SDSS               4
-#define HEATER_2_PIN       -1

--- a/Marlin/pins_GEN6.h
+++ b/Marlin/pins_GEN6.h
@@ -53,28 +53,15 @@
 #define E0_DIR_PIN       2    //Edited @ EJE Electronics 20100715
 #define E0_ENABLE_PIN    3    //Added @ EJE Electronics 20100715
 #define TEMP_0_PIN      5     //changed @ rkoeppl 20110410
-#define TEMP_1_PIN      -1    //changed @ rkoeppl 20110410
 
-
-#define TEMP_2_PIN      -1    //changed @ rkoeppl 20110410
 #define HEATER_0_PIN    14    //changed @ rkoeppl 20110410
-#define HEATER_1_PIN    -1
-#define HEATER_2_PIN    -1
 
-#if MB(GEN6)
-  #define HEATER_BED_PIN  -1    //changed @ rkoeppl 20110410
-  #define TEMP_BED_PIN    -1    //changed @ rkoeppl 20110410
-#else
+#if !MB(GEN6)
   #define HEATER_BED_PIN   1    //changed @ rkoeppl 20110410
   #define TEMP_BED_PIN     0    //changed @ rkoeppl 20110410
 #endif
 
-#define SDPOWER          -1
 #define SDSS          17
-#define LED_PIN         -1    //changed @ rkoeppl 20110410
-#define FAN_PIN         -1    //changed @ rkoeppl 20110410
-#define PS_ON_PIN       -1    //changed @ rkoeppl 20110410
-#define KILL_PIN        -1    //changed @ drakelive 20120830
 //our pin for debugging.
 
 #define DEBUG_PIN        0

--- a/Marlin/pins_GEN7_12.h
+++ b/Marlin/pins_GEN7_12.h
@@ -57,25 +57,14 @@
 #define E0_ENABLE_PIN 24
 
 #define TEMP_0_PIN 1
-#define TEMP_1_PIN -1
-#define TEMP_2_PIN -1
 #define TEMP_BED_PIN 2
 
 #define HEATER_0_PIN 4
-#define HEATER_1_PIN -1
-#define HEATER_2_PIN -1
 #define HEATER_BED_PIN 3
 
-#define KILL_PIN -1
 
-#define SDPOWER -1
-#define SDSS -1 // SCL pin of I2C header
-#define LED_PIN -1
-
-#if (GEN7_VERSION >= 13)
-  // Gen7 v1.3 removed the fan pin
-  #define FAN_PIN -1
-#else
+// Gen7 v1.3 removed the fan pin
+#if GEN7_VERSION < 13
   #define FAN_PIN 31
 #endif
 

--- a/Marlin/pins_GEN7_14.h
+++ b/Marlin/pins_GEN7_14.h
@@ -54,22 +54,10 @@
 #define E0_ENABLE_PIN 25
 
 #define TEMP_0_PIN 1
-#define TEMP_1_PIN -1
-#define TEMP_2_PIN -1
 #define TEMP_BED_PIN 0
 
 #define HEATER_0_PIN 4
-#define HEATER_1_PIN -1
-#define HEATER_2_PIN -1
 #define HEATER_BED_PIN 3
-
-#define KILL_PIN -1
-
-#define SDPOWER -1
-#define SDSS -1 // SCL pin of I2C header
-#define LED_PIN -1
-
-#define FAN_PIN -1
 
 #define PS_ON_PIN 15
 
@@ -79,4 +67,3 @@
 //our RS485 pins
 #define TX_ENABLE_PIN 12
 #define RX_ENABLE_PIN 13
-

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -55,20 +55,13 @@
 #define E0_ENABLE_PIN   24
 
 #define TEMP_0_PIN       2
-#define TEMP_1_PIN      -1
-#define TEMP_2_PIN      -1
 #define TEMP_BED_PIN     1   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
 
 #define HEATER_0_PIN     4
-#define HEATER_1_PIN    -1
-#define HEATER_2_PIN    -1
 #define HEATER_BED_PIN   3  // (bed)
 
-#define SDPOWER         -1
 #define SDSS            31                  // SCL pin of I2C header || CS Pin for SD Card support
-#define LED_PIN         -1
 
-#define FAN_PIN         -1
 #define PS_ON_PIN       19
 //our pin for debugging.
 
@@ -79,10 +72,7 @@
 //#define RX_ENABLE_PIN       13
 
 #define BEEPER_PIN       -1
-#define SD_DETECT_PIN    -1
-#define SUICIDE_PIN      -1    //has to be defined; otherwise Power_off doesn't work
 
-#define KILL_PIN -1
 //Pins for 4bit LCD Support
 #define LCD_PINS_RS 18
 #define LCD_PINS_ENABLE 17

--- a/Marlin/pins_LEAPFROG.h
+++ b/Marlin/pins_LEAPFROG.h
@@ -54,13 +54,9 @@
 #define E1_DIR_PIN          40 //40
 #define E1_ENABLE_PIN       36 //36
 
-#define SDPOWER            -1
 #define SDSS               11
-#define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
 #define LED_PIN            13
 #define FAN_PIN            7
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 #define SOL1_PIN   16
 #define SOL2_PIN    17
 
@@ -69,7 +65,6 @@
 #define HEATER_2_PIN       11 //-1 // 13
 #define TEMP_0_PIN         13 //D27   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
 #define TEMP_1_PIN         15 // 1
-#define TEMP_2_PIN         -1 // 2
 #define HEATER_BED_PIN     10 // 14/15
 #define TEMP_BED_PIN       14 // 1,2 or I2C
 /*  Unused (1) (2) (3) 4 5 6 7 8 9 10 11 12 13 (14) (15) (16) 17 (18) (19) (20) (21) (22) (23) 24 (25) (26) (27) 28 (29) (30) (31)  */

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -63,7 +63,6 @@
 #define E1_DIR_PIN 27
 #define E1_ENABLE_PIN 25
 
-#define SDPOWER -1
 #define SDSS 53
 #define LED_PIN 13
 
@@ -72,19 +71,15 @@
 #define FAN2_PIN 36
 #define FAN_SOFT_PWM
 #define CONTROLLERFAN_PIN FAN2_PIN
-#define PS_ON_PIN -1
-#define KILL_PIN -1
 
 #define HEATER_0_PIN 29 // EXTRUDER 1
 #define HEATER_1_PIN 34 // EXTRUDER 2
-#define HEATER_2_PIN -1
 
 #if TEMP_SENSOR_0 == -1
   #define TEMP_0_PIN 4 // ANALOG NUMBERING
 #else
   #define TEMP_0_PIN 0 // ANALOG NUMBERING
 #endif
-
 
 #if TEMP_SENSOR_1 == -1
   #define TEMP_1_PIN 5 // ANALOG NUMBERING

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -56,28 +56,22 @@
 #define E1_DIR_PIN         36
 #define E1_ENABLE_PIN      30
 
-#define SDPOWER            -1
 #define SDSS               53
 #define LED_PIN            13
 
-
 #define FAN_PIN             7   // IO pin. Buffer needed
 #define PS_ON_PIN          12
-#define KILL_PIN           -1
 
 #define HEATER_0_PIN        9
 #define HEATER_1_PIN        8
-#define HEATER_2_PIN       -1
+#define HEATER_BED_PIN     10   // BED
 
 #if TEMP_SENSOR_0 == -1
   #define TEMP_0_PIN        8   // ANALOG NUMBERING
 #else
   #define TEMP_0_PIN       13   // ANALOG NUMBERING
 #endif
-
 #define TEMP_1_PIN         15   // ANALOG NUMBERING
-#define TEMP_2_PIN         -1   // ANALOG NUMBERING
-#define HEATER_BED_PIN     10   // BED
 #define TEMP_BED_PIN       14   // ANALOG NUMBERING
 
 #define BEEPER_PIN         33   // AUX-4

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -60,44 +60,35 @@
 #define E2_DIR_PIN 24
 #define E2_ENABLE_PIN 22
 
-#define SDPOWER -1
 #define SDSS 53
 #define LED_PIN 13
 
 #define FAN_PIN 7
 #define FAN2_PIN 6
 #define PS_ON_PIN 12
-#define KILL_PIN -1
 
-#define HEATER_0_PIN 9 // EXTRUDER 1
-#define HEATER_1_PIN 8 // EXTRUDER 2
-#define HEATER_2_PIN -1
-
+#define HEATER_0_PIN 9  // EXTRUDER 1
 #if TEMP_SENSOR_0 == -1
-  #define TEMP_0_PIN 4 // ANALOG NUMBERING
+  #define TEMP_0_PIN 4  // ANALOG NUMBERING
 #else
   #define TEMP_0_PIN 13 // ANALOG NUMBERING
 #endif
 
-
+#define HEATER_1_PIN 8  // EXTRUDER 2
 #if TEMP_SENSOR_1 == -1
-  #define TEMP_1_PIN 8 // ANALOG NUMBERING
+  #define TEMP_1_PIN 8  // ANALOG NUMBERING
 #else
   #define TEMP_1_PIN 15 // ANALOG NUMBERING
 #endif
 
-#define TEMP_2_PIN -1 // ANALOG NUMBERING
-
 #define HEATER_BED_PIN 10 // BED
-
 #if TEMP_SENSOR_BED == -1
-  #define TEMP_BED_PIN 8 // ANALOG NUMBERING
+  #define TEMP_BED_PIN 8  // ANALOG NUMBERING
 #else
   #define TEMP_BED_PIN 14 // ANALOG NUMBERING
 #endif
 
 #define BEEPER_PIN 64
-
 
 #define LCD_PINS_RS 14
 #define LCD_PINS_ENABLE 15
@@ -105,7 +96,6 @@
 #define LCD_PINS_D5 31
 #define LCD_PINS_D6 32
 #define LCD_PINS_D7 33
-
 
 // Buttons are directly attached using keypad
 #define BTN_EN1 61
@@ -116,4 +106,3 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SD_DETECT_PIN -1  // Megatronics doesn't use this

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -30,7 +30,6 @@
 
 #define LARGE_FLASH        true
 
-
 #if ENABLED(Z_PROBE_SLED)
   #define SLED_PIN         -1
 #endif
@@ -71,12 +70,10 @@
 #define E2_DIR_PIN         60
 #define E2_ENABLE_PIN      23
 
-#define SDPOWER -1
 #define SDSS 53
 #define LED_PIN 13
 
 #define PS_ON_PIN 12
-#define KILL_PIN -1
 
 #define HEATER_0_PIN 2
 #define HEATER_1_PIN 9
@@ -85,10 +82,26 @@
 #define FAN_PIN 6
 #define FAN2_PIN 7
 
-#define TEMP_0_PIN   (TEMP_SENSOR_0 == -1 ?  11 : 15) // ANALOG NUMBERING
-#define TEMP_1_PIN   (TEMP_SENSOR_1 == -1 ?  10 : 13) // ANALOG NUMBERING
-#define TEMP_2_PIN   (TEMP_SENSOR_2 == -1 ?   9 : 12) // ANALOG NUMBERING
-#define TEMP_BED_PIN (TEMP_SENSOR_BED == -1 ? 8 : 14) // ANALOG NUMBERING
+#if TEMP_SENSOR_0 == -1
+  #define TEMP_0_PIN   11 // ANALOG NUMBERING
+#else
+  #define TEMP_0_PIN   15 // ANALOG NUMBERING
+#endif
+#if TEMP_SENSOR_1 == -1
+  #define TEMP_1_PIN   10 // ANALOG NUMBERING
+#else
+  #define TEMP_1_PIN   13 // ANALOG NUMBERING
+#endif
+#if TEMP_SENSOR_2 == -1
+  #define TEMP_2_PIN    9 // ANALOG NUMBERING
+#else
+  #define TEMP_2_PIN   12 // ANALOG NUMBERING
+#endif
+#if TEMP_SENSOR_BED == -1
+  #define TEMP_BED_PIN  8 // ANALOG NUMBERING
+#else
+  #define TEMP_BED_PIN 14 // ANALOG NUMBERING
+#endif
 
 #define BEEPER_PIN 61
 
@@ -113,4 +126,3 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SD_DETECT_PIN -1 // Megatronics doesn't use this

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -30,18 +30,6 @@
 
 #define LARGE_FLASH         true
 
-
-#undef X_MS1_PIN
-#undef X_MS2_PIN
-#undef Y_MS1_PIN
-#undef Y_MS2_PIN
-#undef Z_MS1_PIN
-#undef Z_MS2_PIN
-#undef E0_MS1_PIN
-#undef E0_MS2_PIN
-#undef E1_MS1_PIN
-#undef E1_MS2_PIN
-
 #define X_STEP_PIN          37
 #define X_DIR_PIN           48
 #define X_MIN_PIN           12
@@ -77,11 +65,7 @@
 
 #if ENABLED(BARICUDA)
   #define HEATER_2_PIN       6
-#else
-  #define HEATER_2_PIN      -1
 #endif
-
-#define TEMP_2_PIN          -1
 
 #define E0_STEP_PIN         34
 #define E0_DIR_PIN          43
@@ -92,8 +76,6 @@
 #define E1_STEP_PIN         -1
 #define E1_DIR_PIN          -1
 #define E1_ENABLE_PIN       -1
-#define E1_MS1_PIN          -1
-#define E1_MS2_PIN          -1
 
 #define MOTOR_CURRENT_PWM_XY_PIN 46
 #define MOTOR_CURRENT_PWM_Z_PIN  45
@@ -101,14 +83,10 @@
 //Motor current PWM conversion, PWM value = MotorCurrentSetting * 255 / range
 #define MOTOR_CURRENT_PWM_RANGE 2000
 #define DEFAULT_PWM_MOTOR_CURRENT  {1300, 1300, 1250}
-#define SDPOWER             -1
 #define SDSS                53
 #define LED_PIN             13
 #define FAN_PIN              8
 #define FAN_1_PIN            6
-#define PS_ON_PIN           -1
-#define KILL_PIN            -1  // 80 with Smart Controller LCD
-#define SUICIDE_PIN         -1  // PIN that has to be turned on right after start, to keep power flowing.
 
 #if ENABLED(ULTRA_LCD)
 

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -60,26 +60,18 @@
 #define E2_DIR_PIN -1
 #define E2_ENABLE_PIN -1
 
-#define SDPOWER -1
 #define SDSS 16
 #define LED_PIN 46
 
 #define FAN_PIN 9
-#define FAN2_PIN -1
-#define PS_ON_PIN -1
-#define KILL_PIN -1
 
-#define HEATER_0_PIN 7 // EXTRUDER 1
-#define HEATER_1_PIN 8 // EXTRUDER 2
-#define HEATER_2_PIN -1
-
-
-#define TEMP_0_PIN 7 // ANALOG NUMBERING
-#define TEMP_1_PIN 6 // ANALOG NUMBERING
-#define TEMP_2_PIN -1 // ANALOG NUMBERING
-
-#define HEATER_BED_PIN 3 // BED
+#define TEMP_0_PIN   7 // ANALOG NUMBERING
+#define TEMP_1_PIN   6 // ANALOG NUMBERING
 #define TEMP_BED_PIN 6 // ANALOG NUMBERING
+
+#define HEATER_0_PIN   7 // EXTRUDER 1
+#define HEATER_1_PIN   8 // EXTRUDER 2
+#define HEATER_BED_PIN 3 // BED
 
 #define BEEPER_PIN -1
 
@@ -90,7 +82,6 @@
 #define LCD_PINS_D6 -1
 #define LCD_PINS_D7 -1
 
-
 // Buttons are directly attached using keypad
 #define BTN_EN1 -1
 #define BTN_EN2 -1
@@ -100,4 +91,3 @@
 #define BLEN_B 1
 #define BLEN_A 0
 
-#define SD_DETECT_PIN -1  // Minitronics doesn't use this

--- a/Marlin/pins_OMCA.h
+++ b/Marlin/pins_OMCA.h
@@ -90,23 +90,14 @@
 #define E2_DIR_PIN         -1 // 20
 #define E2_ENABLE_PIN      -1 // 18
 
-#define SDPOWER            -1
 #define SDSS               11
-#define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
-#define LED_PIN            -1
 #define FAN_PIN            14 // PWM on MIDDLE connector
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 #define HEATER_0_PIN        3 // DONE PWM on RIGHT connector
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
+#define HEATER_BED_PIN      4
+
 #define TEMP_0_PIN          0 // ANALOG INPUT NUMBERING
 #define TEMP_1_PIN          1 // ANALOG
-#define TEMP_2_PIN         -1 // 2
-#define HEATER_BED_PIN      4
 #define TEMP_BED_PIN        2 // 1,2 or I2C
 
 #define I2C_SCL            16

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -81,20 +81,10 @@
 #define E2_DIR_PIN         -1 // 16
 #define E2_ENABLE_PIN      24
 
-#define SDPOWER            -1
 #define SDSS               11
-#define SD_DETECT_PIN      -1 // 10 optional also used as mode pin
-#define LED_PIN            -1
 #define FAN_PIN             3
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 #define HEATER_0_PIN        4
-#define HEATER_1_PIN       -1 // 12
-#define HEATER_2_PIN       -1 // 13
 #define TEMP_0_PIN          0 //D27   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
-#define TEMP_1_PIN         -1 // 1
-#define TEMP_2_PIN         -1 // 2
-#define HEATER_BED_PIN     -1 // 14/15
-#define TEMP_BED_PIN       -1 // 1,2 or I2C
+
 /*  Unused (1) (2) (3) 4 5 6 7 8 9 10 11 12 13 (14) (15) (16) 17 (18) (19) (20) (21) (22) (23) 24 (25) (26) (27) 28 (29) (30) (31)  */

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -81,16 +81,9 @@
 
 #define FILWIDTH_PIN        2  // ANALOG NUMBERING
 
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
-
 ////LCD Pin Setup////
 
-#define SDPOWER            -1
 #define SDSS               26
-#define LED_PIN            -1
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 #if DISABLED(SDSUPPORT)
   // these pins are defined in the SD library if building with SD support

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -75,17 +75,9 @@
 
 #define FILWIDTH_PIN        2  // ANALOG NUMBERING
 
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
-
 ////LCD Pin Setup////
 
-#define SDPOWER            -1
 #define SDSS               20 // Teensylu pin mapping
-#define LED_PIN            -1
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
-#define ALARM_PIN          -1
 
 // uncomment to enable an I2C based DAC like on the Printrboard REVF
 #define DAC_STEPPER_CURRENT

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -40,17 +40,6 @@
   #define SLED_PIN         -1
 #endif
 
-#undef X_MS1_PIN
-#undef X_MS2_PIN
-#undef Y_MS1_PIN
-#undef Y_MS2_PIN
-#undef Z_MS1_PIN
-#undef Z_MS2_PIN
-#undef E0_MS1_PIN
-#undef E0_MS2_PIN
-#undef E1_MS1_PIN
-#undef E1_MS2_PIN
-
 #define X_STEP_PIN 37
 #define X_DIR_PIN 48
 #define X_MIN_PIN 12
@@ -86,11 +75,7 @@
 
 #if ENABLED(BARICUDA)
   #define HEATER_2_PIN 6
-#else
-  #define HEATER_2_PIN -1
 #endif
-
-#define TEMP_2_PIN -1
 
 #define E0_STEP_PIN         34
 #define E0_DIR_PIN          43
@@ -107,7 +92,6 @@
 #define DIGIPOTSS_PIN 38
 #define DIGIPOT_CHANNELS {4,5,3,0,1} // X Y Z E0 E1 digipot channels to stepper driver mapping
 
-#define SDPOWER            -1
 #define SDSS               53
 #define LED_PIN            13
 #define FAN_PIN            8
@@ -121,8 +105,6 @@
   Fan_2 2
 ***********************************************************/
 #define PS_ON_PIN          4
-#define KILL_PIN           -1 //80 with Smart Controller LCD
-#define SUICIDE_PIN        -1  //PIN that has to be turned on right after start, to keep power flowing.
 
 #if ENABLED(ULTRA_LCD)
 

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -87,7 +87,6 @@
 #define E1_DIR_PIN         34
 #define E1_ENABLE_PIN      30
 
-#define SDPOWER            -1
 #define SDSS               53
 #define LED_PIN            13
 
@@ -125,27 +124,18 @@
   #define HEATER_0_PIN      8
 #else
   #define HEATER_0_PIN     10   // EXTRUDER 1
+  #if !MB(RAMPS_14_EEF) && !MB(RAMPS_13_EEF) && !MB(RAMPS_14_SF) && !MB(RAMPS_13_SF)
+    #define HEATER_BED_PIN    8    // BED
+  #endif
 #endif
 
-#if MB(RAMPS_14_SF) || MB(RAMPS_13_SF) || ENABLED(IS_RAMPS_EFB)
-  #define HEATER_1_PIN     -1
-#else
+#if !MB(RAMPS_14_SF) && !MB(RAMPS_13_SF) && !ENABLED(IS_RAMPS_EFB)
   #define HEATER_1_PIN      9   // EXTRUDER 2 (FAN On Sprinter)
 #endif
 
-#define HEATER_2_PIN       -1
-
 #define TEMP_0_PIN         13   // ANALOG NUMBERING
 #define TEMP_1_PIN         15   // ANALOG NUMBERING
-#define TEMP_2_PIN         -1   // ANALOG NUMBERING
-
-#if MB(RAMPS_14_EFF) || MB(RAMPS_14_EEF) || MB(RAMPS_14_SF) || MB(RAMPS_13_EFF) || MB(RAMPS_13_EEF) || MB(RAMPS_13_SF)
-  #define HEATER_BED_PIN   -1    // NO BED
-#else
-  #define HEATER_BED_PIN    8    // BED
-#endif
-
-#define TEMP_BED_PIN         14   // ANALOG NUMBERING
+#define TEMP_BED_PIN       14   // ANALOG NUMBERING
 
 #if ENABLED(Z_PROBE_SLED)
   #define SLED_PIN           -1

--- a/Marlin/pins_RAMPS_OLD.h
+++ b/Marlin/pins_RAMPS_OLD.h
@@ -56,8 +56,6 @@
 #define SDPOWER            48
 #define SDSS               53
 #define LED_PIN            13
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 #if ENABLED(RAMPS_V_1_0) // RAMPS_V_1_0
   #define HEATER_0_PIN     12    // RAMPS 1.0
@@ -69,11 +67,7 @@
   #define FAN_PIN           9    // RAMPS 1.1
 #endif
 
-#define HEATER_1_PIN        -1
-#define HEATER_2_PIN        -1
 #define TEMP_0_PIN          2    // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
-#define TEMP_1_PIN          -1
-#define TEMP_2_PIN          -1
 #define TEMP_BED_PIN        1    // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
 
 // SPI for Max6675 or Max31855 Thermocouple

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -77,10 +77,7 @@
 #define PS_ON_PIN          45
 #define KILL_PIN           46
 
-#if TEMP_SENSOR_0 == 0
-  #define TEMP_0_PIN           -1
-  #define HEATER_0_PIN         -1
-#else
+#if TEMP_SENSOR_0 != 0
   #define HEATER_0_PIN          2   // EXTRUDER 1
   #if TEMP_SENSOR_0 == -1
     #define TEMP_0_PIN          6   // ANALOG NUMBERING - connector *K1* on RUMBA thermocouple ADD ON is used
@@ -89,10 +86,7 @@
   #endif
 #endif
 
-#if TEMP_SENSOR_1 == 0
-  #define TEMP_1_PIN           -1
-  #define HEATER_1_PIN         -1
-#else
+#if TEMP_SENSOR_1 != 0
   #define HEATER_1_PIN          3   // EXTRUDER 2
   #if TEMP_SENSOR_1 == -1
     #define TEMP_1_PIN          5   // ANALOG NUMBERING - connector *K2* on RUMBA thermocouple ADD ON is used
@@ -101,10 +95,7 @@
   #endif
 #endif
 
-#if TEMP_SENSOR_2 == 0
-  #define TEMP_2_PIN          -1
-  #define HEATER_2_PIN        -1
-#else
+#if TEMP_SENSOR_2 != 0
   #define HEATER_2_PIN         6    // EXTRUDER 3
   #if TEMP_SENSOR_2 == -1
     #define TEMP_2_PIN         7    // ANALOG NUMBERING - connector *K3* on RUMBA thermocouple ADD ON is used <-- this can not be used when TEMP_SENSOR_BED is defined as thermocouple
@@ -116,10 +107,7 @@
 //optional for extruder 4 or chamber: #define TEMP_X_PIN         12   // ANALOG NUMBERING - default connector for thermistor *T3* on rumba board is used
 //optional FAN1 can be used as 4th heater output: #define HEATER_3_PIN       8    // EXTRUDER 4
 
-#if TEMP_SENSOR_BED == 0
-  #define TEMP_BED_PIN        -1
-  #define HEATER_BED_PIN      -1
-#else
+#if TEMP_SENSOR_BED != 0
   #define HEATER_BED_PIN       9    // BED
   #if TEMP_SENSOR_BED == -1
     #define TEMP_BED_PIN       7    // ANALOG NUMBERING - connector *K3* on RUMBA thermocouple ADD ON is used <-- this can not be used when TEMP_SENSOR_2 is defined as thermocouple
@@ -128,7 +116,6 @@
   #endif
 #endif
 
-#define SDPOWER            -1
 #define SDSS               53
 #define SD_DETECT_PIN      49
 #define BEEPER_PIN         44

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -43,28 +43,21 @@
 #define E0_STEP_PIN         1
 #define E0_DIR_PIN          0
 
-#define LED_PIN            -1
-#define FAN_PIN            -1
-
 #if MB(AZTEEG_X1) || MB(STB_11) || MB(MELZI)
   #define FAN_PIN           4 // Works for Panelolu2 too
-  #if MB(MELZI)
-    #define LED_PIN        27 // On some broken versions of the Sanguino libraries the pin definitions are wrong, so LED_PIN needs to be 28. But you should upgrade your Sanguino libraries! See #368.
-  #elif MB(STB_11)
-    #define LCD_PIN_BL     17 // LCD backlight LED
-  #endif
+#endif
+
+#if MB(MELZI)
+  #define LED_PIN          27 // On some broken versions of the Sanguino libraries the pin definitions are wrong, so LED_PIN needs to be 28. But you should upgrade your Sanguino libraries! See #368.
+#elif MB(STB_11)
+  #define LCD_PIN_BL       17 // LCD backlight LED
 #endif
 
 #if ENABLED(Z_PROBE_SLED)
   #define SLED_PIN         -1
 #endif
 
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
-
 #define HEATER_0_PIN       13 // (extruder)
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 
 #if ENABLED(SANGUINOLOLU_V_1_2)
 
@@ -89,10 +82,7 @@
 #endif
 
 #define TEMP_0_PIN          7   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 33 extruder)
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
 #define TEMP_BED_PIN        6   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
-#define SDPOWER            -1
 #define SDSS               31
 
 /**
@@ -190,7 +180,3 @@
   #define SD_DETECT_PIN         -1
 
 #endif // MAKRPANEL
-
-// #if FAN_PIN == 12 || FAN_PIN ==13
-//#define FAN_SOFT_PWM
-// #endif

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -53,12 +53,9 @@
 #define E0_ENABLE_PIN      19
 
 #define HEATER_0_PIN       21  // Extruder
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 #define HEATER_BED_PIN     20  // Bed
 #define FAN_PIN            16  // Fan   -- from Teensyduino environment.
                                // For the fan and Teensyduino uses a different pin mapping.
-
 #define X_STOP_PIN         13
 #define Y_STOP_PIN         14
 //#define Z_STOP_PIN         15
@@ -66,9 +63,6 @@
 
 #define TEMP_0_PIN          7  // Extruder / Analog pin numbering
 #define TEMP_BED_PIN        6  // Bed / Analog pin numbering
-
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
 
 #if DISABLED(SDSUPPORT)
   // these pins are defined in the SD library if building with SD support
@@ -103,11 +97,6 @@
 #define EXT_AUX_A4                 4 // Analog
 #define EXT_AUX_A4_IO             44 // Digital IO, 42 (teensy), 44 (marlin)
 
-
-#define SDPOWER            -1
-#define LED_PIN            -1
-#define PS_ON_PIN          -1
-#define SD_DETECT_PIN      -1
 
 #define BEEPER_PIN         -1
 #define LCD_PINS_RS        -1

--- a/Marlin/pins_SETHI.h
+++ b/Marlin/pins_SETHI.h
@@ -57,20 +57,11 @@
 #define E0_ENABLE_PIN 24
 
 #define TEMP_0_PIN 1
-#define TEMP_1_PIN -1
-#define TEMP_2_PIN -1
 #define TEMP_BED_PIN 2
 
 #define HEATER_0_PIN 4
-#define HEATER_1_PIN -1
-#define HEATER_2_PIN -1
 #define HEATER_BED_PIN 3
 
-#define KILL_PIN -1
-
-#define SDPOWER -1
-#define SDSS -1 // SCL pin of I2C header
-#define LED_PIN -1
 
 #if (GEN7_VERSION >= 13)
   // Gen7 v1.3 removed the fan pin

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -93,8 +93,6 @@
 #define E0_ENABLE_PIN      26 // Shared w/x
 
 #define HEATER_0_PIN       15 //  21  // Extruder
-#define HEATER_1_PIN       -1
-#define HEATER_2_PIN       -1
 #define HEATER_BED_PIN     14 // 20  // Bed
 #define FAN_PIN            16 // 22  // Fan
 
@@ -104,15 +102,10 @@
 
 #define TEMP_0_PIN          7 // Extruder / Analog pin numbering
 #define TEMP_BED_PIN        6 // Bed / Analog pin numbering
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
 
-#define SDPOWER            -1
-#define SD_DETECT_PIN      -1
 #define SDSS               20 // 8
 #define LED_PIN             6
 #define PS_ON_PIN          27
-#define KILL_PIN           -1
 
 #if DISABLED(SDSUPPORT)
   // these pins are defined in the SD library if building with SD support

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -72,14 +72,7 @@
 #define TEMP_0_PIN          7  // Extruder / Analog pin numbering
 #define TEMP_BED_PIN        6  // Bed / Analog pin numbering
 
-#define TEMP_1_PIN         -1
-#define TEMP_2_PIN         -1
-
-#define SDPOWER            -1
 #define SDSS                8
-#define LED_PIN            -1
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 #if DISABLED(SDSUPPORT)
   // these pins are defined in the SD library if building with SD support

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -55,9 +55,6 @@
 #define HEATER_1_PIN 3
 #define TEMP_1_PIN 9
 
-#define HEATER_2_PIN -1
-#define TEMP_2_PIN -1
-
 #define E0_STEP_PIN         42
 #define E0_DIR_PIN          43
 #define E0_ENABLE_PIN       37
@@ -66,13 +63,9 @@
 #define E1_DIR_PIN          47
 #define E1_ENABLE_PIN       48
 
-#define SDPOWER            -1
 #define SDSS               53
 #define LED_PIN            8
 #define FAN_PIN            7
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
-#define SUICIDE_PIN        -1  //PIN that has to be turned on right after start, to keep power flowing.
 #define SAFETY_TRIGGERED_PIN     28 //PIN to detect the safety circuit has triggered
 #define MAIN_VOLTAGE_MEASURE_PIN 14 //Analogue PIN to measure the main voltage, with a 100k - 4k7 resitor divider.
 

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -62,9 +62,6 @@
 #define HEATER_1_PIN 3
 #define TEMP_1_PIN 9
 
-#define HEATER_2_PIN -1
-#define TEMP_2_PIN -1
-
 #define E0_STEP_PIN         43
 #define E0_DIR_PIN          45
 #define E0_ENABLE_PIN       41
@@ -73,12 +70,10 @@
 #define E1_DIR_PIN          47
 #define E1_ENABLE_PIN       48
 
-#define SDPOWER            -1
 #define SDSS               53
 #define LED_PIN            13
 #define FAN_PIN            7
 #define PS_ON_PIN          12
-#define KILL_PIN           -1
 #define SUICIDE_PIN        54  //PIN that has to be turned on right after start, to keep power flowing.
 
 #if ENABLED(ULTRA_LCD)

--- a/Marlin/pins_ULTIMAKER_OLD.h
+++ b/Marlin/pins_ULTIMAKER_OLD.h
@@ -51,17 +51,11 @@
 #define Z_MAX_PIN 18
 #define Z_ENABLE_PIN 35
 
-#define HEATER_BED_PIN -1
-#define TEMP_BED_PIN -1
-
-#define HEATER_0_PIN  2
 #define TEMP_0_PIN 8
-
-#define HEATER_1_PIN 1
 #define TEMP_1_PIN 1
 
-#define HEATER_2_PIN -1
-#define TEMP_2_PIN -1
+#define HEATER_0_PIN  2
+#define HEATER_1_PIN  1
 
 #define E0_STEP_PIN         43
 #define E0_DIR_PIN          45
@@ -70,14 +64,6 @@
 #define E1_STEP_PIN         -1
 #define E1_DIR_PIN          -1
 #define E1_ENABLE_PIN       -1
-
-#define SDPOWER            -1
-#define SDSS               -1
-#define LED_PIN            -1
-#define FAN_PIN            -1
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
-#define SUICIDE_PIN        -1  //PIN that has to be turned on right after start, to keep power flowing.
 
 #define LCD_PINS_RS 24
 #define LCD_PINS_ENABLE 22


### PR DESCRIPTION
This is a cleanup that is both obvious and long overdue.

Background: Pins files are "littered" with definitions of pins they don't have, and `#undef` lines only needed due to certain choices in `pins.h`.

This PR removes instances in pins files where:
- Pins are defined as -1 (when they are not overrides of RAMPS pins, for example)
- Adds conditional defines to `pins.h` defining pins not defined by the board.
- Removes the pre-defined pins from the top of `pins.h` that required board-pins to `#undef` them.

This PR additionally:
- Adds microstepping and extruder auto fans to the sensitive pins list
- Adds FAN1 and FAN2 to the sensitive pins list
- Moves the conditional definition of `analogInputToDigitalPin` to `pins.h`
- Alters `analogInputToDigitalPin` to account for `-1` (don't convert it into `0x9F`!)
