### PR TITLE
Move platformio directories out of source tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ applet/
 # Debug files
 *.dSYM/
 *.su
+
+#PlatformIO files/dirs
+.pioenvs
+.piolib

--- a/Marlin/platformio.ini
+++ b/Marlin/platformio.ini
@@ -13,6 +13,8 @@
 
 [platformio]
 src_dir = ./
+envs_dir = ../.pioenvs
+lib_dir = ../.piolib
 env_default = mega2560
 
 [env:mega2560]


### PR DESCRIPTION
This relocates platformio-created directories out of the source tree, which allows for compilation with both Arduino IDE and platformio.  If the .pioenvs directory (which contains the pio object files and such) is a part of the source tree, compilation fails with the Arduino IDE.
