### PR TITLE
Fix for R.D.F.G.S.C. with MEGATRONICS 3 board

### DIFF
--- a/Marlin/pins_3DRAG.h
+++ b/Marlin/pins_3DRAG.h
@@ -86,7 +86,7 @@
   #undef BTN_ENC
   #define BTN_EN1 16
   #define BTN_EN2 17
-  #define BTN_ENC 23 //the click
+  #define BTN_ENC 23
 
 #else
 

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -84,8 +84,4 @@
 #define BTN_EN2 -1
 #define BTN_ENC -1
 
-#define BLEN_C 2
-#define BLEN_B 1
-#define BLEN_A 0
-
 // Cheaptronic v1.0 doesn't use this

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -87,10 +87,6 @@
 
   #define BTN_EN1          14
   #define BTN_EN2          39
-
-  #define BLEN_C            2
-  #define BLEN_B            1
-  #define BLEN_A            0
   #define BTN_ENC          15
 
 #endif // RA_CONTROL_PANEL

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -87,11 +87,11 @@
 
   #define BTN_EN1          14
   #define BTN_EN2          39
-  #define BTN_ENC          15  //the click
 
   #define BLEN_C            2
   #define BLEN_B            1
   #define BLEN_A            0
+  #define BTN_ENC          15
 
 #endif // RA_CONTROL_PANEL
 

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -38,9 +38,6 @@
 
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
 
-  #define BLEN_C 2
-  #define BLEN_B 1
-  #define BLEN_A 0
   #define SD_DETECT_PIN 6
 
 #endif // NEWPANEL && ULTRA_LCD

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -86,5 +86,5 @@
 //buttons are directly attached
 #define BTN_EN1 11
 #define BTN_EN2 10
-#define BTN_ENC 12  //the click
+#define BTN_ENC 12
 

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -113,11 +113,11 @@
   //#define LCD_SCREEN_ROT_90
   //#define LCD_SCREEN_ROT_180
   //#define LCD_SCREEN_ROT_270
-  //The encoder and click button
+
   #define BTN_EN1 48
   #define BTN_EN2 11
-  #define BTN_ENC 10  //the click switch
-  //not connected to a pin
+  #define BTN_ENC 10
+
   #define SD_DETECT_PIN 49
-#endif //Minipanel
+#endif // MINIPANEL
 

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -92,10 +92,6 @@
   #define BTN_EN2         64
   #define BTN_ENC         43
 
-  #define BLEN_C           2
-  #define BLEN_B           1
-  #define BLEN_A           0
-
   #define SD_DETECT_PIN   -1   // RAMPS doesn't use this
 
 #endif // ULTRA_LCD && NEWPANEL

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -101,9 +101,9 @@
 // Buttons are directly attached using keypad
 #define BTN_EN1 61
 #define BTN_EN2 59
-#define BTN_ENC 43 //the click
 
 #define BLEN_C 2
 #define BLEN_B 1
 #define BLEN_A 0
 
+#define BTN_ENC 43

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -101,9 +101,4 @@
 // Buttons are directly attached using keypad
 #define BTN_EN1 61
 #define BTN_EN2 59
-
-#define BLEN_C 2
-#define BLEN_B 1
-#define BLEN_A 0
-
 #define BTN_ENC 43

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -120,10 +120,6 @@
 #define BTN_EN2 45
 #define BTN_ENC 33
 
-#define BLEN_C 2
-#define BLEN_B 1
-#define BLEN_A 0
-
 #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
   #define LCD_PINS_RS     56 // CS chip select / SS chip slave select
   #define LCD_PINS_ENABLE 51 // SID (MOSI)

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -28,7 +28,14 @@
   #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define BOARD_NAME         "Megatronics v3.0"
+#define MEGATRONICS_31
+
+#if ENABLED(MEGATRONICS_31)
+  #define BOARD_NAME       "Megatronics v3.1"
+#else
+  #define BOARD_NAME       "Megatronics v3.0"
+#endif
+
 #define LARGE_FLASH        true
 
 #if ENABLED(Z_PROBE_SLED)
@@ -36,28 +43,28 @@
 #endif
 
 // Servo support
