### PR TITLE
Fix output of heater states

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -97,6 +97,7 @@ void serial_echopair_P(const char* s_P, long v);
 void serial_echopair_P(const char* s_P, float v);
 void serial_echopair_P(const char* s_P, double v);
 void serial_echopair_P(const char* s_P, unsigned long v);
+FORCE_INLINE void serial_echopair_P(const char* s_P, uint8_t v) { serial_echopair_P(s_P, (int)v); }
 FORCE_INLINE void serial_echopair_P(const char* s_P, uint16_t v) { serial_echopair_P(s_P, (int)v); }
 FORCE_INLINE void serial_echopair_P(const char* s_P, bool v) { serial_echopair_P(s_P, (int)v); }
 FORCE_INLINE void serial_echopair_P(const char* s_P, void *v) { serial_echopair_P(s_P, (unsigned long)v); }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4468,8 +4468,7 @@ inline void gcode_M104() {
     #endif
     #if HOTENDS > 1
       HOTEND_LOOP() {
-        SERIAL_PROTOCOLPGM(" T");
-        SERIAL_PROTOCOL(e);
+        SERIAL_PROTOCOLPAIR(" T", e);
         SERIAL_PROTOCOLCHAR(':');
         SERIAL_PROTOCOL_F(thermalManager.degHotend(e), 1);
         SERIAL_PROTOCOLPGM(" /");
@@ -4494,8 +4493,7 @@ inline void gcode_M104() {
     #endif
     #if HOTENDS > 1
       HOTEND_LOOP() {
-        SERIAL_PROTOCOLPGM(" @");
-        SERIAL_PROTOCOL(e);
+        SERIAL_PROTOCOLPAIR(" @", e);
         SERIAL_PROTOCOLCHAR(':');
         #ifdef EXTRUDER_WATTS
           SERIAL_PROTOCOL(((EXTRUDER_WATTS) * thermalManager.getHeaterPower(e)) / 127);
@@ -4507,20 +4505,15 @@ inline void gcode_M104() {
     #endif
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       #if HAS_TEMP_BED
-        SERIAL_PROTOCOLPGM("    ADC B:");
-        SERIAL_PROTOCOL_F(thermalManager.degBed(), 1);
-        SERIAL_PROTOCOLPGM("C->");
-        SERIAL_PROTOCOL_F(thermalManager.rawBedTemp() / OVERSAMPLENR, 0);
+        SERIAL_PROTOCOLPAIR("    ADC B:", thermalManager.current_temperature_bed_raw / OVERSAMPLENR);
       #endif
       HOTEND_LOOP() {
-        SERIAL_PROTOCOLPGM("  T");
-        SERIAL_PROTOCOL(e);
+        SERIAL_PROTOCOLPAIR(" T", e);
         SERIAL_PROTOCOLCHAR(':');
-        SERIAL_PROTOCOL_F(thermalManager.degHotend(e), 1);
-        SERIAL_PROTOCOLPGM("C->");
-        SERIAL_PROTOCOL_F(thermalManager.rawHotendTemp(e) / OVERSAMPLENR, 0);
+        SERIAL_PROTOCOL(thermalManager.current_temperature_raw[e] / OVERSAMPLENR);
       }
     #endif
+    SERIAL_EOL;
   }
 #endif
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -40,7 +40,7 @@
 #endif
 
 #if HOTENDS == 1
-  #define HOTEND_LOOP() const uint8_t e = 0;
+  #define HOTEND_LOOP() const int8_t e = 0;
   #define HOTEND_INDEX  0
   #define EXTRUDER_IDX  0
 #else


### PR DESCRIPTION
Addressing #4428 

Heater states output needs to have a space after each value, and the `->` at the end, where it shows the raw temperature is unlikeable.

@MarlinFirmware/host-software-team
