### PR TITLE
Add Rambo support/env to platformio.ini; properly maps extended pins

### DIFF
--- a/Marlin/platformio.ini
+++ b/Marlin/platformio.ini
@@ -42,3 +42,10 @@ platform = teensy
 framework = arduino
 board = teensy20pp
 build_flags = -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_BRAINWAVE_PRO -D AT90USBxx_TEENSYPP_ASSIGNMENTS
+
+[env:rambo]
+platform = atmelavr
+framework = arduino
+board = reprap_rambo
+build_flags = -I $BUILDSRC_DIR
+board_f_cpu = 16000000L


### PR DESCRIPTION
Found that I couldn't use a Viki2 on a Rambo without specifying a board type of 'reprap_rambo' in platformio.ini, which effectively includes an alternate pins_arduino.h, which in turn properly maps all of the extended pins used on the Rambo.

I would assume this would affect other LCDs or addons that rely on the extended pins, so it makes sense to include the board type/environment in the platformio.ini.
