### PR TITLE
Apply static to Stepper, Endstops, Planner, Temperature classes

### DIFF
--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -36,6 +36,34 @@
 
 Endstops endstops;
 
+// public:
+
+bool  Endstops::enabled = true,
+      Endstops::enabled_globally =
+        #if ENABLED(ENDSTOPS_ONLY_FOR_HOMING)
+          false
+        #else
+          true
+        #endif
+      ;
+volatile char Endstops::endstop_hit_bits; // use X_MIN, Y_MIN, Z_MIN and Z_MIN_PROBE as BIT value
+
+#if ENABLED(Z_DUAL_ENDSTOPS)
+  uint16_t
+#else
+  byte
+#endif
+    Endstops::current_endstop_bits = 0,
+    Endstops::old_endstop_bits = 0;
+
+#if HAS_BED_PROBE
+  volatile bool Endstops::z_probe_enabled = false;
+#endif
+
+/**
+ * Class and Instance Methods
+ */
+
 Endstops::Endstops() {
   enable_globally(
     #if ENABLED(ENDSTOPS_ONLY_FOR_HOMING)

--- a/Marlin/endstops.h
+++ b/Marlin/endstops.h
@@ -33,26 +33,16 @@ class Endstops {
 
   public:
 
-    volatile char endstop_hit_bits; // use X_MIN, Y_MIN, Z_MIN and Z_MIN_PROBE as BIT value
+    static bool enabled, enabled_globally;
+    static volatile char endstop_hit_bits; // use X_MIN, Y_MIN, Z_MIN and Z_MIN_PROBE as BIT value
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      uint16_t current_endstop_bits = 0,
-                   old_endstop_bits = 0;
+      static uint16_t
     #else
-      byte current_endstop_bits = 0,
-               old_endstop_bits = 0;
+      static byte
     #endif
+        current_endstop_bits, old_endstop_bits;
         
-
-    bool enabled = true;
-    bool enabled_globally =
-      #if ENABLED(ENDSTOPS_ONLY_FOR_HOMING)
-        false
-      #else
-        true
-      #endif
-    ;
-
     Endstops();
 
     /**
@@ -63,40 +53,40 @@ class Endstops {
     /**
      * Update the endstops bits from the pins
      */
-    void update();
+    static void update();
 
     /**
      * Print an error message reporting the position when the endstops were last hit.
      */
-    void report_state(); //call from somewhere to create an serial error message with the locations the endstops where hit, in case they were triggered
+    static void report_state(); //call from somewhere to create an serial error message with the locations the endstops where hit, in case they were triggered
 
     /**
      * Report endstop positions in response to M119
      */
-    void M119();
+    static void M119();
 
     // Enable / disable endstop checking globally
-    FORCE_INLINE void enable_globally(bool onoff=true) { enabled_globally = enabled = onoff; }
+    static FORCE_INLINE void enable_globally(bool onoff=true) { enabled_globally = enabled = onoff; }
 
     // Enable / disable endstop checking
-    FORCE_INLINE void enable(bool onoff=true) { enabled = onoff; }
+    static FORCE_INLINE void enable(bool onoff=true) { enabled = onoff; }
 
     // Disable / Enable endstops based on ENSTOPS_ONLY_FOR_HOMING and global enable
-    FORCE_INLINE void not_homing() { enabled = enabled_globally; }
+    static FORCE_INLINE void not_homing() { enabled = enabled_globally; }
 
     // Clear endstops (i.e., they were hit intentionally) to suppress the report
-    FORCE_INLINE void hit_on_purpose() { endstop_hit_bits = 0; }
+    static FORCE_INLINE void hit_on_purpose() { endstop_hit_bits = 0; }
 
     // Enable / disable endstop z-probe checking
     #if HAS_BED_PROBE
-      volatile bool z_probe_enabled = false;
-      FORCE_INLINE void enable_z_probe(bool onoff=true) { z_probe_enabled = onoff; }
+      static volatile bool z_probe_enabled;
+      static FORCE_INLINE void enable_z_probe(bool onoff=true) { z_probe_enabled = onoff; }
     #endif
 
   private:
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      void test_dual_z_endstops(EndstopEnum es1, EndstopEnum es2);
+      static void test_dual_z_endstops(EndstopEnum es1, EndstopEnum es2);
     #endif
 };
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -71,6 +71,64 @@
 
 Planner planner;
 
+  // public:
+
+/**
+ * A ring buffer of moves described in steps
+ */
+block_t Planner::block_buffer[BLOCK_BUFFER_SIZE];
+volatile uint8_t Planner::block_buffer_head = 0;           // Index of the next block to be pushed
+volatile uint8_t Planner::block_buffer_tail = 0;
+
+float Planner::max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
+float Planner::axis_steps_per_unit[NUM_AXIS];
+unsigned long Planner::axis_steps_per_sqr_second[NUM_AXIS];
+unsigned long Planner::max_acceleration_units_per_sq_second[NUM_AXIS]; // Use M201 to override by software
+
+millis_t Planner::min_segment_time;
+float Planner::min_feedrate;
+float Planner::acceleration;         // Normal acceleration mm/s^2  DEFAULT ACCELERATION for all printing moves. M204 SXXXX
+float Planner::retract_acceleration; // Retract acceleration mm/s^2 filament pull-back and push-forward while standing still in the other axes M204 TXXXX
+float Planner::travel_acceleration;  // Travel acceleration mm/s^2  DEFAULT ACCELERATION for all NON printing moves. M204 MXXXX
+float Planner::max_xy_jerk;          // The largest speed change requiring no acceleration
+float Planner::max_z_jerk;
+float Planner::max_e_jerk;
+float Planner::min_travel_feedrate;
+
+#if ENABLED(AUTO_BED_LEVELING_FEATURE)
+  matrix_3x3 Planner::bed_level_matrix; // Transform to compensate for bed level
+#endif
+
+#if ENABLED(AUTOTEMP)
+  float Planner::autotemp_max = 250;
+  float Planner::autotemp_min = 210;
+  float Planner::autotemp_factor = 0.1;
+  bool Planner::autotemp_enabled = false;
+#endif
+
+// private:
+
+long Planner::position[NUM_AXIS] = { 0 };
+
+float Planner::previous_speed[NUM_AXIS];
+
+float Planner::previous_nominal_speed;
+
+#if ENABLED(DISABLE_INACTIVE_EXTRUDER)
+  uint8_t Planner::g_uc_extruder_last_move[EXTRUDERS] = { 0 };
+#endif // DISABLE_INACTIVE_EXTRUDER
+
+#ifdef XY_FREQUENCY_LIMIT
+  // Old direction bits. Used for speed calculations
+  unsigned char Planner::old_direction_bits = 0;
+  // Segment times (in µs). Used for speed calculations
+  long Planner::axis_segment_time[2][3] = { {MAX_FREQ_TIME + 1, 0, 0}, {MAX_FREQ_TIME + 1, 0, 0} };
+#endif
+
+/**
+ * Class and Instance Methods
+ */
+
 Planner::Planner() {
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     bed_level_matrix.set_to_identity();

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -108,27 +108,27 @@ class Planner {
     /**
      * A ring buffer of moves described in steps
      */
-    block_t block_buffer[BLOCK_BUFFER_SIZE];
-    volatile uint8_t block_buffer_head = 0;           // Index of the next block to be pushed
-    volatile uint8_t block_buffer_tail = 0;
+    static block_t block_buffer[BLOCK_BUFFER_SIZE];
+    static volatile uint8_t block_buffer_head;           // Index of the next block to be pushed
+    static volatile uint8_t block_buffer_tail;
 
-    float max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
-    float axis_steps_per_unit[NUM_AXIS];
-    unsigned long axis_steps_per_sqr_second[NUM_AXIS];
-    unsigned long max_acceleration_units_per_sq_second[NUM_AXIS]; // Use M201 to override by software
+    static float max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
+    static float axis_steps_per_unit[NUM_AXIS];
+    static unsigned long axis_steps_per_sqr_second[NUM_AXIS];
+    static unsigned long max_acceleration_units_per_sq_second[NUM_AXIS]; // Use M201 to override by software
 
-    millis_t min_segment_time;
-    float min_feedrate;
-    float acceleration;         // Normal acceleration mm/s^2  DEFAULT ACCELERATION for all printing moves. M204 SXXXX
-    float retract_acceleration; // Retract acceleration mm/s^2 filament pull-back and push-forward while standing still in the other axes M204 TXXXX
-    float travel_acceleration;  // Travel acceleration mm/s^2  DEFAULT ACCELERATION for all NON printing moves. M204 MXXXX
-    float max_xy_jerk;          // The largest speed change requiring no acceleration
-    float max_z_jerk;
-    float max_e_jerk;
-    float min_travel_feedrate;
+    static millis_t min_segment_time;
+    static float min_feedrate;
+    static float acceleration;         // Normal acceleration mm/s^2  DEFAULT ACCELERATION for all printing moves. M204 SXXXX
+    static float retract_acceleration; // Retract acceleration mm/s^2 filament pull-back and push-forward while standing still in the other axes M204 TXXXX
+    static float travel_acceleration;  // Travel acceleration mm/s^2  DEFAULT ACCELERATION for all NON printing moves. M204 MXXXX
+    static float max_xy_jerk;          // The largest speed change requiring no acceleration
+    static float max_z_jerk;
+    static float max_e_jerk;
+    static float min_travel_feedrate;
 
     #if ENABLED(AUTO_BED_LEVELING_FEATURE)
-      matrix_3x3 bed_level_matrix; // Transform to compensate for bed level
+      static matrix_3x3 bed_level_matrix; // Transform to compensate for bed level
     #endif
 
   private:
@@ -137,49 +137,57 @@ class Planner {
      * The current position of the tool in absolute steps
      * Reclculated if any axis_steps_per_unit are changed by gcode
      */
-    long position[NUM_AXIS] = { 0 };
+    static long position[NUM_AXIS];
 
     /**
      * Speed of previous path line segment
      */
-    float previous_speed[NUM_AXIS];
+    static float previous_speed[NUM_AXIS];
 
     /**
      * Nominal speed of previous path line segment
      */
-    float previous_nominal_speed;
+    static float previous_nominal_speed;
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
       /**
        * Counters to manage disabling inactive extruders
        */
-      uint8_t g_uc_extruder_last_move[EXTRUDERS] = { 0 };
+      static uint8_t g_uc_extruder_last_move[EXTRUDERS];
     #endif // DISABLE_INACTIVE_EXTRUDER
 
     #ifdef XY_FREQUENCY_LIMIT
       // Used for the frequency limit
-      #define MAX_FREQ_TIME (1000000.0/XY_FREQUENCY_LIMIT)
+      #define MAX_FREQ_TIME long(1000000.0/XY_FREQUENCY_LIMIT)
       // Old direction bits. Used for speed calculations
-      static unsigned char old_direction_bits = 0;
+      static unsigned char old_direction_bits;
       // Segment times (in µs). Used for speed calculations
-      static long axis_segment_time[2][3] = { {MAX_FREQ_TIME + 1, 0, 0}, {MAX_FREQ_TIME + 1, 0, 0} };
+      static long axis_segment_time[2][3];
     #endif
 
   public:
+
+    /**
+     * Instance Methods
+     */
 
     Planner();
 
     void init();
 
-    void reset_acceleration_rates();
+    /**
+     * Static (class) Methods
+     */
+
+    static void reset_acceleration_rates();
 
     // Manage fans, paste pressure, etc.
-    void check_axes_activity();
+    static void check_axes_activity();
 
     /**
      * Number of moves currently in the planner
      */
-    FORCE_INLINE uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block_buffer_tail + BLOCK_BUFFER_SIZE); }
+    static FORCE_INLINE uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block_buffer_tail + BLOCK_BUFFER_SIZE); }
 
     #if ENABLED(AUTO_BED_LEVELING_FEATURE) || ENABLED(MESH_BED_LEVELING)
 
@@ -187,7 +195,7 @@ class Planner {
         /**
          * The corrected position, applying the bed level matrix
          */
-        vector_3 adjusted_position();
+        static vector_3 adjusted_position();
       #endif
 
       /**
@@ -197,7 +205,7 @@ class Planner {
        *  feed_rate - (target) speed of the move
        *  extruder  - target extruder
        */
-      void buffer_line(float x, float y, float z, const float& e, float feed_rate, const uint8_t extruder);
+      static void buffer_line(float x, float y, float z, const float& e, float feed_rate, const uint8_t extruder);
 
       /**
        * Set the planner.position and individual stepper positions.
@@ -208,30 +216,30 @@ class Planner {
        *
        * Clears previous speed values.
        */
-      void set_position(float x, float y, float z, const float& e);
+      static void set_position(float x, float y, float z, const float& e);
 
     #else
 
-      void buffer_line(const float& x, const float& y, const float& z, const float& e, float feed_rate, const uint8_t extruder);
-      void set_position(const float& x, const float& y, const float& z, const float& e);
+      static void buffer_line(const float& x, const float& y, const float& z, const float& e, float feed_rate, const uint8_t extruder);
+      static void set_position(const float& x, const float& y, const float& z, const float& e);
 
     #endif // AUTO_BED_LEVELING_FEATURE || MESH_BED_LEVELING
 
     /**
      * Set the E position (mm) of the planner (and the E stepper)
      */
-    void set_e_position(const float& e);
+    static void set_e_position(const float& e);
 
     /**
      * Does the buffer have any blocks queued?
      */
-    FORCE_INLINE bool blocks_queued() { return (block_buffer_head != block_buffer_tail); }
+    static FORCE_INLINE bool blocks_queued() { return (block_buffer_head != block_buffer_tail); }
 
     /**
      * "Discards" the block and "releases" the memory.
      * Called when the current block is no longer needed.
      */
-    FORCE_INLINE void discard_current_block() {
+    static FORCE_INLINE void discard_current_block() {
       if (blocks_queued())
         block_buffer_tail = BLOCK_MOD(block_buffer_tail + 1);
     }
@@ -240,7 +248,7 @@ class Planner {
      * The current block. NULL if the buffer is empty.
      * This also marks the block as busy.
      */
-    FORCE_INLINE block_t* get_current_block() {
+    static FORCE_INLINE block_t* get_current_block() {
       if (blocks_queued()) {
         block_t* block = &block_buffer[block_buffer_tail];
         block->busy = true;
@@ -251,12 +259,12 @@ class Planner {
     }
 
     #if ENABLED(AUTOTEMP)
-      float autotemp_max = 250;
-      float autotemp_min = 210;
-      float autotemp_factor = 0.1;
-      bool autotemp_enabled = false;
-      void getHighESpeed();
-      void autotemp_M109();
+      static float autotemp_max;
+      static float autotemp_min;
+      static float autotemp_factor;
+      static bool autotemp_enabled;
+      static void getHighESpeed();
+      static void autotemp_M109();
     #endif
 
   private:
@@ -264,14 +272,14 @@ class Planner {
     /**
      * Get the index of the next / previous block in the ring buffer
      */
-    FORCE_INLINE int8_t next_block_index(int8_t block_index) { return BLOCK_MOD(block_index + 1); }
-    FORCE_INLINE int8_t prev_block_index(int8_t block_index) { return BLOCK_MOD(block_index - 1); }
+    static FORCE_INLINE int8_t next_block_index(int8_t block_index) { return BLOCK_MOD(block_index + 1); }
+    static FORCE_INLINE int8_t prev_block_index(int8_t block_index) { return BLOCK_MOD(block_index - 1); }
 
     /**
      * Calculate the distance (not time) it takes to accelerate
      * from initial_rate to target_rate using the given acceleration:
      */
-    FORCE_INLINE float estimate_acceleration_distance(float initial_rate, float target_rate, float acceleration) {
+    static FORCE_INLINE float estimate_acceleration_distance(float initial_rate, float target_rate, float acceleration) {
       if (acceleration == 0) return 0; // acceleration was 0, set acceleration distance to 0
       return (target_rate * target_rate - initial_rate * initial_rate) / (acceleration * 2);
     }
@@ -284,7 +292,7 @@ class Planner {
      * This is used to compute the intersection point between acceleration and deceleration
      * in cases where the "trapezoid" has no plateau (i.e., never reaches maximum speed)
      */
-    FORCE_INLINE float intersection_distance(float initial_rate, float final_rate, float acceleration, float distance) {
+    static FORCE_INLINE float intersection_distance(float initial_rate, float final_rate, float acceleration, float distance) {
       if (acceleration == 0) return 0; // acceleration was 0, set intersection distance to 0
       return (acceleration * 2 * distance - initial_rate * initial_rate + final_rate * final_rate) / (acceleration * 4);
     }
@@ -294,21 +302,21 @@ class Planner {
      * to reach 'target_velocity' using 'acceleration' within a given
      * 'distance'.
      */
-    FORCE_INLINE float max_allowable_speed(float acceleration, float target_velocity, float distance) {
+    static FORCE_INLINE float max_allowable_speed(float acceleration, float target_velocity, float distance) {
       return sqrt(target_velocity * target_velocity - 2 * acceleration * distance);
     }
 
-    void calculate_trapezoid_for_block(block_t* block, float entry_factor, float exit_factor);
+    static void calculate_trapezoid_for_block(block_t* block, float entry_factor, float exit_factor);
 
-    void reverse_pass_kernel(block_t* previous, block_t* current, block_t* next);
-    void forward_pass_kernel(block_t* previous, block_t* current, block_t* next);
+    static void reverse_pass_kernel(block_t* previous, block_t* current, block_t* next);
+    static void forward_pass_kernel(block_t* previous, block_t* current, block_t* next);
 
-    void reverse_pass();
-    void forward_pass();
+    static void reverse_pass();
+    static void forward_pass();
 
-    void recalculate_trapezoids();
+    static void recalculate_trapezoids();
 
-    void recalculate();
+    static void recalculate();
 
 };
 

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -60,6 +60,55 @@
 
 Stepper stepper; // Singleton
 
+// public:
+
+block_t* Stepper::current_block = NULL;  // A pointer to the block currently being traced
+
+#if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
+  bool Stepper::abort_on_endstop_hit = false;
+#endif
+
+#if ENABLED(Z_DUAL_ENDSTOPS)
+  bool Stepper::performing_homing = false;
+#endif
+
+// private:
+
+unsigned char Stepper::last_direction_bits = 0;        // The next stepping-bits to be output
+unsigned int Stepper::cleaning_buffer_counter = 0;
+
+#if ENABLED(Z_DUAL_ENDSTOPS)
+  bool Stepper::locked_z_motor = false;
+  bool Stepper::locked_z2_motor = false;
+#endif
+
+long  Stepper::counter_X = 0,
+      Stepper::counter_Y = 0,
+      Stepper::counter_Z = 0,
+      Stepper::counter_E = 0;
+
+volatile unsigned long Stepper::step_events_completed = 0; // The number of step events executed in the current block
+
+#if ENABLED(ADVANCE)
+  unsigned char Stepper::old_OCR0A;
+  long  Stepper::final_advance = 0,
+        Stepper::old_advance = 0,
+        Stepper::e_steps[4],
+        Stepper::advance_rate,
+        Stepper::advance;
+#endif
+
+long Stepper::acceleration_time, Stepper::deceleration_time;
+
+volatile long Stepper::count_position[NUM_AXIS] = { 0 };
+volatile signed char Stepper::count_direction[NUM_AXIS] = { 1, 1, 1, 1 };
+
+unsigned short Stepper::acc_step_rate; // needed for deceleration start point
+uint8_t Stepper::step_loops, Stepper::step_loops_nominal;
+unsigned short Stepper::OCR1A_nominal;
+
+volatile long Stepper::endstops_trigsteps[3];
+
 #if ENABLED(DUAL_X_CARRIAGE)
   #define X_APPLY_DIR(v,ALWAYS) \
     if (extruder_duplication_enabled || ALWAYS) { \
@@ -238,7 +287,7 @@ void Stepper::set_directions() {
 
 // "The Stepper Driver Interrupt" - This timer interrupt is the workhorse.
 // It pops blocks from the block_buffer and executes them by pulsing the stepper pins appropriately.
-ISR(TIMER1_COMPA_vect) { stepper.isr(); }
+ISR(TIMER1_COMPA_vect) { Stepper::isr(); }
 
 void Stepper::isr() {
   if (cleaning_buffer_counter) {
@@ -405,7 +454,7 @@ void Stepper::isr() {
 #if ENABLED(ADVANCE)
   // Timer interrupt for E. e_steps is set in the main routine;
   // Timer 0 is shared with millies
-  ISR(TIMER0_COMPA_vect) { stepper.advance_isr(); }
+  ISR(TIMER0_COMPA_vect) { Stepper::advance_isr(); }
 
   void Stepper::advance_isr() {
     old_OCR0A += 52; // ~10kHz interrupt (250000 / 26 = 9615kHz)
@@ -443,6 +492,7 @@ void Stepper::isr() {
 #endif // ADVANCE
 
 void Stepper::init() {
+
   digipot_init(); //Initialize Digipot Motor Current
   microstep_init(); //Initialize Microstepping Pins
 

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -257,11 +257,11 @@ class Stepper {
       NOMORE(step_rate, MAX_STEP_FREQUENCY);
 
       if (step_rate > 20000) { // If steprate > 20kHz >> step 4 times
-        step_rate = (step_rate >> 2) & 0x3fff;
+        step_rate >>= 2;
         step_loops = 4;
       }
       else if (step_rate > 10000) { // If steprate > 10kHz >> step 2 times
-        step_rate = (step_rate >> 1) & 0x7fff;
+        step_rate >>= 1;
         step_loops = 2;
       }
       else {

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -80,49 +80,46 @@ class Stepper {
 
   public:
 
-    block_t* current_block = NULL;  // A pointer to the block currently being traced
+    static block_t* current_block;  // A pointer to the block currently being traced
 
     #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
-      bool abort_on_endstop_hit = false;
+      static bool abort_on_endstop_hit;
     #endif
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      bool performing_homing = false;
+      static bool performing_homing;
     #endif
 
     #if ENABLED(ADVANCE)
-      long e_steps[4];
+      static long e_steps[4];
     #endif
 
   private:
 
-    unsigned char last_direction_bits = 0;        // The next stepping-bits to be output
-    unsigned int cleaning_buffer_counter = 0;
+    static unsigned char last_direction_bits;        // The next stepping-bits to be output
+    static unsigned int cleaning_buffer_counter;
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      bool locked_z_motor = false,
-           locked_z2_motor = false;
+      static bool locked_z_motor, locked_z2_motor;
     #endif
 
     // Counter variables for the Bresenham line tracer
-    long counter_X = 0, counter_Y = 0, counter_Z = 0, counter_E = 0;
-    volatile unsigned long step_events_completed = 0; // The number of step events executed in the current block
+    static long counter_X, counter_Y, counter_Z, counter_E;
+    static volatile unsigned long step_events_completed; // The number of step events executed in the current block
 
     #if ENABLED(ADVANCE)
-      unsigned char old_OCR0A;
-      long advance_rate, advance, final_advance = 0;
-      long old_advance = 0;
+      static unsigned char old_OCR0A;
+      static long advance_rate, advance, old_advance, final_advance;
     #endif
 
-    long acceleration_time, deceleration_time;
+    static long acceleration_time, deceleration_time;
     //unsigned long accelerate_until, decelerate_after, acceleration_rate, initial_rate, final_rate, nominal_rate;
-    unsigned short acc_step_rate; // needed for deceleration start point
-    uint8_t step_loops;
-    uint8_t step_loops_nominal;
-    unsigned short OCR1A_nominal;
+    static unsigned short acc_step_rate; // needed for deceleration start point
+    static uint8_t step_loops, step_loops_nominal;
+    static unsigned short OCR1A_nominal;
 
-    volatile long endstops_trigsteps[3];
-    volatile long endstops_stepsTotal, endstops_stepsDone;
+    static volatile long endstops_trigsteps[3];
+    static volatile long endstops_stepsTotal, endstops_stepsDone;
 
     #if HAS_MOTOR_CURRENT_PWM
       #ifndef PWM_MOTOR_CURRENT
@@ -134,19 +131,19 @@ class Stepper {
     //
     // Positions of stepper motors, in step units
     //
-    volatile long count_position[NUM_AXIS] = { 0 };
+    static volatile long count_position[NUM_AXIS];
 
     //
     // Current direction of stepper motors (+1 or -1)
     //
-    volatile signed char count_direction[NUM_AXIS] = { 1, 1, 1, 1 };
+    static volatile signed char count_direction[NUM_AXIS];
 
   public:
 
     //
     // Constructor / initializer
     //
-    Stepper() {};
+    Stepper() { };
 
     //
     // Initialize stepper hardware
@@ -157,10 +154,10 @@ class Stepper {
     // Interrupt Service Routines
     //
 
-    void isr();
+    static void isr();
 
     #if ENABLED(ADVANCE)
-      void advance_isr();
+      static void advance_isr();
     #endif
 
     //
@@ -177,7 +174,7 @@ class Stepper {
     //
     // Set direction bits for all steppers
     //
-    void set_directions();
+    static void set_directions();
 
     //
     // Get the position of a stepper, in steps
@@ -213,7 +210,7 @@ class Stepper {
     //
     // The direction of a single motor
     //
-    FORCE_INLINE bool motor_direction(AxisEnum axis) { return TEST(last_direction_bits, axis); }
+    static FORCE_INLINE bool motor_direction(AxisEnum axis) { return TEST(last_direction_bits, axis); }
 
     #if HAS_DIGIPOTSS
       void digitalPotWrite(int address, int value);
@@ -251,7 +248,7 @@ class Stepper {
 
   private:
 
-    FORCE_INLINE unsigned short calc_timer(unsigned short step_rate) {
+    static FORCE_INLINE unsigned short calc_timer(unsigned short step_rate) {
       unsigned short timer;
 
       NOMORE(step_rate, MAX_STEP_FREQUENCY);
@@ -283,13 +280,17 @@ class Stepper {
         timer = (unsigned short)pgm_read_word_near(table_address);
         timer -= (((unsigned short)pgm_read_word_near(table_address + 2) * (unsigned char)(step_rate & 0x0007)) >> 3);
       }
-      if (timer < 100) { timer = 100; MYSERIAL.print(MSG_STEPPER_TOO_HIGH); MYSERIAL.println(step_rate); }//(20kHz this should never happen)
+      if (timer < 100) { // (20kHz - this should never happen)
+        timer = 100;
+        MYSERIAL.print(MSG_STEPPER_TOO_HIGH);
+        MYSERIAL.println(step_rate);
+      }
       return timer;
     }
 
     // Initializes the trapezoid generator from the current block. Called whenever a new
     // block begins.
-    FORCE_INLINE void trapezoid_generator_reset() {
+    static FORCE_INLINE void trapezoid_generator_reset() {
 
       static int8_t last_extruder = -1;
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -48,6 +48,145 @@
 
 Temperature thermalManager;
 
+// public:
+
+int Temperature::current_temperature_raw[EXTRUDERS] = { 0 };
+float Temperature::current_temperature[EXTRUDERS] = { 0.0 };
+int Temperature::target_temperature[EXTRUDERS] = { 0 };
+
+int Temperature::current_temperature_bed_raw = 0;
+float Temperature::current_temperature_bed = 0.0;
+int Temperature::target_temperature_bed = 0;
+
+#if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+  float Temperature::redundant_temperature = 0.0;
+#endif
+
+unsigned char Temperature::soft_pwm_bed;
+
+#if ENABLED(FAN_SOFT_PWM)
+  unsigned char Temperature::fanSpeedSoftPwm[FAN_COUNT];
+#endif
+
+#if ENABLED(PIDTEMP)
+  #if ENABLED(PID_PARAMS_PER_EXTRUDER)
+    float Temperature::Kp[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(DEFAULT_Kp),
+          Temperature::Ki[EXTRUDERS] = ARRAY_BY_EXTRUDERS1((DEFAULT_Ki) * (PID_dT)),
+          Temperature::Kd[EXTRUDERS] = ARRAY_BY_EXTRUDERS1((DEFAULT_Kd) / (PID_dT));
+    #if ENABLED(PID_ADD_EXTRUSION_RATE)
+      float Temperature::Kc[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(DEFAULT_Kc);
+    #endif
+  #else
+    float Temperature::Kp = DEFAULT_Kp,
+          Temperature::Ki = (DEFAULT_Ki) * (PID_dT),
+          Temperature::Kd = (DEFAULT_Kd) / (PID_dT);
+    #if ENABLED(PID_ADD_EXTRUSION_RATE)
+      float Temperature::Kc = DEFAULT_Kc;
+    #endif
+  #endif
+#endif
+
+#if ENABLED(PIDTEMPBED)
+  float Temperature::bedKp = DEFAULT_bedKp,
+        Temperature::bedKi = ((DEFAULT_bedKi) * PID_dT),
+        Temperature::bedKd = ((DEFAULT_bedKd) / PID_dT);
+#endif
+
+#if ENABLED(BABYSTEPPING)
+  volatile int Temperature::babystepsTodo[3] = { 0 };
+#endif
+
+#if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
+  int Temperature::watch_target_temp[EXTRUDERS] = { 0 };
+  millis_t Temperature::watch_heater_next_ms[EXTRUDERS] = { 0 };
+#endif
+
+#if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_BED_TEMP_PERIOD > 0
+  int Temperature::watch_target_bed_temp = 0;
+  millis_t Temperature::watch_bed_next_ms = 0;
+#endif
+
+#if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
+  float Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
+#endif
+
+// private:
+
+#if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+  int Temperature::redundant_temperature_raw = 0;
+  float Temperature::redundant_temperature = 0.0;
+#endif
+
+volatile bool Temperature::temp_meas_ready = false;
+
+#if ENABLED(PIDTEMP)
+  float Temperature::temp_iState[EXTRUDERS] = { 0 };
+  float Temperature::temp_dState[EXTRUDERS] = { 0 };
+  float Temperature::pTerm[EXTRUDERS];
+  float Temperature::iTerm[EXTRUDERS];
+  float Temperature::dTerm[EXTRUDERS];
+
+  #if ENABLED(PID_ADD_EXTRUSION_RATE)
+    float Temperature::cTerm[EXTRUDERS];
+    long Temperature::last_position[EXTRUDERS];
+    long Temperature::lpq[LPQ_MAX_LEN];
+    int Temperature::lpq_ptr = 0;
+  #endif
+
+  float Temperature::pid_error[EXTRUDERS];
+  float Temperature::temp_iState_min[EXTRUDERS];
+  float Temperature::temp_iState_max[EXTRUDERS];
+  bool Temperature::pid_reset[EXTRUDERS];
+#endif
+
+#if ENABLED(PIDTEMPBED)
+  float Temperature::temp_iState_bed = { 0 };
+  float Temperature::temp_dState_bed = { 0 };
+  float Temperature::pTerm_bed;
+  float Temperature::iTerm_bed;
+  float Temperature::dTerm_bed;
+  float Temperature::pid_error_bed;
+  float Temperature::temp_iState_min_bed;
+  float Temperature::temp_iState_max_bed;
+#else
+  millis_t Temperature::next_bed_check_ms;
+#endif
+
+unsigned long Temperature::raw_temp_value[4] = { 0 };
+unsigned long Temperature::raw_temp_bed_value = 0;
+
+// Init min and max temp with extreme values to prevent false errors during startup
+int Temperature::minttemp_raw[EXTRUDERS] = ARRAY_BY_EXTRUDERS(HEATER_0_RAW_LO_TEMP , HEATER_1_RAW_LO_TEMP , HEATER_2_RAW_LO_TEMP, HEATER_3_RAW_LO_TEMP);
+int Temperature::maxttemp_raw[EXTRUDERS] = ARRAY_BY_EXTRUDERS(HEATER_0_RAW_HI_TEMP , HEATER_1_RAW_HI_TEMP , HEATER_2_RAW_HI_TEMP, HEATER_3_RAW_HI_TEMP);
+int Temperature::minttemp[EXTRUDERS] = { 0 };
+int Temperature::maxttemp[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(16383);
+
+#ifdef BED_MINTEMP
+  int Temperature::bed_minttemp_raw = HEATER_BED_RAW_LO_TEMP;
+#endif
+
+#ifdef BED_MAXTEMP
+  int Temperature::bed_maxttemp_raw = HEATER_BED_RAW_HI_TEMP;
+#endif
+
+#if ENABLED(FILAMENT_WIDTH_SENSOR)
+  int Temperature::meas_shift_index;  // Index of a delayed sample in buffer
+#endif
+
+#if HAS_AUTO_FAN
+  millis_t Temperature::next_auto_fan_check_ms;
+#endif
+
+unsigned char Temperature::soft_pwm[EXTRUDERS];
+
+#if ENABLED(FAN_SOFT_PWM)
+  unsigned char Temperature::soft_pwm_fan[FAN_COUNT];
+#endif
+
+#if ENABLED(FILAMENT_WIDTH_SENSOR)
+  int Temperature::current_raw_filwidth = 0;  //Holds measured filament diameter - one extruder only
+#endif
+
 #if HAS_PID_HEATING
 
   void Temperature::PID_autotune(float temp, int extruder, int ncycles, bool set_result/*=false*/) {
@@ -283,31 +422,9 @@ Temperature thermalManager;
 
 #endif // HAS_PID_HEATING
 
-#if ENABLED(PIDTEMP)
-
-  #if ENABLED(PID_PARAMS_PER_EXTRUDER)
-
-    float Temperature::Kp[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(DEFAULT_Kp),
-          Temperature::Ki[EXTRUDERS] = ARRAY_BY_EXTRUDERS1((DEFAULT_Ki) * (PID_dT)),
-          Temperature::Kd[EXTRUDERS] = ARRAY_BY_EXTRUDERS1((DEFAULT_Kd) / (PID_dT));
-
-    #if ENABLED(PID_ADD_EXTRUSION_RATE)
-      float Temperature::Kc[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(DEFAULT_Kc);
-    #endif
-
-  #else
-
-    float Temperature::Kp = DEFAULT_Kp,
-          Temperature::Ki = (DEFAULT_Ki) * (PID_dT),
-          Temperature::Kd = (DEFAULT_Kd) / (PID_dT);
-
-    #if ENABLED(PID_ADD_EXTRUSION_RATE)
-      float Temperature::Kc = DEFAULT_Kc;
-    #endif
-
-  #endif
-
-#endif
+/**
+ * Class and Instance Methods
+ */
 
 Temperature::Temperature() { }
 
@@ -1045,7 +1162,17 @@ void Temperature::init() {
 
 #if ENABLED(THERMAL_PROTECTION_HOTENDS) || HAS_THERMALLY_PROTECTED_BED
 
-  void Temperature::thermal_runaway_protection(TRState* state, millis_t* timer, float temperature, float target_temperature, int heater_id, int period_seconds, int hysteresis_degc) {
+  #if ENABLED(THERMAL_PROTECTION_HOTENDS)
+    Temperature::TRState Temperature::thermal_runaway_state_machine[EXTRUDERS] = { TRInactive };
+    millis_t Temperature::thermal_runaway_timer[EXTRUDERS] = { 0 };
+  #endif
+
+  #if HAS_THERMALLY_PROTECTED_BED
+    Temperature::TRState Temperature::thermal_runaway_bed_state_machine = TRInactive;
+    millis_t Temperature::thermal_runaway_bed_timer;
+  #endif
+
+  void Temperature::thermal_runaway_protection(Temperature::TRState* state, millis_t* timer, float temperature, float target_temperature, int heater_id, int period_seconds, int hysteresis_degc) {
 
     static float tr_target_temperature[EXTRUDERS + 1] = { 0.0 };
 
@@ -1240,7 +1367,7 @@ void Temperature::set_current_temp_raw() {
  *  - Check new temperature values for MIN/MAX errors
  *  - Step the babysteps value for each axis towards 0
  */
-ISR(TIMER0_COMPB_vect) { thermalManager.isr(); }
+ISR(TIMER0_COMPB_vect) { Temperature::isr(); }
 
 void Temperature::isr() {
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -42,22 +42,22 @@ class Temperature {
 
   public:
 
-    int current_temperature_raw[EXTRUDERS] = { 0 };
-    float current_temperature[EXTRUDERS] = { 0.0 };
-    int target_temperature[EXTRUDERS] = { 0 };
+    static int current_temperature_raw[EXTRUDERS];
+    static float current_temperature[EXTRUDERS];
+    static int target_temperature[EXTRUDERS];
 
-    int current_temperature_bed_raw = 0;
-    float current_temperature_bed = 0.0;
-    int target_temperature_bed = 0;
+    static int current_temperature_bed_raw;
+    static float current_temperature_bed;
+    static int target_temperature_bed;
 
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-      float redundant_temperature = 0.0;
+      static float redundant_temperature;
     #endif
 
-    unsigned char soft_pwm_bed;
+    static unsigned char soft_pwm_bed;
 
     #if ENABLED(FAN_SOFT_PWM)
-      unsigned char fanSpeedSoftPwm[FAN_COUNT];
+      static unsigned char fanSpeedSoftPwm[FAN_COUNT];
     #endif
 
     #if ENABLED(PIDTEMP) || ENABLED(PIDTEMPBED)
@@ -70,7 +70,7 @@ class Temperature {
 
         static float Kp[EXTRUDERS], Ki[EXTRUDERS], Kd[EXTRUDERS];
         #if ENABLED(PID_ADD_EXTRUSION_RATE)
-          float Kc[EXTRUDERS];
+          static float Kc[EXTRUDERS];
         #endif
         #define PID_PARAM(param, e) Temperature::param[e]
 
@@ -93,116 +93,108 @@ class Temperature {
     #endif
 
     #if ENABLED(PIDTEMPBED)
-      float bedKp = DEFAULT_bedKp,
-            bedKi = ((DEFAULT_bedKi) * PID_dT),
-            bedKd = ((DEFAULT_bedKd) / PID_dT);
+      static float bedKp, bedKi, bedKd;
     #endif
 
     #if ENABLED(BABYSTEPPING)
-      volatile int babystepsTodo[3] = { 0 };
+      static volatile int babystepsTodo[3];
     #endif
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
-      int watch_target_temp[EXTRUDERS] = { 0 };
-      millis_t watch_heater_next_ms[EXTRUDERS] = { 0 };
+      static int watch_target_temp[EXTRUDERS];
+      static millis_t watch_heater_next_ms[EXTRUDERS];
     #endif
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_BED_TEMP_PERIOD > 0
-      int watch_target_bed_temp = 0;
-      millis_t watch_bed_next_ms = 0;
+      static int watch_target_bed_temp;
+      static millis_t watch_bed_next_ms;
     #endif
 
     #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
-      float extrude_min_temp = EXTRUDE_MINTEMP;
-      FORCE_INLINE bool tooColdToExtrude(uint8_t e) { return degHotend(e) < extrude_min_temp; }
+      static float extrude_min_temp;
+      static FORCE_INLINE bool tooColdToExtrude(uint8_t e) { return degHotend(e) < extrude_min_temp; }
     #else
-      FORCE_INLINE bool tooColdToExtrude(uint8_t e) { UNUSED(e); return false; }
+      static FORCE_INLINE bool tooColdToExtrude(uint8_t e) { UNUSED(e); return false; }
     #endif
 
   private:
 
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-      int redundant_temperature_raw = 0;
-      float redundant_temperature = 0.0;
+      static int redundant_temperature_raw;
+      static float redundant_temperature;
     #endif
 
-    volatile bool temp_meas_ready = false;
+    static volatile bool temp_meas_ready;
 
     #if ENABLED(PIDTEMP)
-      float temp_iState[EXTRUDERS] = { 0 };
-      float temp_dState[EXTRUDERS] = { 0 };
-      float pTerm[EXTRUDERS];
-      float iTerm[EXTRUDERS];
-      float dTerm[EXTRUDERS];
+      static float temp_iState[EXTRUDERS];
+      static float temp_dState[EXTRUDERS];
+      static float pTerm[EXTRUDERS];
+      static float iTerm[EXTRUDERS];
+      static float dTerm[EXTRUDERS];
 
       #if ENABLED(PID_ADD_EXTRUSION_RATE)
-        float cTerm[EXTRUDERS];
-        long last_position[EXTRUDERS];
-        long lpq[LPQ_MAX_LEN];
-        int lpq_ptr = 0;
+        static float cTerm[EXTRUDERS];
+        static long last_position[EXTRUDERS];
+        static long lpq[LPQ_MAX_LEN];
+        static int lpq_ptr;
       #endif
 
-      float pid_error[EXTRUDERS];
-      float temp_iState_min[EXTRUDERS];
-      float temp_iState_max[EXTRUDERS];
-      bool pid_reset[EXTRUDERS];
+      static float pid_error[EXTRUDERS];
+      static float temp_iState_min[EXTRUDERS];
+      static float temp_iState_max[EXTRUDERS];
+      static bool pid_reset[EXTRUDERS];
     #endif
 
     #if ENABLED(PIDTEMPBED)
-      float temp_iState_bed = { 0 };
-      float temp_dState_bed = { 0 };
-      float pTerm_bed;
-      float iTerm_bed;
-      float dTerm_bed;
-      float pid_error_bed;
-      float temp_iState_min_bed;
-      float temp_iState_max_bed;
+      static float temp_iState_bed;
+      static float temp_dState_bed;
+      static float pTerm_bed;
+      static float iTerm_bed;
+      static float dTerm_bed;
+      static float pid_error_bed;
+      static float temp_iState_min_bed;
+      static float temp_iState_max_bed;
     #else
-      millis_t next_bed_check_ms;
+      static millis_t next_bed_check_ms;
     #endif
 
-    unsigned long raw_temp_value[4] = { 0 };
-    unsigned long raw_temp_bed_value = 0;
+    static unsigned long raw_temp_value[4];
+    static unsigned long raw_temp_bed_value;
 
     // Init min and max temp with extreme values to prevent false errors during startup
-    int minttemp_raw[EXTRUDERS] = ARRAY_BY_EXTRUDERS(HEATER_0_RAW_LO_TEMP , HEATER_1_RAW_LO_TEMP , HEATER_2_RAW_LO_TEMP, HEATER_3_RAW_LO_TEMP);
-    int maxttemp_raw[EXTRUDERS] = ARRAY_BY_EXTRUDERS(HEATER_0_RAW_HI_TEMP , HEATER_1_RAW_HI_TEMP , HEATER_2_RAW_HI_TEMP, HEATER_3_RAW_HI_TEMP);
-    int minttemp[EXTRUDERS] = { 0 };
-    int maxttemp[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(16383);
+    static int minttemp_raw[EXTRUDERS];
+    static int maxttemp_raw[EXTRUDERS];
+    static int minttemp[EXTRUDERS];
+    static int maxttemp[EXTRUDERS];
 
     #ifdef BED_MINTEMP
-      int bed_minttemp_raw = HEATER_BED_RAW_LO_TEMP;
+      static int bed_minttemp_raw;
     #endif
 
     #ifdef BED_MAXTEMP
-      int bed_maxttemp_raw = HEATER_BED_RAW_HI_TEMP;
+      static int bed_maxttemp_raw;
     #endif
 
     #if ENABLED(FILAMENT_WIDTH_SENSOR)
-      int meas_shift_index;  // Index of a delayed sample in buffer
+      static int meas_shift_index;  // Index of a delayed sample in buffer
     #endif
 
     #if HAS_AUTO_FAN
-      millis_t next_auto_fan_check_ms;
+      static millis_t next_auto_fan_check_ms;
     #endif
 
-    unsigned char soft_pwm[EXTRUDERS];
+    static unsigned char soft_pwm[EXTRUDERS];
 
     #if ENABLED(FAN_SOFT_PWM)
-      unsigned char soft_pwm_fan[FAN_COUNT];
+      static unsigned char soft_pwm_fan[FAN_COUNT];
     #endif
 
     #if ENABLED(FILAMENT_WIDTH_SENSOR)
-      int current_raw_filwidth = 0;  //Holds measured filament diameter - one extruder only
+      static int current_raw_filwidth;  //Holds measured filament diameter - one extruder only
     #endif
 
   public:
-
-    /**
-     * Static (class) methods
-     */
-    static float analog2temp(int raw, uint8_t e);
-    static float analog2tempBed(int raw);
 
     /**
      * Instance Methods
@@ -213,18 +205,24 @@ class Temperature {
     void init();
 
     /**
+     * Static (class) methods
+     */
+    static float analog2temp(int raw, uint8_t e);
+    static float analog2tempBed(int raw);
+
+    /**
      * Called from the Temperature ISR
      */
-    void isr();
+    static void isr();
 
     /**
      * Call periodically to manage heaters
      */
-    void manage_heater();
+    static void manage_heater();
 
     #if ENABLED(FILAMENT_WIDTH_SENSOR)
-      float analog2widthFil(); // Convert raw Filament Width to millimeters
-      int widthFil_to_size_ratio(); // Convert raw Filament Width to an extrusion ratio
+      static float analog2widthFil(); // Convert raw Filament Width to millimeters
+      static int widthFil_to_size_ratio(); // Convert raw Filament Width to an extrusion ratio
     #endif
 
 
@@ -232,68 +230,68 @@ class Temperature {
     //inline so that there is no performance decrease.
     //deg=degreeCelsius
 
-    FORCE_INLINE float degHotend(uint8_t extruder) { return current_temperature[extruder]; }
-    FORCE_INLINE float degBed() { return current_temperature_bed; }
+    static FORCE_INLINE float degHotend(uint8_t extruder) { return current_temperature[extruder]; }
+    static FORCE_INLINE float degBed() { return current_temperature_bed; }
 
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-    FORCE_INLINE float rawHotendTemp(uint8_t extruder) { return current_temperature_raw[extruder]; }
-    FORCE_INLINE float rawBedTemp() { return current_temperature_bed_raw; }
+    static FORCE_INLINE float rawHotendTemp(uint8_t extruder) { return current_temperature_raw[extruder]; }
+    static FORCE_INLINE float rawBedTemp() { return current_temperature_bed_raw; }
     #endif
 
-    FORCE_INLINE float degTargetHotend(uint8_t extruder) { return target_temperature[extruder]; }
-    FORCE_INLINE float degTargetBed() { return target_temperature_bed; }
+    static FORCE_INLINE float degTargetHotend(uint8_t extruder) { return target_temperature[extruder]; }
+    static FORCE_INLINE float degTargetBed() { return target_temperature_bed; }
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
-      void start_watching_heater(int e = 0);
+      static void start_watching_heater(int e = 0);
     #endif
 
     #if ENABLED(THERMAL_PROTECTION_BED) && WATCH_BED_TEMP_PERIOD > 0
-      void start_watching_bed();
+      static void start_watching_bed();
     #endif
 
-    FORCE_INLINE void setTargetHotend(const float& celsius, uint8_t extruder) {
+    static FORCE_INLINE void setTargetHotend(const float& celsius, uint8_t extruder) {
       target_temperature[extruder] = celsius;
       #if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
         start_watching_heater(extruder);
       #endif
     }
 
-    FORCE_INLINE void setTargetBed(const float& celsius) {
+    static FORCE_INLINE void setTargetBed(const float& celsius) {
       target_temperature_bed = celsius;
       #if ENABLED(THERMAL_PROTECTION_BED) && WATCH_BED_TEMP_PERIOD > 0
         start_watching_bed();
       #endif
     }
 
-    FORCE_INLINE bool isHeatingHotend(uint8_t extruder) { return target_temperature[extruder] > current_temperature[extruder]; }
-    FORCE_INLINE bool isHeatingBed() { return target_temperature_bed > current_temperature_bed; }
+    static FORCE_INLINE bool isHeatingHotend(uint8_t extruder) { return target_temperature[extruder] > current_temperature[extruder]; }
+    static FORCE_INLINE bool isHeatingBed() { return target_temperature_bed > current_temperature_bed; }
 
-    FORCE_INLINE bool isCoolingHotend(uint8_t extruder) { return target_temperature[extruder] < current_temperature[extruder]; }
-    FORCE_INLINE bool isCoolingBed() { return target_temperature_bed < current_temperature_bed; }
+    static FORCE_INLINE bool isCoolingHotend(uint8_t extruder) { return target_temperature[extruder] < current_temperature[extruder]; }
+    static FORCE_INLINE bool isCoolingBed() { return target_temperature_bed < current_temperature_bed; }
 
     /**
      * The software PWM power for a heater
      */
-    int getHeaterPower(int heater);
+    static int getHeaterPower(int heater);
 
     /**
      * Switch off all heaters, set all target temperatures to 0
      */
-    void disable_all_heaters();
+    static void disable_all_heaters();
 
     /**
      * Perform auto-tuning for hotend or bed in response to M303
      */
     #if HAS_PID_HEATING
-      void PID_autotune(float temp, int extruder, int ncycles, bool set_result=false);
+      static void PID_autotune(float temp, int extruder, int ncycles, bool set_result=false);
     #endif
 
     /**
      * Update the temp manager when PID values change
      */
-    void updatePID();
+    static void updatePID();
 
-    FORCE_INLINE void autotempShutdown() {
+    static FORCE_INLINE void autotempShutdown() {
       #if ENABLED(AUTOTEMP)
         if (planner.autotemp_enabled) {
           planner.autotemp_enabled = false;
@@ -305,7 +303,7 @@ class Temperature {
 
     #if ENABLED(BABYSTEPPING)
 
-      FORCE_INLINE void babystep_axis(AxisEnum axis, int distance) {
+      static FORCE_INLINE void babystep_axis(AxisEnum axis, int distance) {
         #if ENABLED(COREXY) || ENABLED(COREXZ) || ENABLED(COREYZ)
           #if ENABLED(BABYSTEP_XY)
             switch (axis) {
@@ -337,40 +335,40 @@ class Temperature {
 
   private:
 
-    void set_current_temp_raw();
+    static void set_current_temp_raw();
 
-    void updateTemperaturesFromRawValues();
+    static void updateTemperaturesFromRawValues();
 
     #if ENABLED(HEATER_0_USES_MAX6675)
-      int read_max6675();
+      static int read_max6675();
     #endif
 
-    void checkExtruderAutoFans();
+    static void checkExtruderAutoFans();
 
-    float get_pid_output(int e);
+    static float get_pid_output(int e);
 
     #if ENABLED(PIDTEMPBED)
-      float get_pid_output_bed();
+      static float get_pid_output_bed();
     #endif
 
-    void _temp_error(int e, const char* serial_msg, const char* lcd_msg);
-    void min_temp_error(uint8_t e);
-    void max_temp_error(uint8_t e);
+    static void _temp_error(int e, const char* serial_msg, const char* lcd_msg);
+    static void min_temp_error(uint8_t e);
+    static void max_temp_error(uint8_t e);
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) || HAS_THERMALLY_PROTECTED_BED
 
       typedef enum TRState { TRInactive, TRFirstHeating, TRStable, TRRunaway } TRstate;
 
-      void thermal_runaway_protection(TRState* state, millis_t* timer, float temperature, float target_temperature, int heater_id, int period_seconds, int hysteresis_degc);
+      static void thermal_runaway_protection(TRState* state, millis_t* timer, float temperature, float target_temperature, int heater_id, int period_seconds, int hysteresis_degc);
 
       #if ENABLED(THERMAL_PROTECTION_HOTENDS)
-        TRState thermal_runaway_state_machine[EXTRUDERS] = { TRInactive };
-        millis_t thermal_runaway_timer[EXTRUDERS] = { 0 };
+        static TRState thermal_runaway_state_machine[EXTRUDERS];
+        static millis_t thermal_runaway_timer[EXTRUDERS];
       #endif
 
       #if HAS_THERMALLY_PROTECTED_BED
-        TRState thermal_runaway_bed_state_machine = TRInactive;
-        millis_t thermal_runaway_bed_timer;
+        static TRState thermal_runaway_bed_state_machine;
+        static millis_t thermal_runaway_bed_timer;
       #endif
 
     #endif // THERMAL_PROTECTION


### PR DESCRIPTION
This PR reduces code size (by over 850 bytes) and optimizes performance, here and there, by changing data and methods in the `Stepper`, `Endstops`, `Planner`, and `Temperature` classes to `static`. As part of this rework, variable initialization and declarations need to be added to top of the `.cpp` source code.
- All data and most methods marked `static` in these singletons.
- Static data members declared & initialized in `.cpp` files.

To reduce redundancy, all the `private` data members could be changed into global statics and removed from the class headers altogether. For now I'm leaving these data members in the headers so the headers can form the complete documentation for the classes, if desired, using something like Doxygen or HeaderDoc.
