### PR TITLE
Less greedy regex in travis helper scripts

### DIFF
--- a/buildroot/bin/opt_disable
+++ b/buildroot/bin/opt_disable
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for opt in "$@" ; do
-  eval "sed -i 's/\(\/\/ *\)*\(\#define *$opt\)/\/\/\2/g' Marlin/Configuration.h"
+  eval "sed -i 's/\(\/\/ *\)*\(\#define +$opt[^a-zA-Z0-9_]\)/\/\/\2/g' Marlin/Configuration.h"
 done

--- a/buildroot/bin/opt_enable
+++ b/buildroot/bin/opt_enable
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for opt in "$@" ; do
-  eval "sed -i 's/\/\/ *\(#define *$opt\)/\1/g' Marlin/Configuration.h"
+  eval "sed -i 's/\/\/ *\(#define +$opt[^a-zA-Z0-9_]\)/\1/g' Marlin/Configuration.h"
 done

--- a/buildroot/bin/opt_enable_adv
+++ b/buildroot/bin/opt_enable_adv
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for opt in "$@" ; do
-  eval "sed -i 's/\/\/ *\(#define *$opt\)/\1/g' Marlin/Configuration_adv.h"
+  eval "sed -i 's/\/\/ *\(#define +$opt[^a-zA-Z0-9_]\)/\1/g' Marlin/Configuration_adv.h"
 done

--- a/buildroot/bin/opt_set
+++ b/buildroot/bin/opt_set
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define *$1\) *.*$/\1 $2/g' Marlin/Configuration.h"
+eval "sed -i 's/\(#define +$1 +\)[^ ]*$/\1 $2/g' Marlin/Configuration.h"

--- a/buildroot/bin/opt_set_adv
+++ b/buildroot/bin/opt_set_adv
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define *$1\) *.*$/\1 $2/g' Marlin/Configuration_adv.h"
+eval "sed -i 's/\(#define +$1 +\)[^ ]*$/\1 $2/g' Marlin/Configuration_adv.h"

--- a/buildroot/bin/pins_set
+++ b/buildroot/bin/pins_set
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define *$2\) *.*$/\1 $3/g' Marlin/pins_$1.h"
+eval "sed -i 's/\(#define +$2 +\)[^ ]*$/\1 $3/g' Marlin/pins_$1.h"


### PR DESCRIPTION
As pointed out in #3891 the regular expressions for `opt_enable` and `opt_enable_adv` will enable all options that start with the given string. This PR alters the regular expressions to look for a non-option character (`[^a-zA-Z0-9_]` — hopefully a space or newline) after the option name and to include the extra character in the replacement string.