-#define SERVO0_PIN         46 //AUX3-6
-#define SERVO1_PIN         47 //AUX3-5
-#define SERVO2_PIN         48 //AUX3-4
-#define SERVO3_PIN         49 //AUX3-3
+#define SERVO0_PIN         46 // AUX3-6
+#define SERVO1_PIN         47 // AUX3-5
+#define SERVO2_PIN         48 // AUX3-4
+#define SERVO3_PIN         49 // AUX3-3
 
 #define X_STEP_PIN         58
 #define X_DIR_PIN          57
 #define X_ENABLE_PIN       59
 #define X_MIN_PIN          37
-#define X_MAX_PIN          40 // put to -1 to disable
+#define X_MAX_PIN          40
 
 #define Y_STEP_PIN         5
 #define Y_DIR_PIN          17
 #define Y_ENABLE_PIN       4
 #define Y_MIN_PIN          41
-#define Y_MAX_PIN          38 // put to -1 to disable
+#define Y_MAX_PIN          38
 
 #define Z_STEP_PIN         16
 #define Z_DIR_PIN          11
 #define Z_ENABLE_PIN       3
 #define Z_MIN_PIN          18
-#define Z_MAX_PIN          19 // put to -1 to disable
+#define Z_MAX_PIN          19
 
 #define E0_STEP_PIN        28
 #define E0_DIR_PIN         27
@@ -104,36 +111,11 @@
   #define TEMP_BED_PIN 14 // ANALOG NUMBERING
 #endif
 
+/**
+ * Controllers and LCDs
+ */
 #define BEEPER_PIN 61
 
-#if ENABLED(DOGLCD)
-
-  #if ENABLED(U8GLIB_ST7920)
-    #define LCD_PINS_RS     56 //CS chip select /SS chip slave select
-    #define LCD_PINS_ENABLE 51 //SID (MOSI)
-    #define LCD_PINS_D4     52 //SCK (CLK) clock
-    #define SD_DETECT_PIN 35
-  #endif
-
-#else
-
-  #define LCD_PINS_RS 32
-  #define LCD_PINS_ENABLE 31
-  #define LCD_PINS_D4 14
-  #define LCD_PINS_D5 30
-  #define LCD_PINS_D6 39
-  #define LCD_PINS_D7 15
-  
-  #define SHIFT_CLK 43
-  #define SHIFT_LD 35
-  #define SHIFT_OUT 34
-  #define SHIFT_EN 44
-
-  #define SD_DETECT_PIN 56 // Megatronics v3.1 only
-
-#endif
-
-// Buttons are directly attached using keypad
 #define BTN_EN1 44
 #define BTN_EN2 45
 #define BTN_ENC 33
@@ -141,3 +123,29 @@
 #define BLEN_C 2
 #define BLEN_B 1
 #define BLEN_A 0
+
+#if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+  #define LCD_PINS_RS     56 // CS chip select / SS chip slave select
+  #define LCD_PINS_ENABLE 51 // SID (MOSI)
+  #define LCD_PINS_D4     52 // SCK (CLK) clock
+  #define SD_DETECT_PIN   35
+#else
+  #define LCD_PINS_RS     32
+  #define LCD_PINS_ENABLE 31
+  #define LCD_PINS_D4     14
+  #define LCD_PINS_D5     30
+  #define LCD_PINS_D6     39
+  #define LCD_PINS_D7     15
+  
+  #define SHIFT_CLK       43
+  #define SHIFT_LD        35
+  #define SHIFT_OUT       34
+  #define SHIFT_EN        44
+
+  #if ENABLED(MEGATRONICS_31)
+    #define SD_DETECT_PIN 56
+  #else
+    #define SD_DETECT_PIN -1
+  #endif
+
+#endif

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -74,40 +74,40 @@
 #define HEATER_1_PIN   8 // EXTRUDER 2
 #define HEATER_BED_PIN 3 // BED
 
+/**
+ * Controllers and LCDs
+ */
 #define BEEPER_PIN -1
 
-#if ENABLED(DOGLCD)
+#if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
 
-  #if ENABLED(U8GLIB_ST7920)
-    #define LCD_PINS_RS     15 //CS chip select /SS chip slave select
-    #define LCD_PINS_ENABLE 11 //SID (MOSI)
-    #define LCD_PINS_D4     10 //SCK (CLK) clock     
+  #define LCD_PINS_RS     15 // CS chip select /SS chip slave select
+  #define LCD_PINS_ENABLE 11 // SID (MOSI)
+  #define LCD_PINS_D4     10 // SCK (CLK) clock
 
