### PR TITLE
Mightyboard Revision E preliminary support

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -33,6 +33,7 @@
 #define BOARD_CNCONTROLS_12     112  // Cartesio CN Controls V12
 #define BOARD_CHEAPTRONIC       2    // Cheaptronic v1.0
 #define BOARD_SETHI             20   // Sethi 3D_1
+#define BOARD_MIGHTYBOARD_REVE  200  // Makerbot Mightyboard Revision E
 #define BOARD_RAMPS_OLD         3    // MEGA/RAMPS up to 1.2
 #define BOARD_RAMPS_13_EFB      33   // RAMPS 1.3 (Power outputs: Hotend, Fan, Bed)
 #define BOARD_RAMPS_13_EEB      34   // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Bed)

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -1835,18 +1835,6 @@
   #define PG5_WPORT   PORTG
   #define PG5_DDR     DDRG
   #define PG5_PWM     &OCR0B
-  #undef PG6
-  #define PG6_PIN     PING6
-  #define PG6_RPORT   PING
-  #define PG6_WPORT   PORTG
-  #define PG6_DDR     DDRG
-  #define PG6_PWM     NULL
-  #undef PG7
-  #define PG7_PIN     PING7
-  #define PG7_RPORT   PING
-  #define PG7_WPORT   PORTG
-  #define PG7_DDR     DDRG
-  #define PG7_PWM     NULL
 
   #undef PH0
   #define PH0_PIN     PINH0

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -39,6 +39,8 @@
   #include "pins_CHEAPTRONIC.h"
 #elif MB(SETHI)
   #include "pins_SETHI.h"
+#elif MB(MIGHTYBOARD_REVE)
+  #include "pins_MIGHTYBOARD_REVE.h"
 #elif MB(RAMPS_OLD)
   #include "pins_RAMPS_OLD.h"
 #elif MB(RAMPS_13_EFB)

