### PR TITLE
Rework intermediate idle() and manage_heater() calls in G2/G3 and G5

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -448,11 +448,11 @@
 // @section extras
 
 // Arc interpretation settings:
-#define ARC_SUPPORT  // Disabling this saves ~2660bytes
+#define ARC_SUPPORT  // Disabling this saves ~2738 bytes
 #define MM_PER_ARC_SEGMENT 1
 #define N_ARC_CORRECTION 25
 
-// Support for G5 with XYZE destination and IJPQ offsets
+// Support for G5 with XYZE destination and IJPQ offsets. Needs ~2666 bytes
 //#define BEZIER_CURVE_SUPPORT
 
 const unsigned int dropsegments = 5; //everything with less than this number of steps will be ignored as move and joined with the next movement

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -106,7 +106,7 @@
  * G2  - CW ARC
  * G3  - CCW ARC
  * G4  - Dwell S<seconds> or P<milliseconds>
- * G5  - Cubic B-spline with
+ * G5  - Cubic B-spline with XYZE destination and IJPQ offsets
  * G10 - retract filament according to settings of M207
  * G11 - retract recover filament according to settings of M208
  * G28 - Home one or more axes
@@ -2546,14 +2546,7 @@ inline void gcode_G4() {
   inline void gcode_G5() {
     if (IsRunning()) {
 
-      #ifdef SF_ARC_FIX
-        bool relative_mode_backup = relative_mode;
-        relative_mode = true;
-      #endif
       gcode_get_destination();
-      #ifdef SF_ARC_FIX
-        relative_mode = relative_mode_backup;
-      #endif
 
       float offset[] = {
         code_seen('I') ? code_value() : 0.0,

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7604,13 +7604,14 @@ void prepare_move() {
 
     float feed_rate = feedrate * feedrate_multiplier / 60 / 100.0;
 
-    millis_t previous_ms = millis();
+    millis_t next_ping_ms = millis() + 200UL;
 
     for (i = 1; i < segments; i++) { // Iterate (segments-1) times
 
+      thermalManager.manage_heater();
       millis_t now = millis();
-      if (now - previous_ms > 200UL) {
-        previous_ms = now;
+      if (ELAPSED(now, next_ping_ms)) {
+        next_ping_ms = now + 200UL;
         idle();
       }
 

--- a/Marlin/planner_bezier.cpp
+++ b/Marlin/planner_bezier.cpp
@@ -118,15 +118,15 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
   bez_target[Y_AXIS] = position[Y_AXIS];
   float step = MAX_STEP;
 
-  uint8_t idle_counter = 0;
   millis_t next_ping_ms = millis() + 200UL;
 
   while (t < 1.0) {
 
+    thermalManager.manage_heater();
     millis_t now = millis();
     if (ELAPSED(now, next_ping_ms)) {
       next_ping_ms = now + 200UL;
-      (idle_counter++ & 0x03) ? thermalManager.manage_heater() : idle();
+      idle();
     }
 
     // First try to reduce the step in order to make it sufficiently

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -282,7 +282,6 @@ menuPosition menu_history[10];
 uint8_t menu_history_depth = 0;
 
 millis_t next_lcd_update_ms;
-uint8_t lcd_status_update_delay;
 bool ignore_click = false;
 bool wait_for_unclick;
 bool defer_return_to_status = false;
@@ -2248,9 +2247,13 @@ void lcd_update() {
       }
     #endif //ULTIPANEL
 
-    // Simply redraw the Info Screen 10 times a second
-    if (currentMenu == lcd_status_screen && !(++lcd_status_update_delay % 10))
+    // Here we arrive every ~100ms when ideling often enough.
+    // Instead of tracking the changes simply redraw the Info Screen ~1 time a second.
+    static int8_t lcd_status_update_delay = 1; // first update one loop delayed
+    if (currentMenu == lcd_status_screen && !lcd_status_update_delay--) {
+      lcd_status_update_delay = 9;
       lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
+    }
 
     if (lcdDrawUpdate) {
 


### PR DESCRIPTION
No compromises for the manage_heater(). 
manage_heater() will return immediately when there is nothing to do, but needs a constant detaT to work proper.
Calling idle() only every 200ms results in a display update every ~2 seconds - that should be enough.
For the other functionalities in idle() and manage_inactivity() 200ms is very long, but hopefully works.

---

Speedup screen update delay
and correct a comment.

A module division by 10 is slooooow. (powers of 2 are fast - but then you could AND a bitmask with the same result)

---

Remove SF_ARC_FIX from G5 (Cubic B-spline).
SF_ARC_FIX is a fix for G2/G3 (arcs) where Skeinforge always produced relative instead of absolute coordinates for the endpoint of an arc.
It's very unlikely this is also a problem with Cubic B-splines. More likely is copying from the G2/G3 code.

https://github.com/MarlinFirmware/Marlin/pull/3761#issuecomment-220176654
