### PR TITLE
Script to init the upstream remote for Marlin

### DIFF
--- a/buildroot/share/git/ghtp
+++ b/buildroot/share/git/ghtp
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# ghtp (GitHub Transport Protocol)
+#
+# Set all remotes in the current repo to HTTPS or SSH connection.
+# Useful when switching environments, using public wifi, etc.
+#
+
+GH_SSH="git@github\.com:"
+GH_HTTPS="https:\/\/github\.com\/"
+
+case "$1" in
+  -[Hh]) TYPE=HTTPS ; MATCH="git@" ; FORMULA="$GH_SSH/$GH_HTTPS" ;;
+  -[Ss]) TYPE=SSH ; MATCH="https:" ; FORMULA="$GH_HTTPS/$GH_SSH" ;;
+  *)
+    echo "Usage: `basename $0` -h | -s" 1>&2
+    echo -e " \e[0;92m-h\e[0m to switch to HTTPS" 1>&2
+    echo -e " \e[0;92m-s\e[0m to switch to SSH" 1>&2
+    exit 1
+    ;;
+esac
+
+REMOTES=$(git remote -v | egrep "\t$MATCH" | gawk '{print $1 " " $2}' | sort -u | sed  "s/$FORMULA/")
+
+if [[ -z $REMOTES ]]; then
+  echo "Nothing to do." ; exit
+fi
+
+echo "$REMOTES" | xargs -n2 git remote set-url
+
+echo -n "Remotes set to $TYPE: "
+echo "$REMOTES" | gawk '{printf "%s ", $1}'
+echo

--- a/buildroot/share/git/mfinit
+++ b/buildroot/share/git/mfinit
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#
+# mfinit
+#
+# Create the upstream repository for Marlin
+#
+
+git remote add upstream git@github.com:MarlinFirmware/Marlin.git


### PR DESCRIPTION
The other scripts require an `upstream` remote to be set for the main Marlin repo. This script ensures that it will exist. It may, in future, test for the existence of the remote before adding it, then the other scripts may call it. Note that it creates the remote in `git` mode and not `http` mode. If needed, use `ghtp -h` to change all remotes to `http` after creation.
- Oh yeah, so here's `ghtp` also.

```
Usage: ghtp -h | -s
 -h to switch to HTTPS
 -s to switch to SSH
```
