### PR TITLE
Sled-probe sanity fix, conditionals for remaining types of leveling

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -818,6 +818,16 @@
     #ifndef DELTA_DIAGONAL_ROD_TRIM_TOWER_3
       #define DELTA_DIAGONAL_ROD_TRIM_TOWER_3 0.0
     #endif
+    #if ENABLED(AUTO_BED_LEVELING_GRID)
+      #define DELTA_BED_LEVELING_GRID
+    #endif
+  #endif
+
+  /**
+   * When not using other bed leveling...
+   */
+  #if ENABLED(AUTO_BED_LEVELING_FEATURE) && DISABLED(AUTO_BED_LEVELING_GRID) && DISABLED(DELTA_BED_LEVELING_GRID)
+    #define AUTO_BED_LEVELING_3POINT
   #endif
 
   /**

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -202,11 +202,9 @@
 #if ENABLED(MESH_BED_LEVELING)
   #if ENABLED(DELTA)
     #error "MESH_BED_LEVELING does not yet support DELTA printers."
-  #endif
-  #if ENABLED(AUTO_BED_LEVELING_FEATURE)
+  #elif ENABLED(AUTO_BED_LEVELING_FEATURE)
     #error "Select AUTO_BED_LEVELING_FEATURE or MESH_BED_LEVELING, not both."
-  #endif
-  #if MESH_NUM_X_POINTS > 7 || MESH_NUM_Y_POINTS > 7
+  #elif MESH_NUM_X_POINTS > 7 || MESH_NUM_Y_POINTS > 7
     #error "MESH_NUM_X_POINTS and MESH_NUM_Y_POINTS need to be less than 8."
   #endif
 #elif ENABLED(MANUAL_BED_LEVELING)
@@ -218,6 +216,10 @@
  */
 
 #if PROBE_SELECTED
+
+  #if ENABLED(Z_PROBE_SLED) && ENABLED(DELTA)
+    #error "You cannot use Z_PROBE_SLED with DELTA."
+  #endif
 
   /**
    * NUM_SERVOS is required for a Z servo probe
@@ -327,6 +329,13 @@
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)
 
   /**
+   * Delta has limited bed leveling options
+   */
+  #if ENABLED(DELTA) && DISABLED(AUTO_BED_LEVELING_GRID)
+    #error "You must use AUTO_BED_LEVELING_GRID for DELTA bed leveling."
+  #endif
+
+  /**
    * Require a Z min pin
    */
   #if !PIN_EXISTS(Z_MIN)
@@ -408,25 +417,6 @@
  */
 #if ENABLED(U8GLIB_SSD1306) && ENABLED(U8GLIB_SH1106)
   #error "Only enable one SAV_3DGLCD display type: U8GLIB_SSD1306 or U8GLIB_SH1106."
-#endif
-
-/**
- * Delta has limited bed leveling options
- */
-#if ENABLED(DELTA)
-
-  #if ENABLED(AUTO_BED_LEVELING_FEATURE)
-
-    #if DISABLED(AUTO_BED_LEVELING_GRID)
-      #error "Only AUTO_BED_LEVELING_GRID is supported with DELTA."
-    #endif
-
-    #if ENABLED(Z_PROBE_SLED)
-      #error "You cannot use Z_PROBE_SLED with DELTA."
-    #endif
-
-  #endif
-
 #endif
 
 /**

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -129,18 +129,16 @@ float Planner::previous_nominal_speed;
  * Class and Instance Methods
  */
 
-Planner::Planner() {
-  #if ENABLED(AUTO_BED_LEVELING_FEATURE)
-    bed_level_matrix.set_to_identity();
-  #endif
-  init();
-}
+Planner::Planner() { init(); }
 
 void Planner::init() {
   block_buffer_head = block_buffer_tail = 0;
   memset(position, 0, sizeof(position)); // clear position
   for (int i = 0; i < NUM_AXIS; i++) previous_speed[i] = 0.0;
   previous_nominal_speed = 0.0;
+  #if ENABLED(AUTO_BED_LEVELING_FEATURE)
+    bed_level_matrix.set_to_identity();
+  #endif
 }
 
 /**


### PR DESCRIPTION
- Move planner matrix init to `planner.init`
- Delta Grid Leveling conditional `DELTA_BED_LEVELING_GRID`
- 3-Point Leveling conditional `AUTO_BED_LEVELING_3POINT`
