### PR TITLE
Print an error on bad i2c request

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5038,7 +5038,7 @@ inline void gcode_M121() { endstops.enable_globally(false); }
    */
   inline void gcode_M156() {
     uint8_t addr = code_seen('A') ? code_value_short() : 0;
-    int bytes    = code_seen('B') ? code_value_short() : 0;
+    int bytes    = code_seen('B') ? code_value_short() : 1;
 
     if (addr && bytes > 0 && bytes <= 32) {
       i2c.address(addr);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5040,9 +5040,13 @@ inline void gcode_M121() { endstops.enable_globally(false); }
     uint8_t addr = code_seen('A') ? code_value_short() : 0;
     int bytes    = code_seen('B') ? code_value_short() : 0;
 
-    if (addr && bytes) {
+    if (addr && bytes > 0 && bytes <= 32) {
       i2c.address(addr);
       i2c.reqbytes(bytes);
+    }
+    else {
+      SERIAL_ERROR_START;
+      SERIAL_ERRORLN("Bad i2c request");
     }
   }
 


### PR DESCRIPTION
Reference: https://github.com/MarlinFirmware/Marlin/pull/3713#issuecomment-218333678
- When requesting bytes from i2c, you must request between 1 and 32 bytes.
- If the `B` parameter is left off, just get a single byte.

Note that you cannot request data from "Address 0".
