### PR TITLE
Sort out some header dependencies

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -394,11 +394,6 @@ extern uint8_t active_extruder;
 
 void calculate_volumetric_multipliers();
 
-// Buzzer
-#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
-  #include "buzzer.h"
-#endif
-
 /**
  * Blocking movement and shorthand functions
  */

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -33,20 +33,6 @@
 
 #include "Marlin.h"
 
-#if HAS_ABL
-  #include "vector_3.h"
-#endif
-
-#if ENABLED(AUTO_BED_LEVELING_LINEAR)
-  #include "qr_solve.h"
-#elif ENABLED(MESH_BED_LEVELING)
-  #include "mesh_bed_leveling.h"
-#endif
-
-#if ENABLED(BEZIER_CURVE_SUPPORT)
-  #include "planner_bezier.h"
-#endif
-
 #include "ultralcd.h"
 #include "planner.h"
 #include "stepper.h"
@@ -60,6 +46,23 @@
 #include "nozzle.h"
 #include "duration_t.h"
 #include "types.h"
+
+#if HAS_ABL
+  #include "vector_3.h"
+  #if ENABLED(AUTO_BED_LEVELING_LINEAR)
+    #include "qr_solve.h"
+  #endif
+#elif ENABLED(MESH_BED_LEVELING)
+  #include "mesh_bed_leveling.h"
+#endif
+
+#if ENABLED(BEZIER_CURVE_SUPPORT)
+  #include "planner_bezier.h"
+#endif
+
+#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
+  #include "buzzer.h"
+#endif
 
 #if ENABLED(USE_WATCHDOG)
   #include "watchdog.h"
@@ -4560,7 +4563,9 @@ inline void gcode_M31() {
   SERIAL_ECHO_START;
   SERIAL_ECHOLNPAIR("Print time: ", buffer);
 
-  thermalManager.autotempShutdown();
+  #if ENABLED(AUTOTEMP)
+    thermalManager.autotempShutdown();
+  #endif
 }
 
 #if ENABLED(SDSUPPORT)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2225,8 +2225,8 @@ static void clean_up_after_endstop_or_probe_move() {
     #elif HAS_ABL
 
       if (enable != planner.abl_enabled) {
-        planner.abl_enabled = !planner.abl_enabled;
-        if (!planner.abl_enabled)
+        planner.abl_enabled = enable;
+        if (!enable)
           set_current_from_steppers_for_axis(
             #if ABL_PLANAR
               ALL_AXES

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8823,9 +8823,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
       // For non-interpolated delta calculate every segment
       for (uint16_t s = segments + 1; --s;) {
         DELTA_NEXT(segment_distance[i]);
-        DELTA_IK();
-        ADJUST_DELTA(DELTA_VAR);
-        planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], DELTA_VAR[E_AXIS], _feedrate_mm_s, active_extruder);
+        planner.buffer_line_kinematic(DELTA_VAR, _feedrate_mm_s, active_extruder);
       }
 
     #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -460,13 +460,17 @@ static uint8_t target_extruder;
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-  #define ADJUST_DELTA(V) \
-    if (planner.abl_enabled) { \
-      const float zadj = bilinear_z_offset(V); \
-      delta[A_AXIS] += zadj; \
-      delta[B_AXIS] += zadj; \
-      delta[C_AXIS] += zadj; \
-    }
+  #if ENABLED(DELTA)
+    #define ADJUST_DELTA(V) \
+      if (planner.abl_enabled) { \
+        const float zadj = bilinear_z_offset(V); \
+        delta[A_AXIS] += zadj; \
+        delta[B_AXIS] += zadj; \
+        delta[C_AXIS] += zadj; \
+      }
+  #else
+    #define ADJUST_DELTA(V) if (planner.abl_enabled) { delta[Z_AXIS] += bilinear_z_offset(V); }
+  #endif
 #elif IS_KINEMATIC
   #define ADJUST_DELTA(V) NOOP
 #endif

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -24,7 +24,6 @@
 
 #include "ultralcd.h"
 #include "stepper.h"
-#include "temperature.h"
 #include "language.h"
 
 #include "Marlin.h"

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -198,17 +198,11 @@ class Planner {
 
     static bool is_full() { return (block_buffer_tail == BLOCK_MOD(block_buffer_head + 1)); }
 
-    #if HAS_ABL || ENABLED(MESH_BED_LEVELING)
+    #if PLANNER_LEVELING
+
       #define ARG_X float lx
       #define ARG_Y float ly
       #define ARG_Z float lz
-    #else
-      #define ARG_X const float &lx
-      #define ARG_Y const float &ly
-      #define ARG_Z const float &lz
-    #endif
-
-    #if PLANNER_LEVELING
 
       /**
        * Apply leveling to transform a cartesian position
@@ -217,6 +211,12 @@ class Planner {
       static void apply_leveling(float &lx, float &ly, float &lz);
       static void apply_leveling(float logical[XYZ]) { apply_leveling(logical[X_AXIS], logical[Y_AXIS], logical[Z_AXIS]); }
       static void unapply_leveling(float logical[XYZ]);
+
+    #else
+
+      #define ARG_X const float &lx
+      #define ARG_Y const float &ly
+      #define ARG_Z const float &lz
 
     #endif
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -34,19 +34,10 @@
 
 #include "types.h"
 #include "enum.h"
-#include "MarlinConfig.h"
+#include "Marlin.h"
 
 #if HAS_ABL
   #include "vector_3.h"
-#endif
-
-class Planner;
-extern Planner planner;
-
-#if IS_KINEMATIC
-  // for inline buffer_line_kinematic
-  extern float delta[ABC];
-  void inverse_kinematics(const float logical[XYZ]);
 #endif
 
 /**
@@ -401,5 +392,7 @@ class Planner {
     static void recalculate();
 
 };
+
+extern Planner planner;
 
 #endif // PLANNER_H

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -372,15 +372,15 @@ class Temperature {
      */
     static void updatePID();
 
-    static void autotempShutdown() {
-      #if ENABLED(AUTOTEMP)
+    #if ENABLED(AUTOTEMP)
+      static void autotempShutdown() {
         if (planner.autotemp_enabled) {
           planner.autotemp_enabled = false;
           if (degTargetHotend(EXTRUDER_IDX) > planner.autotemp_min)
             setTargetHotend(0, EXTRUDER_IDX);
         }
-      #endif
-    }
+      }
+    #endif
 
     #if ENABLED(BABYSTEPPING)
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -30,6 +30,10 @@
 #include "configuration_store.h"
 #include "utility.h"
 
+#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
+  #include "buzzer.h"
+#endif
+
 #if ENABLED(BLTOUCH)
   #include "endstops.h"
 #endif
@@ -581,7 +585,9 @@ void kill_screen(const char* lcd_msg) {
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();
-      thermalManager.autotempShutdown();
+      #if ENABLED(AUTOTEMP)
+        thermalManager.autotempShutdown();
+      #endif
       wait_for_heatup = false;
       lcd_setstatus(MSG_PRINT_ABORTED, true);
     }


### PR DESCRIPTION
Prevent circular dependency between `planner` -> `temperature` headers by only including `buzzer.h` from source files, and not from `Marlin.h`. Also, simply drop autoTemp method when autotemp is disabled.
