### PR TITLE
fixed compile error for lcd_quick_feedback function

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2349,7 +2349,9 @@ void kill_screen(const char* lcd_msg) {
     next_button_update_ms = millis() + 500;
 
     // Buzz and wait. The delay is needed for buttons to settle!
-    lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+    #if ENABLED(SPEAKER)
+      lcd_buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+    #endif
     #if ENABLED(LCD_USE_I2C_BUZZER)
       delay(10);
     #elif PIN_EXISTS(BEEPER)


### PR DESCRIPTION
I was getting a compile error because the variables LCD_FEEDBACK_FREQUENCY_DURATION_MS and LCD_FEEDBACK_FREQUENCY_HZ were not defined in that scope.  I added a conditional to check that SPEAKER is enabled.
