### PR TITLE
Workaround for locked SD cards

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -213,7 +213,7 @@ void CardReader::ls()  {
 
 #endif // LONG_FILENAME_HOST_SUPPORT
 
-void CardReader::initsd() {
+void CardReader::initsd(bool silent/*=false*/) {
   cardOK = false;
   if (root.isOpen()) root.close();
 
@@ -227,21 +227,29 @@ void CardReader::initsd() {
     #endif
   ) {
     //if (!card.init(SPI_HALF_SPEED,SDSS))
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM(MSG_SD_INIT_FAIL);
+    if (!silent) {
+      SERIAL_ECHO_START;
+      SERIAL_ECHOLNPGM(MSG_SD_INIT_FAIL);
+    }
   }
   else if (!volume.init(&card)) {
-    SERIAL_ERROR_START;
-    SERIAL_ERRORLNPGM(MSG_SD_VOL_INIT_FAIL);
+    if (!silent) {
+      SERIAL_ERROR_START;
+      SERIAL_ERRORLNPGM(MSG_SD_VOL_INIT_FAIL);
+    }
   }
   else if (!root.openRoot(&volume)) {
-    SERIAL_ERROR_START;
-    SERIAL_ERRORLNPGM(MSG_SD_OPENROOT_FAIL);
+    if (!silent) {
+      SERIAL_ERROR_START;
+      SERIAL_ERRORLNPGM(MSG_SD_OPENROOT_FAIL);
+    }
   }
   else {
     cardOK = true;
-    SERIAL_ECHO_START;
-    SERIAL_ECHOLNPGM(MSG_SD_CARD_OK);
+    if (!silent) {
+      SERIAL_ECHO_START;
+      SERIAL_ECHOLNPGM(MSG_SD_CARD_OK);
+    }
   }
   workDir = root;
   curDir = &root;

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -34,7 +34,7 @@ class CardReader {
 public:
   CardReader();
 
-  void initsd();
+  void initsd(bool silent=false);
   void write_command(char *buf);
   //files auto[0-9].g on the sd card are performed in a row
   //this is to delay autostart and hence the initialisaiton of the sd card to some seconds after the normal init, so the device is available quick after a reset
@@ -107,10 +107,11 @@ extern CardReader card;
 
 #if PIN_EXISTS(SD_DETECT)
   #if ENABLED(SD_DETECT_INVERTED)
-    #define IS_SD_INSERTED (READ(SD_DETECT_PIN) != 0)
+    #define SD_DETECT_INSERT true
   #else
-    #define IS_SD_INSERTED (READ(SD_DETECT_PIN) == 0)
+    #define SD_DETECT_INSERT false
   #endif
+  #define IS_SD_INSERTED (SD_DETECT_INSERT == (READ(SD_DETECT_PIN) != 0))
 #else
   //No card detect line? Assume the card is inserted.
   #define IS_SD_INSERTED true

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -157,6 +157,7 @@
 
 #define MSG_SD_CANT_OPEN_SUBDIR             "Cannot open subdir "
 #define MSG_SD_INIT_FAIL                    "SD init fail"
+#define MSG_SD_LOCKED                       "SD card locked??"
 #define MSG_SD_VOL_INIT_FAIL                "volume.init failed"
 #define MSG_SD_OPENROOT_FAIL                "openRoot failed"
 #define MSG_SD_CARD_OK                      "SD card ok"

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2553,28 +2553,53 @@ void lcd_update() {
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
 
+    // To handle the pin detect behavior for locked SD cards
+    // check the time interval between "insert" and "remove."
+    // If the "remove" follows the "insert" by less than 1s
+    // the card init is retried.
+    static millis_t last_sdpin_change = 0;
+    static bool last_real_sd_status = !SD_DETECT_INSERT;
+
+    // Wait for the real pin state to change
     bool sd_status = IS_SD_INSERTED;
-    if (sd_status != lcd_sd_status && lcd_detected()) {
+    if (sd_status != last_real_sd_status && lcd_detected()) {
+      last_real_sd_status = sd_status;
+      millis_t sdpin_interval = millis() - last_sdpin_change;
+      last_sdpin_change = millis();
+
+      // To maybe revive the LCD if static electricity killed it.
       lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
-      lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
+      lcd_implementation_init(
         #if ENABLED(LCD_PROGRESS_BAR) && ENABLED(ULTIPANEL)
           currentScreen == lcd_status_screen
         #endif
       );
 
-      if (sd_status) {
+      card.release();
+
+      bool spurious = (!sd_status && sdpin_interval < 1000UL);
+
+      if (sd_status || spurious) {
         card.initsd();
-        if (lcd_sd_status != 2) LCD_MESSAGEPGM(MSG_SD_INSERTED);
-      }
-      else {
-        card.release();
-        if (lcd_sd_status != 2) LCD_MESSAGEPGM(MSG_SD_REMOVED);
+        sd_status = card.cardOK;
+        if (spurious && sd_status) {
+          SERIAL_ECHO_START;
+          SERIAL_ECHOLNPGM(MSG_SD_LOCKED);
+        }
       }
 
-      lcd_sd_status = sd_status;
+      if (lcd_sd_status != sd_status) {
+        if (lcd_sd_status != 2) {
+          if (sd_status)
+            LCD_MESSAGEPGM(MSG_SD_INSERTED);
+          else
+            LCD_MESSAGEPGM(MSG_SD_REMOVED);
+        }
+        lcd_sd_status = sd_status;
+      }
     }
 
-  #endif //SDSUPPORT && SD_DETECT_PIN
+  #endif // SDSUPPORT && SD_DETECT_PIN
 
   millis_t ms = millis();
   if (ELAPSED(ms, next_lcd_update_ms)) {


### PR DESCRIPTION
**Background:** When a locked SD card is inserted (or removed) from some LCD controllers, the `SD_DETECT_PIN` will go to the "inserted" state for a moment, then revert back to "removed" state. This prevents use of SD cards if they happen to be write-protected. See #4423 for even more fun details.

**Solution:** The false pin-change seems to always occur in under one second. So this PR adds code to check for this short interval when a "remove" is detected, and checks to see if the card is actually still inserted. This effectively allows the use of locked SD cards.
