### PR TITLE
RCBugFix with UltraLCD active does not compile

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1290,7 +1290,7 @@ static void lcd_status_screen() {
       #if EXTRUDERS == 1
         pos_label = PSTR(MSG_MOVE_E);
       #else
-        switch (e) {
+        switch (eindex) {
           case 0: pos_label = PSTR(MSG_MOVE_E MSG_MOVE_E1); break;
           case 1: pos_label = PSTR(MSG_MOVE_E MSG_MOVE_E2); break;
           #if EXTRUDERS > 2


### PR DESCRIPTION
"e" was renamed to "eindex" in a previous commit
