### PR TITLE
Minor #warning fix for PrintCounter

### DIFF
--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -22,7 +22,6 @@
 
 #include "Marlin.h"
 #include "printcounter.h"
-#include <avr/eeprom.h>
 
 PrintCounter::PrintCounter(): super() {
   this->loadStats();
@@ -123,7 +122,6 @@ void PrintCounter::tick() {
       PrintCounter::debug(PSTR("tick"));
     #endif
 
-    uint16_t t = this->duration();;
     this->data.printTime += this->deltaDuration();
     update_before = now;
   }

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -25,6 +25,8 @@
 
 #include "macros.h"
 #include "stopwatch.h"
+#include <avr/eeprom.h>
+
 
 // Print debug messages with M111 S2
 //#define DEBUG_PRINTCOUNTER


### PR DESCRIPTION
Fixes a `#warning` for a unused `t` var.
