### PR TITLE
Arrange stepper_indirection by axis

### DIFF
--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -42,6 +42,7 @@
 */
 
 #include "stepper_indirection.h"
+
 #include "Configuration.h"
 
 #if ENABLED(HAVE_TMCDRIVER)

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -44,144 +44,311 @@
 #ifndef STEPPER_INDIRECTION_H
 #define STEPPER_INDIRECTION_H
 
-#include "macros.h"
+#include "Configuration.h"
 
-// X motor
+// TMC26X drivers have STEP/DIR on normal pins, but ENABLE via SPI
+#if ENABLED(HAVE_TMCDRIVER)
+  #include <SPI.h>
+  #include <TMC26XStepper.h>
+  void tmc_init();
+#endif
+
+// L6470 has STEP on normal pins, but DIR/ENABLE via SPI
+#if ENABLED(HAVE_L6470DRIVER)
+  #include <SPI.h>
+  #include <L6470.h>
+  void L6470_init();
+#endif
+
+// X Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(X_IS_L6470)
+  extern L6470 stepperX;
+  #define X_ENABLE_INIT NOOP
+  #define X_ENABLE_WRITE(STATE) do{if(STATE) stepperX.Step_Clock(stepperX.getStatus() & STATUS_HIZ); else stepperX.softFree();}while(0)
+  #define X_ENABLE_READ (stepperX.getStatus() & STATUS_HIZ)
+  #define X_DIR_INIT NOOP
+  #define X_DIR_WRITE(STATE) stepperX.Step_Clock(STATE)
+  #define X_DIR_READ (stepperX.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(X_IS_TMC)
+    extern TMC26XStepper stepperX;
+    #define X_ENABLE_INIT NOOP
+    #define X_ENABLE_WRITE(STATE) stepperX.setEnabled(STATE)
+    #define X_ENABLE_READ stepperX.isEnabled()
+  #else
+    #define X_ENABLE_INIT SET_OUTPUT(X_ENABLE_PIN)
+    #define X_ENABLE_WRITE(STATE) WRITE(X_ENABLE_PIN,STATE)
+    #define X_ENABLE_READ READ(X_ENABLE_PIN)
+  #endif
+  #define X_DIR_INIT SET_OUTPUT(X_DIR_PIN)
+  #define X_DIR_WRITE(STATE) WRITE(X_DIR_PIN,STATE)
+  #define X_DIR_READ READ(X_DIR_PIN)
+#endif
 #define X_STEP_INIT SET_OUTPUT(X_STEP_PIN)
 #define X_STEP_WRITE(STATE) WRITE(X_STEP_PIN,STATE)
 #define X_STEP_READ READ(X_STEP_PIN)
 
-#define X_DIR_INIT SET_OUTPUT(X_DIR_PIN)
-#define X_DIR_WRITE(STATE) WRITE(X_DIR_PIN,STATE)
-#define X_DIR_READ READ(X_DIR_PIN)
-
-#define X_ENABLE_INIT SET_OUTPUT(X_ENABLE_PIN)
-#define X_ENABLE_WRITE(STATE) WRITE(X_ENABLE_PIN,STATE)
-#define X_ENABLE_READ READ(X_ENABLE_PIN)
-
-// X2 motor
-#if HAS_X2_ENABLE
-  #define X2_STEP_INIT SET_OUTPUT(X2_STEP_PIN)
-  #define X2_STEP_WRITE(STATE) WRITE(X2_STEP_PIN,STATE)
-  #define X2_STEP_READ READ(X2_STEP_PIN)
-
-  #define X2_DIR_INIT SET_OUTPUT(X2_DIR_PIN)
-  #define X2_DIR_WRITE(STATE) WRITE(X2_DIR_PIN,STATE)
-  #define X2_DIR_READ READ(X_DIR_PIN)
-
-  #define X2_ENABLE_INIT SET_OUTPUT(X2_ENABLE_PIN)
-  #define X2_ENABLE_WRITE(STATE) WRITE(X2_ENABLE_PIN,STATE)
-  #define X2_ENABLE_READ READ(X_ENABLE_PIN)
+// Y Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(Y_IS_L6470)
+  extern L6470 stepperY;
+  #define Y_ENABLE_INIT NOOP
+  #define Y_ENABLE_WRITE(STATE) do{if(STATE) stepperY.Step_Clock(stepperY.getStatus() & STATUS_HIZ); else stepperY.softFree();}while(0)
+  #define Y_ENABLE_READ (stepperY.getStatus() & STATUS_HIZ)
+  #define Y_DIR_INIT NOOP
+  #define Y_DIR_WRITE(STATE) stepperY.Step_Clock(STATE)
+  #define Y_DIR_READ (stepperY.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(Y_IS_TMC)
+    extern TMC26XStepper stepperY;
+    #define Y_ENABLE_INIT NOOP
+    #define Y_ENABLE_WRITE(STATE) stepperY.setEnabled(STATE)
+    #define Y_ENABLE_READ stepperY.isEnabled()
+  #else
+    #define Y_ENABLE_INIT SET_OUTPUT(Y_ENABLE_PIN)
+    #define Y_ENABLE_WRITE(STATE) WRITE(Y_ENABLE_PIN,STATE)
+    #define Y_ENABLE_READ READ(Y_ENABLE_PIN)
+  #endif
+  #define Y_DIR_INIT SET_OUTPUT(Y_DIR_PIN)
+  #define Y_DIR_WRITE(STATE) WRITE(Y_DIR_PIN,STATE)
+  #define Y_DIR_READ READ(Y_DIR_PIN)
 #endif
