### PR TITLE
Added hyphenated strings for full graphic display

### DIFF
--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -46,7 +46,7 @@
 #define MSG_AUTO_HOME_Y                     "Home asse Y"
 #define MSG_AUTO_HOME_Z                     "Home asse Z"
 #define MSG_LEVEL_BED_HOMING                "Home assi XYZ"
-#define MSG_LEVEL_BED_WAITING               "Premi per Iniziare"
+#define MSG_LEVEL_BED_WAITING               "Premi per iniziare"
 #define MSG_LEVEL_BED_NEXT_POINT            "Punto successivo"
 #define MSG_LEVEL_BED_DONE                  "Livel. terminato!"
 #define MSG_LEVEL_BED_CANCEL                "Annulla"
@@ -77,11 +77,19 @@
 #define MSG_MOVE_01MM                       "Muovi di 0.1mm"
 #define MSG_MOVE_1MM                        "Muovi di   1mm"
 #define MSG_MOVE_10MM                       "Muovi di  10mm"
-#define MSG_SPEED                           "Velocità"
+#if ENABLED(DOGLCD)
+  #define MSG_SPEED                         "Velocità"
+#else
+  #define MSG_SPEED                         "Velocita"
+#endif
 #define MSG_BED_Z                           "piatto Z"
 #define MSG_NOZZLE                          "Ugello"
 #define MSG_BED                             "Piatto"
-#define MSG_FAN_SPEED                       "Velocità ventola"
+#if ENABLED(DOGLCD)
+  #define MSG_FAN_SPEED                     "Velocità ventola"
+#else
+  #define MSG_FAN_SPEED                     "Velocita ventola"
+#endif
 #define MSG_FLOW                            "Flusso"
 #define MSG_CONTROL                         "Controllo"
 #define MSG_MIN                             LCD_STR_THERMOMETER " Min"
@@ -147,7 +155,7 @@
 #define MSG_CNG_SDCARD                      "Cambia SD-Card"
 #define MSG_ZPROBE_OUT                      "Z probe out. bed"
 #define MSG_HOME                            "Home"  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
-#define MSG_FIRST                           "first"
+#define MSG_FIRST                           "prima"
 #define MSG_ZPROBE_ZOFFSET                  "Z Offset"
 #define MSG_BABYSTEP_X                      "Babystep X"
 #define MSG_BABYSTEP_Y                      "Babystep Y"
@@ -186,13 +194,21 @@
   #define MSG_INFO_PRINT_COUNT              "Contat. stampa"
   #define MSG_INFO_COMPLETED_PRINTS         "Completati"
   #define MSG_INFO_PRINT_TIME               "Tempo totale"
-  #define MSG_INFO_PRINT_LONGEST            "Lavoro piu lungo"
+  #if ENABLED(DOGLCD)
+    #define MSG_INFO_PRINT_LONGEST          "Lavoro più lungo"
+  #else
+    #define MSG_INFO_PRINT_LONGEST          "Lavoro piu lungo"
+  #endif
   #define MSG_INFO_PRINT_FILAMENT           "Totale estruso"
 #else
   #define MSG_INFO_PRINT_COUNT              "Stampe"
   #define MSG_INFO_COMPLETED_PRINTS         "Completati"
   #define MSG_INFO_PRINT_TIME               "Durata"
-  #define MSG_INFO_PRINT_LONGEST            "Piu lungo"
+  #if ENABLED(DOGLCD)
+    #define MSG_INFO_PRINT_LONGEST          "Più lungo"
+  #else
+    #define MSG_INFO_PRINT_LONGEST          "Piu lungo"
+  #endif
   #define MSG_INFO_PRINT_FILAMENT           "Estruso"
 #endif
 #define MSG_INFO_MIN_TEMP                   "Temp min"


### PR DESCRIPTION
I don't know how to replace some accented letters. e.g. :
-a instead of à and á
or
-a' (with apostrophe) instead of à and á

Both are wrong but probably the last is better for italian users whereas the first is better for small display.
