### PR TITLE
Add G20/G21 and M149 support; refactor code_value functions (MarlinDev PR #196)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -749,6 +749,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -752,12 +752,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -51,8 +51,7 @@ extern size_t  __heap_start, __heap_end, __flp;
 // Declare all the functions we need from Marlin_Main.cpp to do the work!
 //
 
-float code_value();
-long code_value_long();
+int code_value_int();
 bool code_seen(char);
 void serial_echopair_P(const char*, float);
 void serial_echopair_P(const char*, double);
@@ -177,7 +176,7 @@ void gcode_M100() {
 #if ENABLED(M100_FREE_MEMORY_CORRUPTOR)
   if (code_seen('C')) {
     int x;      // x gets the # of locations to corrupt within the memory pool
-    x = code_value();
+    x = code_value_int();
     SERIAL_ECHOLNPGM("Corrupting free memory block.\n");
     ptr = (unsigned char*) __brkval;
     SERIAL_ECHOPAIR("\n__brkval : ", ptr);

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -217,6 +217,9 @@ enum AxisEnum {NO_AXIS = -1, X_AXIS = 0, A_AXIS = 0, Y_AXIS = 1, B_AXIS = 1, Z_A
 
 #define _AXIS(AXIS) AXIS ##_AXIS
 
+typedef enum { LINEARUNIT_MM = 0, LINEARUNIT_INCH = 1 } LinearUnit;
+typedef enum { TEMPUNIT_C = 0, TEMPUNIT_K = 1, TEMPUNIT_F = 2 } TempUnit;
+
 void enable_all_steppers();
 void disable_all_steppers();
 
@@ -288,9 +291,15 @@ extern bool axis_homed[3]; // axis[n].is_homed
 
 // GCode support for external objects
 bool code_seen(char);
-float code_value();
+float code_value_float();
+unsigned long code_value_ulong();
 long code_value_long();
-int16_t code_value_short();
+int code_value_int();
+uint16_t code_value_ushort();
+uint8_t code_value_byte();
+bool code_value_bool();
+float code_value_temp_abs();
+float code_value_temp_diff();
 
 #if ENABLED(DELTA)
   extern float delta[3];

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -298,8 +298,13 @@ int code_value_int();
 uint16_t code_value_ushort();
 uint8_t code_value_byte();
 bool code_value_bool();
+float code_value_linear_units();
+float code_value_per_axis_unit(int axis);
+float code_value_axis_units(int axis);
 float code_value_temp_abs();
 float code_value_temp_diff();
+millis_t code_value_millis();
+millis_t code_value_millis_from_seconds();
 
 #if ENABLED(DELTA)
   extern float delta[3];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1199,10 +1199,10 @@ uint16_t code_value_ushort() { return (uint16_t)strtoul(seen_pointer + 1, NULL, 
 
 uint8_t code_value_byte() { return (uint8_t)(constrain(strtol(seen_pointer + 1, NULL, 10), 0, 255)); }
 
-inline bool code_value_bool() { return code_value_byte() > 0; }
+bool code_value_bool() { return code_value_byte() > 0; }
 
 #if ENABLED(USE_G20G21)
-  inline void set_input_linear_units(LinearUnit units) {
+  void set_input_linear_units(LinearUnit units) {
     switch (units) {
       case LINEARUNIT_INCH:
         linear_unit_modifier = 25.4;
@@ -1215,31 +1215,31 @@ inline bool code_value_bool() { return code_value_byte() > 0; }
     volumetric_unit_modifier = pow(linear_unit_modifier, 3.0);
   }
 
-  inline float axis_unit_modifier(int axis) {
+  float axis_unit_modifier(int axis) {
     return (axis == E_AXIS && volumetric_enabled ? volumetric_unit_modifier : linear_unit_modifier);
   }
 
-  inline float code_value_linear_units() {
+  float code_value_linear_units() {
     return code_value_float() * linear_unit_modifier;
   }
 
-  inline float code_value_per_axis_unit(int axis) {
+  float code_value_per_axis_unit(int axis) {
     return code_value_float() / axis_unit_modifier(axis);
   }
 
-  inline float code_value_axis_units(int axis) {
+  float code_value_axis_units(int axis) {
     return code_value_float() * axis_unit_modifier(axis);
   }
 #else
-  inline float code_value_linear_units() { return code_value_float(); }
+  float code_value_linear_units() { return code_value_float(); }
 
-  inline float code_value_per_axis_unit(int axis) { return code_value_float(); }
+  float code_value_per_axis_unit(int axis) { return code_value_float(); }
 
-  inline float code_value_axis_units(int axis) { return code_value_float(); }
+  float code_value_axis_units(int axis) { return code_value_float(); }
 #endif
 
 #if ENABLED(USE_M149)
-  inline void set_input_temp_units(TempUnit units) {
+  void set_input_temp_units(TempUnit units) {
     input_temp_units = units;
   }
   
@@ -1268,15 +1268,15 @@ inline bool code_value_bool() { return code_value_byte() > 0; }
     }
   }
 #else
-  inline float code_value_temp_abs() { return code_value_float(); }
-  inline float code_value_temp_diff() { return code_value_float(); }
+  float code_value_temp_abs() { return code_value_float(); }
+  float code_value_temp_diff() { return code_value_float(); }
 #endif
 
-inline millis_t code_value_millis() {
+millis_t code_value_millis() {
   return code_value_ulong();
 }
 
-inline millis_t code_value_millis_from_seconds() {
+millis_t code_value_millis_from_seconds() {
   return code_value_float() * 1000;
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1178,14 +1178,14 @@ bool code_has_value() {
 
 float code_value_float() {
   float ret;
-  char *e = strchr(seen_pointer, 'E');
+  char* e = strchr(seen_pointer, 'E');
   if (e) {
     *e = 0;
-    ret = strtod(seen_pointer+1, NULL);
+    ret = strtod(seen_pointer + 1, NULL);
     *e = 'E';
   }
   else
-    ret = strtod(seen_pointer+1, NULL);
+    ret = strtod(seen_pointer + 1, NULL);
   return ret;
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -288,11 +288,11 @@ static int cmd_queue_index_w = 0;
 static int commands_in_queue = 0;
 static char command_queue[BUFSIZE][MAX_CMD_SIZE];
 
-#if ENABLED(USE_G20G21)
+#if ENABLED(INCH_MODE_SUPPORT)
   float linear_unit_modifier = 1.0;
   float volumetric_unit_modifier = 1.0;
 #endif
-#if ENABLED(USE_M149)
+#if ENABLED(TEMPERATURE_UNITS_SUPPORT)
   TempUnit input_temp_units = TEMPUNIT_C;
 #endif
 
@@ -1201,7 +1201,7 @@ uint8_t code_value_byte() { return (uint8_t)(constrain(strtol(seen_pointer + 1, 
 
 bool code_value_bool() { return code_value_byte() > 0; }
 
-#if ENABLED(USE_G20G21)
+#if ENABLED(INCH_MODE_SUPPORT)
   void set_input_linear_units(LinearUnit units) {
     switch (units) {
       case LINEARUNIT_INCH:
@@ -1238,7 +1238,7 @@ bool code_value_bool() { return code_value_byte() > 0; }
   float code_value_axis_units(int axis) { return code_value_float(); }
 #endif
 
-#if ENABLED(USE_M149)
+#if ENABLED(TEMPERATURE_UNITS_SUPPORT)
   void set_input_temp_units(TempUnit units) {
     input_temp_units = units;
   }
@@ -2705,7 +2705,7 @@ inline void gcode_G4() {
 
 #endif //FWRETRACT
 
-#if ENABLED(USE_G20G21)
+#if ENABLED(INCH_MODE_SUPPORT)
   /**
    * G20: Set input mode to inches
    */
@@ -5032,7 +5032,7 @@ inline void gcode_M140() {
 
 #endif
 
-#if ENABLED(USE_M149)
+#if ENABLED(TEMPERATURE_UNITS_SUPPORT)
   /**
    * M149: Set temperature units
    */
@@ -6834,7 +6834,7 @@ void process_next_command() {
 
       #endif // FWRETRACT
 
-      #if ENABLED(USE_G20G21)
+      #if ENABLED(INCH_MODE_SUPPORT)
         case 20: //G20: Inch Mode
           gcode_G20();
           break;
@@ -7102,7 +7102,7 @@ void process_next_command() {
 
       #endif
 
-      #if ENABLED(USE_M149)
+      #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
         case 149:
           gcode_M149();
           break;

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -735,12 +735,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -732,6 +732,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -733,12 +733,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -730,6 +730,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -744,12 +744,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -741,6 +741,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -743,6 +743,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -746,12 +746,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -766,6 +766,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -769,12 +769,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -749,6 +749,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -752,12 +752,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -747,12 +747,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -744,6 +744,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -760,12 +760,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -757,6 +757,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -773,12 +773,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -770,6 +770,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -744,12 +744,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -741,6 +741,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -749,6 +749,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -752,12 +752,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -841,12 +841,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -838,6 +838,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -835,12 +835,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -832,6 +832,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -835,6 +835,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -838,12 +838,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -835,6 +835,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -838,12 +838,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -837,6 +837,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -840,12 +840,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -755,12 +755,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -752,6 +752,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -743,6 +743,16 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 //#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
+//
+// G20/G21 Inch mode support
+//
+#define USE_G20G21
+
+//
+// M149 Set temperature units support
+//
+#define USE_M149
+
 // @section temperature
 
 // Preheat Constants

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -746,12 +746,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //
 // G20/G21 Inch mode support
 //
-#define USE_G20G21
+//#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support
 //
-#define USE_M149
+//#define TEMPERATURE_UNITS_SUPPORT
 
 // @section temperature
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1155,9 +1155,9 @@ void Planner::reset_acceleration_rates() {
 
   void Planner::autotemp_M109() {
     autotemp_enabled = code_seen('F');
-    if (autotemp_enabled) autotemp_factor = code_value();
-    if (code_seen('S')) autotemp_min = code_value();
-    if (code_seen('B')) autotemp_max = code_value();
+    if (autotemp_enabled) autotemp_factor = code_value_temp_diff();
+    if (code_seen('S')) autotemp_min = code_value_temp_abs();
+    if (code_seen('B')) autotemp_max = code_value_temp_abs();
   }
 
 #endif


### PR DESCRIPTION
(This is an update of MarlinDev PR #196.)

G20/21: support for switching input units between millimeters and inches.
M149: support for changing input temperature units.

In support of these changes, code_value() and code_value_short() are replaced with an array of functions which handle converting to the proper types and/or units.

Someone needs to test this on actual hardware; mine is out of commission for the time being. All these changes have worked well for a long time for me, but that's not to say I didn't break something rebasing the changes against this repo.

(Also, it looks like you guys threw astyle requirements under the bus? Just checking.)
