### PR TITLE
Use probe clearance for bump when homing Z with probe

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2256,12 +2256,20 @@ static void homeaxis(AxisEnum axis) {
     if (axis == Z_AXIS) stepper.set_homing_flag(true);
   #endif
 
+  // When homing Z with probe respect probe clearance
+  const float bump = axis_home_dir * (
+    #if HOMING_Z_WITH_PROBE
+      (axis == Z_AXIS) ? max(Z_CLEARANCE_BETWEEN_PROBES, home_bump_mm(Z_AXIS)) :
+    #endif
+    home_bump_mm(axis)
+  );
+
   // 1. Fast move towards endstop until triggered
   // 2. Move away from the endstop by the axis HOME_BUMP_MM
   // 3. Slow move towards endstop until triggered
   do_homing_move(axis, 1.5 * max_length(axis) * axis_home_dir);
-  do_homing_move(axis, -home_bump_mm(axis) * axis_home_dir);
-  do_homing_move(axis, 2 * home_bump_mm(axis) * axis_home_dir, get_homing_bump_feedrate(axis));
+  do_homing_move(axis, -bump);
+  do_homing_move(axis, 2 * bump, get_homing_bump_feedrate(axis));
 
   #if ENABLED(Z_DUAL_ENDSTOPS)
     if (axis == Z_AXIS) {


### PR DESCRIPTION
The larger value, either Z homing bump or probe clearance, should apply when doing the second Z probe in the homing procedure.