-
-// Y motor
 #define Y_STEP_INIT SET_OUTPUT(Y_STEP_PIN)
 #define Y_STEP_WRITE(STATE) WRITE(Y_STEP_PIN,STATE)
 #define Y_STEP_READ READ(Y_STEP_PIN)
 
-#define Y_DIR_INIT SET_OUTPUT(Y_DIR_PIN)
-#define Y_DIR_WRITE(STATE) WRITE(Y_DIR_PIN,STATE)
-#define Y_DIR_READ READ(Y_DIR_PIN)
-
-#define Y_ENABLE_INIT SET_OUTPUT(Y_ENABLE_PIN)
-#define Y_ENABLE_WRITE(STATE) WRITE(Y_ENABLE_PIN,STATE)
-#define Y_ENABLE_READ READ(Y_ENABLE_PIN)
-
-// Y2 motor
-#if HAS_Y2_ENABLE
-  #define Y2_STEP_INIT SET_OUTPUT(Y2_STEP_PIN)
-  #define Y2_STEP_WRITE(STATE) WRITE(Y2_STEP_PIN,STATE)
-  #define Y2_STEP_READ READ(Y2_STEP_PIN)
-
-  #define Y2_DIR_INIT SET_OUTPUT(Y2_DIR_PIN)
-  #define Y2_DIR_WRITE(STATE) WRITE(Y2_DIR_PIN,STATE)
-  #define Y2_DIR_READ READ(Y2_DIR_PIN)
-
-  #define Y2_ENABLE_INIT SET_OUTPUT(Y2_ENABLE_PIN)
-  #define Y2_ENABLE_WRITE(STATE) WRITE(Y2_ENABLE_PIN,STATE)
-  #define Y2_ENABLE_READ READ(Y2_ENABLE_PIN)
-#endif // Y_DUAL_STEPPER_DRIVERS
-
-// Z motor
+// Z Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(Z_IS_L6470)
+  extern L6470 stepperZ;
+  #define Z_ENABLE_INIT NOOP
+  #define Z_ENABLE_WRITE(STATE) do{if(STATE) stepperZ.Step_Clock(stepperZ.getStatus() & STATUS_HIZ); else stepperZ.softFree();}while(0)
+  #define Z_ENABLE_READ (stepperZ.getStatus() & STATUS_HIZ)
+  #define Z_DIR_INIT NOOP
+  #define Z_DIR_WRITE(STATE) stepperZ.Step_Clock(STATE)
+  #define Z_DIR_READ (stepperZ.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(Z_IS_TMC)
+    extern TMC26XStepper stepperZ;
+    #define Z_ENABLE_INIT NOOP
+    #define Z_ENABLE_WRITE(STATE) stepperZ.setEnabled(STATE)
+    #define Z_ENABLE_READ stepperZ.isEnabled()
+  #else
+    #define Z_ENABLE_INIT SET_OUTPUT(Z_ENABLE_PIN)
+    #define Z_ENABLE_WRITE(STATE) WRITE(Z_ENABLE_PIN,STATE)
+    #define Z_ENABLE_READ READ(Z_ENABLE_PIN)
+  #endif
+  #define Z_DIR_INIT SET_OUTPUT(Z_DIR_PIN)
+  #define Z_DIR_WRITE(STATE) WRITE(Z_DIR_PIN,STATE)
+  #define Z_DIR_READ READ(Z_DIR_PIN)
+#endif
 #define Z_STEP_INIT SET_OUTPUT(Z_STEP_PIN)
 #define Z_STEP_WRITE(STATE) WRITE(Z_STEP_PIN,STATE)
 #define Z_STEP_READ READ(Z_STEP_PIN)
 
-#define Z_DIR_INIT SET_OUTPUT(Z_DIR_PIN)
-#define Z_DIR_WRITE(STATE) WRITE(Z_DIR_PIN,STATE)
-#define Z_DIR_READ READ(Z_DIR_PIN)
+// X2 Stepper
+#if HAS_X2_ENABLE
+  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(X2_IS_L6470)
+    extern L6470 stepperX2;
+    #define X2_ENABLE_INIT NOOP
+    #define X2_ENABLE_WRITE(STATE) do{if(STATE) stepperX2.Step_Clock(stepperX2.getStatus() & STATUS_HIZ); else stepperX2.softFree();}while(0)
+    #define X2_ENABLE_READ (stepperX2.getStatus() & STATUS_HIZ)
+    #define X2_DIR_INIT NOOP
+    #define X2_DIR_WRITE(STATE) stepperX2.Step_Clock(STATE)
+    #define X2_DIR_READ (stepperX2.getStatus() & STATUS_DIR)
+  #else
+    #if ENABLED(HAVE_TMCDRIVER) && ENABLED(X2_IS_TMC)
+      extern TMC26XStepper stepperX2;
+      #define X2_ENABLE_INIT NOOP
+      #define X2_ENABLE_WRITE(STATE) stepperX2.setEnabled(STATE)
+      #define X2_ENABLE_READ stepperX2.isEnabled()
+    #else
+      #define X2_ENABLE_INIT SET_OUTPUT(X2_ENABLE_PIN)
+      #define X2_ENABLE_WRITE(STATE) WRITE(X2_ENABLE_PIN,STATE)
+      #define X2_ENABLE_READ READ(X2_ENABLE_PIN)
+    #endif
+    #define X2_DIR_INIT SET_OUTPUT(X2_DIR_PIN)
+    #define X2_DIR_WRITE(STATE) WRITE(X2_DIR_PIN,STATE)
+    #define X2_DIR_READ READ(X2_DIR_PIN)
+  #endif
+  #define X2_STEP_INIT SET_OUTPUT(X2_STEP_PIN)
+  #define X2_STEP_WRITE(STATE) WRITE(X2_STEP_PIN,STATE)
+  #define X2_STEP_READ READ(X2_STEP_PIN)
+#endif
 
