### PR TITLE
Fixes an PSTR overflow with print_xyz()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -580,17 +580,23 @@ static void report_current_position();
     SERIAL_ECHOPAIR(", ", y);
     SERIAL_ECHOPAIR(", ", z);
     SERIAL_ECHOPGM(")");
-    serialprintPGM(suffix);
+
+    if (suffix) serialprintPGM(suffix);
+    else SERIAL_EOL;
   }
-  void print_xyz(const char* prefix,const char* suffix, const float xyz[]) {
+
+  void print_xyz(const char* prefix, const char* suffix, const float xyz[]) {
     print_xyz(prefix, suffix, xyz[X_AXIS], xyz[Y_AXIS], xyz[Z_AXIS]);
   }
+
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
-    void print_xyz(const char* prefix,const char* suffix, const vector_3 &xyz) {
+    void print_xyz(const char* prefix, const char* suffix, const vector_3 &xyz) {
       print_xyz(prefix, suffix, xyz.x, xyz.y, xyz.z);
     }
   #endif
-  #define DEBUG_POS(SUFFIX,VAR) do{ print_xyz(PSTR(STRINGIFY(VAR) "="), PSTR(" : " SUFFIX "\n"), VAR); }while(0)
+
+  #define DEBUG_POS(SUFFIX,VAR) do { \
+    print_xyz(PSTR(STRINGIFY(VAR) "="), PSTR(" : " SUFFIX "\n"), VAR); } while(0)
 #endif
 
 #if ENABLED(DELTA) || ENABLED(SCARA)
@@ -1657,7 +1663,7 @@ static void do_blocking_move_to(float x, float y, float z, float feed_rate = 0.0
   float old_feedrate = feedrate;
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) print_xyz(PSTR("do_blocking_move_to"), "", x, y, z);
+    if (DEBUGGING(LEVELING)) print_xyz(PSTR("do_blocking_move_to"), NULL, x, y, z);
   #endif
 
   #if ENABLED(DELTA)
@@ -6626,7 +6632,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
             delayed_move_time = 0;
             break;
         }
- 
+
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOPAIR("Active extruder parked: ", active_extruder_parked ? "yes" : "no");


### PR DESCRIPTION
Before:

``` cpp
>>> homeaxis(2)
> current_position=(71.00, 133.00, 5.00) : set_probe_deployed
deploy: 1do_probe_raise(5.00)
do_blocking_move_to(71.00, 133.00, 6.50)ODE_URL:https://github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:BQ Hephestos 2 EXTRUDER_COUNT:1 UUID:8d083632-40c5-4649-85b8-43d9ae6c5d55
do_blocking_move_to(71.00, 133.00, 6.50)ODE_URL:https://github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:BQ Hephestos 2 EXTRUDER_COUNT:1 UUID:8d083632-40c5-4649-85b8-43d9ae6c5d55
current_position=(71.00, 133.00, 0.00) : sync_plan_position
current_position=(71.00, 133.00, 0.00) : sync_plan_position
current_position=(71.00, 133.00, 0.00) : > TRIGGER ENDSTOP
```

After:

``` cpp
>>> homeaxis(2)
> current_position=(71.00, 133.00, 5.00) : set_probe_deployed
deploy: 1do_probe_raise(5.00)
do_blocking_move_to(71.00, 133.00, 6.50)
do_blocking_move_to(71.00, 133.00, 6.50)
current_position=(71.00, 133.00, 0.00) : sync_plan_position
current_position=(71.00, 133.00, 0.00) : sync_plan_position
current_position=(71.00, 133.00, 0.00) : > TRIGGER ENDSTOP
```
