### PR TITLE
Patch LIN_ADVANCE to use code_value_float

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -333,7 +333,7 @@ const char axis_codes[NUM_AXIS] = {'X', 'Y', 'Z', 'E'};
 
 static int serial_count = 0;
 
-// GCode parameter pointer used by code_seen(), code_value(), etc.
+// GCode parameter pointer used by code_seen(), code_value_float(), etc.
 static char* seen_pointer;
 
 // Next Immediate GCode Command pointer. NULL if none.

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1124,7 +1124,7 @@ void Stepper::microstep_readings() {
 #if ENABLED(LIN_ADVANCE)
 
   void Stepper::advance_M905() {
-    if (code_seen('K')) extruder_advance_k = code_value();
+    if (code_seen('K')) extruder_advance_k = code_value_float();
     SERIAL_ECHO_START;
     SERIAL_ECHOPAIR("Advance factor: ", extruder_advance_k);
     SERIAL_EOL;


### PR DESCRIPTION
Travis missed this one, but it's catching it now!
