### PR TITLE
Use memset in mbl.reset to save 58 bytes

### DIFF
--- a/Marlin/mesh_bed_leveling.cpp
+++ b/Marlin/mesh_bed_leveling.cpp
@@ -31,9 +31,7 @@
   void mesh_bed_leveling::reset() {
     status = MBL_STATUS_NONE;
     z_offset = 0;
-    for (int8_t y = MESH_NUM_Y_POINTS; y--;)
-      for (int8_t x = MESH_NUM_X_POINTS; x--;)
-        z_values[y][x] = 0;
+    memset(z_values, 0, sizeof(z_values));
   }
 
 #endif  // MESH_BED_LEVELING


### PR DESCRIPTION
The smallest possible code to accomplish this.
