### PR TITLE
RC7 planner fix for very old errant jerk and especially Z axis acceleration bugs

### DIFF
--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -35,7 +35,7 @@
   /**
    * Marlin release version identifier
    */
-  #define SHORT_BUILD_VERSION "1.1.0-RCBugFix"
+  #define SHORT_BUILD_VERSION "1.1.0-RC7"
 
   /**
    * Verbose version identifier which should contain a reference to the location
@@ -48,7 +48,7 @@
    * here we define this default string as the date where the latest release
    * version was tagged.
    */
-  #define STRING_DISTRIBUTION_DATE "2016-07-26 12:00"
+  #define STRING_DISTRIBUTION_DATE "2016-07-31 12:00"
 
   /**
    * Required minimum Configuration.h and Configuration_adv.h file versions.

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -954,17 +954,33 @@ void Planner::check_axes_activity() {
   else {
     // Limit acceleration per axis
     block->acceleration_steps_per_s2 = ceil((block->steps[E_AXIS] ? acceleration : travel_acceleration) * steps_per_mm);
-    if (max_acceleration_steps_per_s2[X_AXIS] < (block->acceleration_steps_per_s2 * block->steps[X_AXIS]) / block->step_event_count)
-      block->acceleration_steps_per_s2 = (max_acceleration_steps_per_s2[X_AXIS] * block->step_event_count) / block->steps[X_AXIS];
-    if (max_acceleration_steps_per_s2[Y_AXIS] < (block->acceleration_steps_per_s2 * block->steps[Y_AXIS]) / block->step_event_count)
-      block->acceleration_steps_per_s2 = (max_acceleration_steps_per_s2[Y_AXIS] * block->step_event_count) / block->steps[Y_AXIS];
-    if (max_acceleration_steps_per_s2[Z_AXIS] < (block->acceleration_steps_per_s2 * block->steps[Z_AXIS]) / block->step_event_count)
-      block->acceleration_steps_per_s2 = (max_acceleration_steps_per_s2[Z_AXIS] * block->step_event_count) / block->steps[Z_AXIS];
-    if (max_acceleration_steps_per_s2[E_AXIS] < (block->acceleration_steps_per_s2 * block->steps[E_AXIS]) / block->step_event_count)
-      block->acceleration_steps_per_s2 = (max_acceleration_steps_per_s2[E_AXIS] * block->step_event_count) / block->steps[E_AXIS];
+
+    // XXX DEBUG (G)
+    serial_echopair_P(PSTR("acceleration="), acceleration); SERIAL_EOL;
+    serial_echopair_P(PSTR("travel_acceleration="), travel_acceleration); SERIAL_EOL;
+    serial_echopair_P(PSTR("steps_per_mm="), steps_per_mm); SERIAL_EOL;
+    serial_echopair_P(PSTR("block->steps[Z_AXIS]="), block->steps[Z_AXIS]); SERIAL_EOL;
+    serial_echopair_P(PSTR("block->step_event_count="), block->step_event_count); SERIAL_EOL;
+    serial_echopair_P(PSTR("block->acceleration_steps_per_s2="), block->acceleration_steps_per_s2); SERIAL_EOL;
+    serial_echopair_P(PSTR("max_acceleration_mm_per_s2[Z_AXIS]="), max_acceleration_mm_per_s2[Z_AXIS]); SERIAL_EOL;
+    serial_echopair_P(PSTR("acceleration_steps_per_s2="), block->acceleration_steps_per_s2); SERIAL_EOL;
+
+    if (max_acceleration_steps_per_s2[X_AXIS] < ((float)block->acceleration_steps_per_s2 * (float)block->steps[X_AXIS] / (float)block->step_event_count) )
+        block->acceleration_steps_per_s2 = max_acceleration_steps_per_s2[X_AXIS];
+    if (max_acceleration_steps_per_s2[Y_AXIS] < ((float)block->acceleration_steps_per_s2 * (float)block->steps[Y_AXIS] / (float)block->step_event_count) )
+        block->acceleration_steps_per_s2 = max_acceleration_steps_per_s2[Y_AXIS];
+    if (max_acceleration_steps_per_s2[E_AXIS] < ((float)block->acceleration_steps_per_s2 * (float)block->steps[E_AXIS] / (float)block->step_event_count) )
+        block->acceleration_steps_per_s2 = max_acceleration_steps_per_s2[E_AXIS];
+    if (max_acceleration_steps_per_s2[Z_AXIS] < ((float)block->acceleration_steps_per_s2 * (float)block->steps[Z_AXIS] / (float)block->step_event_count) )
+        block->acceleration_steps_per_s2 = max_acceleration_steps_per_s2[Z_AXIS];
+
   }
   block->acceleration = block->acceleration_steps_per_s2 / steps_per_mm;
-  block->acceleration_rate = (long)(block->acceleration_steps_per_s2 * 16777216.0 / ((F_CPU) * 0.125));
+  
+  // XXX
+  serial_echopair_P(PSTR("FINAL block->acceleration="), block->acceleration); SERIAL_EOL;
+
+  block->acceleration_rate = (long)(block->acceleration_steps_per_s2 * (16777216.0 / (F_CPU / 8)));
 
   #if 0  // Use old jerk for now
 
@@ -1010,31 +1026,29 @@ void Planner::check_axes_activity() {
   #endif
 
   // Start with a safe speed
-  float vmax_junction = max_xy_jerk * 0.5,
-        vmax_junction_factor = 1.0,
-        mz2 = max_z_jerk * 0.5,
-        me2 = max_e_jerk * 0.5,
-        csz = current_speed[Z_AXIS],
-        cse = current_speed[E_AXIS];
-  if (fabs(csz) > mz2) vmax_junction = min(vmax_junction, mz2);
-  if (fabs(cse) > me2) vmax_junction = min(vmax_junction, me2);
+  float vmax_junction = max_xy_jerk/2; 
+  float vmax_junction_factor = 1.0; 
+  if(fabs(current_speed[Z_AXIS]) > max_z_jerk/2) 
+    vmax_junction = min(vmax_junction, max_z_jerk/2);
+  if(fabs(current_speed[E_AXIS]) > max_e_jerk/2) 
+    vmax_junction = min(vmax_junction, max_e_jerk/2);
   vmax_junction = min(vmax_junction, block->nominal_speed);
   float safe_speed = vmax_junction;
 
   if ((moves_queued > 1) && (previous_nominal_speed > 0.0001)) {
-    float dsx = current_speed[X_AXIS] - previous_speed[X_AXIS],
-          dsy = current_speed[Y_AXIS] - previous_speed[Y_AXIS],
-          dsz = fabs(csz - previous_speed[Z_AXIS]),
-          dse = fabs(cse - previous_speed[E_AXIS]),
-          jerk = HYPOT(dsx, dsy);
-
-    //    if ((fabs(previous_speed[X_AXIS]) > 0.0001) || (fabs(previous_speed[Y_AXIS]) > 0.0001)) {
+    float jerk = sqrt(pow((current_speed[X_AXIS]-previous_speed[X_AXIS]), 2)+pow((current_speed[Y_AXIS]-previous_speed[Y_AXIS]), 2));
+    //    if((fabs(previous_speed[X_AXIS]) > 0.0001) || (fabs(previous_speed[Y_AXIS]) > 0.0001)) {
     vmax_junction = block->nominal_speed;
     //    }
-    if (jerk > max_xy_jerk) vmax_junction_factor = max_xy_jerk / jerk;
-    if (dsz > max_z_jerk) vmax_junction_factor = min(vmax_junction_factor, max_z_jerk / dsz);
-    if (dse > max_e_jerk) vmax_junction_factor = min(vmax_junction_factor, max_e_jerk / dse);
-
+    if (jerk > max_xy_jerk) {
+      vmax_junction_factor = (max_xy_jerk/jerk);
+    } 
+    if(fabs(current_speed[Z_AXIS] - previous_speed[Z_AXIS]) > max_z_jerk) {
+      vmax_junction_factor= min(vmax_junction_factor, (max_z_jerk/fabs(current_speed[Z_AXIS] - previous_speed[Z_AXIS])));
+    } 
+    if(fabs(current_speed[E_AXIS] - previous_speed[E_AXIS]) > max_e_jerk) {
+      vmax_junction_factor = min(vmax_junction_factor, (max_e_jerk/fabs(current_speed[E_AXIS] - previous_speed[E_AXIS])));
+    } 
     vmax_junction = min(previous_nominal_speed, vmax_junction * vmax_junction_factor); // Limit speed to max previous speed
   }
   block->max_entry_speed = vmax_junction;

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 # Marlin 3D Printer Firmware
 
-[![Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg?branch=RCBugFix)](https://travis-ci.org/MarlinFirmware/Marlin)
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224)
-
 <img align="top" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
 
 Additional documentation can be found at [The Marlin Documentation Project](https://www.marlinfw.org/).
 Please test this firmware and inform us if it misbehaves in any way, volunteers are standing by!
 
-## Release Candidate -- Marlin 1.1.0-RCBugFix - 26 July 2016
+## Release Candidate -- Marlin 1.1.0-RC7 - 31 July 2016
 
 __Not for production use – use with caution!__
 
@@ -17,9 +14,7 @@ You can download earlier versions of Marlin on the [Releases page](https://githu
 The latest Release Candidate lives in the ["RC" branch](https://github.com/MarlinFirmware/Marlin/tree/RC). Bugs that we find in the current Release Candidate are patched in the ["RCBugFix" branch](https://github.com/MarlinFirmware/Marlin/tree/RCBugFix), so during beta testing this is where you can always find the latest code on its way towards release.
 
 ## Recent Changes
-- RCBugFix
-
-- RC7 - 26 Jul 2016
+- RC7 - 31 Jul 2016
   - Add Print Job Timer and Print Counter (`PRINTCOUNTER`)
   - New `M600` Filament Change (`FILAMENT_CHANGE_FEATURE`)
   - New `G12` Nozzle Clean (`NOZZLE_CLEAN_FEATURE`)
@@ -85,7 +80,14 @@ Proposed patches should be submitted as a Pull Request against the [RCBugFix](ht
 - Do submit questions and concerns. The "naive" question is often the one we forget to ask.
 - Follow the proper coding style. Pull requests with styling errors will be delayed. See our [Coding Standards](https://github.com/MarlinFirmware/Marlin/wiki/DNE-Coding-Standards) page for more information.
 
-### [RepRap.org Wiki Page](http://reprap.org/wiki/Marlin)
+## Current Status: Testing
+
+Please test this firmware and inform us if it misbehaves in any way. Volunteers are standing by!
+
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224)
+[![Travis Build Status](https://travis-ci.org/MarlinFirmware/MarlinDev.svg)](https://travis-ci.org/MarlinFirmware/MarlinDev)
+
+##### [RepRap.org Wiki Page](http://reprap.org/wiki/Marlin)
 
 ## Credits
 
@@ -115,3 +117,5 @@ More features have been added by:
 Marlin is published under the [GPL license](/LICENSE) because we believe in open development. The GPL comes with both rights and obligations. Whether you use Marlin firmware as the driver for your open or closed-source product, you must keep Marlin open, and you must provide your compatible Marlin source code to end users upon request. The most straightforward way to comply with the Marlin license is to make a fork of Marlin on Github, perform your modifications, and direct users to your modified fork.
 
 While we can't prevent the use of this code in products (3D printers, CNC, etc.) that are closed source or crippled by a patent, we would prefer that you choose another firmware or, better yet, make your own.
+
+[![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)


### PR DESCRIPTION
I've been trying to figure this out myself for weeks -- if not months, on and off. Then I stumbled on the following, from the Joseph Prusa's MK2 release notes ...

> Marlin planner improvements
> 
> Fixes most shifting layers issues. The bug has been in Marlin for ages. Marlin handles jerk speeds wrongly and occasionally put the XY JERK speed on Z axis which prevented the Z axis to go up and the nozzle then crashed on previous layers.

OMG! YES! ME TOO! LOL

So, I manually ported their improvements to the RC7 Marlin code. WHAT A DIFFERENCE! Things run MUCH better now.

I highly recommend this one folks. :-) Hope you like it.
