### PR TITLE
Closes #3826: SD printing will now pause and stop the print counter

### DIFF
--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -86,7 +86,7 @@ void PrintCounter::showStats() {
 
   SERIAL_ECHOPGM(", Failed: ");
   SERIAL_ECHO(this->data.totalPrints - this->data.finishedPrints
-    - (this->isRunning() || this->isPaused()) ? 1 : 0); // Removes 1 from failures with an active counter
+    - ((this->isRunning() || this->isPaused()) ? 1 : 0)); // Removes 1 from failures with an active counter
 
   uint32_t t = this->data.printTime /60;
   SERIAL_ECHOPGM(", Total print time: ");

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -470,14 +470,21 @@ inline void line_to_current(AxisEnum axis) {
 
 #if ENABLED(SDSUPPORT)
 
-  static void lcd_sdcard_pause() { card.pauseSDPrint(); }
+  static void lcd_sdcard_pause() {
+    card.pauseSDPrint();
+    print_job_timer.pause();
+  }
 
-  static void lcd_sdcard_resume() { card.startFileprint(); }
+  static void lcd_sdcard_resume() {
+    card.startFileprint();
+    print_job_timer.start();
+  }
 
   static void lcd_sdcard_stop() {
     stepper.quick_stop();
     card.sdprinting = false;
     card.closefile();
+    print_job_timer.stop();
     thermalManager.autotempShutdown();
     cancel_heatup = true;
     lcd_setstatus(MSG_PRINT_ABORTED, true);


### PR DESCRIPTION
The LCD menu items for SD printing pause/stop have been updated to control also the print job timer. This commit also fixes a small output bug with M78, the failed print counter was displaying the wrong value.

Fixes: #3826