-#define Z_ENABLE_INIT SET_OUTPUT(Z_ENABLE_PIN)
-#define Z_ENABLE_WRITE(STATE) WRITE(Z_ENABLE_PIN,STATE)
-#define Z_ENABLE_READ READ(Z_ENABLE_PIN)
+// Y2 Stepper
+#if HAS_Y2_ENABLE
+  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(Y2_IS_L6470)
+    extern L6470 stepperY2;
+    #define Y2_ENABLE_INIT NOOP
+    #define Y2_ENABLE_WRITE(STATE) do{if(STATE) stepperY2.Step_Clock(stepperY2.getStatus() & STATUS_HIZ); else stepperY2.softFree();}while(0)
+    #define Y2_ENABLE_READ (stepperY2.getStatus() & STATUS_HIZ)
+    #define Y2_DIR_INIT NOOP
+    #define Y2_DIR_WRITE(STATE) stepperY2.Step_Clock(STATE)
+    #define Y2_DIR_READ (stepperY2.getStatus() & STATUS_DIR)
+  #else
+    #if ENABLED(HAVE_TMCDRIVER) && ENABLED(Y2_IS_TMC)
+      extern TMC26XStepper stepperY2;
+      #define Y2_ENABLE_INIT NOOP
+      #define Y2_ENABLE_WRITE(STATE) stepperY2.setEnabled(STATE)
+      #define Y2_ENABLE_READ stepperY2.isEnabled()
+    #else
+      #define Y2_ENABLE_INIT SET_OUTPUT(Y2_ENABLE_PIN)
+      #define Y2_ENABLE_WRITE(STATE) WRITE(Y2_ENABLE_PIN,STATE)
+      #define Y2_ENABLE_READ READ(Y2_ENABLE_PIN)
+    #endif
+    #define Y2_DIR_INIT SET_OUTPUT(Y2_DIR_PIN)
+    #define Y2_DIR_WRITE(STATE) WRITE(Y2_DIR_PIN,STATE)
+    #define Y2_DIR_READ READ(Y2_DIR_PIN)
+  #endif
+  #define Y2_STEP_INIT SET_OUTPUT(Y2_STEP_PIN)
+  #define Y2_STEP_WRITE(STATE) WRITE(Y2_STEP_PIN,STATE)
+  #define Y2_STEP_READ READ(Y2_STEP_PIN)
+#endif
 
-// Z2 motor
+// Z2 Stepper
 #if HAS_Z2_ENABLE
+  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(Z2_IS_L6470)
+    extern L6470 stepperZ2;
+    #define Z2_ENABLE_INIT NOOP
+    #define Z2_ENABLE_WRITE(STATE) do{if(STATE) stepperZ2.Step_Clock(stepperZ2.getStatus() & STATUS_HIZ); else stepperZ2.softFree();}while(0)
+    #define Z2_ENABLE_READ (stepperZ2.getStatus() & STATUS_HIZ)
+    #define Z2_DIR_INIT NOOP
+    #define Z2_DIR_WRITE(STATE) stepperZ2.Step_Clock(STATE)
+    #define Z2_DIR_READ (stepperZ2.getStatus() & STATUS_DIR)
+  #else
+    #if ENABLED(HAVE_TMCDRIVER) && ENABLED(Z2_IS_TMC)
+      extern TMC26XStepper stepperZ2;
+      #define Z2_ENABLE_INIT NOOP
+      #define Z2_ENABLE_WRITE(STATE) stepperZ2.setEnabled(STATE)
+      #define Z2_ENABLE_READ stepperZ2.isEnabled()
+    #else
+      #define Z2_ENABLE_INIT SET_OUTPUT(Z2_ENABLE_PIN)
+      #define Z2_ENABLE_WRITE(STATE) WRITE(Z2_ENABLE_PIN,STATE)
+      #define Z2_ENABLE_READ READ(Z2_ENABLE_PIN)
+    #endif
+    #define Z2_DIR_INIT SET_OUTPUT(Z2_DIR_PIN)
+    #define Z2_DIR_WRITE(STATE) WRITE(Z2_DIR_PIN,STATE)
+    #define Z2_DIR_READ READ(Z2_DIR_PIN)
+  #endif
   #define Z2_STEP_INIT SET_OUTPUT(Z2_STEP_PIN)
   #define Z2_STEP_WRITE(STATE) WRITE(Z2_STEP_PIN,STATE)
   #define Z2_STEP_READ READ(Z2_STEP_PIN)
