### PR TITLE
Cleanup of M48

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3518,22 +3518,16 @@ inline void gcode_G28() {
           float measured_z,
                 z_before = probePointCounter ? Z_RAISE_BETWEEN_PROBINGS + current_position[Z_AXIS] : Z_RAISE_BEFORE_PROBING + home_offset[Z_AXIS];
 
-          if (probePointCounter) {
-            #if ENABLED(DEBUG_LEVELING_FEATURE)
-              if (DEBUGGING(LEVELING)) {
-                SERIAL_ECHOPAIR("z_before = (between) ", (Z_RAISE_BETWEEN_PROBINGS + current_position[Z_AXIS]));
-                SERIAL_EOL;
-              }
-            #endif
-          }
-          else {
-            #if ENABLED(DEBUG_LEVELING_FEATURE)
-              if (DEBUGGING(LEVELING)) {
-                SERIAL_ECHOPAIR("z_before = (before) ", Z_RAISE_BEFORE_PROBING + home_offset[Z_AXIS]);
-                SERIAL_EOL;
-              }
-            #endif
-          }
+          #if ENABLED(DEBUG_LEVELING_FEATURE)
+            if (DEBUGGING(LEVELING)) {
+              SERIAL_ECHOPGM("z_before = (");
+              if (probePointCounter)
+                SERIAL_ECHOPGM("between) ");
+              else
+                SERIAL_ECHOPGM("before) ");
+              SERIAL_ECHOLN(z_before);
+            }
+          #endif
 
           #if ENABLED(DELTA)
             // Avoid probing the corners (outside the round or hexagon print surface) on a delta printer.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4362,18 +4362,18 @@ inline void gcode_M42() {
       /**
        * We don't really have to do this move, but if we don't we can see a
        * funny shift in the Z Height because the user might not have the
-       * Z_RAISE_BEFORE_PROBING height identical to the Z_RAISE_BETWEEN_PROBING
+       * Z_RAISE_BEFORE_PROBING height identical to the Z_RAISE_BETWEEN_PROBINGS
        * height. This gets us back to the probe location at the same height that
        * we have been running around the circle at.
        */
+      bool last_probe = (n == n_samples - 1);
       do_blocking_move_to_xy(X_probe_location - (X_PROBE_OFFSET_FROM_EXTRUDER), Y_probe_location - (Y_PROBE_OFFSET_FROM_EXTRUDER));
-      if (deploy_probe_for_each_reading)
-        sample_set[n] = probe_pt(X_probe_location, Y_probe_location, Z_RAISE_BEFORE_PROBING, ProbeDeployAndStow, verbose_level);
-      else {
-        if (n == n_samples - 1)
-          sample_set[n] = probe_pt(X_probe_location, Y_probe_location, Z_RAISE_BEFORE_PROBING, ProbeStow, verbose_level); else
-          sample_set[n] = probe_pt(X_probe_location, Y_probe_location, Z_RAISE_BEFORE_PROBING, ProbeStay, verbose_level);
-      }
+      sample_set[n] = probe_pt(
+        X_probe_location, Y_probe_location,
+        Z_RAISE_BEFORE_PROBING,
+        deploy_probe_for_each_reading ? ProbeDeployAndStow : last_probe ? ProbeStow : ProbeStay,
+        verbose_level
+      );
 
       /**
        * Get the current mean for the data points we have so far
@@ -4408,7 +4408,7 @@ inline void gcode_M42() {
       }
       if (verbose_level > 0) SERIAL_EOL;
       delay(50);
-      do_blocking_move_to_z(current_position[Z_AXIS] + Z_RAISE_BETWEEN_PROBINGS);
+      do_blocking_move_to_z(current_position[Z_AXIS] + (last_probe ? Z_RAISE_AFTER_PROBING : Z_RAISE_BETWEEN_PROBINGS));
     }  // End of probe loop code
 
     if (verbose_level > 0) {


### PR DESCRIPTION
- Declare autos in `M48` on first use with ternary expressions
- Shrink debug code in `G28`
- Shrink `probe_pt` code in `M48`
- Use only needed stack space for the `sample_set` array in `M48`
