### PR TITLE
Use linear feedrate in gcode_T, not volumetric

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6599,7 +6599,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
   float stored_feedrate = feedrate;
 
   if (code_seen('F')) {
-    float next_feedrate = code_value_axis_units(E_AXIS);
+    float next_feedrate = code_value_axis_units(X_AXIS);
     if (next_feedrate > 0.0) stored_feedrate = feedrate = next_feedrate;
   }
   else {


### PR DESCRIPTION
I assume that the feedrate given in `Tn Fn` applies to the movement feed rate, and not just to the E feedrate (which might be converted into volumetric). If so, this will patch it.
