### PR TITLE
Fix DAC current code

### DIFF
--- a/Marlin/dac_mcp4728.cpp
+++ b/Marlin/dac_mcp4728.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "dac_mcp4728.h"
+#include "enum.h"
 
 #if ENABLED(DAC_STEPPER_CURRENT)
 
@@ -69,9 +70,9 @@ uint8_t mcp4728_analogWrite(uint8_t channel, uint16_t value) {
 uint8_t mcp4728_eepromWrite() {
   Wire.beginTransmission(DAC_DEV_ADDRESS);
   Wire.write(SEQWRITE);
-  for (uint8_t channel = 0; channel < COUNT(mcp4728_values); channel++) {
-    Wire.write(DAC_STEPPER_VREF << 7 | DAC_STEPPER_GAIN << 4 | highByte(mcp4728_values[channel]));
-    Wire.write(lowByte(mcp4728_values[channel]));
+  LOOP_XYZE(i) {
+    Wire.write(DAC_STEPPER_VREF << 7 | DAC_STEPPER_GAIN << 4 | highByte(mcp4728_values[i]));
+    Wire.write(lowByte(mcp4728_values[i]));
   }
   return Wire.endTransmission();
 }
@@ -119,7 +120,7 @@ uint16_t mcp4728_getDrvPct(uint8_t channel) { return uint16_t(100.0 * mcp4728_va
  * Receives all Drive strengths as 0-100 percent values, updates
  * DAC Values array and calls fastwrite to update the DAC.
  */
-void mcp4728_setDrvPct(int16_t pct[XYZE]) {
+void mcp4728_setDrvPct(uint16_t pct[XYZE]) {
   LOOP_XYZE(i) mcp4728_values[i] = 0.01 * pct[i] * (DAC_STEPPER_MAX);
   mcp4728_fastWrite();
 }
@@ -131,9 +132,9 @@ void mcp4728_setDrvPct(int16_t pct[XYZE]) {
  */
 uint8_t mcp4728_fastWrite() {
   Wire.beginTransmission(DAC_DEV_ADDRESS);
-  for (uint8_t channel = 0; channel < COUNT(mcp4728_values); channel++) {
-    Wire.write(highByte(mcp4728_values[channel]));
-    Wire.write(lowByte(mcp4728_values[channel]));
+  LOOP_XYZE(i) {
+    Wire.write(highByte(mcp4728_values[i]));
+    Wire.write(lowByte(mcp4728_values[i]));
   }
   return Wire.endTransmission();
 }

--- a/Marlin/dac_mcp4728.h
+++ b/Marlin/dac_mcp4728.h
@@ -60,7 +60,7 @@ uint16_t mcp4728_getValue(uint8_t channel);
 uint8_t mcp4728_fastWrite();
 uint8_t mcp4728_simpleCommand(byte simpleCommand);
 uint16_t mcp4728_getDrvPct(uint8_t channel);
-void mcp4728_setDrvPct(int16_t pct[XYZE]);
+void mcp4728_setDrvPct(uint16_t pct[XYZE]);
 
 #endif
 #endif // DAC_MCP4728_H


### PR DESCRIPTION
Addressing #5017 – Make sure "enum.h" is included so `LOOP_XYZE` macro is defined. Then use the macro more often.
