### PR TITLE
Show bootscreen later

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -857,8 +857,6 @@ void setup() {
   // loads data from EEPROM if available else uses defaults (and resets step acceleration rate)
   Config_RetrieveSettings();
 
-  lcd_init();
-
   thermalManager.init();    // Initialize temperature loop
 
   #if ENABLED(DELTA) || ENABLED(SCARA)
@@ -906,6 +904,18 @@ void setup() {
     pinMode(STAT_LED_BLUE, OUTPUT);
     digitalWrite(STAT_LED_BLUE, LOW); // turn it off
   #endif
+
+  lcd_init();
+  #if ENABLED(SHOW_BOOTSCREEN)
+    #if ENABLED(DOGLCD)
+      delay(1000);
+    #elif ENABLED(ULTRA_LCD)
+      bootscreen();
+      lcd_init();
+    #endif
+  #endif
+
+
 }
 
 /**
@@ -8283,6 +8293,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
 void kill(const char* lcd_msg) {
   #if ENABLED(ULTRA_LCD)
+    lcd_init();
     lcd_setalertstatuspgm(lcd_msg);
   #else
     UNUSED(lcd_msg);

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -271,10 +271,8 @@ static void lcd_implementation_init() {
       }
     } while (u8g.nextPage());
 
-    if (show_bootscreen) {
-      delay(1000);
-      show_bootscreen = false;
-    }
+    show_bootscreen = false;
+
   #endif
 }
 

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -52,7 +52,10 @@
   #if ENABLED(DOGLCD)
     extern int lcd_contrast;
     void set_lcd_contrast(int value);
+  #elif ENABLED(SHOW_BOOTSCREEN)
+    void bootscreen();
   #endif
+
 
   #define LCD_MESSAGEPGM(x) lcd_setstatuspgm(PSTR(x))
   #define LCD_ALERTMESSAGEPGM(x) lcd_setalertstatuspgm(PSTR(x))

--- a/Marlin/ultralcd_implementation_hitachi_HD44780.h
+++ b/Marlin/ultralcd_implementation_hitachi_HD44780.h
@@ -201,11 +201,6 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
 
 #include "utf_mapper.h"
 
-#if ENABLED(SHOW_BOOTSCREEN)
-  static void bootscreen();
-  static bool show_bootscreen = true;
-#endif
-
 #if ENABLED(LCD_PROGRESS_BAR)
   static millis_t progress_bar_ms = 0;
   #if PROGRESS_MSG_EXPIRE > 0
@@ -394,10 +389,6 @@ static void lcd_implementation_init(
     lcd.begin(LCD_WIDTH, LCD_HEIGHT);
   #endif
 
-  #if ENABLED(SHOW_BOOTSCREEN)
-    if (show_bootscreen) bootscreen();
-  #endif
-
   lcd_set_custom_characters(
     #if ENABLED(LCD_PROGRESS_BAR)
       progress_bar_set
@@ -452,8 +443,7 @@ unsigned lcd_print(char c) { return charset_mapper(c); }
     lcd.setCursor(indent, 2); lcd.print('\x02'); lcd_printPGM(PSTR( "------" ));  lcd.print('\x03');
   }
 
-  static void bootscreen() {
-    show_bootscreen = false;
+  void bootscreen() {
     byte top_left[8] = {
       B00000,
       B00000,


### PR DESCRIPTION
Init display and show bootscreen later, but init display in `kill()`
to init outputs before the bootscreen delays, but being able to display
kill errors.

Fix for  #3973 (pin state at splashscreen)
