### PR TITLE
Add note suggesting RAMBo users use the RAMBo board type or platformio environment

### DIFF
--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -21,6 +21,22 @@
  */
 
 /**
+ * IMPORTANT NOTE:
+ * Rambo users should be sure to compile Marlin using either the RAMBo
+ * board type if using the Arduino IDE - available via the link below - or
+ * the 'rambo' environment if using platformio, by specifying '-e rambo' on
+ * the command line or by changing the value of the 'env_default' variable to
+ * 'rambo' in the supplied platformio.ini.
+ *
+ * If you don't compile using the proper board type, the RAMBo's extended
+ * pins will likely be unavailable and accessories/addons may not work.
+ *
+ * Instructions for installing the Arduino RAMBo board type for the
+ * Arduino IDE are available at:
+ * http://reprap.org/wiki/Rambo_firmware
+ */
+
+/**
  * Rambo pin assignments
  */
 
@@ -127,6 +143,9 @@
 
     #if ENABLED(VIKI2) || ENABLED(miniVIKI)
       #define BEEPER_PIN 44
+      //NB: Panucatt's Viki 2.0 wiring diagram (v1.2) indicates that the
+      //    beeper/buzzer is connected to pin 33; however, the pin used in the
+      //    diagram is actually pin 44, so this is correct.
 
       #define DOGLCD_A0  70
       #define DOGLCD_CS  71
@@ -178,4 +197,3 @@
   #endif // !NEWPANEL
 
 #endif // ULTRA_LCD
-


### PR DESCRIPTION
Add note suggesting RAMBo users use the RAMBo board type or platformio environment, per https://github.com/MarlinFirmware/Marlin/issues/4689#issuecomment-242204482.

Also add note that Viki 2.0 wiring diagram v1.2 has a mistake in it;
