### PR TITLE
Support for SWITCHING_EXTRUDER

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,16 @@ script:
   - opt_set LCD_FEEDBACK_FREQUENCY_DURATION_MS 10
   - opt_set LCD_FEEDBACK_FREQUENCY_HZ 100
   - opt_enable BQ_LCD_SMART_CONTROLLER SPEAKER
+  #
+  # Test SWITCHING_EXTRUDER
+  #
+  - restore_configs
+  - opt_set MOTHERBOARD BOARD_RUMBA
+  - opt_set EXTRUDERS 2
+  - opt_enable NUM_SERVOS
+  - opt_set NUM_SERVOS 1
+  - opt_set TEMP_SENSOR_1 1
+  - opt_enable SWITCHING_EXTRUDER ULTIMAKERCONTROLLER
   - build_marlin
   #
   # Test MINIRAMBO for PWM_MOTOR_CURRENT

--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -539,13 +539,38 @@
    */
   #if ENABLED(SINGLENOZZLE)
     #define HOTENDS 1
+    #define E_STEPPERS EXTRUDERS
     #undef TEMP_SENSOR_1_AS_REDUNDANT
     #undef HOTEND_OFFSET_X
     #undef HOTEND_OFFSET_Y
     #define HOTEND_OFFSET_X { 0 }
     #define HOTEND_OFFSET_Y { 0 }
+  #elif ENABLED(SWITCHING_EXTRUDER)
+    #define HOTENDS EXTRUDERS
+    #define E_STEPPERS 1
+    #ifndef HOTEND_OFFSET_X
+      #define HOTEND_OFFSET_X { 0 }
+    #endif
+    #ifndef HOTEND_OFFSET_Y
+      #define HOTEND_OFFSET_Y { 0 }
+    #endif
+    #ifndef HOTEND_OFFSET_Z
+      #define HOTEND_OFFSET_Z { 0 }
+    #endif
   #else
     #define HOTENDS EXTRUDERS
+    #define E_STEPPERS EXTRUDERS
+  #endif
+
+  /**
+   * SWITCHING_EXTRUDER has multiple hotends, but only one stepper
+   */
+  #if ENABLED(SWITCHING_EXTRUDER)
+    #define ACTIVE_E_STEPPER 0
+    #define BLOCK_E_STEPPER 0
+  #else
+    #define ACTIVE_E_STEPPER active_extruder
+    #define BLOCK_E_STEPPER current_block->active_extruder
   #endif
 
   /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -136,6 +136,15 @@
 // For Cyclops or any "multi-extruder" that shares a single nozzle.
 //#define SINGLENOZZLE
 
+// A dual extruder that uses a single stepper motor
+// Don't forget to set SSDE_SERVO_ANGLES and HOTEND_OFFSET_X/Y/Z
+//#define SWITCHING_EXTRUDER
+#ifdef SWITCHING_EXTRUDER
+  #define SWITCHING_EXTRUDER_SERVO_NR 0
+  #define SWITCHING_EXTRUDER_SERVO_ANGLES { 0, 90 } // Angles for E0, E1
+  //#define HOTEND_OFFSET_Z {0.0, 0.0}
+#endif
+
 // Offset of the extruders (uncomment if using more than one and relying on firmware to position when changing).
 // The offset has to be X=0, Y=0 for the extruder 0 hotend (default extruder).
 // For the other hotends it is their distance from the extruder 0 hotend.

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -178,7 +178,7 @@ void manage_inactivity(bool ignore_stepper_queue = false);
   #define disable_e0() /* nothing */
 #endif
 
-#if (EXTRUDERS > 1) && HAS_E1_ENABLE
+#if E_STEPPERS > 1 && HAS_E1_ENABLE
   #define enable_e1()  E1_ENABLE_WRITE( E_ENABLE_ON)
   #define disable_e1() E1_ENABLE_WRITE(!E_ENABLE_ON)
 #else
@@ -186,7 +186,7 @@ void manage_inactivity(bool ignore_stepper_queue = false);
   #define disable_e1() /* nothing */
 #endif
 
