### PR TITLE
Unconditional do_probe_raise() in probe_pt()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2118,14 +2118,12 @@ static void clean_up_after_endstop_or_probe_move() {
       #endif
       stow_z_probe();
     }
-    #if Z_RAISE_BETWEEN_PROBINGS > 0
-      else {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> do_probe_raise");
-        #endif
-        do_probe_raise(Z_RAISE_BETWEEN_PROBINGS);
-      }
-    #endif
+    else {
+      #if ENABLED(DEBUG_LEVELING_FEATURE)
+        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> do_probe_raise");
+      #endif
+      do_probe_raise(Z_RAISE_BETWEEN_PROBINGS);
+    }
 
     if (verbose_level > 2) {
       SERIAL_PROTOCOLPGM("Bed X: ");


### PR DESCRIPTION
If `Z_RAISE_BETWEEN_PROBINGS` is null or undefined the probe is currently not raised by `home_offset[Z_AXIS]` and `zprobe_zoffset`. But when the smallest bit different from 0 it is.

If an undefined `Z_RAISE_BETWEEN_PROBINGS` expands to 0 (and it does) this is the solution.

A similar asymmetry exists with the newly introduced 'short-cut' in `G28` - but it's the rise before anything is probed - so should not make a difference.

This asymmetry likely causes the effects in #4177  
