### PR TITLE
Need to call dac_init() in setup() for DAC_STEPPER_CURRENT

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -856,6 +856,10 @@ void setup() {
     digipot_i2c_init();
   #endif
 
+  #if ENABLED(DAC_STEPPER_CURRENT)
+    dac_init();
+  #endif
+
   #if ENABLED(Z_PROBE_SLED)
     pinMode(SLED_PIN, OUTPUT);
     digitalWrite(SLED_PIN, LOW); // turn it off


### PR DESCRIPTION
As reported by @StephS in https://github.com/MarlinFirmware/Marlin/pull/3182#issuecomment-222595488