-    #define BTN_EN1 18
-    #define BTN_EN2 17
-    #define BTN_ENC 25
+  #define BTN_EN1         18
+  #define BTN_EN2         17
+  #define BTN_ENC         25
 
-    #define SD_DETECT_PIN 30
-  #endif
+  #define SD_DETECT_PIN   30
 
 #else
 
-  #define LCD_PINS_RS -1
+  #define LCD_PINS_RS     -1
   #define LCD_PINS_ENABLE -1
-  #define LCD_PINS_D4 -1
-  #define LCD_PINS_D5 -1
-  #define LCD_PINS_D6 -1
-  #define LCD_PINS_D7 -1
+  #define LCD_PINS_D4     -1
+  #define LCD_PINS_D5     -1
+  #define LCD_PINS_D6     -1
+  #define LCD_PINS_D7     -1
 
   // Buttons are directly attached using keypad
-  #define BTN_EN1 -1
-  #define BTN_EN2 -1
-  #define BTN_ENC -1
+  #define BTN_EN1         -1
+  #define BTN_EN2         -1
+  #define BTN_ENC         -1
 
   #define BLEN_C 2
   #define BLEN_B 1
   #define BLEN_A 0
 
   #define SD_DETECT_PIN -1  // Minitronics doesn't use this
-
 #endif

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -105,9 +105,5 @@
   #define BTN_EN2         -1
   #define BTN_ENC         -1
 
-  #define BLEN_C 2
-  #define BLEN_B 1
-  #define BLEN_A 0
-
   #define SD_DETECT_PIN -1  // Minitronics doesn't use this
 #endif

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -132,7 +132,7 @@
   //The encoder and click button (FastIO Pins)
   #define BTN_EN1 26
   #define BTN_EN2 27
-  #define BTN_ENC 47  //the click switch
+  #define BTN_ENC 47
 
   #define SDSS 45
   #define SD_DETECT_PIN -1 // FastIO (Manual says 72 I'm not certain cause I can't test)

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -136,7 +136,7 @@
   //The encoder and click button (FastIO Pins)
   #define BTN_EN1 26
   #define BTN_EN2 27
-  #define BTN_ENC 47  //the click switch
+  #define BTN_ENC 47
 
   #define SDSS 45
   #define SD_DETECT_PIN -1 // FastIO (Manual says 72 I'm not certain cause I can't test)

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -113,10 +113,6 @@
   #define BTN_EN2   17
   #define BTN_ENC   18//the click
 
-  #define BLEN_C 2
-  #define BLEN_B 1
-  #define BLEN_A 0
-
   #define SD_DETECT_PIN -1
 
   //encoder rotation values

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -127,11 +127,11 @@
     //buttons are directly attached using AUX-2
     #define BTN_EN1 76
     #define BTN_EN2 77
-    #define BTN_ENC 78  //the click
 
     #define BLEN_C 2
     #define BLEN_B 1
     #define BLEN_A 0
+    #define BTN_ENC 78
 
     #define SD_DETECT_PIN 81 // Ramps doesn't use this
 
@@ -179,7 +179,7 @@
   //The encoder and click button
   #define BTN_EN1 85
   #define BTN_EN2 84
-  #define BTN_ENC 83  //the click switch
+  #define BTN_ENC 83
 
   #define SD_DETECT_PIN -1 // Pin 72 if using easy adapter board
 

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -150,15 +150,6 @@
     #define LCD_PINS_D6 27
     #define LCD_PINS_D7 29
 
-    //bits in the shift register that carry the buttons for:
-    // left up center down right red
-    #define BL_LE 7
-    #define BL_UP 6
-    #define BL_MI 5
-    #define BL_DW 4
-    #define BL_RI 3
-    #define BL_ST 2
-
   #endif // !NEWPANEL
 
 #endif // ULTRA_LCD

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -127,10 +127,6 @@
     //buttons are directly attached using AUX-2
     #define BTN_EN1 76
     #define BTN_EN2 77
