### PR TITLE
  manage_manual_move(); -> ULTIPANEL

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2160,9 +2160,10 @@ bool lcd_blink() {
 void lcd_update() {
   #if ENABLED(ULTIPANEL)
     static millis_t return_to_status_ms = 0;
+
+    manage_manual_move();
   #endif
 
-  manage_manual_move();
 
   lcd_buttons_update();
 


### PR DESCRIPTION
Make the call of   `manage_manual_move()` depandent of `ULTIPANEL`.

Fix for a problem dicussed in #3993
