### PR TITLE
Add a emergency-command parser in MarlinSerial and add M108

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -284,6 +284,12 @@
     #define HardwareSerial_h // trick to disable the standard HWserial
   #endif
 
+  #if ENABLED(EMERGENCY_PARSER)
+    #define EMERGENCY_PARSER_CAPABILITIES " EMERGENCY_CODES:M112,M108,M410"
+  #else
+    #define EMERGENCY_PARSER_CAPABILITIES ""
+  #endif
+
   #include "Arduino.h"
 
   /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -288,6 +288,7 @@ extern float sw_endstop_min[3]; // axis[n].sw_endstop_min
 extern float sw_endstop_max[3]; // axis[n].sw_endstop_max
 extern bool axis_known_position[3]; // axis[n].is_known
 extern bool axis_homed[3]; // axis[n].is_homed
+extern bool cancel_heatup_wait;
 
 // GCode support for external objects
 bool code_seen(char);

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -30,6 +30,7 @@
 
 #include "Marlin.h"
 #include "MarlinSerial.h"
+#include "stepper.h"
 
 #ifndef USBCON
 // this next line disables the entire HardwareSerial.cpp,
@@ -54,6 +55,10 @@ FORCE_INLINE void store_char(unsigned char c) {
       rx_buffer.head = i;
     }
   CRITICAL_SECTION_END;
+
+  #if ENABLED(EMERGENCY_PARSER)
+    emergency_parser(c);
+  #endif
 }
 
 
@@ -309,4 +314,157 @@ MarlinSerial customizedSerial;
 // For AT90USB targets use the UART for BT interfacing
 #if defined(USBCON) && ENABLED(BLUETOOTH)
   HardwareSerial bluetoothSerial;
