### PR TITLE
Delta Forward Kinematics (and LOGICAL_POSITION)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,9 +99,9 @@ script:
   - opt_enable FIX_MOUNTED_PROBE Z_SAFE_HOMING
   - build_marlin
   #
-  # ...with AUTO_BED_LEVELING_FEATURE & DEBUG_LEVELING_FEATURE
+  # ...with AUTO_BED_LEVELING_FEATURE, Z_MIN_PROBE_REPEATABILITY_TEST, & DEBUG_LEVELING_FEATURE
   #
-  - opt_enable AUTO_BED_LEVELING_FEATURE DEBUG_LEVELING_FEATURE
+  - opt_enable AUTO_BED_LEVELING_FEATURE Z_MIN_PROBE_REPEATABILITY_TEST DEBUG_LEVELING_FEATURE
   - build_marlin
   #
   # Test a Sled Z Probe
@@ -365,6 +365,7 @@ script:
   # SCARA Config
   #
   - use_example_configs SCARA
+  - opt_enable AUTO_BED_LEVELING_FEATURE FIX_MOUNTED_PROBE USE_ZMIN_PLUG
   - build_marlin
   #
   # tvrrug Config need to check board type for sanguino atmega644p

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -318,6 +318,10 @@ float code_value_temp_diff();
   void calculate_delta(float cartesian[3]);
   void recalc_delta_settings(float radius, float diagonal_rod);
   float delta_safe_distance_from_top();
+  void set_current_from_steppers();
+  void set_cartesian_from_steppers();
+  void forwardKinematics(float point[3]);
+  void forwardKinematics(float z1, float z2, float z3);
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     extern int delta_grid_spacing[2];
     void adjust_delta(float cartesian[3]);

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -315,7 +315,7 @@ float code_value_temp_diff();
   extern float delta_diagonal_rod_trim_tower_1;
   extern float delta_diagonal_rod_trim_tower_2;
   extern float delta_diagonal_rod_trim_tower_3;
-  void inverse_kinematics(float cartesian[3]);
+  void inverse_kinematics(const float cartesian[3]);
   void recalc_delta_settings(float radius, float diagonal_rod);
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     extern int delta_grid_spacing[2];
@@ -323,7 +323,7 @@ float code_value_temp_diff();
   #endif
 #elif ENABLED(SCARA)
   extern float axis_scaling[3];  // Build size scaling
-  void inverse_kinematics(float cartesian[3]);
+  void inverse_kinematics(const float cartesian[3]);
   void forward_kinematics_SCARA(float f_scara[3]);
 #endif
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -317,10 +317,6 @@ float code_value_temp_diff();
   extern float delta_diagonal_rod_trim_tower_3;
   void calculate_delta(float cartesian[3]);
   void recalc_delta_settings(float radius, float diagonal_rod);
-  float delta_safe_distance_from_top();
-  void set_cartesian_from_steppers();
-  void forwardKinematics(float point[3]);
-  void forwardKinematics(float z1, float z2, float z3);
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     extern int delta_grid_spacing[2];
     void adjust_delta(float cartesian[3]);

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -318,7 +318,6 @@ float code_value_temp_diff();
   void calculate_delta(float cartesian[3]);
   void recalc_delta_settings(float radius, float diagonal_rod);
   float delta_safe_distance_from_top();
-  void set_current_from_steppers();
   void set_cartesian_from_steppers();
   void forwardKinematics(float point[3]);
   void forwardKinematics(float z1, float z2, float z3);

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -315,7 +315,7 @@ float code_value_temp_diff();
   extern float delta_diagonal_rod_trim_tower_1;
   extern float delta_diagonal_rod_trim_tower_2;
   extern float delta_diagonal_rod_trim_tower_3;
-  void calculate_delta(float cartesian[3]);
+  void inverse_kinematics(float cartesian[3]);
   void recalc_delta_settings(float radius, float diagonal_rod);
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     extern int delta_grid_spacing[2];
@@ -323,8 +323,8 @@ float code_value_temp_diff();
   #endif
 #elif ENABLED(SCARA)
   extern float axis_scaling[3];  // Build size scaling
-  void calculate_delta(float cartesian[3]);
-  void calculate_SCARA_forward_Transform(float f_scara[3]);
+  void inverse_kinematics(float cartesian[3]);
+  void forward_kinematics_SCARA(float f_scara[3]);
 #endif
 
 #if ENABLED(Z_DUAL_ENDSTOPS)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7737,7 +7737,7 @@ void clamp_to_software_endstops(float target[3]) {
     delta_diagonal_rod_2_tower_3 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_3);
   }
 
