### PR TITLE
MISO is an input

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1021,7 +1021,8 @@ void Temperature::init() {
     #if DISABLED(SDSUPPORT)
       OUT_WRITE(SCK_PIN, LOW);
       OUT_WRITE(MOSI_PIN, HIGH);
-      OUT_WRITE(MISO_PIN, HIGH);
+      SET_INPUT(MISO_PIN);
+      WRITE(MISO_PIN,1);
     #else
       OUT_WRITE(SS_PIN, HIGH);
     #endif


### PR DESCRIPTION
Fix a setup error introduced in #1555
to make MAX6675 work without SDSUPPORT.

https://github.com/MarlinFirmware/Marlin/issues/4533#issuecomment-238319329
