### PR TITLE
Don't use UTF-strlen() if the text is not UTF

### DIFF
--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_AN_H
 #define LANGUAGE_AN_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_CA_H
 #define LANGUAGE_CA_H
 
-//#define MAPPER_NON
 #define MAPPER_C2C3  // because of "ó"
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -29,8 +29,6 @@
  */
 #ifndef LANGUAGE_CN_H
 #define LANGUAGE_CN_H
-
-#define MAPPER_NON         // For direct ascii codes
 #define DISPLAY_CHARSET_ISO10646_CN
 
 #define WELCOME_MSG                         "\xa4\xa5\xa6\xa7"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -34,7 +34,6 @@
 #ifndef LANGUAGE_CZ_H
 #define LANGUAGE_CZ_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -35,10 +35,6 @@
   #define DISPLAY_CHARSET_ISO10646_1 // use the better font on full graphic displays.
 #endif
 
-#if DISABLED(MAPPER_NON) && DISABLED(MAPPER_C2C3) && DISABLED(MAPPER_D0D1) && DISABLED(MAPPER_D0D1_MOD) && DISABLED(MAPPER_E382E383) && DISABLED(MAPPER_CECF)
-  #define MAPPER_NON         // For direct ascii codes
-#endif
-
 #ifndef WELCOME_MSG
   #define WELCOME_MSG                         MACHINE_NAME " ready."
 #endif

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_ES_H
 #define LANGUAGE_ES_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_EU_H
 #define LANGUAGE_EU_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_FR_H
 #define LANGUAGE_FR_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_hr.h
+++ b/Marlin/language_hr.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_HR_H
 #define LANGUAGE_HR_H
 
-#define MAPPER_NON
 
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_IT_H
 #define LANGUAGE_IT_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -31,7 +31,6 @@
 #ifndef LANGUAGE_KANA_H
 #define LANGUAGE_KANA_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 #define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_KANA

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_NL_H
 #define LANGUAGE_NL_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_PL_H
 #define LANGUAGE_PL_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_PT_BR_H
 #define LANGUAGE_PT_BR_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_PT_BR_UTF_H
 #define LANGUAGE_PT_BR_UTF_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_PT_H
 #define LANGUAGE_PT_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_PT_UTF_H
 #define LANGUAGE_PT_UTF_H
 
-#define MAPPER_NON
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1

--- a/Marlin/language_test.h
+++ b/Marlin/language_test.h
@@ -46,11 +46,10 @@
 //   Kanji (an other Japanese symbol set) uses far more than two codepages. So currently I don't see a chance to map the Unicodes. Its not
 //   impossible to have a close to direct mapping but will need giant conversion tables and fonts (we don't want to have in a embedded system).
 
-
-#define MAPPER_NON         // For direct ascii codes ( until now all languages except ru, de, fi, kana_utf8, ... )
 //#define MAPPER_C2C3        // For most European languages when language file is in utf8
 //#define MAPPER_D0D1        // For Cyrillic
 //#define MAPPER_E382E383    // For Katakana
+//#define MAPPER_NON         // For direct ascii codes. Fall back mapper - if no other is defined.
 
 // Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
 //#define SIMULATE_ROMFONT

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2481,7 +2481,11 @@ void lcd_init() {
 int lcd_strlen(const char* s) {
   int i = 0, j = 0;
   while (s[i]) {
-    if ((s[i] & 0xc0) != 0x80) j++;
+    #ifdef MAPPER_NON
+      j++;
+    #else
+      if ((s[i] & 0xc0) != 0x80) j++;
+    #endif
     i++;
   }
   return j;
@@ -2490,7 +2494,11 @@ int lcd_strlen(const char* s) {
 int lcd_strlen_P(const char* s) {
   int j = 0;
   while (pgm_read_byte(s)) {
-    if ((pgm_read_byte(s) & 0xc0) != 0x80) j++;
+    #ifdef MAPPER_NON
+      j++; 
+    #else
+      if ((pgm_read_byte(s) & 0xc0) != 0x80) j++;
+    #endif
     s++;
   }
   return j;

--- a/Marlin/utf_mapper.h
+++ b/Marlin/utf_mapper.h
@@ -146,14 +146,7 @@
   #endif // DISPLAY_CHARSET_HD44780
 #endif // SIMULATE_ROMFONT
 
-#if ENABLED(MAPPER_NON)
-
-  char charset_mapper(char c) {
-    HARDWARE_CHAR_OUT( c );
-    return 1;
-  }
-
-#elif ENABLED(MAPPER_C2C3)
+#if ENABLED(MAPPER_C2C3)
 
   char charset_mapper(char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
@@ -353,8 +346,13 @@
 
 #else
 
-  #error "You have to define one of the DISPLAY_INPUT_CODE_MAPPERs in your language_xx.h file" // should not occur because (en) will set.
+  #define MAPPER_NON
 
-#endif // code mappers
+  char charset_mapper(char c) {
+    HARDWARE_CHAR_OUT( c );
+    return 1;
+  }
+
+  #endif // code mappers
 
 #endif // UTF_MAPPER_H


### PR DESCRIPTION
Don't use UTF-strlen() if the text is not UTF.
Make MAPPER_NON the fall back mapper.
