### PR TITLE
Allow the command queue to be cleared by commands, lcd menus

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -990,8 +990,11 @@ void loop() {
 
     #endif // SDSUPPORT
 
-    commands_in_queue--;
-    cmd_queue_index_r = (cmd_queue_index_r + 1) % BUFSIZE;
+    // The queue may be reset by a command handler or by code invoked by idle() within a handler
+    if (commands_in_queue) {
+      --commands_in_queue;
+      cmd_queue_index_r = (cmd_queue_index_r + 1) % BUFSIZE;
+    }
   }
   endstops.report_state();
   idle();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -284,11 +284,11 @@ bool axis_homed[3] = { false };
 
 static long gcode_N, gcode_LastN, Stopped_gcode_LastN = 0;
 
-static char* current_command, *current_command_args;
-static int cmd_queue_index_r = 0;
-static int cmd_queue_index_w = 0;
-static int commands_in_queue = 0;
 static char command_queue[BUFSIZE][MAX_CMD_SIZE];
+static char* current_command, *current_command_args;
+static uint8_t cmd_queue_index_r = 0,
+               cmd_queue_index_w = 0,
+               commands_in_queue = 0;
 
 #if ENABLED(INCH_MODE_SUPPORT)
   float linear_unit_factor = 1.0;


### PR DESCRIPTION
Addressing #4042.

**Background:** A command (such as `M190`) may be in progress during an SD print. While waiting for temperature, it will call `idle()` in a loop. The `idle()` function will call `lcd_update()` and a user might invoke `lcd_sdcard_stop()` from there. "Stop print" clears the queue by setting `commands_in_queue` to `0` and cancels heatup, so `M109` returns back to `loop()`, where `process_next_command()` was called. The next thing `loop()` does is `commands_in_queue--`. Since we cleared the command queue within `process_command()`, `commands_in_queue` gets decremented here to `-1`. As a result, code that uses `if (commands_in_queue) { . . . }` will continue to process the queue 65,535 more times — not what we want!

This PR fixes the issue by checking whether `commands_in_queue` is non-zero before decrementing it and moving on to the next command.
- Also use `uint8_t` for the command queue indices, saving 152 bytes of PROGMEM. (And hey, if this bug comes back, it will only process the queue 255 extra times.)
