### PR TITLE
ultralcd.cpp

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1798,8 +1798,8 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM_EDIT(bool, MSG_ENDSTOP_ABORT, &stepper.abort_on_endstop_hit);
     #endif
     #if ENABLED(SCARA)
-      MENU_ITEM_EDIT(float74, MSG_XSCALE, &axis_scaling[X_AXIS], 0.5, 2);
-      MENU_ITEM_EDIT(float74, MSG_YSCALE, &axis_scaling[Y_AXIS], 0.5, 2);
+      MENU_ITEM_EDIT(float52, MSG_XSCALE, &axis_scaling[X_AXIS], 0.5, 2);
+      MENU_ITEM_EDIT(float52, MSG_YSCALE, &axis_scaling[Y_AXIS], 0.5, 2);
     #endif
     END_MENU();
   }


### PR DESCRIPTION
When compiling with the SCARA Configuration.h this compilation error occurs:

```
ultralcd.cpp:1805: undefined reference to `menu_action_setting_edit_float74(char const*, float*, float, float)'
```

Two options:
1) Create the float74 formatting/menu defines/code.  Not sure the intent of the float74 - is it a typo or does the scale factor need that much precision?

2) Switch the float74 to float52.  This solves the compilation problem, but does it miss the intent of the original author?

I still need to check how this item looks on the lcd.  At present just interested in making it compile.
