### PR TITLE
Define Z_MIN_PROBE_PIN always, allowing override

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -270,10 +270,16 @@
   #endif
 
   /**
-   * Z_MIN_PIN and Z_MIN_PROBE_PIN can't co-exist when Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+   * Require a Z min pin
    */
-  #if HAS_Z_MIN && HAS_Z_MIN_PROBE_PIN && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-    #error "A probe cannot have more than one pin! Use Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN or Z_MIN_PROBE_PIN."
+  #if HAS_Z_MIN
+     // Z_MIN_PIN and Z_MIN_PROBE_PIN can't co-exist when Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+    #if HAS_Z_MIN_PROBE_PIN && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+      #error "A probe cannot have more than one pin! Use Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN or Z_MIN_PROBE_PIN."
+    #endif
+  #elif !HAS_Z_MIN_PROBE_PIN || (DISABLED(Z_MIN_PROBE_ENDSTOP) || ENABLED(DISABLE_Z_MIN_PROBE_ENDSTOP))
+    // A pin was set for the Z probe, but not enabled.
+    #error "A probe requires a Z_MIN or Z_PROBE pin. Z_MIN_PIN or Z_MIN_PROBE_PIN must point to a valid hardware pin."
   #endif
 
   /**
@@ -382,15 +388,6 @@
    */
   #if ENABLED(DELTA) && DISABLED(AUTO_BED_LEVELING_GRID)
     #error "You must use AUTO_BED_LEVELING_GRID for DELTA bed leveling."
-  #endif
-
-  /**
-   * Require a Z min pin
-   */
-  #if !PIN_EXISTS(Z_MIN)
-    #if !PIN_EXISTS(Z_MIN_PROBE) || (DISABLED(Z_MIN_PROBE_ENDSTOP) || ENABLED(DISABLE_Z_MIN_PROBE_ENDSTOP)) // It's possible for someone to set a pin for the Z probe, but not enable it.
-      #error "AUTO_BED_LEVELING_FEATURE requires a Z_MIN or Z_PROBE endstop. Z_MIN_PIN or Z_MIN_PROBE_PIN must point to a valid hardware pin."
-    #endif
   #endif
 
   /**

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -60,14 +60,10 @@
   #define Z_MAX_PIN        18
 #endif
 
-
-#if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  //#undef Z_MIN_PIN
-  //#define Z_MIN_PIN        15
-  // Define a pin to use as the signal pin on Arduino for the Z probe endstop.
+#ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN  19
 #endif
-//
+
 #define E2_STEP_PIN        23
 #define E2_DIR_PIN         25
 #define E2_ENABLE_PIN      40

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -41,21 +41,24 @@
 
 #define LARGE_FLASH        true
 
+#define X_STOP_PIN         47
+#define Y_STOP_PIN         18
+#define Z_MAX_PIN          36
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  17
+#endif
+
 #define X_STEP_PIN         33
 #define X_DIR_PIN          32
 #define X_ENABLE_PIN       11
-#define X_STOP_PIN         47
 
 #define Y_STEP_PIN         31
 #define Y_DIR_PIN          30
 #define Y_ENABLE_PIN        8
-#define Y_STOP_PIN         18
 
 #define Z_STEP_PIN         29
 #define Z_DIR_PIN          28
 #define Z_ENABLE_PIN       37
-#define Z_MAX_PIN          36
-#define Z_MIN_PROBE_PIN    17  // Bed Z probe
 
 #define E0_STEP_PIN        35
 #define E0_DIR_PIN         34

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -42,26 +42,30 @@
   #define SLED_PIN         -1
 #endif
 
-#define X_STEP_PIN 37
-#define X_DIR_PIN 48
 #define X_MIN_PIN 12
 #define X_MAX_PIN 24
+#define Y_MIN_PIN 11
+#define Y_MAX_PIN 23
+#define Z_MIN_PIN 10
+#define Z_MAX_PIN 30
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN 10
+#endif
+
+#define X_STEP_PIN 37
+#define X_DIR_PIN 48
 #define X_ENABLE_PIN 29
 #define X_MS1_PIN 40
 #define X_MS2_PIN 41
 
 #define Y_STEP_PIN 36
 #define Y_DIR_PIN 49
-#define Y_MIN_PIN 11
-#define Y_MAX_PIN 23
 #define Y_ENABLE_PIN 28
 #define Y_MS1_PIN 69
 #define Y_MS2_PIN 39
 
 #define Z_STEP_PIN 35
 #define Z_DIR_PIN 47
-#define Z_MIN_PIN 10
-#define Z_MAX_PIN 30
 #define Z_ENABLE_PIN 27
 #define Z_MS1_PIN 68
 #define Z_MS2_PIN 67

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -63,25 +63,29 @@
 #define SERVO2_PIN          5
 #define SERVO3_PIN          4
 
-#define X_STEP_PIN         54
-#define X_DIR_PIN          55
-#define X_ENABLE_PIN       38
 #define X_MIN_PIN           3
 #ifndef X_MAX_PIN
   #define X_MAX_PIN         2
 #endif
+#define Y_MIN_PIN          14
+#define Y_MAX_PIN          15
+#define Z_MIN_PIN          18
+#define Z_MAX_PIN          19
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  32
+#endif
+
+#define X_STEP_PIN         54
+#define X_DIR_PIN          55
+#define X_ENABLE_PIN       38
 
 #define Y_STEP_PIN         60
 #define Y_DIR_PIN          61
 #define Y_ENABLE_PIN       56
-#define Y_MIN_PIN          14
-#define Y_MAX_PIN          15
 
 #define Z_STEP_PIN         46
 #define Z_DIR_PIN          48
 #define Z_ENABLE_PIN       62
-#define Z_MIN_PIN          18
-#define Z_MAX_PIN          19
 
 #define E0_STEP_PIN        26
 #define E0_DIR_PIN         28
@@ -96,11 +100,6 @@
 
 // Use the RAMPS 1.4 Analog input 5 on the AUX2 connector
 #define FILWIDTH_PIN        5 // ANALOG NUMBERING
-
-#if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  // Define a pin to use as the signal pin on Arduino for the Z_PROBE endstop.
-  #define Z_MIN_PROBE_PIN  32
-#endif
 
 // define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
 #define FIL_RUNOUT_PIN      4

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -24,22 +24,15 @@
  * RIGIDBOARD Arduino Mega with RAMPS v1.4 pin assignments
  */
 
