### PR TITLE
Fixes some compiler warnings

### DIFF
--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -474,6 +474,9 @@ static void lcd_implementation_mark_as_selected(uint8_t row, bool isSelected) {
 }
 
 static void lcd_implementation_drawmenu_generic(bool isSelected, uint8_t row, const char* pstr, char pre_char, char post_char) {
+  UNUSED(pstr);
+  UNUSED(pre_char);
+
   char c;
   uint8_t n = LCD_WIDTH - 2;
 
@@ -564,6 +567,7 @@ void lcd_implementation_drawedit(const char* pstr, const char* value=NULL) {
 #if ENABLED(SDSUPPORT)
 
   static void _drawmenu_sd(bool isSelected, uint8_t row, const char* pstr, const char* filename, char* const longFilename, bool isDir) {
+    UNUSED(pstr);
     char c;
     uint8_t n = LCD_WIDTH - 1;
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -386,7 +386,7 @@ void Planner::recalculate() {
 #endif //AUTOTEMP
 
 /**
- * Maintain fans, paste extruder pressure, 
+ * Maintain fans, paste extruder pressure,
  */
 void Planner::check_axes_activity() {
   unsigned char axis_active[NUM_AXIS] = { 0 },
@@ -539,7 +539,7 @@ void Planner::check_axes_activity() {
   while (block_buffer_tail == next_buffer_head) idle();
 
   #if ENABLED(MESH_BED_LEVELING)
-    if (mbl.active()) 
+    if (mbl.active())
       z += mbl.get_z(x - home_offset[X_AXIS], y - home_offset[Y_AXIS]);
   #elif ENABLED(AUTO_BED_LEVELING_FEATURE)
     apply_rotation_xyz(bed_level_matrix, x, y, z);
@@ -1057,7 +1057,7 @@ void Planner::check_axes_activity() {
     // This leads to an enormous number of advance steps due to a huge e_acceleration.
     // The math is correct, but you don't want a retract move done with advance!
     // So this situation is filtered out here.
-    if (!bse || (!bsx && !bsy && !bsz) || stepper.get_advance_k() == 0 || bse == allsteps) {
+    if (!bse || (!bsx && !bsy && !bsz) || stepper.get_advance_k() == 0 || (uint32_t) bse == allsteps) {
       block->use_advance_lead = false;
     }
     else {

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -380,7 +380,7 @@ void Stepper::isr() {
         }
 
       #endif // ADVANCE or LIN_ADVANCE
-      
+
       #define _COUNTER(AXIS) counter_## AXIS
       #define _APPLY_STEP(AXIS) AXIS ##_APPLY_STEP
       #define _INVERT_STEP_PIN(AXIS) INVERT_## AXIS ##_STEP_PIN
@@ -468,7 +468,7 @@ void Stepper::isr() {
       timer = calc_timer(step_rate);
       OCR1A = timer;
       deceleration_time += timer;
-      
+
       #if ENABLED(LIN_ADVANCE)
 
         if (current_block->use_advance_lead)
@@ -998,7 +998,7 @@ void Stepper::digipot_init() {
 
     SPI.begin();
     pinMode(DIGIPOTSS_PIN, OUTPUT);
-    for (int i = 0; i < COUNT(digipot_motor_current); i++) {
+    for (uint8_t i = 0; i < COUNT(digipot_motor_current); i++) {
       //digitalPotWrite(digipot_ch[i], digipot_motor_current[i]);
       digipot_current(i, digipot_motor_current[i]);
     }

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -462,7 +462,7 @@ int Temperature::getHeaterPower(int heater) {
       EXTRUDER_3_AUTO_FAN_PIN == EXTRUDER_2_AUTO_FAN_PIN ? 2 : 3
     };
     uint8_t fanState = 0;
-    for (int f = 0; f <= HOTENDS; f++) {
+    for (int f = 0; f < HOTENDS; f++) {
       if (current_temperature[f] > EXTRUDER_AUTO_FAN_TEMPERATURE)
         SBI(fanState, fanBit[f]);
     }

--- a/Marlin/ultralcd_st7920_u8glib_rrd.h
+++ b/Marlin/ultralcd_st7920_u8glib_rrd.h
@@ -135,7 +135,7 @@ u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi = {u8g_dev_rrd_st7920_128x64_fn, &u8g
 
 class U8GLIB_ST7920_128X64_RRD : public U8GLIB {
  public:
-  U8GLIB_ST7920_128X64_RRD(uint8_t dummy) : U8GLIB(&u8g_dev_st7920_128x64_rrd_sw_spi) {}
+  U8GLIB_ST7920_128X64_RRD(uint8_t dummy) : U8GLIB(&u8g_dev_st7920_128x64_rrd_sw_spi) { UNUSED(dummy); }
 };
 
 


### PR DESCRIPTION
Fixes:

```
sketch\planner.cpp: In static member function 'static void Planner::buffer_line(float, float, float, const float&, float, uint8_t)':

sketch\planner.cpp:1060:82: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

     if (!bse || (!bsx && !bsy && !bsz) || stepper.get_advance_k() == 0 || bse == allsteps) {

                                                                                  ^
```

```
sketch\stepper.cpp: In static member function 'static void Stepper::digipot_init()':

sketch\macros.h:56:39: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]

 #define COUNT(a) (sizeof(a)/sizeof(*a))

                                       ^
```

```
sketch\stepper.cpp:1001:25: note: in expansion of macro 'COUNT'

     for (int i = 0; i < COUNT(digipot_motor_current); i++) {

                         ^

```

```
sketch\temperature.cpp: In static member function 'static void Temperature::checkExtruderAutoFans()':

sketch\temperature.cpp:466:32: warning: array subscript is above array bounds [-Warray-bounds]

       if (current_temperature[f] > EXTRUDER_AUTO_FAN_TEMPERATURE)

                                ^
```

```
In file included from sketch\dogm_lcd_implementation.h:60:0,

                 from sketch\ultralcd.cpp:48:

sketch\ultralcd_st7920_u8glib_rrd.h:138:3: warning: unused parameter 'dummy' [-Wunused-parameter]

   U8GLIB_ST7920_128X64_RRD(uint8_t dummy) : U8GLIB(&u8g_dev_st7920_128x64_rrd_sw_spi) {}

   ^
```
