### PR TITLE
Fallthru in thermal runaway test when TRState changes

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1047,15 +1047,14 @@ void Temperature::init() {
     int heater_index = heater_id >= 0 ? heater_id : EXTRUDERS;
 
     // If the target temperature changes, restart
-    if (tr_target_temperature[heater_index] != target_temperature)
-      *state = TRInactive;
+    if (tr_target_temperature[heater_index] != target_temperature) {
+      tr_target_temperature[heater_index] = target_temperature;
+      *state = target_temperature > 0 ? TRFirstHeating : TRInactive;
+    }
 
     switch (*state) {
       // Inactive state waits for a target temperature to be set
-      case TRInactive:
-        if (target_temperature <= 0) break;
-        tr_target_temperature[heater_index] = target_temperature;
-        *state = TRFirstHeating;
+      case TRInactive: break;
       // When first heating, wait for the temperature to be reached then go to Stable state
       case TRFirstHeating:
         if (temperature < tr_target_temperature[heater_index]) break;

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1048,12 +1048,9 @@ void Temperature::init() {
 
     // If the target temperature changes, restart
     if (tr_target_temperature[heater_index] != target_temperature)
-      *state = TRReset;
+      *state = TRInactive;
 
     switch (*state) {
-      case TRReset:
-        *timer = 0;
-        *state = TRInactive;
       // Inactive state waits for a target temperature to be set
       case TRInactive:
         if (target_temperature <= 0) break;

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -358,17 +358,17 @@ class Temperature {
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) || HAS_THERMALLY_PROTECTED_BED
 
-      typedef enum TRState { TRReset, TRInactive, TRFirstHeating, TRStable, TRRunaway } TRstate;
+      typedef enum TRState { TRInactive, TRFirstHeating, TRStable, TRRunaway } TRstate;
 
       void thermal_runaway_protection(TRState* state, millis_t* timer, float temperature, float target_temperature, int heater_id, int period_seconds, int hysteresis_degc);
 
       #if ENABLED(THERMAL_PROTECTION_HOTENDS)
-        TRState thermal_runaway_state_machine[EXTRUDERS] = { TRReset };
+        TRState thermal_runaway_state_machine[EXTRUDERS] = { TRInactive };
         millis_t thermal_runaway_timer[EXTRUDERS] = { 0 };
       #endif
 
       #if HAS_THERMALLY_PROTECTED_BED
-        TRState thermal_runaway_bed_state_machine = TRReset;
+        TRState thermal_runaway_bed_state_machine = TRInactive;
         millis_t thermal_runaway_bed_timer;
       #endif
 


### PR DESCRIPTION
Addressing #3703 

Background: If the `temperature` (current temperature measurement) changes in-between invocations of `thermal_runaway_protection`, in some rare instances it could cause `*timer` not to be initialized when `TRFirstHeating` state is set.

This PR fixes the issue by falling-through on all state changes, so that as soon as `TRFirstHeating` state is set, the `*timer` value will be set right away.

Additionally:
- The `TRReset` state is no longer needed.
- When the target temperature changes, set the initial state based on whether it is zero or not.
