### PR TITLE
Fix pins for R_D_F_G_S_C with MEGATRONICS 3

### DIFF
--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -106,17 +106,12 @@
 
 #define BEEPER_PIN 61
 
-#if ENABLED(DOGLCD)
-
-  #if ENABLED(U8GLIB_ST7920)
+#if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
     #define LCD_PINS_RS     56 //CS chip select /SS chip slave select
     #define LCD_PINS_ENABLE 51 //SID (MOSI)
     #define LCD_PINS_D4     52 //SCK (CLK) clock
     #define SD_DETECT_PIN 35
-  #endif
-
 #else
-
   #define LCD_PINS_RS 32
   #define LCD_PINS_ENABLE 31
   #define LCD_PINS_D4 14
@@ -130,7 +125,6 @@
   #define SHIFT_EN 44
 
   #define SD_DETECT_PIN 56 // Megatronics v3.1 only
-
 #endif
 
 // Buttons are directly attached using keypad


### PR DESCRIPTION
…RAPHIC_SMART_CONTROLLER

The support for reprapworld LCD boke the code for the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER. See Full Grapics Display does not work any more after #4408  #4439
