### PR TITLE
Add REVERSE_ENCODER_DIRECTION option

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -863,6 +863,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -846,6 +846,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/Felix/Configuration_DUAL.h
+++ b/Marlin/example_configurations/Felix/Configuration_DUAL.h
@@ -844,6 +844,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -855,6 +855,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -857,6 +857,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -880,6 +880,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -863,6 +863,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -858,6 +858,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -871,6 +871,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -884,6 +884,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ENCODER_STEPS_PER_MENU_ITEM 1
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -855,6 +855,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -863,6 +863,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -992,6 +992,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -992,6 +992,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -996,6 +996,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -989,6 +989,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -997,6 +997,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -866,6 +866,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -857,6 +857,13 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //#define ENCODER_STEPS_PER_MENU_ITEM 5
 
 //
+// This option reverses the encoder direction everywhere
+//
+//  Set this option if CLOCKWISE causes values to DECREASE
+//
+//#define REVERSE_ENCODER_DIRECTION
+
+//
 // This option reverses the encoder direction for navigating LCD menus.
 //
 //  If CLOCKWISE normally moves DOWN this makes it go UP.

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2466,9 +2466,15 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
       GET_BUTTON_STATES(buttons);
     #endif //!NEWPANEL
 
-    #if ENABLED(REVERSE_MENU_DIRECTION)
+    #if ENABLED(REVERSE_MENU_DIRECTION) && ENABLED(REVERSE_ENCODER_DIRECTION)
+      #define ENCODER_DIFF_CW  (encoderDiff -= encoderDirection)
+      #define ENCODER_DIFF_CCW (encoderDiff += encoderDirection)
+    #elif ENABLED(REVERSE_MENU_DIRECTION)
       #define ENCODER_DIFF_CW  (encoderDiff += encoderDirection)
       #define ENCODER_DIFF_CCW (encoderDiff -= encoderDirection)
+    #elif ENABLED(REVERSE_ENCODER_DIRECTION)
+      #define ENCODER_DIFF_CW  (encoderDiff--)
+      #define ENCODER_DIFF_CCW (encoderDiff++)
     #else
       #define ENCODER_DIFF_CW  (encoderDiff++)
       #define ENCODER_DIFF_CCW (encoderDiff--)


### PR DESCRIPTION
For some encoders, the default behavior of the encoder wheel is reversed. You can tell if your encoder is backward, because when editing values in the LCD menu they will DECREASE when rotating CLOCKWISE. This option reverses the encoder everywhere, so that it behaves in the preferred manner.

This option should usually be set first, before choosing to set `REVERSE_MENU_DIRECTION`. If menus also move opposite of user-preference before setting `REVERSE_ENCODER_DIRECTION`, this option will fix that, obviating the need to set `REVERSE_MENU_DIRECTION`.
