### PR TITLE
Include days in Graphical LCD print timer

### DIFF
--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -141,14 +141,16 @@ struct duration_t {
    * @param buffer The array pointed to must be able to accommodate 10 bytes
    *
    * Output examples:
-   *  1234567890 (strlen)
-   *  1193046:59
+   *  123456789 (strlen)
+   *  99:59
+   *  11d 12:33
    */
-  void toDigital(char *buffer) const {
-    int h = this->hour(),
-        m = this->minute() % 60;
-
-    sprintf_P(buffer, PSTR("%02i:%02i"), h, m);
+  void toDigital(char *buffer, bool with_days=false) const {
+    int m = this->minute() % 60;
+    if (with_days)
+      sprintf_P(buffer, PSTR("%id %02i:%02i"), this->day(), this->hour() % 24, m);
+    else
+      sprintf_P(buffer, PSTR("%02i:%02i"), this->hour(), m);
   }
 };
 

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -382,11 +382,12 @@ static void lcd_implementation_status_screen() {
       u8g.drawBox(55, 50, (unsigned int)(71 * card.percentDone() * 0.01), 2 - (TALL_FONT_CORRECTION));
     }
 
-    u8g.setPrintPos(80,48);
-
     char buffer[10];
     duration_t elapsed = print_job_timer.duration();
-    elapsed.toDigital(buffer);
+    bool has_days = (elapsed.value > 60*60*24);
+    elapsed.toDigital(buffer, has_days);
+
+    u8g.setPrintPos(has_days ? 71 : 80, 48);
     lcd_print(buffer);
 
   #endif


### PR DESCRIPTION
There's more space on graphical displays, so if the timer goes over 24 hours we can show days.
