### PR TITLE
Add support for i2c slave address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -205,10 +205,11 @@ script:
   - opt_enable ULTIMAKERCONTROLLER FILAMENT_LCD_DISPLAY
   - build_marlin
   #
-  # Enable BEZIER_CURVE_SUPPORT
+  # Enable BEZIER_CURVE_SUPPORT, EXPERIMENTAL_I2CBUS, and I2C_SLAVE_ADDRESS
   #
   - restore_configs
-  - opt_enable_adv BEZIER_CURVE_SUPPORT
+  - opt_enable_adv BEZIER_CURVE_SUPPORT EXPERIMENTAL_I2CBUS
+  - opt_set_adv I2C_SLAVE_ADDRESS 1
   - build_marlin
   #
   # Enable COREXY

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -835,6 +835,14 @@ void servo_init() {
   void enableStepperDrivers() { pinMode(STEPPER_RESET_PIN, INPUT); }  // set to input, which allows it to be pulled high by pullups
 #endif
 
+#if ENABLED(EXPERIMENTAL_I2CBUS) && I2C_SLAVE_ADDRESS > 0
+
+  void i2c_listener(int bytes) {
+    i2c.receive(bytes);        // just echo all bytes received to serial
+  }
+
+#endif
+
 /**
  * Marlin entry-point: Set up before the program loop
  *  - Set up the kill pin, filament runout, power hold
@@ -980,6 +988,10 @@ void setup() {
     for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS; t++)
       for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
         mixing_virtual_tool_mix[t][i] = mixing_factor[i];
+  #endif
+
+  #if ENABLED(EXPERIMENTAL_I2CBUS) && I2C_SLAVE_ADDRESS > 0
+    i2c.onReceive(i2c_listener);
   #endif
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5259,15 +5259,13 @@ inline void gcode_M121() { endstops.enable_globally(false); }
    */
   inline void gcode_M155() {
     // Set the target address
-    if (code_seen('A'))
-      i2c.address(code_value_byte());
+    if (code_seen('A')) i2c.address(code_value_byte());
 
     // Add a new byte to the buffer
-    else if (code_seen('B'))
-      i2c.addbyte(code_value_int());
+    if (code_seen('B')) i2c.addbyte(code_value_byte());
 
     // Flush the buffer to the bus
-    else if (code_seen('S')) i2c.send();
+    if (code_seen('S')) i2c.send();
 
     // Reset and rewind the buffer
     else if (code_seen('R')) i2c.reset();
@@ -5279,11 +5277,11 @@ inline void gcode_M121() { endstops.enable_globally(false); }
    * Usage: M156 A<slave device address base 10> B<number of bytes>
    */
   inline void gcode_M156() {
-    uint8_t addr = code_seen('A') ? code_value_byte() : 0;
-    int bytes    = code_seen('B') ? code_value_int() : 1;
+    if (code_seen('A')) i2c.address(code_value_byte());
 
-    if (addr && bytes > 0 && bytes <= 32) {
-      i2c.address(addr);
+    uint8_t bytes = code_seen('B') ? code_value_byte() : 1;
+
+    if (i2c.addr > 0 && bytes > 0 && bytes <= 32) {
       i2c.reqbytes(bytes);
     }
     else {

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -801,5 +801,6 @@ const unsigned int dropsegments = 2; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -803,5 +803,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -797,5 +797,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -797,5 +797,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -796,5 +796,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -801,5 +801,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -797,5 +797,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -795,5 +795,6 @@ const unsigned int dropsegments = 5; //everything with less than this number of 
 // @section i2cbus
 
 //#define EXPERIMENTAL_I2CBUS
+#define I2C_SLAVE_ADDRESS  0 // Set non-zero to act as a slave
 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/twibus.h
+++ b/Marlin/twibus.h
@@ -60,13 +60,6 @@ class TWIBus {
     const int timeout = 5;
 
     /**
-     * @brief Target device address
-     * @description The target device address. Persists until changed.
-     *              
-     */
-    uint8_t addr = 0;
-
-    /**
      * @brief Number of bytes on buffer
      * @description Number of bytes in the buffer waiting to be flushed to the bus.
      */
@@ -76,10 +69,16 @@ class TWIBus {
      * @brief Internal buffer
      * @details A fixed buffer. TWI commands can be no longer than this.
      */
-    char buffer[30];
+    char buffer[32];
 
 
   public:
+    /**
+     * @brief Target device address
+     * @description The target device address. Persists until changed.
+     */
+    uint8_t addr = 0;
+
     /**
      * @brief Class constructor
      * @details Initialize the TWI bus and clear the buffer


### PR DESCRIPTION
- Add `TWIBus::receive(bytes)` and `TWIBus::onReceive()`
- Add `I2C_SLAVE_ADDRESS` setting
- If `I2C_SLAVE_ADDRESS` is non-zero then `Wire.begin(I2C_SLAVE_ADDRESS)`

Also:
- Increase buffer size to 32 (bug fix)
- Correct debug string for `TWBus::address`
- Corrected and more concise descriptions
- Insert a test of `EXPERIMENTAL_I2CBUS` into Travis test
- Don't reset the target address, so you can just keep sending/requesting
- Allow `M155 A1 B2 S`, `M155 A1 B2`, `M155 A1 S`, `M155 B2 S`
- Allow `M156` without `A` (uses last address)

References: #4586 