### PR TITLE
Support for VIKI2 with MKS 1.3 / 1.4

### DIFF
--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -37,6 +37,88 @@
 #define HEATER_1_PIN        7 // EXTRUDER 2 (-1 on RAMPS 1.4)
 
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)
-  //#undef SD_DETECT_PIN
-  //#define SD_DETECT_PIN 49  // For easy adapter board
+  /**
+   * VIKI2 Has two groups of wires with...
+   *
+   * +Vin     + Input supply, requires 120ma for LCD and mSD card
+   * GND      Ground Pin
+   * MOSI     Data input for LCD and SD
+   * MISO     Data output for SD
+   * SCK      Clock for LCD and SD
+   * AO       Reg. Sel for LCD
+   * LCS      Chip Select for LCD
+   * SDCS     Chip Select for SD
+   * SDCD     Card Detect pin for SD
+   * ENCA     Encoder output A
+   * ENCB     Encoder output B
+   * ENCBTN   Encoder button switch
+   *
+   * BTN      Panel mounted button switch
+   * BUZZER   Piezo buzzer
+   * BLUE-LED Blue LED ring pin (3 to 5v, mosfet buffered)
+   * RED-LED  Red LED ring pin (3 to 5v, mosfet buffered)
+   *
+   * This configuration uses the following arrangement:
+   *
+   * EXP1 D37 = EN2   D35 = EN1     EXP2 D50 = MISO  D52 = SCK
+   *      D17 = BLUE  D16 = RED          D31 = ENC   D53 = SDCS
+   *      D23 = KILL  D25 = BUZZ         D33 = ---   D51 = MOSI
+   *      D27 = A0    D29 = LCS          D49 = SDCD  RST = ---
+   *      GND = GND   5V  = 5V           GND = ---   D41 = ---
+   */
+
+  #undef BTN_EN1
+  #undef BTN_EN2
+  #undef BTN_ENC
+  #undef DOGLCD_A0
+  #undef DOGLCD_CS
+  #undef SD_DETECT_PIN
+  #undef BEEPER_PIN
+  #undef KILL_PIN
+
+  //
+  // VIKI2 12-wire lead
+  //
+
+  // orange/white         SDCD
+  #define SD_DETECT_PIN   49
+
+  // white                ENCA
+  #define BTN_EN1         35
+
+  // green                ENCB
+  #define BTN_EN2         37
+
+  // purple               ENCBTN
+  #define BTN_ENC         31
+
+  // brown                A0
+  #define DOGLCD_A0       27
+
+  // green/white          LCS
+  #define DOGLCD_CS       29
+
+                       // 50    gray   MISO
+                       // 51    yellow MOSI
+                       // 52    orange SCK
+
+  // blue                 SDCS
+  //#define SDSS            53
+
+  //
+  // VIKI2 4-wire lead
+  //
+
+  // blue                 BTN
+  #define KILL_PIN        23
+
+  // green                BUZZER
+  #define BEEPER_PIN      25
+
+  // yellow               RED-LED
+  #define STAT_LED_RED    16
+
+  // white                BLUE-LED
+  #define STAT_LED_BLUE   17
+
 #endif

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -141,22 +141,30 @@
 
 #if ENABLED(ULTRA_LCD)
 
+  #if ENABLED(NEWPANEL) && ENABLED(PANEL_ONE)
+    #define LCD_PINS_RS 40
+    #define LCD_PINS_ENABLE 42
+    #define LCD_PINS_D4 65
+    #define LCD_PINS_D5 66
+    #define LCD_PINS_D6 44
+    #define LCD_PINS_D7 64
+  #else
+    #define BEEPER_PIN 33
+    #define LCD_PINS_RS 16
+    #define LCD_PINS_ENABLE 17
+    #define LCD_PINS_D4 23
+    #define LCD_PINS_D5 25
+    #define LCD_PINS_D6 27
+    #define LCD_PINS_D7 29
+    // Buttons are attached to a shift register
+    // Not wired yet
+    //#define SHIFT_CLK 38
+    //#define SHIFT_LD 42
+    //#define SHIFT_OUT 40
+    //#define SHIFT_EN 17
+  #endif
+
   #if ENABLED(NEWPANEL)
