### PR TITLE
Allow zero raise for deploy/stow

### DIFF
--- a/Marlin/SanityCheck.cpp
+++ b/Marlin/SanityCheck.cpp
@@ -338,8 +338,8 @@
     #error "You must set Z_RAISE_PROBE_DEPLOY_STOW in your configuration."
   #elif !defined(Z_RAISE_BETWEEN_PROBINGS)
     #error "You must set Z_RAISE_BETWEEN_PROBINGS in your configuration."
-  #elif Z_RAISE_PROBE_DEPLOY_STOW < 1
-    #error "Probes need Z_RAISE_PROBE_DEPLOY_STOW >= 1."
+  #elif Z_RAISE_PROBE_DEPLOY_STOW < 0
+    #error "Probes need Z_RAISE_PROBE_DEPLOY_STOW >= 0."
   #elif Z_RAISE_BETWEEN_PROBINGS < 1
     #error "Probes need Z_RAISE_BETWEEN_PROBINGS >= 1."
   #endif


### PR DESCRIPTION
Addressing #4418. If you have a bed that parks at the bottom and you use a probe for Z homing, then `G28` will grind the bed against the bottom before starting to home.