+#endif
 
-  #define Z2_DIR_INIT SET_OUTPUT(Z2_DIR_PIN)
-  #define Z2_DIR_WRITE(STATE) WRITE(Z2_DIR_PIN,STATE)
-  #define Z2_DIR_READ READ(Z2_DIR_PIN)
-
-  #define Z2_ENABLE_INIT SET_OUTPUT(Z2_ENABLE_PIN)
-  #define Z2_ENABLE_WRITE(STATE) WRITE(Z2_ENABLE_PIN,STATE)
-  #define Z2_ENABLE_READ READ(Z2_ENABLE_PIN)
-#endif // Z_DUAL_STEPPER_DRIVERS
-
-// E0 motor
+// E0 Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E0_IS_L6470)
+  extern L6470 stepperE0;
+  #define E0_ENABLE_INIT NOOP
+  #define E0_ENABLE_WRITE(STATE) do{if(STATE) stepperE0.Step_Clock(stepperE0.getStatus() & STATUS_HIZ); else stepperE0.softFree();}while(0)
+  #define E0_ENABLE_READ (stepperE0.getStatus() & STATUS_HIZ)
+  #define E0_DIR_INIT NOOP
+  #define E0_DIR_WRITE(STATE) stepperE0.Step_Clock(STATE)
+  #define E0_DIR_READ (stepperE0.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(E0_IS_TMC)
+    extern TMC26XStepper stepperE0;
+    #define E0_ENABLE_INIT NOOP
+    #define E0_ENABLE_WRITE(STATE) stepperE0.setEnabled(STATE)
+    #define E0_ENABLE_READ stepperE0.isEnabled()
+  #else
+    #define E0_ENABLE_INIT SET_OUTPUT(E0_ENABLE_PIN)
+    #define E0_ENABLE_WRITE(STATE) WRITE(E0_ENABLE_PIN,STATE)
+    #define E0_ENABLE_READ READ(E0_ENABLE_PIN)
+  #endif
+  #define E0_DIR_INIT SET_OUTPUT(E0_DIR_PIN)
+  #define E0_DIR_WRITE(STATE) WRITE(E0_DIR_PIN,STATE)
+  #define E0_DIR_READ READ(E0_DIR_PIN)
+#endif
 #define E0_STEP_INIT SET_OUTPUT(E0_STEP_PIN)
 #define E0_STEP_WRITE(STATE) WRITE(E0_STEP_PIN,STATE)
 #define E0_STEP_READ READ(E0_STEP_PIN)
 
-#define E0_DIR_INIT SET_OUTPUT(E0_DIR_PIN)
-#define E0_DIR_WRITE(STATE) WRITE(E0_DIR_PIN,STATE)
-#define E0_DIR_READ READ(E0_DIR_PIN)
-
-#define E0_ENABLE_INIT SET_OUTPUT(E0_ENABLE_PIN)
-#define E0_ENABLE_WRITE(STATE) WRITE(E0_ENABLE_PIN,STATE)
-#define E0_ENABLE_READ READ(E0_ENABLE_PIN)
-
-// E1 motor
+// E1 Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E1_IS_L6470)
+  extern L6470 stepperE1;
+  #define E1_ENABLE_INIT NOOP
+  #define E1_ENABLE_WRITE(STATE) do{if(STATE) stepperE1.Step_Clock(stepperE1.getStatus() & STATUS_HIZ); else stepperE1.softFree();}while(0)
+  #define E1_ENABLE_READ (stepperE1.getStatus() & STATUS_HIZ)
+  #define E1_DIR_INIT NOOP
+  #define E1_DIR_WRITE(STATE) stepperE1.Step_Clock(STATE)
+  #define E1_DIR_READ (stepperE1.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(E1_IS_TMC)
+    extern TMC26XStepper stepperE1;
+    #define E1_ENABLE_INIT NOOP
+    #define E1_ENABLE_WRITE(STATE) stepperE1.setEnabled(STATE)
+    #define E1_ENABLE_READ stepperE1.isEnabled()
+  #else
+    #define E1_ENABLE_INIT SET_OUTPUT(E1_ENABLE_PIN)
+    #define E1_ENABLE_WRITE(STATE) WRITE(E1_ENABLE_PIN,STATE)
+    #define E1_ENABLE_READ READ(E1_ENABLE_PIN)
+  #endif
+  #define E1_DIR_INIT SET_OUTPUT(E1_DIR_PIN)
+  #define E1_DIR_WRITE(STATE) WRITE(E1_DIR_PIN,STATE)
+  #define E1_DIR_READ READ(E1_DIR_PIN)
+#endif
 #define E1_STEP_INIT SET_OUTPUT(E1_STEP_PIN)
 #define E1_STEP_WRITE(STATE) WRITE(E1_STEP_PIN,STATE)
 #define E1_STEP_READ READ(E1_STEP_PIN)
 