-#if (EXTRUDERS > 2) && HAS_E2_ENABLE
+#if E_STEPPERS > 2 && HAS_E2_ENABLE
   #define enable_e2()  E2_ENABLE_WRITE( E_ENABLE_ON)
   #define disable_e2() E2_ENABLE_WRITE(!E_ENABLE_ON)
 #else
@@ -194,7 +194,7 @@ void manage_inactivity(bool ignore_stepper_queue = false);
   #define disable_e2() /* nothing */
 #endif
 
-#if (EXTRUDERS > 3) && HAS_E3_ENABLE
+#if E_STEPPERS > 3 && HAS_E3_ENABLE
   #define enable_e3()  E3_ENABLE_WRITE( E_ENABLE_ON)
   #define disable_e3() E3_ENABLE_WRITE(!E_ENABLE_ON)
 #else

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -393,7 +393,9 @@ static uint8_t target_extruder;
   float hotend_offset[][HOTENDS] = {
     HOTEND_OFFSET_X,
     HOTEND_OFFSET_Y
-    #if ENABLED(DUAL_X_CARRIAGE)
+    #if ENABLED(SWITCHING_EXTRUDER)
+      , HOTEND_OFFSET_Z
+    #elif ENABLED(DUAL_X_CARRIAGE)
       , { 0 } // Z offsets for each extruder
     #endif
   };
@@ -5201,7 +5203,7 @@ inline void gcode_M200() {
     if (volumetric_enabled) {
       filament_size[target_extruder] = diameter;
       // make sure all extruders have some sane value for the filament size
-      for (int i = 0; i < EXTRUDERS; i++)
+      for (int i = 0; i < E_STEPPERS; i++)
         if (! filament_size[i]) filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
     }
   }
