### PR TITLE
M302: Add "P" parameter, status output

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5703,10 +5703,36 @@ inline void gcode_M226() {
 #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
 
   /**
-   * M302: Allow cold extrudes, or set the minimum extrude S<temperature>.
+   * M302: Allow cold extrudes, or set the minimum extrude temperature
+   *
+   *       S<temperature> sets the minimum extrude temperature
+   *       P<bool> enables (1) or disables (0) cold extrusion
+   *
+   *  Examples:
+   *
+   *       M302         ; report current cold extrusion state
+   *       M302 P0      ; enable cold extrusion checking
+   *       M302 P1      ; disables cold extrusion checking
+   *       M302 S0      ; always allow extrusion (disables checking)
+   *       M302 S170    ; only allow extrusion above 170
+   *       M302 S170 P1 ; set min extrude temp to 170 but leave disabled
    */
   inline void gcode_M302() {
-    thermalManager.extrude_min_temp = code_seen('S') ? code_value_temp_abs() : 0;
+    bool seen_S = code_seen('S');
+    if (seen_S) {
+      thermalManager.extrude_min_temp = code_value_temp_abs();
+      thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0);
+    }
+
+    if (code_seen('P'))
+      thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0) || code_value_bool();
+    else if (!seen_S) {
+      // Report current state
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPAIR("Cold extrudes are ", (thermalManager.allow_cold_extrude ? "en" : "dis"));
+      SERIAL_ECHOPAIR("abled (min temp ", int(thermalManager.extrude_min_temp + 0.5));
+      SERIAL_ECHOLNPGM("C)");
+    }
   }
 
 #endif // PREVENT_DANGEROUS_EXTRUDE

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -50,13 +50,12 @@ Temperature thermalManager;
 
 // public:
 
-int Temperature::current_temperature_raw[HOTENDS] = { 0 };
-float Temperature::current_temperature[HOTENDS] = { 0.0 };
-int Temperature::target_temperature[HOTENDS] = { 0 };
-
-int Temperature::current_temperature_bed_raw = 0;
-float Temperature::current_temperature_bed = 0.0;
-int Temperature::target_temperature_bed = 0;
+float Temperature::current_temperature[HOTENDS] = { 0.0 },
+      Temperature::current_temperature_bed = 0.0;
+int   Temperature::current_temperature_raw[HOTENDS] = { 0 },
+      Temperature::target_temperature[HOTENDS] = { 0 },
+      Temperature::current_temperature_bed_raw = 0,
+      Temperature::target_temperature_bed = 0;
 
 #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
   float Temperature::redundant_temperature = 0.0;
@@ -121,11 +120,11 @@ unsigned char Temperature::soft_pwm_bed;
 volatile bool Temperature::temp_meas_ready = false;
 
 #if ENABLED(PIDTEMP)
-  float Temperature::temp_iState[HOTENDS] = { 0 };
-  float Temperature::temp_dState[HOTENDS] = { 0 };
-  float Temperature::pTerm[HOTENDS];
-  float Temperature::iTerm[HOTENDS];
-  float Temperature::dTerm[HOTENDS];
+  float Temperature::temp_iState[HOTENDS] = { 0 },
+        Temperature::temp_dState[HOTENDS] = { 0 },
+        Temperature::pTerm[HOTENDS],
+        Temperature::iTerm[HOTENDS],
+        Temperature::dTerm[HOTENDS];
 
   #if ENABLED(PID_ADD_EXTRUSION_RATE)
     float Temperature::cTerm[HOTENDS];
@@ -134,21 +133,21 @@ volatile bool Temperature::temp_meas_ready = false;
     int Temperature::lpq_ptr = 0;
   #endif
 
-  float Temperature::pid_error[HOTENDS];
-  float Temperature::temp_iState_min[HOTENDS];
-  float Temperature::temp_iState_max[HOTENDS];
+  float Temperature::pid_error[HOTENDS],
+        Temperature::temp_iState_min[HOTENDS],
+        Temperature::temp_iState_max[HOTENDS];
   bool Temperature::pid_reset[HOTENDS];
 #endif
 
 #if ENABLED(PIDTEMPBED)
-  float Temperature::temp_iState_bed = { 0 };
-  float Temperature::temp_dState_bed = { 0 };
-  float Temperature::pTerm_bed;
-  float Temperature::iTerm_bed;
-  float Temperature::dTerm_bed;
-  float Temperature::pid_error_bed;
-  float Temperature::temp_iState_min_bed;
-  float Temperature::temp_iState_max_bed;
+  float Temperature::temp_iState_bed = { 0 },
+        Temperature::temp_dState_bed = { 0 },
+        Temperature::pTerm_bed,
+        Temperature::iTerm_bed,
+        Temperature::dTerm_bed,
+        Temperature::pid_error_bed,
+        Temperature::temp_iState_min_bed,
+        Temperature::temp_iState_max_bed;
 #else
   millis_t Temperature::next_bed_check_ms;
 #endif
@@ -157,10 +156,10 @@ unsigned long Temperature::raw_temp_value[4] = { 0 };
 unsigned long Temperature::raw_temp_bed_value = 0;
 
 // Init min and max temp with extreme values to prevent false errors during startup