-#define E1_DIR_INIT SET_OUTPUT(E1_DIR_PIN)
-#define E1_DIR_WRITE(STATE) WRITE(E1_DIR_PIN,STATE)
-#define E1_DIR_READ READ(E1_DIR_PIN)
-
-#define E1_ENABLE_INIT SET_OUTPUT(E1_ENABLE_PIN)
-#define E1_ENABLE_WRITE(STATE) WRITE(E1_ENABLE_PIN,STATE)
-#define E1_ENABLE_READ READ(E1_ENABLE_PIN)
-
-// E2 motor
+// E2 Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E2_IS_L6470)
+  extern L6470 stepperE2;
+  #define E2_ENABLE_INIT NOOP
+  #define E2_ENABLE_WRITE(STATE) do{if(STATE) stepperE2.Step_Clock(stepperE2.getStatus() & STATUS_HIZ); else stepperE2.softFree();}while(0)
+  #define E2_ENABLE_READ (stepperE2.getStatus() & STATUS_HIZ)
+  #define E2_DIR_INIT NOOP
+  #define E2_DIR_WRITE(STATE) stepperE2.Step_Clock(STATE)
+  #define E2_DIR_READ (stepperE2.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(E2_IS_TMC)
+    extern TMC26XStepper stepperE2;
+    #define E2_ENABLE_INIT NOOP
+    #define E2_ENABLE_WRITE(STATE) stepperE2.setEnabled(STATE)
+    #define E2_ENABLE_READ stepperE2.isEnabled()
+  #else
+    #define E2_ENABLE_INIT SET_OUTPUT(E2_ENABLE_PIN)
+    #define E2_ENABLE_WRITE(STATE) WRITE(E2_ENABLE_PIN,STATE)
+    #define E2_ENABLE_READ READ(E2_ENABLE_PIN)
+  #endif
+  #define E2_DIR_INIT SET_OUTPUT(E2_DIR_PIN)
+  #define E2_DIR_WRITE(STATE) WRITE(E2_DIR_PIN,STATE)
+  #define E2_DIR_READ READ(E2_DIR_PIN)
+#endif
 #define E2_STEP_INIT SET_OUTPUT(E2_STEP_PIN)
 #define E2_STEP_WRITE(STATE) WRITE(E2_STEP_PIN,STATE)
 #define E2_STEP_READ READ(E2_STEP_PIN)
 
-#define E2_DIR_INIT SET_OUTPUT(E2_DIR_PIN)
-#define E2_DIR_WRITE(STATE) WRITE(E2_DIR_PIN,STATE)
-#define E2_DIR_READ READ(E2_DIR_PIN)
-
-#define E2_ENABLE_INIT SET_OUTPUT(E2_ENABLE_PIN)
-#define E2_ENABLE_WRITE(STATE) WRITE(E2_ENABLE_PIN,STATE)
-#define E2_ENABLE_READ READ(E2_ENABLE_PIN)
-
-// E3 motor
+// E3 Stepper
+#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E3_IS_L6470)
+  extern L6470 stepperE3;
+  #define E3_ENABLE_INIT NOOP
+  #define E3_ENABLE_WRITE(STATE) do{if(STATE) stepperE3.Step_Clock(stepperE3.getStatus() & STATUS_HIZ); else stepperE3.softFree();}while(0)
+  #define E3_ENABLE_READ (stepperE3.getStatus() & STATUS_HIZ)
+  #define E3_DIR_INIT NOOP
+  #define E3_DIR_WRITE(STATE) stepperE3.Step_Clock(STATE)
+  #define E3_DIR_READ (stepperE3.getStatus() & STATUS_DIR)
+#else
+  #if ENABLED(HAVE_TMCDRIVER) && ENABLED(E3_IS_TMC)
+    extern TMC26XStepper stepperE3;
+    #define E3_ENABLE_INIT NOOP
+    #define E3_ENABLE_WRITE(STATE) stepperE3.setEnabled(STATE)
+    #define E3_ENABLE_READ stepperE3.isEnabled()
+  #else
+    #define E3_ENABLE_INIT SET_OUTPUT(E3_ENABLE_PIN)
+    #define E3_ENABLE_WRITE(STATE) WRITE(E3_ENABLE_PIN,STATE)
+    #define E3_ENABLE_READ READ(E3_ENABLE_PIN)
+  #endif
+  #define E3_DIR_INIT SET_OUTPUT(E3_DIR_PIN)
+  #define E3_DIR_WRITE(STATE) WRITE(E3_DIR_PIN,STATE)
+  #define E3_DIR_READ READ(E3_DIR_PIN)
+#endif
 #define E3_STEP_INIT SET_OUTPUT(E3_STEP_PIN)
 #define E3_STEP_WRITE(STATE) WRITE(E3_STEP_PIN,STATE)
 #define E3_STEP_READ READ(E3_STEP_PIN)
 
-#define E3_DIR_INIT SET_OUTPUT(E3_DIR_PIN)
-#define E3_DIR_WRITE(STATE) WRITE(E3_DIR_PIN,STATE)
-#define E3_DIR_READ READ(E3_DIR_PIN)
-
-#define E3_ENABLE_INIT SET_OUTPUT(E3_ENABLE_PIN)
-#define E3_ENABLE_WRITE(STATE) WRITE(E3_ENABLE_PIN,STATE)
-#define E3_ENABLE_READ READ(E3_ENABLE_PIN)
-
+/**
+ * Extruder indirection for the single E axis
+ */
 #if ENABLED(SWITCHING_EXTRUDER)
   #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
   #define NORM_E_DIR() E0_DIR_WRITE(current_block->active_extruder ?  INVERT_E0_DIR : !INVERT_E0_DIR)
