### PR TITLE
Fix bltouch bump

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -318,7 +318,11 @@
 //homing hits the endstop, then retracts by this distance, before it tries to slowly bump again:
 #define X_HOME_BUMP_MM 5
 #define Y_HOME_BUMP_MM 5
-#define Z_HOME_BUMP_MM 2
+#if ENABLED(BLTOUCH)
+  #define Z_HOME_BUMP_MM 5  // Might be possible to tweak a bit smaller, depends on your mount tolerance. If you are getting plate-strikes, increase this value.
+#else
+  #define Z_HOME_BUMP_MM 2
+#endif
 #define HOMING_BUMP_DIVISOR {2, 2, 4}  // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 //#define QUICK_HOME  //if this is defined, if both x and y are to be homed, a diagonal move will be performed initially.
 


### PR DESCRIPTION
We should set Z_BUMP a bit higher for BLTouch users out of the box. If they want to tweak it, they can. Otherwise this will avoid (erroneous) issues reported for double touch.
