### PR TITLE
Simplified variable-size array macros

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -552,32 +552,14 @@
   /**
    * ARRAY_BY_EXTRUDERS based on EXTRUDERS
    */
-  #if EXTRUDERS > 3
-    #define ARRAY_BY_EXTRUDERS(v1, v2, v3, v4) { v1, v2, v3, v4 }
-  #elif EXTRUDERS > 2
-    #define ARRAY_BY_EXTRUDERS(v1, v2, v3, v4) { v1, v2, v3 }
-  #elif EXTRUDERS > 1
-    #define ARRAY_BY_EXTRUDERS(v1, v2, v3, v4) { v1, v2 }
-  #else
-    #define ARRAY_BY_EXTRUDERS(v1, v2, v3, v4) { v1 }
-  #endif
-
-  #define ARRAY_BY_EXTRUDERS1(v1) ARRAY_BY_EXTRUDERS(v1, v1, v1, v1)
+  #define ARRAY_BY_EXTRUDERS(args...) ARRAY_N(EXTRUDERS, args)
+  #define ARRAY_BY_EXTRUDERS1(v1) ARRAY_BY_EXTRUDERS(v1, v1, v1, v1, v1, v1)
 
   /**
    * ARRAY_BY_HOTENDS based on HOTENDS
    */
-  #if HOTENDS > 3
-    #define ARRAY_BY_HOTENDS(v1, v2, v3, v4) { v1, v2, v3, v4 }
-  #elif HOTENDS > 2
-    #define ARRAY_BY_HOTENDS(v1, v2, v3, v4) { v1, v2, v3 }
-  #elif HOTENDS > 1
-    #define ARRAY_BY_HOTENDS(v1, v2, v3, v4) { v1, v2 }
-  #else
-    #define ARRAY_BY_HOTENDS(v1, v2, v3, v4) { v1 }
-  #endif
-
-  #define ARRAY_BY_HOTENDS1(v1) ARRAY_BY_HOTENDS(v1, v1, v1, v1)
+  #define ARRAY_BY_HOTENDS(args...) ARRAY_N(HOTENDS, args)
+  #define ARRAY_BY_HOTENDS1(v1) ARRAY_BY_HOTENDS(v1, v1, v1, v1, v1, v1)
 
   /**
    * Z_DUAL_ENDSTOPS endstop reassignment

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -55,6 +55,17 @@
 #define NUMERIC_SIGNED(a) (NUMERIC(a) || (a) == '-')
 #define COUNT(a) (sizeof(a)/sizeof(*a))
 
+// Macros for initializing arrays
+#define ARRAY_6(v1, v2, v3, v4, v5, v6, args...) { v1, v2, v3, v4, v5, v6 }
+#define ARRAY_5(v1, v2, v3, v4, v5, args...)     { v1, v2, v3, v4, v5 }
+#define ARRAY_4(v1, v2, v3, v4, args...)         { v1, v2, v3, v4 }
+#define ARRAY_3(v1, v2, v3, args...)             { v1, v2, v3 }
+#define ARRAY_2(v1, v2, args...)                 { v1, v2 }
+#define ARRAY_1(v1, args...)                     { v1 }
+
+#define _ARRAY_N(N, args...) ARRAY_ ##N(args)
+#define ARRAY_N(N, args...) _ARRAY_N(N, args)
+
 // Macros for adding
 #define INC_0 1
 #define INC_1 2


### PR DESCRIPTION
It occurred to me that these macros can use substitution instead of conditionals.
