### PR TITLE
Correct hardware endstops default

### DIFF
--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -39,9 +39,9 @@ Endstops endstops;
 Endstops::Endstops() {
   enable_globally(
     #if ENABLED(ENDSTOPS_ONLY_FOR_HOMING)
-      true
-    #else
       false
+    #else
+      true
     #endif
   );
   enable(true);


### PR DESCRIPTION
All credits to @RicardoGA.
Possibly a fix for #3820 and an other one where a Allan Key probe could not be stowed (#3717).
