### PR TITLE
Planner acceleration bugfix and speedup

### DIFF
--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -166,6 +166,11 @@ class Planner {
      * Nominal speed of previous path line segment
      */
     static float previous_nominal_speed;
+	
+	/**
+	 * Limit where 64bit math is necessary for acceleration calculation
+	 */
+	static unsigned long cutoff_32bit;
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
       /**


### PR DESCRIPTION
- Use already existing inverse_millimeters instead of divide by block->millimeters.
- Prevent overflow during acceleration calculation by checking if 64bit math is necessary. Modified idea from Sailfish.
- Save two `uint32_t` (or even `uint64_t`) multiplications by checking if `step[AXIS]` has steps. If not, there is no need to check this axis.

The advantage of the last point depends on the part printed. With my test case, it runs at the same speed as the original PR #4997. Without them, it's still faster than the old acceleration calculation way.
