### PR TITLE
Printcounter bugfix and some new features

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -757,6 +757,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#defined PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -769,7 +769,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // - M75  - Start the print job timer
 // - M76  - Pause the print job timer
 // - M77  - Stop the print job timer
-#defined PRINTJOB_TIMER_AUTOSTART
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4289,21 +4289,23 @@ inline void gcode_M104() {
         thermalManager.setTargetHotend(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset, 1);
     #endif
 
-    /**
-     * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
-     * stand by mode, for instance in a dual extruder setup, without affecting
-     * the running print timer.
-     */
-    if (temp <= (EXTRUDE_MINTEMP)/2) {
-      print_job_timer.stop();
-      LCD_MESSAGEPGM(WELCOME_MSG);
-    }
-    /**
-     * We do not check if the timer is already running because this check will
-     * be done for us inside the Stopwatch::start() method thus a running timer
-     * will not restart.
-     */
-    else print_job_timer.start();
+    #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
+      /**
+       * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
+       * stand by mode, for instance in a dual extruder setup, without affecting
+       * the running print timer.
+       */
+      if (temp <= (EXTRUDE_MINTEMP)/2) {
+        print_job_timer.stop();
+        LCD_MESSAGEPGM(WELCOME_MSG);
+      }
+      /**
+       * We do not check if the timer is already running because this check will
+       * be done for us inside the Stopwatch::start() method thus a running timer
+       * will not restart.
+       */
+      else print_job_timer.start();
+    #endif
 
     if (temp > thermalManager.degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
   }
@@ -4442,21 +4444,23 @@ inline void gcode_M109() {
         thermalManager.setTargetHotend(temp == 0.0 ? 0.0 : temp + duplicate_extruder_temp_offset, 1);
     #endif
 
-    /**
-     * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
-     * stand by mode, for instance in a dual extruder setup, without affecting
-     * the running print timer.
-     */
-    if (temp <= (EXTRUDE_MINTEMP)/2) {
-      print_job_timer.stop();
-      LCD_MESSAGEPGM(WELCOME_MSG);
-    }
-    /**
-     * We do not check if the timer is already running because this check will
-     * be done for us inside the Stopwatch::start() method thus a running timer
-     * will not restart.
-     */
-    else print_job_timer.start();
+    #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
+      /**
+       * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
+       * stand by mode, for instance in a dual extruder setup, without affecting
+       * the running print timer.
+       */
+      if (temp <= (EXTRUDE_MINTEMP)/2) {
+        print_job_timer.stop();
+        LCD_MESSAGEPGM(WELCOME_MSG);
+      }
+      /**
+       * We do not check if the timer is already running because this check will
+       * be done for us inside the Stopwatch::start() method thus a running timer
+       * will not restart.
+       */
+      else print_job_timer.start();
+    #endif
 
     if (temp > thermalManager.degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
   }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4267,7 +4267,10 @@ inline void gcode_M77() {
    * M78: Show print statistics
    */
   inline void gcode_M78() {
-    print_job_timer.showStats();
+    // "M78 S78" will reset the statistics
+    if (code_seen('S') && code_value_short() == 78)
+      print_job_timer.initStats();
+    else print_job_timer.showStats();
   }
 #endif
 

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -740,6 +740,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -749,6 +749,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -751,6 +751,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP    110
 #define ABS_PREHEAT_FAN_SPEED   0   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -774,6 +774,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 60 // K8200: set back to 110 if you have an upgraded heatbed power supply
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -757,6 +757,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -752,6 +752,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -765,6 +765,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -778,6 +778,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -749,6 +749,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -757,6 +757,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 110
 #define ABS_PREHEAT_FAN_SPEED 0   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -886,6 +886,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -886,6 +886,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -890,6 +890,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -883,6 +883,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -891,6 +891,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -760,6 +760,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -751,6 +751,19 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define ABS_PREHEAT_HPB_TEMP 100
 #define ABS_PREHEAT_FAN_SPEED 255   // Insert Value between 0 and 255
 
+//
+// Print job timer
+//
+// This options allows you configure if the print job timer should automatically
+// start and stop counting when a M104 or M109 is received.
+//
+// If disabled you can control the print timer start and stop using the
+// following G-Code list:
+//
+// - M75  - Start the print job timer
+// - M76  - Pause the print job timer
+// - M77  - Stop the print job timer
+#define PRINTJOB_TIMER_AUTOSTART
 
 //
 // Print Counter

--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -149,7 +149,9 @@ void PrintCounter::stop() {
     PrintCounter::debug(PSTR("stop"));
   #endif
 
+  if (!this->isRunning()) return;
   super::stop();
+
   this->data.finishedPrints++;
   this->data.printTime += this->deltaDuration();
   this->saveStats();


### PR DESCRIPTION
This PR does the following changes:
- Sending `M78 S78` resets the print stats
- Fixes a bug where `M77` would always increment the print job statistics
- Adds a new config option `#define PRINTJOB_TIMER_AUTOSTART`, when disabled we don't start the print timer with `M104` and `M109`
