### PR TITLE
Makes safe_delay() to be fully compatible with delay()

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -35,12 +35,10 @@
 
 #include "MarlinConfig.h"
 
-#include "fastio.h"
-
 #include "enum.h"
+#include "types.h"
+#include "fastio.h"
 #include "utility.h"
-
-typedef unsigned long millis_t;
 
 #ifdef USBCON
   #include "HardwareSerial.h"

--- a/Marlin/types.h
+++ b/Marlin/types.h
@@ -1,0 +1,28 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef __TYPES_H__
+#define __TYPES_H__
+
+typedef unsigned long millis_t;
+
+#endif

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -21,9 +21,10 @@
  */
 
 #include "Marlin.h"
+#include "utility.h"
 #include "temperature.h"
 
-void safe_delay(uint16_t ms) {
+void safe_delay(millis_t ms) {
   while (ms > 50) {
     ms -= 50;
     delay(50);

--- a/Marlin/utility.h
+++ b/Marlin/utility.h
@@ -20,4 +20,9 @@
  *
  */
 
-void safe_delay(uint16_t ms);
+#ifndef __UTILITY_H__
+#define __UTILITY_H__
+
+void safe_delay(millis_t ms);
+
+#endif


### PR DESCRIPTION
Makes `safe_delay()` to be fully [type] compatible with `delay()`.
Also adds a `types.h` file which will accommodate `typedef` and `struct` definitions.
