### PR TITLE
Rename some vars to clarify their relationship to acceleration

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -426,7 +426,7 @@
    */
   #if ENABLED(ADVANCE)
     #define EXTRUSION_AREA (0.25 * (D_FILAMENT) * (D_FILAMENT) * M_PI)
-    #define STEPS_PER_CUBIC_MM_E (axis_steps_per_unit[E_AXIS] / (EXTRUSION_AREA))
+    #define STEPS_PER_CUBIC_MM_E (axis_steps_per_mm[E_AXIS] / (EXTRUSION_AREA))
   #endif
 
   #if ENABLED(ULTIPANEL) && DISABLED(ELB_FULL_GRAPHIC_CONTROLLER)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -156,7 +156,7 @@
  * M84  - Disable steppers until next move,
  *        or use S<seconds> to specify an inactivity timeout, after which the steppers will be disabled.  S0 to disable the timeout.
  * M85  - Set inactivity shutdown timer with parameter S<seconds>. To disable set zero (default)
- * M92  - Set planner.axis_steps_per_unit - same syntax as G92
+ * M92  - Set planner.axis_steps_per_mm - same syntax as G92
  * M104 - Set extruder target temp
  * M105 - Read current temp
  * M106 - Fan on
@@ -1675,7 +1675,7 @@ static void setup_for_endstop_move() {
        * is not where we said to go.
        */
       long stop_steps = stepper.position(Z_AXIS);
-      float mm = start_z - float(start_steps - stop_steps) / planner.axis_steps_per_unit[Z_AXIS];
+      float mm = start_z - float(start_steps - stop_steps) / planner.axis_steps_per_mm[Z_AXIS];
       current_position[Z_AXIS] = mm;
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -5147,15 +5147,15 @@ inline void gcode_M92() {
       if (i == E_AXIS) {
         float value = code_value_per_axis_unit(i);
         if (value < 20.0) {
-          float factor = planner.axis_steps_per_unit[i] / value; // increase e constants if M92 E14 is given for netfab.
+          float factor = planner.axis_steps_per_mm[i] / value; // increase e constants if M92 E14 is given for netfab.
           planner.max_e_jerk *= factor;
           planner.max_feedrate[i] *= factor;
           planner.max_acceleration_steps_per_s2[i] *= factor;
         }
-        planner.axis_steps_per_unit[i] = value;
+        planner.axis_steps_per_mm[i] = value;
       }
       else {
-        planner.axis_steps_per_unit[i] = code_value_per_axis_unit(i);
+        planner.axis_steps_per_mm[i] = code_value_per_axis_unit(i);
       }
     }
   }
@@ -5190,9 +5190,9 @@ static void report_current_position() {
     SERIAL_EOL;
 
     SERIAL_PROTOCOLPGM("SCARA step Cal - Theta:");
-    SERIAL_PROTOCOL(delta[X_AXIS] / 90 * planner.axis_steps_per_unit[X_AXIS]);
+    SERIAL_PROTOCOL(delta[X_AXIS] / 90 * planner.axis_steps_per_mm[X_AXIS]);
     SERIAL_PROTOCOLPGM("   Psi+Theta:");
-    SERIAL_PROTOCOL((delta[Y_AXIS] - delta[X_AXIS]) / 90 * planner.axis_steps_per_unit[Y_AXIS]);
+    SERIAL_PROTOCOL((delta[Y_AXIS] - delta[X_AXIS]) / 90 * planner.axis_steps_per_mm[Y_AXIS]);
     SERIAL_EOL; SERIAL_EOL;
   #endif
 }
@@ -5347,7 +5347,7 @@ inline void gcode_M201() {
 #if 0 // Not used for Sprinter/grbl gen6
   inline void gcode_M202() {
     for (int8_t i = 0; i < NUM_AXIS; i++) {
-      if (code_seen(axis_codes[i])) axis_travel_steps_per_sqr_second[i] = code_value_axis_units(i) * planner.axis_steps_per_unit[i];
+      if (code_seen(axis_codes[i])) axis_travel_steps_per_sqr_second[i] = code_value_axis_units(i) * planner.axis_steps_per_mm[i];
     }
   }
 #endif
@@ -8209,8 +8209,8 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
         }
         float oldepos = current_position[E_AXIS], oldedes = destination[E_AXIS];
         planner.buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS],
