### PR TITLE
Output a message for SD read errors

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1140,6 +1140,10 @@ inline void get_serial_commands() {
           card.printingHasFinished();
           card.checkautostart(true);
         }
+        else if (n == -1) {
+          SERIAL_ERROR_START;
+          SERIAL_ECHOLNPGM(MSG_SD_ERR_READ);
+        }
         if (sd_char == '#') stop_buffering = true;
 
         sd_comment_mode = false; //for new command

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -171,6 +171,7 @@
 #define MSG_SD_PRINTING_BYTE                "SD printing byte "
 #define MSG_SD_NOT_PRINTING                 "Not SD printing"
 #define MSG_SD_ERR_WRITE_TO_FILE            "error writing to file"
+#define MSG_SD_ERR_READ                     "SD read error"
 #define MSG_SD_CANT_ENTER_SUBDIR            "Cannot enter subdir: "
 
 #define MSG_STEPPER_TOO_HIGH                "Steprate too high: "


### PR DESCRIPTION
As suggested at https://github.com/MarlinFirmware/Marlin/issues/4075#issuecomment-226987297

We hope these errors are rare. This will help track down SPI conflicts and other issues preventing reliable SD reading.