@@ -224,342 +391,5 @@
   #define NORM_E_DIR() E0_DIR_WRITE(!INVERT_E0_DIR)
   #define REV_E_DIR() E0_DIR_WRITE(INVERT_E0_DIR)
 #endif
-
-//////////////////////////////////
-// Pin redefines for TMC drivers.
-// TMC26X drivers have step and dir on normal pins, but everything else via SPI
-//////////////////////////////////
-#if ENABLED(HAVE_TMCDRIVER)
-  #include <SPI.h>
-  #include <TMC26XStepper.h>
-
-  void tmc_init();
-  #if ENABLED(X_IS_TMC)
-    extern TMC26XStepper stepperX;
-    #undef X_ENABLE_INIT
-    #define X_ENABLE_INIT ((void)0)
-
-    #undef X_ENABLE_WRITE
-    #define X_ENABLE_WRITE(STATE) stepperX.setEnabled(STATE)
-
-    #undef X_ENABLE_READ
-    #define X_ENABLE_READ stepperX.isEnabled()
-
-  #endif
-  #if ENABLED(X2_IS_TMC)
-    extern TMC26XStepper stepperX2;
-    #undef X2_ENABLE_INIT
-    #define X2_ENABLE_INIT ((void)0)
-
-    #undef X2_ENABLE_WRITE
-    #define X2_ENABLE_WRITE(STATE) stepperX2.setEnabled(STATE)
-
-    #undef X2_ENABLE_READ
-    #define X2_ENABLE_READ stepperX2.isEnabled()
-  #endif
-  #if ENABLED(Y_IS_TMC)
-    extern TMC26XStepper stepperY;
-    #undef Y_ENABLE_INIT
-    #define Y_ENABLE_INIT ((void)0)
-
-    #undef Y_ENABLE_WRITE
-    #define Y_ENABLE_WRITE(STATE) stepperY.setEnabled(STATE)
-
-    #undef Y_ENABLE_READ
-    #define Y_ENABLE_READ stepperY.isEnabled()
-  #endif
-  #if ENABLED(Y2_IS_TMC)
-    extern TMC26XStepper stepperY2;
-    #undef Y2_ENABLE_INIT
-    #define Y2_ENABLE_INIT ((void)0)
-
-    #undef Y2_ENABLE_WRITE
-    #define Y2_ENABLE_WRITE(STATE) stepperY2.setEnabled(STATE)
-
-    #undef Y2_ENABLE_READ
-    #define Y2_ENABLE_READ stepperY2.isEnabled()
-  #endif
-  #if ENABLED(Z_IS_TMC)
-    extern TMC26XStepper stepperZ;
-    #undef Z_ENABLE_INIT
-    #define Z_ENABLE_INIT ((void)0)
-
-    #undef Z_ENABLE_WRITE
-    #define Z_ENABLE_WRITE(STATE) stepperZ.setEnabled(STATE)
-
-    #undef Z_ENABLE_READ
-    #define Z_ENABLE_READ stepperZ.isEnabled()
-  #endif
-  #if ENABLED(Z2_IS_TMC)
-    extern TMC26XStepper stepperZ2;
-    #undef Z2_ENABLE_INIT
-    #define Z2_ENABLE_INIT ((void)0)
-
-    #undef Z2_ENABLE_WRITE
-    #define Z2_ENABLE_WRITE(STATE) stepperZ2.setEnabled(STATE)
-
-    #undef Z2_ENABLE_READ
-    #define Z2_ENABLE_READ stepperZ2.isEnabled()
-  #endif
-  #if ENABLED(E0_IS_TMC)
-    extern TMC26XStepper stepperE0;
-    #undef E0_ENABLE_INIT
-    #define E0_ENABLE_INIT ((void)0)
-
-    #undef E0_ENABLE_WRITE
-    #define E0_ENABLE_WRITE(STATE) stepperE0.setEnabled(STATE)
-
-    #undef E0_ENABLE_READ
-    #define E0_ENABLE_READ stepperE0.isEnabled()
-  #endif
-  #if ENABLED(E1_IS_TMC)
-    extern TMC26XStepper stepperE1;
-    #undef E1_ENABLE_INIT
-    #define E1_ENABLE_INIT ((void)0)
-
-    #undef E1_ENABLE_WRITE
-    #define E1_ENABLE_WRITE(STATE) stepperE1.setEnabled(STATE)
-
-    #undef E1_ENABLE_READ
-    #define E1_ENABLE_READ stepperE1.isEnabled()
-  #endif
-  #if ENABLED(E2_IS_TMC)
-    extern TMC26XStepper stepperE2;
-    #undef E2_ENABLE_INIT
-    #define E2_ENABLE_INIT ((void)0)
-
-    #undef E2_ENABLE_WRITE
-    #define E2_ENABLE_WRITE(STATE) stepperE2.setEnabled(STATE)
-
-    #undef E2_ENABLE_READ
-    #define E2_ENABLE_READ stepperE2.isEnabled()
-  #endif
-  #if ENABLED(E3_IS_TMC)
-    extern TMC26XStepper stepperE3;
-    #undef E3_ENABLE_INIT
-    #define E3_ENABLE_INIT ((void)0)
-
-    #undef E3_ENABLE_WRITE
-    #define E3_ENABLE_WRITE(STATE) stepperE3.setEnabled(STATE)
-
-    #undef E3_ENABLE_READ
-    #define E3_ENABLE_READ stepperE3.isEnabled()
-  #endif
-
-#endif  // HAVE_TMCDRIVER
-
-//////////////////////////////////
-// Pin redefines for L6470 drivers.
-// L640 drivers have step on normal pins, but dir and everything else via SPI
-//////////////////////////////////
-#if ENABLED(HAVE_L6470DRIVER)
-
-  #include <SPI.h>
-  #include <L6470.h>
-
-  void L6470_init();
-  #if ENABLED(X_IS_L6470)
-    extern L6470 stepperX;
-    #undef X_ENABLE_INIT
-    #define X_ENABLE_INIT ((void)0)
-
-    #undef X_ENABLE_WRITE
-    #define X_ENABLE_WRITE(STATE) {if(STATE) stepperX.Step_Clock(stepperX.getStatus() & STATUS_HIZ); else stepperX.softFree();}
-
-    #undef X_ENABLE_READ
-    #define X_ENABLE_READ (stepperX.getStatus() & STATUS_HIZ)
-
-    #undef X_DIR_INIT
-    #define X_DIR_INIT ((void)0)
-
-    #undef X_DIR_WRITE
-    #define X_DIR_WRITE(STATE) stepperX.Step_Clock(STATE)
-
-    #undef X_DIR_READ
-    #define X_DIR_READ (stepperX.getStatus() & STATUS_DIR)
-
-  #endif
-  #if ENABLED(X2_IS_L6470)
-    extern L6470 stepperX2;
-    #undef X2_ENABLE_INIT
-    #define X2_ENABLE_INIT ((void)0)
-
-    #undef X2_ENABLE_WRITE
-    #define X2_ENABLE_WRITE(STATE) (if(STATE) stepperX2.Step_Clock(stepperX2.getStatus() & STATUS_HIZ); else stepperX2.softFree();)
-
-    #undef X2_ENABLE_READ
-    #define X2_ENABLE_READ (stepperX2.getStatus() & STATUS_HIZ)
-
-    #undef X2_DIR_INIT
-    #define X2_DIR_INIT ((void)0)
-
-    #undef X2_DIR_WRITE
-    #define X2_DIR_WRITE(STATE) stepperX2.Step_Clock(STATE)
-
-    #undef X2_DIR_READ
-    #define X2_DIR_READ (stepperX2.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(Y_IS_L6470)
-    extern L6470 stepperY;
-    #undef Y_ENABLE_INIT
-    #define Y_ENABLE_INIT ((void)0)
-
-    #undef Y_ENABLE_WRITE
-    #define Y_ENABLE_WRITE(STATE) (if(STATE) stepperY.Step_Clock(stepperY.getStatus() & STATUS_HIZ); else stepperY.softFree();)
-
-    #undef Y_ENABLE_READ
-    #define Y_ENABLE_READ (stepperY.getStatus() & STATUS_HIZ)
-
-    #undef Y_DIR_INIT
-    #define Y_DIR_INIT ((void)0)
-
-    #undef Y_DIR_WRITE
-    #define Y_DIR_WRITE(STATE) stepperY.Step_Clock(STATE)
-
-    #undef Y_DIR_READ
-    #define Y_DIR_READ (stepperY.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(Y2_IS_L6470)
-    extern L6470 stepperY2;
-    #undef Y2_ENABLE_INIT
-    #define Y2_ENABLE_INIT ((void)0)
-
-    #undef Y2_ENABLE_WRITE
-    #define Y2_ENABLE_WRITE(STATE) (if(STATE) stepperY2.Step_Clock(stepperY2.getStatus() & STATUS_HIZ); else stepperY2.softFree();)
-
-    #undef Y2_ENABLE_READ
-    #define Y2_ENABLE_READ (stepperY2.getStatus() & STATUS_HIZ)
-
-    #undef Y2_DIR_INIT
-    #define Y2_DIR_INIT ((void)0)
-
-    #undef Y2_DIR_WRITE
-    #define Y2_DIR_WRITE(STATE) stepperY2.Step_Clock(STATE)
-
-    #undef Y2_DIR_READ
-    #define Y2_DIR_READ (stepperY2.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(Z_IS_L6470)
-    extern L6470 stepperZ;
-    #undef Z_ENABLE_INIT
-    #define Z_ENABLE_INIT ((void)0)
-
-    #undef Z_ENABLE_WRITE
-    #define Z_ENABLE_WRITE(STATE) (if(STATE) stepperZ.Step_Clock(stepperZ.getStatus() & STATUS_HIZ); else stepperZ.softFree();)
-
-    #undef Z_ENABLE_READ
-    #define Z_ENABLE_READ (stepperZ.getStatus() & STATUS_HIZ)
-
-    #undef Z_DIR_INIT
-    #define Z_DIR_INIT ((void)0)
-
-    #undef Z_DIR_WRITE
-    #define Z_DIR_WRITE(STATE) stepperZ.Step_Clock(STATE)
-
-    #undef Y_DIR_READ
-    #define Y_DIR_READ (stepperZ.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(Z2_IS_L6470)
-    extern L6470 stepperZ2;
-    #undef Z2_ENABLE_INIT
-    #define Z2_ENABLE_INIT ((void)0)
-
-    #undef Z2_ENABLE_WRITE
-    #define Z2_ENABLE_WRITE(STATE) (if(STATE) stepperZ2.Step_Clock(stepperZ2.getStatus() & STATUS_HIZ); else stepperZ2.softFree();)
-
-    #undef Z2_ENABLE_READ
-    #define Z2_ENABLE_READ (stepperZ2.getStatus() & STATUS_HIZ)
-
-    #undef Z2_DIR_INIT
-    #define Z2_DIR_INIT ((void)0)
-
-    #undef Z2_DIR_WRITE
-    #define Z2_DIR_WRITE(STATE) stepperZ2.Step_Clock(STATE)
-
-    #undef Y2_DIR_READ
-    #define Y2_DIR_READ (stepperZ2.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(E0_IS_L6470)
-    extern L6470 stepperE0;
-    #undef E0_ENABLE_INIT
-    #define E0_ENABLE_INIT ((void)0)
-
-    #undef E0_ENABLE_WRITE
-    #define E0_ENABLE_WRITE(STATE) (if(STATE) stepperE0.Step_Clock(stepperE0.getStatus() & STATUS_HIZ); else stepperE0.softFree();)
-
-    #undef E0_ENABLE_READ
-    #define E0_ENABLE_READ (stepperE0.getStatus() & STATUS_HIZ)
-
-    #undef E0_DIR_INIT
-    #define E0_DIR_INIT ((void)0)
-
-    #undef E0_DIR_WRITE
-    #define E0_DIR_WRITE(STATE) stepperE0.Step_Clock(STATE)
-
-    #undef E0_DIR_READ
-    #define E0_DIR_READ (stepperE0.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(E1_IS_L6470)
-    extern L6470 stepperE1;
-    #undef E1_ENABLE_INIT
-    #define E1_ENABLE_INIT ((void)0)
-
-    #undef E1_ENABLE_WRITE
-    #define E1_ENABLE_WRITE(STATE) (if(STATE) stepperE1.Step_Clock(stepperE1.getStatus() & STATUS_HIZ); else stepperE1.softFree();)
-
-    #undef E1_ENABLE_READ
-    #define E1_ENABLE_READ (stepperE1.getStatus() & STATUS_HIZ)
-
-    #undef E1_DIR_INIT
-    #define E1_DIR_INIT ((void)0)
-
-    #undef E1_DIR_WRITE
-    #define E1_DIR_WRITE(STATE) stepperE1.Step_Clock(STATE)
-
-    #undef E1_DIR_READ
-    #define E1_DIR_READ (stepperE1.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(E2_IS_L6470)
-    extern L6470 stepperE2;
-    #undef E2_ENABLE_INIT
-    #define E2_ENABLE_INIT ((void)0)
-
-    #undef E2_ENABLE_WRITE
-    #define E2_ENABLE_WRITE(STATE) (if(STATE) stepperE2.Step_Clock(stepperE2.getStatus() & STATUS_HIZ); else stepperE2.softFree();)
-
-    #undef E2_ENABLE_READ
-    #define E2_ENABLE_READ (stepperE2.getStatus() & STATUS_HIZ)
-
-    #undef E2_DIR_INIT
-    #define E2_DIR_INIT ((void)0)
-
-    #undef E2_DIR_WRITE
-    #define E2_DIR_WRITE(STATE) stepperE2.Step_Clock(STATE)
-
-    #undef E2_DIR_READ
-    #define E2_DIR_READ (stepperE2.getStatus() & STATUS_DIR)
-  #endif
-  #if ENABLED(E3_IS_L6470)
-    extern L6470 stepperE3;
-    #undef E3_ENABLE_INIT
-    #define E3_ENABLE_INIT ((void)0)
-
-    #undef E3_ENABLE_WRITE
-    #define E3_ENABLE_WRITE(STATE) (if(STATE) stepperE3.Step_Clock(stepperE3.getStatus() & STATUS_HIZ); else stepperE3.softFree();)
-
-    #undef E3_ENABLE_READ
-    #define E3_ENABLE_READ (stepperE3.getStatus() & STATUS_HIZ)
-
-    #undef E3_DIR_INIT
-    #define E3_DIR_INIT ((void)0)
-
-    #undef E3_DIR_WRITE
-    #define E3_DIR_WRITE(STATE) stepperE3.Step_Clock(STATE)
-
-    #undef E3_DIR_READ
-    #define E3_DIR_READ (stepperE3.getStatus() & STATUS_DIR)
-  #endif
-
-#endif  //HAVE_L6470DRIVER
 
 #endif // STEPPER_INDIRECTION_H


### PR DESCRIPTION
Methodical cleanup of `stepper_indirection.h` to get rid of `#undef` and give it a more logical arrangement, by axis.
