### PR TITLE
Implements clean nozzle feature (Lulzbot's REWIPE)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -211,6 +211,12 @@ script:
   - opt_enable PRINTCOUNTER
   - build_marlin
   #
+  # Test CLEAN_NOZZLE_FEATURE
+  #
+  - restore_configs
+  - opt_enable AUTO_BED_LEVELING_FEATURE CLEAN_NOZZLE_FEATURE FIX_MOUNTED_PROBE
+  - build_marlin
+  #
   #
   ######## STANDARD LCD/PANELS ##############
   #

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -801,15 +801,20 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 //       "strokes" i.e. back-and-forth movements between the starting and end
 //       points.
 //
-//   P1: This starts a zig-zag pattern between (Xs, Ys) and (Xe, Ye), "S"
-//       defines the number of zig-zag triangles to be done. Each "side"
-//       cannot be less than 5mm. As an example "G12 P1 S3" will execute:
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
 //
-//                                                /|   /|   /| (Xe, Ye)
-//                                               / |  / |  / |
-//                                              /  | /  | /  |
-//                                    (Xs, Ys) /   |/   |/   |
-//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
 //
 // Caveats: End point Z should use the same value as Start point Z.
 //
@@ -820,8 +825,8 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 
 #if ENABLED(CLEAN_NOZZLE_FEATURE)
   #define CLEAN_NOZZLE_STROKES  12
-  #define CLEAN_NOZZLE_START_PT { 30, 30, (Z_MIN_POS + 1), 0}
-  #define CLEAN_NOZZLE_END_PT   {100, 60, (Z_MIN_POS + 1), 0}
+  #define CLEAN_NOZZLE_START_PT { 30, 30, (Z_MIN_POS + 5), 0}
+  #define CLEAN_NOZZLE_END_PT   {100, 60, (Z_MIN_POS + 5), 0}
   //                            {  X,  Y,               Z, E}
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -788,6 +788,44 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (Xs, Ys) and (Xe, Ye), "S"
+//       defines the number of zig-zag triangles to be done. Each "side"
+//       cannot be less than 5mm. As an example "G12 P1 S3" will execute:
+//
+//                                                /|   /|   /| (Xe, Ye)
+//                                               / |  / |  / |
+//                                              /  | /  | /  |
+//                                    (Xs, Ys) /   |/   |/   |
+//
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define CLEAN_NOZZLE_FEATURE
+
+#if ENABLED(CLEAN_NOZZLE_FEATURE)
+  #define CLEAN_NOZZLE_STROKES  12
+  #define CLEAN_NOZZLE_START_PT { 30, 30, (Z_MIN_POS + 1), 0}
+  #define CLEAN_NOZZLE_END_PT   {100, 60, (Z_MIN_POS + 1), 0}
+  //                            {  X,  Y,               Z, E}
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -821,13 +821,18 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
 // may change to add new functionality like different wipe patterns.
 //
-//#define CLEAN_NOZZLE_FEATURE
+//#define NOZZLE_CLEAN_FEATURE
 
-#if ENABLED(CLEAN_NOZZLE_FEATURE)
-  #define CLEAN_NOZZLE_STROKES  12
-  #define CLEAN_NOZZLE_START_PT { 30, 30, (Z_MIN_POS + 5), 0}
-  #define CLEAN_NOZZLE_END_PT   {100, 60, (Z_MIN_POS + 5), 0}
-  //                            {  X,  Y,               Z, E}
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
 #endif
 
 //

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2717,18 +2717,15 @@ inline void gcode_G4() {
 
 #endif //FWRETRACT
 
-#if ENABLED(CLEAN_NOZZLE_FEATURE) && ENABLED(AUTO_BED_LEVELING_FEATURE)
+#if ENABLED(NOZZLE_CLEAN_FEATURE) && ENABLED(AUTO_BED_LEVELING_FEATURE)
   #include "nozzle.h"
 
   inline void gcode_G12() {
     // Don't allow nozzle cleaning without homing first
-    if (!axis_homed[X_AXIS] || !axis_homed[Y_AXIS] || !axis_homed[Z_AXIS]) {
-      axis_unhomed_error(true);
-      return;
-    }
+    if (axis_unhomed_error(true, true, true)) { return; }
 
     uint8_t const pattern = code_seen('P') ? code_value_ushort() : 0;
-    uint8_t const strokes = code_seen('S') ? code_value_ushort() : CLEAN_NOZZLE_STROKES;
+    uint8_t const strokes = code_seen('S') ? code_value_ushort() : NOZZLE_CLEAN_STROKES;
     uint8_t const objects = code_seen('T') ? code_value_ushort() : 3;
 
     Nozzle::clean(pattern, strokes, objects);
@@ -6796,11 +6793,11 @@ void process_next_command() {
           break;
       #endif // FWRETRACT
 
-      #if ENABLED(CLEAN_NOZZLE_FEATURE) && ENABLED(AUTO_BED_LEVELING_FEATURE)
+      #if ENABLED(NOZZLE_CLEAN_FEATURE) && HAS_BED_PROBE
         case 12:
           gcode_G12(); // G12: Clean Nozzle
           break;
-      #endif // CLEAN_NOZZLE_FEATURE
+      #endif // NOZZLE_CLEAN_FEATURE
 
       #if ENABLED(INCH_MODE_SUPPORT)
         case 20: //G20: Inch Mode

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2718,7 +2718,7 @@ inline void gcode_G4() {
 #endif //FWRETRACT
 
 #if ENABLED(CLEAN_NOZZLE_FEATURE) && ENABLED(AUTO_BED_LEVELING_FEATURE)
-  #include "clean_nozzle.h"
+  #include "nozzle.h"
 
   inline void gcode_G12() {
     // Don't allow nozzle cleaning without homing first
@@ -2729,8 +2729,9 @@ inline void gcode_G4() {
 
     uint8_t const pattern = code_seen('P') ? code_value_ushort() : 0;
     uint8_t const strokes = code_seen('S') ? code_value_ushort() : CLEAN_NOZZLE_STROKES;
+    uint8_t const objects = code_seen('T') ? code_value_ushort() : 3;
 
-    CleanNozzle::start(pattern, strokes);
+    Nozzle::clean(pattern, strokes, objects);
   }
 #endif
 

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -649,8 +649,8 @@
 /**
  * Nozzle cleaning
  */
-#if ENABLED(CLEAN_NOZZLE_FEATURE) && DISABLED(AUTO_BED_LEVELING_FEATURE)
-  #error You must enable AUTO_BED_LEVELING_FEATURE for CLEAN_NOZZLE_FEATURE to work
+#if ENABLED(NOZZLE_CLEAN_FEATURE) && !HAS_BED_PROBE
+  #error Due to internal dependencies you must have a bed probe for NOZZLE_CLEAN_FEATURE to work
 #endif
 
 #endif //SANITYCHECK_H

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -646,4 +646,11 @@
   #error "ABS_PREHEAT_FAN_SPEED is now PREHEAT_2_FAN_SPEED. Please update your configuration."
 #endif
 
+/**
+ * Nozzle cleaning
+ */
+#if ENABLED(CLEAN_NOZZLE_FEATURE) && DISABLED(AUTO_BED_LEVELING_FEATURE)
+  #error You must enable AUTO_BED_LEVELING_FEATURE for CLEAN_NOZZLE_FEATURE to work
+#endif
+
 #endif //SANITYCHECK_H

--- a/Marlin/clean_nozzle.h
+++ b/Marlin/clean_nozzle.h
@@ -1,0 +1,112 @@
+/*
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __CLEAN_NOZZLE_H__
+#define __CLEAN_NOZZLE_H__
+
+#include "Marlin.h"
+#include "point_t.h"
+
+/**
+ * @brief CleanNozzle class
+ *
+ * @todo: Do not ignore the end.z value and allow XYZ movements
+ * @todo: Currently this feature needs AUTO_BED_LEVELING_FEATURE to be active
+ *  due to the do_blocking_move_to*() functions.
+ */
+class CleanNozzle {
+  private:
+    /**
+     * @brief Stroke clean pattern
+     * @details Wipes the nozzle back and forth in a linear movement
+     *
+     * @param start point_t defining the starting point
+     * @param end point_t defining the ending point
+     * @param strokes number of strokes to execute
+     */
+    static void stroke(point_t const &start, point_t const &end, uint8_t const &strokes)
+    __attribute__ ((optimize ("Os"))) {
+      // Move to the starting point
+      do_blocking_move_to_xy(start.x, start.y);
+      do_blocking_move_to_z(start.z);
+
+      // Start the stroke pattern
+      for (uint8_t i = 0; i < (strokes >>1); i++) {
+        do_blocking_move_to_xy(end.x, end.y);
+        do_blocking_move_to_xy(start.x, start.y);
+      }
+    }
+
+    /**
+     * @brief Zig-zag clean pattern
+     * @details Apply a zig-zag cleanning pattern
+     *
+     * @param start point_t defining the starting point
+     * @param end point_t defining the ending point
+     * @param triangles number of triangles to execute
+     */
+    static void zigzag(point_t const &start, point_t const &end, uint8_t const &triangles)
+    __attribute__ ((optimize ("Os"))) {
+      // Move to the starting point
+      do_blocking_move_to_xy(start.x, start.y);
+      do_blocking_move_to_z(start.z);
+
+      // Calculate the triangle side
+      float const a = fabs(end.x - start.x) / triangles;
+
+      // Don't allow the sides (a, b) to be smaller than 5mm
+      if (a < 5 || fabs(end.y - start.y) < 5) return;
+
+      // Start the zig-zag pattern
+      for (uint8_t i = 0; i < triangles; i++) {
+        float const x = start.x + (a * (i + 1));
+        do_blocking_move_to_xy(x, end.y);
+        do_blocking_move_to_y(start.y);
+      }
+    }
+
+  public:
+    /**
+     * @brief Clean the nozzle
+     * @details Starts the selected clean procedure pattern
+     *
+     * @param pattern one of the available patterns
+     * @param argument depends on the cleaning pattern
+     */
+    static void start(uint8_t const &pattern, uint8_t const &argument)
+    __attribute__ ((optimize ("Os"))) {
+      switch (pattern) {
+        case 1:
+          CleanNozzle::zigzag(
+            CLEAN_NOZZLE_START_PT,
+            CLEAN_NOZZLE_END_PT, argument);
+          break;
+
+        default:
+          CleanNozzle::stroke(
+            CLEAN_NOZZLE_START_PT,
+            CLEAN_NOZZLE_END_PT, argument);
+      }
+    }
+};
+
+#endif

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -268,12 +268,12 @@
     #define  DEFAULT_Kp 18
     #define  DEFAULT_Ki 1
     #define  DEFAULT_Kd 100
-    
+
     // Cartesio extruderV6 40W Volcano
     //#define  DEFAULT_Kp 50
     //#define  DEFAULT_Ki 9
     //#define  DEFAULT_Kd 70
-    
+
     // Cartesio extruderV6 40W Cyclops
     //#define  DEFAULT_Kp 18
     //#define  DEFAULT_Ki 1
@@ -313,7 +313,7 @@
     #define  DEFAULT_bedKp 390
     #define  DEFAULT_bedKi 70
     #define  DEFAULT_bedKd 546
-   
+
     //24V 250W silicone heater on to 4mm glass CartesioM
     //#define  DEFAULT_bedKp 303
     //#define  DEFAULT_bedKi 42
@@ -785,6 +785,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_TEMP_HOTEND 240
 #define PREHEAT_2_TEMP_BED    110
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
+
+//
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
 
 //
 // Print job timer

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -771,6 +771,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -769,6 +769,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -780,6 +780,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -782,6 +782,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -805,6 +805,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -788,6 +788,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   165 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -788,6 +788,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   165 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -788,6 +788,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -786,6 +786,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -796,6 +796,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -809,6 +809,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -780,6 +780,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -788,6 +788,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -883,6 +883,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -877,6 +877,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -880,6 +880,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -880,6 +880,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -882,6 +882,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -791,6 +791,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -782,6 +782,54 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 //
+// Clean Nozzle Feature -- EXPERIMENTAL
+//
+// When enabled allows the user to send G12 to start the nozzle cleaning
+// process, the G-Code accepts two parameters:
+//   "P" for pattern selection
+//   "S" for defining the number of strokes/repetitions
+//
+// Available list of patterns:
+//   P0: This is the default pattern, this process requires a sponge type
+//       material at a fixed bed location, the cleaning process is based on
+//       "strokes" i.e. back-and-forth movements between the starting and end
+//       points.
+//
+//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
+//       defines the number of zig-zag triangles to be done. "S" defines the
+//       number of strokes aka one back-and-forth movement. As an example
+//       sending "G12 P1 S1 T3" will execute:
+//
+//          --
+//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
+//         |           |    /  \      /  \      /  \    |
+//       A |           |   /    \    /    \    /    \   |
+//         |           |  /      \  /      \  /      \  |
+//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
+//          --         +--------------------------------+
+//                       |________|_________|_________|
+//                           T1        T2        T3
+//
+// Caveats: End point Z should use the same value as Start point Z.
+//
+// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
+// may change to add new functionality like different wipe patterns.
+//
+//#define NOZZLE_CLEAN_FEATURE
+
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  // Number of pattern repetitions
+  #define NOZZLE_CLEAN_STROKES  12
+
+  //                            {  X,  Y,               Z}
+  #define NOZZLE_CLEAN_START_PT { 30, 30, (Z_MIN_POS + 5)}
+  #define NOZZLE_CLEAN_END_PT   {100, 60, (Z_MIN_POS + 5)}
+
+  // Moves the nozzle to the parked position
+  #define NOZZLE_CLEAN_PARK
+#endif
+
+//
 // Print job timer
 //
 // Enable this option to automatically start and stop the

--- a/Marlin/point_t.h
+++ b/Marlin/point_t.h
@@ -28,6 +28,19 @@ struct point_t {
   float y;
   float z;
   float e;
+
+  point_t(float const x, float const y)
+    : point_t(x, y, NAN, NAN) {}
+
+  point_t(float const x, float const y, float const z)
+    : point_t(x, y, z, NAN) {}
+
+  point_t(float const x, float const y, float const z, float const e) {
+    this->x = x;
+    this->y = y;
+    this->z = z;
+    this->e = e;
+  }
 };
 
 #endif

--- a/Marlin/point_t.h
+++ b/Marlin/point_t.h
@@ -1,0 +1,33 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __POINT_T__
+#define __POINT_T__
+
+struct point_t {
+  float x;
+  float y;
+  float z;
+  float e;
+};
+
+#endif


### PR DESCRIPTION
This is the implementation for the @alephobjects `REWIPE` feature discussed at #3553 by @scalez.

``` cpp
//
// Clean Nozzle Feature -- EXPERIMENTAL
//
// When enabled allows the user to send G12 to start the nozzle cleaning
// process, the G-Code accepts two parameters:
//   "P" for pattern selection
//   "S" for defining the number of strokes/repetitions
//
// Available list of patterns:
//   P0: This is the default pattern, this process requires a sponge type
//       material at a fixed bed location, the cleaning process is based on
//       "strokes" i.e. back-and-forth movements between the starting and end
//       points.
//
//   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
//       defines the number of zig-zag triangles to be done. "S" defines the
//       number of strokes aka one back-and-forth movement. As an example
//       sending "G12 P1 S1 T3" will execute:
//
//          --
//         |  (X0, Y1) |     /\        /\        /\     | (X1, Y1)
//         |           |    /  \      /  \      /  \    |
//       A |           |   /    \    /    \    /    \   |
//         |           |  /      \  /      \  /      \  |
//         |  (X0, Y0) | /        \/        \/        \ | (X1, Y0)
//          --         +--------------------------------+
//                       |________|_________|_________|
//                           T1        T2        T3
//
// Caveats: End point Z should use the same value as Start point Z.
//
// Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
// may change to add new functionality like different wipe patterns.
```

Do not merge yet this PR as it still requires some tweaks, including the update of all example config files.
