### PR TITLE
Improved LCD contrast handling

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -249,7 +249,14 @@
    * Default LCD contrast for dogm-like LCD displays
    */
   #if ENABLED(DOGLCD)
-    #define HAS_LCD_CONTRAST (DISABLED(U8GLIB_ST7920) && DISABLED(U8GLIB_SSD1306) && DISABLED(U8GLIB_SH1106))
+
+    #define HAS_LCD_CONTRAST ( \
+        ENABLED(MAKRPANEL) \
+     || ENABLED(VIKI2) \
+     || ENABLED(miniVIKI) \
+     || ENABLED(ELB_FULL_GRAPHIC_CONTROLLER) \
+    )
+
     #if HAS_LCD_CONTRAST
       #ifndef LCD_CONTRAST_MIN
         #define LCD_CONTRAST_MIN 0

--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -61,10 +61,14 @@
     #define ULTIMAKERCONTROLLER //as available from the Ultimaker online store.
 
     #if ENABLED(miniVIKI)
+      #define LCD_CONTRAST_MIN  75
+      #define LCD_CONTRAST_MAX 115
       #define DEFAULT_LCD_CONTRAST 95
     #elif ENABLED(VIKI2)
       #define DEFAULT_LCD_CONTRAST 40
     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
+      #define LCD_CONTRAST_MIN  90
+      #define LCD_CONTRAST_MAX 130
       #define DEFAULT_LCD_CONTRAST 110
       #define U8GLIB_LM6059_AF
       #define SD_DETECT_INVERTED
@@ -246,8 +250,16 @@
    */
   #if ENABLED(DOGLCD)
     #define HAS_LCD_CONTRAST (DISABLED(U8GLIB_ST7920) && DISABLED(U8GLIB_SSD1306) && DISABLED(U8GLIB_SH1106))
-    #if HAS_LCD_CONTRAST && !defined(DEFAULT_LCD_CONTRAST)
-      #define DEFAULT_LCD_CONTRAST 32
+    #if HAS_LCD_CONTRAST
+      #ifndef LCD_CONTRAST_MIN
+        #define LCD_CONTRAST_MIN 0
+      #endif
+      #ifndef LCD_CONTRAST_MAX
+        #define LCD_CONTRAST_MAX 63
+      #endif
+      #ifndef DEFAULT_LCD_CONTRAST
+        #define DEFAULT_LCD_CONTRAST 32
+      #endif
     #endif
   #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5636,7 +5636,7 @@ inline void gcode_M226() {
    * M250: Read and optionally set the LCD contrast
    */
   inline void gcode_M250() {
-    if (code_seen('C')) lcd_setcontrast(code_value_short() & 0x3F);
+    if (code_seen('C')) set_lcd_contrast(code_value_short());
     SERIAL_PROTOCOLPGM("lcd contrast value: ");
     SERIAL_PROTOCOL(lcd_contrast);
     SERIAL_EOL;

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -367,7 +367,14 @@
 #endif
 
 #if ENCODER_PULSES_PER_STEP < 0
-  #error "ENCODER_PULSES_PER_STEP should not be negative, use REVERSE_MENU_DIRECTION instead"
+  #error "ENCODER_PULSES_PER_STEP should not be negative, use REVERSE_MENU_DIRECTION instead."
+#endif
+
+/**
+ * SAV_3DGLCD display options
+ */
+#if ENABLED(U8GLIB_SSD1306) && ENABLED(U8GLIB_SH1106)
+  #error "Only enable one SAV_3DGLCD display type: U8GLIB_SSD1306 or U8GLIB_SH1106."
 #endif
 
 /**

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1716,23 +1716,18 @@ static void lcd_control_volumetric_menu() {
   static void lcd_set_contrast() {
     ENCODER_DIRECTION_NORMAL();
     if (encoderPosition) {
-      #if ENABLED(U8GLIB_LM6059_AF)
-        lcd_contrast += encoderPosition;
-        lcd_contrast &= 0xFF;
-      #else
-        lcd_contrast -= encoderPosition;
-        lcd_contrast &= 0x3F;
-      #endif
+      set_lcd_contrast(lcd_contrast + encoderPosition);
       encoderPosition = 0;
       lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
-      u8g.setContrast(lcd_contrast);
     }
     if (lcdDrawUpdate) {
-      #if ENABLED(U8GLIB_LM6059_AF)
-        lcd_implementation_drawedit(PSTR(MSG_CONTRAST), itostr3(lcd_contrast));
-      #else
-        lcd_implementation_drawedit(PSTR(MSG_CONTRAST), itostr2(lcd_contrast));
-      #endif
+      lcd_implementation_drawedit(PSTR(MSG_CONTRAST),
+        #if LCD_CONTRAST_MAX >= 100
+          itostr3(lcd_contrast)
+        #else
+          itostr2(lcd_contrast)
+        #endif
+      );
     }
     if (LCD_CLICKED) lcd_goto_previous_menu(true);
   }
@@ -2384,8 +2379,8 @@ void lcd_setalertstatuspgm(const char* message) {
 void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
 #if HAS_LCD_CONTRAST
-  void lcd_setcontrast(uint8_t value) {
-    lcd_contrast = value & 0x3F;
+  void set_lcd_contrast(int value) {
+    lcd_contrast = constrain(value, LCD_CONTRAST_MIN, LCD_CONTRAST_MAX);
     u8g.setContrast(lcd_contrast);
   }
 #endif

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -53,7 +53,7 @@
 
   #if ENABLED(DOGLCD)
     extern int lcd_contrast;
-    void lcd_setcontrast(uint8_t value);
+    void set_lcd_contrast(int value);
   #endif
 
   #define LCD_MESSAGEPGM(x) lcd_setstatuspgm(PSTR(x))


### PR DESCRIPTION
Based on MarlinFirmware/MarlinDev#200 from @eboston
- Rename `lcd_setcontrast` to `set_lcd_contrast`
- Add `LCD_CONTRAST_(MIN|MAX)` defines, default 0-63
- Constrain LCD contrast to min/max wherever it is set (by `set_lcd_contrast`)
- Include a contrast range for `miniVIKI` (for completeness)
- Use positive conditions for `HAS_LCD_CONTRAST`
- Add a sanity check for mutually-exclusive `SAV_3DGLCD` display options

References: https://github.com/MarlinFirmware/Marlin/issues/751#issuecomment-222982148, https://github.com/MarlinFirmware/Marlin/issues/3912#issuecomment-222922425
