### PR TITLE
Ensure a minimum height before XY move in probe_pt

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2104,7 +2104,10 @@ static void clean_up_after_endstop_or_probe_move() {
 
     float old_feedrate = feedrate;
 
-    // Raise by z_raise, then move the Z probe to the given XY
+    // Ensure a minimum height before moving the probe
+    do_probe_raise(Z_RAISE_BETWEEN_PROBINGS);
+
+    // Move to the XY where we shall probe
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR("> do_blocking_move_to_xy(", x - (X_PROBE_OFFSET_FROM_EXTRUDER));
@@ -2112,7 +2115,6 @@ static void clean_up_after_endstop_or_probe_move() {
         SERIAL_ECHOLNPGM(")");
       }
     #endif
-
     feedrate = XY_PROBE_FEEDRATE;
     do_blocking_move_to_xy(x - (X_PROBE_OFFSET_FROM_EXTRUDER), y - (Y_PROBE_OFFSET_FROM_EXTRUDER));
 


### PR DESCRIPTION
Addressing #4145

The `probe_pt` function may want to move in XY before deploying or enabling the probe. This PR ensures that there's enough room for that first move by raising Z to `Z_RAISE_BETWEEN_PROBINGS` before the `deploy_z_probe` call. After the first point, `probe_pt` will always be at least at this height, so this should have no effect on subsequent calls.
