### PR TITLE
Individual axis homing menu items

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1035,6 +1035,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1018,6 +1018,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -1027,6 +1027,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -1029,6 +1029,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1052,6 +1052,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1035,6 +1035,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -41,6 +41,13 @@
 #include "boards.h"
 #include "macros.h"
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //===========================================================================
 //============================= Getting Started =============================
 //===========================================================================

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1043,6 +1043,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -1056,6 +1056,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -1027,6 +1027,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1035,6 +1035,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -1164,6 +1164,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1164,6 +1164,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1168,6 +1168,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1161,6 +1161,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1169,6 +1169,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1038,6 +1038,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1029,6 +1029,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define SAV_3DLCD
 
+//
+// Individual Axis Homing
+//
+// When active will add individual axis homing menu items to the LCD.
+//
+//#define INDIVIDUAL_AXIS_HOMING_MENU
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -64,6 +64,15 @@
 #ifndef MSG_AUTO_HOME
   #define MSG_AUTO_HOME                       "Auto home"
 #endif
+#ifndef MSG_AUTO_HOME_X
+  #define MSG_AUTO_HOME_X                     "Home X"
+#endif
+#ifndef MSG_AUTO_HOME_Y
+  #define MSG_AUTO_HOME_Y                     "Home Y"
+#endif
+#ifndef MSG_AUTO_HOME_Z
+  #define MSG_AUTO_HOME_Z                     "Home Z"
+#endif
 #ifndef MSG_LEVEL_BED_HOMING
   #define MSG_LEVEL_BED_HOMING                "Homing XYZ"
 #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1093,6 +1093,11 @@ static void lcd_prepare_menu() {
   // Auto Home
   //
   MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
+  #if ENABLED(INDIVIDUAL_AXIS_HOMING_MENU)
+    MENU_ITEM(gcode, "Home X", PSTR("G28 X"));
+    MENU_ITEM(gcode, "Home Y", PSTR("G28 Y"));
+    MENU_ITEM(gcode, "Home Z", PSTR("G28 Z"));
+  #endif
 
   //
   // Set Home Offsets

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1094,9 +1094,9 @@ static void lcd_prepare_menu() {
   //
   MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
   #if ENABLED(INDIVIDUAL_AXIS_HOMING_MENU)
-    MENU_ITEM(gcode, "Home X", PSTR("G28 X"));
-    MENU_ITEM(gcode, "Home Y", PSTR("G28 Y"));
-    MENU_ITEM(gcode, "Home Z", PSTR("G28 Z"));
+    MENU_ITEM(gcode, MSG_AUTO_HOME_X, PSTR("G28 X"));
+    MENU_ITEM(gcode, MSG_AUTO_HOME_Y, PSTR("G28 Y"));
+    MENU_ITEM(gcode, MSG_AUTO_HOME_Z, PSTR("G28 Z"));
   #endif
 
   //


### PR DESCRIPTION
Adds a configurable option (disabled by default) which adds individual axis homing to the LCD menu. Idea taken from #3698.
