### PR TITLE
Document DEBUG_LEVELING_FEATURE

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -669,6 +669,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -669,6 +669,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -651,6 +651,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -649,6 +649,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -661,6 +661,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -663,6 +663,10 @@
 // @section bedlevel
 
 #define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -686,6 +686,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -669,6 +669,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -669,6 +669,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -669,6 +669,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -666,6 +666,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -677,6 +677,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -690,6 +690,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -661,6 +661,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -669,6 +669,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/delta/biv2.5/Configuration.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration.h
@@ -758,6 +758,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -752,6 +752,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -755,6 +755,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -749,6 +749,10 @@
 // @section bedlevel
 
 #define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -750,6 +750,10 @@
 // @section bedlevel
 
 #define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -672,6 +672,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -659,6 +659,10 @@
 // @section bedlevel
 
 //#define AUTO_BED_LEVELING_FEATURE // Delete the comment to enable (remove // at the start of the line)
+
+// Enable this feature to get detailed logging of G28, G29, M48, etc.
+// Logging is off by default. Enable this logging feature with 'M111 S32'.
+// NOTE: Requires a huge amount of PROGMEM.
 //#define DEBUG_LEVELING_FEATURE
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)


### PR DESCRIPTION
Explain that you must use `M111 S32` to enable `DEBUG_LEVELING_FEATURE`.

Website documentation will of course mention that you can add on other debug bits.
