### PR TITLE
MBL: Add option to configure resting position for G28 all axis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -525,6 +525,8 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
   #define MESH_NUM_Y_POINTS 3
   #define MESH_HOME_SEARCH_Z 4  // Z after Home, bed somewhere below but above 0.0.
 
+  //#define MESH_G28_REST_ORIGIN // Enable to make 'G28' all axis to rest at origin [0,0,0]
+
   //#define MANUAL_BED_LEVELING  // Add display menu option for bed leveling.
 
   #if ENABLED(MANUAL_BED_LEVELING)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2867,17 +2867,19 @@ inline void gcode_G28() {
     #endif
   #endif
 
-  // For mesh leveling move back to Z=0
+  // Enable mesh leveling again
   #if ENABLED(MESH_BED_LEVELING)
     if (mbl_was_active && home_all_axis) {
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       sync_plan_position();
       mbl.active = 1;
-      current_position[Z_AXIS] = 0.0;
-      set_destination_to_current();
-      feedrate = homing_feedrate[Z_AXIS];
-      line_to_destination();
-      stepper.synchronize();
+      #if ENABLED(MESH_G28_REST_ORIGIN)
+        current_position[Z_AXIS] = 0.0;
+        set_destination_to_current();
+        feedrate = homing_feedrate[Z_AXIS];
+        line_to_destination();
+        stepper.synchronize();
+      #endif
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) DEBUG_POS("mbl_was_active", current_position);
       #endif


### PR DESCRIPTION
Because there is no requirement (when using MBL) that the endstop for Z triggers when the nozzle is touching the bed the nozzle can be left in this position rather be moved to `[0,0,0]` touching the bed.

There has been a couple of request for either of these behavior and this PR try to facilitate it with a new configuration option `MESH_G28_REST_ORIGIN`. Default OFF.

Enabled it will move the nozzle to `[0,0,0]` and disabled it will leave the nozzle at the Z endstop trigger position.

As `G29` as a last step in the probing pattern makes a `G28` this will also affect that.

Tested by @brainscan https://github.com/MarlinFirmware/MarlinDev/issues/162#issuecomment-220195062 