+#endif
+
+#if ENABLED(EMERGENCY_PARSER)
+
+  // Currently looking for: M112,M108,M410
+  // If you alter the parser please don't forget to update the capabilities in Conditionals.h
+
+  void emergency_parser(unsigned char c) {
+
+    enum e_parser_state {
+      state_RESET,
+      state_M,
+      state_M1,
+      state_M10,
+      state_M11,
+      state_M2,
+      state_M3,
+      state_M4,
+      state_M41,
+      state_IGNORE // to '\n'
+    };
+
+    static e_parser_state state = state_RESET;
+
+    switch (state) {
+      case state_RESET:
+        switch (c) {
+          case 'M':
+            state = state_M;
+            break;
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M:
+        switch (c) {
+          case '1':
+            state = state_M1;
+            break;
+          case '2':
+            state = state_M2;
+            break;
+          case '3':
+            state = state_M3;
+            break;
+          case '4':
+            state = state_M4;
+            break;
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M1:
+        switch (c) {
+          case '0':
+            state = state_M10;
+            break;
+          case '1':
+            state = state_M11;
+            break;
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M2:
+        switch (c) {
+          case '3': // M23
+          case '8': // M28
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M3:
+        switch (c) {
+          case '0': // M30
+          case '2': // M32
+          case '3': // M33
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M10:
+        switch (c) {
+          case '8': // M108
+            { state = state_RESET; cancel_heatup_wait = true; }
+            break;
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M11:
+        switch (c) {
+          case '2': // M112
+            state = state_RESET; kill(PSTR(MSG_KILLED));
+            break;
+          case '7': // M117
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M4:
+        switch (c) {
+          case '1':
+            state = state_M41;
+            break;
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_M41:
+        switch (c) {
+          case '0':
+            { state = state_RESET; stepper.quick_stop(); }
+            break;
+          case ';':
+            state = state_IGNORE;
+            break;
+          default: state = state_RESET;
+        }
+      break;
+
+      case state_IGNORE:
+        if (c == '\n') state = state_RESET;
+      break;
+
+      default:
+        state = state_RESET;
+    }
+  }
 #endif

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -101,6 +101,11 @@ struct ring_buffer {
   extern ring_buffer rx_buffer;
 #endif
 
+#if ENABLED(EMERGENCY_PARSER)
+  #include "language.h"
+  void emergency_parser(unsigned char c);
+#endif
+
 class MarlinSerial { //: public Stream
 
   public:
@@ -141,6 +146,10 @@ class MarlinSerial { //: public Stream
             rx_buffer.head = i;
           }
         CRITICAL_SECTION_END;
+
+        #if ENABLED(EMERGENCY_PARSER)
+          emergency_parser(c);
+        #endif
       }
     }
 

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -567,6 +567,13 @@
 #endif
 
 /**
+ * emergency-command parser
+ */
+#if ENABLED(EMERGENCY_PARSER) && ENABLED(USBCON)
+  #error "EMERGENCY_PARSER does not work on boards with AT90USB processors (USBCON)."
+#endif
+
+ /**
  * Warnings for old configurations
  */
 #if WATCH_TEMP_PERIOD > 500

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -526,6 +526,11 @@ const unsigned int dropsegments = 2; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 26
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 8
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -528,6 +528,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -522,6 +522,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -522,6 +522,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -521,6 +521,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -526,6 +526,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -522,6 +522,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -520,6 +520,11 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 #define MAX_CMD_SIZE 96
 #define BUFSIZE 4
 
+// EMERGENCY_PARSER activates an emergency-command parser before the command is entered into the serial receive buffer.
+// Currently handles M112, M410, M108
+// Does not work on boards using AT90USB (USBCON) processors!
+#define EMERGENCY_PARSER
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -128,7 +128,7 @@
 #define MSG_INVALID_EXTRUDER                "Invalid extruder"
 #define MSG_INVALID_SOLENOID                "Invalid solenoid"
 #define MSG_ERR_NO_THERMISTORS              "No thermistors - no temperature"
-#define MSG_M115_REPORT                     "FIRMWARE_NAME:Marlin " DETAILED_BUILD_VERSION " SOURCE_CODE_URL:" SOURCE_CODE_URL " PROTOCOL_VERSION:" PROTOCOL_VERSION " MACHINE_TYPE:" MACHINE_NAME " EXTRUDER_COUNT:" STRINGIFY(EXTRUDERS) " UUID:" MACHINE_UUID "\n"
+#define MSG_M115_REPORT                     "FIRMWARE_NAME:Marlin " DETAILED_BUILD_VERSION " SOURCE_CODE_URL:" SOURCE_CODE_URL " PROTOCOL_VERSION:" PROTOCOL_VERSION " MACHINE_TYPE:" MACHINE_NAME " EXTRUDER_COUNT:" STRINGIFY(EXTRUDERS) " UUID:" MACHINE_UUID EMERGENCY_PARSER_CAPABILITIES "\n"
 #define MSG_COUNT_X                         " Count X: "
 #define MSG_COUNT_A                         " Count A: "
 #define MSG_ERR_KILLED                      "Printer halted. kill() called!"

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -238,8 +238,10 @@ unsigned char Temperature::soft_pwm[HOTENDS];
       soft_pwm_bed = bias = d = (MAX_BED_POWER) / 2;
     #endif
 
+    cancel_heatup_wait = false;
+
     // PID Tuning loop
-    for (;;) {
+    while (!cancel_heatup_wait) {
 
       millis_t ms = millis();
 
@@ -420,6 +422,9 @@ unsigned char Temperature::soft_pwm[HOTENDS];
         return;
       }
       lcd_update();
+    }
+    if (cancel_heatup_wait) {
+      disable_all_heaters();
     }
   }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -559,7 +559,7 @@ static void lcd_status_screen() {
       stepper.quick_stop();
       print_job_timer.stop();
       thermalManager.autotempShutdown();
-      cancel_heatup = true;
+      cancel_heatup_wait = true;
       lcd_setstatus(MSG_PRINT_ABORTED, true);
       #if DISABLED(DELTA) && DISABLED(SCARA)
         set_current_position_from_planner();

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -95,7 +95,7 @@
   extern int absPreheatHPBTemp;
   extern int absPreheatFanSpeed;
 
-  extern bool cancel_heatup;
+  extern bool cancel_heatup_wait;
 
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     extern millis_t previous_lcd_status_ms;


### PR DESCRIPTION
Add a emergency-command parser in MarlinSerial located in MarlinSerial's RX interrupt.

The parser tries to find and execute M112,M108,M410 before the commands disappear in the RX-buffer.
To avoid false positives M117, comments and commands followed by filenames (M23, M28, M30, M32, M33) are recognized.

This enables Marlin to receive and react on the Emergency command at every time - regardless of if the buffers are full or not. Remains the task to convince the hosts to send the commands. To inform the hosts about the new feature a new entry in the M115-report was made. "EMERGENCY_CODES:M112,M108,M410;".

The parser is fast. It allways only needs two switch decisions and one assignment of the new state for every character.

One proble remains. If the host has send a incomplete line before sending an emergency command the emergency commamd could be omittet when the parser is in `state_IGNORE`.
In that case the host should send "\ncommand\n"

Also introducing M108 to break the waiting for the heaters in M109, M190 and M303.

Rename `cancel_heatup` to `cancel_heatup_wait` to better see the purpose.
