### PR TITLE
Always disable SLOWDOWN for DELTA/SCARA

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -143,10 +143,11 @@
   #endif
 
   /**
-   * DELTA should ignore Z_SAFE_HOMING
+   * DELTA should ignore Z_SAFE_HOMING and SLOWDOWN
    */
   #if ENABLED(DELTA)
     #undef Z_SAFE_HOMING
+    #undef SLOWDOWN
   #endif
 
   /**


### PR DESCRIPTION
Addressing #4501

The configuration warns about using `SLOWDOWN` with `DELTA`, but disables it automatically for `SCARA`. Seems as though we should just always disable it automatically for `DELTA`. Otherwise users will forget.
