### PR TITLE
CARTESIO_UI has lcd contrast

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -255,6 +255,7 @@
 
     #define HAS_LCD_CONTRAST ( \
         ENABLED(MAKRPANEL) \
+     || ENABLED(CARTESIO_UI) \
      || ENABLED(VIKI2) \
      || ENABLED(miniVIKI) \
      || ENABLED(ELB_FULL_GRAPHIC_CONTROLLER) \


### PR DESCRIPTION
Include this display in the flag definition.

Reference: https://github.com/MarlinFirmware/Marlin/pull/3957#issuecomment-228700765
