### PR TITLE
Rename some auto/locals to avoid name conflict

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -155,18 +155,18 @@ void Planner::calculate_trapezoid_for_block(block_t* block, float entry_factor, 
   NOLESS(initial_rate, 120);
   NOLESS(final_rate, 120);
 
-  long acceleration = block->acceleration_st;
-  int32_t accelerate_steps = ceil(estimate_acceleration_distance(initial_rate, block->nominal_rate, acceleration));
-  int32_t decelerate_steps = floor(estimate_acceleration_distance(block->nominal_rate, final_rate, -acceleration));
+  long accel = block->acceleration_st;
+  int32_t accelerate_steps = ceil(estimate_acceleration_distance(initial_rate, block->nominal_rate, accel));
+  int32_t decelerate_steps = floor(estimate_acceleration_distance(block->nominal_rate, final_rate, -accel));
 
   // Calculate the size of Plateau of Nominal Rate.
   int32_t plateau_steps = block->step_event_count - accelerate_steps - decelerate_steps;
 
   // Is the Plateau of Nominal Rate smaller than nothing? That means no cruising, and we will
-  // have to use intersection_distance() to calculate when to abort acceleration and start braking
+  // have to use intersection_distance() to calculate when to abort accel and start braking
   // in order to reach the final_rate exactly at the end of this block.
   if (plateau_steps < 0) {
-    accelerate_steps = ceil(intersection_distance(initial_rate, final_rate, acceleration, block->step_event_count));
+    accelerate_steps = ceil(intersection_distance(initial_rate, final_rate, accel, block->step_event_count));
     accelerate_steps = max(accelerate_steps, 0); // Check limits due to numerical round-off
     accelerate_steps = min((uint32_t)accelerate_steps, block->step_event_count);//(We can cast here to unsigned, because the above line ensures that we are above zero)
     plateau_steps = 0;

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -281,9 +281,9 @@ class Planner {
      * Calculate the distance (not time) it takes to accelerate
      * from initial_rate to target_rate using the given acceleration:
      */
-    static float estimate_acceleration_distance(float initial_rate, float target_rate, float acceleration) {
-      if (acceleration == 0) return 0; // acceleration was 0, set acceleration distance to 0
-      return (target_rate * target_rate - initial_rate * initial_rate) / (acceleration * 2);
+    static float estimate_acceleration_distance(float initial_rate, float target_rate, float accel) {
+      if (accel == 0) return 0; // accel was 0, set acceleration distance to 0
+      return (target_rate * target_rate - initial_rate * initial_rate) / (accel * 2);
     }
 
     /**
@@ -294,9 +294,9 @@ class Planner {
      * This is used to compute the intersection point between acceleration and deceleration
      * in cases where the "trapezoid" has no plateau (i.e., never reaches maximum speed)
      */
-    static float intersection_distance(float initial_rate, float final_rate, float acceleration, float distance) {
-      if (acceleration == 0) return 0; // acceleration was 0, set intersection distance to 0
-      return (acceleration * 2 * distance - initial_rate * initial_rate + final_rate * final_rate) / (acceleration * 4);
+    static float intersection_distance(float initial_rate, float final_rate, float accel, float distance) {
+      if (accel == 0) return 0; // accel was 0, set intersection distance to 0
+      return (accel * 2 * distance - initial_rate * initial_rate + final_rate * final_rate) / (accel * 4);
     }
 
     /**
@@ -304,8 +304,8 @@ class Planner {
      * to reach 'target_velocity' using 'acceleration' within a given
      * 'distance'.
      */
-    static float max_allowable_speed(float acceleration, float target_velocity, float distance) {
-      return sqrt(target_velocity * target_velocity - 2 * acceleration * distance);
+    static float max_allowable_speed(float accel, float target_velocity, float distance) {
+      return sqrt(target_velocity * target_velocity - 2 * accel * distance);
     }
 
     static void calculate_trapezoid_for_block(block_t* block, float entry_factor, float exit_factor);


### PR DESCRIPTION
Rename auto / local vars named `acceleration` in `planner.cpp` and `planner.h` to avoid confusing them with `planner.acceleration` and `current_block->acceleration`.