-
-    #define BLEN_C 2
-    #define BLEN_B 1
-    #define BLEN_A 0
     #define BTN_ENC 78
 
     #define SD_DETECT_PIN 81 // Ramps doesn't use this
@@ -162,8 +158,6 @@
     #define BL_DW 4
     #define BL_RI 3
     #define BL_ST 2
-    #define BLEN_B 1
-    #define BLEN_A 0
 
   #endif // !NEWPANEL
 

--- a/Marlin/pins_RAMPS_14.h
+++ b/Marlin/pins_RAMPS_14.h
@@ -256,7 +256,7 @@
       //The encoder and click button
       #define BTN_EN1 40
       #define BTN_EN2 63
-      #define BTN_ENC 59  //the click switch
+      #define BTN_ENC 59
       //not connected to a pin
       #define SD_DETECT_PIN 49
 

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -89,10 +89,6 @@
 //buttons are directly attached
 #define BTN_EN1 40
 #define BTN_EN2 41
-
-#define BLEN_C 2
-#define BLEN_B 1
-#define BLEN_A 0
 #define BTN_ENC 19
 
 #define SD_DETECT_PIN 39

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -89,10 +89,10 @@
 //buttons are directly attached
 #define BTN_EN1 40
 #define BTN_EN2 41
-#define BTN_ENC 19  //the click
 
 #define BLEN_C 2
 #define BLEN_B 1
 #define BLEN_A 0
+#define BTN_ENC 19
 
 #define SD_DETECT_PIN 39

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -58,7 +58,6 @@
     void bootscreen();
   #endif
 
-
   #define LCD_MESSAGEPGM(x) lcd_setstatuspgm(PSTR(x))
   #define LCD_ALERTMESSAGEPGM(x) lcd_setalertstatuspgm(PSTR(x))
 
@@ -93,7 +92,20 @@
 
   bool lcd_blink();
 
-  #if ENABLED(REPRAPWORLD_KEYPAD)
+  #if ENABLED(ULTIPANEL)
+    #define BLEN_A 0
+    #define BLEN_B 1
+    // Encoder click is directly connected
+    #if BUTTON_EXISTS(ENC)
+      #define BLEN_C 2
+      #define EN_C (_BV(BLEN_C))
+    #endif
+    #define EN_A (_BV(BLEN_A))
+    #define EN_B (_BV(BLEN_B))
+    #define EN_C (_BV(BLEN_C))
+  #endif
+
+  #if ENABLED(REPRAPWORLD_KEYPAD) // is also ULTIPANEL and NEWPANEL
 
     #define REPRAPWORLD_BTN_OFFSET 0 // bit offset into buttons for shift register values
 
@@ -135,35 +147,10 @@
                                               EN_REPRAPWORLD_KEYPAD_LEFT) \
                                             )
 
-  #endif // REPRAPWORLD_KEYPAD
-
-  #if ENABLED(NEWPANEL)
-
-    #define EN_C (_BV(BLEN_C))
-    #define EN_B (_BV(BLEN_B))
-    #define EN_A (_BV(BLEN_A))
-
-    #if ENABLED(REPRAPWORLD_KEYPAD)
-      #define LCD_CLICKED ((buttons&EN_C) || (buttons_reprapworld_keypad&EN_REPRAPWORLD_KEYPAD_F1))
-    #else
-      #define LCD_CLICKED (buttons&EN_C)
-    #endif
-
-  #else //!NEWPANEL
-
-    //atomic, do not change
-    #define B_LE (_BV(BL_LE))
-    #define B_UP (_BV(BL_UP))
-    #define B_MI (_BV(BL_MI))
-    #define B_DW (_BV(BL_DW))
-    #define B_RI (_BV(BL_RI))
-    #define B_ST (_BV(BL_ST))
-    #define EN_B (_BV(BLEN_B))
-    #define EN_A (_BV(BLEN_A))
-
-    #define LCD_CLICKED ((buttons&B_MI)||(buttons&B_ST))
-
-  #endif //!NEWPANEL
+    #define LCD_CLICKED ((buttons & EN_C) || (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1))
+  #elif ENABLED(NEWPANEL)
+    #define LCD_CLICKED (buttons & EN_C)
+  #endif
 
 #else //no LCD
   FORCE_INLINE void lcd_update() {}

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -42,20 +42,9 @@
  * Implementation of the LCD display routines for a DOGM128 graphic display.
  * These are common LCD 128x64 pixel graphic displays.
  */
