### PR TITLE
Auto-select power plugs for RAMPS derivatives

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -267,4 +267,42 @@
     #define BOOTSCREEN_TIMEOUT 2500
   #endif
 
+  /**
+   * Extruders have some combination of stepper motors and hotends
+   * so we separate these concepts into the defines:
+   *
+   *  EXTRUDERS    - Number of Selectable Tools
+   *  HOTENDS      - Number of hotends, whether connected or separate
+   *  E_STEPPERS   - Number of actual E stepper motors
+   *  TOOL_E_INDEX - Index to use when getting/setting the tool state
+   *  
+   */
+  #if ENABLED(SINGLENOZZLE)             // One hotend, multi-extruder
+    #define HOTENDS      1
+    #define E_STEPPERS   EXTRUDERS
+    #define E_MANUAL     EXTRUDERS
+    #define TOOL_E_INDEX current_block->active_extruder
+    #undef TEMP_SENSOR_1_AS_REDUNDANT
+    #undef HOTEND_OFFSET_X
+    #undef HOTEND_OFFSET_Y
+  #elif ENABLED(SWITCHING_EXTRUDER)     // One E stepper, unified E axis, two hotends
+    #define HOTENDS      EXTRUDERS
+    #define E_STEPPERS   1
+    #define E_MANUAL     1
+    #define TOOL_E_INDEX 0
+    #ifndef HOTEND_OFFSET_Z
+      #define HOTEND_OFFSET_Z { 0 }
+    #endif
+  #elif ENABLED(MIXING_EXTRUDER)        // Multi-stepper, unified E axis, one hotend
+    #define HOTENDS      1
+    #define E_STEPPERS   MIXING_STEPPERS
+    #define E_MANUAL     1
+    #define TOOL_E_INDEX 0
+  #else                                 // One stepper, E axis, and hotend per tool
+    #define HOTENDS      EXTRUDERS
+    #define E_STEPPERS   EXTRUDERS
+    #define E_MANUAL     EXTRUDERS
+    #define TOOL_E_INDEX current_block->active_extruder
+  #endif
+
 #endif //CONDITIONALS_LCD_H

--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -326,44 +326,6 @@
   #define HAS_PID_FOR_BOTH (ENABLED(PIDTEMP) && ENABLED(PIDTEMPBED))
 
   /**
-   * Extruders have some combination of stepper motors and hotends
-   * so we separate these concepts into the defines:
-   *
-   *  EXTRUDERS    - Number of Selectable Tools
-   *  HOTENDS      - Number of hotends, whether connected or separate
-   *  E_STEPPERS   - Number of actual E stepper motors
-   *  TOOL_E_INDEX - Index to use when getting/setting the tool state
-   *  
-   */
-  #if ENABLED(SINGLENOZZLE)             // One hotend, multi-extruder
-    #define HOTENDS      1
-    #define E_STEPPERS   EXTRUDERS
-    #define E_MANUAL     EXTRUDERS
-    #define TOOL_E_INDEX current_block->active_extruder
-    #undef TEMP_SENSOR_1_AS_REDUNDANT
-    #undef HOTEND_OFFSET_X
-    #undef HOTEND_OFFSET_Y
-  #elif ENABLED(SWITCHING_EXTRUDER)     // One E stepper, unified E axis, two hotends
-    #define HOTENDS      EXTRUDERS
-    #define E_STEPPERS   1
-    #define E_MANUAL     1
-    #define TOOL_E_INDEX 0
-    #ifndef HOTEND_OFFSET_Z
-      #define HOTEND_OFFSET_Z { 0 }
-    #endif
-  #elif ENABLED(MIXING_EXTRUDER)        // Multi-stepper, unified E axis, one hotend
-    #define HOTENDS      1
-    #define E_STEPPERS   MIXING_STEPPERS
-    #define E_MANUAL     1
-    #define TOOL_E_INDEX 0
-  #else                                 // One stepper, E axis, and hotend per tool
-    #define HOTENDS      EXTRUDERS
-    #define E_STEPPERS   EXTRUDERS
-    #define E_MANUAL     EXTRUDERS
-    #define TOOL_E_INDEX current_block->active_extruder
-  #endif
-
-  /**
    * Default hotend offsets, if not defined
    */
   #if HOTENDS > 1

