### PR TITLE
for boards with AD5206 digipoti

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6193,6 +6193,10 @@ inline void gcode_M907() {
       if (code_seen(axis_codes[i])) digipot_current(i, code_value());
     if (code_seen('B')) digipot_current(4, code_value());
     if (code_seen('S')) for (int i = 0; i <= 4; i++) digipot_current(i, code_value());
+    if (code_seen('X')) digipot_current(0, code_value());
+    if (code_seen('Y')) digipot_current(1, code_value());
+    if (code_seen('Z')) digipot_current(2, code_value());
+    if (code_seen('E')) digipot_current(3, code_value());
   #endif
   #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
     if (code_seen('X')) digipot_current(0, code_value());


### PR DESCRIPTION
Before, M907 could not be used to set individual current limits. (M908 and a look at the settings in pins.h was necessary). This patch fixes that. It's useful to experimentally find the best current setting for your steppers, without constant firmware re-flashing.
