### PR TITLE
Always define temp sensor, heater pins for RUMBA

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1138,7 +1138,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -1137,7 +1137,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 #define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1121,7 +1121,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -1119,7 +1119,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -1130,7 +1130,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -1132,7 +1132,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1155,7 +1155,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1138,7 +1138,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1138,7 +1138,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1146,7 +1146,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -1159,7 +1159,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -1130,7 +1130,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1138,7 +1138,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -1223,7 +1223,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1217,7 +1217,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1220,7 +1220,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1220,7 +1220,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1222,7 +1222,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1141,7 +1141,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1132,7 +1132,7 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
-// Temperature status LEDs that display the hotend and bet temperature.
+// Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.
 //#define TEMP_STAT_LEDS

--- a/Marlin/pins_CNCONTROLS_12.h
+++ b/Marlin/pins_CNCONTROLS_12.h
@@ -8,101 +8,96 @@
 
 //#define LARGE_FLASH true
 
- #define X_ENABLE_PIN           26
- #define X_STEP_PIN             25
- #define X_DIR_PIN              27
- #define X_MIN_PIN              19
- #define X_MAX_PIN              -1
- 
- #define Y_ENABLE_PIN           29
- #define Y_STEP_PIN             28
- #define Y_DIR_PIN              30
- #define Y_MIN_PIN              22
- #define Y_MAX_PIN              -1
- 
- #define Z_ENABLE_PIN           32
- #define Z_STEP_PIN             31
- #define Z_DIR_PIN              33
- #define Z_MIN_PIN              23
- #define Z_MAX_PIN              -1
+#define X_ENABLE_PIN          26
+#define X_STEP_PIN            25
+#define X_DIR_PIN             27
+#define X_MIN_PIN             19
+#define X_MAX_PIN             -1
 
+#define Y_ENABLE_PIN          29
+#define Y_STEP_PIN            28
+#define Y_DIR_PIN             30
+#define Y_MIN_PIN             22
+#define Y_MAX_PIN             -1
 
-//Tools
+#define Z_ENABLE_PIN          32
+#define Z_STEP_PIN            31
+#define Z_DIR_PIN             33
+#define Z_MIN_PIN             23
+#define Z_MAX_PIN             -1
 
- #define E0_ENABLE_PIN          58
- #define E0_STEP_PIN            57
- #define E0_DIR_PIN             55
- #define HEATER_0_PIN           11
- #define TEMP_0_PIN             0   // ANALOG INPUT !!
-// #define TOOL_0_PIN             56
-// #define TOOL_0_PWM_PIN         10 // used for red warning led at dual extruder
- 
- #define E1_ENABLE_PIN          60
- #define E1_STEP_PIN            61
- #define E1_DIR_PIN             62
- #define HEATER_1_PIN           9 
- #define TEMP_1_PIN             9  // 9 for tool3 -> 13 for chambertemp
-// #define TOOL_1_PIN             59
-// #define TOOL_1_PWM_PIN         8 // used for lights at dual extruder
- 
- #define E2_ENABLE_PIN          44
- #define E2_STEP_PIN            46
- #define E2_DIR_PIN             66
- #define HEATER_2_PIN           6
- #define TEMP_2_PIN             13 // 10 for tool3 -> 13 for chambertemp
-// #define TOOL_2_PIN             4
-// #define TOOL_2_PWM_PIN         5
- 
- #define E3_ENABLE_PIN          47
- #define E3_STEP_PIN            45
- #define E3_DIR_PIN             69
- #define HEATER_3_PIN           3  
- #define TEMP_3_PIN             11  // 11 for tool4 -> 13 for chambertemp
-// #define TOOL_3_PIN             14
-// #define TOOL_3_PWM_PIN         2
- 
- #define HEATER_BED_PIN         24
- #define TEMP_BED_PIN           14   // ANALOG INPUT !! 
- 
-//common I/O
+#define E0_ENABLE_PIN         58
+#define E0_STEP_PIN           57
+#define E0_DIR_PIN            55
+#define HEATER_0_PIN          11
+#define TEMP_0_PIN            0   // ANALOG INPUT !!
 
