### PR TITLE
No delay for the smallest LCD moves

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1707,12 +1707,6 @@ static void clean_up_after_endstop_or_probe_move() {
 
   /**
    * Raise Z to a minimum height to make room for a probe to move
-   *
-   * zprobe_zoffset: Negative of the Z height where the probe engages
-   *        z_raise: The probing raise distance
-   *
-   * The zprobe_zoffset is negative for a switch below the nozzle, so
-   * multiply by Z_HOME_DIR (-1) to move enough away from the bed.
    */
   inline void do_probe_raise(float z_raise) {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -1723,7 +1717,7 @@ static void clean_up_after_endstop_or_probe_move() {
     #endif
     float z_dest = home_offset[Z_AXIS] + z_raise;
 
-    if ((Z_HOME_DIR) < 0 && zprobe_zoffset < 0)
+    if (zprobe_zoffset < 0)
       z_dest -= zprobe_zoffset;
 
     if (z_dest > current_position[Z_AXIS])

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1303,12 +1303,14 @@ void kill_screen(const char* lcd_msg) {
 
   #endif // DELTA_CALIBRATION_MENU
 
+  float move_menu_scale;
+
   /**
    * If the most recent manual move hasn't been fed to the planner yet,
    * and the planner can accept one, send immediately
    */
   inline void manage_manual_move() {
-    if (manual_move_axis != (int8_t)NO_AXIS && millis() >= manual_move_start_time && !planner.is_full()) {
+    if (manual_move_axis != (int8_t)NO_AXIS && ELAPSED(millis(), manual_move_start_time) && !planner.is_full()) {
       #if ENABLED(DELTA)
         calculate_delta(current_position);
         planner.buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], current_position[E_AXIS], manual_feedrate[manual_move_axis]/60, manual_move_e_index);
@@ -1331,7 +1333,7 @@ void kill_screen(const char* lcd_msg) {
     #if EXTRUDERS > 1
       if (axis == E_AXIS) manual_move_e_index = eindex >= 0 ? eindex : active_extruder;
     #endif
-    manual_move_start_time = millis() + 500UL; // 1/2 second delay
+    manual_move_start_time = millis() + (move_menu_scale < 0.99 ? 0UL : 250UL); // delay for bigger moves
     manual_move_axis = (int8_t)axis;
   }
 
@@ -1340,8 +1342,6 @@ void kill_screen(const char* lcd_msg) {
    * "Prepare" > "Move Axis" submenu
    *
    */
-
-  float move_menu_scale;
 
   static void _lcd_move_xyz(const char* name, AxisEnum axis, float min, float max) {
     if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }


### PR DESCRIPTION
Apply a 1/4 second delay for manual moves of 1mm or greater, but no delay for smaller moves.
- Sneak in a commit fixing probe raise on Delta and other Max-Z endstop machines.
