### PR TITLE
Fix raise by MIN_Z_HEIGHT_FOR_HOMING (first attempt)

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -783,14 +783,11 @@
         #define XY_PROBE_SPEED 4000
       #endif
     #endif
-    #ifndef Z_RAISE_PROBE_DEPLOY_STOW
-      #if defined(Z_RAISE_BEFORE_PROBING) && defined(Z_RAISE_AFTER_PROBING)
-        #define Z_RAISE_PROBE_DEPLOY_STOW (max(Z_RAISE_BEFORE_PROBING, Z_RAISE_AFTER_PROBING))
-      #else
-        #error "You must set Z_RAISE_PROBE_DEPLOY_STOW in your configuration."
-      #endif
+    #if Z_RAISE_BETWEEN_PROBINGS > Z_RAISE_PROBE_DEPLOY_STOW
+      #define _Z_RAISE_PROBE_DEPLOY_STOW Z_RAISE_BETWEEN_PROBINGS
+    #else
+      #define _Z_RAISE_PROBE_DEPLOY_STOW Z_RAISE_PROBE_DEPLOY_STOW
     #endif
-    #define _Z_RAISE_PROBE_DEPLOY_STOW (max(Z_RAISE_PROBE_DEPLOY_STOW, Z_RAISE_BETWEEN_PROBINGS))
   #endif
 
   /**

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -293,6 +293,21 @@
     //#endif
   #endif
 
+  /**
+   * Make sure Z raise values are set
+   */
+  #if defined(Z_RAISE_BEFORE_PROBING) || defined(Z_RAISE_AFTER_PROBING)
+    #error "Z_RAISE_(BEFORE|AFTER)_PROBING are deprecated. Use Z_RAISE_PROBE_DEPLOY_STOW instead."
+  #elif !defined(Z_RAISE_PROBE_DEPLOY_STOW)
+    #error "You must set Z_RAISE_PROBE_DEPLOY_STOW in your configuration."
+  #elif !defined(Z_RAISE_BETWEEN_PROBINGS)
+    #error "You must set Z_RAISE_BETWEEN_PROBINGS in your configuration."
+  #elif Z_RAISE_PROBE_DEPLOY_STOW < 1
+    #error "Probes need Z_RAISE_PROBE_DEPLOY_STOW >= 1."
+  #elif Z_RAISE_BETWEEN_PROBINGS < 1
+    #error "Probes need Z_RAISE_BETWEEN_PROBINGS >= 1."
+  #endif
+
 #else
 
   /**


### PR DESCRIPTION
When doing the initial raise for homing (which occurs before homing X and Y) we don't need to include the probe offset. This lift is just always done over the current Z position. The Z axis will be lifted more, if needed later, to deploy the probe before homing Z.

Reference: #4208
- Sanity check the probe raise values. There should always be raises for probing.
- Also, it looks like X and Y re-home after quick-homing. This PR includes a patch for that.