- //#define TEMP_CHAMBER_PIN        13  // ANALOG INPUT !!
- #define FIL_RUNOUT_PIN            18
- //#define PWM_1_PIN               12
- //#define PWM_2_PIN               13 
- //#define SPARE_IO                17  
- #define FAN_PIN                   5 // 5 is PWMtool3 -> 7 is common PWM pin for all tools 
- 
- 
-//user interface
+#define E1_ENABLE_PIN         60
+#define E1_STEP_PIN           61
+#define E1_DIR_PIN            62
+#define HEATER_1_PIN           9
+#define TEMP_1_PIN             9  // 9 for tool3 -> 13 for chambertemp
 
- #define BEEPER_PIN                16
+#define E2_ENABLE_PIN         44
+#define E2_STEP_PIN           46
+#define E2_DIR_PIN            66
+#define HEATER_2_PIN           6
+#define TEMP_2_PIN            13  // 10 for tool3 -> 13 for chambertemp
 
- // Pins for DOGM SPI LCD Support
- #define DOGLCD_A0             39
- #define DOGLCD_CS             35
- #define DOGLCD_MOSI           48
- #define DOGLCD_SCK            49
- #define LCD_SCREEN_ROT_180
- 
- //The encoder and click button 
- #define BTN_EN1 36
- #define BTN_EN2 34
- #define BTN_ENC 38  //the click switch
+#define E3_ENABLE_PIN         47
+#define E3_STEP_PIN           45
+#define E3_DIR_PIN            69
+#define HEATER_3_PIN           3
+#define TEMP_3_PIN            11  // 11 for tool4 -> 13 for chambertemp
 
- //hardware buttons for manual movement of XYZ
- #define SHIFT_OUT             42
- #define SHIFT_LD              41
- #define SHIFT_CLK             40
+#define HEATER_BED_PIN        24
+#define TEMP_BED_PIN          14  // ANALOG INPUT !!
 
- 
- //#define UI1                 43
- //#define UI2                 37
- 
+// Tools
 
-// Other 
+//#define TOOL_0_PIN          56
+//#define TOOL_0_PWM_PIN      10  // red warning led at dual extruder
+//#define TOOL_1_PIN          59
+//#define TOOL_1_PWM_PIN       8  // lights at dual extruder
+//#define TOOL_2_PIN           4
+//#define TOOL_2_PWM_PIN       5
+//#define TOOL_3_PIN          14
+//#define TOOL_3_PWM_PIN       2
 
- #define SDSS                  53
- #define SD_DETECT_PIN         15
- #define STAT_LED_BLUE         -1
- #define STAT_LED_RED          10 // TOOL_0_PWM_PIN 
+// Common I/O
+
+//#define TEMP_CHAMBER_PIN    13  // ANALOG INPUT !!
+#define FIL_RUNOUT_PIN        18
+//#define PWM_1_PIN           12
+//#define PWM_2_PIN           13
+//#define SPARE_IO            17
+#define FAN_PIN                5  // 5 is PWMtool3 -> 7 is common PWM pin for all tools
+
+// User interface
+#define BEEPER_PIN            16
+
+// Pins for DOGM SPI LCD Support
+#define DOGLCD_A0             39
+#define DOGLCD_CS             35
+#define DOGLCD_MOSI           48
+#define DOGLCD_SCK            49
+#define LCD_SCREEN_ROT_180
+
+// The encoder and click button
+#define BTN_EN1 36
+#define BTN_EN2 34
+#define BTN_ENC 38
+
+// Hardware buttons for manual movement of XYZ
+#define SHIFT_OUT             42
+#define SHIFT_LD              41
+#define SHIFT_CLK             40
+
+//#define UI1                 43
+//#define UI2                 37
+
+// Other
+#define SDSS                  53
+#define SD_DETECT_PIN         15
+#define STAT_LED_BLUE         -1
+#define STAT_LED_RED          10 // TOOL_0_PWM_PIN

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -77,43 +77,36 @@
 #define PS_ON_PIN          45
 #define KILL_PIN           46
 