-
-#if ENABLED(ULTIPANEL)
-  #define BLEN_A 0
-  #define BLEN_B 1
-  #define BLEN_C 2
-  #define EN_A (_BV(BLEN_A))
-  #define EN_B (_BV(BLEN_B))
-  #define EN_C (_BV(BLEN_C))
-  #define LCD_CLICKED (buttons&EN_C)
-#endif
-
-#include "dogm_bitmaps.h"
 #include "ultralcd.h"
 #include "ultralcd_st7920_u8glib_rrd.h"
+#include "dogm_bitmaps.h"
 #include "duration_t.h"
 
 #include <U8glib.h>

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -39,18 +39,6 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
 // via a shift/i2c register.
 
 #if ENABLED(ULTIPANEL)
-  // All UltiPanels might have an encoder - so this is always be mapped onto first two bits
-  #define BLEN_B 1
-  #define BLEN_A 0
-
-  #define EN_B (_BV(BLEN_B)) // The two encoder pins are connected through BTN_EN1 and BTN_EN2
-  #define EN_A (_BV(BLEN_A))
-
-  #if BUTTON_EXISTS(ENC)
-    // encoder click is directly connected
-    #define BLEN_C 2
-    #define EN_C (_BV(BLEN_C))
-  #endif
 
   //
   // Setup other button mappings of each panel
@@ -80,51 +68,35 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
 
   #elif ENABLED(LCD_I2C_PANELOLU2)
 
-    #if BUTTON_EXISTS(ENC)
-
-      #undef LCD_CLICKED
-      #define LCD_CLICKED (buttons&EN_C)
-
-    #else // Read through I2C if not directly connected to a pin
+    #if !BUTTON_EXISTS(ENC) // Use I2C if not directly connected to a pin
 
       #define B_I2C_BTN_OFFSET 3 // (the first three bit positions reserved for EN_A, EN_B, EN_C)
 
       #define B_MI (PANELOLU2_ENCODER_C<<B_I2C_BTN_OFFSET) // requires LiquidTWI2 library v1.2.3 or later
 
       #undef LCD_CLICKED
-      #define LCD_CLICKED (buttons&B_MI)
+      #define LCD_CLICKED (buttons & B_MI)
 
       // I2C buttons take too long to read inside an interrupt context and so we read them during lcd_update
       #define LCD_HAS_SLOW_BUTTONS
 
     #endif
 
-  #elif ENABLED(REPRAPWORLD_KEYPAD)
-
-    // REPRAPWORLD_KEYPAD defined in ultralcd.h
-
-  #elif ENABLED(NEWPANEL)
-    #define LCD_CLICKED (buttons&EN_C)
-
-  #else // old style ULTIPANEL
-    //bits in the shift register that carry the buttons for:
-    // left up center down right red(stop)
-    #define BL_LE 7
-    #define BL_UP 6
-    #define BL_MI 5
-    #define BL_DW 4
-    #define BL_RI 3
-    #define BL_ST 2
-
-    //automatic, do not change
+  #elif DISABLED(NEWPANEL) // old style ULTIPANEL
+    // Shift register bits correspond to buttons:
+    #define BL_LE 7   // Left
+    #define BL_UP 6   // Up
+    #define BL_MI 5   // Middle
+    #define BL_DW 4   // Down
+    #define BL_RI 3   // Right
+    #define BL_ST 2   // Red Button
     #define B_LE (_BV(BL_LE))
     #define B_UP (_BV(BL_UP))
     #define B_MI (_BV(BL_MI))
     #define B_DW (_BV(BL_DW))
     #define B_RI (_BV(BL_RI))
     #define B_ST (_BV(BL_ST))
-
-    #define LCD_CLICKED (buttons&(B_MI|B_ST))
+    #define LCD_CLICKED ((buttons & B_MI) || (buttons & B_ST))
   #endif
 
 #endif //ULTIPANEL


### PR DESCRIPTION
Rebase, cleanup of #4441, addressing #4439

When #4408 added support for RepRapWorld LCD, it improperly overrode the pins for other LCDs like the `REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER`. This PR restores those pin definitions.