-int Temperature::minttemp_raw[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_RAW_LO_TEMP , HEATER_1_RAW_LO_TEMP , HEATER_2_RAW_LO_TEMP, HEATER_3_RAW_LO_TEMP);
-int Temperature::maxttemp_raw[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_RAW_HI_TEMP , HEATER_1_RAW_HI_TEMP , HEATER_2_RAW_HI_TEMP, HEATER_3_RAW_HI_TEMP);
-int Temperature::minttemp[HOTENDS] = { 0 };
-int Temperature::maxttemp[HOTENDS] = ARRAY_BY_HOTENDS1(16383);
+int Temperature::minttemp_raw[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_RAW_LO_TEMP , HEATER_1_RAW_LO_TEMP , HEATER_2_RAW_LO_TEMP, HEATER_3_RAW_LO_TEMP),
+    Temperature::maxttemp_raw[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_RAW_HI_TEMP , HEATER_1_RAW_HI_TEMP , HEATER_2_RAW_HI_TEMP, HEATER_3_RAW_HI_TEMP),
+    Temperature::minttemp[HOTENDS] = { 0 },
+    Temperature::maxttemp[HOTENDS] = ARRAY_BY_HOTENDS1(16383);
 
 #ifdef MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED
   int Temperature::consecutive_low_temperature_error[HOTENDS] = { 0 };

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -107,6 +107,7 @@ unsigned char Temperature::soft_pwm_bed;
 #endif
 
 #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
+  bool Temperature::allow_cold_extrude = false;
   float Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
 #endif
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -52,13 +52,12 @@ class Temperature {
 
   public:
 
-    static int current_temperature_raw[HOTENDS];
-    static float current_temperature[HOTENDS];
-    static int target_temperature[HOTENDS];
-
-    static int current_temperature_bed_raw;
-    static float current_temperature_bed;
-    static int target_temperature_bed;
+    static float current_temperature[HOTENDS],
+                 current_temperature_bed;
+    static int   current_temperature_raw[HOTENDS],
+                 target_temperature[HOTENDS],
+                 current_temperature_bed_raw,
+                 target_temperature_bed;
 
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
       static float redundant_temperature;
@@ -143,11 +142,11 @@ class Temperature {
     static volatile bool temp_meas_ready;
 
     #if ENABLED(PIDTEMP)
-      static float temp_iState[HOTENDS];
-      static float temp_dState[HOTENDS];
-      static float pTerm[HOTENDS];
-      static float iTerm[HOTENDS];
-      static float dTerm[HOTENDS];
+      static float temp_iState[HOTENDS],
+                   temp_dState[HOTENDS],
+                   pTerm[HOTENDS],
+                   iTerm[HOTENDS],
+                   dTerm[HOTENDS];
 
       #if ENABLED(PID_ADD_EXTRUSION_RATE)
         static float cTerm[HOTENDS];
@@ -156,33 +155,33 @@ class Temperature {
         static int lpq_ptr;
       #endif
 
-      static float pid_error[HOTENDS];
-      static float temp_iState_min[HOTENDS];
-      static float temp_iState_max[HOTENDS];
+      static float pid_error[HOTENDS],
+                   temp_iState_min[HOTENDS],
+                   temp_iState_max[HOTENDS];
       static bool pid_reset[HOTENDS];
     #endif
 
     #if ENABLED(PIDTEMPBED)
-      static float temp_iState_bed;
-      static float temp_dState_bed;
-      static float pTerm_bed;
-      static float iTerm_bed;
-      static float dTerm_bed;
-      static float pid_error_bed;
-      static float temp_iState_min_bed;
-      static float temp_iState_max_bed;
+      static float temp_iState_bed,
+                   temp_dState_bed,
+                   pTerm_bed,
+                   iTerm_bed,
+                   dTerm_bed,
+                   pid_error_bed,
+                   temp_iState_min_bed,
+                   temp_iState_max_bed;
     #else
       static millis_t next_bed_check_ms;
     #endif
 
-    static unsigned long raw_temp_value[4];
-    static unsigned long raw_temp_bed_value;
+    static unsigned long raw_temp_value[4],
+                         raw_temp_bed_value;
 
     // Init min and max temp with extreme values to prevent false errors during startup
-    static int minttemp_raw[HOTENDS];
-    static int maxttemp_raw[HOTENDS];
-    static int minttemp[HOTENDS];
-    static int maxttemp[HOTENDS];
+    static int minttemp_raw[HOTENDS],
+               maxttemp_raw[HOTENDS],
+               minttemp[HOTENDS],
+               maxttemp[HOTENDS];
 
     #ifdef MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED
       static int consecutive_low_temperature_error[HOTENDS];

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -121,12 +121,13 @@ class Temperature {
     #endif
 
     #if ENABLED(PREVENT_DANGEROUS_EXTRUDE)
+      static bool allow_cold_extrude;
       static float extrude_min_temp;
       static bool tooColdToExtrude(uint8_t e) {
         #if HOTENDS == 1
           UNUSED(e);
         #endif
-        return degHotend(HOTEND_INDEX) < extrude_min_temp;
+        return allow_cold_extrude ? false : degHotend(HOTEND_INDEX) < extrude_min_temp;
       }
     #else
       static bool tooColdToExtrude(uint8_t e) { UNUSED(e); return false; }


### PR DESCRIPTION
- RepRapFirmware [uses the "P" parameter instead of "S"](https://github.com/reprappro/RepRapFirmware/blob/46ced15c5f6d1195545f2736b8090f14b2c0242b/GCodes.cpp#L3420) to turn cold extrusion on / off.
- Repetier-Firmware [uses the "S" parameter as a boolean](https://github.com/luc-github/Repetier-Firmware-0.92/blob/44a1430032513559d3f3ae7e16c567e6ce9fa144/src/ArduinoAVR/Repetier/Commands.cpp#L1521) to turn cold extrusion on / off.
- Marlin 1.0.x uses the "S" parameter to set the minimum extrusion temperature.

This PR introduces…
- `M302 P<1|0>` turns cold extrusion on|off without affecting the min temp (RepRapFirmware).
- `M302` (no parameters) displays the current cold extrusion settings (RepRapFirmware).
