### PR TITLE
Set language display charset in language.h

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -25,7 +25,8 @@
 
 #include "MarlinConfig.h"
 
-//#define SIMULATE_ROMFONT //Comment in to see what is seen on the character based displays
+// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
+//#define SIMULATE_ROMFONT
 
 // Fallback if no language is set. DON'T CHANGE
 #ifndef LCD_LANGUAGE

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -25,6 +25,8 @@
 
 #include "MarlinConfig.h"
 
+//#define SIMULATE_ROMFONT //Comment in to see what is seen on the character based displays
+
 // Fallback if no language is set. DON'T CHANGE
 #ifndef LCD_LANGUAGE
   #define LCD_LANGUAGE en
@@ -239,6 +241,11 @@
 #define INCLUDE_LANGUAGE LANGUAGE_INCL(LCD_LANGUAGE)
 
 #include INCLUDE_LANGUAGE
+
+#if DISABLED(SIMULATE_ROMFONT) && DISABLED(DISPLAY_CHARSET_ISO10646_1) && DISABLED(DISPLAY_CHARSET_ISO10646_5) && DISABLED(DISPLAY_CHARSET_ISO10646_KANA) && DISABLED(DISPLAY_CHARSET_ISO10646_GREEK) && DISABLED(DISPLAY_CHARSET_ISO10646_CN)
+  #define DISPLAY_CHARSET_ISO10646_1 // use the better font on full graphic displays.
+#endif
+
 #include "language_en.h"
 
 #endif //__LANGUAGE_H

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_AN_H
 #define LANGUAGE_AN_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " parada."

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_BG_H
 
 #define MAPPER_D0D1                // For Cyrillic
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_5
 
 #define WELCOME_MSG                         MACHINE_NAME " Готов."

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_CA_H
 
 #define MAPPER_C2C3  // because of "ó"
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " preparada."

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -34,8 +34,6 @@
 #ifndef LANGUAGE_CZ_H
 #define LANGUAGE_CZ_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " pripraven."

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_DA_H
 
 #define MAPPER_C2C3
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " er klar"

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_DE_H
 
 #define MAPPER_C2C3
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " bereit"

--- a/Marlin/language_el-gr.h
+++ b/Marlin/language_el-gr.h
@@ -30,9 +30,6 @@
 #ifndef LANGUAGE_EL_GR_H
 #define LANGUAGE_EL_GR_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
-
 //#define MAPPER_CECF
 //#define DISPLAY_CHARSET_ISO10646_GREEK
 

--- a/Marlin/language_el.h
+++ b/Marlin/language_el.h
@@ -30,9 +30,6 @@
 #ifndef LANGUAGE_EL_H
 #define LANGUAGE_EL_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
-
 #define MAPPER_CECF
 #define DISPLAY_CHARSET_ISO10646_GREEK
 

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -30,11 +30,6 @@
 #ifndef LANGUAGE_EN_H
 #define LANGUAGE_EN_H
 
-//#define SIMULATE_ROMFONT //Comment in to see what is seen on the character based displays
-#if DISABLED(SIMULATE_ROMFONT) && DISABLED(DISPLAY_CHARSET_ISO10646_1) && DISABLED(DISPLAY_CHARSET_ISO10646_5) && DISABLED(DISPLAY_CHARSET_ISO10646_KANA) && DISABLED(DISPLAY_CHARSET_ISO10646_GREEK) && DISABLED(DISPLAY_CHARSET_ISO10646_CN)
-  #define DISPLAY_CHARSET_ISO10646_1 // use the better font on full graphic displays.
-#endif
-
 #ifndef WELCOME_MSG
   #define WELCOME_MSG                         MACHINE_NAME " ready."
 #endif

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_ES_H
 #define LANGUAGE_ES_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " lista."

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_EU_H
 #define LANGUAGE_EU_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " prest."

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_FI_H
 
 #define MAPPER_C2C3
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " valmis."

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_FR_H
 #define LANGUAGE_FR_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " prete."

--- a/Marlin/language_gl.h
+++ b/Marlin/language_gl.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_GL_H
 
 #define MAPPER_C2C3
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " lista."

--- a/Marlin/language_hr.h
+++ b/Marlin/language_hr.h
@@ -30,9 +30,6 @@
 #ifndef LANGUAGE_HR_H
 #define LANGUAGE_HR_H
 
-
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1 // use the better font on full graphic displays.
 
 #define WELCOME_MSG                         MACHINE_NAME " spreman."

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_IT_H
 #define LANGUAGE_IT_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " pronto."

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -32,8 +32,6 @@
 #define LANGUAGE_KANA_UTF_H
 
 #define MAPPER_E382E383
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_KANA
 
 // This just to show the potential benefit of unicode.

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_NL_H
 #define LANGUAGE_NL_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " gereed."

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_PL_H
 #define LANGUAGE_PL_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " gotowy."

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_PT_BR_H
 #define LANGUAGE_PT_BR_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " pronto."

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_PT_BR_UTF_H
 #define LANGUAGE_PT_BR_UTF_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " pronto."

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_PT_H
 #define LANGUAGE_PT_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " pronto."

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -30,8 +30,6 @@
 #ifndef LANGUAGE_PT_UTF_H
 #define LANGUAGE_PT_UTF_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_1
 
 #define WELCOME_MSG                         MACHINE_NAME " pronto."

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -31,8 +31,6 @@
 #define LANGUAGE_RU_H
 
 #define MAPPER_D0D1                // For Cyrillic
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_5
 
 #define WELCOME_MSG                         MACHINE_NAME " Готов."

--- a/Marlin/language_test.h
+++ b/Marlin/language_test.h
@@ -51,8 +51,6 @@
 //#define MAPPER_E382E383    // For Katakana
 //#define MAPPER_NON         // For direct ascii codes. Fall back mapper - if no other is defined.
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-//#define SIMULATE_ROMFONT
 
 // Select the better font for full graphic displays.
 //#define DISPLAY_CHARSET_ISO10646_1


### PR DESCRIPTION
Language display charset more appropriate checked in the `language.h` file.

Also only include `SIMULATE_ROMFONT` in `language.h`.

@esenapaj I noticed that `SIMULATE_ROMFONT` is always set for `language_kana.h`. Is that definitely needed?
