### PR TITLE
Patch for COREYZ, tweak to scaled feedrate macro

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -261,7 +261,7 @@ extern int feedrate_percentage;
 
 #define MMM_TO_MMS(MM_M) ((MM_M)/60.0)
 #define MMS_TO_MMM(MM_S) ((MM_S)*60.0)
-#define MMM_SCALED(MM_M) ((MM_M)*feedrate_percentage/100.0)
+#define MMM_SCALED(MM_M) ((MM_M)*feedrate_percentage*0.01)
 #define MMS_SCALED(MM_S) MMM_SCALED(MM_S)
 #define MMM_TO_MMS_SCALED(MM_M) (MMS_SCALED(MMM_TO_MMS(MM_M)))
 

--- a/Marlin/enum.h
+++ b/Marlin/enum.h
@@ -42,7 +42,7 @@ enum AxisEnum {
   E_AXIS  = 3,
   X_HEAD  = 4,
   Y_HEAD  = 5,
-  Z_HEAD  = 5
+  Z_HEAD  = 6
 };
 
 #define LOOP_XYZ(VAR)  for (uint8_t VAR=X_AXIS; VAR<=Z_AXIS; VAR++)

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -782,7 +782,7 @@ void Planner::check_axes_activity() {
    * Having the real displacement of the head, we can calculate the total movement length and apply the desired speed.
    */
   #if ENABLED(COREXY) || ENABLED(COREXZ) || ENABLED(COREYZ)
-    float delta_mm[6];
+    float delta_mm[7];
     #if ENABLED(COREXY)
       delta_mm[X_HEAD] = dx * steps_to_mm[A_AXIS];
       delta_mm[Y_HEAD] = dy * steps_to_mm[B_AXIS];


### PR DESCRIPTION
- CoreYZ needs separate slots for Y and Z head positions
- Multiply `feedrate_percentage` by `0.01` rather than divide by `100.0`
