### PR TITLE
Drop FORCE_INLINE from endstops.h

### DIFF
--- a/Marlin/endstops.h
+++ b/Marlin/endstops.h
@@ -66,21 +66,21 @@ class Endstops {
     static void M119();
 
     // Enable / disable endstop checking globally
-    static FORCE_INLINE void enable_globally(bool onoff=true) { enabled_globally = enabled = onoff; }
+    static void enable_globally(bool onoff=true) { enabled_globally = enabled = onoff; }
 
     // Enable / disable endstop checking
-    static FORCE_INLINE void enable(bool onoff=true) { enabled = onoff; }
+    static void enable(bool onoff=true) { enabled = onoff; }
 
     // Disable / Enable endstops based on ENSTOPS_ONLY_FOR_HOMING and global enable
-    static FORCE_INLINE void not_homing() { enabled = enabled_globally; }
+    static void not_homing() { enabled = enabled_globally; }
 
     // Clear endstops (i.e., they were hit intentionally) to suppress the report
-    static FORCE_INLINE void hit_on_purpose() { endstop_hit_bits = 0; }
+    static void hit_on_purpose() { endstop_hit_bits = 0; }
 
     // Enable / disable endstop z-probe checking
     #if HAS_BED_PROBE
       static volatile bool z_probe_enabled;
-      static FORCE_INLINE void enable_z_probe(bool onoff=true) { z_probe_enabled = onoff; }
+      static void enable_z_probe(bool onoff=true) { z_probe_enabled = onoff; }
     #endif
 
   private:


### PR DESCRIPTION
`FORCE_INLINE` seems to have no effect with standard optimization.
