### PR TITLE
Do interpolated moves for Allen Key deploy/stow

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1821,7 +1821,7 @@ static void clean_up_after_endstop_or_probe_move() {
           destination[X_AXIS] = Z_PROBE_ALLEN_KEY_DEPLOY_1_X;
           destination[Y_AXIS] = Z_PROBE_ALLEN_KEY_DEPLOY_1_Y;
           destination[Z_AXIS] = Z_PROBE_ALLEN_KEY_DEPLOY_1_Z;
-          prepare_move_to_destination_raw(); // this will also set_current_to_destination
+          prepare_move_to_destination(); // this will also set_current_to_destination
 
           // Move to engage deployment
           if (Z_PROBE_ALLEN_KEY_DEPLOY_2_FEEDRATE != Z_PROBE_ALLEN_KEY_DEPLOY_1_FEEDRATE)
@@ -1832,7 +1832,7 @@ static void clean_up_after_endstop_or_probe_move() {
             destination[Y_AXIS] = Z_PROBE_ALLEN_KEY_DEPLOY_2_Y;
           if (Z_PROBE_ALLEN_KEY_DEPLOY_2_Z != Z_PROBE_ALLEN_KEY_DEPLOY_1_Z)
             destination[Z_AXIS] = Z_PROBE_ALLEN_KEY_DEPLOY_2_Z;
-          prepare_move_to_destination_raw();
+          prepare_move_to_destination();
 
           #ifdef Z_PROBE_ALLEN_KEY_DEPLOY_3_X
             if (Z_PROBE_ALLEN_KEY_DEPLOY_3_FEEDRATE != Z_PROBE_ALLEN_KEY_DEPLOY_2_FEEDRATE)
@@ -1848,14 +1848,14 @@ static void clean_up_after_endstop_or_probe_move() {
             if (Z_PROBE_ALLEN_KEY_DEPLOY_3_Z != Z_PROBE_ALLEN_KEY_DEPLOY_2_Z)
               destination[Z_AXIS] = Z_PROBE_ALLEN_KEY_DEPLOY_3_Z;
 
-            prepare_move_to_destination_raw();
+            prepare_move_to_destination();
           #endif
         }
 
       // Partially Home X,Y for safety
       destination[X_AXIS] *= 0.75;
       destination[Y_AXIS] *= 0.75;
-      prepare_move_to_destination_raw(); // this will also set_current_to_destination
+      prepare_move_to_destination(); // this will also set_current_to_destination
 
       feedrate = old_feedrate;
 
@@ -1921,7 +1921,7 @@ static void clean_up_after_endstop_or_probe_move() {
       destination[X_AXIS] = Z_PROBE_ALLEN_KEY_STOW_1_X;
       destination[Y_AXIS] = Z_PROBE_ALLEN_KEY_STOW_1_Y;
       destination[Z_AXIS] = Z_PROBE_ALLEN_KEY_STOW_1_Z;
-      prepare_move_to_destination_raw();
+      prepare_move_to_destination();
 
       // Move the nozzle down to push the Z probe into retracted position
       if (Z_PROBE_ALLEN_KEY_STOW_2_FEEDRATE != Z_PROBE_ALLEN_KEY_STOW_1_FEEDRATE)
@@ -1931,7 +1931,7 @@ static void clean_up_after_endstop_or_probe_move() {
       if (Z_PROBE_ALLEN_KEY_STOW_2_Y != Z_PROBE_ALLEN_KEY_STOW_1_Y)
         destination[Y_AXIS] = Z_PROBE_ALLEN_KEY_STOW_2_Y;
       destination[Z_AXIS] = Z_PROBE_ALLEN_KEY_STOW_2_Z;
-      prepare_move_to_destination_raw();
+      prepare_move_to_destination();
 
       // Move up for safety
       if (Z_PROBE_ALLEN_KEY_STOW_3_FEEDRATE != Z_PROBE_ALLEN_KEY_STOW_2_FEEDRATE)
@@ -1941,13 +1941,13 @@ static void clean_up_after_endstop_or_probe_move() {
       if (Z_PROBE_ALLEN_KEY_STOW_3_Y != Z_PROBE_ALLEN_KEY_STOW_2_Y)
         destination[Y_AXIS] = Z_PROBE_ALLEN_KEY_STOW_3_Y;
       destination[Z_AXIS] = Z_PROBE_ALLEN_KEY_STOW_3_Z;
-      prepare_move_to_destination_raw();
+      prepare_move_to_destination();
 
       // Home XY for safety
       feedrate = homing_feedrate[X_AXIS] / 2;
       destination[X_AXIS] = 0;
       destination[Y_AXIS] = 0;
-      prepare_move_to_destination_raw(); // this will also set_current_to_destination
+      prepare_move_to_destination(); // this will also set_current_to_destination
 
       feedrate = old_feedrate;
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7537,7 +7537,7 @@ void mesh_buffer_line(float x, float y, float z, const float e, float feed_rate,
 
 #if ENABLED(DUAL_X_CARRIAGE)
 
-  inline bool prepare_move_dual_x_carriage() {
+  inline bool prepare_move_to_destination_dualx() {
     if (active_extruder_parked) {
       if (dual_x_carriage_mode == DXC_DUPLICATION_MODE && active_extruder == 0) {
         // move duplicate extruder into correct duplication position.
@@ -7576,7 +7576,7 @@ void mesh_buffer_line(float x, float y, float z, const float e, float feed_rate,
 
 #if DISABLED(DELTA) && DISABLED(SCARA)
 
-  inline bool prepare_cartesian_move_to_destination() {
+  inline bool prepare_move_to_destination_cartesian() {
     // Do not use feedrate_multiplier for E or Z only moves
     if (current_position[X_AXIS] == destination[X_AXIS] && current_position[Y_AXIS] == destination[Y_AXIS]) {
       line_to_destination();
@@ -7637,9 +7637,9 @@ void prepare_move_to_destination() {
     if (!prepare_delta_move_to(destination)) return;
   #else
     #if ENABLED(DUAL_X_CARRIAGE)
-      if (!prepare_move_dual_x_carriage()) return;
+      if (!prepare_move_to_destination_dualx()) return;
     #endif
-    if (!prepare_cartesian_move_to_destination()) return;
+    if (!prepare_move_to_destination_cartesian()) return;
   #endif
 
   set_current_to_destination();


### PR DESCRIPTION
For deploy and stow of the Allen Key probe, moves may dip due to `prepare_move_to_destination_raw`. So use `prepare_move_to_destination` instead.

Also rename…
- `prepare_move_dual_x_carriage` => `prepare_move_to_destination_dualx`
- `prepare_cartesian_move_to_destination` => `prepare_move_to_destination_cartesian`

…so all these functions follow the same pattern.
