### PR TITLE
add endstop monitor to M43 command

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -214,6 +214,9 @@ void manage_inactivity(bool ignore_stepper_queue = false);
               G38_endstop_hit; // flag from the interrupt handler to indicate if the endstop went active
 #endif
 
+#if ENABLED(PINS_DEBUGGING)
+  extern bool endstop_monitor_flag;
+#endif
 /**
  * The axis order in all axis related arrays is X, Y, Z, E
  */

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4467,8 +4467,6 @@ inline void gcode_G92() {
       }
       else while (wait_for_user) idle();
 
-      wait_for_user = false;
-
     #endif
 
 #if ENABLED(ULTIPANEL)
@@ -9261,8 +9259,14 @@ void prepare_move_to_destination() {
       bool new_led = (max_temp > 55.0) ? true : (max_temp < 54.0) ? false : red_led;
       if (new_led != red_led) {
         red_led = new_led;
-        WRITE(STAT_LED_RED_PIN, new_led ? HIGH : LOW);
-        WRITE(STAT_LED_BLUE_PIN, new_led ? LOW : HIGH);
+        #if PIN_EXISTS(STAT_LED_RED)
+          WRITE(STAT_LED_RED_PIN, new_led ? HIGH : LOW);
+          #if PIN_EXISTS(STAT_LED_BLUE)
+            WRITE(STAT_LED_BLUE_PIN, new_led ? LOW : HIGH);
+          #endif
+        #else
+          WRITE(STAT_LED_BLUE_PIN, new_led ? HIGH : LOW);
+        #endif
       }
     }
   }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4752,8 +4752,10 @@ inline void gcode_M42() {
           report_pin_state(pin);
     
     if (code_seen('E')) {
-      endstop_monitor_flag = endstop_monitor_flag ? false : true;
-      SERIAL_PROTOCOLLN((endstop_monitor_flag ? "endstop monitor active" : "endstop monitor disabled"));
+      endstop_monitor_flag ^= true;
+      SERIAL_PROTOCOLPGM("endstop monitor ");
+      SERIAL_PROTOCOL(endstop_monitor_flag ? "en" : "dis");
+      SERIAL_PROTOCOLLNPGM("abled");
     }    
   }
 

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -57,372 +57,598 @@ static bool report_pin_name(int8_t pin) {
     if (pin == 1) { SERIAL_ECHOPGM("TXD"); return true; }
   #endif
 
-  #if PIN_EXISTS(SERVO0)
-    PIN_SAY(SERVO0_PIN);
+  #if defined(__FD) && __FD > -1   // Pin list updated from 7 OCT RCBugfix branch
+    PIN_SAY(__FD)
   #endif
-  #if PIN_EXISTS(SERVO1)
-    PIN_SAY(SERVO1_PIN);
+  #if defined(__FS) && __FS > -1
+    PIN_SAY(__FS)
   #endif
-  #if PIN_EXISTS(SERVO2)
-    PIN_SAY(SERVO2_PIN);
+  #if defined(__GD) && __GD > -1
+    PIN_SAY(__GD)
   #endif
-  #if PIN_EXISTS(SERVO3)
-    PIN_SAY(SERVO3_PIN);
+  #if defined(__GS) && __GS > -1
+    PIN_SAY(__GS)
   #endif
-
-  #if PIN_EXISTS(X_MIN)
-    PIN_SAY(X_MIN_PIN);
+  #if defined(AVR_MISO_PIN) && AVR_MISO_PIN > -1
+    PIN_SAY(AVR_MISO_PIN)
   #endif
-  #if PIN_EXISTS(X_MAX)
-    PIN_SAY(X_MAX_PIN);
+  #if defined(AVR_MOSI_PIN) && AVR_MOSI_PIN > -1
+    PIN_SAY(AVR_MOSI_PIN)
   #endif
-  #if PIN_EXISTS(Y_MIN)
-    PIN_SAY(Y_MIN_PIN);
+  #if defined(AVR_SCK_PIN) && AVR_SCK_PIN > -1
+    PIN_SAY(AVR_SCK_PIN)
   #endif
-  #if PIN_EXISTS(Y_MAX)
-    PIN_SAY(Y_MAX_PIN);
+  #if defined(AVR_SS_PIN) && AVR_SS_PIN > -1
+    PIN_SAY(AVR_SS_PIN)
   #endif
-  #if PIN_EXISTS(Z_MIN)
-    PIN_SAY(Z_MIN_PIN);
+  #if defined(BEEPER_PIN) && BEEPER_PIN > -1
+    PIN_SAY(BEEPER_PIN)
   #endif
-  #if PIN_EXISTS(Z_MAX)
-    PIN_SAY(Z_MAX_PIN);
+  #if defined(BTN_CENTER) && BTN_CENTER > -1
+    PIN_SAY(BTN_CENTER)
   #endif
-  #if PIN_EXISTS(Z_MIN_PROBE)
-    PIN_SAY(Z_MIN_PROBE_PIN);
+  #if defined(BTN_DOWN) && BTN_DOWN > -1
+    PIN_SAY(BTN_DOWN)
   #endif
-  #if PIN_EXISTS(X_STEP)
-    PIN_SAY(X_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(X_DIR)
-    PIN_SAY(X_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(X_ENABLE)
-    PIN_SAY(X_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(X_MS1)
-    PIN_SAY(X_MS1_PIN);
-  #endif
-  #if PIN_EXISTS(X_MS2)
-    PIN_SAY(X_MS2_PIN);
-  #endif
-  #if PIN_EXISTS(X2_STEP)
-    PIN_SAY(X2_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(X2_DIR)
-    PIN_SAY(X2_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(X2_ENABLE)
-    PIN_SAY(X2_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(Y_STEP)
-    PIN_SAY(Y_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(Y_DIR)
-    PIN_SAY(Y_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(Y_ENABLE)
-    PIN_SAY(Y_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(Y_MS1)
-    PIN_SAY(Y_MS1_PIN);
-  #endif
-  #if PIN_EXISTS(Y_MS2)
-    PIN_SAY(Y_MS2_PIN);
-  #endif
-  #if PIN_EXISTS(Y2_STEP)
-    PIN_SAY(Y2_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(Y2_DIR)
-    PIN_SAY(Y2_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(Y2_ENABLE)
-    PIN_SAY(Y2_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(Z_STEP)
-    PIN_SAY(Z_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(Z_DIR)
-    PIN_SAY(Z_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(Z_ENABLE)
-    PIN_SAY(Z_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(Z_MS1)
-    PIN_SAY(Z_MS1_PIN);
-  #endif
-  #if PIN_EXISTS(Z_MS2)
-    PIN_SAY(Z_MS2_PIN);
-  #endif
-  #if PIN_EXISTS(Z2_STEP)
-    PIN_SAY(Z2_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(Z2_DIR)
-    PIN_SAY(Z2_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(Z2_ENABLE)
-    PIN_SAY(Z2_ENABLE_PIN);
-  #endif
-
-  #if PIN_EXISTS(E0_STEP)
-    PIN_SAY(E0_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(E0_DIR)
-    PIN_SAY(E0_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(E0_ENABLE)
-    PIN_SAY(E0_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(E0_MS1)
-    PIN_SAY(E0_MS1_PIN);
-  #endif
-  #if PIN_EXISTS(E0_MS2)
-    PIN_SAY(E0_MS2_PIN);
-  #endif
-  #if PIN_EXISTS(E1_STEP)
-    PIN_SAY(E1_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(E1_DIR)
-    PIN_SAY(E1_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(E1_ENABLE)
-    PIN_SAY(E1_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(E1_MS1)
-    PIN_SAY(E1_MS1_PIN);
-  #endif
-  #if PIN_EXISTS(E1_MS2)
-    PIN_SAY(E1_MS2_PIN);
-  #endif
-  #if PIN_EXISTS(E2_STEP)
-    PIN_SAY(E2_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(E2_DIR)
-    PIN_SAY(E2_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(E2_ENABLE)
-    PIN_SAY(E2_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(E3_STEP)
-    PIN_SAY(E3_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(E3_DIR)
-    PIN_SAY(E3_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(E3_ENABLE)
-    PIN_SAY(E3_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(E4_STEP)
-    PIN_SAY(E4_STEP_PIN);
-  #endif
-  #if PIN_EXISTS(E4_DIR)
-    PIN_SAY(E4_DIR_PIN);
-  #endif
-  #if PIN_EXISTS(E4_ENABLE)
-    PIN_SAY(E4_ENABLE_PIN);
-  #endif
-
-  #if PIN_EXISTS(FAN)
-    PIN_SAY(FAN_PIN);
-  #endif
-  #if PIN_EXISTS(FAN1)
-    PIN_SAY(FAN1_PIN);
-  #endif
-  #if PIN_EXISTS(FAN2)
-    PIN_SAY(FAN2_PIN);
-  #endif
-  #if PIN_EXISTS(CONTROLLERFAN)
-    PIN_SAY(CONTROLLERFAN_PIN);
-  #endif
-  #if PIN_EXISTS(EXTRUDER_0_AUTO_FAN)
-    PIN_SAY(EXTRUDER_0_AUTO_FAN_PIN);
-  #endif
-  #if PIN_EXISTS(EXTRUDER_1_AUTO_FAN)
-    PIN_SAY(EXTRUDER_1_AUTO_FAN_PIN);
-  #endif
-  #if PIN_EXISTS(EXTRUDER_2_AUTO_FAN)
-    PIN_SAY(EXTRUDER_2_AUTO_FAN_PIN);
-  #endif
-  #if PIN_EXISTS(EXTRUDER_3_AUTO_FAN)
-    PIN_SAY(EXTRUDER_3_AUTO_FAN_PIN);
-  #endif
-  #if PIN_EXISTS(HEATER_0)
-    PIN_SAY(HEATER_0_PIN);
-  #endif
-  #if PIN_EXISTS(HEATER_1)
-    PIN_SAY(HEATER_1_PIN);
-  #endif
-  #if PIN_EXISTS(HEATER_2)
-    PIN_SAY(HEATER_2_PIN);
-  #endif
-  #if PIN_EXISTS(HEATER_3)
-    PIN_SAY(HEATER_3_PIN);
-  #endif
-  #if PIN_EXISTS(HEATER_BED)
-    PIN_SAY(HEATER_BED_PIN);
-  #endif
-
-  #if PIN_EXISTS(X_ATT)
-    PIN_SAY(X_ATT_PIN);
-  #endif
-  #if PIN_EXISTS(Y_ATT)
-    PIN_SAY(Y_ATT_PIN);
-  #endif
-  #if PIN_EXISTS(Z_ATT)
-    PIN_SAY(Z_ATT_PIN);
-  #endif
-  #if PIN_EXISTS(E0_ATT)
-    PIN_SAY(E0_ATT_PIN);
-  #endif
-
-  #if PIN_EXISTS(TEMP_0)
-    ANALOG_PIN_SAY(TEMP_0_PIN);
-  #endif
-  #if PIN_EXISTS(TEMP_1)
-    ANALOG_PIN_SAY(TEMP_1_PIN);
-  #endif
-  #if PIN_EXISTS(TEMP_2)
-    ANALOG_PIN_SAY(TEMP_2_PIN);
-  #endif
-  #if PIN_EXISTS(TEMP_3)
-    ANALOG_PIN_SAY(TEMP_3_PIN);
-  #endif
-  #if PIN_EXISTS(TEMP_BED)
-    ANALOG_PIN_SAY(TEMP_BED_PIN);
-  #endif
-  #if PIN_EXISTS(FILWIDTH)
-    ANALOG_PIN_SAY(FILWIDTH_PIN);
-  #endif
-
-  #if PIN_EXISTS(BEEPER)
-    PIN_SAY(BEEPER_PIN);
-  #endif
-  #if PIN_EXISTS(SLED)
-    PIN_SAY(SLED_PIN);
-  #endif
-  #if PIN_EXISTS(FIL_RUNOUT)
-    PIN_SAY(FIL_RUNOUT_PIN);
-  #endif
-
-  #if PIN_EXISTS(LED)
-    PIN_SAY(LED_PIN);
-  #endif
-  // #if defined(DEBUG_LED) && DEBUG_LED > -1
-  //   PIN_SAY(DEBUG_LED);
-  // #endif
-  #if PIN_EXISTS(STAT_LED_RED)
-    PIN_SAY(STAT_LED_RED_PIN);
-  #endif
-  #if PIN_EXISTS(STAT_LED_BLUE)
-    PIN_SAY(STAT_LED_BLUE_PIN);
-  #endif
-
-  #if PIN_EXISTS(DIGIPOTSS)
-    PIN_SAY(DIGIPOTSS_PIN);
-  #endif
-
-  #if PIN_EXISTS(SCK)
-    PIN_SAY(SCK_PIN);
-  #endif
-  #if PIN_EXISTS(MISO)
-    PIN_SAY(MISO_PIN);
-  #endif
-  #if PIN_EXISTS(MOSI)
-    PIN_SAY(MOSI_PIN);
-  #endif
-  #if PIN_EXISTS(SS)
-    PIN_SAY(SS_PIN);
-  #endif
-
-  #if PIN_EXISTS(SD_DETECT)
-    PIN_SAY(SD_DETECT_PIN);
-  #endif
-
-  #if defined(SDPOWER) && SDPOWER > -1
-    PIN_SAY(SDPOWER);
-  #endif
-  #if defined(SDSS) && SDSS > -1
-    PIN_SAY(SDSS);
-  #endif
-  #if defined(I2C_SCL) && I2C_SCL > -1
-    PIN_SAY(I2C_SCL);
-  #endif
-  #if defined(I2C_SDA) && I2C_SDA > -1
-    PIN_SAY(I2C_SDA);
-  #endif
-  #if defined(SCL) && SCL > -1
-    PIN_SAY(SCL);
-  #endif
-  #if defined(SDA) && SDA > -1
-    PIN_SAY(SDA);
-  #endif
-
-  #if PIN_EXISTS(PS_ON)
-    PIN_SAY(PS_ON_PIN);
-  #endif
-  #if PIN_EXISTS(KILL)
-    PIN_SAY(KILL_PIN);
-  #endif
-  #if PIN_EXISTS(SUICIDE)
-    PIN_SAY(SUICIDE_PIN);
-  #endif
-  #if PIN_EXISTS(DEBUG)
-    PIN_SAY(DEBUG_PIN);
-  #endif
-  #if PIN_EXISTS(PHOTOGRAPH)
-    PIN_SAY(PHOTOGRAPH_PIN);
-  #endif
-
-  #if PIN_EXISTS(BEEPER)
-    PIN_SAY(BEEPER_PIN);
+  #if defined(BTN_DWN) && BTN_DWN > -1
+    PIN_SAY(BTN_DWN)
   #endif
   #if defined(BTN_EN1) && BTN_EN1 > -1
-    PIN_SAY(BTN_EN1);
+    PIN_SAY(BTN_EN1)
   #endif
   #if defined(BTN_EN2) && BTN_EN2 > -1
-    PIN_SAY(BTN_EN2);
+    PIN_SAY(BTN_EN2)
   #endif
   #if defined(BTN_ENC) && BTN_ENC > -1
-    PIN_SAY(BTN_ENC);
+    PIN_SAY(BTN_ENC)
   #endif
-  #if defined(LCD_PINS_RS) && LCD_PINS_RS > -1
-    PIN_SAY(LCD_PINS_RS);
+  #if defined(BTN_HOME) && BTN_HOME > -1
+    PIN_SAY(BTN_HOME)
   #endif
-  #if defined(LCD_PINS_ENABLE) && LCD_PINS_ENABLE > -1
-    PIN_SAY(LCD_PINS_ENABLE);
+  #if defined(BTN_LEFT) && BTN_LEFT > -1
+    PIN_SAY(BTN_LEFT)
+  #endif
+  #if defined(BTN_LFT) && BTN_LFT > -1
+    PIN_SAY(BTN_LFT)
+  #endif
+  #if defined(BTN_RIGHT) && BTN_RIGHT > -1
+    PIN_SAY(BTN_RIGHT)
+  #endif
+  #if defined(BTN_RT) && BTN_RT > -1
+    PIN_SAY(BTN_RT)
+  #endif
+  #if defined(BTN_UP) && BTN_UP > -1
+    PIN_SAY(BTN_UP)
+  #endif
+  #if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
+    PIN_SAY(CONTROLLERFAN_PIN)
+  #endif
+  #if defined(DAC_DISABLE_PIN) && DAC_DISABLE_PIN > -1
+    PIN_SAY(DAC_DISABLE_PIN)
+  #endif
+  #if defined(DAC_STEPPER_GAIN) && DAC_STEPPER_GAIN > -1
+    PIN_SAY(DAC_STEPPER_GAIN)
+  #endif
+  #if defined(DAC_STEPPER_VREF) && DAC_STEPPER_VREF > -1
+    PIN_SAY(DAC_STEPPER_VREF)
+  #endif
+  #if defined(DEBUG_PIN) && DEBUG_PIN > -1
+    PIN_SAY(DEBUG_PIN)
+  #endif
+  #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
+    PIN_SAY(DIGIPOTSS_PIN)
+  #endif
+  #if defined(DIO_COUNT) && DIO_COUNT > -1
+    PIN_SAY(DIO_COUNT)
+  #endif
+  #if defined(DOGLCD_A0) && DOGLCD_A0 > -1
+    PIN_SAY(DOGLCD_A0)
+  #endif
+  #if defined(DOGLCD_CS) && DOGLCD_CS > -1
+    PIN_SAY(DOGLCD_CS)
+  #endif
+  #if defined(DOGLCD_MOSI) && DOGLCD_MOSI > -1
+    PIN_SAY(DOGLCD_MOSI)
+  #endif
+  #if defined(DOGLCD_SCK) && DOGLCD_SCK > -1
+    PIN_SAY(DOGLCD_SCK)
+  #endif
+  #if defined(E0_ATT_PIN) && E0_ATT_PIN > -1
+    PIN_SAY(E0_ATT_PIN)
+  #endif
+  #if defined(E0_DIR_PIN) && E0_DIR_PIN > -1
+    PIN_SAY(E0_DIR_PIN)
+  #endif
+  #if defined(E0_ENABLE_PIN) && E0_ENABLE_PIN > -1
+    PIN_SAY(E0_ENABLE_PIN)
+  #endif
+  #if defined(E0_MS1_PIN) && E0_MS1_PIN > -1
+    PIN_SAY(E0_MS1_PIN)
+  #endif
+  #if defined(E0_MS2_PIN) && E0_MS2_PIN > -1
+    PIN_SAY(E0_MS2_PIN)
+  #endif
+  #if defined(E0_STEP_PIN) && E0_STEP_PIN > -1
+    PIN_SAY(E0_STEP_PIN)
+  #endif
+  #if defined(E1_DIR_PIN) && E1_DIR_PIN > -1
+    PIN_SAY(E1_DIR_PIN)
+  #endif
+  #if defined(E1_ENABLE_PIN) && E1_ENABLE_PIN > -1
+    PIN_SAY(E1_ENABLE_PIN)
+  #endif
+  #if defined(E1_MS1_PIN) && E1_MS1_PIN > -1
+    PIN_SAY(E1_MS1_PIN)
+  #endif
+  #if defined(E1_MS2_PIN) && E1_MS2_PIN > -1
+    PIN_SAY(E1_MS2_PIN)
+  #endif
+  #if defined(E1_STEP_PIN) && E1_STEP_PIN > -1
+    PIN_SAY(E1_STEP_PIN)
+  #endif
+  #if defined(E2_DIR_PIN) && E2_DIR_PIN > -1
+    PIN_SAY(E2_DIR_PIN)
+  #endif
+  #if defined(E2_ENABLE_PIN) && E2_ENABLE_PIN > -1
+    PIN_SAY(E2_ENABLE_PIN)
+  #endif
+  #if defined(E2_STEP_PIN) && E2_STEP_PIN > -1
+    PIN_SAY(E2_STEP_PIN)
+  #endif
+  #if defined(E3_DIR_PIN) && E3_DIR_PIN > -1
+    PIN_SAY(E3_DIR_PIN)
+  #endif
+  #if defined(E3_ENABLE_PIN) && E3_ENABLE_PIN > -1
+    PIN_SAY(E3_ENABLE_PIN)
+  #endif
+  #if defined(E3_STEP_PIN) && E3_STEP_PIN > -1
+    PIN_SAY(E3_STEP_PIN)
+  #endif
+  #if defined(E4_DIR_PIN) && E4_DIR_PIN > -1
+    PIN_SAY(E4_DIR_PIN)
+  #endif
+  #if defined(E4_ENABLE_PIN) && E4_ENABLE_PIN > -1
+    PIN_SAY(E4_ENABLE_PIN)
+  #endif
+  #if defined(E4_STEP_PIN) && E4_STEP_PIN > -1
+    PIN_SAY(E4_STEP_PIN)
+  #endif
+  #if defined(encrot1) && encrot1 > -1
+    PIN_SAY(encrot1)
+  #endif
+  #if defined(encrot2) && encrot2 > -1
+    PIN_SAY(encrot2)
+  #endif
+  #if defined(encrot3) && encrot3 > -1
+    PIN_SAY(encrot3)
+  #endif
+  #if defined(EXT_AUX_A0_IO) && EXT_AUX_A0_IO > -1
+    PIN_SAY(EXT_AUX_A0_IO)
+  #endif
+  #if defined(EXT_AUX_A1) && EXT_AUX_A1 > -1
+    PIN_SAY(EXT_AUX_A1)
+  #endif
+  #if defined(EXT_AUX_A1_IO) && EXT_AUX_A1_IO > -1
+    PIN_SAY(EXT_AUX_A1_IO)
+  #endif
+  #if defined(EXT_AUX_A2) && EXT_AUX_A2 > -1
+    PIN_SAY(EXT_AUX_A2)
+  #endif
+  #if defined(EXT_AUX_A2_IO) && EXT_AUX_A2_IO > -1
+    PIN_SAY(EXT_AUX_A2_IO)
+  #endif
+  #if defined(EXT_AUX_A3) && EXT_AUX_A3 > -1
+    PIN_SAY(EXT_AUX_A3)
+  #endif
+  #if defined(EXT_AUX_A3_IO) && EXT_AUX_A3_IO > -1
+    PIN_SAY(EXT_AUX_A3_IO)
+  #endif
+  #if defined(EXT_AUX_A4) && EXT_AUX_A4 > -1
+    PIN_SAY(EXT_AUX_A4)
+  #endif
+  #if defined(EXT_AUX_A4_IO) && EXT_AUX_A4_IO > -1
+    PIN_SAY(EXT_AUX_A4_IO)
+  #endif
+  #if defined(EXT_AUX_PWM_D24) && EXT_AUX_PWM_D24 > -1
+    PIN_SAY(EXT_AUX_PWM_D24)
+  #endif
+  #if defined(EXT_AUX_RX1_D2) && EXT_AUX_RX1_D2 > -1
+    PIN_SAY(EXT_AUX_RX1_D2)
+  #endif
+  #if defined(EXT_AUX_SDA_D1) && EXT_AUX_SDA_D1 > -1
+    PIN_SAY(EXT_AUX_SDA_D1)
+  #endif
+  #if defined(EXT_AUX_TX1_D3) && EXT_AUX_TX1_D3 > -1
+    PIN_SAY(EXT_AUX_TX1_D3)
+  #endif
+  #if defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1
+    PIN_SAY(EXTRUDER_0_AUTO_FAN_PIN)
+  #endif
+  #if defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1
+    PIN_SAY(EXTRUDER_1_AUTO_FAN_PIN)
+  #endif
+  #if defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1
+    PIN_SAY(EXTRUDER_2_AUTO_FAN_PIN)
+  #endif
+  #if defined(EXTRUDER_3_AUTO_FAN_PIN) && EXTRUDER_3_AUTO_FAN_PIN > -1
+    PIN_SAY(EXTRUDER_3_AUTO_FAN_PIN)
+  #endif
+  #if defined(FAN_PIN) && FAN_PIN > -1
+    PIN_SAY(FAN_PIN)
+  #endif
+  #if defined(FAN0_PIN) && FAN0_PIN > -1
+    PIN_SAY(FAN0_PIN)
+  #endif
+  #if defined(FAN1_PIN) && FAN1_PIN > -1
+    PIN_SAY(FAN1_PIN)
+  #endif
+  #if defined(FAN2_PIN) && FAN2_PIN > -1
+    PIN_SAY(FAN2_PIN)
+  #endif
+  #if defined(FIL_RUNOUT_PIN) && FIL_RUNOUT_PIN > -1
+    PIN_SAY(FIL_RUNOUT_PIN)
+  #endif
+  #if defined(FILWIDTH_PIN) && FILWIDTH_PIN > -1
+    ANALOG_PIN_SAY(FILWIDTH_PIN)
+  #endif
+  #if defined(GEN7_VERSION) && GEN7_VERSION > -1
+    PIN_SAY(GEN7_VERSION)
+  #endif
+  #if defined(HEATER_0_PIN) && HEATER_0_PIN > -1
+    PIN_SAY(HEATER_0_PIN)
+  #endif
+  #if defined(HEATER_1_PIN) && HEATER_1_PIN > -1
+    PIN_SAY(HEATER_1_PIN)
+  #endif
+  #if defined(HEATER_2_PIN) && HEATER_2_PIN > -1
+    PIN_SAY(HEATER_2_PIN)
+  #endif
+  #if defined(HEATER_3_PIN) && HEATER_3_PIN > -1
+    PIN_SAY(HEATER_3_PIN)
+  #endif
+  #if defined(HEATER_4_PIN) && HEATER_4_PIN > -1
+    PIN_SAY(HEATER_4_PIN)
+  #endif
+  #if defined(HEATER_5_PIN) && HEATER_5_PIN > -1
+    PIN_SAY(HEATER_5_PIN)
+  #endif
+  #if defined(HEATER_6_PIN) && HEATER_6_PIN > -1
+    PIN_SAY(HEATER_6_PIN)
+  #endif
+  #if defined(HEATER_7_PIN) && HEATER_7_PIN > -1
+    PIN_SAY(HEATER_7_PIN)
+  #endif
+  #if defined(HEATER_BED_PIN) && HEATER_BED_PIN > -1
+    PIN_SAY(HEATER_BED_PIN)
+  #endif
+  #if defined(I2C_SCL) && I2C_SCL > -1
+    PIN_SAY(I2C_SCL)
+  #endif
+  #if defined(I2C_SDA) && I2C_SDA > -1
+    PIN_SAY(I2C_SDA)
+  #endif
+  #if defined(KILL_PIN) && KILL_PIN > -1
+    PIN_SAY(KILL_PIN)
+  #endif
+  #if defined(LCD_BACKLIGHT_PIN) && LCD_BACKLIGHT_PIN > -1
+    PIN_SAY(LCD_BACKLIGHT_PIN)
+  #endif
+  #if defined(LCD_CONTRAST) && LCD_CONTRAST > -1
+    PIN_SAY(LCD_CONTRAST)
   #endif
   #if defined(LCD_PINS_D4) && LCD_PINS_D4 > -1
-    PIN_SAY(LCD_PINS_D4);
+    PIN_SAY(LCD_PINS_D4)
   #endif
   #if defined(LCD_PINS_D5) && LCD_PINS_D5 > -1
-    PIN_SAY(LCD_PINS_D5);
+    PIN_SAY(LCD_PINS_D5)
   #endif
   #if defined(LCD_PINS_D6) && LCD_PINS_D6 > -1
-    PIN_SAY(LCD_PINS_D6);
+    PIN_SAY(LCD_PINS_D6)
   #endif
   #if defined(LCD_PINS_D7) && LCD_PINS_D7 > -1
-    PIN_SAY(LCD_PINS_D7);
+    PIN_SAY(LCD_PINS_D7)
+  #endif
+  #if defined(LCD_PINS_ENABLE) && LCD_PINS_ENABLE > -1
+    PIN_SAY(LCD_PINS_ENABLE)
+  #endif
+  #if defined(LCD_PINS_RS) && LCD_PINS_RS > -1
+    PIN_SAY(LCD_PINS_RS)
+  #endif
+  #if defined(LCD_SDSS) && LCD_SDSS > -1
+    PIN_SAY(LCD_SDSS)
+  #endif
+  #if defined(LED_PIN) && LED_PIN > -1
+    PIN_SAY(LED_PIN)
+  #endif
+  #if defined(MAIN_VOLTAGE_MEASURE_PIN) && MAIN_VOLTAGE_MEASURE_PIN > -1
+    PIN_SAY(MAIN_VOLTAGE_MEASURE_PIN)
+  #endif
+  #if defined(MAX6675_SS) && MAX6675_SS > -1
+    PIN_SAY(MAX6675_SS)
+  #endif
+  #if defined(MISO_PIN) && MISO_PIN > -1
+    PIN_SAY(MISO_PIN)
+  #endif
+  #if defined(MOSFET_D_PIN) && MOSFET_D_PIN > -1
+    PIN_SAY(MOSFET_D_PIN)
+  #endif
+  #if defined(MOSI_PIN) && MOSI_PIN > -1
+    PIN_SAY(MOSI_PIN)
+  #endif
+  #if defined(MOTOR_CURRENT_PWM_E_PIN) && MOTOR_CURRENT_PWM_E_PIN > -1
+    PIN_SAY(MOTOR_CURRENT_PWM_E_PIN)
+  #endif
+  #if defined(MOTOR_CURRENT_PWM_XY_PIN) && MOTOR_CURRENT_PWM_XY_PIN > -1
+    PIN_SAY(MOTOR_CURRENT_PWM_XY_PIN)
+  #endif
+  #if defined(MOTOR_CURRENT_PWM_Z_PIN) && MOTOR_CURRENT_PWM_Z_PIN > -1
+    PIN_SAY(MOTOR_CURRENT_PWM_Z_PIN)
+  #endif
+  #if defined(NUM_TLCS) && NUM_TLCS > -1
+    PIN_SAY(NUM_TLCS)
+  #endif
+  #if defined(PHOTOGRAPH_PIN) && PHOTOGRAPH_PIN > -1
+    PIN_SAY(PHOTOGRAPH_PIN)
+  #endif
+  #if defined(PS_ON_PIN) && PS_ON_PIN > -1
+    PIN_SAY(PS_ON_PIN)
+  #endif
+  #if defined(RAMPS_D10_PIN) && RAMPS_D10_PIN > -1
+    PIN_SAY(RAMPS_D10_PIN)
+  #endif
+  #if defined(RAMPS_D8_PIN) && RAMPS_D8_PIN > -1
+    PIN_SAY(RAMPS_D8_PIN)
+  #endif
+  #if defined(RAMPS_D9_PIN) && RAMPS_D9_PIN > -1
+    PIN_SAY(RAMPS_D9_PIN)
+  #endif
+  #if defined(RX_ENABLE_PIN) && RX_ENABLE_PIN > -1
+    PIN_SAY(RX_ENABLE_PIN)
+  #endif
+  #if defined(SAFETY_TRIGGERED_PIN) && SAFETY_TRIGGERED_PIN > -1
+    PIN_SAY(SAFETY_TRIGGERED_PIN)
+  #endif
+  #if defined(SCK_PIN) && SCK_PIN > -1
+    PIN_SAY(SCK_PIN)
+  #endif
+  #if defined(SCL) && SCL > -1
+    PIN_SAY(SCL)
+  #endif
+  #if defined(SD_DETECT_PIN) && SD_DETECT_PIN > -1
+    PIN_SAY(SD_DETECT_PIN)
+  #endif
+  #if defined(SDA) && SDA > -1
+    PIN_SAY(SDA)
+  #endif
+  #if defined(SDPOWER) && SDPOWER > -1
+    PIN_SAY(SDPOWER)
+  #endif
+  #if defined(SDSS) && SDSS > -1
+    PIN_SAY(SDSS)
+  #endif
+  #if defined(SERVO0_PIN) && SERVO0_PIN > -1
+    PIN_SAY(SERVO0_PIN)
+  #endif
+  #if defined(SERVO1_PIN) && SERVO1_PIN > -1
+    PIN_SAY(SERVO1_PIN)
+  #endif
+  #if defined(SERVO2_PIN) && SERVO2_PIN > -1
+    PIN_SAY(SERVO2_PIN)
+  #endif
+  #if defined(SERVO3_PIN) && SERVO3_PIN > -1
+    PIN_SAY(SERVO3_PIN)
+  #endif
+  #if defined(SHIFT_CLK) && SHIFT_CLK > -1
+    PIN_SAY(SHIFT_CLK)
+  #endif
+  #if defined(SHIFT_EN) && SHIFT_EN > -1
+    PIN_SAY(SHIFT_EN)
+  #endif
+  #if defined(SHIFT_LD) && SHIFT_LD > -1
+    PIN_SAY(SHIFT_LD)
+  #endif
+  #if defined(SHIFT_OUT) && SHIFT_OUT > -1
+    PIN_SAY(SHIFT_OUT)
+  #endif
+  #if defined(SLED_PIN) && SLED_PIN > -1
+    PIN_SAY(SLED_PIN)
+  #endif
+  #if defined(SLEEP_WAKE_PIN) && SLEEP_WAKE_PIN > -1
+    PIN_SAY(SLEEP_WAKE_PIN)
+  #endif
+  #if defined(SOL1_PIN) && SOL1_PIN > -1
+    PIN_SAY(SOL1_PIN)
+  #endif
+  #if defined(SOL2_PIN) && SOL2_PIN > -1
+    PIN_SAY(SOL2_PIN)
+  #endif
+  #if defined(SPINDLE_ENABLE_PIN) && SPINDLE_ENABLE_PIN > -1
+    PIN_SAY(SPINDLE_ENABLE_PIN)
+  #endif
+  #if defined(SPINDLE_SPEED_PIN) && SPINDLE_SPEED_PIN > -1
+    PIN_SAY(SPINDLE_SPEED_PIN)
+  #endif
+  #if defined(SS_PIN) && SS_PIN > -1
+    PIN_SAY(SS_PIN)
+  #endif
+  #if defined(STAT_LED_BLUE_PIN) && STAT_LED_BLUE_PIN > -1
+    PIN_SAY(STAT_LED_BLUE_PIN)
+  #endif
+  #if defined(STAT_LED_RED_PIN) && STAT_LED_RED_PIN > -1
+    PIN_SAY(STAT_LED_RED_PIN)
+  #endif
+  #if defined(STEPPER_RESET_PIN) && STEPPER_RESET_PIN > -1
+    PIN_SAY(STEPPER_RESET_PIN)
+  #endif
+  #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
+    PIN_SAY(SUICIDE_PIN)
+  #endif
+  #if defined(TC1) && TC1 > -1
+    ANALOG_PIN_SAY(TC1)
+  #endif
+  #if defined(TC2) && TC2 > -1
+    ANALOG_PIN_SAY(TC2)
+  #endif
+  #if defined(TEMP_0_PIN) && TEMP_0_PIN > -1
+    ANALOG_PIN_SAY(TEMP_0_PIN)
+  #endif
+  #if defined(TEMP_1_PIN) && TEMP_1_PIN > -1
+    ANALOG_PIN_SAY(TEMP_1_PIN)
+  #endif
+  #if defined(TEMP_2_PIN) && TEMP_2_PIN > -1
+    ANALOG_PIN_SAY(TEMP_2_PIN)
+  #endif
+  #if defined(TEMP_3_PIN) && TEMP_3_PIN > -1
+    ANALOG_PIN_SAY(TEMP_3_PIN)
+  #endif
+  #if defined(TEMP_4_PIN) && TEMP_4_PIN > -1
+    ANALOG_PIN_SAY(TEMP_4_PIN)
+  #endif
+  #if defined(TEMP_BED_PIN) && TEMP_BED_PIN > -1
+    ANALOG_PIN_SAY(TEMP_BED_PIN)
+  #endif
+  #if defined(TEMP_X_PIN) && TEMP_X_PIN > -1
+    ANALOG_PIN_SAY(TEMP_X_PIN)
+  #endif
+  #if defined(TLC_BLANK_BIT) && TLC_BLANK_BIT > -1
+    PIN_SAY(TLC_BLANK_BIT)
+  #endif
+  #if defined(TLC_BLANK_PIN) && TLC_BLANK_PIN > -1
+    PIN_SAY(TLC_BLANK_PIN)
+  #endif
+  #if defined(TLC_CLOCK_BIT) && TLC_CLOCK_BIT > -1
+    PIN_SAY(TLC_CLOCK_BIT)
+  #endif
+  #if defined(TLC_CLOCK_PIN) && TLC_CLOCK_PIN > -1
+    PIN_SAY(TLC_CLOCK_PIN)
+  #endif
+  #if defined(TLC_DATA_BIT) && TLC_DATA_BIT > -1
+    PIN_SAY(TLC_DATA_BIT)
+  #endif
+  #if defined(TLC_DATA_PIN) && TLC_DATA_PIN > -1
+    PIN_SAY(TLC_DATA_PIN)
+  #endif
+  #if defined(TLC_XLAT_PIN) && TLC_XLAT_PIN > -1
+    PIN_SAY(TLC_XLAT_PIN)
+  #endif
+  #if defined(TX_ENABLE_PIN) && TX_ENABLE_PIN > -1
+    PIN_SAY(TX_ENABLE_PIN)
+  #endif
+  #if defined(UNUSED_PWM) && UNUSED_PWM > -1
+    PIN_SAY(UNUSED_PWM)
+  #endif
+  #if defined(X_ATT_PIN) && X_ATT_PIN > -1
+    PIN_SAY(X_ATT_PIN)
+  #endif
+  #if defined(X_DIR_PIN) && X_DIR_PIN > -1
+    PIN_SAY(X_DIR_PIN)
+  #endif
+  #if defined(X_ENABLE_PIN) && X_ENABLE_PIN > -1
+    PIN_SAY(X_ENABLE_PIN)
+  #endif
+  #if defined(X_MAX_PIN) && X_MAX_PIN > -1
+    PIN_SAY(X_MAX_PIN)
+  #endif
+  #if defined(X_MIN_PIN) && X_MIN_PIN > -1
+    PIN_SAY(X_MIN_PIN)
+  #endif
+  #if defined(X_MS1_PIN) && X_MS1_PIN > -1
+    PIN_SAY(X_MS1_PIN)
+  #endif
+  #if defined(X_MS2_PIN) && X_MS2_PIN > -1
+    PIN_SAY(X_MS2_PIN)
+  #endif
+  #if defined(X_STEP_PIN) && X_STEP_PIN > -1
+    PIN_SAY(X_STEP_PIN)
+  #endif
+  #if defined(X_STOP_PIN) && X_STOP_PIN > -1
+    PIN_SAY(X_STOP_PIN)
+  #endif
+  #if defined(X2_DIR_PIN) && X2_DIR_PIN > -1
+    PIN_SAY(X2_DIR_PIN)
+  #endif
+  #if defined(X2_ENABLE_PIN) && X2_ENABLE_PIN > -1
+    PIN_SAY(X2_ENABLE_PIN)
+  #endif
+  #if defined(X2_STEP_PIN) && X2_STEP_PIN > -1
+    PIN_SAY(X2_STEP_PIN)
+  #endif
+  #if defined(Y_ATT_PIN) && Y_ATT_PIN > -1
+    PIN_SAY(Y_ATT_PIN)
+  #endif
+  #if defined(Y_DIR_PIN) && Y_DIR_PIN > -1
+    PIN_SAY(Y_DIR_PIN)
+  #endif
+  #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
+    PIN_SAY(Y_ENABLE_PIN)
+  #endif
+  #if defined(Y_MAX_PIN) && Y_MAX_PIN > -1
+    PIN_SAY(Y_MAX_PIN)
+  #endif
+  #if defined(Y_MIN_PIN) && Y_MIN_PIN > -1
+    PIN_SAY(Y_MIN_PIN)
+  #endif
+  #if defined(Y_MS1_PIN) && Y_MS1_PIN > -1
+    PIN_SAY(Y_MS1_PIN)
+  #endif
+  #if defined(Y_MS2_PIN) && Y_MS2_PIN > -1
+    PIN_SAY(Y_MS2_PIN)
+  #endif
+  #if defined(Y_STEP_PIN) && Y_STEP_PIN > -1
+    PIN_SAY(Y_STEP_PIN)
+  #endif
+  #if defined(Y_STOP_PIN) && Y_STOP_PIN > -1
+    PIN_SAY(Y_STOP_PIN)
+  #endif
+  #if defined(Y2_DIR_PIN) && Y2_DIR_PIN > -1
+    PIN_SAY(Y2_DIR_PIN)
+  #endif
+  #if defined(Y2_ENABLE_PIN) && Y2_ENABLE_PIN > -1
+    PIN_SAY(Y2_ENABLE_PIN)
+  #endif
+  #if defined(Y2_STEP_PIN) && Y2_STEP_PIN > -1
+    PIN_SAY(Y2_STEP_PIN)
+  #endif
+  #if defined(Z_ATT_PIN) && Z_ATT_PIN > -1
+    PIN_SAY(Z_ATT_PIN)
+  #endif
+  #if defined(Z_DIR_PIN) && Z_DIR_PIN > -1
+    PIN_SAY(Z_DIR_PIN)
+  #endif
+  #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
+    PIN_SAY(Z_ENABLE_PIN)
+  #endif
+  #if defined(Z_MAX_PIN) && Z_MAX_PIN > -1
+    PIN_SAY(Z_MAX_PIN)
+  #endif
+  #if defined(Z_MIN_PIN) && Z_MIN_PIN > -1
+    PIN_SAY(Z_MIN_PIN)
+  #endif
+  #if defined(Z_MIN_PROBE_PIN) && Z_MIN_PROBE_PIN > -1
+    PIN_SAY(Z_MIN_PROBE_PIN)
+  #endif
+  #if defined(Z_MS1_PIN) && Z_MS1_PIN > -1
+    PIN_SAY(Z_MS1_PIN)
+  #endif
+  #if defined(Z_MS2_PIN) && Z_MS2_PIN > -1
+    PIN_SAY(Z_MS2_PIN)
+  #endif
+  #if defined(Z_STEP_PIN) && Z_STEP_PIN > -1
+    PIN_SAY(Z_STEP_PIN)
+  #endif
+  #if defined(Z_STOP_PIN) && Z_STOP_PIN > -1
+    PIN_SAY(Z_STOP_PIN)
+  #endif
+  #if defined(Z2_DIR_PIN) && Z2_DIR_PIN > -1
+    PIN_SAY(Z2_DIR_PIN)
+  #endif
+  #if defined(Z2_ENABLE_PIN) && Z2_ENABLE_PIN > -1
+    PIN_SAY(Z2_ENABLE_PIN)
+  #endif
+  #if defined(Z2_STEP_PIN) && Z2_STEP_PIN > -1
+    PIN_SAY(Z2_STEP_PIN)
   #endif
 
-  #if PIN_EXISTS(RAMPS_D8)
-    PIN_SAY(RAMPS_D8_PIN);
-  #endif
-  #if PIN_EXISTS(RAMPS_D9)
-    PIN_SAY(RAMPS_D9_PIN);
-  #endif
-  #if PIN_EXISTS(RAMPS_D10)
-    PIN_SAY(RAMPS_D10_PIN);
-  #endif
-  #if PIN_EXISTS(MOSFET_D)
-    PIN_SAY(MOSFET_D_PIN);
-  #endif
-
-  #if PIN_EXISTS(TX_ENABLE)
-    PIN_SAY(TX_ENABLE_PIN);
-  #endif
-  #if PIN_EXISTS(RX_ENABLE)
-    PIN_SAY(RX_ENABLE_PIN);
-  #endif
 
   SERIAL_ECHOPGM("<unused>");
   return false;

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -34,8 +34,8 @@
 #endif
 
 #define _PIN_SAY(NAME) { SERIAL_ECHOPGM(STRINGIFY(NAME)); return true; }
-#define PIN_SAY(NAME) if (pin == NAME) _PIN_SAY(_##NAME##_);
-#define ANALOG_PIN_SAY(NAME) if (pin == analogInputToDigitalPin(NAME)) _PIN_SAY(_##NAME##_);
+#define PIN_SAY(NAME) if (pin == NAME) _PIN_SAY(_##NAME##_)
+#define ANALOG_PIN_SAY(NAME) if (pin == analogInputToDigitalPin(NAME)) _PIN_SAY(_##NAME##_)
 #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && ((P) <= analogInputToDigitalPin(15) || (P) <= analogInputToDigitalPin(5)))
 
 // Report pin name for a given fastio digital pin index
@@ -56,598 +56,600 @@ static bool report_pin_name(int8_t pin) {
   #if defined(TXD) && TXD > -1
     if (pin == 1) { SERIAL_ECHOPGM("TXD"); return true; }
   #endif
-
+  
   #if defined(__FD) && __FD > -1   // Pin list updated from 7 OCT RCBugfix branch
-    PIN_SAY(__FD)
+    PIN_SAY(__FD);
   #endif
   #if defined(__FS) && __FS > -1
-    PIN_SAY(__FS)
+    PIN_SAY(__FS);
   #endif
   #if defined(__GD) && __GD > -1
-    PIN_SAY(__GD)
+    PIN_SAY(__GD);
   #endif
   #if defined(__GS) && __GS > -1
-    PIN_SAY(__GS)
+    PIN_SAY(__GS);
   #endif
-  #if defined(AVR_MISO_PIN) && AVR_MISO_PIN > -1
-    PIN_SAY(AVR_MISO_PIN)
+  #if PIN_EXISTS(AVR_MISO)
+    PIN_SAY(AVR_MISO_PIN);
   #endif
-  #if defined(AVR_MOSI_PIN) && AVR_MOSI_PIN > -1
-    PIN_SAY(AVR_MOSI_PIN)
+  #if PIN_EXISTS(AVR_MOSI)
+    PIN_SAY(AVR_MOSI_PIN);
   #endif
-  #if defined(AVR_SCK_PIN) && AVR_SCK_PIN > -1
-    PIN_SAY(AVR_SCK_PIN)
+  #if PIN_EXISTS(AVR_SCK)
+    PIN_SAY(AVR_SCK_PIN);
   #endif
-  #if defined(AVR_SS_PIN) && AVR_SS_PIN > -1
-    PIN_SAY(AVR_SS_PIN)
+  #if PIN_EXISTS(AVR_SS)
+    PIN_SAY(AVR_SS_PIN);
   #endif
-  #if defined(BEEPER_PIN) && BEEPER_PIN > -1
-    PIN_SAY(BEEPER_PIN)
+  #if PIN_EXISTS(BEEPER)
+    PIN_SAY(BEEPER_PIN);
   #endif
   #if defined(BTN_CENTER) && BTN_CENTER > -1
-    PIN_SAY(BTN_CENTER)
+    PIN_SAY(BTN_CENTER);
   #endif
   #if defined(BTN_DOWN) && BTN_DOWN > -1
-    PIN_SAY(BTN_DOWN)
+    PIN_SAY(BTN_DOWN);
   #endif
   #if defined(BTN_DWN) && BTN_DWN > -1
-    PIN_SAY(BTN_DWN)
+    PIN_SAY(BTN_DWN);
   #endif
   #if defined(BTN_EN1) && BTN_EN1 > -1
-    PIN_SAY(BTN_EN1)
+    PIN_SAY(BTN_EN1);
   #endif
   #if defined(BTN_EN2) && BTN_EN2 > -1
-    PIN_SAY(BTN_EN2)
+    PIN_SAY(BTN_EN2);
   #endif
   #if defined(BTN_ENC) && BTN_ENC > -1
-    PIN_SAY(BTN_ENC)
+    PIN_SAY(BTN_ENC);
   #endif
   #if defined(BTN_HOME) && BTN_HOME > -1
-    PIN_SAY(BTN_HOME)
+    PIN_SAY(BTN_HOME);
   #endif
   #if defined(BTN_LEFT) && BTN_LEFT > -1
-    PIN_SAY(BTN_LEFT)
+    PIN_SAY(BTN_LEFT);
   #endif
   #if defined(BTN_LFT) && BTN_LFT > -1
-    PIN_SAY(BTN_LFT)
+    PIN_SAY(BTN_LFT);
   #endif
   #if defined(BTN_RIGHT) && BTN_RIGHT > -1
-    PIN_SAY(BTN_RIGHT)
+    PIN_SAY(BTN_RIGHT);
   #endif
   #if defined(BTN_RT) && BTN_RT > -1
-    PIN_SAY(BTN_RT)
+    PIN_SAY(BTN_RT);
   #endif
   #if defined(BTN_UP) && BTN_UP > -1
-    PIN_SAY(BTN_UP)
+    PIN_SAY(BTN_UP);
   #endif
-  #if defined(CONTROLLERFAN_PIN) && CONTROLLERFAN_PIN > -1
-    PIN_SAY(CONTROLLERFAN_PIN)
+  #if PIN_EXISTS(CONTROLLERFAN)
+    PIN_SAY(CONTROLLERFAN_PIN);
   #endif
-  #if defined(DAC_DISABLE_PIN) && DAC_DISABLE_PIN > -1
-    PIN_SAY(DAC_DISABLE_PIN)
+  #if PIN_EXISTS(DAC_DISABLE)
+    PIN_SAY(DAC_DISABLE_PIN);
   #endif
   #if defined(DAC_STEPPER_GAIN) && DAC_STEPPER_GAIN > -1
-    PIN_SAY(DAC_STEPPER_GAIN)
+    PIN_SAY(DAC_STEPPER_GAIN);
   #endif
   #if defined(DAC_STEPPER_VREF) && DAC_STEPPER_VREF > -1
-    PIN_SAY(DAC_STEPPER_VREF)
+    PIN_SAY(DAC_STEPPER_VREF);
   #endif
-  #if defined(DEBUG_PIN) && DEBUG_PIN > -1
-    PIN_SAY(DEBUG_PIN)
+  #if PIN_EXISTS(DEBUG)
+    PIN_SAY(DEBUG_PIN);
   #endif
-  #if defined(DIGIPOTSS_PIN) && DIGIPOTSS_PIN > -1
-    PIN_SAY(DIGIPOTSS_PIN)
+  #if PIN_EXISTS(DIGIPOTSS)
+    PIN_SAY(DIGIPOTSS_PIN);
   #endif
   #if defined(DIO_COUNT) && DIO_COUNT > -1
-    PIN_SAY(DIO_COUNT)
+    PIN_SAY(DIO_COUNT);
   #endif
   #if defined(DOGLCD_A0) && DOGLCD_A0 > -1
-    PIN_SAY(DOGLCD_A0)
+    PIN_SAY(DOGLCD_A0);
   #endif
   #if defined(DOGLCD_CS) && DOGLCD_CS > -1
-    PIN_SAY(DOGLCD_CS)
+    PIN_SAY(DOGLCD_CS);
   #endif
   #if defined(DOGLCD_MOSI) && DOGLCD_MOSI > -1
-    PIN_SAY(DOGLCD_MOSI)
+    PIN_SAY(DOGLCD_MOSI);
   #endif
   #if defined(DOGLCD_SCK) && DOGLCD_SCK > -1
-    PIN_SAY(DOGLCD_SCK)
+    PIN_SAY(DOGLCD_SCK);
   #endif
-  #if defined(E0_ATT_PIN) && E0_ATT_PIN > -1
-    PIN_SAY(E0_ATT_PIN)
+  #if PIN_EXISTS(E0_ATT)
+    PIN_SAY(E0_ATT_PIN);
   #endif
-  #if defined(E0_DIR_PIN) && E0_DIR_PIN > -1
-    PIN_SAY(E0_DIR_PIN)
+  #if PIN_EXISTS(E0_DIR)
+    PIN_SAY(E0_DIR_PIN);
   #endif
-  #if defined(E0_ENABLE_PIN) && E0_ENABLE_PIN > -1
-    PIN_SAY(E0_ENABLE_PIN)
+  #if PIN_EXISTS(E0_ENABLE)
+    PIN_SAY(E0_ENABLE_PIN);
   #endif
-  #if defined(E0_MS1_PIN) && E0_MS1_PIN > -1
-    PIN_SAY(E0_MS1_PIN)
+  #if PIN_EXISTS(E0_MS1)
+    PIN_SAY(E0_MS1_PIN);
   #endif
-  #if defined(E0_MS2_PIN) && E0_MS2_PIN > -1
-    PIN_SAY(E0_MS2_PIN)
+  #if PIN_EXISTS(E0_MS2)
+    PIN_SAY(E0_MS2_PIN);
   #endif
-  #if defined(E0_STEP_PIN) && E0_STEP_PIN > -1
-    PIN_SAY(E0_STEP_PIN)
+  #if PIN_EXISTS(E0_STEP)
+    PIN_SAY(E0_STEP_PIN);
   #endif
-  #if defined(E1_DIR_PIN) && E1_DIR_PIN > -1
-    PIN_SAY(E1_DIR_PIN)
+  #if PIN_EXISTS(E1_DIR)
+    PIN_SAY(E1_DIR_PIN);
   #endif
-  #if defined(E1_ENABLE_PIN) && E1_ENABLE_PIN > -1
-    PIN_SAY(E1_ENABLE_PIN)
+  #if PIN_EXISTS(E1_ENABLE)
+    PIN_SAY(E1_ENABLE_PIN);
   #endif
-  #if defined(E1_MS1_PIN) && E1_MS1_PIN > -1
-    PIN_SAY(E1_MS1_PIN)
+  #if PIN_EXISTS(E1_MS1)
+    PIN_SAY(E1_MS1_PIN);
   #endif
-  #if defined(E1_MS2_PIN) && E1_MS2_PIN > -1
-    PIN_SAY(E1_MS2_PIN)
+  #if PIN_EXISTS(E1_MS2)
+    PIN_SAY(E1_MS2_PIN);
   #endif
-  #if defined(E1_STEP_PIN) && E1_STEP_PIN > -1
-    PIN_SAY(E1_STEP_PIN)
+  #if PIN_EXISTS(E1_STEP)
+    PIN_SAY(E1_STEP_PIN);
   #endif
-  #if defined(E2_DIR_PIN) && E2_DIR_PIN > -1
-    PIN_SAY(E2_DIR_PIN)
+  #if PIN_EXISTS(E2_DIR)
+    PIN_SAY(E2_DIR_PIN);
   #endif
-  #if defined(E2_ENABLE_PIN) && E2_ENABLE_PIN > -1
-    PIN_SAY(E2_ENABLE_PIN)
+  #if PIN_EXISTS(E2_ENABLE)
+    PIN_SAY(E2_ENABLE_PIN);
   #endif
-  #if defined(E2_STEP_PIN) && E2_STEP_PIN > -1
-    PIN_SAY(E2_STEP_PIN)
+  #if PIN_EXISTS(E2_STEP)
+    PIN_SAY(E2_STEP_PIN);
   #endif
-  #if defined(E3_DIR_PIN) && E3_DIR_PIN > -1
-    PIN_SAY(E3_DIR_PIN)
+  #if PIN_EXISTS(E3_DIR)
+    PIN_SAY(E3_DIR_PIN);
   #endif
-  #if defined(E3_ENABLE_PIN) && E3_ENABLE_PIN > -1
-    PIN_SAY(E3_ENABLE_PIN)
+  #if PIN_EXISTS(E3_ENABLE)
+    PIN_SAY(E3_ENABLE_PIN);
   #endif
-  #if defined(E3_STEP_PIN) && E3_STEP_PIN > -1
-    PIN_SAY(E3_STEP_PIN)
+  #if PIN_EXISTS(E3_STEP)
+    PIN_SAY(E3_STEP_PIN);
   #endif
-  #if defined(E4_DIR_PIN) && E4_DIR_PIN > -1
-    PIN_SAY(E4_DIR_PIN)
+  #if PIN_EXISTS(E4_DIR)
+    PIN_SAY(E4_DIR_PIN);
   #endif
-  #if defined(E4_ENABLE_PIN) && E4_ENABLE_PIN > -1
-    PIN_SAY(E4_ENABLE_PIN)
+  #if PIN_EXISTS(E4_ENABLE)
+    PIN_SAY(E4_ENABLE_PIN);
   #endif
-  #if defined(E4_STEP_PIN) && E4_STEP_PIN > -1
-    PIN_SAY(E4_STEP_PIN)
+  #if PIN_EXISTS(E4_STEP)
+    PIN_SAY(E4_STEP_PIN);
   #endif
   #if defined(encrot1) && encrot1 > -1
-    PIN_SAY(encrot1)
+    PIN_SAY(encrot1);
   #endif
   #if defined(encrot2) && encrot2 > -1
-    PIN_SAY(encrot2)
+    PIN_SAY(encrot2);
   #endif
   #if defined(encrot3) && encrot3 > -1
-    PIN_SAY(encrot3)
+    PIN_SAY(encrot3);
   #endif
   #if defined(EXT_AUX_A0_IO) && EXT_AUX_A0_IO > -1
-    PIN_SAY(EXT_AUX_A0_IO)
+    PIN_SAY(EXT_AUX_A0_IO);
   #endif
   #if defined(EXT_AUX_A1) && EXT_AUX_A1 > -1
-    PIN_SAY(EXT_AUX_A1)
+    PIN_SAY(EXT_AUX_A1);
   #endif
   #if defined(EXT_AUX_A1_IO) && EXT_AUX_A1_IO > -1
-    PIN_SAY(EXT_AUX_A1_IO)
+    PIN_SAY(EXT_AUX_A1_IO);
   #endif
   #if defined(EXT_AUX_A2) && EXT_AUX_A2 > -1
-    PIN_SAY(EXT_AUX_A2)
+    PIN_SAY(EXT_AUX_A2);
   #endif
   #if defined(EXT_AUX_A2_IO) && EXT_AUX_A2_IO > -1
-    PIN_SAY(EXT_AUX_A2_IO)
+    PIN_SAY(EXT_AUX_A2_IO);
   #endif
   #if defined(EXT_AUX_A3) && EXT_AUX_A3 > -1
-    PIN_SAY(EXT_AUX_A3)
+    PIN_SAY(EXT_AUX_A3);
   #endif
   #if defined(EXT_AUX_A3_IO) && EXT_AUX_A3_IO > -1
-    PIN_SAY(EXT_AUX_A3_IO)
+    PIN_SAY(EXT_AUX_A3_IO);
   #endif
   #if defined(EXT_AUX_A4) && EXT_AUX_A4 > -1
-    PIN_SAY(EXT_AUX_A4)
+    PIN_SAY(EXT_AUX_A4);
   #endif
   #if defined(EXT_AUX_A4_IO) && EXT_AUX_A4_IO > -1
-    PIN_SAY(EXT_AUX_A4_IO)
+    PIN_SAY(EXT_AUX_A4_IO);
   #endif
   #if defined(EXT_AUX_PWM_D24) && EXT_AUX_PWM_D24 > -1
-    PIN_SAY(EXT_AUX_PWM_D24)
+    PIN_SAY(EXT_AUX_PWM_D24);
   #endif
   #if defined(EXT_AUX_RX1_D2) && EXT_AUX_RX1_D2 > -1
-    PIN_SAY(EXT_AUX_RX1_D2)
+    PIN_SAY(EXT_AUX_RX1_D2);
   #endif
   #if defined(EXT_AUX_SDA_D1) && EXT_AUX_SDA_D1 > -1
-    PIN_SAY(EXT_AUX_SDA_D1)
+    PIN_SAY(EXT_AUX_SDA_D1);
   #endif
   #if defined(EXT_AUX_TX1_D3) && EXT_AUX_TX1_D3 > -1
-    PIN_SAY(EXT_AUX_TX1_D3)
+    PIN_SAY(EXT_AUX_TX1_D3);
   #endif
-  #if defined(EXTRUDER_0_AUTO_FAN_PIN) && EXTRUDER_0_AUTO_FAN_PIN > -1
-    PIN_SAY(EXTRUDER_0_AUTO_FAN_PIN)
+  #if PIN_EXISTS(EXTRUDER_0_AUTO_FAN)
+    PIN_SAY(EXTRUDER_0_AUTO_FAN_PIN);
   #endif
-  #if defined(EXTRUDER_1_AUTO_FAN_PIN) && EXTRUDER_1_AUTO_FAN_PIN > -1
-    PIN_SAY(EXTRUDER_1_AUTO_FAN_PIN)
+  #if PIN_EXISTS(EXTRUDER_1_AUTO_FAN)
+    PIN_SAY(EXTRUDER_1_AUTO_FAN_PIN);
   #endif
-  #if defined(EXTRUDER_2_AUTO_FAN_PIN) && EXTRUDER_2_AUTO_FAN_PIN > -1
-    PIN_SAY(EXTRUDER_2_AUTO_FAN_PIN)
+  #if PIN_EXISTS(EXTRUDER_2_AUTO_FAN)
+    PIN_SAY(EXTRUDER_2_AUTO_FAN_PIN);
   #endif
-  #if defined(EXTRUDER_3_AUTO_FAN_PIN) && EXTRUDER_3_AUTO_FAN_PIN > -1
-    PIN_SAY(EXTRUDER_3_AUTO_FAN_PIN)
+  #if PIN_EXISTS(EXTRUDER_3_AUTO_FAN)
+    PIN_SAY(EXTRUDER_3_AUTO_FAN_PIN);
   #endif
-  #if defined(FAN_PIN) && FAN_PIN > -1
-    PIN_SAY(FAN_PIN)
+  #if PIN_EXISTS(FAN)
+    PIN_SAY(FAN_PIN);
   #endif
-  #if defined(FAN0_PIN) && FAN0_PIN > -1
-    PIN_SAY(FAN0_PIN)
+  #if PIN_EXISTS(FAN0)
+    PIN_SAY(FAN0_PIN);
   #endif
-  #if defined(FAN1_PIN) && FAN1_PIN > -1
-    PIN_SAY(FAN1_PIN)
+  #if PIN_EXISTS(FAN1)
+    PIN_SAY(FAN1_PIN);
   #endif
-  #if defined(FAN2_PIN) && FAN2_PIN > -1
-    PIN_SAY(FAN2_PIN)
+  #if PIN_EXISTS(FAN2)
+    PIN_SAY(FAN2_PIN);
   #endif
-  #if defined(FIL_RUNOUT_PIN) && FIL_RUNOUT_PIN > -1
-    PIN_SAY(FIL_RUNOUT_PIN)
+  #if PIN_EXISTS(FIL_RUNOUT)
+    PIN_SAY(FIL_RUNOUT_PIN);
   #endif
-  #if defined(FILWIDTH_PIN) && FILWIDTH_PIN > -1
-    ANALOG_PIN_SAY(FILWIDTH_PIN)
+  #if PIN_EXISTS(FILWIDTH)
+    ANALOG_PIN_SAY(FILWIDTH_PIN);
   #endif
   #if defined(GEN7_VERSION) && GEN7_VERSION > -1
-    PIN_SAY(GEN7_VERSION)
+    PIN_SAY(GEN7_VERSION);
   #endif
-  #if defined(HEATER_0_PIN) && HEATER_0_PIN > -1
-    PIN_SAY(HEATER_0_PIN)
+  #if PIN_EXISTS(HEATER_0)
+    PIN_SAY(HEATER_0_PIN);
   #endif
-  #if defined(HEATER_1_PIN) && HEATER_1_PIN > -1
-    PIN_SAY(HEATER_1_PIN)
+  #if PIN_EXISTS(HEATER_1)
+    PIN_SAY(HEATER_1_PIN);
   #endif
-  #if defined(HEATER_2_PIN) && HEATER_2_PIN > -1
-    PIN_SAY(HEATER_2_PIN)
+  #if PIN_EXISTS(HEATER_2)
+    PIN_SAY(HEATER_2_PIN);
   #endif
-  #if defined(HEATER_3_PIN) && HEATER_3_PIN > -1
-    PIN_SAY(HEATER_3_PIN)
+  #if PIN_EXISTS(HEATER_3)
+    PIN_SAY(HEATER_3_PIN);
   #endif
-  #if defined(HEATER_4_PIN) && HEATER_4_PIN > -1
-    PIN_SAY(HEATER_4_PIN)
+  #if PIN_EXISTS(HEATER_4)
+    PIN_SAY(HEATER_4_PIN);
   #endif
-  #if defined(HEATER_5_PIN) && HEATER_5_PIN > -1
-    PIN_SAY(HEATER_5_PIN)
+  #if PIN_EXISTS(HEATER_5)
+    PIN_SAY(HEATER_5_PIN);
   #endif
-  #if defined(HEATER_6_PIN) && HEATER_6_PIN > -1
-    PIN_SAY(HEATER_6_PIN)
+  #if PIN_EXISTS(HEATER_6)
+    PIN_SAY(HEATER_6_PIN);
   #endif
-  #if defined(HEATER_7_PIN) && HEATER_7_PIN > -1
-    PIN_SAY(HEATER_7_PIN)
+  #if PIN_EXISTS(HEATER_7)
+    PIN_SAY(HEATER_7_PIN);
   #endif
-  #if defined(HEATER_BED_PIN) && HEATER_BED_PIN > -1
-    PIN_SAY(HEATER_BED_PIN)
+  #if PIN_EXISTS(HEATER_BED)
+    PIN_SAY(HEATER_BED_PIN);
   #endif
   #if defined(I2C_SCL) && I2C_SCL > -1
-    PIN_SAY(I2C_SCL)
+    PIN_SAY(I2C_SCL);
   #endif
   #if defined(I2C_SDA) && I2C_SDA > -1
-    PIN_SAY(I2C_SDA)
+    PIN_SAY(I2C_SDA);
   #endif
-  #if defined(KILL_PIN) && KILL_PIN > -1
-    PIN_SAY(KILL_PIN)
+  #if PIN_EXISTS(KILL)
+    PIN_SAY(KILL_PIN);
   #endif
-  #if defined(LCD_BACKLIGHT_PIN) && LCD_BACKLIGHT_PIN > -1
-    PIN_SAY(LCD_BACKLIGHT_PIN)
+  #if PIN_EXISTS(LCD_BACKLIGHT)
+    PIN_SAY(LCD_BACKLIGHT_PIN);
   #endif
   #if defined(LCD_CONTRAST) && LCD_CONTRAST > -1
-    PIN_SAY(LCD_CONTRAST)
+    PIN_SAY(LCD_CONTRAST);
   #endif
   #if defined(LCD_PINS_D4) && LCD_PINS_D4 > -1
-    PIN_SAY(LCD_PINS_D4)
+    PIN_SAY(LCD_PINS_D4);
   #endif
   #if defined(LCD_PINS_D5) && LCD_PINS_D5 > -1
-    PIN_SAY(LCD_PINS_D5)
+    PIN_SAY(LCD_PINS_D5);
   #endif
   #if defined(LCD_PINS_D6) && LCD_PINS_D6 > -1
-    PIN_SAY(LCD_PINS_D6)
+    PIN_SAY(LCD_PINS_D6);
   #endif
   #if defined(LCD_PINS_D7) && LCD_PINS_D7 > -1
-    PIN_SAY(LCD_PINS_D7)
+    PIN_SAY(LCD_PINS_D7);
   #endif
   #if defined(LCD_PINS_ENABLE) && LCD_PINS_ENABLE > -1
-    PIN_SAY(LCD_PINS_ENABLE)
+    PIN_SAY(LCD_PINS_ENABLE);
   #endif
   #if defined(LCD_PINS_RS) && LCD_PINS_RS > -1
-    PIN_SAY(LCD_PINS_RS)
+    PIN_SAY(LCD_PINS_RS);
   #endif
   #if defined(LCD_SDSS) && LCD_SDSS > -1
-    PIN_SAY(LCD_SDSS)
+    PIN_SAY(LCD_SDSS);
   #endif
-  #if defined(LED_PIN) && LED_PIN > -1
-    PIN_SAY(LED_PIN)
+  #if PIN_EXISTS(LED)
+    PIN_SAY(LED_PIN);
   #endif
-  #if defined(MAIN_VOLTAGE_MEASURE_PIN) && MAIN_VOLTAGE_MEASURE_PIN > -1
-    PIN_SAY(MAIN_VOLTAGE_MEASURE_PIN)
+  #if PIN_EXISTS(MAIN_VOLTAGE_MEASURE)
+    PIN_SAY(MAIN_VOLTAGE_MEASURE_PIN);
   #endif
   #if defined(MAX6675_SS) && MAX6675_SS > -1
-    PIN_SAY(MAX6675_SS)
+    PIN_SAY(MAX6675_SS);
   #endif
-  #if defined(MISO_PIN) && MISO_PIN > -1
-    PIN_SAY(MISO_PIN)
+  #if PIN_EXISTS(MISO)
+    PIN_SAY(MISO_PIN);
   #endif
-  #if defined(MOSFET_D_PIN) && MOSFET_D_PIN > -1
-    PIN_SAY(MOSFET_D_PIN)
+  #if PIN_EXISTS(MOSFET_D)
+    PIN_SAY(MOSFET_D_PIN);
   #endif
-  #if defined(MOSI_PIN) && MOSI_PIN > -1
-    PIN_SAY(MOSI_PIN)
+  #if PIN_EXISTS(MOSI)
+    PIN_SAY(MOSI_PIN);
   #endif
-  #if defined(MOTOR_CURRENT_PWM_E_PIN) && MOTOR_CURRENT_PWM_E_PIN > -1
-    PIN_SAY(MOTOR_CURRENT_PWM_E_PIN)
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
+    PIN_SAY(MOTOR_CURRENT_PWM_E_PIN);
   #endif
-  #if defined(MOTOR_CURRENT_PWM_XY_PIN) && MOTOR_CURRENT_PWM_XY_PIN > -1
-    PIN_SAY(MOTOR_CURRENT_PWM_XY_PIN)
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
+    PIN_SAY(MOTOR_CURRENT_PWM_XY_PIN);
   #endif
-  #if defined(MOTOR_CURRENT_PWM_Z_PIN) && MOTOR_CURRENT_PWM_Z_PIN > -1
-    PIN_SAY(MOTOR_CURRENT_PWM_Z_PIN)
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
+    PIN_SAY(MOTOR_CURRENT_PWM_Z_PIN);
   #endif
   #if defined(NUM_TLCS) && NUM_TLCS > -1
-    PIN_SAY(NUM_TLCS)
+    PIN_SAY(NUM_TLCS);
   #endif
-  #if defined(PHOTOGRAPH_PIN) && PHOTOGRAPH_PIN > -1
-    PIN_SAY(PHOTOGRAPH_PIN)
+  #if PIN_EXISTS(PHOTOGRAPH)
+    PIN_SAY(PHOTOGRAPH_PIN);
   #endif
-  #if defined(PS_ON_PIN) && PS_ON_PIN > -1
-    PIN_SAY(PS_ON_PIN)
+  #if PIN_EXISTS(PS_ON)
+    PIN_SAY(PS_ON_PIN);
   #endif
-  #if defined(RAMPS_D10_PIN) && RAMPS_D10_PIN > -1
-    PIN_SAY(RAMPS_D10_PIN)
+  #if PIN_EXISTS(RAMPS_D10)
+    PIN_SAY(RAMPS_D10_PIN);
   #endif
-  #if defined(RAMPS_D8_PIN) && RAMPS_D8_PIN > -1
-    PIN_SAY(RAMPS_D8_PIN)
+  #if PIN_EXISTS(RAMPS_D8)
+    PIN_SAY(RAMPS_D8_PIN);
   #endif
-  #if defined(RAMPS_D9_PIN) && RAMPS_D9_PIN > -1
-    PIN_SAY(RAMPS_D9_PIN)
+  #if PIN_EXISTS(RAMPS_D9)
+    PIN_SAY(RAMPS_D9_PIN);
   #endif
-  #if defined(RX_ENABLE_PIN) && RX_ENABLE_PIN > -1
-    PIN_SAY(RX_ENABLE_PIN)
+  #if PIN_EXISTS(RX_ENABLE)
+    PIN_SAY(RX_ENABLE_PIN);
   #endif
-  #if defined(SAFETY_TRIGGERED_PIN) && SAFETY_TRIGGERED_PIN > -1
-    PIN_SAY(SAFETY_TRIGGERED_PIN)
+  #if PIN_EXISTS(SAFETY_TRIGGERED)
+    PIN_SAY(SAFETY_TRIGGERED_PIN);
   #endif
-  #if defined(SCK_PIN) && SCK_PIN > -1
-    PIN_SAY(SCK_PIN)
+  #if PIN_EXISTS(SCK)
+    PIN_SAY(SCK_PIN);
   #endif
   #if defined(SCL) && SCL > -1
-    PIN_SAY(SCL)
+    PIN_SAY(SCL);
   #endif
-  #if defined(SD_DETECT_PIN) && SD_DETECT_PIN > -1
-    PIN_SAY(SD_DETECT_PIN)
+  #if PIN_EXISTS(SD_DETECT)
+    PIN_SAY(SD_DETECT_PIN);
   #endif
   #if defined(SDA) && SDA > -1
-    PIN_SAY(SDA)
+    PIN_SAY(SDA);
   #endif
   #if defined(SDPOWER) && SDPOWER > -1
-    PIN_SAY(SDPOWER)
+    PIN_SAY(SDPOWER);
   #endif
   #if defined(SDSS) && SDSS > -1
-    PIN_SAY(SDSS)
+    PIN_SAY(SDSS);
   #endif
-  #if defined(SERVO0_PIN) && SERVO0_PIN > -1
-    PIN_SAY(SERVO0_PIN)
+  #if PIN_EXISTS(SERVO0)
+    PIN_SAY(SERVO0_PIN);
   #endif
-  #if defined(SERVO1_PIN) && SERVO1_PIN > -1
-    PIN_SAY(SERVO1_PIN)
+  #if PIN_EXISTS(SERVO1)
+    PIN_SAY(SERVO1_PIN);
   #endif
-  #if defined(SERVO2_PIN) && SERVO2_PIN > -1
-    PIN_SAY(SERVO2_PIN)
+  #if PIN_EXISTS(SERVO2)
+    PIN_SAY(SERVO2_PIN);
   #endif
-  #if defined(SERVO3_PIN) && SERVO3_PIN > -1
-    PIN_SAY(SERVO3_PIN)
+  #if PIN_EXISTS(SERVO3)
+    PIN_SAY(SERVO3_PIN);
   #endif
   #if defined(SHIFT_CLK) && SHIFT_CLK > -1
-    PIN_SAY(SHIFT_CLK)
+    PIN_SAY(SHIFT_CLK);
   #endif
   #if defined(SHIFT_EN) && SHIFT_EN > -1
-    PIN_SAY(SHIFT_EN)
+    PIN_SAY(SHIFT_EN);
   #endif
   #if defined(SHIFT_LD) && SHIFT_LD > -1
-    PIN_SAY(SHIFT_LD)
+    PIN_SAY(SHIFT_LD);
   #endif
   #if defined(SHIFT_OUT) && SHIFT_OUT > -1
-    PIN_SAY(SHIFT_OUT)
+    PIN_SAY(SHIFT_OUT);
   #endif
-  #if defined(SLED_PIN) && SLED_PIN > -1
-    PIN_SAY(SLED_PIN)
+  #if PIN_EXISTS(SLED)
+    PIN_SAY(SLED_PIN);
   #endif
-  #if defined(SLEEP_WAKE_PIN) && SLEEP_WAKE_PIN > -1
-    PIN_SAY(SLEEP_WAKE_PIN)
+  #if PIN_EXISTS(SLEEP_WAKE)
+    PIN_SAY(SLEEP_WAKE_PIN);
   #endif
-  #if defined(SOL1_PIN) && SOL1_PIN > -1
-    PIN_SAY(SOL1_PIN)
+  #if PIN_EXISTS(SOL1)
+    PIN_SAY(SOL1_PIN);
   #endif
-  #if defined(SOL2_PIN) && SOL2_PIN > -1
-    PIN_SAY(SOL2_PIN)
+  #if PIN_EXISTS(SOL2)
+    PIN_SAY(SOL2_PIN);
   #endif
-  #if defined(SPINDLE_ENABLE_PIN) && SPINDLE_ENABLE_PIN > -1
-    PIN_SAY(SPINDLE_ENABLE_PIN)
+  #if PIN_EXISTS(SPINDLE_ENABLE)
+    PIN_SAY(SPINDLE_ENABLE_PIN);
   #endif
-  #if defined(SPINDLE_SPEED_PIN) && SPINDLE_SPEED_PIN > -1
-    PIN_SAY(SPINDLE_SPEED_PIN)
+  #if PIN_EXISTS(SPINDLE_SPEED)
+    PIN_SAY(SPINDLE_SPEED_PIN);
   #endif
-  #if defined(SS_PIN) && SS_PIN > -1
-    PIN_SAY(SS_PIN)
+  #if PIN_EXISTS(SS)
+    PIN_SAY(SS_PIN);
   #endif
-  #if defined(STAT_LED_BLUE_PIN) && STAT_LED_BLUE_PIN > -1
-    PIN_SAY(STAT_LED_BLUE_PIN)
+  #if PIN_EXISTS(STAT_LED_BLUE)
+    PIN_SAY(STAT_LED_BLUE_PIN);
   #endif
-  #if defined(STAT_LED_RED_PIN) && STAT_LED_RED_PIN > -1
-    PIN_SAY(STAT_LED_RED_PIN)
+  #if PIN_EXISTS(STAT_LED_RED)
+    PIN_SAY(STAT_LED_RED_PIN);
   #endif
-  #if defined(STEPPER_RESET_PIN) && STEPPER_RESET_PIN > -1
-    PIN_SAY(STEPPER_RESET_PIN)
+  #if PIN_EXISTS(STEPPER_RESET)
+    PIN_SAY(STEPPER_RESET_PIN);
   #endif
-  #if defined(SUICIDE_PIN) && SUICIDE_PIN > -1
-    PIN_SAY(SUICIDE_PIN)
+  #if PIN_EXISTS(SUICIDE)
+    PIN_SAY(SUICIDE_PIN);
   #endif
   #if defined(TC1) && TC1 > -1
-    ANALOG_PIN_SAY(TC1)
+    ANALOG_PIN_SAY(TC1);
   #endif
   #if defined(TC2) && TC2 > -1
-    ANALOG_PIN_SAY(TC2)
+    ANALOG_PIN_SAY(TC2);
   #endif
-  #if defined(TEMP_0_PIN) && TEMP_0_PIN > -1
-    ANALOG_PIN_SAY(TEMP_0_PIN)
+  #if PIN_EXISTS(TEMP_0)
+    ANALOG_PIN_SAY(TEMP_0_PIN);
   #endif
-  #if defined(TEMP_1_PIN) && TEMP_1_PIN > -1
-    ANALOG_PIN_SAY(TEMP_1_PIN)
+  #if PIN_EXISTS(TEMP_1)
+    ANALOG_PIN_SAY(TEMP_1_PIN);
   #endif
-  #if defined(TEMP_2_PIN) && TEMP_2_PIN > -1
-    ANALOG_PIN_SAY(TEMP_2_PIN)
+  #if PIN_EXISTS(TEMP_2)
+    ANALOG_PIN_SAY(TEMP_2_PIN);
   #endif
-  #if defined(TEMP_3_PIN) && TEMP_3_PIN > -1
-    ANALOG_PIN_SAY(TEMP_3_PIN)
+  #if PIN_EXISTS(TEMP_3)
+    ANALOG_PIN_SAY(TEMP_3_PIN);
   #endif
-  #if defined(TEMP_4_PIN) && TEMP_4_PIN > -1
-    ANALOG_PIN_SAY(TEMP_4_PIN)
+  #if PIN_EXISTS(TEMP_4)
+    ANALOG_PIN_SAY(TEMP_4_PIN);
   #endif
-  #if defined(TEMP_BED_PIN) && TEMP_BED_PIN > -1
-    ANALOG_PIN_SAY(TEMP_BED_PIN)
+  #if PIN_EXISTS(TEMP_BED)
+    ANALOG_PIN_SAY(TEMP_BED_PIN);
   #endif
-  #if defined(TEMP_X_PIN) && TEMP_X_PIN > -1
-    ANALOG_PIN_SAY(TEMP_X_PIN)
+  #if PIN_EXISTS(TEMP_X)
+    ANALOG_PIN_SAY(TEMP_X_PIN);
   #endif
   #if defined(TLC_BLANK_BIT) && TLC_BLANK_BIT > -1
-    PIN_SAY(TLC_BLANK_BIT)
+    PIN_SAY(TLC_BLANK_BIT);
   #endif
-  #if defined(TLC_BLANK_PIN) && TLC_BLANK_PIN > -1
-    PIN_SAY(TLC_BLANK_PIN)
+  #if PIN_EXISTS(TLC_BLANK)
+    PIN_SAY(TLC_BLANK_PIN);
   #endif
   #if defined(TLC_CLOCK_BIT) && TLC_CLOCK_BIT > -1
-    PIN_SAY(TLC_CLOCK_BIT)
+    PIN_SAY(TLC_CLOCK_BIT);
   #endif
-  #if defined(TLC_CLOCK_PIN) && TLC_CLOCK_PIN > -1
-    PIN_SAY(TLC_CLOCK_PIN)
+  #if PIN_EXISTS(TLC_CLOCK)
+    PIN_SAY(TLC_CLOCK_PIN);
   #endif
   #if defined(TLC_DATA_BIT) && TLC_DATA_BIT > -1
-    PIN_SAY(TLC_DATA_BIT)
+    PIN_SAY(TLC_DATA_BIT);
   #endif
-  #if defined(TLC_DATA_PIN) && TLC_DATA_PIN > -1
-    PIN_SAY(TLC_DATA_PIN)
+  #if PIN_EXISTS(TLC_DATA)
+    PIN_SAY(TLC_DATA_PIN);
   #endif
-  #if defined(TLC_XLAT_PIN) && TLC_XLAT_PIN > -1
-    PIN_SAY(TLC_XLAT_PIN)
+  #if PIN_EXISTS(TLC_XLAT)
+    PIN_SAY(TLC_XLAT_PIN);
   #endif
-  #if defined(TX_ENABLE_PIN) && TX_ENABLE_PIN > -1
-    PIN_SAY(TX_ENABLE_PIN)
+  #if PIN_EXISTS(TX_ENABLE)
+    PIN_SAY(TX_ENABLE_PIN);
   #endif
   #if defined(UNUSED_PWM) && UNUSED_PWM > -1
-    PIN_SAY(UNUSED_PWM)
+    PIN_SAY(UNUSED_PWM);
   #endif
-  #if defined(X_ATT_PIN) && X_ATT_PIN > -1
-    PIN_SAY(X_ATT_PIN)
+  #if PIN_EXISTS(X_ATT)
+    PIN_SAY(X_ATT_PIN);
   #endif
-  #if defined(X_DIR_PIN) && X_DIR_PIN > -1
-    PIN_SAY(X_DIR_PIN)
+  #if PIN_EXISTS(X_DIR)
+    PIN_SAY(X_DIR_PIN);
   #endif
-  #if defined(X_ENABLE_PIN) && X_ENABLE_PIN > -1
-    PIN_SAY(X_ENABLE_PIN)
+  #if PIN_EXISTS(X_ENABLE)
+    PIN_SAY(X_ENABLE_PIN);
   #endif
-  #if defined(X_MAX_PIN) && X_MAX_PIN > -1
-    PIN_SAY(X_MAX_PIN)
+  #if PIN_EXISTS(X_MAX)
+    PIN_SAY(X_MAX_PIN);
   #endif
-  #if defined(X_MIN_PIN) && X_MIN_PIN > -1
-    PIN_SAY(X_MIN_PIN)
+  #if PIN_EXISTS(X_MIN)
+    PIN_SAY(X_MIN_PIN);
   #endif
-  #if defined(X_MS1_PIN) && X_MS1_PIN > -1
-    PIN_SAY(X_MS1_PIN)
+  #if PIN_EXISTS(X_MS1)
+    PIN_SAY(X_MS1_PIN);
   #endif
-  #if defined(X_MS2_PIN) && X_MS2_PIN > -1
-    PIN_SAY(X_MS2_PIN)
+  #if PIN_EXISTS(X_MS2)
+    PIN_SAY(X_MS2_PIN);
   #endif
-  #if defined(X_STEP_PIN) && X_STEP_PIN > -1
-    PIN_SAY(X_STEP_PIN)
+  #if PIN_EXISTS(X_STEP)
+    PIN_SAY(X_STEP_PIN);
   #endif
-  #if defined(X_STOP_PIN) && X_STOP_PIN > -1
-    PIN_SAY(X_STOP_PIN)
+  #if PIN_EXISTS(X_STOP)
+    PIN_SAY(X_STOP_PIN);
   #endif
-  #if defined(X2_DIR_PIN) && X2_DIR_PIN > -1
-    PIN_SAY(X2_DIR_PIN)
+  #if PIN_EXISTS(X2_DIR)
+    PIN_SAY(X2_DIR_PIN);
   #endif
-  #if defined(X2_ENABLE_PIN) && X2_ENABLE_PIN > -1
-    PIN_SAY(X2_ENABLE_PIN)
+  #if PIN_EXISTS(X2_ENABLE)
+    PIN_SAY(X2_ENABLE_PIN);
   #endif
-  #if defined(X2_STEP_PIN) && X2_STEP_PIN > -1
-    PIN_SAY(X2_STEP_PIN)
+  #if PIN_EXISTS(X2_STEP)
+    PIN_SAY(X2_STEP_PIN);
   #endif
-  #if defined(Y_ATT_PIN) && Y_ATT_PIN > -1
-    PIN_SAY(Y_ATT_PIN)
+  #if PIN_EXISTS(Y_ATT)
+    PIN_SAY(Y_ATT_PIN);
   #endif
-  #if defined(Y_DIR_PIN) && Y_DIR_PIN > -1
-    PIN_SAY(Y_DIR_PIN)
+  #if PIN_EXISTS(Y_DIR)
+    PIN_SAY(Y_DIR_PIN);
   #endif
-  #if defined(Y_ENABLE_PIN) && Y_ENABLE_PIN > -1
-    PIN_SAY(Y_ENABLE_PIN)
+  #if PIN_EXISTS(Y_ENABLE)
+    PIN_SAY(Y_ENABLE_PIN);
   #endif
-  #if defined(Y_MAX_PIN) && Y_MAX_PIN > -1
-    PIN_SAY(Y_MAX_PIN)
+  #if PIN_EXISTS(Y_MAX)
+    PIN_SAY(Y_MAX_PIN);
   #endif
-  #if defined(Y_MIN_PIN) && Y_MIN_PIN > -1
-    PIN_SAY(Y_MIN_PIN)
+  #if PIN_EXISTS(Y_MIN)
+    PIN_SAY(Y_MIN_PIN);
   #endif
-  #if defined(Y_MS1_PIN) && Y_MS1_PIN > -1
-    PIN_SAY(Y_MS1_PIN)
+  #if PIN_EXISTS(Y_MS1)
+    PIN_SAY(Y_MS1_PIN);
   #endif
-  #if defined(Y_MS2_PIN) && Y_MS2_PIN > -1
-    PIN_SAY(Y_MS2_PIN)
+  #if PIN_EXISTS(Y_MS2)
+    PIN_SAY(Y_MS2_PIN);
   #endif
-  #if defined(Y_STEP_PIN) && Y_STEP_PIN > -1
-    PIN_SAY(Y_STEP_PIN)
+  #if PIN_EXISTS(Y_STEP)
+    PIN_SAY(Y_STEP_PIN);
   #endif
-  #if defined(Y_STOP_PIN) && Y_STOP_PIN > -1
-    PIN_SAY(Y_STOP_PIN)
+  #if PIN_EXISTS(Y_STOP)
+    PIN_SAY(Y_STOP_PIN);
   #endif
-  #if defined(Y2_DIR_PIN) && Y2_DIR_PIN > -1
-    PIN_SAY(Y2_DIR_PIN)
+  #if PIN_EXISTS(Y2_DIR)
+    PIN_SAY(Y2_DIR_PIN);
   #endif
-  #if defined(Y2_ENABLE_PIN) && Y2_ENABLE_PIN > -1
-    PIN_SAY(Y2_ENABLE_PIN)
+  #if PIN_EXISTS(Y2_ENABLE)
+    PIN_SAY(Y2_ENABLE_PIN);
   #endif
-  #if defined(Y2_STEP_PIN) && Y2_STEP_PIN > -1
-    PIN_SAY(Y2_STEP_PIN)
+  #if PIN_EXISTS(Y2_STEP)
+    PIN_SAY(Y2_STEP_PIN);
   #endif
-  #if defined(Z_ATT_PIN) && Z_ATT_PIN > -1
-    PIN_SAY(Z_ATT_PIN)
+  #if PIN_EXISTS(Z_ATT)
+    PIN_SAY(Z_ATT_PIN);
   #endif
-  #if defined(Z_DIR_PIN) && Z_DIR_PIN > -1
-    PIN_SAY(Z_DIR_PIN)
+  #if PIN_EXISTS(Z_DIR)
+    PIN_SAY(Z_DIR_PIN);
   #endif
-  #if defined(Z_ENABLE_PIN) && Z_ENABLE_PIN > -1
-    PIN_SAY(Z_ENABLE_PIN)
+  #if PIN_EXISTS(Z_ENABLE)
+    PIN_SAY(Z_ENABLE_PIN);
   #endif
-  #if defined(Z_MAX_PIN) && Z_MAX_PIN > -1
-    PIN_SAY(Z_MAX_PIN)
+  #if PIN_EXISTS(Z_MAX)
+    PIN_SAY(Z_MAX_PIN);
   #endif
-  #if defined(Z_MIN_PIN) && Z_MIN_PIN > -1
-    PIN_SAY(Z_MIN_PIN)
+  #if PIN_EXISTS(Z_MIN)
+    PIN_SAY(Z_MIN_PIN);
   #endif
-  #if defined(Z_MIN_PROBE_PIN) && Z_MIN_PROBE_PIN > -1
-    PIN_SAY(Z_MIN_PROBE_PIN)
+  #if PIN_EXISTS(Z_MIN_PROBE)
+    PIN_SAY(Z_MIN_PROBE_PIN);
   #endif
-  #if defined(Z_MS1_PIN) && Z_MS1_PIN > -1
-    PIN_SAY(Z_MS1_PIN)
+  #if PIN_EXISTS(Z_MS1)
+    PIN_SAY(Z_MS1_PIN);
   #endif
-  #if defined(Z_MS2_PIN) && Z_MS2_PIN > -1
-    PIN_SAY(Z_MS2_PIN)
+  #if PIN_EXISTS(Z_MS2)
+    PIN_SAY(Z_MS2_PIN);
   #endif
-  #if defined(Z_STEP_PIN) && Z_STEP_PIN > -1
-    PIN_SAY(Z_STEP_PIN)
+  #if PIN_EXISTS(Z_STEP)
+    PIN_SAY(Z_STEP_PIN);
   #endif
-  #if defined(Z_STOP_PIN) && Z_STOP_PIN > -1
-    PIN_SAY(Z_STOP_PIN)
+  #if PIN_EXISTS(Z_STOP)
+    PIN_SAY(Z_STOP_PIN);
   #endif
-  #if defined(Z2_DIR_PIN) && Z2_DIR_PIN > -1
-    PIN_SAY(Z2_DIR_PIN)
+  #if PIN_EXISTS(Z2_DIR)
+    PIN_SAY(Z2_DIR_PIN);
   #endif
-  #if defined(Z2_ENABLE_PIN) && Z2_ENABLE_PIN > -1
-    PIN_SAY(Z2_ENABLE_PIN)
+  #if PIN_EXISTS(Z2_ENABLE)
+    PIN_SAY(Z2_ENABLE_PIN);
   #endif
-  #if defined(Z2_STEP_PIN) && Z2_STEP_PIN > -1
-    PIN_SAY(Z2_STEP_PIN)
+  #if PIN_EXISTS(Z2_STEP)
+    PIN_SAY(Z2_STEP_PIN);
   #endif
+
+
 
 
   SERIAL_ECHOPGM("<unused>");

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -35,11 +35,12 @@
   #define DIO_COUNT 22
 #endif
 
+#define  NAME_FORMAT "%-28s"
 
-#define _PIN_SAY(NAME) { sprintf(buffer, "%-20s", NAME); SERIAL_ECHO(buffer); return true; }
+#define _PIN_SAY(NAME) { sprintf(buffer, NAME_FORMAT, NAME); SERIAL_ECHO(buffer); return true; }
 #define PIN_SAY(NAME) if (pin == NAME) _PIN_SAY(#NAME);
 
-#define _ANALOG_PIN_SAY(NAME)   { sprintf(buffer, "%-20s", NAME); SERIAL_ECHO(buffer); pin_is_analog = true; return true; }
+#define _ANALOG_PIN_SAY(NAME)   { sprintf(buffer, NAME_FORMAT, NAME); SERIAL_ECHO(buffer); pin_is_analog = true; return true; }
 #define ANALOG_PIN_SAY(NAME) if (pin == analogInputToDigitalPin(NAME)) _ANALOG_PIN_SAY(#NAME);
 
 #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && ((P) <= analogInputToDigitalPin(15) || (P) <= analogInputToDigitalPin(5)))
@@ -80,10 +81,10 @@ static bool report_pin_name(int8_t pin,bool &pin_is_analog) {
   else SERIAL_ECHOPGM("       ");
 
   #if defined(RXD) && RXD > -1
-    if (pin == 0) { SERIAL_ECHOPGM("RXD                 "); return true; }
+    if (pin == 0) { sprintf(buffer, NAME_FORMAT, "RXD"); SERIAL_ECHO(buffer); return true; }
   #endif
   #if defined(TXD) && TXD > -1
-    if (pin == 1) { SERIAL_ECHOPGM("TXD                 "); return true; }
+    if (pin == 1) { sprintf(buffer, NAME_FORMAT, "TXD"); SERIAL_ECHO(buffer); return true; }
   #endif
 
   
@@ -681,8 +682,8 @@ static bool report_pin_name(int8_t pin,bool &pin_is_analog) {
     PIN_SAY(Z2_STEP_PIN);
   #endif
 
-
-  SERIAL_ECHOPGM("<unused>            ");
+  sprintf(buffer, NAME_FORMAT, "<unused> ");
+  SERIAL_ECHO(buffer);
   
   return false;
 }  //  report_pin_name
@@ -722,7 +723,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER1B:
-        if (TCCR1B & (_BV(COM1B1) | _BV(COM1B0))){
+        if (TCCR1A & (_BV(COM1B1) | _BV(COM1B0))){
           sprintf(buffer, "PWM:  %4d",OCR1B); 
           SERIAL_ECHO(buffer);
           return true;
@@ -730,7 +731,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break; 
       case TIMER1C:
-        if (TCCR1C & (_BV(COM1C1) | _BV(COM1C0))){
+        if (TCCR1A & (_BV(COM1C1) | _BV(COM1C0))){
           sprintf(buffer, "PWM:  %4d",OCR1C); 
           SERIAL_ECHO(buffer);
           return true;
@@ -749,7 +750,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER2B:
-        if (TCCR2B & (_BV(COM2B1) | _BV(COM2B0))){
+        if (TCCR2A & (_BV(COM2B1) | _BV(COM2B0))){
           sprintf(buffer, "PWM:  %4d",OCR2B); 
           SERIAL_ECHO(buffer);
           return true;
@@ -768,7 +769,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER3B:
-        if (TCCR3B & (_BV(COM3B1) | _BV(COM3B0))){
+        if (TCCR3A & (_BV(COM3B1) | _BV(COM3B0))){
           sprintf(buffer, "PWM:  %4d",OCR3B); 
           SERIAL_ECHO(buffer);
           return true;
@@ -776,7 +777,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER3C:
-        if (TCCR3C & (_BV(COM3C1) | _BV(COM3C0))){
+        if (TCCR3A & (_BV(COM3C1) | _BV(COM3C0))){
           sprintf(buffer, "PWM:  %4d",OCR3C); 
           SERIAL_ECHO(buffer);
           return true;
@@ -795,7 +796,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER4B:
-        if (TCCR4B & (_BV(COM4B1) | _BV(COM4B0))){
+        if (TCCR4A & (_BV(COM4B1) | _BV(COM4B0))){
           sprintf(buffer, "PWM:  %4d",OCR4B); 
           SERIAL_ECHO(buffer);
           return true;
@@ -803,7 +804,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER4C:
-        if (TCCR4C & (_BV(COM4C1) | _BV(COM4C0))){
+        if (TCCR4A & (_BV(COM4C1) | _BV(COM4C0))){
           sprintf(buffer, "PWM:  %4d",OCR4C); 
           SERIAL_ECHO(buffer);
           return true;
@@ -822,7 +823,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER5B:
-        if (TCCR5B & (_BV(COM5B1) | _BV(COM5B0))){
+        if (TCCR5A & (_BV(COM5B1) | _BV(COM5B0))){
           sprintf(buffer, "PWM:  %4d",OCR5B); 
           SERIAL_ECHO(buffer);
           return true;
@@ -830,7 +831,7 @@ static bool PWM_status(uint8_t pin) {
         else return false;
         break;
       case TIMER5C:
-        if (TCCR5C & (_BV(COM5C1) | _BV(COM5C0))){
+        if (TCCR5A & (_BV(COM5C1) | _BV(COM5C0))){
           sprintf(buffer, "PWM:  %4d",OCR5C); 
           SERIAL_ECHO(buffer);
           return true;

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -561,9 +561,9 @@ static bool report_pin_name(int8_t pin) {
   #if PIN_EXISTS(X_STEP)
     PIN_SAY(X_STEP_PIN);
   #endif
-  #if PIN_EXISTS(X_STOP)
-    PIN_SAY(X_STOP_PIN);
-  #endif
+//  #if PIN_EXISTS(X_STOP)
+//   PIN_SAY(X_STOP_PIN);  // reported as either X_MIN or X_MAX depending on homing direction
+//  #endif
   #if PIN_EXISTS(X2_DIR)
     PIN_SAY(X2_DIR_PIN);
   #endif
@@ -594,9 +594,9 @@ static bool report_pin_name(int8_t pin) {
   #if PIN_EXISTS(Y_MS2)
     PIN_SAY(Y_MS2_PIN);
   #endif
-  #if PIN_EXISTS(Y_STEP)
-    PIN_SAY(Y_STEP_PIN);
-  #endif
+//  #if PIN_EXISTS(Y_STEP)
+//    PIN_SAY(Y_STEP_PIN);  // reported as either Y_MIN or Y_MAX depending on homing direction
+//  #endif
   #if PIN_EXISTS(Y_STOP)
     PIN_SAY(Y_STOP_PIN);
   #endif
@@ -636,9 +636,9 @@ static bool report_pin_name(int8_t pin) {
   #if PIN_EXISTS(Z_STEP)
     PIN_SAY(Z_STEP_PIN);
   #endif
-  #if PIN_EXISTS(Z_STOP)
-    PIN_SAY(Z_STOP_PIN);
-  #endif
+//  #if PIN_EXISTS(Z_STOP)
+//    PIN_SAY(Z_STOP_PIN);  // reported as either Z_MIN or Z_MAX depending on homing direction
+//  #endif
   #if PIN_EXISTS(Z2_DIR)
     PIN_SAY(Z2_DIR_PIN);
   #endif

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -49,11 +49,6 @@
   static uint8_t heater_ttbllen_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN, HEATER_2_TEMPTABLE_LEN, HEATER_3_TEMPTABLE_LEN);
 #endif
 
-#if ENABLED(PINS_DEBUGGING)
-  static uint16_t old_endstop_bits_local = 0; //for endstop monitor routine
-  static uint8_t  local_LED_status = 0;
-#endif
-
 Temperature thermalManager;
 
 // public:
@@ -1400,7 +1395,6 @@ void Temperature::set_current_temp_raw() {
 
 #if ENABLED(PINS_DEBUGGING)
 
-  void endstop_monitor() {
   /**  
    * monitors endstops & Z probe for changes
    *
@@ -1411,8 +1405,12 @@ void Temperature::set_current_temp_raw() {
    * that won't matter because this is all manual.
    *
    */ 
-
+   
+  void endstop_monitor() {
+    static uint16_t old_endstop_bits_local = 0;
+    static uint8_t  local_LED_status = 0;
     if (endstop_monitor_flag ) {
+      
       uint16_t current_endstop_bits_local = 0;
       #if HAS_X_MIN
         current_endstop_bits_local |= (READ(X_MIN_PIN) ? _BV(X_MIN) : 0) ;
@@ -1471,8 +1469,7 @@ void Temperature::set_current_temp_raw() {
       
       if (current_endstop_bits_local != old_endstop_bits_local) {
         analogWrite(LED_PIN, local_LED_status );                // toggle LED
-        SERIAL_PROTOCOLPGM("\n");                               // make it easy to see the message
-        SERIAL_PROTOCOLPGM("\n");
+        SERIAL_PROTOCOLPGM("\n\n");                               // make it easy to see the message
         old_endstop_bits_local = current_endstop_bits_local ;   // get ready for next change
         local_LED_status  = (local_LED_status ? 0 : 255);
       }  

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -49,6 +49,11 @@
   static uint8_t heater_ttbllen_map[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN, HEATER_2_TEMPTABLE_LEN, HEATER_3_TEMPTABLE_LEN);
 #endif
 
+#if ENABLED(PINS_DEBUGGING)
+  static uint16_t old_endstop_bits_local = 0; //for endstop monitor routine
+  static uint8_t  local_LED_status = 0;
+#endif
+
 Temperature thermalManager;
 
 // public:
@@ -1390,7 +1395,90 @@ void Temperature::set_current_temp_raw() {
   #endif
   current_temperature_bed_raw = raw_temp_bed_value;
   temp_meas_ready = true;
+
 }
+
+#if ENABLED(PINS_DEBUGGING)
+
+  void endstop_monitor() {
+  /**  
+   * monitors endstops & Z probe for changes
+   *
+   * If a change is detected then the LED is toggled and
+   * a message is sent out the serial port
+   *
+   * Yes, we could miss a rapid back & forth change but
+   * that won't matter because this is all manual.
+   *
+   */ 
+
+    if (endstop_monitor_flag ) {
+      uint16_t current_endstop_bits_local = 0;
+      #if HAS_X_MIN
+        current_endstop_bits_local |= (READ(X_MIN_PIN) ? _BV(X_MIN) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(X_MIN)) {
+          SERIAL_PROTOCOLPAIR("X_MIN: ", ((current_endstop_bits_local & _BV(X_MIN)) ? 1 : 0));
+        }
+      #endif
+      #if HAS_X_MAX
+        current_endstop_bits_local |= (READ(X_MAX_PIN) ? _BV(X_MAX) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(X_MAX)) {
+          SERIAL_PROTOCOLPAIR("   X_MAX: ", ((current_endstop_bits_local & _BV(X_MAX)) ? 1 : 0));
+        }
+      #endif
+      #if HAS_Y_MIN
+        current_endstop_bits_local |= (READ(Y_MIN_PIN) ? _BV(Y_MIN) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Y_MIN)) {
+          SERIAL_PROTOCOLPAIR("   Y_MIN: ", ((current_endstop_bits_local & _BV(Y_MIN)) ? 1 : 0));
+        }
+      #endif
+      #if HAS_Y_MAX
+        current_endstop_bits_local |= (READ(Y_MAX_PIN) ? _BV(Y_MAX) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Y_MAX)) {
+          SERIAL_PROTOCOLPAIR("   Y_MAX: ", ((current_endstop_bits_local & _BV(Y_MAX)) ? 1 : 0));
+        }
+      #endif
+      #if HAS_Z_MIN
+        current_endstop_bits_local |= (READ(Z_MIN_PIN) ? _BV(Z_MIN) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Z_MIN)) {
+          SERIAL_PROTOCOLPAIR("   Z_MIN: ", ((current_endstop_bits_local & _BV(Z_MIN)) ? 1 : 0));
+        }
+      #endif
+      #if HAS_Z_MAX
+        current_endstop_bits_local |= (READ(Z_MAX_PIN) ? _BV(Z_MAX) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Z_MAX)) {
+          SERIAL_PROTOCOLPAIR("   Z_MAX: ", ((current_endstop_bits_local & _BV(Z_MAX)) ? 1 : 0));
+        }
+      #endif     
+      #if HAS_Z_MIN_PROBE_PIN
+        current_endstop_bits_local |= (READ(Z_MIN_PROBE_PIN) ? _BV(Z_MIN_PROBE) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Z_MIN_PROBE)) {
+          SERIAL_PROTOCOLPAIR("   PROBE: ", ((current_endstop_bits_local & _BV(Z_MIN_PROBE)) ? 1 : 0));
+        }
+      #endif     
+      #if HAS_Z2_MIN
+        current_endstop_bits_local |= (READ(Z2_MIN_PIN) ? _BV(Z2_MIN) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Z2_MIN)) {
+          SERIAL_PROTOCOLPAIR("   Z2_MIN: ", ((current_endstop_bits_local & _BV(Z2_MIN)) ? 1 : 0));
+        }
+      #endif
+      #if HAS_Z2_MAX
+        current_endstop_bits_local |= (READ(Z2_MAX_PIN) ? _BV(Z2_MAX) : 0) ;
+        if ((current_endstop_bits_local ^ old_endstop_bits_local) & _BV(Z2_MAX)) {
+          SERIAL_PROTOCOLPAIR("   Z2_MAX: ", ((current_endstop_bits_local & _BV(Z2_MAX)) ? 1 : 0));
+        }
+      #endif
+      
+      if (current_endstop_bits_local != old_endstop_bits_local) {
+        analogWrite(LED_PIN, local_LED_status );                // toggle LED
+        SERIAL_PROTOCOLPGM("\n");                               // make it easy to see the message
+        SERIAL_PROTOCOLPGM("\n");
+        old_endstop_bits_local = current_endstop_bits_local ;   // get ready for next change
+        local_LED_status  = (local_LED_status ? 0 : 255);
+      }  
+    }  
+  }  
+#endif  // PINS_DEBUGGING
 
 /**
  * Timer 0 is shared with millies so don't change the prescaler.
@@ -1411,8 +1499,8 @@ void Temperature::isr() {
   static uint8_t temp_count = 0;
   static TempState temp_state = StartupDelay;
   static uint8_t pwm_count = _BV(SOFT_PWM_SCALE);
-
-  // Static members for each heater
+ 
+   // Static members for each heater
   #if ENABLED(SLOW_PWM_HEATERS)
     static uint8_t slow_pwm_count = 0;
     #define ISR_STATICS(n) \
@@ -1875,4 +1963,13 @@ void Temperature::isr() {
       }
     }
   #endif //BABYSTEPPING
+  
+
+  #if ENABLED(PINS_DEBUGGING)
+    // run the endstop monitor at 15Hz
+    static uint8_t endstop_monitor_count = 16;  // offset this check from the others
+    endstop_monitor_count += _BV(1);  //  15 Hz
+    endstop_monitor_count &= 0x7F;
+    if (endstop_monitor_count == 0) endstop_monitor();  // report changes in endstop status
+  #endif  
 }


### PR DESCRIPTION
Added a debug/setup aid that I call endstop monitor.

This routine monitors the endstops and the probe and, if a change is
detected, sends a message to the host and toggles the LED.

This routine runs in the background so normal machine operation is not
affected.

M43 E toggles the function on & off.

The main routine was added to the temperature ISR.  The call to the
routine mimics a slow PWM.  It gets called at a 15Hz rate.

It adds 1 global variable and two static variables.

I also updated the pin list in pinsDebug.h.  All the previous pins are
still present.  I took a copy of RCBugFix from 7 Oct, did a grep to get
all the #defines, kept the ones that had a pin, added in all the
previous pins, & then used Excel to create the "#if pin ... print pin
... #endif" sequence.

I'm not sure what the intent of the pin list in pinsDebug.h so just
ignore my changes if they conflict with something.

I also added M43 to the list of implemented commands in Marlin_main.cpp