--- a/Marlin/pins_FELIX2.h
+++ b/Marlin/pins_FELIX2.h
@@ -30,6 +30,7 @@
 
 #define BOARD_NAME "Felix 2.0+"
 
+// Power outputs EFBF or EFBE
 #define MOSFET_D_PIN 7
 
 #include "pins_RAMPS.h"

--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -35,6 +35,7 @@
 
 #define BOARD_NAME "MKS > v1.3"
 
+// Power outputs EFBF or EFBE
 #define MOSFET_D_PIN 7
 
 #include "pins_RAMPS.h"

--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -30,6 +30,7 @@
 
 #define BOARD_NAME "MKS BASE 1.0"
 
+// Power outputs EFBF or EFBE
 #define MOSFET_D_PIN 7
 
 #include "pins_RAMPS.h"

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -115,7 +115,7 @@
 #endif
 
 // Augmentation for auto-assigning RAMPS plugs
-#if DISABLED(IS_RAMPS_EEB) && DISABLED(IS_RAMPS_EEF) && DISABLED(IS_RAMPS_EFB) && DISABLED(IS_RAMPS_EFF) && DISABLED(IS_RAMPS_SF)
+#if DISABLED(IS_RAMPS_EEB) && DISABLED(IS_RAMPS_EEF) && DISABLED(IS_RAMPS_EFB) && DISABLED(IS_RAMPS_EFF) && DISABLED(IS_RAMPS_SF) && !PIN_EXISTS(MOSFET_D)
   #if HOTENDS > 1
     #if TEMP_SENSOR_BED
       #define IS_RAMPS_EEB
@@ -163,7 +163,7 @@
   #define CONTROLLERFAN_PIN  -1
 #elif ENABLED(IS_RAMPS_SF)                     // Spindle, Fan
   #define FAN_PIN        RAMPS_D8_PIN
-#else                                          // Non-specific are "EFB" by legacy
+#else                                          // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
   #define FAN_PIN        RAMPS_D9_PIN
   #define HEATER_BED_PIN RAMPS_D8_PIN
   #if HOTENDS == 1

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -114,10 +114,7 @@
   #define SLED_PIN           -1
 #endif
 
-/*
-
 // Augmentation for auto-assigning RAMPS plugs
-
 #if DISABLED(IS_RAMPS_EEB) && DISABLED(IS_RAMPS_EEF) && DISABLED(IS_RAMPS_EFB) && DISABLED(IS_RAMPS_EFF) && DISABLED(IS_RAMPS_SF)
   #if HOTENDS > 1
     #if TEMP_SENSOR_BED
@@ -131,8 +128,6 @@
     #define IS_RAMPS_EFF
   #endif
 #endif
-
-*/
 
 /**
  * Hi Voltage PWM Pin Assignments


### PR DESCRIPTION
Reference: https://github.com/MarlinFirmware/Marlin/issues/2071#issuecomment-236656692

**Background**: RAMPS derivatives like Azteeg X3, Felix 2, etc. always presume "EFB" for the high current outputs. Some of these boards then add `HEATER_1_PIN` (usually as pin 7), leaving 8, 9, and 10 as the B, F, and E pins. My previous PR #4463 moved all the high current output assignment code to its own block. Power output pins are set based on the RAMPS variant: EFB, EFF, EEF, or EEB, as explicitly set by `MOTHERBOARD`. For RAMPS derivatives the pre-selection of EFB was left in place.

This PR uses a little added logic to auto-select which RAMPS variant applies for RAMPS derivatives also, based on the number of `HOTENDS` and whether `TEMP_SENSOR_BED` is set.

To support the setting of pins options based on `HOTENDS`, the `EXTRUDERS`-to-`HOTENDS` logic is moved to `Conditionals_LCD.h`.
