### PR TITLE
implement M3, M4 & M5 spindle control commands 

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -810,4 +810,103 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ *  
+ *  Spindle control
+ * 
+ *  The M3, M4 & M5 g-code commands are used to turn the spindle on and off & to set the
+ *  spindle speed.  In this implementation the M4 command is the same as the M3 (assumes
+ *  the spindle rotates in one direction only).
+ * 
+ *  SuperPid is a router/spindle speed controller used in the CNC milling community.
+ *  Marlin can be used to turn the spindle on and off.  It can also be used to set
+ *  the spindle speed from 5,000 to 30,000 RPM.  
+ *
+ *  You'll need to select a 3.3V - 5V signal for the ON/OFF function and optionally
+ *  choose a 0-5V PWM pin for the speed control.
+ *
+ *  uncomment the following to enable the ON/OFF function
+ */
+ 
+//#define SPINDLE_ENABLE
+ 
+ //  uncomment the following to enable speed control
+//#define SPINDLE_SPEED  
+
+ // If SPINDLE_SPEED is enabled but SPINDLE_ENABLE isn't then SPINDLE_SPEED is ignored.
+ 
+#define SPINDLE_ENABLE_INVERT  false   // set to "true" if  the spindle on/off function is reversed
+#define SPINDLE_SPEED_INVERT  true   // set to "true" if the spindle speeds up when you want it to go slower
+#define SPINDLE_POWER_UP_DELAY  5    // delay in seconds to allow the spindle to come up to speed
+#define SPINDLE_POWER_DOWN_DELAY  5    // delay in seconds to allow the spindle to stop
+
+/**
+ *  The M3 & M4 commands use the following equation to convert PWM duty cycle to spindle speed 
+ * 
+ *  RPM = PWM duty cycle * RPM_slope  +  RPM_intercept
+ *    where PWM duty cycle varies from 0 to 100
+ *
+ *  set the following for your controller (ALL MUST BE SET)
+ */
+ 
+#define RPM_SLOPE 302.00    // SuperPID & AzteegX3pro controller pin 5
+#define RPM_INTERCEPT 0     // SuperPID & AzteegX3pro controller pin 5
+#define RPM_MIN  5000       // SuperPID
+#define RPM_MAX 30000       // SuperPID
+ 
+/**
+ *
+ *  In the pins.h file for your board you'll need to add the following:
+ *   #define SPINDLE_ENABLE_PIN xx     // xx is the digital pin number
+ *   #define SPINDLE_SPEED_PIN yy      // yy is the digital pin number
+ *
+ *  Selecting the pin for SPINDLE_ENABLE_PIN is fairly easy.  Just select any free digital
+ *  pin with a 0 to 3.3V-5V logic levels.  
+ *
+ *  It is HIGHLY RECOMMENDED that an external 1k-10k pull up resistor be connected to the 
+ *  SPINDLE_ENABLE_PIN.  This will prevent the spindle from powering on briefly during
+ *  power up or when the controller is reset (which happens whenever you connect or 
+ *  disconnect from the controller). 
+ *
+ *  Picking the PWM pin can be tricky.  There are only 14 PWM pins on an ATMEGA2561.  Some are 
+ *  used by the system interrupts so are unavailable.  Others are usually hardwired in the
+ *  controller to functions you can't do without.  Fans, servos and some specialized functions
+ *  all want to have a PWM pin.  Usually you'll end up picking a function you can do without, 
+ *  commenting that function out (or not enabling it) and assigning it's pin number to the
+ *  speed pin.
+ * 
+ *  Use the following table when selecting the speed pin.
+ *   
+ *  ATMEGA2561 PWM assignments & users
+ *  
+ *  There are 15 PWM ports assigned to 14 physical pins.
+ *     Pin 13 has two ports assigned to it.
+ *  
+ *      Timer   Digital Normally    Used by         Optional    
+ *      & Port   Pin    assigned    system          users   
+ *      TIMER3B   2     X_MAX                       servo
+ *      TIMER3C   3     X_MIN                       servo
+ *      TIMER0B   4     HEATER_4    temp & milli ISR 
+ *      TIMER3A   5     HEATER_5                    servo
+ *      TIMER4A   6     HEATER_6        
+ *      TIMER4B   7     LCD     
+ *      TIMER4C   8     HOTBED      
+ *      TIMER2B   9     HEATER_1        
+ *      TIMER2A   10    HEATER_0        
+ *      TIMER1A   11    HEATER_7    stepper ISR     E axis waveform generator
+ *      TIMER1B   12    PS_ON_PIN   stepper ISR     E axis waveform generator
+ *      TIMER0A   13    LED         step adv ISR    
+ *      TIMER1C   13    LED         LED PWM 
+ *      TIMER5C   44    LCD                         stepper motor current XY PWM
+ *      TIMER5B   45    LCD                         stepper motor current Z PWM
+ *      TIMER5A   46    Z_STEP                      stepper motor current E PWM
+ *  
+ *  In addition to the above, fans can be assigned to PWM pins.  If you pick a pin that's 
+ *  already assigned to a fan then you'll need to delete the fan or change it's pin assignment.
+ *  This needs to be done even if FAN_FAST_PWM is disabled.
+ *  
+ *  NOTE: If you pick a pin that's hardwired to a heater then you'll probably have to connect
+ *        an external 1k-10k pull up resistor to the pin.
+ *   
+ */ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -909,4 +909,9 @@
  *        an external 1k-10k pull up resistor to the pin.
  *   
  */ 
