### PR TITLE
MBL patch for index maths

### DIFF
--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -24,8 +24,10 @@
 
 #if ENABLED(MESH_BED_LEVELING)
 
-  #define MESH_X_DIST ((MESH_MAX_X - (MESH_MIN_X))/(MESH_NUM_X_POINTS - 1))
-  #define MESH_Y_DIST ((MESH_MAX_Y - (MESH_MIN_Y))/(MESH_NUM_Y_POINTS - 1))
+  #define MESH_X_DIST ((MESH_MAX_X - (MESH_MIN_X)) / (MESH_NUM_X_POINTS - 1))
+  #define MESH_Y_DIST ((MESH_MAX_Y - (MESH_MIN_Y)) / (MESH_NUM_Y_POINTS - 1))
+  #define PROBE_X_DIST ((MESH_MAX_X - (MESH_MIN_X)) / (MESH_NUM_X_POINTS))
+  #define PROBE_Y_DIST ((MESH_MAX_Y - (MESH_MIN_Y)) / (MESH_NUM_Y_POINTS))
 
   class mesh_bed_leveling {
   public:
@@ -64,12 +66,12 @@
     }
 
     int8_t probe_index_x(float x) {
-      int8_t px = int(x - (MESH_MIN_X) + (MESH_X_DIST) / 2) / (MESH_X_DIST);
+      int8_t px = int(x - (MESH_MIN_X) + (PROBE_X_DIST) / 2) / (PROBE_X_DIST);
       return (px >= 0 && px < (MESH_NUM_X_POINTS)) ? px : -1;
     }
 
     int8_t probe_index_y(float y) {
-      int8_t py = int(y - (MESH_MIN_Y) + (MESH_Y_DIST) / 2) / (MESH_Y_DIST);
+      int8_t py = int(y - (MESH_MIN_Y) + (PROBE_Y_DIST) / 2) / (PROBE_Y_DIST);
       return (py >= 0 && py < (MESH_NUM_Y_POINTS)) ? py : -1;
     }
 


### PR DESCRIPTION
When calculating the index of a probe point, we need to divide the grid up by the number of probe points. When calculating the index of a grid cel, we need to divide by the number of cels, which is one less than the number of probe points. This PR corrects the previous error, which wrongly used the number of grid cels instead of using the number of probe points in the case of `probe_index_x` and `probe_index_y`.
