### PR TITLE
Remove SCARA axis_scaling

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -317,7 +317,6 @@ float code_value_temp_diff();
                delta_diagonal_rod_trim_tower_3;
   void recalc_delta_settings(float radius, float diagonal_rod);
 #elif IS_SCARA
-  extern float axis_scaling[ABC];  // Build size scaling
   void forward_kinematics_SCARA(const float &a, const float &b);
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -253,7 +253,6 @@
  * M362 - SCARA calibration: Move to cal-position PsiA (0 deg calibration)
  * M363 - SCARA calibration: Move to cal-position PsiB (90 deg calibration - steps per degree)
  * M364 - SCARA calibration: Move to cal-position PSIC (90 deg to Theta calibration position)
- * M365 - SCARA calibration: Scaling factor, X, Y, Z axis
  * ************* SCARA End ***************
  *
  * ************ Custom codes - This can change to suit future G-code regulations
@@ -505,8 +504,7 @@ static uint8_t target_extruder;
               L2_2 = sq(float(L2));
 
   float delta_segments_per_second = SCARA_SEGMENTS_PER_SECOND,
-        delta[ABC],
-        axis_scaling[ABC] = { 1, 1, 1 };    // Build size scaling, default to 1
+        delta[ABC];
 #endif
 
 float cartes[XYZ] = { 0 };
