### PR TITLE
DELTA should ignore Z_SAFE_HOMING

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -147,6 +147,13 @@
   #endif
 
   /**
+   * DELTA should ignore Z_SAFE_HOMING
+   */
+  #if ENABLED(DELTA)
+    #undef Z_SAFE_HOMING
+  #endif
+
+  /**
    * Safe Homing Options
    */
   #if ENABLED(Z_SAFE_HOMING)


### PR DESCRIPTION
In reference to https://github.com/MarlinFirmware/Marlin/issues/4430#issuecomment-235726442

Why would a Wookiee, an 8-foot-tall Wookiee, want to live on Endor, with a bunch of 2-foot-tall Ewoks? That does not make sense! But more important, you have to ask yourself: What does this have to do with this case? Nothing. Ladies and gentlemen, it has nothing to do with this case! It does not make sense! Look at me. I'm a lawyer defending a major record company, and I'm talkin' about Chewbacca! Does that make sense? Ladies and gentlemen, I am not making any sense! None of this makes sense! And so you have to remember, when you're in that jury room deliberatin' and conjugatin' the Emancipation Proclamation, does it make sense? No! Ladies and gentlemen of this supposed jury, it does not make sense! If Chewbacca lives on Endor, you must acquit! The defense rests.
