### PR TITLE
Fix comments on EXPERIMENTAL_I2CBUS

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -709,9 +709,9 @@ const unsigned int dropsegments = 2; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -721,12 +721,12 @@ const unsigned int dropsegments = 2; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -711,9 +711,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -723,12 +723,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -705,9 +705,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -717,12 +717,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -705,9 +705,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -717,12 +717,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -704,9 +704,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -716,12 +716,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -709,9 +709,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -721,12 +721,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -705,9 +705,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -717,12 +717,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -703,9 +703,9 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * devices on the bus.
  *
  * ; Example #1
- * ; This macro send the string "Marlin" to the slave device with address 0x63
+ * ; This macro send the string "Marlin" to the slave device with address 0x63 (99)
  * ; It uses multiple M155 commands with one B<base 10> arg
- * M155 A63  ; Target slave address
+ * M155 A99  ; Target slave address
  * M155 B77  ; M
  * M155 B97  ; a
  * M155 B114 ; r
@@ -715,12 +715,12 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
  * M155 S1   ; Send the current buffer
  *
  * ; Example #2
- * ; Request 6 bytes from slave device with address 0x63
- * M156 A63 B5
+ * ; Request 6 bytes from slave device with address 0x63 (99)
+ * M156 A99 B5
  *
  * ; Example #3
  * ; Example serial output of a M156 request
- * echo:i2c-reply: from:63 bytes:5 data:hello
+ * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
 // @section i2cbus


### PR DESCRIPTION
Addresses for the i2c bus feature are specified in decimal, not hexadecimal (which would be problematic).

Reference: https://github.com/MarlinFirmware/Marlin/issues/4068#issuecomment-227266160