-                         destination[E_AXIS] + (EXTRUDER_RUNOUT_EXTRUDE) * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_unit[E_AXIS],
-                         (EXTRUDER_RUNOUT_SPEED) / 60. * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_unit[E_AXIS], active_extruder);
+                         destination[E_AXIS] + (EXTRUDER_RUNOUT_EXTRUDE) * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_mm[E_AXIS],
+                         (EXTRUDER_RUNOUT_SPEED) / 60. * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_mm[E_AXIS], active_extruder);
       current_position[E_AXIS] = oldepos;
       destination[E_AXIS] = oldedes;
       planner.set_e_position_mm(oldepos);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5150,7 +5150,7 @@ inline void gcode_M92() {
           float factor = planner.axis_steps_per_unit[i] / value; // increase e constants if M92 E14 is given for netfab.
           planner.max_e_jerk *= factor;
           planner.max_feedrate[i] *= factor;
-          planner.axis_steps_per_sqr_second[i] *= factor;
+          planner.max_acceleration_steps_per_s2[i] *= factor;
         }
         planner.axis_steps_per_unit[i] = value;
       }
@@ -5337,7 +5337,7 @@ inline void gcode_M200() {
 inline void gcode_M201() {
   for (int8_t i = 0; i < NUM_AXIS; i++) {
     if (code_seen(axis_codes[i])) {
-      planner.max_acceleration_units_per_sq_second[i] = code_value_axis_units(i);
+      planner.max_acceleration_mm_per_s2[i] = code_value_axis_units(i);
     }
   }
   // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -43,7 +43,7 @@
  *
  *  100  Version (char x4)
  *
- *  104  M92 XYZE  planner.axis_steps_per_unit (float x4)
+ *  104  M92 XYZE  planner.axis_steps_per_mm (float x4)
  *  120  M203 XYZE planner.max_feedrate (float x4)
  *  136  M201 XYZE planner.max_acceleration_mm_per_s2 (uint32_t x4)
  *  152  M204 P    planner.acceleration (float)
@@ -173,7 +173,7 @@ void Config_StoreSettings()  {
   char ver[4] = "000";
   int i = EEPROM_OFFSET;
   EEPROM_WRITE_VAR(i, ver); // invalidate data first
-  EEPROM_WRITE_VAR(i, planner.axis_steps_per_unit);
+  EEPROM_WRITE_VAR(i, planner.axis_steps_per_mm);
   EEPROM_WRITE_VAR(i, planner.max_feedrate);
   EEPROM_WRITE_VAR(i, planner.max_acceleration_mm_per_s2);
   EEPROM_WRITE_VAR(i, planner.acceleration);
@@ -353,7 +353,7 @@ void Config_RetrieveSettings() {
     float dummy = 0;
 
     // version number match
-    EEPROM_READ_VAR(i, planner.axis_steps_per_unit);
+    EEPROM_READ_VAR(i, planner.axis_steps_per_mm);
     EEPROM_READ_VAR(i, planner.max_feedrate);
     EEPROM_READ_VAR(i, planner.max_acceleration_mm_per_s2);
 
@@ -527,7 +527,7 @@ void Config_ResetDefault() {
   float tmp2[] = DEFAULT_MAX_FEEDRATE;
   long tmp3[] = DEFAULT_MAX_ACCELERATION;
   for (uint8_t i = 0; i < NUM_AXIS; i++) {
-    planner.axis_steps_per_unit[i] = tmp1[i];
+    planner.axis_steps_per_mm[i] = tmp1[i];
     planner.max_feedrate[i] = tmp2[i];
     planner.max_acceleration_mm_per_s2[i] = tmp3[i];
     #if ENABLED(SCARA)
@@ -652,10 +652,10 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHOLNPGM("Steps per unit:");
     CONFIG_ECHO_START;
   }
-  SERIAL_ECHOPAIR("  M92 X", planner.axis_steps_per_unit[X_AXIS]);
-  SERIAL_ECHOPAIR(" Y", planner.axis_steps_per_unit[Y_AXIS]);
-  SERIAL_ECHOPAIR(" Z", planner.axis_steps_per_unit[Z_AXIS]);
-  SERIAL_ECHOPAIR(" E", planner.axis_steps_per_unit[E_AXIS]);
+  SERIAL_ECHOPAIR("  M92 X", planner.axis_steps_per_mm[X_AXIS]);
+  SERIAL_ECHOPAIR(" Y", planner.axis_steps_per_mm[Y_AXIS]);
+  SERIAL_ECHOPAIR(" Z", planner.axis_steps_per_mm[Z_AXIS]);
+  SERIAL_ECHOPAIR(" E", planner.axis_steps_per_mm[E_AXIS]);
   SERIAL_EOL;
 
   CONFIG_ECHO_START;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -45,7 +45,7 @@
  *
  *  104  M92 XYZE  planner.axis_steps_per_unit (float x4)
  *  120  M203 XYZE planner.max_feedrate (float x4)
- *  136  M201 XYZE planner.max_acceleration_units_per_sq_second (uint32_t x4)
+ *  136  M201 XYZE planner.max_acceleration_mm_per_s2 (uint32_t x4)
  *  152  M204 P    planner.acceleration (float)
  *  156  M204 R    planner.retract_acceleration (float)
  *  160  M204 T    planner.travel_acceleration (float)
@@ -175,7 +175,7 @@ void Config_StoreSettings()  {
   EEPROM_WRITE_VAR(i, ver); // invalidate data first
   EEPROM_WRITE_VAR(i, planner.axis_steps_per_unit);
   EEPROM_WRITE_VAR(i, planner.max_feedrate);
-  EEPROM_WRITE_VAR(i, planner.max_acceleration_units_per_sq_second);
+  EEPROM_WRITE_VAR(i, planner.max_acceleration_mm_per_s2);
   EEPROM_WRITE_VAR(i, planner.acceleration);
   EEPROM_WRITE_VAR(i, planner.retract_acceleration);
   EEPROM_WRITE_VAR(i, planner.travel_acceleration);
@@ -355,7 +355,7 @@ void Config_RetrieveSettings() {
     // version number match
     EEPROM_READ_VAR(i, planner.axis_steps_per_unit);
     EEPROM_READ_VAR(i, planner.max_feedrate);
-    EEPROM_READ_VAR(i, planner.max_acceleration_units_per_sq_second);
+    EEPROM_READ_VAR(i, planner.max_acceleration_mm_per_s2);
 
     // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
     planner.reset_acceleration_rates();
@@ -529,7 +529,7 @@ void Config_ResetDefault() {
   for (uint8_t i = 0; i < NUM_AXIS; i++) {
     planner.axis_steps_per_unit[i] = tmp1[i];
     planner.max_feedrate[i] = tmp2[i];
-    planner.max_acceleration_units_per_sq_second[i] = tmp3[i];
+    planner.max_acceleration_mm_per_s2[i] = tmp3[i];
     #if ENABLED(SCARA)
       if (i < COUNT(axis_scaling))
         axis_scaling[i] = 1;
@@ -687,10 +687,10 @@ void Config_PrintSettings(bool forReplay) {
     SERIAL_ECHOLNPGM("Maximum Acceleration (mm/s2):");
     CONFIG_ECHO_START;
   }
-  SERIAL_ECHOPAIR("  M201 X", planner.max_acceleration_units_per_sq_second[X_AXIS]);
-  SERIAL_ECHOPAIR(" Y", planner.max_acceleration_units_per_sq_second[Y_AXIS]);
-  SERIAL_ECHOPAIR(" Z", planner.max_acceleration_units_per_sq_second[Z_AXIS]);
-  SERIAL_ECHOPAIR(" E", planner.max_acceleration_units_per_sq_second[E_AXIS]);
+  SERIAL_ECHOPAIR("  M201 X", planner.max_acceleration_mm_per_s2[X_AXIS]);
+  SERIAL_ECHOPAIR(" Y", planner.max_acceleration_mm_per_s2[Y_AXIS]);
+  SERIAL_ECHOPAIR(" Z", planner.max_acceleration_mm_per_s2[Z_AXIS]);
+  SERIAL_ECHOPAIR(" E", planner.max_acceleration_mm_per_s2[E_AXIS]);
   SERIAL_EOL;
   CONFIG_ECHO_START;
   if (!forReplay) {

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -155,7 +155,7 @@ void Planner::calculate_trapezoid_for_block(block_t* block, float entry_factor, 
   NOLESS(initial_rate, 120);
   NOLESS(final_rate, 120);
 
-  long accel = block->acceleration_st;
+  long accel = block->acceleration_steps_per_s2;
   int32_t accelerate_steps = ceil(estimate_acceleration_distance(initial_rate, block->nominal_rate, accel));
   int32_t decelerate_steps = floor(estimate_acceleration_distance(block->nominal_rate, final_rate, -accel));
 
@@ -936,27 +936,27 @@ void Planner::check_axes_activity() {
   float steps_per_mm = block->step_event_count / block->millimeters;
   long bsx = block->steps[X_AXIS], bsy = block->steps[Y_AXIS], bsz = block->steps[Z_AXIS], bse = block->steps[E_AXIS];
   if (bsx == 0 && bsy == 0 && bsz == 0) {
-    block->acceleration_st = ceil(retract_acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
+    block->acceleration_steps_per_s2 = ceil(retract_acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
   }
   else if (bse == 0) {
-    block->acceleration_st = ceil(travel_acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
+    block->acceleration_steps_per_s2 = ceil(travel_acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
   }
   else {
-    block->acceleration_st = ceil(acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
+    block->acceleration_steps_per_s2 = ceil(acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
   }
   // Limit acceleration per axis
-  unsigned long acc_st = block->acceleration_st,
                 xsteps = max_acceleration_steps_per_s2[X_AXIS],
                 ysteps = max_acceleration_steps_per_s2[Y_AXIS],
                 zsteps = max_acceleration_steps_per_s2[Z_AXIS],
                 esteps = max_acceleration_steps_per_s2[E_AXIS],
+  unsigned long acc_st = block->acceleration_steps_per_s2,
                 allsteps = block->step_event_count;
   if (xsteps < (acc_st * bsx) / allsteps) acc_st = (xsteps * allsteps) / bsx;
   if (ysteps < (acc_st * bsy) / allsteps) acc_st = (ysteps * allsteps) / bsy;
   if (zsteps < (acc_st * bsz) / allsteps) acc_st = (zsteps * allsteps) / bsz;
   if (esteps < (acc_st * bse) / allsteps) acc_st = (esteps * allsteps) / bse;
 
-  block->acceleration_st = acc_st;
+  block->acceleration_steps_per_s2 = acc_st;
   block->acceleration = acc_st / steps_per_mm;
   block->acceleration_rate = (long)(acc_st * 16777216.0 / (F_CPU / 8.0));
 
@@ -1057,7 +1057,7 @@ void Planner::check_axes_activity() {
       block->advance = 0;
     }
     else {
-      long acc_dist = estimate_acceleration_distance(0, block->nominal_rate, block->acceleration_st);
+      long acc_dist = estimate_acceleration_distance(0, block->nominal_rate, block->acceleration_steps_per_s2);
       float advance = ((STEPS_PER_CUBIC_MM_E) * (EXTRUDER_ADVANCE_K)) * (cse * cse * (EXTRUSION_AREA) * (EXTRUSION_AREA)) * 256;
       block->advance = advance;
       block->advance_rate = acc_dist ? advance / (float)acc_dist : 0;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -82,8 +82,8 @@ volatile uint8_t Planner::block_buffer_tail = 0;
 
 float Planner::max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
 float Planner::axis_steps_per_unit[NUM_AXIS];
-unsigned long Planner::axis_steps_per_sqr_second[NUM_AXIS];
-unsigned long Planner::max_acceleration_units_per_sq_second[NUM_AXIS]; // Use M201 to override by software
+unsigned long Planner::max_acceleration_steps_per_s2[NUM_AXIS];
+unsigned long Planner::max_acceleration_mm_per_s2[NUM_AXIS]; // Use M201 to override by software
 
 millis_t Planner::min_segment_time;
 float Planner::min_feedrate;
@@ -946,10 +946,10 @@ void Planner::check_axes_activity() {
   }
   // Limit acceleration per axis
   unsigned long acc_st = block->acceleration_st,
-                xsteps = axis_steps_per_sqr_second[X_AXIS],
-                ysteps = axis_steps_per_sqr_second[Y_AXIS],
-                zsteps = axis_steps_per_sqr_second[Z_AXIS],
-                esteps = axis_steps_per_sqr_second[E_AXIS],
+                xsteps = max_acceleration_steps_per_s2[X_AXIS],
+                ysteps = max_acceleration_steps_per_s2[Y_AXIS],
+                zsteps = max_acceleration_steps_per_s2[Z_AXIS],
+                esteps = max_acceleration_steps_per_s2[E_AXIS],
                 allsteps = block->step_event_count;
   if (xsteps < (acc_st * bsx) / allsteps) acc_st = (xsteps * allsteps) / bsx;
   if (ysteps < (acc_st * bsy) / allsteps) acc_st = (ysteps * allsteps) / bsy;
@@ -1148,7 +1148,7 @@ void Planner::set_e_position_mm(const float& e) {
 // Recalculate the steps/s^2 acceleration rates, based on the mm/s^2
 void Planner::reset_acceleration_rates() {
   for (int i = 0; i < NUM_AXIS; i++)
-    axis_steps_per_sqr_second[i] = max_acceleration_units_per_sq_second[i] * axis_steps_per_unit[i];
+    max_acceleration_steps_per_s2[i] = max_acceleration_mm_per_s2[i] * axis_steps_per_unit[i];
 }
 
 #if ENABLED(AUTOTEMP)

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -945,16 +945,16 @@ void Planner::check_axes_activity() {
     block->acceleration_steps_per_s2 = ceil(acceleration * steps_per_mm); // convert to: acceleration steps/sec^2
   }
   // Limit acceleration per axis
-                xsteps = max_acceleration_steps_per_s2[X_AXIS],
-                ysteps = max_acceleration_steps_per_s2[Y_AXIS],
-                zsteps = max_acceleration_steps_per_s2[Z_AXIS],
-                esteps = max_acceleration_steps_per_s2[E_AXIS],
   unsigned long acc_st = block->acceleration_steps_per_s2,
+                x_acc_st = max_acceleration_steps_per_s2[X_AXIS],
+                y_acc_st = max_acceleration_steps_per_s2[Y_AXIS],
+                z_acc_st = max_acceleration_steps_per_s2[Z_AXIS],
+                e_acc_st = max_acceleration_steps_per_s2[E_AXIS],
                 allsteps = block->step_event_count;
-  if (xsteps < (acc_st * bsx) / allsteps) acc_st = (xsteps * allsteps) / bsx;
-  if (ysteps < (acc_st * bsy) / allsteps) acc_st = (ysteps * allsteps) / bsy;
-  if (zsteps < (acc_st * bsz) / allsteps) acc_st = (zsteps * allsteps) / bsz;
-  if (esteps < (acc_st * bse) / allsteps) acc_st = (esteps * allsteps) / bse;
+  if (x_acc_st < (acc_st * bsx) / allsteps) acc_st = (x_acc_st * allsteps) / bsx;
+  if (y_acc_st < (acc_st * bsy) / allsteps) acc_st = (y_acc_st * allsteps) / bsy;
+  if (z_acc_st < (acc_st * bsz) / allsteps) acc_st = (z_acc_st * allsteps) / bsz;
+  if (e_acc_st < (acc_st * bse) / allsteps) acc_st = (e_acc_st * allsteps) / bse;
 
   block->acceleration_steps_per_s2 = acc_st;
   block->acceleration = acc_st / steps_per_mm;

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -114,8 +114,8 @@ class Planner {
 
     static float max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
     static float axis_steps_per_unit[NUM_AXIS];
-    static unsigned long axis_steps_per_sqr_second[NUM_AXIS];
-    static unsigned long max_acceleration_units_per_sq_second[NUM_AXIS]; // Use M201 to override by software
+    static unsigned long max_acceleration_steps_per_s2[NUM_AXIS];
+    static unsigned long max_acceleration_mm_per_s2[NUM_AXIS]; // Use M201 to override by software
 
     static millis_t min_segment_time;
     static float min_feedrate;

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -58,9 +58,9 @@ typedef struct {
   long steps[NUM_AXIS];                     // Step count along each axis
   unsigned long step_event_count;           // The number of step events required to complete this block
 
-  long accelerate_until;                    // The index of the step event on which to stop acceleration
-  long decelerate_after;                    // The index of the step event on which to start decelerating
-  long acceleration_rate;                   // The acceleration rate used for acceleration calculation
+  long accelerate_until,                    // The index of the step event on which to stop acceleration
+       decelerate_after,                    // The index of the step event on which to start decelerating
+       acceleration_rate;                   // The acceleration rate used for acceleration calculation
 
   unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
 
@@ -72,27 +72,26 @@ typedef struct {
   #endif
 
   // Fields used by the motion planner to manage acceleration
-  float nominal_speed;                               // The nominal speed for this block in mm/sec
-  float entry_speed;                                 // Entry speed at previous-current junction in mm/sec
-  float max_entry_speed;                             // Maximum allowable junction entry speed in mm/sec
-  float millimeters;                                 // The total travel of this block in mm
-  float acceleration;                                // acceleration mm/sec^2
-  unsigned char recalculate_flag;                    // Planner flag to recalculate trapezoids on entry junction
-  unsigned char nominal_length_flag;                 // Planner flag for nominal speed always reached
+  float nominal_speed,                               // The nominal speed for this block in mm/sec
+        entry_speed,                                 // Entry speed at previous-current junction in mm/sec
+        max_entry_speed,                             // Maximum allowable junction entry speed in mm/sec
+        millimeters,                                 // The total travel of this block in mm
+        acceleration;                                // acceleration mm/sec^2
+  unsigned char recalculate_flag,                    // Planner flag to recalculate trapezoids on entry junction
+                nominal_length_flag;                 // Planner flag for nominal speed always reached
 
   // Settings for the trapezoid generator
-  unsigned long nominal_rate;                        // The nominal step rate for this block in step_events/sec
-  unsigned long initial_rate;                        // The jerk-adjusted step rate at start of block
-  unsigned long final_rate;                          // The minimal rate at exit
-  unsigned long acceleration_steps_per_s2;           // acceleration steps/sec^2
+  unsigned long nominal_rate,                        // The nominal step rate for this block in step_events/sec
+                initial_rate,                        // The jerk-adjusted step rate at start of block
+                final_rate,                          // The minimal rate at exit
+                acceleration_steps_per_s2;           // acceleration steps/sec^2
 
   #if FAN_COUNT > 0
     unsigned long fan_speed[FAN_COUNT];
   #endif
 
   #if ENABLED(BARICUDA)
-    unsigned long valve_pressure;
-    unsigned long e_to_p_pressure;
+    unsigned long valve_pressure, e_to_p_pressure;
   #endif
 
   volatile char busy;

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -112,7 +112,7 @@ class Planner {
     static volatile uint8_t block_buffer_tail;
 
     static float max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
-    static float axis_steps_per_unit[NUM_AXIS];
+    static float axis_steps_per_mm[NUM_AXIS];
     static unsigned long max_acceleration_steps_per_s2[NUM_AXIS];
     static unsigned long max_acceleration_mm_per_s2[NUM_AXIS]; // Use M201 to override by software
 
@@ -134,7 +134,7 @@ class Planner {
 
     /**
      * The current position of the tool in absolute steps
-     * Reclculated if any axis_steps_per_unit are changed by gcode
+     * Reclculated if any axis_steps_per_mm are changed by gcode
      */
     static long position[NUM_AXIS];
 
@@ -212,7 +212,7 @@ class Planner {
        * Set the planner.position and individual stepper positions.
        * Used by G92, G28, G29, and other procedures.
        *
-       * Multiplies by axis_steps_per_unit[] and does necessary conversion
+       * Multiplies by axis_steps_per_mm[] and does necessary conversion
        * for COREXY / COREXZ / COREYZ to set the corresponding stepper positions.
        *
        * Clears previous speed values.

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -84,7 +84,7 @@ typedef struct {
   unsigned long nominal_rate;                        // The nominal step rate for this block in step_events/sec
   unsigned long initial_rate;                        // The jerk-adjusted step rate at start of block
   unsigned long final_rate;                          // The minimal rate at exit
-  unsigned long acceleration_st;                     // acceleration steps/sec^2
+  unsigned long acceleration_steps_per_s2;           // acceleration steps/sec^2
 
   #if FAN_COUNT > 0
     unsigned long fan_speed[FAN_COUNT];

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -754,7 +754,7 @@ float Stepper::get_axis_position_mm(AxisEnum axis) {
   #else
     axis_steps = position(axis);
   #endif
-  return axis_steps / planner.axis_steps_per_unit[axis];
+  return axis_steps / planner.axis_steps_per_mm[axis];
 }
 
 void Stepper::finish_and_disable() {

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -243,7 +243,7 @@ class Stepper {
     // Triggered position of an axis in mm (not core-savvy)
     //
     static FORCE_INLINE float triggered_position_mm(AxisEnum axis) {
-      return endstops_trigsteps[axis] / planner.axis_steps_per_unit[axis];
+      return endstops_trigsteps[axis] / planner.axis_steps_per_mm[axis];
     }
 
   private:

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -556,7 +556,7 @@ float Temperature::get_pid_output(int e) {
               lpq[lpq_ptr++] = 0;
             }
             if (lpq_ptr >= lpq_len) lpq_ptr = 0;
-            cTerm[_CTERM_INDEX] = (lpq[lpq_ptr] / planner.axis_steps_per_unit[E_AXIS]) * PID_PARAM(Kc, e);
+            cTerm[_CTERM_INDEX] = (lpq[lpq_ptr] / planner.axis_steps_per_mm[E_AXIS]) * PID_PARAM(Kc, e);
             pid_output += cTerm[e];
           }
         #endif //PID_ADD_EXTRUSION_RATE

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1692,14 +1692,14 @@ static void lcd_control_motion_menu() {
   MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_E, &planner.max_acceleration_mm_per_s2[E_AXIS], 100, 99000, _reset_acceleration_rates);
   MENU_ITEM_EDIT(float5, MSG_A_RETRACT, &planner.retract_acceleration, 100, 99000);
   MENU_ITEM_EDIT(float5, MSG_A_TRAVEL, &planner.travel_acceleration, 100, 99000);
-  MENU_ITEM_EDIT(float52, MSG_XSTEPS, &planner.axis_steps_per_unit[X_AXIS], 5, 9999);
-  MENU_ITEM_EDIT(float52, MSG_YSTEPS, &planner.axis_steps_per_unit[Y_AXIS], 5, 9999);
+  MENU_ITEM_EDIT(float52, MSG_XSTEPS, &planner.axis_steps_per_mm[X_AXIS], 5, 9999);
+  MENU_ITEM_EDIT(float52, MSG_YSTEPS, &planner.axis_steps_per_mm[Y_AXIS], 5, 9999);
   #if ENABLED(DELTA)
-    MENU_ITEM_EDIT(float52, MSG_ZSTEPS, &planner.axis_steps_per_unit[Z_AXIS], 5, 9999);
+    MENU_ITEM_EDIT(float52, MSG_ZSTEPS, &planner.axis_steps_per_mm[Z_AXIS], 5, 9999);
   #else
-    MENU_ITEM_EDIT(float51, MSG_ZSTEPS, &planner.axis_steps_per_unit[Z_AXIS], 5, 9999);
+    MENU_ITEM_EDIT(float51, MSG_ZSTEPS, &planner.axis_steps_per_mm[Z_AXIS], 5, 9999);
   #endif
-  MENU_ITEM_EDIT(float51, MSG_ESTEPS, &planner.axis_steps_per_unit[E_AXIS], 5, 9999);
+  MENU_ITEM_EDIT(float51, MSG_ESTEPS, &planner.axis_steps_per_mm[E_AXIS], 5, 9999);
   #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
     MENU_ITEM_EDIT(bool, MSG_ENDSTOP_ABORT, &stepper.abort_on_endstop_hit);
   #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1686,10 +1686,10 @@ static void lcd_control_motion_menu() {
   MENU_ITEM_EDIT(float3, MSG_VMAX MSG_E, &planner.max_feedrate[E_AXIS], 1, 999);
   MENU_ITEM_EDIT(float3, MSG_VMIN, &planner.min_feedrate, 0, 999);
   MENU_ITEM_EDIT(float3, MSG_VTRAV_MIN, &planner.min_travel_feedrate, 0, 999);
-  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_X, &planner.max_acceleration_units_per_sq_second[X_AXIS], 100, 99000, _reset_acceleration_rates);
-  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_Y, &planner.max_acceleration_units_per_sq_second[Y_AXIS], 100, 99000, _reset_acceleration_rates);
-  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_Z, &planner.max_acceleration_units_per_sq_second[Z_AXIS], 10, 99000, _reset_acceleration_rates);
-  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_E, &planner.max_acceleration_units_per_sq_second[E_AXIS], 100, 99000, _reset_acceleration_rates);
+  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_X, &planner.max_acceleration_mm_per_s2[X_AXIS], 100, 99000, _reset_acceleration_rates);
+  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_Y, &planner.max_acceleration_mm_per_s2[Y_AXIS], 100, 99000, _reset_acceleration_rates);
+  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_Z, &planner.max_acceleration_mm_per_s2[Z_AXIS], 10, 99000, _reset_acceleration_rates);
+  MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_E, &planner.max_acceleration_mm_per_s2[E_AXIS], 100, 99000, _reset_acceleration_rates);
   MENU_ITEM_EDIT(float5, MSG_A_RETRACT, &planner.retract_acceleration, 100, 99000);
   MENU_ITEM_EDIT(float5, MSG_A_TRAVEL, &planner.travel_acceleration, 100, 99000);
   MENU_ITEM_EDIT(float52, MSG_XSTEPS, &planner.axis_steps_per_unit[X_AXIS], 5, 9999);


### PR DESCRIPTION
As noted by @edwilliams16 in https://github.com/MarlinFirmware/Marlin/issues/3961#issuecomment-224828180

Variables related to acceleration, whether expressed in units or in steps, need some clarification.
- `Planner::axis_steps_per_sqr_second` => `Planner::max_acceleration_steps_per_s2`
- `block_t::acceleration_st` => `block_t::acceleration_steps_per_s2`

For concision, the following suffixes are changed…
- `per_sq_second` => `per_s2`
- `per_sqr_second` => `per_s2`

The planner and stepper classes are both standardized around millimeters. So `unit` and `units` are replaced with `mm` where possible.
