### PR TITLE
Optimize, reduce size of MarlinSerial

### DIFF
--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -68,8 +68,8 @@ FORCE_INLINE void store_char(unsigned char c) {
 }
 
 #if TX_BUFFER_SIZE > 0
-  FORCE_INLINE void _tx_udr_empty_irq(void)
-  {
+
+  FORCE_INLINE void _tx_udr_empty_irq(void) {
     // If interrupts are enabled, there must be more data in the output
     // buffer. Send the next byte
     uint8_t t = tx_buffer.tail;
@@ -95,7 +95,7 @@ FORCE_INLINE void store_char(unsigned char c) {
     }
   #endif
 
-#endif
+#endif // TX_BUFFER_SIZE
 
 #if defined(M_USARTx_RX_vect)
   ISR(M_USARTx_RX_vect) {
@@ -160,15 +160,8 @@ void MarlinSerial::checkRx(void) {
 }
 
 int MarlinSerial::peek(void) {
-  int v;
   CRITICAL_SECTION_START;
-  uint8_t t = rx_buffer.tail;
-  if (rx_buffer.head == t) {
-    v = -1;
-  }
-  else {
-    v = rx_buffer.buffer[t];
-  }
+    int v = rx_buffer.head == rx_buffer.tail ? -1 : rx_buffer.buffer[rx_buffer.tail];
   CRITICAL_SECTION_END;
   return v;
 }
@@ -176,22 +169,22 @@ int MarlinSerial::peek(void) {
 int MarlinSerial::read(void) {
   int v;
   CRITICAL_SECTION_START;
-  uint8_t t = rx_buffer.tail;
-  if (rx_buffer.head == t) {
-    v = -1;
-  }
-  else {
-    v = rx_buffer.buffer[t];
-    rx_buffer.tail = (uint8_t)(t + 1) & (RX_BUFFER_SIZE - 1);
-  }
+    uint8_t t = rx_buffer.tail;
+    if (rx_buffer.head == t) {
+      v = -1;
+    }
+    else {
+      v = rx_buffer.buffer[t];
+      rx_buffer.tail = (uint8_t)(t + 1) & (RX_BUFFER_SIZE - 1);
+    }
   CRITICAL_SECTION_END;
   return v;
 }
 
 uint8_t MarlinSerial::available(void) {
   CRITICAL_SECTION_START;
-    uint8_t h = rx_buffer.head;
-    uint8_t t = rx_buffer.tail;
+    uint8_t h = rx_buffer.head,
+            t = rx_buffer.tail;
   CRITICAL_SECTION_END;
   return (uint8_t)(RX_BUFFER_SIZE + h - t) & (RX_BUFFER_SIZE - 1);
 }
@@ -251,11 +244,10 @@ void MarlinSerial::flush(void) {
     }
 
     tx_buffer.buffer[tx_buffer.head] = c;
-    { CRITICAL_SECTION_START;
-        tx_buffer.head = i;
-        SBI(M_UCSRxB, M_UDRIEx);
-      CRITICAL_SECTION_END;
-    }
+    CRITICAL_SECTION_START;
+      tx_buffer.head = i;
+      SBI(M_UCSRxB, M_UDRIEx);
+    CRITICAL_SECTION_END;
     return;
   }
 
@@ -386,23 +378,18 @@ void MarlinSerial::println(double n, int digits) {
 // Private Methods /////////////////////////////////////////////////////////////
 
 void MarlinSerial::printNumber(unsigned long n, uint8_t base) {
-  unsigned char buf[8 * sizeof(long)]; // Assumes 8-bit chars.
-  unsigned long i = 0;
-
-  if (n == 0) {
+  if (n) {
+    unsigned char buf[8 * sizeof(long)]; // Enough space for base 2
+    int8_t i = 0;
+    while (n) {
+      buf[i++] = n % base;
+      n /= base;
+    }
+    while (i--)
+      print((char)(buf[i] + (buf[i] < 10 ? '0' : 'A' - 10)));
+  }
+  else
     print('0');
-    return;
-  }
-
-  while (n > 0) {
-    buf[i++] = n % base;
-    n /= base;
-  }
-
-  for (; i > 0; i--)
-    print((char)(buf[i - 1] < 10 ?
-                 '0' + buf[i - 1] :
-                 'A' + buf[i - 1] - 10));
 }
 
 void MarlinSerial::printFloat(double number, uint8_t digits) {
@@ -415,7 +402,7 @@ void MarlinSerial::printFloat(double number, uint8_t digits) {
   // Round correctly so that print(1.999, 2) prints as "2.00"
   double rounding = 0.5;
   for (uint8_t i = 0; i < digits; ++i)
-    rounding /= 10.0;
+    rounding *= 0.1;
 
   number += rounding;
 
@@ -425,14 +412,15 @@ void MarlinSerial::printFloat(double number, uint8_t digits) {
   print(int_part);
 
   // Print the decimal point, but only if there are digits beyond
-  if (digits > 0) print('.');
-
-  // Extract digits from the remainder one at a time
-  while (digits-- > 0) {
-    remainder *= 10.0;
-    int toPrint = int(remainder);
-    print(toPrint);
-    remainder -= toPrint;
+  if (digits) {
+    print('.');
+    // Extract digits from the remainder one at a time
+    while (digits--) {
+      remainder *= 10.0;
+      int toPrint = int(remainder);
+      print(toPrint);
+      remainder -= toPrint;
+    }
   }
 }
 // Preinstantiate Objects //////////////////////////////////////////////////////
@@ -534,4 +522,5 @@ MarlinSerial customizedSerial;
         }
     }
   }
+
 #endif

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -127,47 +127,47 @@ class MarlinSerial { //: public Stream
 
   public:
     MarlinSerial();
-    void begin(long);
-    void end();
-    int peek(void);
-    int read(void);
-    void flush(void);
-    uint8_t available(void);
-    void checkRx(void);
-    void write(uint8_t c);
+    static void begin(long);
+    static void end();
+    static int peek(void);
+    static int read(void);
+    static void flush(void);
+    static uint8_t available(void);
+    static void checkRx(void);
+    static void write(uint8_t c);
     #if TX_BUFFER_SIZE > 0
-      uint8_t availableForWrite(void);
-      void flushTX(void);
+      static uint8_t availableForWrite(void);
+      static void flushTX(void);
     #endif
 
   private:
-    void printNumber(unsigned long, uint8_t);
-    void printFloat(double, uint8_t);
+    static void printNumber(unsigned long, uint8_t);
+    static void printFloat(double, uint8_t);
 
   public:
-    FORCE_INLINE void write(const char* str) { while (*str) write(*str++); }
-    FORCE_INLINE void write(const uint8_t* buffer, size_t size) { while (size--) write(*buffer++); }
-    FORCE_INLINE void print(const String& s) { for (int i = 0; i < (int)s.length(); i++) write(s[i]); }
-    FORCE_INLINE void print(const char* str) { write(str); }
+    static FORCE_INLINE void write(const char* str) { while (*str) write(*str++); }
+    static FORCE_INLINE void write(const uint8_t* buffer, size_t size) { while (size--) write(*buffer++); }
+    static FORCE_INLINE void print(const String& s) { for (int i = 0; i < (int)s.length(); i++) write(s[i]); }
+    static FORCE_INLINE void print(const char* str) { write(str); }
 
-    void print(char, int = BYTE);
-    void print(unsigned char, int = BYTE);
-    void print(int, int = DEC);
-    void print(unsigned int, int = DEC);
-    void print(long, int = DEC);
-    void print(unsigned long, int = DEC);
-    void print(double, int = 2);
+    static void print(char, int = BYTE);
+    static void print(unsigned char, int = BYTE);
+    static void print(int, int = DEC);
+    static void print(unsigned int, int = DEC);
+    static void print(long, int = DEC);
+    static void print(unsigned long, int = DEC);
+    static void print(double, int = 2);
 
-    void println(const String& s);
-    void println(const char[]);
-    void println(char, int = BYTE);
-    void println(unsigned char, int = BYTE);
-    void println(int, int = DEC);
-    void println(unsigned int, int = DEC);
-    void println(long, int = DEC);
-    void println(unsigned long, int = DEC);
-    void println(double, int = 2);
-    void println(void);
+    static void println(const String& s);
+    static void println(const char[]);
+    static void println(char, int = BYTE);
+    static void println(unsigned char, int = BYTE);
+    static void println(int, int = DEC);
+    static void println(unsigned int, int = DEC);
+    static void println(long, int = DEC);
+    static void println(unsigned long, int = DEC);
+    static void println(double, int = 2);
+    static void println(void);
 };
 
 extern MarlinSerial customizedSerial;


### PR DESCRIPTION
- Make all MarlinSerial methods `static` to reduce call overhead and code size. (~100 bytes)
- Apply some minor performance optimizations
