### PR TITLE
Tiny calc_timer speedup

### DIFF
--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -257,11 +257,11 @@ class Stepper {
       NOMORE(step_rate, MAX_STEP_FREQUENCY);
 
       if (step_rate > 20000) { // If steprate > 20kHz >> step 4 times
-        step_rate = (step_rate >> 2) & 0x3fff;
+        step_rate >>= 2;
         step_loops = 4;
       }
       else if (step_rate > 10000) { // If steprate > 10kHz >> step 2 times
-        step_rate = (step_rate >> 1) & 0x7fff;
+        step_rate >>= 1;
         step_loops = 2;
       }
       else {


### PR DESCRIPTION
There's no need to use the `&` operator in these operations. `step_rate` is `unsigned short`.
