### PR TITLE
Always do a brief delay in `lcd_quick_feedback`

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1999,9 +1999,8 @@ static void lcd_status_screen() {
       lcd.buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
     #elif PIN_EXISTS(BEEPER)
       buzzer.tone(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
-    #else
-      delay(LCD_FEEDBACK_FREQUENCY_DURATION_MS);
     #endif
+    delay(10); // needed for buttons to settle
   }
 
   /**


### PR DESCRIPTION
We forgot when creating the non-blocking `beep` classes that LCD buttons need the delay in `lcd_quick_feedback` or they tend to flake out.

Reference: #4127
