### PR TITLE
Patch duration_t toDigital method

### DIFF
--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -146,12 +146,14 @@ struct duration_t {
    *  11d 12:33
    */
   void toDigital(char *buffer, bool with_days=false) const {
-    uint16_t h = uint16_t(this->hour() % 24UL),
+    uint16_t h = uint16_t(this->hour()),
              m = uint16_t(this->minute() % 60UL);
     if (with_days)
       sprintf_P(buffer, PSTR("%ud %02u:%02u"), this->day(), h, m);
+    else if (h < 100)
+      sprintf_P(buffer, PSTR("%02u:%02u"), h % 24, m);
     else
-      sprintf_P(buffer, PSTR("%02u:%02u"), h, m);
+      sprintf_P(buffer, PSTR("%u:%02u"), h, m);
   }
 };
 

--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -146,11 +146,12 @@ struct duration_t {
    *  11d 12:33
    */
   void toDigital(char *buffer, bool with_days=false) const {
-    int m = this->minute() % 60;
+    uint16_t h = uint16_t(this->hour() % 24UL),
+             m = uint16_t(this->minute() % 60UL);
     if (with_days)
-      sprintf_P(buffer, PSTR("%id %02i:%02i"), this->day(), this->hour() % 24, m);
+      sprintf_P(buffer, PSTR("%ud %02u:%02u"), this->day(), h, m);
     else
-      sprintf_P(buffer, PSTR("%02i:%02i"), this->hour(), m);
+      sprintf_P(buffer, PSTR("%02u:%02u"), h, m);
   }
 };
 


### PR DESCRIPTION
Split off from #4734 

Add the ability to display more than 99 hours.
Also use `%u` for unsigned values.
