### PR TITLE
Fix acceleration and feedrate following bq/Marlin

### DIFF
--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -743,10 +743,10 @@
 // default settings
 
 #define DEFAULT_AXIS_STEPS_PER_UNIT   {80,80,4000,100.47095761381482}  // default steps per unit for Ultimaker
-#define DEFAULT_MAX_FEEDRATE          {250, 250, 3.3, 25}    // (mm/sec)
-#define DEFAULT_MAX_ACCELERATION      {3000,3000,100,10000}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for Skeinforge 40+, for older versions raise them a lot.
+#define DEFAULT_MAX_FEEDRATE          {200, 200, 3.3, 25}    // (mm/sec)
+#define DEFAULT_MAX_ACCELERATION      {1100,1100,100,10000}    // X, Y, Z, E maximum start speed for accelerated moves. E default values are good for Skeinforge 40+, for older versions raise them a lot.
 
-#define DEFAULT_ACCELERATION          1000    // X, Y, Z and E acceleration in mm/s^2 for printing moves
+#define DEFAULT_ACCELERATION          650    // X, Y, Z and E acceleration in mm/s^2 for printing moves
 #define DEFAULT_RETRACT_ACCELERATION  1000   // E acceleration in mm/s^2 for retracts
 #define DEFAULT_TRAVEL_ACCELERATION   1000    // X, Y, Z acceleration in mm/s^2 for travel (non printing) moves
 


### PR DESCRIPTION
Following bq/Marlin@8a3a2703a0081f7ee45375f971928b4e14e99637 commit.
In addition they didn't define PREFER_MAX_FEEDRATE that set:
`#define DEFAULT_MAX_FEEDRATE          {200, 200, 3.3, 25}    // (mm/sec)`
instead of defaults:
`#define DEFAULT_MAX_FEEDRATE          {85, 85, 3.3, 25}    // (mm/sec)`

I use the first because the last is really restrictive. But tell me what do you think.
However I've the hephestos and 85mm/s is A LOT for this printer. I currently print at max 60mm/s.