-    #if ENABLED(PANEL_ONE)
-      #define LCD_PINS_RS 40
-      #define LCD_PINS_ENABLE 42
-      #define LCD_PINS_D4 65
-      #define LCD_PINS_D5 66
-      #define LCD_PINS_D6 44
-      #define LCD_PINS_D7 64
-    #else
-      #define LCD_PINS_RS 16
-      #define LCD_PINS_ENABLE 17
-      #define LCD_PINS_D4 23
-      #define LCD_PINS_D5 25
-      #define LCD_PINS_D6 27
-      #define LCD_PINS_D7 29
-    #endif
 
     #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
       #define BEEPER_PIN 37
@@ -272,26 +280,7 @@
       #endif
 
     #endif
-  #else // !NEWPANEL (Old-style panel with shift register)
-
-    // No Beeper added
-    #define BEEPER_PIN 33
-
-    // Buttons are attached to a shift register
-    // Not wired yet
-    //#define SHIFT_CLK 38
-    //#define SHIFT_LD 42
-    //#define SHIFT_OUT 40
-    //#define SHIFT_EN 17
-
-    #define LCD_PINS_RS 16
-    #define LCD_PINS_ENABLE 17
-    #define LCD_PINS_D4 23
-    #define LCD_PINS_D5 25
-    #define LCD_PINS_D6 27
-    #define LCD_PINS_D7 29
-
-  #endif // !NEWPANEL
+  #endif // NEWPANEL
 
 #endif // ULTRA_LCD
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -189,9 +189,10 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     static void menu_action_sddirectory(const char* filename, char* longFilename);
   #endif
 
-  #define ENCODER_FEEDRATE_DEADZONE 10
-
   #if DISABLED(LCD_I2C_VIKI)
+    #ifndef ENCODER_FEEDRATE_DEADZONE
+      #define ENCODER_FEEDRATE_DEADZONE 10
+    #endif
     #ifndef ENCODER_STEPS_PER_MENU_ITEM
       #define ENCODER_STEPS_PER_MENU_ITEM 5
     #endif
@@ -199,6 +200,9 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
       #define ENCODER_PULSES_PER_STEP 1
     #endif
   #else
+    #ifndef ENCODER_FEEDRATE_DEADZONE
+      #define ENCODER_FEEDRATE_DEADZONE 4
+    #endif
     #ifndef ENCODER_STEPS_PER_MENU_ITEM
       #define ENCODER_STEPS_PER_MENU_ITEM 2 // VIKI LCD rotary encoder uses a different number of steps per rotation
     #endif


### PR DESCRIPTION
There's no "official" layout for connecting a Viki 2 to an MKS Gen 1.3 and up. But I had to do this today, so here's how I chose to wire them together. I wired all the leads in the 4-wire group to EXP1 and most of the leads in the 12-wire group to EXP2.

So far I can't get the `BTN_ENC` pin to register in the firmware, but this might just be a hardware problem with this display. (I tried assigning `KILL_PIN` to the pin where I connected the purple ENCBTN lead but it didn't register as a kill pin either. So I think the purple lead is just dead on this unit.)
# 

![mks-gen-v1 3-1 4-viki2](https://cloud.githubusercontent.com/assets/698003/16756814/6d188540-47bc-11e6-9ae8-c0dc79dab4b1.gif)

```
 EXP1 D37 = EN2   D35 = EN1     EXP2 D50 = MISO  D52 = SCK
      D17 = BLUE  D16 = RED          D31 = ENC   D53 = SDCS (SDSS)
      D23 = KILL  D25 = BUZZ         D33 = ---   D51 = MOSI
      D27 = A0    D29 = CS           D49 = SDCD  RST = ---
      GND = GND   5V  = 5V           GND = ---   D41 = ---
```