+ 
+ /**
+ * Add M43 command for pins info and testing
+ */
+#define PINS_DEBUGGING
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -126,6 +126,9 @@
  *
  * M0   - Unconditional stop - Wait for user to press a button on the LCD (Only if ULTRA_LCD is enabled)
  * M1   - Same as M0
+ * M3   - Turn spindle on and set spindle speed
+ * M4   - Same as M3
+ * M5   - Turn spindle off
  * M17  - Enable/Power all stepper motors
  * M18  - Disable all stepper motors; same as M84
  * M20  - List SD card. (Requires SDSUPPORT)
@@ -4450,6 +4453,131 @@ inline void gcode_G92() {
   }
 
 #endif // ULTIPANEL || EMERGENCY_PARSER
+ 
+/**
+ * M3 & M4 spindle commands
+ *  S=0 turns off spindle
+ *  if speed pwm output not defined then just turns it on
+ *
+ *  need at least 12.8KHz (50Hz * 256) for spindle PWM 
+ *    must use hardware PWM because all ISRs are too slow 
+ *        Stepper::isr too slow
+ *        temperature ISR too slow
+ *
+ * NOTE - WGM bits for timers 3, 4 & 5 need to be either 0001 or 0101.
+ *       Any other setting will result in a PWM signal that doesn't
+ *       go from 0 volts to 5 volts.
+ *       
+ *       The system automatically sets those bits to 0001 so special
+ *       initialization is not needed.
+ *       
+ *       WGM bits for timer 2 are automatically set by the system to
+ *       001.  This produces an acceptable 0 volts to 5 volts signal.
+ *       Special initialization is not needed.
+ *       
+ * NOTE - A minimum PWM frequency of 50 Hz is needed.  All of the 
+ *        pre-scaler factors for timers 2, 3, 4 & 5 are acceptable. 
+ *
+ *  SPINDLE_ENABLE_PIN needs an external pullup or else could turn on 
+ *  spindle  during power up or when connecting to the host (usually 
+ *  goes through a reset which sets all I/O pins to tristate)
+ *
+ *  PWM duty cycle goes from 0 (off) to 255 (always on) 
+ * 
+ */  
+#if ENABLED(SPINDLE_ENABLE)
+
+  inline void delay_for_spindle_power_up() {
+    refresh_cmd_timeout();                                                       // wait for spindle to come up to speed
+    if (SPINDLE_POWER_UP_DELAY > 0)  while (PENDING(millis(), SPINDLE_POWER_UP_DELAY * 1000 + previous_cmd_ms)) idle();
+    else                             while (PENDING(millis(), 1000 + previous_cmd_ms)) idle();         // allow at least 1 second for power up
+  }
+  
+  inline void delay_for_spindle_power_down() {
+    refresh_cmd_timeout();                                                       // wait for spindle to come up to speed
+    if (SPINDLE_POWER_DOWN_DELAY >= 0)  while (PENDING(millis(), SPINDLE_POWER_DOWN_DELAY * 1000 + previous_cmd_ms + 1)) idle(); 
+    else                                while (PENDING(millis(), 1000 + previous_cmd_ms)) idle();    // allow at least 1 second for power down
+  }
+
+  inline void gcode_M3_M4() {
+
+    // this is the "pretty" version.  It accepts RPM as input
+    #if ENABLED(SPINDLE_SPEED)
+  
+      // use gcode_M4() to get the points needed to compute the RPM vs OCRxx_VAL line
+  
+      // Our final value for OCRxx_VAL is an unsigned 8 bit value between 0 and 255 which usually means uint8_t.
+      // Went to uint16_t because some of the uint8_t calculations would sometimes give 1000 0000 rather than 1111 1111.
+      // Then needed to AND the uint16_t result with 0xffff to make sure we only wrote the byte of interest.
+  
+      float spindle_speed = code_seen('S') ? code_value_float() : 0; 
+      if (spindle_speed == 0) { 
+        stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle off
+        WRITE(SPINDLE_ENABLE_PIN, !SPINDLE_ENABLE_INVERT);  //turn spindle off (active low);
+        delay_for_spindle_power_down();
+      }
+      else {
+        int16_t OCRxx_VAL = 2.55 * (spindle_speed - RPM_INTERCEPT)/RPM_SLOPE;      // convert RPM to PWM duty cycle
+        float temp = 2.55 * (spindle_speed - RPM_INTERCEPT)/RPM_SLOPE;
+        if (temp >= 255)                OCRxx_VAL = 255;                                        //limit to max the Atmel PWM will support
+        if (spindle_speed <= RPM_MIN)   OCRxx_VAL = 2.55 * (RPM_MIN - RPM_INTERCEPT)/RPM_SLOPE; // minimum setting
+        if (spindle_speed >= RPM_MAX)   OCRxx_VAL = 2.55 * (RPM_MAX - RPM_INTERCEPT)/RPM_SLOPE; // limit to max RPM
+        if (SPINDLE_SPEED_INVERT==true) OCRxx_VAL = 255 - OCRxx_VAL ; 
+        stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle on
+        WRITE(SPINDLE_ENABLE_PIN, SPINDLE_ENABLE_INVERT);  // turn spindle on (active low)
+        analogWrite(SPINDLE_SPEED_PIN, OCRxx_VAL & 0xff);  //only write lowest byte 
+        delay_for_spindle_power_up();
+      } 
+    #else
+      stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle on
+      WRITE(SPINDLE_ENABLE_PIN, SPINDLE_ENABLE_INVERT);  //turn spindle on (active low) if spindle speed option not enabled
+      delay_for_spindle_power_up();
+    #endif
+  } 
+ 
+/**
+ * gcode_M4 is used for debugging and to get the points needed to compute the RPM vs OCRxx_VAL line
+ * 
+ * it accepts inputs of 0-255
+ *
+ * To use it you'll need to change the M4 command from "gcode_M3_M4()" to "gcode_M4()"
+ *   
+ * This was used to get the RPM vs. OCRxx PWM values
+ * That was thrown into Excel to determine a best fit line
+ * for use in the M3 routine.
+ */
+
+  inline void gcode_M4() {
+    #if ENABLED(SPINDLE_SPEED)
+      uint8_t spindle_speed = code_seen('S') ? code_value_byte() : 0; 
+      if (spindle_speed == 0) { 
+        stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle off
+        WRITE(SPINDLE_ENABLE_PIN, !SPINDLE_ENABLE_INVERT);  //turn spindle off (active low);
+        delay_for_spindle_power_down();
+      }
+      else {
+        stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle on 
+        WRITE(SPINDLE_ENABLE_PIN, SPINDLE_ENABLE_INVERT); //turn spindle on (active low) if spindle speed option not enabled
+        if (SPINDLE_SPEED_INVERT) spindle_speed = 255 - spindle_speed ;
+        analogWrite(SPINDLE_SPEED_PIN, spindle_speed);
+        delay_for_spindle_power_up();
+      } 
+    #else
+      stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle on
+      WRITE(SPINDLE_ENABLE_PIN, SPINDLE_ENABLE_INVERT);  //turn spindle on (active low) if spindle speed option not enabled
+      delay_for_spindle_power_up();
+    #endif
+  }
+
+ /**
+ * M5 turn off spindle
+ */
+  inline void gcode_M5() {
+    stepper.synchronize();   // wait until previous movement commands (G0, G1, G2 & G3) have completed before turning spindle off
+    WRITE(SPINDLE_ENABLE_PIN, !SPINDLE_ENABLE_INVERT);  // turn spindle off
+    delay_for_spindle_power_down();
+  }
+#endif //SPINDLE_ENABLE
 
 /**
  * M17: Enable power on all stepper motors
@@ -7630,6 +7758,20 @@ void process_next_command() {
           gcode_M0_M1();
           break;
       #endif // ULTIPANEL
+     
+      #if ENABLED(SPINDLE_ENABLE)
+        case 3:
+          gcode_M3_M4();  // M3 - turn spindle on and set spindle speed
+          break;          // synchronizes with movement commands  
+                          
+        case 4:           
+          gcode_M3_M4();  // M4 is the same as M3
+          break;          
+          
+        case 5:
+          gcode_M5();     // M5 - turn spindle off
+          break;          // synchronizes with movement commands 
+     #endif
 
       case 17:
         gcode_M17();
@@ -9633,6 +9775,14 @@ void setup() {
   setup_photpin();
   servo_init();
 
+  #if ENABLED(SPINDLE_ENABLE)
+    OUT_WRITE(SPINDLE_ENABLE_PIN, !SPINDLE_ENABLE_INVERT);  //init spindle to off;
+    #if ENABLED(SPINDLE_SPEED)
+      pinMode(SPINDLE_SPEED_PIN, OUTPUT);
+      analogWrite(SPINDLE_SPEED_PIN, SPINDLE_SPEED_INVERT ? 255 : 0);  //set to lowest speed
+    #endif
+  #endif 
+ 
   #if HAS_BED_PROBE
     endstops.enable_z_probe(false);
   #endif

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -996,3 +996,53 @@
 #if COUNT_LCD_24 > 1
   #error "Please select no more than one LCD controller option."
 #endif
+
+#if ENABLED( SPINDLE_ENABLE)
+  #if !PIN_EXISTS(SPINDLE_ENABLE)
+    #error "SPINDLE_ENABLE requires SPINDLE_ENABLE_PIN."
+  #elif !defined(SPINDLE_ENABLE_INVERT) || !(SPINDLE_ENABLE_INVERT == true || SPINDLE_ENABLE_INVERT == false)
+    #error "SPINDLE_ENABLE_INVERT missing or incorrectly defined"
+  #elif ENABLED (SPINDLE_SPEED) && PIN_EXISTS(SPINDLE_SPEED)
+    #if !((SPINDLE_SPEED_PIN >=2 && SPINDLE_SPEED_PIN <= 13) || (SPINDLE_SPEED_PIN >=44 && SPINDLE_SPEED_PIN <= 46) )
+      #error "SPINDLE_SPEED_PIN not assigned to a PWM pin"
+    #elif !defined(SPINDLE_SPEED_INVERT) || !(SPINDLE_SPEED_INVERT == true || SPINDLE_SPEED_INVERT == false)
+      #error "SPINDLE_SPEED_INVERT missing or incorrectly defined"
+    #elif !defined(RPM_SLOPE) || !defined(RPM_INTERCEPT) || !defined(RPM_MIN) || !defined(RPM_MAX)
+      #error "spindle speed equation constant(s) missing"
+    #elif SPINDLE_SPEED_PIN == 4 || SPINDLE_SPEED_PIN == 11 || SPINDLE_SPEED_PIN == 12 || SPINDLE_SPEED_PIN == 13
+      #error "Counter/Timer for SPINDLE_SPEED PWM pin is used by a system interrupt "
+    #elif PIN_EXISTS(X_MAX) &&  X_MAX_PIN == SPINDLE_SPEED_PIN && defined(USE_XMAX_PLUG)
+      #error "SPINDLE_SPEED pin is in use by X_MAX endstop"
+    #elif PIN_EXISTS(X_MIN) &&  X_MIN_PIN == SPINDLE_SPEED_PIN && defined(USE_XMIN_PLUG)
+      #error "SPINDLE_SPEED pin is in use by X_MIN endstop "
+    #elif PIN_EXISTS(Z_STEP) &&  Z_STEP_PIN == SPINDLE_SPEED_PIN
+      #error "SPINDLE_SPEED pin in use by Z_STEP "
+    #elif defined(NUM_SERVOS) && (NUM_SERVOS > 0) &&  (SPINDLE_SPEED_PIN == 2 || SPINDLE_SPEED_PIN ==  3 || SPINDLE_SPEED_PIN == 5)
+      #error "Counter/Timer for SPINDLE_SPEED PWM pin is used by the servo system "
+    #elif PIN_EXISTS(EXTRUDER_0_AUTO_FAN) && SPINDLE_SPEED_PIN == EXTRUDER_0_AUTO_FAN_PIN
+      #error "SPINDLE_SPEED PWM pin is used by EXTRUDER_0_AUTO_FAN_PIN"
+    #elif PIN_EXISTS(EXTRUDER_1_AUTO_FAN) && SPINDLE_SPEED_PIN == EXTRUDER_1_AUTO_FAN_PIN 
+      #error "SPINDLE_SPEED PWM pin is used by EXTRUDER_1_AUTO_FAN_PIN"
+    #elif PIN_EXISTS(EXTRUDER_2_AUTO_FAN) && SPINDLE_SPEED_PIN == EXTRUDER_2_AUTO_FAN_PIN 
+      #error "SPINDLE_SPEED PWM pin is used by EXTRUDER_2_AUTO_FAN_PIN"
+    #elif PIN_EXISTS(EXTRUDER_3_AUTO_FAN) && SPINDLE_SPEED_PIN == EXTRUDER_3_AUTO_FAN_PIN  
+      #error "SPINDLE_SPEED PWM pin is used by EXTRUDER_3_AUTO_FAN_PIN"
+    #elif PIN_EXISTS(FAN) && SPINDLE_SPEED_PIN == FAN_PIN 
+      #error "SPINDLE_SPEED PWM pin is used FAN_PIN "
+    #elif PIN_EXISTS(FAN0) && SPINDLE_SPEED_PIN == FAN0_PIN 
+      #error "SPINDLE_SPEED PWM pin is used FAN0_PIN "
+    #elif PIN_EXISTS(FAN1) && SPINDLE_SPEED_PIN == FAN1_PIN
+      #error "SPINDLE_SPEED PWM pin is used FAN1_PIN "
+    #elif PIN_EXISTS(FAN2) && SPINDLE_SPEED_PIN == FAN2_PIN
+     #error "SPINDLE_SPEED PWM pin is used FAN2_PIN "
+    #elif PIN_EXISTS(CONTROLLERFAN) && SPINDLE_SPEED_PIN == CONTROLLERFAN_PIN
+      #error "SPINDLE_SPEED PWM pin is used by CONTROLLERFAN_PIN "
+    #elif PIN_EXISTS(MOTOR_CURRENT_PWM_XY) &&  SPINDLE_SPEED_PIN == MOTOR_CURRENT_PWM_XY_PIN
+      #error "SPINDLE_SPEED PWM pin is used by MOTOR_CURRENT_PWM_XY"
+    #elif PIN_EXISTS(MOTOR_CURRENT_PWM_Z) &&  SPINDLE_SPEED_PIN == MOTOR_CURRENT_PWM_Z_PIN
+      #error "SPINDLE_SPEED PWM pin is used by MOTOR_CURRENT_PWM_Z"
+    #elif PIN_EXISTS(MOTOR_CURRENT_PWM_E) &&  SPINDLE_SPEED_PIN == MOTOR_CURRENT_PWM_E_PIN
+      #error "SPINDLE_SPEED PWM pin is used by MOTOR_CURRENT_PWM_E"
+    #endif  
+  #endif
+#endif   //SPINDLE_ENABLE


### PR DESCRIPTION
all code changes are in Marlin_main.cpp

none of the existing code was changed

section added to config_adv to enable/disable the new commands & to explain the hardware changes needed to properly connect to the spindle controller

There's lots of competition for the PWM pins so added a section in sanity.h to check that the selected pin doesn't conflict with other selections.
