### PR TITLE
BLTouch probe sensor

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -369,6 +369,21 @@
   #endif //!MANUAL_HOME_POSITIONS
 
   /**
+   * The BLTouch Probe emulates a servo probe
+   */
+  #if ENABLED(BLTOUCH)
+    #undef Z_ENDSTOP_SERVO_NR
+    #undef Z_SERVO_ANGLES
+    #define Z_ENDSTOP_SERVO_NR 0
+    #define Z_SERVO_ANGLES {10,90} // For BLTouch 10=deploy, 90=retract
+    #undef DEACTIVATE_SERVOS_AFTER_MOVE
+    #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+      #undef Z_MIN_ENDSTOP_INVERTING
+      #define Z_MIN_ENDSTOP_INVERTING false
+    #endif
+  #endif
+
+  /**
    * Auto Bed Leveling and Z Probe Repeatability Test
    */
   #define HAS_PROBING_PROCEDURE (ENABLED(AUTO_BED_LEVELING_FEATURE) || ENABLED(Z_MIN_PROBE_REPEATABILITY_TEST))

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -465,6 +465,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -465,6 +465,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -447,6 +447,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -445,6 +445,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -457,6 +457,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -459,6 +459,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 #define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -482,6 +482,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -442,6 +442,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -442,6 +442,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -465,6 +465,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -462,6 +462,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -473,6 +473,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -486,6 +486,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -457,6 +457,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -465,6 +465,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -507,6 +507,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -507,6 +507,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -507,6 +507,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -496,6 +496,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -505,6 +505,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 #define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -468,6 +468,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = false; // set to true to invert the l
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -455,6 +455,9 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 // its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
 
+// The BLTouch probe emulates a servo probe.
+//#define BLTOUCH
+
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0
 //#define Z_SERVO_ANGLES {70,0} // Z Servo Deploy and Stow angles

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -359,11 +359,11 @@ void Stepper::isr() {
   if (current_block) {
 
     // Update endstops state, if enabled
-    #if HAS_BED_PROBE
-      if (endstops.enabled || endstops.z_probe_enabled) endstops.update();
-    #else
-      if (endstops.enabled) endstops.update();
-    #endif
+    if (endstops.enabled
+      #if HAS_BED_PROBE
+        || endstops.z_probe_enabled
+      #endif
+    ) endstops.update();
 
     // Take multiple steps per interrupt (For high speed moves)
     for (int8_t i = 0; i < step_loops; i++) {


### PR DESCRIPTION
The BLTouch probe emulates a servo probe. This PR adds a `BLTOUCH` probe option and an entry in `Conditionals.h` to apply the appropriate servo angles.

Reference: #3902
