### PR TITLE
Parse M905 args in Marlin_main.cpp

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6491,7 +6491,7 @@ inline void gcode_M503() {
    */
   inline void gcode_M905() {
     stepper.synchronize();
-    stepper.advance_M905();
+    stepper.advance_M905(code_seen('K') ? code_value_float() : -1.0);
   }
 #endif
 

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1123,8 +1123,8 @@ void Stepper::microstep_readings() {
 
 #if ENABLED(LIN_ADVANCE)
 
-  void Stepper::advance_M905() {
-    if (code_seen('K')) extruder_advance_k = code_value_float();
+  void Stepper::advance_M905(const float &k) {
+    if (k >= 0) extruder_advance_k = k;
     SERIAL_ECHO_START;
     SERIAL_ECHOPAIR("Advance factor: ", extruder_advance_k);
     SERIAL_EOL;

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -256,7 +256,7 @@ class Stepper {
     }
 
     #if ENABLED(LIN_ADVANCE)
-      void advance_M905();
+      void advance_M905(const float &k);
       FORCE_INLINE int get_advance_k() { return extruder_advance_k; }
     #endif
 


### PR DESCRIPTION
Instead of using `code_value` functions in remote places.
