### PR TITLE
Banish do_blocking_move_to_axis_pos

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -407,9 +407,7 @@ void calculate_volumetric_multipliers();
  * Blocking movement and shorthand functions
  */
 inline void do_blocking_move_to(float x, float y, float z, float fr_mm_m=0.0);
-inline void do_blocking_move_to_axis_pos(AxisEnum axis, float where, float fr_mm_m=0.0);
 inline void do_blocking_move_to_x(float x, float fr_mm_m=0.0);
-inline void do_blocking_move_to_y(float y);
 inline void do_blocking_move_to_z(float z, float fr_mm_m=0.0);
 inline void do_blocking_move_to_xy(float x, float y, float fr_mm_m=0.0);
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1755,15 +1755,15 @@ void do_blocking_move_to(float x, float y, float z, float fr_mm_m /*=0.0*/) {
 
   feedrate_mm_m = old_feedrate_mm_m;
 }
-
-void do_blocking_move_to_axis_pos(AxisEnum axis, float where, float fr_mm_m/*=0.0*/) {
-  current_position[axis] = where;
-  do_blocking_move_to(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], fr_mm_m);
+void do_blocking_move_to_x(float x, float fr_mm_m/*=0.0*/) {
+  do_blocking_move_to(x, current_position[Y_AXIS], current_position[Z_AXIS], fr_mm_m);
 }
-void do_blocking_move_to_x(float x, float fr_mm_m/*=0.0*/) { do_blocking_move_to_axis_pos(X_AXIS, x, fr_mm_m); }
-void do_blocking_move_to_y(float y) { do_blocking_move_to_axis_pos(Y_AXIS, y); }
-void do_blocking_move_to_z(float z, float fr_mm_m/*=0.0*/) { do_blocking_move_to_axis_pos(Z_AXIS, z, fr_mm_m); }
-void do_blocking_move_to_xy(float x, float y, float fr_mm_m/*=0.0*/) { do_blocking_move_to(x, y, current_position[Z_AXIS], fr_mm_m); }
+void do_blocking_move_to_z(float z, float fr_mm_m/*=0.0*/) {
+  do_blocking_move_to(current_position[X_AXIS], current_position[Y_AXIS], z, fr_mm_m);
+}
+void do_blocking_move_to_xy(float x, float y, float fr_mm_m/*=0.0*/) {
+  do_blocking_move_to(x, y, current_position[Z_AXIS], fr_mm_m);
+}
 
 //
 // Prepare to do endstop or probe moves


### PR DESCRIPTION
Forgot that `do_blocking_move_to_axis_pos` broke the rules and set `current_position[axis]` before calling `do_blocking_move_to`. A lucky hit. Fixed the same issue earlier but missed this instance.
