### PR TITLE
Repair SPI-pins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,12 @@ script:
   - opt_enable PIDTEMPBED
   - build_marlin
   #
+  # Test MAX6675
+  #
+  - restore_configs
+  - opt_set TEMP_SENSOR_0 -2
+  - build_marlin
+  #
   # Test a "Fix Mounted" Probe along with Safe Homing
   #
   - restore_configs

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -456,17 +456,87 @@
 
 #define HAS_DIGIPOTSS (PIN_EXISTS(DIGIPOTSS))
 
-#ifndef SCK_PIN
-  #define SCK_PIN  SCK
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
+  #ifndef SCK_PIN
+    #define SCK_PIN  13
+  #endif
+  #ifndef MISO_PIN
+    #define MISO_PIN 12
+  #endif
+  #ifndef MOSI_PIN
+    #define MOSI_PIN 11
+  #endif
+  #ifndef SS_PIN
+    #define SS_PIN   10
+  #endif
+#elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__)
+  #ifndef SCK_PIN
+    #define SCK_PIN  7
+  #endif
+  #ifndef MISO_PIN
+    #define MISO_PIN 6
+  #endif
+  #ifndef MOSI_PIN
+    #define MOSI_PIN 5
+  #endif
+  #ifndef SS_PIN
+    #define SS_PIN   4
+  #endif
+#elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
+  #ifndef SCK_PIN
+    #define SCK_PIN  52
+  #endif
+  #ifndef MISO_PIN
+    #define MISO_PIN 50
+  #endif
+  #ifndef MOSI_PIN
+    #define MOSI_PIN 51
+  #endif
+  #ifndef SS_PIN
+    #define SS_PIN   53
+  #endif
+#elif defined(__AVR_AT90USB1287__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB647__)
+  #ifndef AT90USBxx_TEENSYPP_ASSIGNMENTS // Use traditional Marlin pin assignments
+    #ifndef SCK_PIN
+      #define SCK_PIN  9
+    #endif
+    #ifndef MISO_PIN
+      #define MISO_PIN 11
+    #endif
+    #ifndef MOSI_PIN
+      #define MOSI_PIN 10
+    #endif
+    #ifndef SS_PIN
+      #define SS_PIN   8
+    #endif
+  #else
+    #ifndef SCK_PIN
+      #define SCK_PIN  21
+    #endif
+    #ifndef MISO_PIN
+      #define MISO_PIN 23
+    #endif
+    #ifndef MOSI_PIN
+      #define MOSI_PIN 22
+    #endif
+    #ifndef SS_PIN
+      #define SS_PIN   20
+    #endif
+  #endif
+#elif defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__)
+  #ifndef SCK_PIN
+    #define SCK_PIN  10
+  #endif
+  #ifndef MISO_PIN
+    #define MISO_PIN 12
+  #endif
+  #ifndef MOSI_PIN
+    #define MOSI_PIN 11
+  #endif
+  #ifndef SS_PIN
+    #define SS_PIN   16
+  #endif
 #endif
-#ifndef MISO_PIN
-  #define MISO_PIN MISO
-#endif
-#ifndef MOSI_PIN
-  #define MOSI_PIN MOSI
-#endif
-#ifndef SS_PIN
-  #define SS_PIN   SS
-#endif
+
 
 #endif //__PINS_H

--- a/Marlin/pins_BQ_ZUM_MEGA_3D.h
+++ b/Marlin/pins_BQ_ZUM_MEGA_3D.h
@@ -56,6 +56,7 @@
 #define DIGIPOTSS_PIN     22
 #define DIGIPOT_CHANNELS  { 4, 5, 3, 0, 1 }
 
+#undef FAN1_PIN
 #define FAN1_PIN          7
 
 #undef PS_ON_PIN             // 12

--- a/buildroot/bin/restore_configs
+++ b/buildroot/bin/restore_configs
@@ -2,7 +2,7 @@
 
 cp Marlin/Configuration.h.backup      Marlin/Configuration.h
 cp Marlin/Configuration_adv.h.backup  Marlin/Configuration_adv.h
-cp Marlin/pins_RAMPS_14.h.backup      Marlin/pins_RAMPS_14.h
+cp Marlin/pins_RAMPS.h.backup      Marlin/pins_RAMPS.h
 
 if [ -f Marlin/_Bootscreen.h ]; then
   rm Marlin/_Bootscreen.h


### PR DESCRIPTION
SCK_PIN and co. can't be defined as DIO[number] they mus be defined as pure number.
So rebuilding the processor based #if-structure of fastio.h in pins.h.

Add Travis test for MAX6675
