### PR TITLE
language_en.h

### DIFF
--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -320,6 +320,12 @@
 #ifndef MSG_ESTEPS
   #define MSG_ESTEPS                          "Esteps/mm"
 #endif
+#ifndef MSG_XSCALE
+  #define MSG_XSCALE                          "XscaleFact"
+#endif
+#ifndef MSG_YSCALE
+  #define MSG_YSCALE                          "YscaleFact"
+#endif
 #ifndef MSG_TEMPERATURE
   #define MSG_TEMPERATURE                     "Temperature"
 #endif


### PR DESCRIPTION
When compiling with the SCARA configuration.h the defines MSG_XSCALE and MSG_YSCALE are missing and cause a compilation failure in the ultralcd.cpp file.

I assume these defines will also need to be added to the other language files?  Is there a process to get people proficient in the other languages to add them?  A placeholder could be put in so that it compiles for them.

I still need to check how the menu item actually looks on the screen.
