### PR TITLE
Fix debug output in probe_pt

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2107,10 +2107,9 @@ static void clean_up_after_endstop_or_probe_move() {
     // Raise by z_raise, then move the Z probe to the given XY
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("> do_blocking_move_to ", x - (X_PROBE_OFFSET_FROM_EXTRUDER));
+        SERIAL_ECHOPAIR("> do_blocking_move_to_xy(", x - (X_PROBE_OFFSET_FROM_EXTRUDER));
         SERIAL_ECHOPAIR(", ", y - (Y_PROBE_OFFSET_FROM_EXTRUDER));
-        SERIAL_ECHOPAIR(", ", max(current_position[Z_AXIS], Z_RAISE_BETWEEN_PROBINGS));
-        SERIAL_EOL;
+        SERIAL_ECHOLNPGM(")");
       }
     #endif
 


### PR DESCRIPTION
As noted in #4145, the debug logging is incorrect in `probe_pt`. However, no additional Z move should be added to `probe_pt` because the function already does a raise for deployment, and after probing it always does either a raise for stowing or a raise to move to the next position.
