### PR TITLE
Only report finished prints longer than 1 min

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -614,7 +614,8 @@ void CardReader::printingHasFinished() {
     if (SD_FINISHED_STEPPERRELEASE)
       enqueue_and_echo_commands_P(PSTR(SD_FINISHED_RELEASECOMMAND));
     print_job_timer.stop();
-    enqueue_and_echo_commands_P(PSTR("M31"));
+    if (print_job_timer.duration() > 60)
+      enqueue_and_echo_commands_P(PSTR("M31"));
   }
 }
 


### PR DESCRIPTION
When using an SD Card with `auto0.g` or other GCode files that perform quick tasks, which may print messages to the screen, etc., we don't want the status message to be replaced by "0s" or other small durations when the "print" has finished. So for any GCode files or print jobs from SD that take less than a minute, skip reporting the duration.