@@ -5441,7 +5443,7 @@ inline void gcode_M206() {
    *   T<tool>
    *   X<xoffset>
    *   Y<yoffset>
-   *   Z<zoffset> - Available with DUAL_X_CARRIAGE
+   *   Z<zoffset> - Available with DUAL_X_CARRIAGE and SWITCHING_EXTRUDER
    */
   inline void gcode_M218() {
     if (get_target_extruder_from_command(218)) return;
@@ -5449,7 +5451,7 @@ inline void gcode_M206() {
     if (code_seen('X')) hotend_offset[X_AXIS][target_extruder] = code_value_axis_units(X_AXIS);
     if (code_seen('Y')) hotend_offset[Y_AXIS][target_extruder] = code_value_axis_units(Y_AXIS);
 
-    #if ENABLED(DUAL_X_CARRIAGE)
+    #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_EXTRUDER)
       if (code_seen('Z')) hotend_offset[Z_AXIS][target_extruder] = code_value_axis_units(Z_AXIS);
     #endif
 
@@ -5460,7 +5462,7 @@ inline void gcode_M206() {
       SERIAL_ECHO(hotend_offset[X_AXIS][e]);
       SERIAL_CHAR(',');
       SERIAL_ECHO(hotend_offset[Y_AXIS][e]);
-      #if ENABLED(DUAL_X_CARRIAGE)
+      #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_EXTRUDER)
         SERIAL_CHAR(',');
         SERIAL_ECHO(hotend_offset[Z_AXIS][e]);
       #endif
@@ -6451,6 +6453,13 @@ inline void gcode_M999() {
   FlushSerialRequestResend();
 }
 
+#if ENABLED(SWITCHING_EXTRUDER)
+  inline void move_extruder_servo(uint8_t e) {
+    const int angles[2] = SWITCHING_EXTRUDER_SERVO_ANGLES;
+    MOVE_SERVO(SWITCHING_EXTRUDER_SERVO_NR, angles[e]);
+  }
+#endif
+
 /**
  * T0-T3: Switch tool, usually switching extruders
  *
@@ -6485,12 +6494,30 @@ inline void gcode_T(uint8_t tmp_extruder) {
         if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE && IsRunning() &&
             (delayed_move_time || current_position[X_AXIS] != x_home_pos(active_extruder))) {
           // Park old head: 1) raise 2) move to park position 3) lower
-          planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] + TOOLCHANGE_PARK_ZLIFT,
-                           current_position[E_AXIS], planner.max_feedrate[Z_AXIS], active_extruder);
-          planner.buffer_line(x_home_pos(active_extruder), current_position[Y_AXIS], current_position[Z_AXIS] + TOOLCHANGE_PARK_ZLIFT,
-                           current_position[E_AXIS], planner.max_feedrate[X_AXIS], active_extruder);
-          planner.buffer_line(x_home_pos(active_extruder), current_position[Y_AXIS], current_position[Z_AXIS],
-                           current_position[E_AXIS], planner.max_feedrate[Z_AXIS], active_extruder);
+          planner.buffer_line(
+            current_position[X_AXIS],
+            current_position[Y_AXIS],
+            current_position[Z_AXIS] + TOOLCHANGE_PARK_ZLIFT,
+            current_position[E_AXIS],
+            planner.max_feedrate[Z_AXIS],
+            active_extruder
+          );
+          planner.buffer_line(
+            x_home_pos(active_extruder),
+            current_position[Y_AXIS],
+            current_position[Z_AXIS] + TOOLCHANGE_PARK_ZLIFT,
+            current_position[E_AXIS],
+            planner.max_feedrate[X_AXIS],
+            active_extruder
+          );
+          planner.buffer_line(
+            x_home_pos(active_extruder),
+            current_position[Y_AXIS],
+            current_position[Z_AXIS],
+            current_position[E_AXIS],
+            planner.max_feedrate[Z_AXIS],
+            active_extruder
+          );
           stepper.synchronize();
         }
 
@@ -6524,6 +6551,39 @@ inline void gcode_T(uint8_t tmp_extruder) {
         }
         // No extra case for AUTO_BED_LEVELING_FEATURE in DUAL_X_CARRIAGE. Does that mean they don't work together?
       #else // !DUAL_X_CARRIAGE
+
+        #if ENABLED(SWITCHING_EXTRUDER)
+          // <0 if the new nozzle is higher, >0 if lower. A bigger raise when lower.
+          float z_diff = hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder],
+                z_raise = 0.3 + (z_diff > 0.0 ? z_diff : 0.0);
+
+          // Always raise by some amount
+          planner.buffer_line(
+            current_position[X_AXIS],
+            current_position[Y_AXIS],
+            current_position[Z_AXIS] + z_raise,
+            current_position[E_AXIS],
+            planner.max_feedrate[Z_AXIS],
+            active_extruder
+          );
+          stepper.synchronize();
+
+          move_extruder_servo(active_extruder);
+          delay(500);
+
+          // Move back down, if needed
+          if (z_raise != z_diff) {
+            planner.buffer_line(
+              current_position[X_AXIS],
+              current_position[Y_AXIS],
+              current_position[Z_AXIS] + z_diff,
+              current_position[E_AXIS],
+              planner.max_feedrate[Z_AXIS],
+              active_extruder
+            );
+            stepper.synchronize();
+          }
+        #endif
 
         //
         // Set current_position to the position of the new nozzle.
@@ -6608,7 +6668,6 @@ inline void gcode_T(uint8_t tmp_extruder) {
           position_shift[i] += xydiff[i];
           update_software_endstops((AxisEnum)i);
         }
-
         // Set the new active extruder
         active_extruder = tmp_extruder;
 
@@ -7842,14 +7901,14 @@ void prepare_move_to_destination() {
       nextMotorCheck = ms + 2500UL; // Not a time critical function, so only check every 2.5s
       if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON || thermalManager.soft_pwm_bed > 0
           || E0_ENABLE_READ == E_ENABLE_ON // If any of the drivers are enabled...
-          #if EXTRUDERS > 1
+          #if E_STEPPERS > 1
             || E1_ENABLE_READ == E_ENABLE_ON
             #if HAS_X2_ENABLE
               || X2_ENABLE_READ == X_ENABLE_ON
             #endif
-            #if EXTRUDERS > 2
+            #if E_STEPPERS > 2
               || E2_ENABLE_READ == E_ENABLE_ON
-              #if EXTRUDERS > 3
+              #if E_STEPPERS > 3
                 || E3_ENABLE_READ == E_ENABLE_ON
               #endif
             #endif
@@ -8111,25 +8170,29 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
   #endif
 
   #if ENABLED(EXTRUDER_RUNOUT_PREVENT)
-    if (ELAPSED(ms, previous_cmd_ms + (EXTRUDER_RUNOUT_SECONDS) * 1000UL))
-      if (thermalManager.degHotend(active_extruder) > EXTRUDER_RUNOUT_MINTEMP) {
+    if (ELAPSED(ms, previous_cmd_ms + (EXTRUDER_RUNOUT_SECONDS) * 1000UL)
+      && thermalManager.degHotend(active_extruder) > EXTRUDER_RUNOUT_MINTEMP) {
+      #if ENABLED(SWITCHING_EXTRUDER)
+        bool oldstatus = E0_ENABLE_READ;
+        enable_e0();
+      #else // !SWITCHING_EXTRUDER
         bool oldstatus;
         switch (active_extruder) {
           case 0:
             oldstatus = E0_ENABLE_READ;
             enable_e0();
             break;
-          #if EXTRUDERS > 1
+          #if E_STEPPERS > 1
             case 1:
               oldstatus = E1_ENABLE_READ;
               enable_e1();
               break;
-            #if EXTRUDERS > 2
+            #if E_STEPPERS > 2
               case 2:
                 oldstatus = E2_ENABLE_READ;
                 enable_e2();
                 break;
-              #if EXTRUDERS > 3
+              #if E_STEPPERS > 3
                 case 3:
                   oldstatus = E3_ENABLE_READ;
                   enable_e3();
@@ -8138,37 +8201,43 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
             #endif
           #endif
         }
-        float oldepos = current_position[E_AXIS], oldedes = destination[E_AXIS];
-        planner.buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS],
-                         destination[E_AXIS] + (EXTRUDER_RUNOUT_EXTRUDE) * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_mm[E_AXIS],
-                         (EXTRUDER_RUNOUT_SPEED) / 60. * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_mm[E_AXIS], active_extruder);
+      #endif // !SWITCHING_EXTRUDER
+
+      float oldepos = current_position[E_AXIS], oldedes = destination[E_AXIS];
+      planner.buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS],
+                       destination[E_AXIS] + (EXTRUDER_RUNOUT_EXTRUDE) * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_unit[E_AXIS],
+                       (EXTRUDER_RUNOUT_SPEED) / 60. * (EXTRUDER_RUNOUT_ESTEPS) / planner.axis_steps_per_unit[E_AXIS], active_extruder);
       current_position[E_AXIS] = oldepos;
       destination[E_AXIS] = oldedes;
       planner.set_e_position_mm(oldepos);
       previous_cmd_ms = ms; // refresh_cmd_timeout()
       stepper.synchronize();
-      switch (active_extruder) {
-        case 0:
-          E0_ENABLE_WRITE(oldstatus);
-          break;
-        #if EXTRUDERS > 1
-          case 1:
-            E1_ENABLE_WRITE(oldstatus);
+      #if ENABLED(SWITCHING_EXTRUDER)
+        E0_ENABLE_WRITE(oldstatus);
+      #else
+        switch (active_extruder) {
+          case 0:
+            E0_ENABLE_WRITE(oldstatus);
             break;
-          #if EXTRUDERS > 2
-            case 2:
-              E2_ENABLE_WRITE(oldstatus);
+          #if E_STEPPERS > 1
+            case 1:
+              E1_ENABLE_WRITE(oldstatus);
               break;
-            #if EXTRUDERS > 3
-              case 3:
-                E3_ENABLE_WRITE(oldstatus);
+            #if E_STEPPERS > 2
+              case 2:
+                E2_ENABLE_WRITE(oldstatus);
                 break;
+              #if E_STEPPERS > 3
+                case 3:
+                  E3_ENABLE_WRITE(oldstatus);
+                  break;
+              #endif
             #endif
           #endif
-        #endif
-      }
+        }
+      #endif // !SWITCHING_EXTRUDER
     }
-  #endif
+  #endif // EXTRUDER_RUNOUT_PREVENT
 
   #if ENABLED(DUAL_X_CARRIAGE)
     // handle delayed move timeout

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -179,6 +179,21 @@
 #endif
 
 /**
+ * Single Stepper Dual Extruder with switching servo
+ */
+#if ENABLED(SWITCHING_EXTRUDER)
+  #if ENABLED(SINGLENOZZLE)
+    #error "SINGLENOZZLE and SWITCHING_EXTRUDER are incompatible."
+  #elif ENABLED(DUAL_X_CARRIAGE)
+    #error "SINGLENOZZLE and DUAL_X_CARRIAGE are incompatible."
+  #elif EXTRUDERS != 2
+    #error "SWITCHING_EXTRUDER requires exactly 2 EXTRUDERS."
+  #elif NUM_SERVOS < 1
+    #error "SWITCHING_EXTRUDER requires NUM_SERVOS >= 1."
+  #endif
+#endif
+
+/**
  * Limited number of servos
  */
 #if defined(NUM_SERVOS) && NUM_SERVOS > 0

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -256,6 +256,9 @@
 #ifndef MSG_PID_C
   #define MSG_PID_C                           "PID-C"
 #endif
+#ifndef MSG_SELECT
+  #define MSG_SELECT                          "Select"
+#endif
 #ifndef MSG_E1
   #define MSG_E1                              " E1"
 #endif

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -368,15 +368,15 @@
 #if ENABLED(DUAL_X_CARRIAGE)
   // The X2 axis, if any, should be the next open extruder port
   #ifndef X2_STEP_PIN
-    #define X2_STEP_PIN   _EPIN(EXTRUDERS, STEP)
-    #define X2_DIR_PIN    _EPIN(EXTRUDERS, DIR)
-    #define X2_ENABLE_PIN _EPIN(EXTRUDERS, ENABLE)
+    #define X2_STEP_PIN   _EPIN(E_STEPPERS, STEP)
+    #define X2_DIR_PIN    _EPIN(E_STEPPERS, DIR)
+    #define X2_ENABLE_PIN _EPIN(E_STEPPERS, ENABLE)
   #endif
   #undef _X2_PINS
   #define _X2_PINS X2_STEP_PIN, X2_DIR_PIN, X2_ENABLE_PIN,
-  #define Y2_Z2_E_INDEX INCREMENT(EXTRUDERS)
+  #define Y2_Z2_E_INDEX INCREMENT(E_STEPPERS)
 #else
-  #define Y2_Z2_E_INDEX EXTRUDERS
+  #define Y2_Z2_E_INDEX E_STEPPERS
 #endif
 
 // The Y2 axis, if any, should be the next open extruder port

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -332,7 +332,7 @@ void Stepper::isr() {
       #endif
 
       // #if ENABLED(ADVANCE)
-      //   e_steps[current_block->active_extruder] = 0;
+      //   e_steps[BLOCK_E_STEPPER] = 0;
       // #endif
     }
     else {
@@ -376,7 +376,7 @@ void Stepper::isr() {
         counter_E += current_block->steps[E_AXIS];
         if (counter_E > 0) {
           counter_E -= current_block->step_event_count;
-          e_steps[current_block->active_extruder] += motor_direction(E_AXIS) ? -1 : 1;
+          e_steps[BLOCK_E_STEPPER] += motor_direction(E_AXIS) ? -1 : 1;
         }
 
       #endif // ADVANCE or LIN_ADVANCE
@@ -445,7 +445,7 @@ void Stepper::isr() {
         //NOLESS(advance, current_block->advance);
 
         // Do E steps + advance steps
-        e_steps[current_block->active_extruder] += ((advance >> 8) - old_advance);
+        e_steps[BLOCK_E_STEPPER] += ((advance >> 8) - old_advance);
         old_advance = advance >> 8;
 
       #endif // ADVANCE or LIN_ADVANCE
@@ -481,7 +481,7 @@ void Stepper::isr() {
 
         // Do E steps + advance steps
         uint32_t advance_whole = advance >> 8;
-        e_steps[current_block->active_extruder] += advance_whole - old_advance;
+        e_steps[BLOCK_E_STEPPER] += advance_whole - old_advance;
         old_advance = advance_whole;
 
       #endif // ADVANCE or LIN_ADVANCE

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -318,7 +318,7 @@ class Stepper {
         advance = current_block->initial_advance;
         final_advance = current_block->final_advance;
         // Do E steps + advance steps
-        e_steps[current_block->active_extruder] += ((advance >>8) - old_advance);
+        e_steps[BLOCK_E_STEPPER] += ((advance >>8) - old_advance);
         old_advance = advance >>8;
       #endif
       deceleration_time = 0;

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -182,7 +182,11 @@
 #define E3_ENABLE_WRITE(STATE) WRITE(E3_ENABLE_PIN,STATE)
 #define E3_ENABLE_READ READ(E3_ENABLE_PIN)
 
-#if EXTRUDERS > 3
+#if ENABLED(SWITCHING_EXTRUDER)
+  #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
+  #define NORM_E_DIR() E0_DIR_WRITE(current_block->active_extruder ?  INVERT_E0_DIR : !INVERT_E0_DIR)
+  #define  REV_E_DIR() E0_DIR_WRITE(current_block->active_extruder ? !INVERT_E0_DIR :  INVERT_E0_DIR)
+#elif EXTRUDERS > 3
   #define E_STEP_WRITE(v) {switch(current_block->active_extruder){case 3:E3_STEP_WRITE(v);break;case 2:E2_STEP_WRITE(v);break;case 1:E1_STEP_WRITE(v);break;default:E0_STEP_WRITE(v);}}
   #define NORM_E_DIR() {switch(current_block->active_extruder){case 3:E3_DIR_WRITE(!INVERT_E3_DIR);break;case 2:E2_DIR_WRITE(!INVERT_E2_DIR);break;case 1:E1_DIR_WRITE(!INVERT_E1_DIR);break;default:E0_DIR_WRITE(!INVERT_E0_DIR);}}
   #define REV_E_DIR() {switch(current_block->active_extruder){case 3:E3_DIR_WRITE(INVERT_E3_DIR);break;case 2:E2_DIR_WRITE(INVERT_E2_DIR);break;case 1:E1_DIR_WRITE(INVERT_E1_DIR);break;default:E0_DIR_WRITE(INVERT_E0_DIR);}}

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1276,7 +1276,7 @@ static void lcd_status_screen() {
   #endif
   static void lcd_move_z() { _lcd_move_xyz(PSTR(MSG_MOVE_Z), Z_AXIS, sw_endstop_min[Z_AXIS], sw_endstop_max[Z_AXIS]); }
   static void lcd_move_e(
-    #if EXTRUDERS > 1
+    #if E_STEPPERS > 1
       int8_t eindex = -1
     #endif
   ) {
@@ -1285,7 +1285,7 @@ static void lcd_status_screen() {
       current_position[E_AXIS] += float((int32_t)encoderPosition) * move_menu_scale;
       encoderPosition = 0;
       manual_move_to_current(E_AXIS
-        #if EXTRUDERS > 1
+        #if E_STEPPERS > 1
           , eindex
         #endif
       );
@@ -1293,35 +1293,35 @@ static void lcd_status_screen() {
     }
     if (lcdDrawUpdate) {
       PGM_P pos_label;
-      #if EXTRUDERS == 1
+      #if E_STEPPERS == 1
         pos_label = PSTR(MSG_MOVE_E);
       #else
         switch (eindex) {
           case 0: pos_label = PSTR(MSG_MOVE_E MSG_MOVE_E1); break;
           case 1: pos_label = PSTR(MSG_MOVE_E MSG_MOVE_E2); break;
-          #if EXTRUDERS > 2
+          #if E_STEPPERS > 2
             case 2: pos_label = PSTR(MSG_MOVE_E MSG_MOVE_E3); break;
-            #if EXTRUDERS > 3
+            #if E_STEPPERS > 3
               case 3: pos_label = PSTR(MSG_MOVE_E MSG_MOVE_E4); break;
-            #endif //EXTRUDERS > 3
-          #endif //EXTRUDERS > 2
+            #endif // E_STEPPERS > 3
+          #endif // E_STEPPERS > 2
         }
-      #endif //EXTRUDERS > 1
+      #endif // E_STEPPERS > 1
       lcd_implementation_drawedit(pos_label, ftostr41sign(current_position[E_AXIS]));
     }
     if (LCD_CLICKED) lcd_goto_previous_menu(true);
   }
 
-  #if EXTRUDERS > 1
+  #if E_STEPPERS > 1
     static void lcd_move_e0() { lcd_move_e(0); }
     static void lcd_move_e1() { lcd_move_e(1); }
-    #if EXTRUDERS > 2
+    #if E_STEPPERS > 2
       static void lcd_move_e2() { lcd_move_e(2); }
-      #if EXTRUDERS > 3
+      #if E_STEPPERS > 3
         static void lcd_move_e3() { lcd_move_e(3); }
       #endif
     #endif
-  #endif // EXTRUDERS > 1
+  #endif // E_STEPPERS > 1
 
   /**
    *
@@ -1343,20 +1343,29 @@ static void lcd_status_screen() {
       MENU_ITEM(submenu, MSG_MOVE_X, lcd_move_x);
       MENU_ITEM(submenu, MSG_MOVE_Y, lcd_move_y);
     }
+
     if (move_menu_scale < 10.0) {
       if (_MOVE_XYZ_ALLOWED) MENU_ITEM(submenu, MSG_MOVE_Z, lcd_move_z);
-      #if EXTRUDERS == 1
+
+      #if ENABLED(SWITCHING_EXTRUDER)
+        if (active_extruder)
+          MENU_ITEM(gcode, MSG_SELECT MSG_E1, PSTR("T0"));
+        else
+          MENU_ITEM(gcode, MSG_SELECT MSG_E2, PSTR("T1"));
+      #endif
+
+      #if E_STEPPERS == 1
         MENU_ITEM(submenu, MSG_MOVE_E, lcd_move_e);
       #else
         MENU_ITEM(submenu, MSG_MOVE_E MSG_MOVE_E1, lcd_move_e0);
         MENU_ITEM(submenu, MSG_MOVE_E MSG_MOVE_E2, lcd_move_e1);
-        #if EXTRUDERS > 2
+        #if E_STEPPERS > 2
           MENU_ITEM(submenu, MSG_MOVE_E MSG_MOVE_E3, lcd_move_e2);
-          #if EXTRUDERS > 3
+          #if E_STEPPERS > 3
             MENU_ITEM(submenu, MSG_MOVE_E MSG_MOVE_E4, lcd_move_e3);
           #endif
         #endif
-      #endif // EXTRUDERS > 1
+      #endif // E_STEPPERS > 1
     }
     END_MENU();
   }


### PR DESCRIPTION
As requested by [Peter Stoneham](https://plus.google.com/100637857751025322015).

This PR adds support for an extruder with:
- A single stepper motor
- Two nozzles
- Two pinch-wheels, either side of the drive-gear
- A servo to switch the pinch-wheel
- Reversed stepper direction for T1

As with other funky extruders, this maintains a single E axis. The E stepper direction is reversed automagically —transparently at the stepper level— whenever the tool changes.
