### PR TITLE
K8400 has 1xXY an 2xZ endstop plugs

### DIFF
--- a/Marlin/pins_K8400.h
+++ b/Marlin/pins_K8400.h
@@ -37,10 +37,12 @@
 
 #include "pins_3DRAG.h"
 
-#undef  X_MAX_PIN
-#define X_MAX_PIN     -1
-#undef  Y_MAX_PIN
-#define Y_MAX_PIN     -1
+#undef X_MAX_PIN
+#undef X_MIN_PIN
+#undef Y_MAX_PIN
+#undef Y_MIN_PIN
+#define X_STOP_PIN  3
+#define Y_STOP_PIN 14
 
 #undef E1_STEP_PIN
 #define E1_STEP_PIN   32


### PR DESCRIPTION
Addressing #4909. Instead of just undefining the plugs, reassign them to `X_MIN_STOP` and `X_MAX_STOP` to be auto-assigned by `pins.h`.
