### PR TITLE
Fix various issues with MBL command M421

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5851,19 +5851,22 @@ inline void gcode_M410() { stepper.quick_stop(); }
     if ((hasY = code_seen('Y'))) y = code_value();
     if ((hasZ = code_seen('Z'))) z = code_value();
 
-    if (!hasX || !hasY || !hasZ) {
+    if (hasX && hasY && hasZ) {
+
+      int8_t ix = mbl.select_x_index(x),
+             iy = mbl.select_y_index(y);
+
+      if (ix >= 0 && iy >= 0)
+        mbl.set_z(ix, iy, z);
+      else {
+        SERIAL_ERROR_START;
+        SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
+      }
+    }
+    else {
       SERIAL_ERROR_START;
       SERIAL_ERRORLNPGM(MSG_ERR_M421_REQUIRES_XYZ);
-      err = true;
     }
-
-    if (x >= MESH_NUM_X_POINTS || y >= MESH_NUM_Y_POINTS) {
-      SERIAL_ERROR_START;
-      SERIAL_ERRORLNPGM(MSG_ERR_MESH_INDEX_OOB);
-      err = true;
-    }
-
-    if (!err) mbl.set_z(mbl.select_x_index(x), mbl.select_y_index(y), z);
   }
 
 #endif

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -738,7 +738,8 @@ void Config_PrintSettings(bool forReplay) {
         CONFIG_ECHO_START;
         SERIAL_ECHOPAIR("  M421 X", mbl.get_x(x));
         SERIAL_ECHOPAIR(" Y", mbl.get_y(y));
-        SERIAL_ECHOPAIR(" Z", mbl.z_values[y][x]);
+        SERIAL_ECHOPGM(" Z");
+        SERIAL_PROTOCOL_F(mbl.z_values[y][x], 5);
         SERIAL_EOL;
       }
     }

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -148,7 +148,7 @@
 #define MSG_Z_PROBE                         "z_probe: "
 #define MSG_ERR_MATERIAL_INDEX              "M145 S<index> out of range (0-1)"
 #define MSG_ERR_M421_REQUIRES_XYZ           "M421 requires XYZ parameters"
-#define MSG_ERR_MESH_INDEX_OOB              "Mesh XY index is out of bounds"
+#define MSG_ERR_MESH_XY                     "Mesh XY cannot be resolved"
 #define MSG_ERR_M428_TOO_FAR                "Too far from reference point"
 #define MSG_ERR_M303_DISABLED               "PIDTEMP disabled"
 #define MSG_M119_REPORT                     "Reporting endstop status"

--- a/Marlin/mesh_bed_leveling.cpp
+++ b/Marlin/mesh_bed_leveling.cpp
@@ -31,8 +31,8 @@
   void mesh_bed_leveling::reset() {
     active = 0;
     z_offset = 0;
-    for (int y = 0; y < MESH_NUM_Y_POINTS; y++)
-      for (int x = 0; x < MESH_NUM_X_POINTS; x++)
+    for (int8_t y = MESH_NUM_Y_POINTS; y--;)
+      for (int8_t x = MESH_NUM_X_POINTS; x--;)
         z_values[y][x] = 0;
   }
 

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -37,32 +37,34 @@
 
     void reset();
 
-    float get_x(int i) { return MESH_MIN_X + (MESH_X_DIST) * i; }
-    float get_y(int i) { return MESH_MIN_Y + (MESH_Y_DIST) * i; }
-    void set_z(int ix, int iy, float z) { z_values[iy][ix] = z; }
+    static FORCE_INLINE float get_x(int8_t i) { return MESH_MIN_X + (MESH_X_DIST) * i; }
+    static FORCE_INLINE float get_y(int8_t i) { return MESH_MIN_Y + (MESH_Y_DIST) * i; }
+    void set_z(int8_t ix, int8_t iy, float z) { z_values[iy][ix] = z; }
 
-    inline void zigzag(int index, int &ix, int &iy) {
+    inline void zigzag(int8_t index, int8_t &ix, int8_t &iy) {
       ix = index % (MESH_NUM_X_POINTS);
       iy = index / (MESH_NUM_X_POINTS);
       if (iy & 1) ix = (MESH_NUM_X_POINTS - 1) - ix; // Zig zag
     }
 
-    void set_zigzag_z(int index, float z) {
+    void set_zigzag_z(int8_t index, float z) {
       int ix, iy;
       zigzag(index, ix, iy);
       set_z(ix, iy, z);
     }
 
-    int select_x_index(float x) {
-      int i = 1;
-      while (x > get_x(i) && i < MESH_NUM_X_POINTS - 1) i++;
-      return i - 1;
+    int8_t select_x_index(float x) {
+      for (uint8_t i = MESH_NUM_X_POINTS; i--;)
+        if (fabs(x - get_x(i)) <= (MESH_X_DIST) / 2)
+          return i;
+      return -1;
     }
 
-    int select_y_index(float y) {
-      int i = 1;
-      while (y > get_y(i) && i < MESH_NUM_Y_POINTS - 1) i++;
-      return i - 1;
+    int8_t select_y_index(float y) {
+      for (uint8_t i = MESH_NUM_Y_POINTS; i--;)
+        if (fabs(y - get_y(i)) <= (MESH_Y_DIST) / 2)
+          return i;
+      return -1;
     }
 
     float calc_z0(float a0, float a1, float z1, float a2, float z2) {
@@ -72,8 +74,9 @@
     }
 
     float get_z(float x0, float y0) {
-      int x_index = select_x_index(x0);
-      int y_index = select_y_index(y0);
+      int8_t x_index = select_x_index(x0);
+      int8_t y_index = select_y_index(y0);
+      if (x_index < 0 || y_index < 0) return z_offset;
       float z1 = calc_z0(x0,
                          get_x(x_index), z_values[y_index][x_index],
                          get_x(x_index + 1), z_values[y_index][x_index + 1]);


### PR DESCRIPTION
Addressing issues noted in #3745
- Output more precise `M421` Z values in the `M503` report
- Change point-to-index matching to simply use nearest-point
- Use 8-bit integers for MBL indices
- Fix: `M421` reports an error and fails for good XY values
