### PR TITLE
.gitignore comments in correct format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,38 @@
-/**
- * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- *
- * Based on Sprinter and grbl.
- * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+#
+# Marlin 3D Printer Firmware
+# Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+#
+# Based on Sprinter and grbl.
+# Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
 
-// Our automatic versioning scheme generates the following file
-// NEVER put it in the repository
+# Our automatic versioning scheme generates the following file
+# NEVER put it in the repository
 _Version.h
 
-//
-// OS
-//
+#
+# OS
+#
 applet/
 *.DS_Store
 
 
-//
-// Misc
-//
+#
+# Misc
+#
 *~
 *.orig
 *.rej
@@ -45,9 +44,9 @@ applet/
 *.swp
 
 
-//
-// C++
-//
+#
+# C++
+#
 # Compiled Object files
 *.slo
 *.lo
@@ -79,9 +78,9 @@ applet/
 *.app
 
 
-//
-// C
-//
+#
+# C
+#
 # Object files
 *.o
 *.ko


### PR DESCRIPTION
Use `#` for comments in `.gitignore`.
C-style comments may be interpreted as wildcards or paths.
