### PR TITLE
Fix feedrate in gcode_T (max_feedrate is mm/s)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6633,11 +6633,13 @@ inline void gcode_T(uint8_t tmp_extruder) {
       if (next_feedrate > 0.0) stored_feedrate = feedrate = next_feedrate;
     }
     else {
-      #ifdef XY_TRAVEL_SPEED
-        feedrate = XY_TRAVEL_SPEED;
-      #else
-        feedrate = min(planner.max_feedrate[X_AXIS], planner.max_feedrate[Y_AXIS]);
-      #endif
+      feedrate =
+        #ifdef XY_TRAVEL_SPEED
+          XY_TRAVEL_SPEED
+        #else
+          min(planner.max_feedrate[X_AXIS], planner.max_feedrate[Y_AXIS]) * 60
+        #endif
+      ;
     }
 
     if (tmp_extruder != active_extruder) {

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -80,7 +80,7 @@ block_t Planner::block_buffer[BLOCK_BUFFER_SIZE];
 volatile uint8_t Planner::block_buffer_head = 0;           // Index of the next block to be pushed
 volatile uint8_t Planner::block_buffer_tail = 0;
 
-float Planner::max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
+float Planner::max_feedrate[NUM_AXIS]; // Max speeds in mm per second
 float Planner::axis_steps_per_mm[NUM_AXIS];
 unsigned long Planner::max_acceleration_steps_per_s2[NUM_AXIS];
 unsigned long Planner::max_acceleration_mm_per_s2[NUM_AXIS]; // Use M201 to override by software

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -115,7 +115,7 @@ class Planner {
     static volatile uint8_t block_buffer_head;           // Index of the next block to be pushed
     static volatile uint8_t block_buffer_tail;
 
-    static float max_feedrate[NUM_AXIS]; // Max speeds in mm per minute
+    static float max_feedrate[NUM_AXIS]; // Max speeds in mm per second
     static float axis_steps_per_mm[NUM_AXIS];
     static unsigned long max_acceleration_steps_per_s2[NUM_AXIS];
     static unsigned long max_acceleration_mm_per_s2[NUM_AXIS]; // Use M201 to override by software


### PR DESCRIPTION
The `feedrate` set in `gcode_T` (when the `F` parameter is left out) is incorrect. This patch multiplies it by 60 and correctly labels the `max_feedrate[]` array as mm/s, not mm/m.
