### PR TITLE
Fixed SERVO pins on Azteeg X3

### DIFF
--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -32,6 +32,11 @@
 
 #include "pins_RAMPS_13.h"
 
+#undef SERVO0_PIN
+#undef SERVO1_PIN
+#define SERVO0_PIN  44  // SERVO1 port
+#define SERVO1_PIN  55  // SERVO2 port
+
 //
 // LCD / Controller
 //


### PR DESCRIPTION
Azteeg X3 rev 2.0 uses different pins than RAMPS for its two servo ports. Previous revisions did not have servo ports so it didn't matter before.