-#include "pins_RAMPS.h"
-
-#undef BOARD_NAME
 #define BOARD_NAME "RigidBoard"
 
-#if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #undef Z_MAX_PIN
-  #define Z_MAX_PIN -1
-  #undef Z_MIN_PROBE_PIN
+#define RAMPS_D10_PIN       9    // EXTRUDER 1
+#define MOSFET_D_PIN       12    // EXTRUDER 2 or FAN
+#ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN  19    // Z-MAX pin J14 End Stops
 #endif
 
-#undef HEATER_0_PIN
-#undef HEATER_1_PIN
-#define HEATER_0_PIN        9    // EXTRUDER 1
-#define HEATER_1_PIN       12    // EXTRUDER 2 (FAN On Sprinter)
+#include "pins_RAMPS.h"
 
 #undef TEMP_0_PIN
 #undef TEMP_1_PIN

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -53,8 +53,7 @@
 #define Z_MIN_PIN          33
 #define Z_MAX_PIN          32
 
-#if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  // Define a pin to use as the signal pin on Arduino for the Z probe endstop.
+#ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN  33
 #endif
 


### PR DESCRIPTION
In response to #4507

The "new principle" for the pins files is to always define the default pin number that will be used for a certain function, even if that function may be disabled or another pin may be used. For pins that are commonly overridden we wrap them in `#ifdef`.

So this PR applies the general idea to `Z_MIN_PROBE_PIN`. In most cases the pin is defined as the same as the `Z_MIN` pin, so you can either use the Z min probe or a Z min endstop, but not both.

In general, it would be good to automate this where possible. For example, when you have min and max endstop plugs and are only using 3 of them, the first unused plug (usually `X_MIN` or `X_MAX`) could be applied to the Z min probe. For cases where you specifically want to share a plug with an existing endstop you could override the pin or set a flag indicating you want to share the Z_MIN pin (for example).

Currently it remains unclear which pin will be used, while we offer several options where fewer might suffice:
- `Z_MIN_PROBE_ENDSTOP` - Without this option `Z_MIN_PROBE_PIN` will be un-defined.
- `Z_MIN_PROBE_PIN` - Override to set a custom pin, otherwise board-specific (usually `Z_MIN`)
- `Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN` - Use the `Z_MIN_PIN` pin for endstop _and_ probe.
- `DISABLE_Z_MIN_PROBE_ENDSTOP` - Don't use the defined `Z_MIN_PROBE_PIN` pin. (Why?)

One thing I am unclear about:
- Can the probe and an active Z_MIN endstop switch share the same pin? Can you do `G28` with the Z endstop switch but then do `G29` with the probe sensor? In that case, the probe would not deploy and stow on `G28` but only on `G29`.
- In all other cases —where the probe should have its own pin— shouldn't it be possible to automatically assign the pin to the first unused endstop pin? Or, if a board defines a "preferred" pin, then that could be the fallback.
