### PR TITLE
Readable DEBUG output (and some spaces removed at EOL)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -574,21 +574,24 @@ static void report_current_position();
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
   void print_xyz(const char* suffix, const float x, const float y, const float z) {
-    SERIAL_ECHOPAIR("(", x);
+    SERIAL_ECHOPAIR(" (", x);
     SERIAL_ECHOPAIR(", ", y);
     SERIAL_ECHOPAIR(", ", z);
-    SERIAL_ECHOLNPGM(") ");
+    SERIAL_ECHO(") ");
     SERIAL_ECHO(suffix);
+    SERIAL_EOL;
   }
+
   void print_xyz(const char* suffix, const float xyz[]) {
     print_xyz(suffix, xyz[X_AXIS], xyz[Y_AXIS], xyz[Z_AXIS]);
   }
+
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     void print_xyz(const char* suffix, const vector_3 &xyz) {
       print_xyz(suffix, xyz.x, xyz.y, xyz.z);
     }
   #endif
-  #define DEBUG_POS(PREFIX,VAR) do{ SERIAL_ECHOPGM(PREFIX); print_xyz(" > " STRINGIFY(VAR), VAR); }while(0)
+  #define DEBUG_POS(PREFIX,VAR) do{ SERIAL_ECHOPGM(PREFIX); print_xyz("> " STRINGIFY(VAR), VAR); }while(0)
 #endif
 
 #if ENABLED(DELTA) || ENABLED(SCARA)
@@ -1965,6 +1968,7 @@ static void clean_up_after_endstop_or_probe_move() {
       if (DEBUGGING(LEVELING)) {
         DEBUG_POS("set_probe_deployed", current_position);
         SERIAL_ECHOPAIR("deploy: ", deploy);
+        SERIAL_EOL;
       }
     #endif
 
@@ -4333,7 +4337,7 @@ inline void gcode_M104() {
 
     #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
       /**
-       * Stop the timer at the end of print, starting is managed by 
+       * Stop the timer at the end of print, starting is managed by
        * 'heat and wait' M109.
        * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
        * stand by mode, for instance in a dual extruder setup, without affecting
@@ -4645,7 +4649,7 @@ inline void gcode_M109() {
       #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
         if (code_value_temp_abs() > BED_MINTEMP) {
           /**
-          * We start the timer when 'heating and waiting' command arrives, LCD 
+          * We start the timer when 'heating and waiting' command arrives, LCD
           * functions never wait. Cooling down managed by extruders.
           *
           * We do not check if the timer is already running because this check will


### PR DESCRIPTION
Please refer to #4263...  

Because of @Blue-Marlin and @thinkyhead, we now have a much better formatted DEBUG info...

Accessorily my editor removed some white space at the end of some lines... I did not feel like reverting those.
