### PR TITLE
Improves travis buildroot regexp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ before_install:
   #
 install:
   #
-  # Install arduino 1.6.8
-  - wget http://downloads-02.arduino.cc/arduino-1.6.8-linux64.tar.xz
-  - tar xf arduino-1.6.8-linux64.tar.xz
-  - sudo mv arduino-1.6.8 /usr/local/share/arduino
+  # Install arduino 1.6.9
+  - wget http://downloads-02.arduino.cc/arduino-1.6.9-linux64.tar.xz
+  - tar xf arduino-1.6.9-linux64.tar.xz
+  - sudo mv arduino-1.6.9 /usr/local/share/arduino
   - ln -s /usr/local/share/arduino/arduino ${TRAVIS_BUILD_DIR}/buildroot/bin/arduino
   #
   # Install: LiquidCrystal_I2C library
@@ -105,7 +105,8 @@ script:
   - opt_enable NUM_SERVOS Z_ENDSTOP_SERVO_NR SERVO_ENDSTOP_ANGLES DEACTIVATE_SERVOS_AFTER_MOVE
   - build_marlin
   #
-  # Test EEPROM_SETTINGS, EEPROM_CHITCHAT, M100_FREE_MEMORY_WATCHER, INCH_MODE_SUPPORT, TEMPERATURE_UNITS_SUPPORT
+  # Test EEPROM_SETTINGS, EEPROM_CHITCHAT, M100_FREE_MEMORY_WATCHER,
+  #   INCH_MODE_SUPPORT, TEMPERATURE_UNITS_SUPPORT
   #
   - restore_configs
   - opt_enable EEPROM_SETTINGS EEPROM_CHITCHAT M100_FREE_MEMORY_WATCHER INCH_MODE_SUPPORT TEMPERATURE_UNITS_SUPPORT
@@ -130,7 +131,57 @@ script:
   - opt_enable BQ_LCD_SMART_CONTROLLER SPEAKER
   - build_marlin
   #
-  ### LCDS ###
+  # Enable FILAMENTCHANGEENABLE
+  #
+  - restore_configs
+  - opt_enable FILAMENTCHANGEENABLE ULTIMAKERCONTROLLER
+  - build_marlin
+  #
+  # Enable filament sensor
+  #
+  - restore_configs
+  - opt_enable FILAMENT_WIDTH_SENSOR
+  - build_marlin
+  #
+  # Enable filament sensor with LCD display
+  #
+  - opt_enable ULTIMAKERCONTROLLER FILAMENT_LCD_DISPLAY
+  - build_marlin
+  #
+  # Enable BEZIER_CURVE_SUPPORT
+  #
+  - restore_configs
+  - opt_enable_adv BEZIER_CURVE_SUPPORT
+  - build_marlin
+  #
+  # Enable COREXY
+  #
+  - restore_configs
+  - opt_enable COREXY
+  - build_marlin
+  #
+  # Enable COREXZ
+  #
+  - restore_configs
+  - opt_enable COREXZ
+  - build_marlin
+  #
+  # Enable Z_DUAL_STEPPER_DRIVERS, Z_DUAL_ENDSTOPS
+  #
+  - restore_configs
+  - opt_enable_adv Z_DUAL_STEPPER_DRIVERS Z_DUAL_ENDSTOPS
+  - pins_set RAMPS_14 X_MAX_PIN -1
+  - opt_set_adv Z2_MAX_PIN 2
+  - build_marlin
+  #
+  # Test PRINTCOUNTER
+  #
+  - restore_configs
+  - opt_enable PRINTCOUNTER
+  - build_marlin
+  #
+  #
+  ######## STANDARD LCD/PANELS ##############
   #
   # ULTRA_LCD
   #
@@ -188,79 +239,34 @@ script:
   - opt_enable RA_CONTROL_PANEL
   - build_marlin
   #
-  ### I2C PANELS ###
+  ######## I2C LCD/PANELS ##############
+  #
+  # !!!ATTENTION!!!
+  # Most I2C configurations are failing at the moment because they require
+  # a different Liquid Crystal library "LiquidTWI2".
   #
   # LCD_I2C_SAINSMART_YWROBOT
-  # Failing at the moment needs different library
+  #
   #- restore_configs
   #- opt_enable LCD_I2C_SAINSMART_YWROBOT
   #- build_marlin
   #
   # LCD_I2C_PANELOLU2
   #
