### PR TITLE
Make Conditionals.h a catch-all for old configs

### DIFF
--- a/Marlin/Conditionals.h
+++ b/Marlin/Conditionals.h
@@ -24,4 +24,4 @@
  * Conditionals.h
  * OBSOLETE: Replaced by Conditionals_LCD.h and Conditionals_post.h
  */
-#include "SanityCheck.h"
+#error "Old configurations? Please delete all #include lines from Configuration.h and Configuration_adv.h."

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -451,7 +451,7 @@ MarlinSerial customizedSerial;
 #if ENABLED(EMERGENCY_PARSER)
 
   // Currently looking for: M108, M112, M410
-  // If you alter the parser please don't forget to update the capabilities in Conditionals.h
+  // If you alter the parser please don't forget to update the capabilities in Conditionals_post.h
 
   FORCE_INLINE void emergency_parser(unsigned char c) {
 


### PR DESCRIPTION
Prevent compilation before old configurations are fixed up by removing all #include lines.
