### PR TITLE
PINS_DEBUGGING and M43: Read pin states

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5961,7 +5961,8 @@ inline void gcode_M206() {
 
   /**
    * M209: Enable automatic retract (M209 S1)
-   *       detect if the slicer did not support G10/11: every normal extrude-only move will be classified as retract depending on the direction.
+   *   For slicers that don't support G10/11, reversed extrude-only
+   *   moves will be classified as retraction.
    */
   inline void gcode_M209() {
     if (code_seen('S')) {
@@ -7597,90 +7598,83 @@ void process_next_command() {
 
     case 'M': switch (codenum) {
       #if ENABLED(ULTIPANEL) || ENABLED(EMERGENCY_PARSER)
-        case 0: // M0 - Unconditional stop - Wait for user button press on LCD
-        case 1: // M1 - Conditional stop - Wait for user button press on LCD
+        case 0: // M0: Unconditional stop - Wait for user button press on LCD
+        case 1: // M1: Conditional stop - Wait for user button press on LCD
           gcode_M0_M1();
           break;
       #endif // ULTIPANEL
 
-      case 17:
+      case 17: // M17: Enable all stepper motors
         gcode_M17();
         break;
 
       #if ENABLED(SDSUPPORT)
-        case 20: // M20 - list SD card
+        case 20: // M20: list SD card
           gcode_M20(); break;
-        case 21: // M21 - init SD card
+        case 21: // M21: init SD card
           gcode_M21(); break;
-        case 22: //M22 - release SD card
+        case 22: // M22: release SD card
           gcode_M22(); break;
-        case 23: //M23 - Select file
+        case 23: // M23: Select file
           gcode_M23(); break;
-        case 24: //M24 - Start SD print
+        case 24: // M24: Start SD print
           gcode_M24(); break;
-        case 25: //M25 - Pause SD print
+        case 25: // M25: Pause SD print
           gcode_M25(); break;
-        case 26: //M26 - Set SD index
+        case 26: // M26: Set SD index
           gcode_M26(); break;
-        case 27: //M27 - Get SD status
+        case 27: // M27: Get SD status
           gcode_M27(); break;
-        case 28: //M28 - Start SD write
+        case 28: // M28: Start SD write
           gcode_M28(); break;
-        case 29: //M29 - Stop SD write
+        case 29: // M29: Stop SD write
           gcode_M29(); break;
-        case 30: //M30 <filename> Delete File
+        case 30: // M30 <filename> Delete File
           gcode_M30(); break;
-        case 32: //M32 - Select file and start SD print
+        case 32: // M32: Select file and start SD print
           gcode_M32(); break;
 
         #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
-          case 33: //M33 - Get the long full path to a file or folder
+          case 33: // M33: Get the long full path to a file or folder
             gcode_M33(); break;
-        #endif // LONG_FILENAME_HOST_SUPPORT
+        #endif
 
-        case 928: //M928 - Start SD write
+        case 928: // M928: Start SD write
           gcode_M928(); break;
       #endif //SDSUPPORT
 
-      case 31: //M31 take time since the start of the SD print or an M109 command
-        gcode_M31();
-        break;
+      case 31: // M31: Report time since the start of SD print or last M109
+        gcode_M31(); break;
 
       case 42: //M42 -Change pin status via gcode
         gcode_M42();
         break;
 
       #if ENABLED(Z_MIN_PROBE_REPEATABILITY_TEST)
-        case 48: // M48 Z probe repeatability
+        case 48: // M48: Z probe repeatability test
           gcode_M48();
           break;
       #endif // Z_MIN_PROBE_REPEATABILITY_TEST
 
-      case 75: // Start print timer
-        gcode_M75();
-        break;
-
-      case 76: // Pause print timer
-        gcode_M76();
-        break;
-
-      case 77: // Stop print timer
-        gcode_M77();
-        break;
+      case 75: // M75: Start print timer
+        gcode_M75(); break;
+      case 76: // M76: Pause print timer
+        gcode_M76(); break;
+      case 77: // M77: Stop print timer
+        gcode_M77(); break;
 
       #if ENABLED(PRINTCOUNTER)
-        case 78: // Show print statistics
-          gcode_M78();
-          break;
+        case 78: // M78: Show print statistics
+          gcode_M78(); break;
       #endif
 
       #if ENABLED(M100_FREE_MEMORY_WATCHER)
-        case 100:
+        case 100: // M100: Free Memory Report
           gcode_M100();
           break;
       #endif
 
-      case 104: // M104
+      case 104: // M104: Set hot end temperature
         gcode_M104();
         break;
 
@@ -7714,21 +7708,21 @@ void process_next_command() {
           break;
       #endif
 
-      case 140: // M140: Set bed temp
+      case 140: // M140: Set bed temperature
         gcode_M140();
         break;
 
-      case 105: // M105: Read current temperature
+      case 105: // M105: Report current temperature
         gcode_M105();
         KEEPALIVE_STATE(NOT_BUSY);
         return; // "ok" already printed
 
-      case 109: // M109: Wait for temperature
+      case 109: // M109: Wait for hotend temperature to reach target
         gcode_M109();
         break;
 
       #if HAS_TEMP_BED
-        case 190: // M190: Wait for bed heater to reach target
+        case 190: // M190: Wait for bed temperature to reach target
           gcode_M190();
           break;
       #endif // HAS_TEMP_BED
@@ -7776,17 +7770,17 @@ void process_next_command() {
         gcode_M81();
         break;
 
-      case 82:
+      case 82: // M83: Set E axis normal mode (same as other axes)
         gcode_M82();
         break;
-      case 83:
+      case 83: // M83: Set E axis relative mode
         gcode_M83();
         break;
-      case 18: // (for compatibility)
-      case 84: // M84
+      case 18: // M18 => M84
+      case 84: // M84: Disable all steppers or set timeout
         gcode_M18_M84();
         break;
-      case 85: // M85
+      case 85: // M85: Set inactivity stepper shutdown timeout
         gcode_M85();
         break;
       case 92: // M92: Set the steps-per-unit for one or more axes
@@ -7820,51 +7814,51 @@ void process_next_command() {
       #endif
 
       #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
-        case 149:
+        case 149: // M149: Set temperature units
           gcode_M149();
           break;
       #endif
 
       #if ENABLED(BLINKM)
 
-        case 150: // M150
+        case 150: // M150: Set the BlinkM LCD color
           gcode_M150();
           break;
 
-      #endif //BLINKM
+      #endif // BLINKM
 
       #if ENABLED(EXPERIMENTAL_I2CBUS)
 
-        case 155:
+        case 155: // M155: Send data to an i2c slave
           gcode_M155();
           break;
 
-        case 156:
+        case 156: // M156: Request data from an i2c slave
           gcode_M156();
           break;
 
       #endif //EXPERIMENTAL_I2CBUS
 
       #if ENABLED(MIXING_EXTRUDER)
-        case 163: // M163 S<int> P<float> set weight for a mixing extruder
+        case 163: // M163: Set a component weight for mixing extruder
           gcode_M163();
           break;
         #if MIXING_VIRTUAL_TOOLS > 1
-          case 164: // M164 S<int> save current mix as a virtual extruder
+          case 164: // M164: Save current mix as a virtual extruder
             gcode_M164();
             break;
         #endif
         #if ENABLED(DIRECT_MIXING_IN_G1)
-          case 165: // M165 [ABCDHI]<float> set multiple mix weights
+          case 165: // M165: Set multiple mix weights
             gcode_M165();
             break;
         #endif
       #endif
 
-      case 200: // M200 D<diameter> Set filament diameter and set E axis units to cubic. (Use S0 to revert to linear units.)
+      case 200: // M200: Set filament diameter, E to cubic units
         gcode_M200();
         break;
-      case 201: // M201
+      case 201: // M201: Set max acceleration for print moves (units/s^2)
         gcode_M201();
         break;
       #if 0 // Not used for Sprinter/grbl gen6
@@ -7872,180 +7866,180 @@ void process_next_command() {
           gcode_M202();
           break;
       #endif
-      case 203: // M203 max feedrate units/sec
+      case 203: // M203: Set max feedrate (units/sec)
         gcode_M203();
         break;
-      case 204: // M204 acclereration S normal moves T filmanent only moves
+      case 204: // M204: Set acceleration
         gcode_M204();
         break;
-      case 205: //M205 advanced settings:  minimum travel speed S=while printing T=travel only,  B=minimum segment time X= maximum xy jerk, Z=maximum Z jerk
+      case 205: //M205: Set advanced settings
         gcode_M205();
         break;
-      case 206: // M206 additional homing offset
+      case 206: // M206: Set home offsets
         gcode_M206();
         break;
 
       #if ENABLED(DELTA)
-        case 665: // M665 set delta configurations L<diagonal_rod> R<delta_radius> S<segments_per_sec>
+        case 665: // M665: Set delta configurations
           gcode_M665();
           break;
       #endif
 
       #if ENABLED(DELTA) || ENABLED(Z_DUAL_ENDSTOPS)
-        case 666: // M666 set delta / dual endstop adjustment
+        case 666: // M666: Set delta or dual endstop adjustment
           gcode_M666();
           break;
       #endif
 
       #if ENABLED(FWRETRACT)
-        case 207: // M207 - Set Retract Length: S<length>, Feedrate: F<units/min>, and Z lift: Z<distance>
+        case 207: // M207: Set Retract Length, Feedrate, and Z lift
           gcode_M207();
           break;
-        case 208: // M208 - Set Recover (unretract) Additional (!) Length: S<length> and Feedrate: F<units/min>
+        case 208: // M208: Set Recover (unretract) Additional Length and Feedrate
           gcode_M208();
           break;
-        case 209: // M209 - Turn Automatic Retract Detection on/off: S<bool> (For slicers that don't support G10/11). Every normal extrude-only move will be classified as retract depending on the direction.
+        case 209: // M209: Turn Automatic Retract Detection on/off
           gcode_M209();
           break;
       #endif // FWRETRACT
 
-      case 211: // M211 - Enable, Disable, and/or Report software endstops
+      case 211: // M211: Enable, Disable, and/or Report software endstops
         gcode_M211();
         break;
 
       #if HOTENDS > 1
-        case 218: // M218 - Set a tool offset: T<index> X<offset> Y<offset>
+        case 218: // M218: Set a tool offset
           gcode_M218();
           break;
       #endif
 
-      case 220: // M220 - Set Feedrate Percentage: S<percent> ("FR" on your LCD)
+      case 220: // M220: Set Feedrate Percentage: S<percent> ("FR" on your LCD)
         gcode_M220();
         break;
 
-      case 221: // M221 - Set Flow Percentage: S<percent>
+      case 221: // M221: Set Flow Percentage
         gcode_M221();
         break;
 
-      case 226: // M226 P<pin number> S<pin state>- Wait until the specified pin reaches the state required
+      case 226: // M226: Wait until a pin reaches a state
         gcode_M226();
         break;
 
       #if HAS_SERVOS
-        case 280: // M280 - set servo position absolute. P: servo index, S: angle or microseconds
+        case 280: // M280: Set servo position absolute
           gcode_M280();
           break;
       #endif // HAS_SERVOS
 
       #if HAS_BUZZER
-        case 300: // M300 - Play beep tone
+        case 300: // M300: Play beep tone
           gcode_M300();
           break;
       #endif // HAS_BUZZER
 
       #if ENABLED(PIDTEMP)
-        case 301: // M301
+        case 301: // M301: Set hotend PID parameters
           gcode_M301();
           break;
       #endif // PIDTEMP
 
       #if ENABLED(PIDTEMPBED)
-        case 304: // M304
+        case 304: // M304: Set bed PID parameters
           gcode_M304();
           break;
       #endif // PIDTEMPBED
 
       #if defined(CHDK) || HAS_PHOTOGRAPH
-        case 240: // M240  Triggers a camera by emulating a Canon RC-1 : http://www.doc-diy.net/photo/rc-1_hacked/
+        case 240: // M240: Trigger a camera by emulating a Canon RC-1 : http://www.doc-diy.net/photo/rc-1_hacked/
           gcode_M240();
           break;
       #endif // CHDK || PHOTOGRAPH_PIN
 
       #if HAS_LCD_CONTRAST
-        case 250: // M250  Set LCD contrast value: C<value> (value 0..63)
+        case 250: // M250: Set LCD contrast
           gcode_M250();
           break;
       #endif // HAS_LCD_CONTRAST
 
       #if ENABLED(PREVENT_COLD_EXTRUSION)
-        case 302: // allow cold extrudes, or set the minimum extrude temperature
+        case 302: // M302: Allow cold extrudes (set the minimum extrude temperature)
           gcode_M302();
           break;
       #endif // PREVENT_COLD_EXTRUSION
 
-      case 303: // M303 PID autotune
+      case 303: // M303: PID autotune
         gcode_M303();
         break;
 
       #if ENABLED(MORGAN_SCARA)
-        case 360:  // M360 SCARA Theta pos1
+        case 360:  // M360: SCARA Theta pos1
           if (gcode_M360()) return;
           break;
-        case 361:  // M361 SCARA Theta pos2
+        case 361:  // M361: SCARA Theta pos2
           if (gcode_M361()) return;
           break;
-        case 362:  // M362 SCARA Psi pos1
+        case 362:  // M362: SCARA Psi pos1
           if (gcode_M362()) return;
           break;
-        case 363:  // M363 SCARA Psi pos2
+        case 363:  // M363: SCARA Psi pos2
           if (gcode_M363()) return;
           break;
-        case 364:  // M364 SCARA Psi pos3 (90 deg to Theta)
+        case 364:  // M364: SCARA Psi pos3 (90 deg to Theta)
           if (gcode_M364()) return;
           break;
       #endif // SCARA
 
-      case 400: // M400 finish all moves
+      case 400: // M400: Finish all moves
         gcode_M400();
         break;
 
       #if HAS_BED_PROBE
-        case 401:
+        case 401: // M401: Deploy probe
           gcode_M401();
           break;
-        case 402:
+        case 402: // M402: Stow probe
           gcode_M402();
           break;
       #endif // HAS_BED_PROBE
 
       #if ENABLED(FILAMENT_WIDTH_SENSOR)
-        case 404:  //M404 Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or display nominal filament width
+        case 404:  // M404: Enter the nominal filament width (3mm, 1.75mm ) N<3.0> or display nominal filament width
           gcode_M404();
           break;
-        case 405:  //M405 Turn on filament sensor for control
+        case 405:  // M405: Turn on filament sensor for control
           gcode_M405();
           break;
-        case 406:  //M406 Turn off filament sensor for control
+        case 406:  // M406: Turn off filament sensor for control
           gcode_M406();
           break;
-        case 407:   //M407 Display measured filament diameter
+        case 407:   // M407: Display measured filament diameter
           gcode_M407();
           break;
       #endif // ENABLED(FILAMENT_WIDTH_SENSOR)
 
       #if ENABLED(MESH_BED_LEVELING)
-        case 420: // M420 Enable/Disable Mesh Bed Leveling
+        case 420: // M420: Enable/Disable Mesh Bed Leveling
           gcode_M420();
           break;
-        case 421: // M421 Set a Mesh Bed Leveling Z coordinate
+        case 421: // M421: Set a Mesh Bed Leveling Z coordinate
           gcode_M421();
           break;
       #endif
 
-      case 428: // M428 Apply current_position to home_offset
+      case 428: // M428: Apply current_position to home_offset
         gcode_M428();
         break;
 
-      case 500: // M500 Store settings in EEPROM
+      case 500: // M500: Store settings in EEPROM
         gcode_M500();
         break;
-      case 501: // M501 Read settings from EEPROM
+      case 501: // M501: Read settings from EEPROM
         gcode_M501();
         break;
-      case 502: // M502 Revert to default settings
+      case 502: // M502: Revert to default settings
         gcode_M502();
         break;
-      case 503: // M503 print settings currently in memory
+      case 503: // M503: print settings currently in memory
         gcode_M503();
         break;
 
@@ -8056,46 +8050,46 @@ void process_next_command() {
       #endif
 
       #if HAS_BED_PROBE
-        case 851: // Set Z Probe Z Offset
+        case 851: // M851: Set Z Probe Z Offset
           gcode_M851();
           break;
       #endif // HAS_BED_PROBE
 
       #if ENABLED(FILAMENT_CHANGE_FEATURE)
-        case 600: //Pause for filament change X[pos] Y[pos] Z[relative lift] E[initial retract] L[later retract distance for removal]
+        case 600: // M600: Pause for filament change
           gcode_M600();
           break;
       #endif // FILAMENT_CHANGE_FEATURE
 
       #if ENABLED(DUAL_X_CARRIAGE)
-        case 605:
+        case 605: // M605: Set Dual X Carriage movement mode
           gcode_M605();
           break;
       #endif // DUAL_X_CARRIAGE
 
       #if ENABLED(LIN_ADVANCE)
-        case 905: // M905 Set advance factor.
+        case 905: // M905: Set advance K factor.
           gcode_M905();
           break;
       #endif
 
-      case 907: // M907 Set digital trimpot motor current using axis codes.
+      case 907: // M907: Set digital trimpot motor current using axis codes.
         gcode_M907();
         break;
 
       #if HAS_DIGIPOTSS || ENABLED(DAC_STEPPER_CURRENT)
 
-        case 908: // M908 Control digital trimpot directly.
+        case 908: // M908: Control digital trimpot directly.
           gcode_M908();
           break;
 
         #if ENABLED(DAC_STEPPER_CURRENT) // As with Printrbot RevF
 
-          case 909: // M909 Print digipot/DAC current value
+          case 909: // M909: Print digipot/DAC current value
             gcode_M909();
             break;
 
-          case 910: // M910 Commit digipot/DAC value to external EEPROM
+          case 910: // M910: Commit digipot/DAC value to external EEPROM
             gcode_M910();
             break;
 
@@ -8105,11 +8099,11 @@ void process_next_command() {
 
       #if HAS_MICROSTEPS
 
-        case 350: // M350 Set microstepping mode. Warning: Steps per unit remains unchanged. S code sets stepping mode for all drivers.
+        case 350: // M350: Set microstepping mode. Warning: Steps per unit remains unchanged. S code sets stepping mode for all drivers.
           gcode_M350();
           break;
 
-        case 351: // M351 Toggle MS1 MS2 pins directly, S# determines MS1 or MS2, X# sets the pin high/low.
+        case 351: // M351: Toggle MS1 MS2 pins directly, S# determines MS1 or MS2, X# sets the pin high/low.
           gcode_M351();
           break;
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -816,4 +816,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -818,4 +818,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -812,4 +812,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -812,4 +812,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -812,4 +812,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -817,4 +817,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -812,4 +812,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -810,4 +810,9 @@
 //#define EXPERIMENTAL_I2CBUS
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
+/**
+ * Add M43 command for pins info and testing
+ */
+//#define PINS_DEBUGGING
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -275,8 +275,6 @@
   #define DIO21_DDR   DDRC
   #define DIO21_PWM   NULL
 
-
-
   #undef PB0
   #define PB0_PIN     PINB0
   #define PB0_RPORT   PINB

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -230,6 +230,9 @@
 #ifndef HEATER_3_PIN
   #define HEATER_3_PIN -1
 #endif
+#ifndef HEATER_4_PIN
+  #define HEATER_4_PIN -1
+#endif
 #ifndef HEATER_BED_PIN
   #define HEATER_BED_PIN -1
 #endif
@@ -280,6 +283,7 @@
 #define _E1_PINS
 #define _E2_PINS
 #define _E3_PINS
+#define _E4_PINS
 
 #if EXTRUDERS > 1
   #undef _E1_PINS
@@ -290,6 +294,10 @@
     #if EXTRUDERS > 3
       #undef _E3_PINS
       #define _E3_PINS E3_STEP_PIN, E3_DIR_PIN, E3_ENABLE_PIN,
+      #if EXTRUDERS > 4
+        #undef _E4_PINS
+        #define _E4_PINS E4_STEP_PIN, E4_DIR_PIN, E4_ENABLE_PIN,
+      #endif
     #endif
   #endif
 #endif
@@ -298,6 +306,7 @@
 #define _H1_PINS
 #define _H2_PINS
 #define _H3_PINS
+#define _H4_PINS
 
 #if HOTENDS > 1
   #undef _H1_PINS
@@ -308,6 +317,10 @@
     #if HOTENDS > 3
       #undef _H3_PINS
       #define _H3_PINS HEATER_3_PIN, EXTRUDER_3_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_3_PIN),
+      #if HOTENDS > 4
+        #undef _H4_PINS
+        #define _H4_PINS HEATER_4_PIN, marlinAnalogInputToDigitalPin(TEMP_4_PIN),
+      #endif
     #endif
   #endif
 #elif ENABLED(MIXING_EXTRUDER)
@@ -319,6 +332,10 @@
     #if MIXING_STEPPERS > 3
       #undef _E3_PINS
       #define _E3_PINS E3_STEP_PIN, E3_DIR_PIN, E3_ENABLE_PIN,
+      #if MIXING_STEPPERS > 4
+        #undef _E4_PINS
+        #define _E4_PINS E4_STEP_PIN, E4_DIR_PIN, E4_ENABLE_PIN,
+      #endif
     #endif
   #endif
 #endif
@@ -451,8 +468,8 @@
     Y_STEP_PIN, Y_DIR_PIN, Y_ENABLE_PIN, Y_MIN_PIN, Y_MAX_PIN, \
     Z_STEP_PIN, Z_DIR_PIN, Z_ENABLE_PIN, Z_MIN_PIN, Z_MAX_PIN, Z_MIN_PROBE_PIN, \
     PS_ON_PIN, HEATER_BED_PIN, FAN_PIN, FAN1_PIN, FAN2_PIN, CONTROLLERFAN_PIN, \
-    _E0_PINS _E1_PINS _E2_PINS _E3_PINS BED_PINS \
-    _H0_PINS _H1_PINS _H2_PINS _H3_PINS \
+    _E0_PINS _E1_PINS _E2_PINS _E3_PINS _E4_PINS BED_PINS \
+    _H0_PINS _H1_PINS _H2_PINS _H3_PINS _H4_PINS \
     _X2_PINS _Y2_PINS _Z2_PINS \
     X_MS1_PIN, X_MS2_PIN, Y_MS1_PIN, Y_MS2_PIN, Z_MS1_PIN, Z_MS2_PIN \
   }

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -276,7 +276,7 @@
 #endif
 
 // Marlin needs to account for pins that equal -1
-#define marlinAnalogInputToDigitalPin(p) ((p) == -1 ? -1 : (p) + 0xA0)
+#define marlinAnalogInputToDigitalPin(p) ((p) == -1 ? -1 : analogInputToDigitalPin(p))
 
 // List of pins which to ignore when asked to change by gcode, 0 and 1 are RX and TX, do not mess with those!
 #define _E0_PINS E0_STEP_PIN, E0_DIR_PIN, E0_ENABLE_PIN, E0_MS1_PIN, E0_MS2_PIN,

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -1,0 +1,447 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// How many DIO pins are defined?
+#if defined(DIO85_PIN)
+  #define DIO_COUNT 86
+#elif defined(DIO53_PIN)
+  #define DIO_COUNT 54
+#elif defined(DIO47_PIN)
+  #define DIO_COUNT 48
+#elif defined(DIO31_PIN)
+  #define DIO_COUNT 32
+#elif defined(DIO21_PIN)
+  #define DIO_COUNT 22
+#endif
+
+#define _PIN_SAY(NAME) { SERIAL_ECHOPGM(STRINGIFY(NAME)); return true; }
+#define PIN_SAY(NAME) if (pin == NAME) _PIN_SAY(_##NAME##_);
+#define ANALOG_PIN_SAY(NAME) if (pin == analogInputToDigitalPin(NAME)) _PIN_SAY(_##NAME##_);
+#define IS_ANALOG(P) if ((P) >= analogInputToDigitalPin(0) && ((P) <= analogInputToDigitalPin(15) || (P) <= analogInputToDigitalPin(5)))
+
+// Report pin name for a given fastio digital pin index
+static bool report_pin_name(int8_t pin) {
+
+  SERIAL_ECHO((int)pin);
+  SERIAL_CHAR(' ');
+
+  if (IS_ANALOG(pin)) {
+    SERIAL_CHAR('('); SERIAL_CHAR('A');
+    SERIAL_ECHO(int(pin - analogInputToDigitalPin(0)));
+    SERIAL_CHAR(')'); SERIAL_CHAR(' ');
+  }
+
+  #if defined(RXD) && RXD > -1
+    if (pin == 0) { SERIAL_ECHOPGM("RXD"); return true; }
+  #endif
+  #if defined(TXD) && TXD > -1
+    if (pin == 1) { SERIAL_ECHOPGM("TXD"); return true; }
+  #endif
+
+  #if PIN_EXISTS(SERVO0)
+    PIN_SAY(SERVO0_PIN);
+  #endif
+  #if PIN_EXISTS(SERVO1)
+    PIN_SAY(SERVO1_PIN);
+  #endif
+  #if PIN_EXISTS(SERVO2)
+    PIN_SAY(SERVO2_PIN);
+  #endif
+  #if PIN_EXISTS(SERVO3)
+    PIN_SAY(SERVO3_PIN);
+  #endif
+
+  #if PIN_EXISTS(X_MIN)
+    PIN_SAY(X_MIN_PIN);
+  #endif
+  #if PIN_EXISTS(X_MAX)
+    PIN_SAY(X_MAX_PIN);
+  #endif
+  #if PIN_EXISTS(Y_MIN)
+    PIN_SAY(Y_MIN_PIN);
+  #endif
+  #if PIN_EXISTS(Y_MAX)
+    PIN_SAY(Y_MAX_PIN);
+  #endif
+  #if PIN_EXISTS(Z_MIN)
+    PIN_SAY(Z_MIN_PIN);
+  #endif
+  #if PIN_EXISTS(Z_MAX)
+    PIN_SAY(Z_MAX_PIN);
+  #endif
+  #if PIN_EXISTS(Z_MIN_PROBE)
+    PIN_SAY(Z_MIN_PROBE_PIN);
+  #endif
+  #if PIN_EXISTS(X_STEP)
+    PIN_SAY(X_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(X_DIR)
+    PIN_SAY(X_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(X_ENABLE)
+    PIN_SAY(X_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(X_MS1)
+    PIN_SAY(X_MS1_PIN);
+  #endif
+  #if PIN_EXISTS(X_MS2)
+    PIN_SAY(X_MS2_PIN);
+  #endif
+  #if PIN_EXISTS(X2_STEP)
+    PIN_SAY(X2_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(X2_DIR)
+    PIN_SAY(X2_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(X2_ENABLE)
+    PIN_SAY(X2_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(Y_STEP)
+    PIN_SAY(Y_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(Y_DIR)
+    PIN_SAY(Y_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(Y_ENABLE)
+    PIN_SAY(Y_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(Y_MS1)
+    PIN_SAY(Y_MS1_PIN);
+  #endif
+  #if PIN_EXISTS(Y_MS2)
+    PIN_SAY(Y_MS2_PIN);
+  #endif
+  #if PIN_EXISTS(Y2_STEP)
+    PIN_SAY(Y2_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(Y2_DIR)
+    PIN_SAY(Y2_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(Y2_ENABLE)
+    PIN_SAY(Y2_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(Z_STEP)
+    PIN_SAY(Z_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(Z_DIR)
+    PIN_SAY(Z_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(Z_ENABLE)
+    PIN_SAY(Z_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(Z_MS1)
+    PIN_SAY(Z_MS1_PIN);
+  #endif
+  #if PIN_EXISTS(Z_MS2)
+    PIN_SAY(Z_MS2_PIN);
+  #endif
+  #if PIN_EXISTS(Z2_STEP)
+    PIN_SAY(Z2_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(Z2_DIR)
+    PIN_SAY(Z2_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(Z2_ENABLE)
+    PIN_SAY(Z2_ENABLE_PIN);
+  #endif
+
+  #if PIN_EXISTS(E0_STEP)
+    PIN_SAY(E0_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(E0_DIR)
+    PIN_SAY(E0_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(E0_ENABLE)
+    PIN_SAY(E0_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(E0_MS1)
+    PIN_SAY(E0_MS1_PIN);
+  #endif
+  #if PIN_EXISTS(E0_MS2)
+    PIN_SAY(E0_MS2_PIN);
+  #endif
+  #if PIN_EXISTS(E1_STEP)
+    PIN_SAY(E1_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(E1_DIR)
+    PIN_SAY(E1_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(E1_ENABLE)
+    PIN_SAY(E1_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(E1_MS1)
+    PIN_SAY(E1_MS1_PIN);
+  #endif
+  #if PIN_EXISTS(E1_MS2)
+    PIN_SAY(E1_MS2_PIN);
+  #endif
+  #if PIN_EXISTS(E2_STEP)
+    PIN_SAY(E2_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(E2_DIR)
+    PIN_SAY(E2_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(E2_ENABLE)
+    PIN_SAY(E2_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(E3_STEP)
+    PIN_SAY(E3_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(E3_DIR)
+    PIN_SAY(E3_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(E3_ENABLE)
+    PIN_SAY(E3_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(E4_STEP)
+    PIN_SAY(E4_STEP_PIN);
+  #endif
+  #if PIN_EXISTS(E4_DIR)
+    PIN_SAY(E4_DIR_PIN);
+  #endif
+  #if PIN_EXISTS(E4_ENABLE)
+    PIN_SAY(E4_ENABLE_PIN);
+  #endif
+
+  #if PIN_EXISTS(FAN)
+    PIN_SAY(FAN_PIN);
+  #endif
+  #if PIN_EXISTS(FAN1)
+    PIN_SAY(FAN1_PIN);
+  #endif
+  #if PIN_EXISTS(FAN2)
+    PIN_SAY(FAN2_PIN);
+  #endif
+  #if PIN_EXISTS(CONTROLLERFAN)
+    PIN_SAY(CONTROLLERFAN_PIN);
+  #endif
+  #if PIN_EXISTS(EXTRUDER_0_AUTO_FAN)
+    PIN_SAY(EXTRUDER_0_AUTO_FAN_PIN);
+  #endif
+  #if PIN_EXISTS(EXTRUDER_1_AUTO_FAN)
+    PIN_SAY(EXTRUDER_1_AUTO_FAN_PIN);
+  #endif
+  #if PIN_EXISTS(EXTRUDER_2_AUTO_FAN)
+    PIN_SAY(EXTRUDER_2_AUTO_FAN_PIN);
+  #endif
+  #if PIN_EXISTS(EXTRUDER_3_AUTO_FAN)
+    PIN_SAY(EXTRUDER_3_AUTO_FAN_PIN);
+  #endif
+  #if PIN_EXISTS(HEATER_0)
+    PIN_SAY(HEATER_0_PIN);
+  #endif
+  #if PIN_EXISTS(HEATER_1)
+    PIN_SAY(HEATER_1_PIN);
+  #endif
+  #if PIN_EXISTS(HEATER_2)
+    PIN_SAY(HEATER_2_PIN);
+  #endif
+  #if PIN_EXISTS(HEATER_3)
+    PIN_SAY(HEATER_3_PIN);
+  #endif
+  #if PIN_EXISTS(HEATER_BED)
+    PIN_SAY(HEATER_BED_PIN);
+  #endif
+
+  #if PIN_EXISTS(X_ATT)
+    PIN_SAY(X_ATT_PIN);
+  #endif
+  #if PIN_EXISTS(Y_ATT)
+    PIN_SAY(Y_ATT_PIN);
+  #endif
+  #if PIN_EXISTS(Z_ATT)
+    PIN_SAY(Z_ATT_PIN);
+  #endif
+  #if PIN_EXISTS(E0_ATT)
+    PIN_SAY(E0_ATT_PIN);
+  #endif
+
+  #if PIN_EXISTS(TEMP_0)
+    ANALOG_PIN_SAY(TEMP_0_PIN);
+  #endif
+  #if PIN_EXISTS(TEMP_1)
+    ANALOG_PIN_SAY(TEMP_1_PIN);
+  #endif
+  #if PIN_EXISTS(TEMP_2)
+    ANALOG_PIN_SAY(TEMP_2_PIN);
+  #endif
+  #if PIN_EXISTS(TEMP_3)
+    ANALOG_PIN_SAY(TEMP_3_PIN);
+  #endif
+  #if PIN_EXISTS(TEMP_BED)
+    ANALOG_PIN_SAY(TEMP_BED_PIN);
+  #endif
+  #if PIN_EXISTS(FILWIDTH)
+    ANALOG_PIN_SAY(FILWIDTH_PIN);
+  #endif
+
+  #if PIN_EXISTS(BEEPER)
+    PIN_SAY(BEEPER_PIN);
+  #endif
+  #if PIN_EXISTS(SLED)
+    PIN_SAY(SLED_PIN);
+  #endif
+  #if PIN_EXISTS(FIL_RUNOUT)
+    PIN_SAY(FIL_RUNOUT_PIN);
+  #endif
+
+  #if PIN_EXISTS(LED)
+    PIN_SAY(LED_PIN);
+  #endif
+  // #if defined(DEBUG_LED) && DEBUG_LED > -1
+  //   PIN_SAY(DEBUG_LED);
+  // #endif
+  #if PIN_EXISTS(STAT_LED_RED)
+    PIN_SAY(STAT_LED_RED_PIN);
+  #endif
+  #if PIN_EXISTS(STAT_LED_BLUE)
+    PIN_SAY(STAT_LED_BLUE_PIN);
+  #endif
+
+  #if PIN_EXISTS(DIGIPOTSS)
+    PIN_SAY(DIGIPOTSS_PIN);
+  #endif
+
+  #if PIN_EXISTS(SCK)
+    PIN_SAY(SCK_PIN);
+  #endif
+  #if PIN_EXISTS(MISO)
+    PIN_SAY(MISO_PIN);
+  #endif
+  #if PIN_EXISTS(MOSI)
+    PIN_SAY(MOSI_PIN);
+  #endif
+  #if PIN_EXISTS(SS)
+    PIN_SAY(SS_PIN);
+  #endif
+
+  #if PIN_EXISTS(SD_DETECT)
+    PIN_SAY(SD_DETECT_PIN);
+  #endif
+
+  #if defined(SDPOWER) && SDPOWER > -1
+    PIN_SAY(SDPOWER);
+  #endif
+  #if defined(SDSS) && SDSS > -1
+    PIN_SAY(SDSS);
+  #endif
+  #if defined(I2C_SCL) && I2C_SCL > -1
+    PIN_SAY(I2C_SCL);
+  #endif
+  #if defined(I2C_SDA) && I2C_SDA > -1
+    PIN_SAY(I2C_SDA);
+  #endif
+  #if defined(SCL) && SCL > -1
+    PIN_SAY(SCL);
+  #endif
+  #if defined(SDA) && SDA > -1
+    PIN_SAY(SDA);
+  #endif
+
+  #if PIN_EXISTS(PS_ON)
+    PIN_SAY(PS_ON_PIN);
+  #endif
+  #if PIN_EXISTS(KILL)
+    PIN_SAY(KILL_PIN);
+  #endif
+  #if PIN_EXISTS(SUICIDE)
+    PIN_SAY(SUICIDE_PIN);
+  #endif
+  #if PIN_EXISTS(DEBUG)
+    PIN_SAY(DEBUG_PIN);
+  #endif
+  #if PIN_EXISTS(PHOTOGRAPH)
+    PIN_SAY(PHOTOGRAPH_PIN);
+  #endif
+
+  #if PIN_EXISTS(BEEPER)
+    PIN_SAY(BEEPER_PIN);
+  #endif
+  #if defined(BTN_EN1) && BTN_EN1 > -1
+    PIN_SAY(BTN_EN1);
+  #endif
+  #if defined(BTN_EN2) && BTN_EN2 > -1
+    PIN_SAY(BTN_EN2);
+  #endif
+  #if defined(BTN_ENC) && BTN_ENC > -1
+    PIN_SAY(BTN_ENC);
+  #endif
+  #if defined(LCD_PINS_RS) && LCD_PINS_RS > -1
+    PIN_SAY(LCD_PINS_RS);
+  #endif
+  #if defined(LCD_PINS_ENABLE) && LCD_PINS_ENABLE > -1
+    PIN_SAY(LCD_PINS_ENABLE);
+  #endif
+  #if defined(LCD_PINS_D4) && LCD_PINS_D4 > -1
+    PIN_SAY(LCD_PINS_D4);
+  #endif
+  #if defined(LCD_PINS_D5) && LCD_PINS_D5 > -1
+    PIN_SAY(LCD_PINS_D5);
+  #endif
+  #if defined(LCD_PINS_D6) && LCD_PINS_D6 > -1
+    PIN_SAY(LCD_PINS_D6);
+  #endif
+  #if defined(LCD_PINS_D7) && LCD_PINS_D7 > -1
+    PIN_SAY(LCD_PINS_D7);
+  #endif
+
+  #if PIN_EXISTS(RAMPS_D8)
+    PIN_SAY(RAMPS_D8_PIN);
+  #endif
+  #if PIN_EXISTS(RAMPS_D9)
+    PIN_SAY(RAMPS_D9_PIN);
+  #endif
+  #if PIN_EXISTS(RAMPS_D10)
+    PIN_SAY(RAMPS_D10_PIN);
+  #endif
+  #if PIN_EXISTS(MOSFET_D)
+    PIN_SAY(MOSFET_D_PIN);
+  #endif
+
+  #if PIN_EXISTS(TX_ENABLE)
+    PIN_SAY(TX_ENABLE_PIN);
+  #endif
+  #if PIN_EXISTS(RX_ENABLE)
+    PIN_SAY(RX_ENABLE_PIN);
+  #endif
+
+  SERIAL_ECHOPGM("<unused>");
+  return false;
+}
+
+inline void report_pin_state(int8_t pin) {
+  if (report_pin_name(pin)) {
+    if (pin_is_protected(pin))
+      SERIAL_ECHOPGM(" (protected)");
+    else {
+      SERIAL_ECHOPGM(" = ");
+      pinMode(pin, INPUT_PULLUP);
+      SERIAL_ECHO(digitalRead(pin));
+      if (IS_ANALOG(pin)) {
+        SERIAL_CHAR(' '); SERIAL_CHAR('(');
+        SERIAL_ECHO(analogRead(pin - analogInputToDigitalPin(0)));
+        SERIAL_CHAR(')');
+      }
+    }
+  }
+  SERIAL_EOL;
+}

--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -75,8 +75,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          1  // Analog
-#define TEMP_BED_PIN        0  // Analog
+#define TEMP_0_PIN          1   // Analog Input
+#define TEMP_BED_PIN        0   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_99.h
+++ b/Marlin/pins_99.h
@@ -55,8 +55,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          6   // ANALOG INPUT - NOT DIGITAL OUTPUT
-#define TEMP_BED_PIN       10
+#define TEMP_0_PIN          6   // Analog Input
+#define TEMP_BED_PIN       10   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_A4JP.h
+++ b/Marlin/pins_A4JP.h
@@ -40,7 +40,7 @@
 
 #define SLED_PIN -1
 
-#define FILWIDTH_PIN        3  // ANALOG NUMBERING
+#define FILWIDTH_PIN        3   // Analog Input
 
 /************************************************
  * Rambo pin assignments old
@@ -112,8 +112,8 @@
 #define FAN0_PIN             6
 #define FAN1_PIN             2
 
-#define TEMP_0_PIN           0
-#define TEMP_BED_PIN         7
+#define TEMP_0_PIN           0   // Analog Input
+#define TEMP_BED_PIN         7   // Analog Input
 
 #define SDSS                53
 #define LED_PIN             13

--- a/Marlin/pins_BAM_DICE_DUE.h
+++ b/Marlin/pins_BAM_DICE_DUE.h
@@ -34,5 +34,5 @@
 
 #undef TEMP_0_PIN
 #undef TEMP_1_PIN
-#define TEMP_0_PIN          9 // ANALOG NUMBERING
-#define TEMP_1_PIN         11 // ANALOG NUMBERING
+#define TEMP_0_PIN          9   // Analog Input
+#define TEMP_1_PIN         11   // Analog Input

--- a/Marlin/pins_BRAINWAVE.h
+++ b/Marlin/pins_BRAINWAVE.h
@@ -68,8 +68,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          7  // Extruder / Analog pin numbering
-#define TEMP_BED_PIN        6  // Bed / Analog pin numbering
+#define TEMP_0_PIN          7   // Analog Input
+#define TEMP_BED_PIN        6   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -78,9 +78,9 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          2  // Extruder / Analog pin numbering
-#define TEMP_1_PIN          1  // Spare / Analog pin numbering
-#define TEMP_BED_PIN        0  // Bed / Analog pin numbering
+#define TEMP_0_PIN          2   // Analog Input
+#define TEMP_1_PIN          1   // Analog Input
+#define TEMP_BED_PIN        0   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -64,9 +64,9 @@
 //
 // Temperature sensors
 //
-#define TEMP_0_PIN         15
-#define TEMP_1_PIN         14
-#define TEMP_BED_PIN       13
+#define TEMP_0_PIN         15   // Analog Input
+#define TEMP_1_PIN         14   // Analog Input
+#define TEMP_BED_PIN       13   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_CNCONTROLS_11.h
+++ b/Marlin/pins_CNCONTROLS_11.h
@@ -51,11 +51,11 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          0  // ANALOG INPUT !!
-#define TEMP_1_PIN          3  // 3 for tool2 -> 2 for chambertemp
-#define TEMP_2_PIN          2  // 9 for tool3 -> 2 for chambertemp
-#define TEMP_3_PIN         11  // 11 for tool4 -> 2 for chambertemp
-#define TEMP_BED_PIN        1  // ANALOG INPUT !!
+#define TEMP_0_PIN          0   // Analog Input
+#define TEMP_1_PIN          3   // Analog Input.  3 for tool2 -> 2 for chambertemp
+#define TEMP_2_PIN          2   // Analog Input.  9 for tool3 -> 2 for chambertemp
+#define TEMP_3_PIN         11   // Analog Input. 11 for tool4 -> 2 for chambertemp
+#define TEMP_BED_PIN        1   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_CNCONTROLS_12.h
+++ b/Marlin/pins_CNCONTROLS_12.h
@@ -51,12 +51,12 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          0  // ANALOG INPUT !!
-#define TEMP_1_PIN          9  // 9 for tool2 -> 13 for chambertemp
-#define TEMP_2_PIN         13  // 10 for tool3 -> 13 for chambertemp
-#define TEMP_3_PIN         11  // 11 for tool4 -> 13 for chambertemp
-#define TEMP_BED_PIN       14  // ANALOG INPUT !!
-//#define TEMP_CHAMBER_PIN   13  // ANALOG INPUT !!
+#define TEMP_0_PIN          0   // Analog Input
+#define TEMP_1_PIN          9   // Analog Input.  9 for tool2 -> 13 for chambertemp
+#define TEMP_2_PIN         13   // Analog Input. 10 for tool3 -> 13 for chambertemp
+#define TEMP_3_PIN         11   // Analog Input. 11 for tool4 -> 13 for chambertemp
+#define TEMP_BED_PIN       14   // Analog Input
+//#define TEMP_CHAMBER_PIN   13   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -77,10 +77,10 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          3 // ANALOG NUMBERING
-#define TEMP_1_PIN          2 // ANALOG NUMBERING
-#define TEMP_2_PIN          1 // ANALOG NUMBERING
-#define TEMP_BED_PIN        0 // ANALOG NUMBERING
+#define TEMP_0_PIN          3   // Analog Input
+#define TEMP_1_PIN          2   // Analog Input
+#define TEMP_2_PIN          1   // Analog Input
+#define TEMP_BED_PIN        0   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_GEN3_MONOLITHIC.h
+++ b/Marlin/pins_GEN3_MONOLITHIC.h
@@ -60,7 +60,7 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          0
+#define TEMP_0_PIN          0   // Analog Input
 
 //
 // Heaters

--- a/Marlin/pins_GEN3_PLUS.h
+++ b/Marlin/pins_GEN3_PLUS.h
@@ -61,8 +61,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          0   // ANALOG INPUT (pin 33 extruder)
-#define TEMP_BED_PIN        5   // ANALOG INPUT (pin 34 bed)
+#define TEMP_0_PIN          0   // Analog Input (pin 33 extruder)
+#define TEMP_BED_PIN        5   // Analog Input (pin 34 bed)
 
 //
 // Heaters

--- a/Marlin/pins_GEN6.h
+++ b/Marlin/pins_GEN6.h
@@ -56,23 +56,23 @@
 #define Z_DIR_PIN          28
 #define Z_ENABLE_PIN       29
 
-#define E0_STEP_PIN         4    //Edited @ EJE Electronics 20100715
-#define E0_DIR_PIN          2    //Edited @ EJE Electronics 20100715
-#define E0_ENABLE_PIN       3    //Added @ EJE Electronics 20100715
+#define E0_STEP_PIN         4   //Edited @ EJE Electronics 20100715
+#define E0_DIR_PIN          2   //Edited @ EJE Electronics 20100715
+#define E0_ENABLE_PIN       3   //Added @ EJE Electronics 20100715
 
 //
 // Temperature Sensor
 //
-#define TEMP_0_PIN          5    //changed @ rkoeppl 20110410
+#define TEMP_0_PIN          5   // Analog Input
 
 //
 // Heaters
 //
-#define HEATER_0_PIN       14    //changed @ rkoeppl 20110410
+#define HEATER_0_PIN       14   //changed @ rkoeppl 20110410
 
 #if !MB(GEN6)
-  #define HEATER_BED_PIN    1    //changed @ rkoeppl 20110410
-  #define TEMP_BED_PIN      0    //changed @ rkoeppl 20110410
+  #define HEATER_BED_PIN    1   //changed @ rkoeppl 20110410
+  #define TEMP_BED_PIN      0   // Analog Input
 #endif
 
 //

--- a/Marlin/pins_GEN7_12.h
+++ b/Marlin/pins_GEN7_12.h
@@ -73,8 +73,8 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          1
-#define TEMP_BED_PIN        2
+#define TEMP_0_PIN          1   // Analog Input
+#define TEMP_BED_PIN        2   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_GEN7_14.h
+++ b/Marlin/pins_GEN7_14.h
@@ -32,40 +32,49 @@
 
 #define GEN7_VERSION 14 // v1.4
 
-//x axis pins
-#define X_STEP_PIN 29
-#define X_DIR_PIN 28
-#define X_ENABLE_PIN 25
-#define X_STOP_PIN 0
+//
+// Limit switches
+//
+#define X_STOP_PIN          0
+#define Y_STOP_PIN          1
+#define Z_STOP_PIN          2
 
-//y axis pins
-#define Y_STEP_PIN 27
-#define Y_DIR_PIN 26
-#define Y_ENABLE_PIN 25
-#define Y_STOP_PIN 1
+//
+// Steppers
+//
+#define X_STEP_PIN         29
+#define X_DIR_PIN          28
+#define X_ENABLE_PIN       25
 
-//z axis pins
-#define Z_STEP_PIN 23
-#define Z_DIR_PIN 22
-#define Z_ENABLE_PIN 25
-#define Z_STOP_PIN 2
+#define Y_STEP_PIN         27
+#define Y_DIR_PIN          26
+#define Y_ENABLE_PIN       25
 
-//extruder pins
-#define E0_STEP_PIN 19
-#define E0_DIR_PIN 18
-#define E0_ENABLE_PIN 25
+#define Z_STEP_PIN         23
+#define Z_DIR_PIN          22
+#define Z_ENABLE_PIN       25
 
-#define TEMP_0_PIN 1
-#define TEMP_BED_PIN 0
+#define E0_STEP_PIN        19
+#define E0_DIR_PIN         18
+#define E0_ENABLE_PIN      25
 
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN          1   // Analog Input
+#define TEMP_BED_PIN        0   // Analog Input
+
+//
+// Heaters
+//
 #define HEATER_0_PIN 4
 #define HEATER_BED_PIN 3
 
 #define PS_ON_PIN 15
 
-//our pin for debugging.
+// A pin for debugging
 #define DEBUG_PIN 0
 
-//our RS485 pins
+// RS485 pins
 #define TX_ENABLE_PIN 12
 #define RX_ENABLE_PIN 13

--- a/Marlin/pins_GEN7_CUSTOM.h
+++ b/Marlin/pins_GEN7_CUSTOM.h
@@ -33,58 +33,66 @@
 
 #define BOARD_NAME      "Gen7 Custom"
 
-//x axis pins
-#define X_STEP_PIN      21                  // different from standard GEN7
-#define X_DIR_PIN       20                  // different from standard GEN7
-#define X_ENABLE_PIN    24
+//
+// Limit Switches
+//
 #define X_STOP_PIN       0
+#define Y_STOP_PIN       1
+#define Z_STOP_PIN       2
 
-//y axis pins
+//
+// Steppers
+//
+#define X_STEP_PIN      21   // different from standard GEN7
+#define X_DIR_PIN       20   // different from standard GEN7
+#define X_ENABLE_PIN    24
+
 #define Y_STEP_PIN      23
 #define Y_DIR_PIN       22
 #define Y_ENABLE_PIN    24
-#define Y_STOP_PIN       1
 
-//z axis pins
 #define Z_STEP_PIN      26
 #define Z_DIR_PIN       25
 #define Z_ENABLE_PIN    24
-#define Z_STOP_PIN       2
 
-//extruder pins
 #define E0_STEP_PIN     28
 #define E0_DIR_PIN      27
 #define E0_ENABLE_PIN   24
 
-#define TEMP_0_PIN       2
-#define TEMP_BED_PIN     1   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!! (pin 34 bed)
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN       2   // Analog Input
+#define TEMP_BED_PIN     1   // Analog Input (pin 34 bed)
 
+//
+// Heaters
+//
 #define HEATER_0_PIN     4
 #define HEATER_BED_PIN   3  // (bed)
 
 #define SDSS            31                  // SCL pin of I2C header || CS Pin for SD Card support
 
 #define PS_ON_PIN       19
-//our pin for debugging.
 
+// A pin for debugging
 #define DEBUG_PIN       -1
 
-//our RS485 pins
-//#define TX_ENABLE_PIN       12
-//#define RX_ENABLE_PIN       13
+#define BEEPER_PIN      -1
 
-#define BEEPER_PIN       -1
-
-//Pins for 4bit LCD Support
-#define LCD_PINS_RS 18
+// 4bit LCD Support
+#define LCD_PINS_RS     18
 #define LCD_PINS_ENABLE 17
-#define LCD_PINS_D4 16
-#define LCD_PINS_D5 15
-#define LCD_PINS_D6 13
-#define LCD_PINS_D7 14
+#define LCD_PINS_D4     16
+#define LCD_PINS_D5     15
+#define LCD_PINS_D6     13
+#define LCD_PINS_D7     14
 
-//buttons are directly attached
-#define BTN_EN1 11
-#define BTN_EN2 10
-#define BTN_ENC 12
+// Buttons are directly attached
+#define BTN_EN1         11
+#define BTN_EN2         10
+#define BTN_ENC         12
 
+// RS485 pins
+//#define TX_ENABLE_PIN   12
+//#define RX_ENABLE_PIN   13

--- a/Marlin/pins_LEAPFROG.h
+++ b/Marlin/pins_LEAPFROG.h
@@ -74,9 +74,9 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         13 //D27   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
-#define TEMP_1_PIN         15 // 1
-#define TEMP_BED_PIN       14 // 1,2 or I2C
+#define TEMP_0_PIN         13   // Analog Input (D27)
+#define TEMP_1_PIN         15   // Analog Input (1)
+#define TEMP_BED_PIN       14   // Analog Input (1,2 or I2C)
 
 //
 // Heaters / Fans

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -92,23 +92,23 @@
 // Temperature Sensors
 //
 #if TEMP_SENSOR_0 == -1
-  #define TEMP_0_PIN        4 // ANALOG NUMBERING
+  #define TEMP_0_PIN        4   // Analog Input
 #else
-  #define TEMP_0_PIN        0 // ANALOG NUMBERING
+  #define TEMP_0_PIN        0   // Analog Input
 #endif
 
 #if TEMP_SENSOR_1 == -1
-  #define TEMP_1_PIN        5 // ANALOG NUMBERING
+  #define TEMP_1_PIN        5   // Analog Input
 #else
-  #define TEMP_1_PIN        2 // ANALOG NUMBERING
+  #define TEMP_1_PIN        2   // Analog Input
 #endif
 
-#define TEMP_2_PIN          3 // ANALOG NUMBERING
+#define TEMP_2_PIN          3   // Analog Input
 
 #if TEMP_SENSOR_BED == -1
-  #define TEMP_BED_PIN      6 // ANALOG NUMBERING
+  #define TEMP_BED_PIN      6   // Analog Input
 #else
-  #define TEMP_BED_PIN      1 // ANALOG NUMBERING
+  #define TEMP_BED_PIN      1   // Analog Input
 #endif
 
 //

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -82,12 +82,12 @@
 // Temperature Sensors
 //
 #if TEMP_SENSOR_0 == -1
-  #define TEMP_0_PIN        8   // ANALOG NUMBERING
+  #define TEMP_0_PIN        8   // Analog Input
 #else
-  #define TEMP_0_PIN       13   // ANALOG NUMBERING
+  #define TEMP_0_PIN       13   // Analog Input
 #endif
-#define TEMP_1_PIN         15   // ANALOG NUMBERING
-#define TEMP_BED_PIN       14   // ANALOG NUMBERING
+#define TEMP_1_PIN         15   // Analog Input
+#define TEMP_BED_PIN       14   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -86,21 +86,21 @@
 // Temperature Sensors
 //
 #if TEMP_SENSOR_0 == -1
-  #define TEMP_0_PIN        4 // ANALOG NUMBERING
+  #define TEMP_0_PIN        4   // Analog Input
 #else
-  #define TEMP_0_PIN       13 // ANALOG NUMBERING
+  #define TEMP_0_PIN       13   // Analog Input
 #endif
 
 #if TEMP_SENSOR_1 == -1
-  #define TEMP_1_PIN        8 // ANALOG NUMBERING
+  #define TEMP_1_PIN        8   // Analog Input
 #else
-  #define TEMP_1_PIN       15 // ANALOG NUMBERING
+  #define TEMP_1_PIN       15   // Analog Input
 #endif
 
 #if TEMP_SENSOR_BED == -1
-  #define TEMP_BED_PIN      8 // ANALOG NUMBERING
+  #define TEMP_BED_PIN      8   // Analog Input
 #else
-  #define TEMP_BED_PIN     14 // ANALOG NUMBERING
+  #define TEMP_BED_PIN     14   // Analog Input
 #endif
 
 //

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -102,24 +102,24 @@
 // Temperature Sensors
 //
 #if TEMP_SENSOR_0 == -1
-  #define TEMP_0_PIN       11 // ANALOG NUMBERING
+  #define TEMP_0_PIN       11   // Analog Input
 #else
-  #define TEMP_0_PIN       15 // ANALOG NUMBERING
+  #define TEMP_0_PIN       15   // Analog Input
 #endif
 #if TEMP_SENSOR_1 == -1
-  #define TEMP_1_PIN       10 // ANALOG NUMBERING
+  #define TEMP_1_PIN       10   // Analog Input
 #else
-  #define TEMP_1_PIN       13 // ANALOG NUMBERING
+  #define TEMP_1_PIN       13   // Analog Input
 #endif
 #if TEMP_SENSOR_2 == -1
-  #define TEMP_2_PIN        9 // ANALOG NUMBERING
+  #define TEMP_2_PIN        9   // Analog Input
 #else
-  #define TEMP_2_PIN       12 // ANALOG NUMBERING
+  #define TEMP_2_PIN       12   // Analog Input
 #endif
 #if TEMP_SENSOR_BED == -1
-  #define TEMP_BED_PIN      8 // ANALOG NUMBERING
+  #define TEMP_BED_PIN      8   // Analog Input
 #else
-  #define TEMP_BED_PIN     14 // ANALOG NUMBERING
+  #define TEMP_BED_PIN     14   // Analog Input
 #endif
 
 //

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -89,9 +89,9 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN          0
-#define TEMP_1_PIN          1
-#define TEMP_BED_PIN        2
+#define TEMP_0_PIN          0   // Analog Input
+#define TEMP_1_PIN          1   // Analog Input
+#define TEMP_BED_PIN        2   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -74,9 +74,9 @@
 #define SDSS               16
 #define LED_PIN            46
 
-#define TEMP_0_PIN          7 // ANALOG NUMBERING
-#define TEMP_1_PIN          6 // ANALOG NUMBERING
-#define TEMP_BED_PIN        6 // ANALOG NUMBERING
+#define TEMP_0_PIN          7   // Analog Input
+#define TEMP_1_PIN          6   // Analog Input
+#define TEMP_BED_PIN        6   // Analog Input
 
 //
 // Heaters / Fans

--- a/Marlin/pins_OMCA.h
+++ b/Marlin/pins_OMCA.h
@@ -98,9 +98,9 @@
 #define HEATER_0_PIN        3 // DONE PWM on RIGHT connector
 #define HEATER_BED_PIN      4
 
-#define TEMP_0_PIN          0 // ANALOG INPUT NUMBERING
-#define TEMP_1_PIN          1 // ANALOG
-#define TEMP_BED_PIN        2 // 1,2 or I2C
+#define TEMP_0_PIN          0   // Analog Input
+#define TEMP_1_PIN          1   // Analog Input
+#define TEMP_BED_PIN        2   // Analog Input (1,2 or I2C)
 
 #define I2C_SCL            16
 #define I2C_SDA            17

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -56,20 +56,27 @@
 
 #define BOARD_NAME         "Alpha OMCA"
 
+//
+// Limit Switches
+//
+#define X_STOP_PIN          0
+#define Y_STOP_PIN          1
+#define Z_STOP_PIN          2
+
+//
+// Steppers
+//
 #define X_STEP_PIN         21
 #define X_DIR_PIN          20
 #define X_ENABLE_PIN       24
-#define X_STOP_PIN          0
 
 #define Y_STEP_PIN         23
 #define Y_DIR_PIN          22
 #define Y_ENABLE_PIN       24
-#define Y_STOP_PIN          1
 
 #define Z_STEP_PIN         26
 #define Z_DIR_PIN          25
 #define Z_ENABLE_PIN       24
-#define Z_STOP_PIN          2
 
 #define E0_STEP_PIN        28
 #define E0_DIR_PIN         27
@@ -83,10 +90,17 @@
 #define E2_DIR_PIN         -1 // 16
 #define E2_ENABLE_PIN      24
 
-#define SDSS               11
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN          0   // Analog Input (D27)
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN        4
 #define FAN_PIN             3
 
-#define HEATER_0_PIN        4
-#define TEMP_0_PIN          0 //D27   // MUST USE ANALOG INPUT NUMBERING NOT DIGITAL OUTPUT NUMBERING!!!!!!!!!
+#define SDSS               11
 
 /*  Unused (1) (2) (3) 4 5 6 7 8 9 10 11 12 13 (14) (15) (16) 17 (18) (19) (20) (21) (22) (23) 24 (25) (26) (27) 28 (29) (30) (31)  */

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -79,10 +79,11 @@
   #define Y_STOP_PIN        8 // Ystop in Ystop socket
 #endif
 #define Z_STOP_PIN         36
-#define TEMP_0_PIN          1  // Extruder / Analog pin numbering
-#define TEMP_BED_PIN        0  // Bed / Analog pin numbering
 
-#define FILWIDTH_PIN        2  // ANALOG NUMBERING
+#define TEMP_0_PIN          1   // Analog Input
+#define TEMP_BED_PIN        0   // Analog Input
+
+#define FILWIDTH_PIN        2   // Analog Input
 
 ////LCD Pin Setup////
 


### PR DESCRIPTION
Upon request from a printer builder…
- Add an option to report all pin mappings and states
- Add `M43` command to print a single pin state or all pin states
