### PR TITLE
Make Allen Key Probe stow

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2068,6 +2068,8 @@ static void clean_up_after_endstop_or_probe_move() {
                                                    // Would a goto be less ugly?
       //while (!_TRIGGERED_WHEN_STOWED_TEST) { idle(); // would offer the opportunity
       // for a triggered when stowed manual probe.
+      if(!deploy) endstops.enable_z_probe( deploy ); // Switch off triggered when stowed probes early
+                                                     // Else a Allen-Key probe can't be stowed.
     #endif
 
     #if ENABLED(Z_PROBE_SLED)


### PR DESCRIPTION
by switching off the tests for the probe before the stow move.
Fix for #4532 
