### PR TITLE
Heal the watchdog

### DIFF
--- a/Marlin/buzzer.h
+++ b/Marlin/buzzer.h
@@ -24,8 +24,8 @@
 #define __BUZZER_H__
 
 #include "fastio.h"
-#include "watchdog.h"
 #include "circularqueue.h"
+#include "temperature.h"
 
 #define TONE_QUEUE_LENGTH 4
 
@@ -106,9 +106,7 @@ class Buzzer {
       while (buffer.isFull()) {
         delay(5);
         this->tick();
-        #if ENABLED(USE_WATCHDOG)
-          watchdog_reset();
-        #endif
+        thermalManager.manage_heater();
       }
       this->buffer.enqueue((tone_t) { duration, frequency });
     }


### PR DESCRIPTION
Heal the watchdog by replacing the unnecessary call to `watchdog_reset()` by
`thermalManager.manage_heater()`

See discussion in 'New feature: Non blocking tone queue #3995'
