### PR TITLE
Add working PlatformIO support

### DIFF
--- a/Marlin/platformio.ini
+++ b/Marlin/platformio.ini
@@ -1,0 +1,44 @@
+#
+# Project Configuration File
+#
+# A detailed documentation with the EXAMPLES is located here:
+# http://docs.platformio.org/en/latest/projectconf.html
+#
+
+# A sign `#` at the beginning of the line indicates a comment
+# Comment lines are ignored.
+
+# Automatic targets - enable auto-uploading
+# targets = upload
+
+[platformio]
+src_dir = ./
+env_default = mega2560
+
+[env:mega2560]
+platform = atmelavr
+framework = arduino
+board = megaatmega2560
+build_flags = -I $BUILDSRC_DIR
+board_f_cpu = 16000000L
+
+[env:mega1280]
+platform = atmelavr
+framework = arduino
+board = megaatmega1280
+build_flags = -I $BUILDSRC_DIR
+board_f_cpu = 16000000L
+
+[env:printrboard]
+platform = teensy
+framework = arduino
+board = teensy20pp
+build_flags =  -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_PRINTRBOARD
+# Bug in arduino framework does not allow boards running at 20Mhz
+#board_f_cpu = 20000000L
+
+[env:brainwavepro]
+platform = teensy
+framework = arduino
+board = teensy20pp
+build_flags = -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_BRAINWAVE_PRO -D AT90USBxx_TEENSYPP_ASSIGNMENTS


### PR DESCRIPTION
I noticed PlatformIO was removed from RCBugFix branch for lack of support.
I corrected RC branch _platform.ino_ file, removing AUTOMATIC_VERSIONING (see #3724).

The old AUTOMATIC_VERSIONING implementation is easy to fix, but I'm not sure it's cross platform.

As alternative an advanded user can still:
- manually use _/buildroot/bin/generate_version_header_for_marlin_
- add "-D USE_AUTOMATIC_VERSIONING" to build_flags in _platformio.ini_
