### PR TITLE
Fix stepper compile error with motor_current_setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -155,6 +155,12 @@ script:
   - opt_enable BQ_LCD_SMART_CONTROLLER SPEAKER
   - build_marlin
   #
+  # Test MINIRAMBO for PWM_MOTOR_CURRENT
+  #
+  - restore_configs
+  - opt_set MOTHERBOARD BOARD_MINIRAMBO
+  - build_marlin
+  #
   # Enable FILAMENTCHANGEENABLE
   #
   - restore_configs

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -134,7 +134,7 @@ class Stepper {
       #ifndef PWM_MOTOR_CURRENT
         #define PWM_MOTOR_CURRENT DEFAULT_PWM_MOTOR_CURRENT
       #endif
-      const int motor_current_setting[3] = PWM_MOTOR_CURRENT;
+      static constexpr int motor_current_setting[3] = PWM_MOTOR_CURRENT;
     #endif
 
     //


### PR DESCRIPTION
As noted by @scalez in https://github.com/MarlinFirmware/Marlin/pull/3131#discussion_r67724672
- Make the variable `static constexpr`
- Add a travis test for `PWM_MOTOR_CURRENT`
