### PR TITLE
Support for VIKI2 in RAMPS and derivatives

### DIFF
--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -26,26 +26,18 @@
 
 #include "pins_RAMPS_14_EFB.h"
 
-//LCD Pins//
-
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
 
-  #define BEEPER_PIN        33
-
- // Pins for DOGM SPI LCD Support
+  #undef DOGLCD_A0
+  #undef DOGLCD_CS
+  #undef BTN_ENC
   #define DOGLCD_A0         31
   #define DOGLCD_CS         32
-  #define LCD_SCREEN_ROT_180
-
- //The encoder and click button
-  #define BTN_EN1           22
-  #define BTN_EN2            7
-  #define BTN_ENC           12  //the click switch
-
-  #define SDSS              53
-  #define SD_DETECT         -1  // Pin 49 if using display sd interface
+  #define BTN_ENC           12
 
   #if ENABLED(TEMP_STAT_LEDS)
+    #undef STAT_LED_RED
+    #undef STAT_LED_BLUE
     #define STAT_LED_RED    64
     #define STAT_LED_BLUE   63
   #endif

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -105,27 +105,10 @@
 #undef SERVO0_PIN
 #define SERVO0_PIN         47
 
-//LCD Pins//
-
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
-  #define BEEPER_PIN       33
-  // Pins for DOGM SPI LCD Support
-  #define DOGLCD_A0        44
-  #define DOGLCD_CS        45
-  #define LCD_SCREEN_ROT_180
-
-  //The encoder and click button
-  #define BTN_EN1          22
-  #define BTN_EN2           7
-  #define BTN_ENC          39  //the click switch
-
-  #define SDSS             53
-  #define SD_DETECT_PIN 49
-
-  #define KILL_PIN         31
-#endif
-
-#if ENABLED(TEMP_STAT_LEDS)
-  #define STAT_LED_RED     32
-  #define STAT_LED_BLUE    35
+  #undef SD_DETECT_PIN
+  #define SD_DETECT_PIN 49  // For easy adapter board
+#elif ENABLED(TEMP_STAT_LEDS)
+  #define STAT_LED_RED   32
+  #define STAT_LED_BLUE  35
 #endif

--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -33,3 +33,8 @@
 
 #undef HEATER_1_PIN
 #define HEATER_1_PIN        7 // EXTRUDER 2 (-1 on RAMPS 1.4)
+
+#if ENABLED(VIKI2) || ENABLED(miniVIKI)
+  //#undef SD_DETECT_PIN
+  //#define SD_DETECT_PIN 49  // For easy adapter board
+#endif

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -183,6 +183,27 @@
       #define BTN_ENC -1
       #define LCD_SDSS 53
       #define SD_DETECT_PIN 49
+    #elif ENABLED(VIKI2) || ENABLED(miniVIKI)
+      #define BEEPER_PIN       33
+
+      // Pins for DOGM SPI LCD Support
+      #define DOGLCD_A0        44
+      #define DOGLCD_CS        45
+      #define LCD_SCREEN_ROT_180
+
+      #define BTN_EN1          22
+      #define BTN_EN2           7
+      #define BTN_ENC          39
+
+      #define SDSS             53
+      #define SD_DETECT_PIN    -1  // Pin 49 for display sd interface, 72 for easy adapter board
+
+      #define KILL_PIN         31
+
+      #if ENABLED(TEMP_STAT_LEDS)
+        #define STAT_LED_RED   32
+        #define STAT_LED_BLUE  35
+      #endif
     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
       #define BTN_EN1 35  // reverse if the encoder turns the wrong way.
       #define BTN_EN2 37


### PR DESCRIPTION
The Viki2 display was not generally supported for RAMPS. This adds the generic Viki2 pins to `pins_RAMPS_14.h` and uses overrides for the RAMPS derivative boards.

Thanks to @Blue-Marlin for guidance in https://github.com/MarlinFirmware/Marlin/issues/4164#issuecomment-229219088
