### PR TITLE
Improve FILAMENT_RUNOUT_SENSOR, FILRUNOUT_PIN

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -686,14 +686,16 @@ void setup_killpin() {
   #endif
 }
 
-void setup_filrunoutpin() {
-  #if HAS_FILRUNOUT
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+
+  void setup_filrunoutpin() {
     pinMode(FILRUNOUT_PIN, INPUT);
     #if ENABLED(ENDSTOPPULLUP_FIL_RUNOUT)
       WRITE(FILRUNOUT_PIN, HIGH);
     #endif
-  #endif
-}
+  }
+
+#endif
 
 // Set home pin
 void setup_homepin(void) {
@@ -802,8 +804,12 @@ void setup() {
     MCUCR = 0x80;
   #endif
 
+  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+    setup_filrunoutpin();
+  #endif
+
   setup_killpin();
-  setup_filrunoutpin();
+
   setup_powerhold();
 
   #if HAS_STEPPER_RESET
@@ -8144,7 +8150,7 @@ void idle(
  */
 void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
-  #if HAS_FILRUNOUT
+  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
     if (IS_SD_PRINTING && !(READ(FILRUNOUT_PIN) ^ FIL_RUNOUT_INVERTING))
       handle_filament_runout();
   #endif

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -125,6 +125,17 @@
 #endif
 
 /**
+ * Filament Runout needs a pin and SD Support
+ */
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #if !HAS_FILRUNOUT
+    #error "FILAMENT_RUNOUT_SENSOR requires FILRUNOUT_PIN."
+  #elif DISABLED(SDSUPPORT)
+    #error "FILAMENT_RUNOUT_SENSOR requires SDSUPPORT."
+  #endif
+#endif
+
+/**
  * Filament Change with Extruder Runout Prevention
  */
 #if ENABLED(FILAMENTCHANGEENABLE) && ENABLED(EXTRUDER_RUNOUT_PREVENT)

--- a/Marlin/pins_CNCONTROLS_12.h
+++ b/Marlin/pins_CNCONTROLS_12.h
@@ -67,7 +67,7 @@
 //common I/O
 
  //#define TEMP_CHAMBER_PIN        13  // ANALOG INPUT !!
- //#define FILAMENT_RUNOUT_SENSOR  18
+ #define FILRUNOUT_PIN             18
  //#define PWM_1_PIN               12
  //#define PWM_2_PIN               13 
  //#define SPARE_IO                17  

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -98,10 +98,8 @@
   #define Z_MIN_PROBE_PIN  32
 #endif
 
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  // define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
-  #define FILRUNOUT_PIN     4
-#endif
+// define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
+#define FILRUNOUT_PIN       4
 
 #if MB(RAMPS_14_EFF) || MB(RAMPS_13_EFF) || ENABLED(IS_RAMPS_EFB)
   #define FAN_PIN           9 // (Sprinter config)


### PR DESCRIPTION
- Always define `FILRUNOUT_PIN` for those boards that assign one.
- Make code dependent on `FILAMENT_RUNOUT_SENSOR` instead of the pin.
- Sanity check for the pin and for `SDSUPPORT` if this feature is enabled.
