### PR TITLE
Fix serial output for MBL, M303

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -71,6 +71,7 @@
 #define SERIAL_PROTOCOLLNPGM(x) do{ serialprintPGM(PSTR(x "\n")); }while(0)
 
 #define SERIAL_PROTOCOLPAIR(name, value) SERIAL_ECHOPAIR(name, value)
+#define SERIAL_PROTOCOLLNPAIR(name, value) do{ SERIAL_ECHOPAIR(name, value); SERIAL_EOL; }while(0)
 
 extern const char errormagic[] PROGMEM;
 extern const char echomagic[] PROGMEM;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3280,10 +3280,9 @@ inline void gcode_G28() {
       case MeshReport:
         if (mbl.has_mesh()) {
           SERIAL_PROTOCOLPAIR("State: ", mbl.active() ? "On" : "Off");
-          SERIAL_PROTOCOLPAIR("\nNum X,Y: ", MESH_NUM_X_POINTS);
-          SERIAL_PROTOCOLCHAR(','); SERIAL_PROTOCOL(MESH_NUM_Y_POINTS);
-          SERIAL_PROTOCOLPAIR("\nZ search height: ", MESH_HOME_SEARCH_Z);
-          SERIAL_PROTOCOLPGM("\nZ offset: "); SERIAL_PROTOCOL_F(mbl.z_offset, 5);
+          SERIAL_PROTOCOLLNPGM("\nNum X,Y: " STRINGIFY(MESH_NUM_X_POINTS) "," STRINGIFY(MESH_NUM_Y_POINTS));
+          SERIAL_PROTOCOLLNPGM("Z search height: " STRINGIFY(MESH_HOME_SEARCH_Z));
+          SERIAL_PROTOCOLPGM("Z offset: "); SERIAL_PROTOCOL_F(mbl.z_offset, 5);
           SERIAL_PROTOCOLLNPGM("\nMeasured points:");
           for (py = 0; py < MESH_NUM_Y_POINTS; py++) {
             for (px = 0; px < MESH_NUM_X_POINTS; px++) {

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -395,8 +395,7 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
     if (file.open(curDir, fname, O_READ)) {
       filesize = file.fileSize();
       SERIAL_PROTOCOLPAIR(MSG_SD_FILE_OPENED, fname);
-      SERIAL_PROTOCOLPAIR(MSG_SD_SIZE, filesize);
-      SERIAL_EOL;
+      SERIAL_PROTOCOLLNPAIR(MSG_SD_SIZE, filesize);
       sdpos = 0;
 
       SERIAL_PROTOCOLLNPGM(MSG_SD_FILE_SELECTED);
@@ -417,8 +416,7 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
     }
     else {
       saving = true;
-      SERIAL_PROTOCOLPAIR(MSG_SD_WRITE_TO_FILE, name);
-      SERIAL_EOL;
+      SERIAL_PROTOCOLLNPAIR(MSG_SD_WRITE_TO_FILE, name);
       lcd_setstatus(fname);
     }
   }
@@ -449,6 +447,7 @@ void CardReader::removeFile(char* name) {
         if (!myDir.open(curDir, subdirname, O_READ)) {
           SERIAL_PROTOCOLPAIR("open failed, File: ", subdirname);
           SERIAL_PROTOCOLCHAR('.');
+          SERIAL_EOL;
           return;
         }
         else {


### PR DESCRIPTION
A few carriage-returns were missing, and there were some opportunities to use `STRINGIFY` instead of `SERIAL_PROTOCOLPAIR`.