--- a/Marlin/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/pins_MIGHTYBOARD_REVE.h
@@ -1,0 +1,205 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Mightyboard Rev.E pin assignments
+ */
+
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
+  #error "Oops! Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
+#endif
+
+#define DEFAULT_MACHINE_NAME    "MB Replicator"
+#define BOARD_NAME              "Mightyboard"
+
+#define LARGE_FLASH true
+
+//
+// Servos
+//
+#define SERVO0_PIN         36 // C1 (1280-EX1)
+#define SERVO1_PIN         37 // C0 (1280-EX2)
+#define SERVO2_PIN         40 // G1 (1280-EX3)
+#define SERVO3_PIN         41 // G0 (1280-EX4)
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          49 // L0
+#define X_MAX_PIN          48 // L1
+#define Y_MIN_PIN          47 // L2
+#define Y_MAX_PIN          46 // L3
+#define Z_MIN_PIN          43 // L6
+#define Z_MAX_PIN          42 // L7
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  42
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN         55 // F1
+#define X_DIR_PIN          54 // F0
+#define X_ENABLE_PIN       56 // F2
+
+#define Y_STEP_PIN         59 // F5
+#define Y_DIR_PIN          58 // F4
+#define Y_ENABLE_PIN       60 // F6
+
+#define Z_STEP_PIN         63 // K1
+#define Z_DIR_PIN          62 // K0
+#define Z_ENABLE_PIN       64 // K2
+
+#define E0_STEP_PIN        25 // A3
+#define E0_DIR_PIN         24 // A2
+#define E0_ENABLE_PIN      26 // A4
+
+#define E1_STEP_PIN        29 // A7
+#define E1_DIR_PIN         28 // A6
+#define E1_ENABLE_PIN      39 // G2
+
+//
+// I2C Digipots - MCP4018
+// Address 5E (2F << 1)
+// Set from 0 - 127 with stop bit.
+// (Ex. 3F << 1 | 1)
+//
+#define DIGIPOTS_I2C_SCL    76 // J5
+#define DIGIPOTS_I2C_SDA_X  57 // F3
+#define DIGIPOTS_I2C_SDA_Y  61 // F7
+#define DIGIPOTS_I2C_SDA_Z  65 // K3
+#define DIGIPOTS_I2C_SDA_E0 27 // A5
+#define DIGIPOTS_I2C_SDA_E1 77 // J6
+
+//
+// Temperature Sensors
+//
+#define TEMP_BED_PIN       69 // K7
+
+// SPI for Max6675 or Max31855 Thermocouple
+// Uses a separate SPI bus
+//
+//  3 E5 DO (SO)
+//  5 E3 CS1
+//  2 E4 CS2
+// 78 E2 SCK
+//
+#define THERMO_SCK_PIN     78 // E2
+#define THERMO_DO_PIN       3 // E5
+#define THERMO_CS1          5 // E3
+#define THERMO_CS2          2 // E4
+
+//
+// Augmentation for auto-assigning plugs
+//
+// Two thermocouple connectors allows for either
+// 2 extruders or 1 extruder and a heated bed.
+// With no heated bed, an additional 24V fan is possible.
+//
+#define MOSFET_A_PIN     6 // H3
+#define MOSFET_B_PIN     9 // B5
+#define MOSFET_C_PIN    45 // L4
+#define MOSFET_D_PIN    44 // L5
+
+#if HOTENDS > 1
+  #if TEMP_SENSOR_BED
+    #define IS_EEB
+  #else
+    #define IS_EEF
+  #endif
+#elif TEMP_SENSOR_BED
+  #define IS_EFB
+#else
+  #define IS_EFF
+#endif
+
+//
+// Heaters / Fans (24V)
+//
+#define HEATER_0_PIN     MOSFET_A_PIN
+
+#if ENABLED(IS_EFB)                            // Hotend, Fan, Bed
+  #define FAN_PIN        MOSFET_B_PIN
+  #define HEATER_BED_PIN MOSFET_C_PIN
+#elif ENABLED(IS_EEF)                          // Hotend, Hotend, Fan
+  #define HEATER_1_PIN   MOSFET_B_PIN
+  #define FAN_PIN        MOSFET_C_PIN
+#elif ENABLED(IS_EEB)                          // Hotend, Hotend, Bed
+  #define HEATER_1_PIN   MOSFET_B_PIN
+  #define HEATER_BED_PIN MOSFET_C_PIN
+#elif ENABLED(IS_EFF)                          // Hotend, Fan, Fan
+  #define FAN_PIN        MOSFET_B_PIN
+  #define FAN1_PIN       MOSFET_C_PIN
+#elif ENABLED(IS_SF)                           // Spindle, Fan
+  #define FAN_PIN        MOSFET_C_PIN
+#endif
+
+#ifndef FAN_PIN
+  #define FAN_PIN MOSFET_D_PIN
+#endif
+
+//
+// Extruder Auto Fan Pins
+//
+#define EXTRUDER_0_AUTO_FAN  7 // H4
+#define EXTRUDER_1_AUTO_FAN 12 // B6
+
+//
+// Misc. Functions
+//
+#define LED_PIN             13 // B7
+#define CUTOFF_RESET_PIN    16 // H1
+#define CUTOFF_TEST_PIN     17 // H0
+
+//
+// LCD / Controller
+//
+// Replicator uses a 3-wire SR controller with HD44780
+// For now, pretend it's the SAV
+//
+#define SAV_3DLCD
+#define SR_DATA_PIN         34 // C3
+#define SR_CLK_PIN          35 // C2
+#define SR_STROBE_PIN       33 // C4
+
+#define BTN_UP              75 // J4
+#define BTN_DOWN            73 // J3
+#define BTN_LEFT            72 // J2
+#define BTN_RIGHT           14 // J1
+#define BTN_CENTER          15 // J0
+#define BTN_ENC             BTN_CENTER
+
+#define BEEPER_PIN           4 // G5
+
+#define STAT_LED_RED        32 // C5
+#define STAT_LED_BLUE       31 // C6 (Actually green)
+
+//
+// SD Card
+//
+#define SDSS                53 // B0
+#define SD_DETECT_PIN       30 // C7
+

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -161,7 +161,11 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
   #include <LCD.h>
   #include <LiquidCrystal_SR.h>
   #define LCD_CLASS LiquidCrystal_SR
-  LCD_CLASS lcd(SR_DATA_PIN, SR_CLK_PIN);
+  #if defined(SR_STROBE_PIN)
+    LCD_CLASS lcd(SR_DATA_PIN, SR_CLK_PIN, SR_STROBE_PIN);
+  #else
+    LCD_CLASS lcd(SR_DATA_PIN, SR_CLK_PIN);
+  #endif
 #elif ENABLED(LCM1602)
   #include <Wire.h>
   #include <LCD.h>


### PR DESCRIPTION
This is the initial pins definitions for the Mightyboard Revision E, as a starting-point to support the Makerbot Replicator series of 3D printers. This is not functional because Marlin has limited support for some features. Marlin will need the following augmentations before it will be supportable:
- Support for two or more MAX6675 thermocouples
- Support for multiple i2c buses to control the MCP4018 digital pots
- Support for one additional unidirectional SPI bus, to read the thermocouples
- Support for an RGB LED that may work differently from `BLINKM`

The MCP4018 requires separate I2C buses because it has a fixed address (0x2F << 1 = 0x5E)
The thermocouples share the same `SCK` and `DO` pins, with their own `CS` pins.
The controller interface port connects to a 3-wire shift-register display controller
