### PR TITLE
Fix stopSDPrint so it works when paused

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -60,35 +60,34 @@
   #include "stopwatch.h"
 #endif
 
-#define SERIAL_CHAR(x) MYSERIAL.write(x)
+extern const char echomagic[] PROGMEM;
+extern const char errormagic[] PROGMEM;
+
+#define SERIAL_CHAR(x) (MYSERIAL.write(x))
 #define SERIAL_EOL SERIAL_CHAR('\n')
 
-#define SERIAL_PROTOCOLCHAR(x) SERIAL_CHAR(x)
-#define SERIAL_PROTOCOL(x) MYSERIAL.print(x)
-#define SERIAL_PROTOCOL_F(x,y) MYSERIAL.print(x,y)
-#define SERIAL_PROTOCOLPGM(x) serialprintPGM(PSTR(x))
-#define SERIAL_PROTOCOLLN(x) do{ MYSERIAL.print(x); SERIAL_EOL; }while(0)
-#define SERIAL_PROTOCOLLNPGM(x) do{ serialprintPGM(PSTR(x "\n")); }while(0)
+#define SERIAL_PROTOCOLCHAR(x)              SERIAL_CHAR(x)
+#define SERIAL_PROTOCOL(x)                  (MYSERIAL.print(x))
+#define SERIAL_PROTOCOL_F(x,y)              (MYSERIAL.print(x,y))
+#define SERIAL_PROTOCOLPGM(x)               (serialprintPGM(PSTR(x)))
+#define SERIAL_PROTOCOLLN(x)                do{ MYSERIAL.print(x); SERIAL_EOL; }while(0)
+#define SERIAL_PROTOCOLLNPGM(x)             (serialprintPGM(PSTR(x "\n")))
+#define SERIAL_PROTOCOLPAIR(name, value)    (serial_echopair_P(PSTR(name),(value)))
+#define SERIAL_PROTOCOLLNPAIR(name, value)  do{ SERIAL_PROTOCOLPAIR(name, value); SERIAL_EOL; }while(0)
 
-#define SERIAL_PROTOCOLPAIR(name, value) SERIAL_ECHOPAIR(name, value)
-#define SERIAL_PROTOCOLLNPAIR(name, value) do{ SERIAL_ECHOPAIR(name, value); SERIAL_EOL; }while(0)
+#define SERIAL_ECHO_START             (serialprintPGM(echomagic))
+#define SERIAL_ECHO(x)                 SERIAL_PROTOCOL(x)
+#define SERIAL_ECHOPGM(x)              SERIAL_PROTOCOLPGM(x)
+#define SERIAL_ECHOLN(x)               SERIAL_PROTOCOLLN(x)
+#define SERIAL_ECHOLNPGM(x)            SERIAL_PROTOCOLLNPGM(x)
+#define SERIAL_ECHOPAIR(name,value)    SERIAL_PROTOCOLPAIR(name, value)
+#define SERIAL_ECHOLNPAIR(name, value) SERIAL_PROTOCOLLNPAIR(name, value)
 
-extern const char errormagic[] PROGMEM;
-extern const char echomagic[] PROGMEM;
-
-#define SERIAL_ERROR_START serialprintPGM(errormagic)
-#define SERIAL_ERROR(x) SERIAL_PROTOCOL(x)
-#define SERIAL_ERRORPGM(x) SERIAL_PROTOCOLPGM(x)
-#define SERIAL_ERRORLN(x) SERIAL_PROTOCOLLN(x)
-#define SERIAL_ERRORLNPGM(x) SERIAL_PROTOCOLLNPGM(x)
-
-#define SERIAL_ECHO_START serialprintPGM(echomagic)
-#define SERIAL_ECHO(x) SERIAL_PROTOCOL(x)
-#define SERIAL_ECHOPGM(x) SERIAL_PROTOCOLPGM(x)
-#define SERIAL_ECHOLN(x) SERIAL_PROTOCOLLN(x)
-#define SERIAL_ECHOLNPGM(x) SERIAL_PROTOCOLLNPGM(x)
-
-#define SERIAL_ECHOPAIR(name,value) (serial_echopair_P(PSTR(name),(value)))
+#define SERIAL_ERROR_START            (serialprintPGM(errormagic))
+#define SERIAL_ERROR(x)                SERIAL_PROTOCOL(x)
+#define SERIAL_ERRORPGM(x)             SERIAL_PROTOCOLPGM(x)
+#define SERIAL_ERRORLN(x)              SERIAL_PROTOCOLLN(x)
+#define SERIAL_ERRORLNPGM(x)           SERIAL_PROTOCOLLNPGM(x)
 
 void serial_echopair_P(const char* s_P, const char *v);
 void serial_echopair_P(const char* s_P, char v);

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -276,19 +276,12 @@ void CardReader::openAndPrintFile(const char *name) {
 }
 
 void CardReader::startFileprint() {
-  if (cardOK)
-    sdprinting = true;
-}
-
-void CardReader::pauseSDPrint() {
-  if (sdprinting) sdprinting = false;
+  if (cardOK) sdprinting = true;
 }
 
 void CardReader::stopSDPrint() {
-  if (sdprinting) {
-    sdprinting = false;
-    file.close();
-  }
+  sdprinting = false;
+  if (isFileOpen()) file.close();
 }
 
 void CardReader::openLogFile(char* name) {
@@ -340,7 +333,6 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
      SERIAL_ECHOPGM("Now doing file: ");
      SERIAL_ECHOLN(name);
     }
-    file.close();
   }
   else { //opening fresh file
     file_subcall_ctr = 0; //resetting procedure depth in case user cancels print while in procedure
@@ -348,7 +340,8 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
     SERIAL_ECHOPGM("Now fresh file: ");
     SERIAL_ECHOLN(name);
   }
-  sdprinting = false;
+
+  stopSDPrint();
 
   SdFile myDir;
   curDir = &root;
@@ -425,8 +418,7 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
 void CardReader::removeFile(char* name) {
   if (!cardOK) return;
 
-  file.close();
-  sdprinting = false;
+  stopSDPrint();
 
   SdFile myDir;
   curDir = &root;

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -51,7 +51,6 @@ public:
   void release();
   void openAndPrintFile(const char *name);
   void startFileprint();
-  void pauseSDPrint();
   void stopSDPrint();
   void getStatus();
   void printingHasFinished();
@@ -70,6 +69,7 @@ public:
   void updir();
   void setroot();
 
+  FORCE_INLINE void pauseSDPrint() { sdprinting = false; }
   FORCE_INLINE bool isFileOpen() { return file.isOpen(); }
   FORCE_INLINE bool eof() { return sdpos >= filesize; }
   FORCE_INLINE int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }


### PR DESCRIPTION
Addressing #4598

This PR fixes a longstanding bug in the `CardReader` class, where if a print is paused, it cannot be stopped.

Also…
- Apply changes to reduce code size in CardReader by 230 bytes.
- Pretty up serial macros in `Marlin.h`
