### PR TITLE
Repair MarlinSerial with TX-buffer

### DIFF
--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -244,10 +244,11 @@ void MarlinSerial::flush(void) {
     }
 
     tx_buffer.buffer[tx_buffer.head] = c;
-    CRITICAL_SECTION_START;
-      tx_buffer.head = i;
-      SBI(M_UCSRxB, M_UDRIEx);
-    CRITICAL_SECTION_END;
+    { CRITICAL_SECTION_START;
+        tx_buffer.head = i;
+        SBI(M_UCSRxB, M_UDRIEx);
+      CRITICAL_SECTION_END;
+    }
     return;
   }
 


### PR DESCRIPTION
These '{'/'}' are important to avoid the redefinition of `unsigned char _sreg = SREG;`
at the same level.
Used in

```
#define CRITICAL_SECTION_START  unsigned char _sreg = SREG; cli();
```
