### PR TITLE
Improve MINIMUM_STEPPER_PULSE

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -708,4 +708,7 @@
     #define MAX_PROBE_Y (min(Y_MAX_POS, Y_MAX_POS + Y_PROBE_OFFSET_FROM_EXTRUDER))
   #endif
 
+  // Stepper pulse duration, in cycles
+  #define STEP_PULSE_CYCLES ((MINIMUM_STEPPER_PULSE) * CYCLES_PER_MICROSECOND)
+
 #endif // CONDITIONALS_POST_H

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -36,6 +36,9 @@
   #define CRITICAL_SECTION_END    SREG = _sreg;
 #endif
 
+// Clock speed factor
+#define CYCLES_PER_MICROSECOND (F_CPU / 1000000UL) // 16 or 20
+
 // Remove compiler warning on an unused variable
 #define UNUSED(x) (void) (x)
 

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -460,8 +460,10 @@ void Stepper::isr() {
         _APPLY_STEP(AXIS)(_INVERT_STEP_PIN(AXIS),0); \
       }
 
+    #define CYCLES_EATEN_BY_CODE 240
+
     // If a minimum pulse time was specified get the CPU clock
-    #if MINIMUM_STEPPER_PULSE > 0
+    #if STEP_PULSE_CYCLES > CYCLES_EATEN_BY_CODE
       static uint32_t pulse_start;
       pulse_start = TCNT0;
     #endif
@@ -494,9 +496,8 @@ void Stepper::isr() {
     #endif // !ADVANCE && !LIN_ADVANCE
 
     // For a minimum pulse time wait before stopping pulses
-    #if MINIMUM_STEPPER_PULSE > 0
-      #define CYCLES_EATEN_BY_CODE 10
-      while ((uint32_t)(TCNT0 - pulse_start) < (MINIMUM_STEPPER_PULSE * (F_CPU / 1000000UL)) - CYCLES_EATEN_BY_CODE) { /* nada */ }
+    #if STEP_PULSE_CYCLES > CYCLES_EATEN_BY_CODE
+      while ((uint32_t)(TCNT0 - pulse_start) < STEP_PULSE_CYCLES - CYCLES_EATEN_BY_CODE) { /* nada */ }
     #endif
 
     #if HAS_X_STEP
@@ -688,10 +689,12 @@ void Stepper::isr() {
         E## INDEX ##_STEP_WRITE(INVERT_E_STEP_PIN); \
       }
 
+    #define CYCLES_EATEN_BY_E 60
+
     // Step all E steppers that have steps
     for (uint8_t i = 0; i < step_loops; i++) {
 
-      #if MINIMUM_STEPPER_PULSE > 0
+      #if STEP_PULSE_CYCLES > CYCLES_EATEN_BY_E
         static uint32_t pulse_start;
         pulse_start = TCNT0;
       #endif
@@ -708,9 +711,8 @@ void Stepper::isr() {
       #endif
 
       // For a minimum pulse time wait before stopping pulses
-      #if MINIMUM_STEPPER_PULSE > 0
-        #define CYCLES_EATEN_BY_E 10
-        while ((uint32_t)(TCNT0 - pulse_start) < (MINIMUM_STEPPER_PULSE * (F_CPU / 1000000UL)) - CYCLES_EATEN_BY_E) { /* nada */ }
+      #if STEP_PULSE_CYCLES > CYCLES_EATEN_BY_E
+        while ((uint32_t)(TCNT0 - pulse_start) < STEP_PULSE_CYCLES - CYCLES_EATEN_BY_E) { /* nada */ }
       #endif
 
       STOP_E_PULSE(0);


### PR DESCRIPTION
Apply slightly more robust handling of `MINIMUM_STEPPER_PULSE` to make sure that no harmful delay is added to the stepper ISR when not needed. The code that tests for the delay to expire itself includes doing a `long` subtraction, `long` compare, and a short branch. That code alone may consume enough cycles to produce the required delay in some instances, so it's not the cleanest approach.

Testing with an oscilloscope indicates that the code to do normal stepping, with a single stepper active, uses over 15µs. So stepper pulses are already quite long for the main ISR. With advance stepping that duration reduces, but still produces an adequate pulse duration.

On the other hand, the advance ISR code uses far fewer cycles and much more likely needs `MINIMUM_STEPPER_PULSE` applied. I've taken a crude approach as a first step to make sure that the main stepper ISR isn't bogged down if we only need a delay for the advance ISR.
- Reckon stepper pulse duration in CPU cycles
- Reckon cycles eaten by code in cycles
- Don't include delay code if not needed
- Assume 240c is the minimal duration of the stepping code
- Assume 60c is used up by advance for a single E stepper

In the near future we can figure out baseline values for `CYCLES_EATEN_BY_CODE` and `CYCLES_EATEN_BY_E` based on the number of enabled steppers, and probably take a more fine-grained approach by inserting `nop` commands and using `switch`. Example:

``` cpp
switch (microsec) {
  case 5:
    asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n");
  case 4:
    asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n");
  case 3:
    asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n");
  case 2:
    asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n");
  case 1:
    asm("nop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\nnop\n");
}
```