-#if TEMP_SENSOR_0 != 0
-  #define HEATER_0_PIN          2   // EXTRUDER 1
-  #if TEMP_SENSOR_0 == -1
-    #define TEMP_0_PIN          6   // ANALOG NUMBERING - connector *K1* on RUMBA thermocouple ADD ON is used
-  #else
-    #define TEMP_0_PIN         15   // ANALOG NUMBERING - default connector for thermistor *T0* on rumba board is used
-  #endif
+#define HEATER_0_PIN        2   // EXTRUDER 1
+#define HEATER_1_PIN        3   // EXTRUDER 2
+#define HEATER_2_PIN        6   // EXTRUDER 3
+
+#if TEMP_SENSOR_0 == -1
+  #define TEMP_0_PIN        6   // ANALOG NUMBERING - connector *K1* on RUMBA thermocouple ADD ON is used
+#else
+  #define TEMP_0_PIN       15   // ANALOG NUMBERING - default connector for thermistor *T0* on rumba board is used
 #endif
 
-#if TEMP_SENSOR_1 != 0
-  #define HEATER_1_PIN          3   // EXTRUDER 2
-  #if TEMP_SENSOR_1 == -1
-    #define TEMP_1_PIN          5   // ANALOG NUMBERING - connector *K2* on RUMBA thermocouple ADD ON is used
-  #else
-    #define TEMP_1_PIN         14   // ANALOG NUMBERING - default connector for thermistor *T1* on rumba board is used
-  #endif
+#if TEMP_SENSOR_1 == -1
+  #define TEMP_1_PIN        5   // ANALOG NUMBERING - connector *K2* on RUMBA thermocouple ADD ON is used
+#else
+  #define TEMP_1_PIN       14   // ANALOG NUMBERING - default connector for thermistor *T1* on rumba board is used
 #endif
 
-#if TEMP_SENSOR_2 != 0
-  #define HEATER_2_PIN         6    // EXTRUDER 3
-  #if TEMP_SENSOR_2 == -1
-    #define TEMP_2_PIN         7    // ANALOG NUMBERING - connector *K3* on RUMBA thermocouple ADD ON is used <-- this can not be used when TEMP_SENSOR_BED is defined as thermocouple
-  #else
-    #define TEMP_2_PIN         13   // ANALOG NUMBERING - default connector for thermistor *T2* on rumba board is used
-  #endif
+#if TEMP_SENSOR_2 == -1
+  #define TEMP_2_PIN        7   // ANALOG NUMBERING - connector *K3* on RUMBA thermocouple ADD ON is used <-- this can not be used when TEMP_SENSOR_BED is defined as thermocouple
+#else
+  #define TEMP_2_PIN       13   // ANALOG NUMBERING - default connector for thermistor *T2* on rumba board is used
 #endif
 
 //optional for extruder 4 or chamber: #define TEMP_X_PIN         12   // ANALOG NUMBERING - default connector for thermistor *T3* on rumba board is used
 //optional FAN1 can be used as 4th heater output: #define HEATER_3_PIN       8    // EXTRUDER 4
 
-#if TEMP_SENSOR_BED != 0
-  #define HEATER_BED_PIN       9    // BED
-  #if TEMP_SENSOR_BED == -1
-    #define TEMP_BED_PIN       7    // ANALOG NUMBERING - connector *K3* on RUMBA thermocouple ADD ON is used <-- this can not be used when TEMP_SENSOR_2 is defined as thermocouple
-  #else
-    #define TEMP_BED_PIN      11    // ANALOG NUMBERING - default connector for thermistor *THB* on rumba board is used
-  #endif
+#define HEATER_BED_PIN      9    // BED
+#if TEMP_SENSOR_BED == -1
+  #define TEMP_BED_PIN      7    // ANALOG NUMBERING - connector *K3* on RUMBA thermocouple ADD ON is used <-- this can not be used when TEMP_SENSOR_2 is defined as thermocouple
+#else
+  #define TEMP_BED_PIN     11    // ANALOG NUMBERING - default connector for thermistor *THB* on rumba board is used
 #endif
 
 #define SDSS               53


### PR DESCRIPTION
Pins for temp sensors and heaters should always be defined, unconditionally, by pins files.