-  - restore_configs
-  - opt_enable LCD_I2C_PANELOLU2
-  - build_marlin
+  #- restore_configs
+  #- opt_enable LCD_I2C_PANELOLU2
+  #- build_marlin
   #
   # LCD_I2C_VIKI
   #
-  - restore_configs
-  - opt_enable LCD_I2C_VIKI
-  - build_marlin
+  #- restore_configs
+  #- opt_enable LCD_I2C_VIKI
+  #- build_marlin
   #
   # LCM1602
   #
   - restore_configs
   - opt_enable LCM1602
-  - build_marlin
-  #
-  # Enable FILAMENTCHANGEENABLE
-  #
-  - restore_configs
-  - opt_enable FILAMENTCHANGEENABLE ULTIMAKERCONTROLLER
-  - build_marlin
-  #
-  # Enable filament sensor
-  #
-  - restore_configs
-  - opt_enable FILAMENT_WIDTH_SENSOR
-  - build_marlin
-  #
-  # Enable filament sensor with LCD display
-  #
-  - opt_enable ULTIMAKERCONTROLLER FILAMENT_LCD_DISPLAY
-  - build_marlin
-  #
-  # Enable BEZIER_CURVE_SUPPORT
-  #
-  - restore_configs
-  - opt_enable_adv BEZIER_CURVE_SUPPORT
-  - build_marlin
-  #
-  # Enable COREXY
-  #
-  - restore_configs
-  - opt_enable COREXY
-  - build_marlin
-  #
-  # Enable COREXZ
-  #
-  - restore_configs
-  - opt_enable COREXZ
-  - build_marlin
-  #
-  # Enable Z_DUAL_STEPPER_DRIVERS, Z_DUAL_ENDSTOPS
-  #
-  - restore_configs
-  - opt_enable_adv Z_DUAL_STEPPER_DRIVERS Z_DUAL_ENDSTOPS
-  - pins_set RAMPS_14 X_MAX_PIN -1
-  - opt_set_adv Z2_MAX_PIN 2
-  - build_marlin
-  #
-  # Test PRINTCOUNTER
-  #
-  - restore_configs
-  - opt_enable PRINTCOUNTER
   - build_marlin
   #
   #

--- a/buildroot/bin/opt_disable
+++ b/buildroot/bin/opt_disable
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for opt in "$@" ; do
-  eval "sed -i 's/\(\/\/ *\)*\(\#define +$opt[^a-zA-Z0-9_]\)/\/\/\2/g' Marlin/Configuration.h"
+  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
 done

--- a/buildroot/bin/opt_disable_adv
+++ b/buildroot/bin/opt_disable_adv
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+for opt in "$@" ; do
+  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
+done

--- a/buildroot/bin/opt_enable
+++ b/buildroot/bin/opt_enable
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for opt in "$@" ; do
-  eval "sed -i 's/\/\/ *\(#define +$opt[^a-zA-Z0-9_]\)/\1/g' Marlin/Configuration.h"
+  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
 done

--- a/buildroot/bin/opt_enable_adv
+++ b/buildroot/bin/opt_enable_adv
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 for opt in "$@" ; do
-  eval "sed -i 's/\/\/ *\(#define +$opt[^a-zA-Z0-9_]\)/\1/g' Marlin/Configuration_adv.h"
+  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
 done

--- a/buildroot/bin/opt_set
+++ b/buildroot/bin/opt_set
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define +$1 +\)[^ ]*$/\1 $2/g' Marlin/Configuration.h"
+eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"

--- a/buildroot/bin/opt_set_adv
+++ b/buildroot/bin/opt_set_adv
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define +$1 +\)[^ ]*$/\1 $2/g' Marlin/Configuration_adv.h"
+eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"

--- a/buildroot/bin/pins_set
+++ b/buildroot/bin/pins_set
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define +$2 +\)[^ ]*$/\1 $3/g' Marlin/pins_$1.h"
+eval "sed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/pins_${1}.h"


### PR DESCRIPTION
Follow up #3906: The regular expressions are not working properly as most of the Travis tests are outputting the text bellow, which is a sign of options aren't being manipulated.

```
Sketch uses 52,456 bytes (20%) of program storage space. Maximum is 253,952 bytes.
Global variables use 2,961 bytes (36%) of dynamic memory, leaving 5,231 bytes for local variables. Maximum is 8,192 bytes.
```

I also took the opportunity to upgrade travis Arduino IDE version to 1.6.9.
