### PR TITLE
Use Z_RAISE_BETWEEN_PROBINGS with MBL

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3137,7 +3137,9 @@ inline void gcode_G28() {
     feedrate = homing_feedrate[X_AXIS];
 
     current_position[Z_AXIS] = MESH_HOME_SEARCH_Z
-      #if MIN_Z_HEIGHT_FOR_HOMING > 0
+      #if Z_RAISE_BETWEEN_PROBINGS > MIN_Z_HEIGHT_FOR_HOMING
+        + Z_RAISE_BETWEEN_PROBINGS
+      #elif MIN_Z_HEIGHT_FOR_HOMING > 0
         + MIN_Z_HEIGHT_FOR_HOMING
       #endif
     ;
@@ -3147,7 +3149,7 @@ inline void gcode_G28() {
     current_position[Y_AXIS] = y + home_offset[Y_AXIS];
     line_to_current_position();
 
-    #if MIN_Z_HEIGHT_FOR_HOMING > 0
+    #if Z_RAISE_BETWEEN_PROBINGS > 0 || MIN_Z_HEIGHT_FOR_HOMING > 0
       current_position[Z_AXIS] = MESH_HOME_SEARCH_Z;
       line_to_current_position();
     #endif
@@ -3252,7 +3254,9 @@ inline void gcode_G28() {
         else {
           // One last "return to the bed" (as originally coded) at completion
           current_position[Z_AXIS] = MESH_HOME_SEARCH_Z
-            #if MIN_Z_HEIGHT_FOR_HOMING > 0
+            #if Z_RAISE_BETWEEN_PROBINGS > MIN_Z_HEIGHT_FOR_HOMING
+              + Z_RAISE_BETWEEN_PROBINGS
+            #elif MIN_Z_HEIGHT_FOR_HOMING > 0
               + MIN_Z_HEIGHT_FOR_HOMING
             #endif
           ;


### PR DESCRIPTION
Without some kind of raise between moves, Mesh Bed Leveling (MBL) tends to scrape the nozzle on the bed. Previously we used `Z_MIN_HEIGHT_FOR_HOMING` if it was set. This PR causes `_mbl_goto_xy` to use `Z_RAISE_BETWEEN_PROBINGS` if it's a larger value, or if `Z_MIN_HEIGHT_FOR_HOMING` is unset.

References: #4088