-  void inverse_kinematics(float cartesian[3]) {
+  void inverse_kinematics(const float in_cartesian[3]) {
 
     delta[TOWER_1] = sqrt(delta_diagonal_rod_2_tower_1
                           - sq(delta_tower1_x - cartesian[X_AXIS])
@@ -8353,7 +8353,7 @@ void prepare_move_to_destination() {
     //SERIAL_ECHOPGM(" delta[Y_AXIS]="); SERIAL_ECHOLN(delta[Y_AXIS]);
   }
 
-  void inverse_kinematics(float cartesian[3]) {
+  void inverse_kinematics(const float cartesian[3]) {
     // Inverse kinematics.
     // Perform SCARA IK and place results in delta[3].
     // The maths and first version were done by QHARLEY.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -336,9 +336,6 @@ float home_offset[3] = { 0 };
 // Software Endstops. Default to configured limits.
 float sw_endstop_min[3] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS };
 float sw_endstop_max[3] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
-#if ENABLED(DELTA)
-  float delta_clip_start_height = Z_MAX_POS;
-#endif
 
 #if FAN_COUNT > 0
   int fanSpeeds[FAN_COUNT] = { 0 };
@@ -481,8 +478,8 @@ static uint8_t target_extruder;
   float delta_diagonal_rod_2_tower_1 = sq(delta_diagonal_rod + delta_diagonal_rod_trim_tower_1);
   float delta_diagonal_rod_2_tower_2 = sq(delta_diagonal_rod + delta_diagonal_rod_trim_tower_2);
   float delta_diagonal_rod_2_tower_3 = sq(delta_diagonal_rod + delta_diagonal_rod_trim_tower_3);
-  //float delta_diagonal_rod_2 = sq(delta_diagonal_rod);
   float delta_segments_per_second = DELTA_SEGMENTS_PER_SECOND;
+  float delta_clip_start_height = Z_MAX_POS;
   #if ENABLED(AUTO_BED_LEVELING_FEATURE)
     int delta_grid_spacing[2] = { 0, 0 };
     float bed_level[AUTO_BED_LEVELING_GRID_POINTS][AUTO_BED_LEVELING_GRID_POINTS];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -487,6 +487,7 @@ static uint8_t target_extruder;
     int delta_grid_spacing[2] = { 0, 0 };
     float bed_level[AUTO_BED_LEVELING_GRID_POINTS][AUTO_BED_LEVELING_GRID_POINTS];
   #endif
+  float delta_safe_distance_from_top();
 #else
   static bool home_all_axis = true;
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6076,18 +6076,9 @@ inline void gcode_M400() { stepper.synchronize(); }
 
 void quickstop_stepper() {
   stepper.quick_stop();
-  #if DISABLED(DELTA) && DISABLED(SCARA)
+  #if DISABLED(SCARA)
     stepper.synchronize();
-    #if ENABLED(AUTO_BED_LEVELING_FEATURE)
-      vector_3 pos = planner.adjusted_position(); // values directly from steppers...
-      current_position[X_AXIS] = pos.x;
-      current_position[Y_AXIS] = pos.y;
-      current_position[Z_AXIS] = pos.z;
-    #else
-      current_position[X_AXIS] = stepper.get_axis_position_mm(X_AXIS);
-      current_position[Y_AXIS] = stepper.get_axis_position_mm(Y_AXIS);
-      current_position[Z_AXIS] = stepper.get_axis_position_mm(Z_AXIS);
-    #endif
+    set_current_from_steppers();
     sync_plan_position();                       // ...re-apply to planner position
   #endif
 }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7998,7 +7998,7 @@ void mesh_line_to_destination(float fr_mm_m, uint8_t x_splits = 0xff, uint8_t y_
 
       inverse_kinematics(target);
 
-      #if ENABLED(AUTO_BED_LEVELING_FEATURE)
+      #if ENABLED(DELTA) && ENABLED(AUTO_BED_LEVELING_FEATURE)
         if (!bed_leveling_in_progress) adjust_delta(target);
       #endif
 
@@ -8248,7 +8248,7 @@ void prepare_move_to_destination() {
 
       #if ENABLED(DELTA) || ENABLED(SCARA)
         inverse_kinematics(arc_target);
-        #if ENABLED(AUTO_BED_LEVELING_FEATURE)
+        #if ENABLED(DELTA) && ENABLED(AUTO_BED_LEVELING_FEATURE)
           adjust_delta(arc_target);
         #endif
         planner.buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], arc_target[E_AXIS], fr_mm_s, active_extruder);
@@ -8260,7 +8260,7 @@ void prepare_move_to_destination() {
     // Ensure last segment arrives at target location.
     #if ENABLED(DELTA) || ENABLED(SCARA)
       inverse_kinematics(target);
-      #if ENABLED(AUTO_BED_LEVELING_FEATURE)
+      #if ENABLED(DELTA) && ENABLED(AUTO_BED_LEVELING_FEATURE)
         adjust_delta(target);
       #endif
       planner.buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], target[E_AXIS], fr_mm_s, active_extruder);

--- a/Marlin/planner_bezier.cpp
+++ b/Marlin/planner_bezier.cpp
@@ -189,7 +189,7 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
     clamp_to_software_endstops(bez_target);
 
     #if ENABLED(DELTA) || ENABLED(SCARA)
-      calculate_delta(bez_target);
+      inverse_kinematics(bez_target);
       #if ENABLED(AUTO_BED_LEVELING_FEATURE)
         adjust_delta(bez_target);
       #endif

--- a/Marlin/planner_bezier.cpp
+++ b/Marlin/planner_bezier.cpp
@@ -190,7 +190,7 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
 
     #if ENABLED(DELTA) || ENABLED(SCARA)
       inverse_kinematics(bez_target);
-      #if ENABLED(AUTO_BED_LEVELING_FEATURE)
+      #if ENABLED(DELTA) && ENABLED(AUTO_BED_LEVELING_FEATURE)
         adjust_delta(bez_target);
       #endif
       planner.buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], bez_target[E_AXIS], fr_mm_s, extruder);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -564,7 +564,7 @@ void kill_screen(const char* lcd_msg) {
 
   inline void line_to_current(AxisEnum axis) {
     #if ENABLED(DELTA)
-      calculate_delta(current_position);
+      inverse_kinematics(current_position);
       planner.buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(manual_feedrate_mm_m[axis]), active_extruder);
     #else // !DELTA
       planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(manual_feedrate_mm_m[axis]), active_extruder);
@@ -1301,7 +1301,7 @@ void kill_screen(const char* lcd_msg) {
   inline void manage_manual_move() {
     if (manual_move_axis != (int8_t)NO_AXIS && ELAPSED(millis(), manual_move_start_time) && !planner.is_full()) {
       #if ENABLED(DELTA)
-        calculate_delta(current_position);
+        inverse_kinematics(current_position);
         planner.buffer_line(delta[X_AXIS], delta[Y_AXIS], delta[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(manual_feedrate_mm_m[manual_move_axis]), manual_move_e_index);
       #else
         planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], MMM_TO_MMS(manual_feedrate_mm_m[manual_move_axis]), manual_move_e_index);


### PR DESCRIPTION
Derived from AnHardt/Marlin#60

Background: Up to now, if you wanted to get the "current position" of a 3D printer based on the stepper positions, you could only do so on Cartesian, Core, and SCARA. We didn't have that for Delta. So when probing, we generally just looked at the distance traveled to figure out where Z ended up. And after a "quick stop" where the steppers were interrupted, there was no way to recover the current position from a Delta.

Considerations: Whenever we use "sub-systems" that rely on an idealized coordinate system (MBL, kinematics, etc.), we need to subtract the coordinate space offsets before using the coordinates. Otherwise `M206` and `G92` will cause havoc.

Solutions:
- Add functions to convert ABC tower positions to XYZ cartesian positions.
- Add a `set_current_from_steppers` function that works for all kinematics.
- Address bugs where the coordinate-space offsets weren't added or removed.
  - Apply `LOGICAL_POSITION` where needed to add offsets to coordinates.
  - Apply `RAW_POSITION` where needed to remove offsets from coordinates.

Additional changes:
- Consolidate `DELTA`-specific declarations in `Marlin_main.cpp`.
- Generalize kinematic function names (i.e., "kinematic" instead of "delta").
- Don't include calls to `adjust_delta` with `SCARA` (compile errors).
- Add a Travis CI test for `SCARA` with ABL.
- Add a Travis CI test for `Z_MIN_PROBE_REPEATABILITY_TEST`.
