### PR TITLE
Add an SD Card stop function, use in ultralcd

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -282,6 +282,13 @@ void CardReader::pauseSDPrint() {
   if (sdprinting) sdprinting = false;
 }
 
+void CardReader::stopSDPrint() {
+  if (sdprinting) {
+    sdprinting = false;
+    file.close();
+  }
+}
+
 void CardReader::openLogFile(char* name) {
   logging = true;
   openFile(name, false);

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -48,6 +48,7 @@ public:
   void openAndPrintFile(const char *name);
   void startFileprint();
   void pauseSDPrint();
+  void stopSDPrint();
   void getStatus();
   void printingHasFinished();
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -496,17 +496,16 @@ static void lcd_status_screen() {
     }
 
     static void lcd_sdcard_stop() {
-      stepper.quick_stop();
-      #if DISABLED(DELTA) && DISABLED(SCARA)
-        set_current_position_from_planner();
-      #endif // !DELTA && !SCARA
+      card.stopSDPrint();
       clear_command_queue();
-      card.sdprinting = false;
-      card.closefile();
+      stepper.quick_stop();
       print_job_timer.stop();
       thermalManager.autotempShutdown();
       cancel_heatup = true;
       lcd_setstatus(MSG_PRINT_ABORTED, true);
+      #if DISABLED(DELTA) && DISABLED(SCARA)
+        set_current_position_from_planner();
+      #endif // !DELTA && !SCARA
     }
 
   #endif //SDSUPPORT


### PR DESCRIPTION
Small adjustment to the "Stop print" command from LCD. With this tweak, SD printing is stopped first before clearing the command buffer. While updating the position is done last. We're still looking for clues as to why the SD command buffer might be getting repeatedly re-injected after "Stop print."