@@ -5750,8 +5748,8 @@ inline void gcode_M303() {
     if (IsRunning()) {
       //gcode_get_destination(); // For X Y Z E F
       forward_kinematics_SCARA(delta_a, delta_b);
-      destination[X_AXIS] = cartes[X_AXIS] / axis_scaling[X_AXIS];
-      destination[Y_AXIS] = cartes[Y_AXIS] / axis_scaling[Y_AXIS];
+      destination[X_AXIS] = cartes[X_AXIS];
+      destination[Y_AXIS] = cartes[Y_AXIS];
       destination[Z_AXIS] = current_position[Z_AXIS];
       prepare_move_to_destination();
       //ok_to_send();
@@ -5798,15 +5796,6 @@ inline void gcode_M303() {
   inline bool gcode_M364() {
     SERIAL_ECHOLNPGM(" Cal: Theta-Psi 90");
     return SCARA_move_to_cal(45, 135);
-  }
-
-  /**
-   * M365: SCARA calibration: Scaling factor, X, Y, Z axis
-   */
-  inline void gcode_M365() {
-    LOOP_XYZ(i)
-      if (code_seen(axis_codes[i]))
-        axis_scaling[i] = code_value_float();
   }
 
 #endif // SCARA
@@ -7407,9 +7396,6 @@ void process_next_command() {
         case 364:  // M364 SCARA Psi pos3 (90 deg to Theta)
           if (gcode_M364()) return;
           break;
-        case 365: // M365 Set SCARA scaling for X Y Z
-          gcode_M365();
-          break;
       #endif // SCARA
 
       case 400: // M400 finish all moves
@@ -8359,8 +8345,8 @@ void prepare_move_to_destination() {
 
     static float C2, S2, SK1, SK2, THETA, PSI;
 
-    float sx = RAW_X_POSITION(cartesian[X_AXIS]) * axis_scaling[X_AXIS] - SCARA_OFFSET_X,  //Translate SCARA to standard X Y
-          sy = RAW_Y_POSITION(cartesian[Y_AXIS]) * axis_scaling[Y_AXIS] - SCARA_OFFSET_Y;  // With scaling factor.
+    float sx = RAW_X_POSITION(cartesian[X_AXIS]) - SCARA_OFFSET_X,  //Translate SCARA to standard X Y
+          sy = RAW_Y_POSITION(cartesian[Y_AXIS]) - SCARA_OFFSET_Y;  // With scaling factor.
 
     #if (L1 == L2)
       C2 = HYPOT2(sx, sy) / (2 * L1_2) - 1;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,7 +36,7 @@
  *
  */
 
-#define EEPROM_VERSION "V24"
+#define EEPROM_VERSION "V25"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
@@ -105,24 +105,21 @@
  * DOGLCD:
  *  379  M250 C    lcd_contrast (int)
  *
- * SCARA:
- *  381  M365 XYZ  axis_scaling (float x3)
- *
  * FWRETRACT:
- *  393  M209 S    autoretract_enabled (bool)
- *  394  M207 S    retract_length (float)
- *  398  M207 W    retract_length_swap (float)
- *  402  M207 F    retract_feedrate_mm_s (float)
- *  406  M207 Z    retract_zlift (float)
- *  410  M208 S    retract_recover_length (float)
- *  414  M208 W    retract_recover_length_swap (float)
- *  418  M208 F    retract_recover_feedrate_mm_s (float)
+ *  381  M209 S    autoretract_enabled (bool)
+ *  382  M207 S    retract_length (float)
+ *  386  M207 W    retract_length_swap (float)
+ *  390  M207 F    retract_feedrate_mm_s (float)
+ *  394  M207 Z    retract_zlift (float)
+ *  398  M208 S    retract_recover_length (float)
+ *  402  M208 W    retract_recover_length_swap (float)
+ *  406  M208 F    retract_recover_feedrate_mm_s (float)
  *
  * Volumetric Extrusion:
- *  422  M200 D    volumetric_enabled (bool)
- *  423  M200 T D  filament_size (float x4) (T0..3)
+ *  410  M200 D    volumetric_enabled (bool)
+ *  411  M200 T D  filament_size (float x4) (T0..3)
  *
- *  439  This Slot is Available!
+ *  427  This Slot is Available!
  *
  */
 #include "Marlin.h"
@@ -330,13 +327,6 @@ void Config_StoreSettings()  {
   #endif
   EEPROM_WRITE(lcd_contrast);
 
-  #if IS_SCARA
-    EEPROM_WRITE(axis_scaling); // 3 floats
-  #else
-    dummy = 1.0f;
-    EEPROM_WRITE(dummy);
-  #endif
-
   #if ENABLED(FWRETRACT)
     EEPROM_WRITE(autoretract_enabled);
     EEPROM_WRITE(retract_length);
@@ -520,12 +510,6 @@ void Config_RetrieveSettings() {
     #endif
     EEPROM_READ(lcd_contrast);
 
-    #if IS_SCARA
-      EEPROM_READ(axis_scaling);  // 3 floats
-    #else
-      EEPROM_READ(dummy);
-    #endif
-
     #if ENABLED(FWRETRACT)
       EEPROM_READ(autoretract_enabled);
       EEPROM_READ(retract_length);
@@ -584,10 +568,6 @@ void Config_ResetDefault() {
     planner.axis_steps_per_mm[i] = tmp1[i];
     planner.max_feedrate_mm_s[i] = tmp2[i];
     planner.max_acceleration_mm_per_s2[i] = tmp3[i];
-    #if IS_SCARA
-      if (i < COUNT(axis_scaling))
-        axis_scaling[i] = 1;
-    #endif
   }
 
   planner.acceleration = DEFAULT_ACCELERATION;
@@ -715,18 +695,6 @@ void Config_PrintSettings(bool forReplay) {
   SERIAL_EOL;
 
   CONFIG_ECHO_START;
-
-  #if IS_SCARA
-    if (!forReplay) {
-      SERIAL_ECHOLNPGM("Scaling factors:");
-      CONFIG_ECHO_START;
-    }
-    SERIAL_ECHOPAIR("  M365 X", axis_scaling[X_AXIS]);
-    SERIAL_ECHOPAIR(" Y", axis_scaling[Y_AXIS]);
-    SERIAL_ECHOPAIR(" Z", axis_scaling[Z_AXIS]);
-    SERIAL_EOL;
-    CONFIG_ECHO_START;
-  #endif // SCARA
 
   if (!forReplay) {
     SERIAL_ECHOLNPGM("Maximum feedrates (mm/s):");

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1823,10 +1823,6 @@ void kill_screen(const char* lcd_msg) {
     #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
       MENU_ITEM_EDIT(bool, MSG_ENDSTOP_ABORT, &stepper.abort_on_endstop_hit);
     #endif
-    #if IS_SCARA
-      MENU_ITEM_EDIT(float74, MSG_XSCALE, &axis_scaling[X_AXIS], 0.5, 2);
-      MENU_ITEM_EDIT(float74, MSG_YSCALE, &axis_scaling[Y_AXIS], 0.5, 2);
-    #endif
     END_MENU();
   }
 


### PR DESCRIPTION
This feature can't be used to scale up 3D prints. It will just leave gaps between the lines. However it might be used for other kinds of tools. However, instead of scaling your pen drawings or laser engravings with `axis_scaling`, the better course is to regenerate the GCode using your slicer or InkScape plugin. So this feature is being dropped.

In support of this change, the EEPROM version is bumped to V25.
