### PR TITLE
Debug char, fix compile errors for lcd pins

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -105,6 +105,7 @@ extern const char echomagic[] PROGMEM;
 
 #define SERIAL_ECHOPAIR(name,value) (serial_echopair_P(PSTR(name),(value)))
 
+void serial_echopair_P(const char* s_P, char v);
 void serial_echopair_P(const char* s_P, int v);
 void serial_echopair_P(const char* s_P, long v);
 void serial_echopair_P(const char* s_P, float v);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -572,6 +572,7 @@ void prepare_move_to_destination();
   void plan_cubic_move(const float offset[4]);
 #endif
 
+void serial_echopair_P(const char* s_P, char v)          { serialprintPGM(s_P); SERIAL_CHAR(v); }
 void serial_echopair_P(const char* s_P, int v)           { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char* s_P, long v)          { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char* s_P, float v)         { serialprintPGM(s_P); SERIAL_ECHO(v); }

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -149,19 +149,21 @@
     #define LCD_PINS_D6 44
     #define LCD_PINS_D7 64
   #else
-    #define BEEPER_PIN 33
     #define LCD_PINS_RS 16
     #define LCD_PINS_ENABLE 17
     #define LCD_PINS_D4 23
     #define LCD_PINS_D5 25
     #define LCD_PINS_D6 27
     #define LCD_PINS_D7 29
-    // Buttons are attached to a shift register
-    // Not wired yet
-    //#define SHIFT_CLK 38
-    //#define SHIFT_LD 42
-    //#define SHIFT_OUT 40
-    //#define SHIFT_EN 17
+    #if DISABLED(NEWPANEL)
+      #define BEEPER_PIN 33
+      // Buttons are attached to a shift register
+      // Not wired yet
+      //#define SHIFT_CLK 38
+      //#define SHIFT_LD 42
+      //#define SHIFT_OUT 40
+      //#define SHIFT_EN 17
+    #endif
   #endif
 
   #if ENABLED(NEWPANEL)


### PR DESCRIPTION
- Add a character debug option, so single letters can be output
- Fix compile errors with redefined lcd pins. Reference: https://github.com/MarlinFirmware/Marlin/pull/4277#issuecomment-233170317
- Small reduction in lcd status code 
