### PR TITLE
Revised DAC Drive Strength Menu add

### DIFF
--- a/Marlin/dac_mcp4728.cpp
+++ b/Marlin/dac_mcp4728.cpp
@@ -34,7 +34,7 @@
 
 #if ENABLED(DAC_STEPPER_CURRENT)
 
-uint16_t     mcp4728_values[4];
+uint16_t     mcp4728_values[XYZE];
 
 /**
  * Begin I2C, get current values (input register and eeprom) of mcp4728
@@ -116,11 +116,10 @@ uint16_t mcp4728_getVout(uint8_t channel) {
 uint16_t mcp4728_getDrvPct(uint8_t channel) {return (uint16_t)(.5+(((float)mcp4728_values[channel]*100)/DAC_STEPPER_MAX));}
 
 /* Recieves all Drive strengths as 0-100 percent values, updates DAC Values array and calls fastwrite to update the DAC */
-void mcp4728_setDrvPct(float xPct, float yPct, float zPct, float ePct) {
-  mcp4728_values[0] = (xPct * DAC_STEPPER_MAX)/100;
-  mcp4728_values[1] = (yPct * DAC_STEPPER_MAX)/100;
-  mcp4728_values[2] = (zPct * DAC_STEPPER_MAX)/100;
-  mcp4728_values[3] = (ePct * DAC_STEPPER_MAX)/100;
+void mcp4728_setDrvPct(int16_t pct[XYZE]) {
+  for (uint8_t i=0; i <= 3; i++) {
+    mcp4728_values[i] = ((float)pct[i] * DAC_STEPPER_MAX)/100;
+  }
   mcp4728_fastWrite();
 }
 

--- a/Marlin/dac_mcp4728.cpp
+++ b/Marlin/dac_mcp4728.cpp
@@ -112,6 +112,18 @@ uint16_t mcp4728_getVout(uint8_t channel) {
 }
 */
 
+/* Returns DAC values as a 0-100 percentage of drive strength */
+uint16_t mcp4728_getDrvPct(uint8_t channel) {return (uint16_t)(.5+(((float)mcp4728_values[channel]*100)/DAC_STEPPER_MAX));}
+
+/* Recieves all Drive strengths as 0-100 percent values, updates DAC Values array and calls fastwrite to update the DAC */
+void mcp4728_setDrvPct(float xPct, float yPct, float zPct, float ePct) {
+  mcp4728_values[0] = (xPct * DAC_STEPPER_MAX)/100;
+  mcp4728_values[1] = (yPct * DAC_STEPPER_MAX)/100;
+  mcp4728_values[2] = (zPct * DAC_STEPPER_MAX)/100;
+  mcp4728_values[3] = (ePct * DAC_STEPPER_MAX)/100;
+  mcp4728_fastWrite();
+}
+
 /**
  * FastWrite input register values - All DAC ouput update. refer to DATASHEET 5.6.1
  * DAC Input and PowerDown bits update.

--- a/Marlin/dac_mcp4728.h
+++ b/Marlin/dac_mcp4728.h
@@ -60,7 +60,7 @@ uint16_t mcp4728_getValue(uint8_t channel);
 uint8_t mcp4728_fastWrite();
 uint8_t mcp4728_simpleCommand(byte simpleCommand);
 uint16_t mcp4728_getDrvPct(uint8_t channel);
-void mcp4728_setDrvPct(float xPct, float yPct, float zPct, float ePct);
+void mcp4728_setDrvPct(int16_t pct[XYZE]);
 
 #endif
 #endif

--- a/Marlin/dac_mcp4728.h
+++ b/Marlin/dac_mcp4728.h
@@ -32,7 +32,7 @@
 #if ENABLED(DAC_STEPPER_CURRENT)
 #include "Wire.h"
 
-#define defaultVDD     5000
+#define defaultVDD     DAC_STEPPER_MAX //was 5000 but differs with internal Vref
 #define BASE_ADDR      0x60
 #define RESET          0B00000110
 #define WAKE           0B00001001
@@ -59,6 +59,8 @@ uint8_t mcp4728_setGain_all(uint8_t value);
 uint16_t mcp4728_getValue(uint8_t channel);
 uint8_t mcp4728_fastWrite();
 uint8_t mcp4728_simpleCommand(byte simpleCommand);
+uint16_t mcp4728_getDrvPct(uint8_t channel);
+void mcp4728_setDrvPct(float xPct, float yPct, float zPct, float ePct);
 
 #endif
 #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -544,6 +544,15 @@
 #ifndef MSG_FILAMENT_CHANGE_OPTION_RESUME
   #define MSG_FILAMENT_CHANGE_OPTION_RESUME   "Resume print"
 #endif
+#ifndef MSG_DRIVE_STRENGTH
+  #define MSG_DRIVE_STRENGTH                  "Drive Strength"
+#endif
+#ifndef MSG_DAC_PERCENT
+  #define MSG_DAC_PERCENT                     "Driver %"
+#endif
+#ifndef MSG_DAC_EEPROM_WRITE
+  #define MSG_DAC_EEPROM_WRITE                "DAC EEPROM Write"
+#endif
 #if LCD_HEIGHT >= 4
   #ifndef MSG_FILAMENT_CHANGE_INIT_1
     #define MSG_FILAMENT_CHANGE_INIT_1          "Wait for start"

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -49,6 +49,7 @@
 
   bool dac_present = false;
   const uint8_t dac_order[NUM_AXIS] = DAC_STEPPER_ORDER;
+  uint16_t dac_channel_pct[XYZE];
 
   int dac_init() {
     #if PIN_EXISTS(DAC_DISABLE)

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -86,7 +86,7 @@
   }
 
   static float dac_perc(int8_t n) { return 100.0 * mcp4728_getValue(dac_order[n]) / DAC_STEPPER_MAX; }
-  static float dac_amps(int8_t n) { return mcp4728_getVout(dac_order[n]) / (8.0 * DAC_STEPPER_SENSE); }
+  static float dac_amps(int8_t n) { return (mcp4728_getDrvPct(dac_order[n])*DAC_STEPPER_MAX) / (8.0 * DAC_STEPPER_SENSE); }
   
   int16_t dac_current_get_percent(int8_t axis) {return mcp4728_getDrvPct(dac_order[axis]); }
   void dac_current_set_percents(int16_t pct[XYZE]) {

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -86,7 +86,13 @@
   }
 
   static float dac_perc(int8_t n) { return 100.0 * mcp4728_getValue(dac_order[n]) / DAC_STEPPER_MAX; }
-  static float dac_amps(int8_t n) { return ((2.048 * mcp4728_getValue(dac_order[n])) / 4096.0) / (8.0 * DAC_STEPPER_SENSE); }
+  static float dac_amps(int8_t n) { return mcp4728_getVout(dac_order[n]) / (8.0 * DAC_STEPPER_SENSE); }
+  
+  int16_t dac_current_get_percent(int8_t axis) {return mcp4728_getDrvPct(dac_order[axis]); }
+  void dac_current_set_percents(int16_t pct[XYZE]) {
+    LOOP_XYZE(i) dac_channel_pct[i] = pct[dac_order[i]];
+    mcp4728_setDrvPct(dac_channel_pct);
+  }
 
   void dac_print_values() {
     if (!dac_present) return;
@@ -94,16 +100,15 @@
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPGM("Stepper current values in % (Amps):");
     SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR(" X:",  dac_perc(0));
-    SERIAL_ECHOPAIR(" (",   dac_amps(0));
-    SERIAL_ECHOPAIR(") Y:", dac_perc(1));
-    SERIAL_ECHOPAIR(" (",   dac_amps(1));
-    SERIAL_ECHOPAIR(") Z:", dac_perc(2));
-    SERIAL_ECHOPAIR(" (",   dac_amps(2));
-    SERIAL_ECHOPAIR(") E:", dac_perc(3));
-    SERIAL_ECHOPAIR(" (",   dac_amps(3));
-    SERIAL_CHAR(')');
-    SERIAL_EOL;
+    SERIAL_ECHOPAIR(" X:",  dac_perc(X_AXIS)); 
+    SERIAL_ECHOPAIR(" (",   dac_amps(X_AXIS));
+    SERIAL_ECHOPAIR(") Y:", dac_perc(Y_AXIS));
+    SERIAL_ECHOPAIR(" (",   dac_amps(Y_AXIS));
+    SERIAL_ECHOPAIR(") Z:", dac_perc(Z_AXIS));
+    SERIAL_ECHOPAIR(" (",   dac_amps(Z_AXIS));
+    SERIAL_ECHOPAIR(") E:", dac_perc(E_AXIS));
+    SERIAL_ECHOPAIR(" (",   dac_amps(E_AXIS));
+    SERIAL_ECHOLN(")");
   }
 
   void dac_commit_eeprom() {

--- a/Marlin/stepper_dac.h
+++ b/Marlin/stepper_dac.h
@@ -51,5 +51,7 @@ void dac_current_percent(uint8_t channel, float val);
 void dac_current_raw(uint8_t channel, uint16_t val);
 void dac_print_values();
 void dac_commit_eeprom();
+int16_t dac_current_get_percent(int8_t axis) ;
+void dac_current_set_percents(int16_t pct[XYZE]);
 
 #endif // STEPPER_DAC_H

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -122,6 +122,7 @@ uint16_t driverX, driverY, driverZ, driverE;
   static void dac_driver_commit();
   static void dac_driver_getValues();
   static void lcd_dac_menu();
+  static void lcd_dac_write_eeprom();
   #endif
 
   #if ENABLED(LCD_INFO_MENU)
@@ -870,10 +871,9 @@ void kill_screen(const char* lcd_msg) {
     driverE = mcp4728_getDrvPct(3);
   } 
 
-  static void dac_driver_commit() 
-  {
-    mcp4728_setDrvPct(driverX, driverY, driverZ, driverE);
-  }
+  static void dac_driver_commit() { mcp4728_setDrvPct(driverX, driverY, driverZ, driverE); }
+
+  static void dac_driver_eeprom_write() { mcp4728_eepromWrite(); }
   
   static void lcd_dac_menu()
   {
@@ -884,6 +884,7 @@ void kill_screen(const char* lcd_msg) {
     MENU_ITEM_EDIT_CALLBACK(int3, "Driver Y%", &driverY, 0, 100, dac_driver_commit);
     MENU_ITEM_EDIT_CALLBACK(int3, "Driver Z%", &driverZ, 0, 100, dac_driver_commit);
     MENU_ITEM_EDIT_CALLBACK(int3, "Driver E%", &driverE, 0, 100, dac_driver_commit);
+    MENU_ITEM(function, "Write DAC EEPROM", dac_driver_eeprom_write);
    END_MENU();
   }
  #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1568,7 +1568,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM(submenu, MSG_RETRACT, lcd_control_retract_menu);
     #endif
     #if ENABLED(DAC_STEPPER_CURRENT)
-      MENU_ITEM(submenu, MSG_DRIVE_STRENGTH, lcd_dac_menu); //MSG_DRIVE_STRENGTH to be added to language.h as "Drive Strength"
+      MENU_ITEM(submenu, MSG_DRIVE_STRENGTH, lcd_dac_menu); 
     #endif
 
     #if ENABLED(EEPROM_SETTINGS)

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -866,7 +866,7 @@ void kill_screen(const char* lcd_msg) {
   #if ENABLED(DAC_STEPPER_CURRENT)
     static void dac_driver_getValues() {LOOP_XYZE(i) driverPercent[i] = dac_current_get_percent(i); } 
   
-    static void dac_driver_commit() { dac_current_set_percents(driverPercent[]); }
+    static void dac_driver_commit() { dac_current_set_percents(driverPercent); }
   
     static void dac_driver_eeprom_write() { dac_commit_eeprom(); }
     


### PR DESCRIPTION
Adding Drive Strength for boards using the mcp4728 DAC to provide stepper driver reference voltage. Menus allow users to adjust drive strength via the LCD controller.
