### PR TITLE
inline to fix warnings, smaller build size (sometimes)

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -407,11 +407,11 @@ void calculate_volumetric_multipliers();
 /**
  * Blocking movement and shorthand functions
  */
-static void do_blocking_move_to(float x, float y, float z, float fr_mm_m=0.0);
-static void do_blocking_move_to_axis_pos(AxisEnum axis, float where, float fr_mm_m=0.0);
-static void do_blocking_move_to_x(float x, float fr_mm_m=0.0);
-static void do_blocking_move_to_y(float y);
-static void do_blocking_move_to_z(float z, float fr_mm_m=0.0);
-static void do_blocking_move_to_xy(float x, float y, float fr_mm_m=0.0);
+inline void do_blocking_move_to(float x, float y, float z, float fr_mm_m=0.0);
+inline void do_blocking_move_to_axis_pos(AxisEnum axis, float where, float fr_mm_m=0.0);
+inline void do_blocking_move_to_x(float x, float fr_mm_m=0.0);
+inline void do_blocking_move_to_y(float y);
+inline void do_blocking_move_to_z(float z, float fr_mm_m=0.0);
+inline void do_blocking_move_to_xy(float x, float y, float fr_mm_m=0.0);
 
 #endif //MARLIN_H


### PR DESCRIPTION
**Background:** The compiler complains because functions declared `static` in a shared header are only defined in one compilation unit (`Marlin_main.cpp`). This is easy to fix, but it would be nice if we could use `static` for the size reduction is produces as a side-effect.
- Default config:
  - 52,426 without `static` or `inline`
  - 51,930 with `static` or `inline` – saves 496 bytes ?!
- With `NOZZLE_CLEAN` (calling these functions from 2 code units):
  - 53,854 without `static` or `inline`
  - 53,854 with `inline`
  - 53,618 with `static` – saves 236 bytes ?!
