### PR TITLE
Show up to 99:59 in digital time

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8671,7 +8671,7 @@ void kill(const char* lcd_msg) {
     UNUSED(lcd_msg);
   #endif
 
-  for (int i = 5; i--;) delay(100); // Wait a short time
+  delay(500); // Wait a short time
 
   cli(); // Stop interrupts
   thermalManager.disable_all_heaters();

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -744,6 +744,6 @@
 /**
  * emergency-command parser
  */
-#if ENABLED(EMERGENCY_PARSER) && ENABLED(USBCON)
+#if ENABLED(EMERGENCY_PARSER) && defined(USBCON)
   #error "EMERGENCY_PARSER does not work on boards with AT90USB processors (USBCON)."
 #endif

--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -145,7 +145,7 @@ struct duration_t {
    *  1193046:59
    */
   void toDigital(char *buffer) const {
-    int h = this->hour() % 24,
+    int h = this->hour(),
         m = this->minute() % 60;
 
     sprintf_P(buffer, PSTR("%02i:%02i"), h, m);


### PR DESCRIPTION
Addressing #4565, #4566

The digital formatted time was only allowing up to 23:59. With this PR it will show up to 99:59.

Also…
- Just call `delay(500)` once in `kill()`
- Fix a compile error with `SanityCheck.h`
