### PR TITLE
Bugfix: iteration invokes undefined behavior

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -342,7 +342,7 @@ int Temperature::getHeaterPower(int heater) {
       EXTRUDER_3_AUTO_FAN_PIN == EXTRUDER_2_AUTO_FAN_PIN ? 2 : 3
     };
     uint8_t fanState = 0;
-    for (int f = 0; f <= 3; f++) {
+    for (int f = 0; f <= EXTRUDERS; f++) {
       if (current_temperature[f] > EXTRUDER_AUTO_FAN_TEMPERATURE)
         SBI(fanState, fanBit[f]);
     }


### PR DESCRIPTION
Quick fix for the compiler warning.

``` cpp
sketch\temperature.cpp: In member function 'void Temperature::checkExtruderAutoFans()':

sketch\temperature.cpp:346:32: warning: iteration 1u invokes undefined behavior [-Waggressive-loop-optimizations]

       if (current_temperature[f] > EXTRUDER_AUTO_FAN_TEMPERATURE)

                                ^

sketch\temperature.cpp:345:5: note: containing loop

     for (int f = 0; f <= 3; f++) {

     ^
```
