### PR TITLE
Prevent the 'tone(f,d)' function from being interrupted

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -215,7 +215,6 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 /**
  * The axis order in all axis related arrays is X, Y, Z, E
  */
-#define NUM_AXIS 4
 #define _AXIS(AXIS) AXIS ##_AXIS
 
 void enable_all_steppers();

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -29,9 +29,11 @@
   Modified 14 February 2016 by Andreas Hardtung (added tx buffer)
 */
 
-#include "Marlin.h"
 #include "MarlinSerial.h"
+
 #include "stepper.h"
+
+#include "Marlin.h"
 
 #ifndef USBCON
 // this next line disables the entire HardwareSerial.cpp,

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -31,13 +31,8 @@
 
 #ifndef MarlinSerial_h
 #define MarlinSerial_h
-#include "Marlin.h"
 
-#ifndef CRITICAL_SECTION_START
-  #define CRITICAL_SECTION_START  unsigned char _sreg = SREG; cli();
-  #define CRITICAL_SECTION_END    SREG = _sreg;
-#endif
-
+#include "MarlinConfig.h"
 
 #ifndef SERIAL_PORT
   #define SERIAL_PORT 0

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -61,6 +61,7 @@
 #include "math.h"
 #include "nozzle.h"
 #include "duration_t.h"
+#include "types.h"
 
 #if ENABLED(USE_WATCHDOG)
   #include "watchdog.h"

--- a/Marlin/buzzer.h
+++ b/Marlin/buzzer.h
@@ -23,6 +23,7 @@
 #ifndef __BUZZER_H__
 #define __BUZZER_H__
 
+#include "types.h"
 #include "fastio.h"
 #include "circularqueue.h"
 #include "temperature.h"
@@ -127,7 +128,9 @@ class Buzzer {
 
         if (this->state.tone.frequency > 0) {
           #if ENABLED(SPEAKER)
+            CRITICAL_SECTION_START;
             ::tone(BEEPER_PIN, this->state.tone.frequency, this->state.tone.duration);
+            CRITICAL_SECTION_END;
           #else
             this->on();
           #endif

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -20,12 +20,14 @@
  *
  */
 
-#include "Marlin.h"
 #include "cardreader.h"
+
 #include "ultralcd.h"
 #include "stepper.h"
 #include "temperature.h"
 #include "language.h"
+
+#include "Marlin.h"
 
 #if ENABLED(SDSUPPORT)
 

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -23,11 +23,15 @@
 #ifndef CARDREADER_H
 #define CARDREADER_H
 
+#include "MarlinConfig.h"
+
 #if ENABLED(SDSUPPORT)
 
 #define MAX_DIR_DEPTH 10          // Maximum folder depth
 
 #include "SdFile.h"
+
+#include "types.h"
 #include "enum.h"
 
 class CardReader {

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -23,6 +23,8 @@
 #ifndef MACROS_H
 #define MACROS_H
 
+#define NUM_AXIS 4
+
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 // Bracket code that shouldn't be interrupted

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -58,12 +58,13 @@
  *
  */
 
-#include "Marlin.h"
 #include "planner.h"
 #include "stepper.h"
 #include "temperature.h"
 #include "ultralcd.h"
 #include "language.h"
+
+#include "Marlin.h"
 
 #if ENABLED(MESH_BED_LEVELING)
   #include "mesh_bed_leveling.h"

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -32,7 +32,8 @@
 #ifndef PLANNER_H
 #define PLANNER_H
 
-#include "Marlin.h"
+#include "types.h"
+#include "MarlinConfig.h"
 
 #if ENABLED(AUTO_BED_LEVELING_FEATURE)
   #include "vector_3.h"

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -47,6 +47,7 @@
 #include "speed_lookuptable.h"
 #include "stepper_indirection.h"
 #include "language.h"
+#include "types.h"
 
 class Stepper;
 extern Stepper stepper;

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -27,9 +27,10 @@
 #ifndef TEMPERATURE_H
 #define TEMPERATURE_H
 
-#include "Marlin.h"
 #include "planner.h"
 #include "thermistortables.h"
+
+#include "MarlinConfig.h"
 
 #if ENABLED(PID_EXTRUSION_SCALING)
   #include "stepper.h"


### PR DESCRIPTION
Addressing #4513

**Background**: The Arduino `tone()` function starts a tone with a given pitch on devices with a pitch generator (`SPEAKER`). Evidently if an interrupt occurs during the call to `tone()` strange sounds may result, usually a high pitched tone that never stops.

**Solution**: Bracket the call to `tone()` with calls to `CRITICAL_SECTION_START` and `CRITICAL_SECTION_END`.
