### PR TITLE
FIX for endstop adjustemt on delta is offset

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2414,6 +2414,10 @@ static void homeaxis(AxisEnum axis) {
   // Move slowly towards the endstop until triggered
   line_to_axis_pos(axis, 2 * home_bump_mm(axis) * axis_home_dir, get_homing_bump_feedrate(axis));
 
+  // reset current_position to 0 to reflect hitting endpoint
+  current_position[axis] = 0;
+  sync_plan_position();
+
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) DEBUG_POS("> TRIGGER ENDSTOP", current_position);
   #endif
@@ -2430,7 +2434,6 @@ static void homeaxis(AxisEnum axis) {
         lockZ1 = (z_endstop_adj < 0);
 
       if (lockZ1) stepper.set_z_lock(true); else stepper.set_z2_lock(true);
-      sync_plan_position();
 
       // Move to the adjusted endstop height
       line_to_axis_pos(axis, adj);
@@ -2443,7 +2446,6 @@ static void homeaxis(AxisEnum axis) {
   #if ENABLED(DELTA)
     // retrace by the amount specified in endstop_adj
     if (endstop_adj[axis] * axis_home_dir < 0) {
-      sync_plan_position();
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) {
           SERIAL_ECHOPAIR("> endstop_adj = ", endstop_adj[axis]);


### PR DESCRIPTION
During homing, line_to_axis_pos will make a path which moves across the
endstop trigger point. The move is stopped at endstop, so current_position
should also be adjusted to reflect this!

Caused error in subsequent call in endstop adjustment, since the movement
would assume a wrong starting position.
