### PR TITLE
Add Cartesio CN Controls V11

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -29,6 +29,7 @@
 #define BOARD_GEN7_12           11   // Gen7 v1.1, v1.2
 #define BOARD_GEN7_13           12   // Gen7 v1.3
 #define BOARD_GEN7_14           13   // Gen7 v1.4
+#define BOARD_CNCONTROLS_11     111  // Cartesio CN Controls V11
 #define BOARD_CNCONTROLS_12     112  // Cartesio CN Controls V12
 #define BOARD_CHEAPTRONIC       2    // Cheaptronic v1.0
 #define BOARD_SETHI             20   // Sethi 3D_1

--- a/Marlin/dogm_lcd_implementation.h
+++ b/Marlin/dogm_lcd_implementation.h
@@ -145,8 +145,13 @@
   //U8GLIB_ST7920_128X64_RRD u8g(0,0,0);
   U8GLIB_ST7920_128X64_RRD u8g(0);
 #elif defined(CARTESIO_UI)
-  // The CartesioUI display with SW-SPI
-  U8GLIB_DOGM128 u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);
+  // The CartesioUI display
+  #if DOGLCD_MOSI != -1 && DOGLCD_SCK != -1
+    // using SW-SPI
+    U8GLIB_DOGM128 u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);
+  #else
+    U8GLIB_DOGM128 u8g(DOGLCD_CS, DOGLCD_A0);
+  #endif
 #elif ENABLED(U8GLIB_LM6059_AF)
   // Based on the Adafruit ST7565 (http://www.adafruit.com/products/250)
   U8GLIB_LM6059 u8g(DOGLCD_CS, DOGLCD_A0);

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -118,6 +118,7 @@
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
+  //#define MOTHERBOARD BOARD_CNCONTROLS_11
   #define MOTHERBOARD BOARD_CNCONTROLS_12
 #endif
 

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -31,6 +31,8 @@
   #include "pins_GEN7_13.h"
 #elif MB(GEN7_14)
   #include "pins_GEN7_14.h"
+#elif MB(CNCONTROLS_11)
+  #include "pins_CNCONTROLS_11.h"
 #elif MB(CNCONTROLS_12)
   #include "pins_CNCONTROLS_12.h"
 #elif MB(CHEAPTRONIC)
@@ -422,4 +424,3 @@
 #define HAS_DIGIPOTSS (PIN_EXISTS(DIGIPOTSS))
 
 #endif //__PINS_H
-

--- a/Marlin/pins_CNCONTROLS_11.h
+++ b/Marlin/pins_CNCONTROLS_11.h
@@ -1,0 +1,101 @@
+/**
+ * CartesioV11 pin assignments
+ */
+
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
+  #error Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu.
+#endif
+
+#define BOARD_NAME            "CN Controls V11"
+
+//#define LARGE_FLASH true
+
+#define X_ENABLE_PIN          35
+#define X_STEP_PIN            34
+#define X_DIR_PIN             36
+#define X_MIN_PIN             43
+#define X_MAX_PIN             -1
+
+#define Y_ENABLE_PIN          38
+#define Y_STEP_PIN            37
+#define Y_DIR_PIN             39
+#define Y_MIN_PIN             45
+#define Y_MAX_PIN             -1
+
+#define Z_ENABLE_PIN          41
+#define Z_STEP_PIN            40
+#define Z_DIR_PIN             48
+#define Z_MIN_PIN             42
+#define Z_MAX_PIN             -1
+
+#define E0_ENABLE_PIN          3
+#define E0_STEP_PIN           29
+#define E0_DIR_PIN            28
+#define HEATER_0_PIN           5
+#define TEMP_0_PIN             0  // ANALOG INPUT !!
+
+#define E1_ENABLE_PIN         60
+#define E1_STEP_PIN           61
+#define E1_DIR_PIN            62
+#define HEATER_1_PIN          58
+#define TEMP_1_PIN             3  // 3 for tool2 -> 2 for chambertemp
+
+#define E2_ENABLE_PIN         16
+#define E2_STEP_PIN           15
+#define E2_DIR_PIN            14
+#define HEATER_2_PIN          64
+#define TEMP_2_PIN             2  // 9 for tool3 -> 2 for chambertemp
+
+#define E3_ENABLE_PIN         47
+#define E3_STEP_PIN           44
+#define E3_DIR_PIN            49
+#define HEATER_3_PIN          46
+#define TEMP_3_PIN            11  // 11 for tool4 -> 2 for chambertemp
+
+#define HEATER_BED_PIN         2
+#define TEMP_BED_PIN           1  // ANALOG INPUT !!
+
+// Tools
+
+//#define TOOL_0_PIN           4
+//#define TOOL_1_PIN          59
+//#define TOOL_2_PIN           8
+//#define TOOL_3_PIN          30
+//#define TOOL_PWM_PIN         7  // common PWM pin for all tools
+
+// Common I/O
+
+//#define TEMP_CHAMBER_PIN     2  // ANALOG INPUT !!
+//#define FIL_RUNOUT_PIN      -1
+//#define PWM_1_PIN           11
+//#define PWM_2_PIN           10
+//#define SPARE_IO            12
+//#define FAN_PIN              7  // common PWM pin for all tools
+
+// User interface
+#define BEEPER_PIN             6
+
+// Pins for DOGM SPI LCD Support
+#define DOGLCD_A0             26
+#define DOGLCD_CS             24
+#define DOGLCD_MOSI           -1
+#define DOGLCD_SCK            -1
+
+// The encoder and click button
+#define BTN_EN1               23
+#define BTN_EN2               25
+#define BTN_ENC               27
+
+// Hardware buttons for manual movement of XYZ
+#define SHIFT_OUT             19
+#define SHIFT_LD              18
+#define SHIFT_CLK             17
+
+//#define UI1                 31
+//#define UI2                 22
+
+// Other
+#define SDSS                  53
+#define SD_DETECT_PIN         13
+#define STAT_LED_BLUE         -1
+#define STAT_LED_RED          31

--- a/Marlin/pins_CNCONTROLS_12.h
+++ b/Marlin/pins_CNCONTROLS_12.h
@@ -32,13 +32,13 @@
 #define E0_STEP_PIN           57
 #define E0_DIR_PIN            55
 #define HEATER_0_PIN          11
-#define TEMP_0_PIN            0   // ANALOG INPUT !!
+#define TEMP_0_PIN             0  // ANALOG INPUT !!
 
 #define E1_ENABLE_PIN         60
 #define E1_STEP_PIN           61
 #define E1_DIR_PIN            62
 #define HEATER_1_PIN           9
-#define TEMP_1_PIN             9  // 9 for tool3 -> 13 for chambertemp
+#define TEMP_1_PIN             9  // 9 for tool2 -> 13 for chambertemp
 
 #define E2_ENABLE_PIN         44
 #define E2_STEP_PIN           46
@@ -86,9 +86,9 @@
 #define LCD_SCREEN_ROT_180
 
 // The encoder and click button
-#define BTN_EN1 36
-#define BTN_EN2 34
-#define BTN_ENC 38
+#define BTN_EN1               36
+#define BTN_EN2               34
+#define BTN_ENC               38
 
 // Hardware buttons for manual movement of XYZ
 #define SHIFT_OUT             42


### PR DESCRIPTION
This should add proper pins for the older CN Controls V11 board based on a schematic from the manufacturer.

I am not expecting anyone to merge this immediately and would like some feedback, suggestions first. For instance, I am not quite satisfied with the way I had to check for use of HW SPI in `dogm_lcd_implementation.h`.

cc @maukcc - perhaps you could double-check the pin assignment :wink: 
