### PR TITLE
Centralize click-handling in the LCD loop

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -270,7 +270,7 @@ extern bool axis_known_position[XYZ]; // axis[n].is_known
 extern bool axis_homed[XYZ]; // axis[n].is_homed
 extern volatile bool wait_for_heatup;
 
-#if ENABLED(ULTIPANEL) || ENABLED(EMERGENCY_PARSER)
+#if ENABLED(EMERGENCY_PARSER) || ENABLED(ULTIPANEL)
   extern volatile bool wait_for_user;
 #endif
 

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -508,10 +508,7 @@ MarlinSerial customizedSerial;
         if (c == '\n') {
           switch (state) {
             case state_M108:
-              wait_for_heatup = false;
-              #if DISABLED(ULTIPANEL)
-                wait_for_user = false;
-              #endif
+              wait_for_user = wait_for_heatup = false;
               break;
             case state_M112:
               kill(PSTR(MSG_KILLED));

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5519,46 +5519,26 @@ inline void gcode_M140() {
    */
   inline void gcode_M145() {
     int8_t material = code_seen('S') ? (int8_t)code_value_int() : 0;
-    if (material < 0 || material > 1) {
+    if (material < 0 || material >= COUNT(lcd_preheat_hotend_temp)) {
       SERIAL_ERROR_START;
       SERIAL_ERRORLNPGM(MSG_ERR_MATERIAL_INDEX);
     }
     else {
       int v;
-      switch (material) {
-        case 0:
-          if (code_seen('H')) {
-            v = code_value_int();
-            preheatHotendTemp1 = constrain(v, EXTRUDE_MINTEMP, HEATER_0_MAXTEMP - 15);
-          }
-          if (code_seen('F')) {
-            v = code_value_int();
-            preheatFanSpeed1 = constrain(v, 0, 255);
-          }
-          #if TEMP_SENSOR_BED != 0
-            if (code_seen('B')) {
-              v = code_value_int();
-              preheatBedTemp1 = constrain(v, BED_MINTEMP, BED_MAXTEMP - 15);
-            }
-          #endif
-          break;
-        case 1:
-          if (code_seen('H')) {
-            v = code_value_int();
-            preheatHotendTemp2 = constrain(v, EXTRUDE_MINTEMP, HEATER_0_MAXTEMP - 15);
-          }
-          if (code_seen('F')) {
-            v = code_value_int();
-            preheatFanSpeed2 = constrain(v, 0, 255);
-          }
-          #if TEMP_SENSOR_BED != 0
-            if (code_seen('B')) {
-              v = code_value_int();
-              preheatBedTemp2 = constrain(v, BED_MINTEMP, BED_MAXTEMP - 15);
-            }
-          #endif
-          break;
+      if (code_seen('H')) {
+        v = code_value_int();
+        lcd_preheat_hotend_temp[material] = constrain(v, EXTRUDE_MINTEMP, HEATER_0_MAXTEMP - 15);
       }
+      if (code_seen('F')) {
+        v = code_value_int();
+        lcd_preheat_fan_speed[material] = constrain(v, 0, 255);
+      }
+      #if TEMP_SENSOR_BED != 0
+        if (code_seen('B')) {
+          v = code_value_int();
+          lcd_preheat_bed_temp[material] = constrain(v, BED_MINTEMP, BED_MAXTEMP - 15);
+        }
+      #endif
     }
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5549,13 +5549,9 @@ inline void gcode_M140() {
    * M149: Set temperature units
    */
   inline void gcode_M149() {
-    if (code_seen('C')) {
-      set_input_temp_units(TEMPUNIT_C);
-    } else if (code_seen('K')) {
-      set_input_temp_units(TEMPUNIT_K);
-    } else if (code_seen('F')) {
-      set_input_temp_units(TEMPUNIT_F);
-    }
+         if (code_seen('C')) set_input_temp_units(TEMPUNIT_C);
+    else if (code_seen('K')) set_input_temp_units(TEMPUNIT_K);
+    else if (code_seen('F')) set_input_temp_units(TEMPUNIT_F);
   }
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5518,8 +5518,8 @@ inline void gcode_M140() {
    *   F<fan speed>
    */
   inline void gcode_M145() {
-    int8_t material = code_seen('S') ? (int8_t)code_value_int() : 0;
-    if (material < 0 || material >= COUNT(lcd_preheat_hotend_temp)) {
+    uint8_t material = code_seen('S') ? (uint8_t)code_value_int() : 0;
+    if (material >= COUNT(lcd_preheat_hotend_temp)) {
       SERIAL_ERROR_START;
       SERIAL_ERRORLNPGM(MSG_ERR_MATERIAL_INDEX);
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1046,7 +1046,12 @@ inline void get_serial_commands() {
 
       #if DISABLED(EMERGENCY_PARSER)
         // If command was e-stop process now
-        if (strcmp(command, "M108") == 0) wait_for_heatup = false;
+        if (strcmp(command, "M108") == 0) {
+          wait_for_heatup = false;
+          #if ENABLED(ULTIPANEL)
+            wait_for_user = false;
+          #endif
+        }
         if (strcmp(command, "M112") == 0) kill(PSTR(MSG_KILLED));
         if (strcmp(command, "M410") == 0) { quickstop_stepper(); }
       #endif
@@ -4414,7 +4419,6 @@ inline void gcode_G92() {
           dontExpireStatus();
         #endif
       }
-      lcd_ignore_click();
 
     #else
 
@@ -4425,53 +4429,28 @@ inline void gcode_G92() {
 
     #endif
 
-    #if ENABLED(EMERGENCY_PARSER)
-      wait_for_user = true;
-    #endif
-
+    wait_for_user = true;
     KEEPALIVE_STATE(PAUSED_FOR_USER);
 
     stepper.synchronize();
     refresh_cmd_timeout();
 
-    #if ENABLED(ULTIPANEL)
-
-      #if ENABLED(EMERGENCY_PARSER)
-        #define M1_WAIT_CONDITION (!lcd_clicked() && wait_for_user)
+    if (codenum > 0) {
+      codenum += previous_cmd_ms;  // wait until this time for a click
+      while (PENDING(millis(), codenum) && wait_for_user) idle();
+    }
+    else {
+      #if ENABLED(ULTIPANEL)
+        if (lcd_detected()) {
+          while (wait_for_user) idle();
+          IS_SD_PRINTING ? LCD_MESSAGEPGM(MSG_RESUMING) : LCD_MESSAGEPGM(WELCOME_MSG);
+        }
       #else
-        #define M1_WAIT_CONDITION !lcd_clicked()
+        while (wait_for_user) idle();
       #endif
+    }
 
-      if (codenum > 0) {
-        codenum += previous_cmd_ms;  // wait until this time for a click
-        while (PENDING(millis(), codenum) && M1_WAIT_CONDITION) idle();
-        lcd_ignore_click(false);
-      }
-      else if (lcd_detected()) {
-        while (M1_WAIT_CONDITION) idle();
-      }
-      else goto ExitM1;
-
-      IS_SD_PRINTING ? LCD_MESSAGEPGM(MSG_RESUMING) : LCD_MESSAGEPGM(WELCOME_MSG);
-
-    #else
-
-      if (codenum > 0) {
-        codenum += previous_cmd_ms;  // wait until this time for an M108
-        while (PENDING(millis(), codenum) && wait_for_user) idle();
-      }
-      else while (wait_for_user) idle();
-
-    #endif
-
-#if ENABLED(ULTIPANEL)
-  ExitM1:
-#endif
-
-    #if ENABLED(EMERGENCY_PARSER)
-      wait_for_user = false;
-    #endif
-
+    wait_for_user = false;
     KEEPALIVE_STATE(IN_HANDLER);
   }
 
@@ -6874,7 +6853,10 @@ inline void gcode_M503() {
     // Wait for filament insert by user and press button
     lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INSERT);
 
-    while (!lcd_clicked()) {
+    // LCD click or M108 will clear this
+    wait_for_user = true;
+
+    while (wait_for_user) {
       #if HAS_BUZZER
         millis_t ms = millis();
         if (ms >= next_buzz) {
@@ -6884,9 +6866,6 @@ inline void gcode_M503() {
       #endif
       idle(true);
     }
-    delay(100);
-    while (lcd_clicked()) idle(true);
-    delay(100);
 
     // Show load message
     lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_LOAD);

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -86,12 +86,9 @@
  *  301  M666 Z    z_endstop_adj (float)
  *
  * ULTIPANEL:
- *  305  M145 S0 H preheatHotendTemp1 (int)
- *  307  M145 S0 B preheatBedTemp1 (int)
- *  309  M145 S0 F preheatFanSpeed1 (int)
- *  311  M145 S1 H preheatHotendTemp2 (int)
- *  313  M145 S1 B preheatBedTemp2 (int)
- *  315  M145 S1 F preheatFanSpeed2 (int)
+ *  305  M145 S0 H lcd_preheat_hotend_temp (int x2)
+ *  309  M145 S0 B lcd_preheat_bed_temp (int x2)
+ *  313  M145 S0 F lcd_preheat_fan_speed (int x2)
  *
  * PIDTEMP:
  *  317  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0] (float x4)
@@ -277,16 +274,14 @@ void Config_Postprocess() {
     #endif
 
     #if DISABLED(ULTIPANEL)
-      int preheatHotendTemp1 = PREHEAT_1_TEMP_HOTEND, preheatBedTemp1 = PREHEAT_1_TEMP_BED, preheatFanSpeed1 = PREHEAT_1_FAN_SPEED,
-          preheatHotendTemp2 = PREHEAT_2_TEMP_HOTEND, preheatBedTemp2 = PREHEAT_2_TEMP_BED, preheatFanSpeed2 = PREHEAT_2_FAN_SPEED;
+      const int lcd_preheat_hotend_temp[2] = { PREHEAT_1_TEMP_HOTEND, PREHEAT_2_TEMP_HOTEND },
+                lcd_preheat_bed_temp[2] = { PREHEAT_1_TEMP_BED, PREHEAT_2_TEMP_BED },
+                lcd_preheat_fan_speed[2] = { PREHEAT_1_FAN_SPEED, PREHEAT_2_FAN_SPEED };
     #endif // !ULTIPANEL
 
-    EEPROM_WRITE(preheatHotendTemp1);
-    EEPROM_WRITE(preheatBedTemp1);
-    EEPROM_WRITE(preheatFanSpeed1);
-    EEPROM_WRITE(preheatHotendTemp2);
-    EEPROM_WRITE(preheatBedTemp2);
-    EEPROM_WRITE(preheatFanSpeed2);
+    EEPROM_WRITE(lcd_preheat_hotend_temp);
+    EEPROM_WRITE(lcd_preheat_bed_temp);
+    EEPROM_WRITE(lcd_preheat_fan_speed);
 
     for (uint8_t e = 0; e < MAX_EXTRUDERS; e++) {
 
@@ -465,16 +460,12 @@ void Config_Postprocess() {
       #endif
 
       #if DISABLED(ULTIPANEL)
-        int preheatHotendTemp1, preheatBedTemp1, preheatFanSpeed1,
-            preheatHotendTemp2, preheatBedTemp2, preheatFanSpeed2;
+        int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
       #endif
 
-      EEPROM_READ(preheatHotendTemp1);
-      EEPROM_READ(preheatBedTemp1);
-      EEPROM_READ(preheatFanSpeed1);
-      EEPROM_READ(preheatHotendTemp2);
-      EEPROM_READ(preheatBedTemp2);
-      EEPROM_READ(preheatFanSpeed2);
+      EEPROM_READ(lcd_preheat_hotend_temp);
+      EEPROM_READ(lcd_preheat_bed_temp);
+      EEPROM_READ(lcd_preheat_fan_speed);
 
       #if ENABLED(PIDTEMP)
         for (uint8_t e = 0; e < MAX_EXTRUDERS; e++) {
@@ -639,12 +630,12 @@ void Config_ResetDefault() {
   #endif
 
   #if ENABLED(ULTIPANEL)
-    preheatHotendTemp1 = PREHEAT_1_TEMP_HOTEND;
-    preheatBedTemp1 = PREHEAT_1_TEMP_BED;
-    preheatFanSpeed1 = PREHEAT_1_FAN_SPEED;
-    preheatHotendTemp2 = PREHEAT_2_TEMP_HOTEND;
-    preheatBedTemp2 = PREHEAT_2_TEMP_BED;
-    preheatFanSpeed2 = PREHEAT_2_FAN_SPEED;
+    lcd_preheat_hotend_temp[0] = PREHEAT_1_TEMP_HOTEND;
+    lcd_preheat_hotend_temp[1] = PREHEAT_2_TEMP_HOTEND;
+    lcd_preheat_bed_temp[0] = PREHEAT_1_TEMP_BED;
+    lcd_preheat_bed_temp[1] = PREHEAT_2_TEMP_BED;
+    lcd_preheat_fan_speed[0] = PREHEAT_1_FAN_SPEED;
+    lcd_preheat_fan_speed[1] = PREHEAT_2_FAN_SPEED;
   #endif
 
   #if HAS_LCD_CONTRAST
@@ -863,15 +854,13 @@ void Config_ResetDefault() {
         SERIAL_ECHOLNPGM("Material heatup parameters:");
         CONFIG_ECHO_START;
       }
-      SERIAL_ECHOPAIR("  M145 S0 H", preheatHotendTemp1);
-      SERIAL_ECHOPAIR(" B", preheatBedTemp1);
-      SERIAL_ECHOPAIR(" F", preheatFanSpeed1);
-      SERIAL_EOL;
-      CONFIG_ECHO_START;
-      SERIAL_ECHOPAIR("  M145 S1 H", preheatHotendTemp2);
-      SERIAL_ECHOPAIR(" B", preheatBedTemp2);
-      SERIAL_ECHOPAIR(" F", preheatFanSpeed2);
-      SERIAL_EOL;
+      for (uint8_t i = 0; i < COUNT(lcd_preheat_hotend_temp); i++) {
+        SERIAL_ECHOPAIR("  M145 S", (int)i);
+        SERIAL_ECHOPAIR(" H", lcd_preheat_hotend_temp[i]);
+        SERIAL_ECHOPAIR(" B", lcd_preheat_bed_temp[i]);
+        SERIAL_ECHOPAIR(" F", lcd_preheat_fan_speed[i]);
+        SERIAL_EOL;
+      }
     #endif // ULTIPANEL
 
     #if HAS_PID_HEATING

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -264,7 +264,7 @@ class Planner {
      *  fr_mm_s      - (target) speed of the move (mm/s)
      *  extruder     - target extruder
      */
-    static FORCE_INLINE void buffer_line(ARG_X, ARG_Y, ARG_Z, const float &e, float fr_mm_s, const uint8_t extruder) {
+    static FORCE_INLINE void buffer_line(ARG_X, ARG_Y, ARG_Z, const float &e, const float &fr_mm_s, const uint8_t extruder) {
       #if PLANNER_LEVELING && IS_CARTESIAN
         apply_leveling(lx, ly, lz);
       #endif
@@ -280,7 +280,7 @@ class Planner {
      *  fr_mm_s  - (target) speed of the move (mm/s)
      *  extruder - target extruder
      */
-    static FORCE_INLINE void buffer_line_kinematic(const float target[XYZE], float fr_mm_s, const uint8_t extruder) {
+    static FORCE_INLINE void buffer_line_kinematic(const float target[XYZE], const float &fr_mm_s, const uint8_t extruder) {
       #if PLANNER_LEVELING
         float pos[XYZ] = { target[X_AXIS], target[Y_AXIS], target[Z_AXIS] };
         apply_leveling(pos);
@@ -311,9 +311,9 @@ class Planner {
       _set_position_mm(lx, ly, lz, e);
     }
     static void set_position_mm_kinematic(const float position[NUM_AXIS]);
-    static void set_position_mm(const AxisEnum axis, const float& v);
-    static FORCE_INLINE void set_z_position_mm(const float& z) { set_position_mm(Z_AXIS, z); }
-    static FORCE_INLINE void set_e_position_mm(const float& e) { set_position_mm(E_AXIS, e); }
+    static void set_position_mm(const AxisEnum axis, const float &v);
+    static FORCE_INLINE void set_z_position_mm(const float &z) { set_position_mm(Z_AXIS, z); }
+    static FORCE_INLINE void set_e_position_mm(const float &e) { set_position_mm(E_AXIS, e); }
 
     /**
      * Sync from the stepper positions. (e.g., after an interrupted move)
@@ -369,7 +369,7 @@ class Planner {
      * Calculate the distance (not time) it takes to accelerate
      * from initial_rate to target_rate using the given acceleration:
      */
-    static float estimate_acceleration_distance(float initial_rate, float target_rate, float accel) {
+    static float estimate_acceleration_distance(const float &initial_rate, const float &target_rate, const float &accel) {
       if (accel == 0) return 0; // accel was 0, set acceleration distance to 0
       return (sq(target_rate) - sq(initial_rate)) / (accel * 2);
     }
@@ -382,7 +382,7 @@ class Planner {
      * This is used to compute the intersection point between acceleration and deceleration
      * in cases where the "trapezoid" has no plateau (i.e., never reaches maximum speed)
      */
-    static float intersection_distance(float initial_rate, float final_rate, float accel, float distance) {
+    static float intersection_distance(const float &initial_rate, const float &final_rate, const float &accel, const float &distance) {
       if (accel == 0) return 0; // accel was 0, set intersection distance to 0
       return (accel * 2 * distance - sq(initial_rate) + sq(final_rate)) / (accel * 4);
     }
@@ -392,7 +392,7 @@ class Planner {
      * to reach 'target_velocity' using 'acceleration' within a given
      * 'distance'.
      */
-    static float max_allowable_speed(float accel, float target_velocity, float distance) {
+    static float max_allowable_speed(const float &accel, const float &target_velocity, const float &distance) {
       return sqrt(sq(target_velocity) - 2 * accel * distance);
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -43,8 +43,7 @@
   #include "duration_t.h"
 #endif
 
-int preheatHotendTemp1, preheatBedTemp1, preheatFanSpeed1,
-    preheatHotendTemp2, preheatBedTemp2, preheatFanSpeed2;
+int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
 
 #if ENABLED(FILAMENT_LCD_DISPLAY)
   millis_t previous_lcd_status_ms = 0;
@@ -887,29 +886,29 @@ void kill_screen(const char* lcd_msg) {
   }
 
   #if TEMP_SENSOR_0 != 0
-    void lcd_preheat_pla0() { _lcd_preheat(0, preheatHotendTemp1, preheatBedTemp1, preheatFanSpeed1); }
-    void lcd_preheat_abs0() { _lcd_preheat(0, preheatHotendTemp2, preheatBedTemp2, preheatFanSpeed2); }
+    void lcd_preheat_pla0() { _lcd_preheat(0, lcd_preheat_hotend_temp[0], lcd_preheat_bed_temp[0], lcd_preheat_fan_speed[0]); }
+    void lcd_preheat_abs0() { _lcd_preheat(0, lcd_preheat_hotend_temp[1], lcd_preheat_bed_temp[1], lcd_preheat_fan_speed[1]); }
   #endif
 
   #if HOTENDS > 1
-    void lcd_preheat_pla1() { _lcd_preheat(1, preheatHotendTemp1, preheatBedTemp1, preheatFanSpeed1); }
-    void lcd_preheat_abs1() { _lcd_preheat(1, preheatHotendTemp2, preheatBedTemp2, preheatFanSpeed2); }
+    void lcd_preheat_pla1() { _lcd_preheat(1, lcd_preheat_hotend_temp[0], lcd_preheat_bed_temp[0], lcd_preheat_fan_speed[0]); }
+    void lcd_preheat_abs1() { _lcd_preheat(1, lcd_preheat_hotend_temp[1], lcd_preheat_bed_temp[1], lcd_preheat_fan_speed[1]); }
     #if HOTENDS > 2
-      void lcd_preheat_pla2() { _lcd_preheat(2, preheatHotendTemp1, preheatBedTemp1, preheatFanSpeed1); }
-      void lcd_preheat_abs2() { _lcd_preheat(2, preheatHotendTemp2, preheatBedTemp2, preheatFanSpeed2); }
+      void lcd_preheat_pla2() { _lcd_preheat(2, lcd_preheat_hotend_temp[0], lcd_preheat_bed_temp[0], lcd_preheat_fan_speed[0]); }
+      void lcd_preheat_abs2() { _lcd_preheat(2, lcd_preheat_hotend_temp[1], lcd_preheat_bed_temp[1], lcd_preheat_fan_speed[1]); }
       #if HOTENDS > 3
-        void lcd_preheat_pla3() { _lcd_preheat(3, preheatHotendTemp1, preheatBedTemp1, preheatFanSpeed1); }
-        void lcd_preheat_abs3() { _lcd_preheat(3, preheatHotendTemp2, preheatBedTemp2, preheatFanSpeed2); }
+        void lcd_preheat_pla3() { _lcd_preheat(3, lcd_preheat_hotend_temp[0], lcd_preheat_bed_temp[0], lcd_preheat_fan_speed[0]); }
+        void lcd_preheat_abs3() { _lcd_preheat(3, lcd_preheat_hotend_temp[1], lcd_preheat_bed_temp[1], lcd_preheat_fan_speed[1]); }
       #endif
     #endif
 
     void lcd_preheat_pla0123() {
       #if HOTENDS > 1
-        thermalManager.setTargetHotend(preheatHotendTemp1, 1);
+        thermalManager.setTargetHotend(lcd_preheat_hotend_temp[0], 1);
         #if HOTENDS > 2
-          thermalManager.setTargetHotend(preheatHotendTemp1, 2);
+          thermalManager.setTargetHotend(lcd_preheat_hotend_temp[0], 2);
           #if HOTENDS > 3
-            thermalManager.setTargetHotend(preheatHotendTemp1, 3);
+            thermalManager.setTargetHotend(lcd_preheat_hotend_temp[0], 3);
           #endif
         #endif
       #endif
@@ -917,11 +916,11 @@ void kill_screen(const char* lcd_msg) {
     }
     void lcd_preheat_abs0123() {
       #if HOTENDS > 1
-        thermalManager.setTargetHotend(preheatHotendTemp2, 1);
+        thermalManager.setTargetHotend(lcd_preheat_hotend_temp[1], 1);
         #if HOTENDS > 2
-          thermalManager.setTargetHotend(preheatHotendTemp2, 2);
+          thermalManager.setTargetHotend(lcd_preheat_hotend_temp[1], 2);
           #if HOTENDS > 3
-            thermalManager.setTargetHotend(preheatHotendTemp2, 3);
+            thermalManager.setTargetHotend(lcd_preheat_hotend_temp[1], 3);
           #endif
         #endif
       #endif
@@ -931,8 +930,8 @@ void kill_screen(const char* lcd_msg) {
   #endif // HOTENDS > 1
 
   #if TEMP_SENSOR_BED != 0
-    void lcd_preheat_pla_bedonly() { _lcd_preheat(0, 0, preheatBedTemp1, preheatFanSpeed1); }
-    void lcd_preheat_abs_bedonly() { _lcd_preheat(0, 0, preheatBedTemp2, preheatFanSpeed2); }
+    void lcd_preheat_pla_bedonly() { _lcd_preheat(0, 0, lcd_preheat_bed_temp[0], lcd_preheat_fan_speed[0]); }
+    void lcd_preheat_abs_bedonly() { _lcd_preheat(0, 0, lcd_preheat_bed_temp[1], lcd_preheat_fan_speed[1]); }
   #endif
 
   #if TEMP_SENSOR_0 != 0 && (TEMP_SENSOR_1 != 0 || TEMP_SENSOR_2 != 0 || TEMP_SENSOR_3 != 0 || TEMP_SENSOR_BED != 0)
@@ -1766,20 +1765,15 @@ void kill_screen(const char* lcd_msg) {
     END_MENU();
   }
 
-  /**
-   *
-   * "Temperature" > "Preheat PLA conf" submenu
-   *
-   */
-  static void lcd_control_temperature_preheat_pla_settings_menu() {
+  static void _lcd_control_temperature_preheat_settings_menu(uint8_t material) {
     START_MENU();
     MENU_BACK(MSG_TEMPERATURE);
-    MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &preheatFanSpeed1, 0, 255);
+    MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &lcd_preheat_fan_speed[material], 0, 255);
     #if TEMP_SENSOR_0 != 0
-      MENU_ITEM_EDIT(int3, MSG_NOZZLE, &preheatHotendTemp1, HEATER_0_MINTEMP, HEATER_0_MAXTEMP - 15);
+      MENU_ITEM_EDIT(int3, MSG_NOZZLE, &lcd_preheat_hotend_temp[material], HEATER_0_MINTEMP, HEATER_0_MAXTEMP - 15);
     #endif
     #if TEMP_SENSOR_BED != 0
-      MENU_ITEM_EDIT(int3, MSG_BED, &preheatBedTemp1, BED_MINTEMP, BED_MAXTEMP - 15);
+      MENU_ITEM_EDIT(int3, MSG_BED, &lcd_preheat_bed_temp[material], BED_MINTEMP, BED_MAXTEMP - 15);
     #endif
     #if ENABLED(EEPROM_SETTINGS)
       MENU_ITEM(function, MSG_STORE_EPROM, Config_StoreSettings);
@@ -1789,24 +1783,17 @@ void kill_screen(const char* lcd_msg) {
 
   /**
    *
+   * "Temperature" > "Preheat PLA conf" submenu
+   *
+   */
+  static void lcd_control_temperature_preheat_pla_settings_menu() { _lcd_control_temperature_preheat_settings_menu(0); }
+
+  /**
+   *
    * "Temperature" > "Preheat ABS conf" submenu
    *
    */
-  static void lcd_control_temperature_preheat_abs_settings_menu() {
-    START_MENU();
-    MENU_BACK(MSG_TEMPERATURE);
-    MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &preheatFanSpeed2, 0, 255);
-    #if TEMP_SENSOR_0 != 0
-      MENU_ITEM_EDIT(int3, MSG_NOZZLE, &preheatHotendTemp2, HEATER_0_MINTEMP, HEATER_0_MAXTEMP - 15);
-    #endif
-    #if TEMP_SENSOR_BED != 0
-      MENU_ITEM_EDIT(int3, MSG_BED, &preheatBedTemp2, BED_MINTEMP, BED_MAXTEMP - 15);
-    #endif
-    #if ENABLED(EEPROM_SETTINGS)
-      MENU_ITEM(function, MSG_STORE_EPROM, Config_StoreSettings);
-    #endif
-    END_MENU();
-  }
+  static void lcd_control_temperature_preheat_abs_settings_menu() { _lcd_control_temperature_preheat_settings_menu(1); }
 
   static void _reset_acceleration_rates() { planner.reset_acceleration_rates(); }
   static void _planner_refresh_positioning() { planner.refresh_positioning(); }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -243,7 +243,6 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
    *
    * START_MENU    Opening code for a screen with menu items.
    *               Scroll as-needed to keep the selected line in view.
-   *               'wasClicked' indicates the controller was clicked.
    */
   #define START_SCREEN() \
     START_SCREEN_OR_MENU(LCD_HEIGHT); \
@@ -257,7 +256,6 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     if (encoderLine >= encoderTopLine + LCD_HEIGHT) { \
       encoderTopLine = encoderLine - (LCD_HEIGHT - 1); \
     } \
-    bool wasClicked = LCD_CLICKED; \
     bool _skipStatic = true; \
     SCREEN_OR_MENU_LOOP()
 
@@ -288,8 +286,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     if (_menuLineNr == _thisItemNr) { \
       if (lcdDrawUpdate) \
         lcd_implementation_drawmenu_ ## TYPE(encoderLine == _thisItemNr, _lcdLineNr, PSTR(LABEL), ## __VA_ARGS__); \
-      if (wasClicked && encoderLine == _thisItemNr) { \
-        lcd_quick_feedback()
+      if (lcd_clicked && encoderLine == _thisItemNr) {
 
   #define _MENU_ITEM_PART_2(TYPE, ...) \
         menu_action_ ## TYPE(__VA_ARGS__); \
@@ -381,9 +378,8 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
   menuPosition screen_history[10];
   uint8_t screen_history_depth = 0;
 
-  bool ignore_click = false;
-  bool wait_for_unclick;
-  bool defer_return_to_status = false;
+  // LCD and menu clicks
+  bool lcd_clicked, wait_for_unclick, defer_return_to_status;
 
   // Variables used when editing values.
   const char* editLabel;
@@ -392,9 +388,9 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
   screenFunc_t callbackFunc;              // call this after editing
 
   /**
-   * General function to go directly to a menu
+   * General function to go directly to a screen
    */
-  static void lcd_goto_screen(screenFunc_t screen, const bool feedback = false, const uint32_t encoder = 0) {
+  static void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0) {
     if (currentScreen != screen) {
       currentScreen = screen;
       encoderPosition = encoder;
@@ -402,7 +398,6 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
         defer_return_to_status = false;
         screen_history_depth = 0;
       }
-      if (feedback) lcd_quick_feedback();
       lcd_implementation_clear();
       #if ENABLED(LCD_PROGRESS_BAR)
         // For LCD_PROGRESS_BAR re-initialize custom characters
@@ -427,17 +422,11 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
       --screen_history_depth;
       lcd_goto_screen(
         screen_history[screen_history_depth].menu_function,
-        feedback,
         screen_history[screen_history_depth].encoder_position
       );
     }
     else
       lcd_return_to_status();
-  }
-
-  void lcd_ignore_click(bool b) {
-    ignore_click = b;
-    wait_for_unclick = false;
   }
 
 #endif // ULTIPANEL
@@ -493,23 +482,7 @@ static void lcd_status_screen() {
 
   #if ENABLED(ULTIPANEL)
 
-    bool current_click = LCD_CLICKED;
-
-    if (ignore_click) {
-      if (wait_for_unclick) {
-        if (!current_click)
-          ignore_click = wait_for_unclick = false;
-        else
-          current_click = false;
-      }
-      else if (current_click) {
-        lcd_quick_feedback();
-        wait_for_unclick = true;
-        current_click = false;
-      }
-    }
-
-    if (current_click) {
+    if (lcd_clicked) {
       #if ENABLED(FILAMENT_LCD_DISPLAY)
         previous_lcd_status_ms = millis();  // get status message to show up for a while
       #endif
@@ -518,7 +491,7 @@ static void lcd_status_screen() {
           false
         #endif
       );
-      lcd_goto_screen(lcd_main_menu, true);
+      lcd_goto_screen(lcd_main_menu);
     }
 
     #if ENABLED(ULTIPANEL_FEEDMULTIPLY)
@@ -676,7 +649,7 @@ void kill_screen(const char* lcd_msg) {
     long babysteps_done = 0;
 
     static void _lcd_babystep(const AxisEnum axis, const char* msg) {
-      if (LCD_CLICKED) { defer_return_to_status = false; lcd_goto_previous_menu(true); return; }
+      if (lcd_clicked) { defer_return_to_status = false; return lcd_goto_previous_menu(true); }
       ENCODER_DIRECTION_NORMAL();
       if (encoderPosition) {
         int babystep_increment = (int32_t)encoderPosition * BABYSTEP_MULTIPLICATOR;
@@ -1092,12 +1065,12 @@ void kill_screen(const char* lcd_msg) {
       }
 
       static bool debounce_click = false;
-      if (LCD_CLICKED) {
+      if (lcd_clicked) {
         if (!debounce_click) {
           debounce_click = true; // ignore multiple "clicks" in a row
           mbl.set_zigzag_z(_lcd_level_bed_position++, current_position[Z_AXIS]);
           if (_lcd_level_bed_position == (MESH_NUM_X_POINTS) * (MESH_NUM_Y_POINTS)) {
-            lcd_goto_screen(_lcd_level_bed_done, true);
+            lcd_goto_screen(_lcd_level_bed_done);
 
             current_position[Z_AXIS] = MESH_HOME_SEARCH_Z + Z_HOMING_HEIGHT;
             line_to_current(Z_AXIS);
@@ -1113,7 +1086,7 @@ void kill_screen(const char* lcd_msg) {
             #endif
           }
           else {
-            lcd_goto_screen(_lcd_level_goto_next_point, true);
+            lcd_goto_screen(_lcd_level_goto_next_point);
           }
         }
       }
@@ -1171,7 +1144,7 @@ void kill_screen(const char* lcd_msg) {
      */
     static void _lcd_level_bed_homing_done() {
       if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_WAITING));
-      if (LCD_CLICKED) {
+      if (lcd_clicked) {
         _lcd_level_bed_position = 0;
         current_position[Z_AXIS] = MESH_HOME_SEARCH_Z
           #if Z_HOME_DIR > 0
@@ -1179,7 +1152,7 @@ void kill_screen(const char* lcd_msg) {
           #endif
         ;
         planner.set_position_mm(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS]);
-        lcd_goto_screen(_lcd_level_goto_next_point, true);
+        lcd_goto_screen(_lcd_level_goto_next_point);
       }
     }
 
@@ -1385,7 +1358,7 @@ void kill_screen(const char* lcd_msg) {
    */
 
   static void _lcd_move_xyz(const char* name, AxisEnum axis) {
-    if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+    if (lcd_clicked) { return lcd_goto_previous_menu(true); }
     ENCODER_DIRECTION_NORMAL();
     if (encoderPosition) {
       refresh_cmd_timeout();
@@ -1425,7 +1398,7 @@ void kill_screen(const char* lcd_msg) {
       int8_t eindex=-1
     #endif
   ) {
-    if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+    if (lcd_clicked) { return lcd_goto_previous_menu(true); }
     ENCODER_DIRECTION_NORMAL();
     if (encoderPosition) {
       current_position[E_AXIS] += float((int32_t)encoderPosition) * move_menu_scale;
@@ -1924,7 +1897,7 @@ void kill_screen(const char* lcd_msg) {
    */
   #if HAS_LCD_CONTRAST
     static void lcd_set_contrast() {
-      if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+      if (lcd_clicked) { return lcd_goto_previous_menu(true); }
       ENCODER_DIRECTION_NORMAL();
       if (encoderPosition) {
         set_lcd_contrast(lcd_contrast + encoderPosition);
@@ -1991,7 +1964,7 @@ void kill_screen(const char* lcd_msg) {
      */
     void lcd_sdcard_menu() {
       ENCODER_DIRECTION_MENUS();
-      if (lcdDrawUpdate == 0 && LCD_CLICKED == 0) return; // nothing to do (so don't thrash the SD card)
+      if (!lcdDrawUpdate && !lcd_clicked) return; // nothing to do (so don't thrash the SD card)
       uint16_t fileCnt = card.getnrfilenames();
       START_MENU();
       MENU_BACK(MSG_MAIN);
@@ -2037,7 +2010,7 @@ void kill_screen(const char* lcd_msg) {
        *
        */
       static void lcd_info_stats_menu() {
-        if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+        if (lcd_clicked) { return lcd_goto_previous_menu(true); }
 
         char buffer[21];
         printStatistics stats = print_job_timer.getStats();
@@ -2071,7 +2044,7 @@ void kill_screen(const char* lcd_msg) {
      *
      */
     static void lcd_info_thermistors_menu() {
-      if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+      if (lcd_clicked) { return lcd_goto_previous_menu(true); }
       START_SCREEN();
       #define THERMISTOR_ID TEMP_SENSOR_0
       #include "thermistornames.h"
@@ -2123,7 +2096,7 @@ void kill_screen(const char* lcd_msg) {
      *
      */
     static void lcd_info_board_menu() {
-      if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+      if (lcd_clicked) { return lcd_goto_previous_menu(true); }
       START_SCREEN();
       STATIC_ITEM(BOARD_NAME, true, true);                           // MyPrinterController
       STATIC_ITEM(MSG_INFO_BAUDRATE ": " STRINGIFY(BAUDRATE), true); // Baud: 250000
@@ -2144,7 +2117,7 @@ void kill_screen(const char* lcd_msg) {
      *
      */
     static void lcd_info_printer_menu() {
-      if (LCD_CLICKED) { lcd_goto_previous_menu(true); return; }
+      if (lcd_clicked) { return lcd_goto_previous_menu(true); }
       START_SCREEN();
       STATIC_ITEM(MSG_MARLIN, true, true);                             // Marlin
       STATIC_ITEM(SHORT_BUILD_VERSION, true);                          // x.x.x-Branch
@@ -2334,16 +2307,15 @@ void kill_screen(const char* lcd_msg) {
   #define menu_edit_type(_type, _name, _strFunc, scale) \
     bool _menu_edit_ ## _name () { \
       ENCODER_DIRECTION_NORMAL(); \
-      bool isClicked = LCD_CLICKED; \
       if ((int32_t)encoderPosition < 0) encoderPosition = 0; \
       if ((int32_t)encoderPosition > maxEditValue) encoderPosition = maxEditValue; \
       if (lcdDrawUpdate) \
         lcd_implementation_drawedit(editLabel, _strFunc(((_type)((int32_t)encoderPosition + minEditValue)) / scale)); \
-      if (isClicked) { \
+      if (lcd_clicked) { \
         *((_type*)editValue) = ((_type)((int32_t)encoderPosition + minEditValue)) / scale; \
         lcd_goto_previous_menu(true); \
       } \
-      return isClicked; \
+      return lcd_clicked; \
     } \
     void menu_edit_ ## _name () { _menu_edit_ ## _name(); } \
     void menu_edit_callback_ ## _name () { if (_menu_edit_ ## _name ()) (*callbackFunc)(); } \
@@ -2614,9 +2586,20 @@ void lcd_update() {
   #if ENABLED(ULTIPANEL)
     static millis_t return_to_status_ms = 0;
     manage_manual_move();
-  #endif
 
-  lcd_buttons_update();
+    lcd_buttons_update();
+
+    // If the action button is pressed...
+    if (LCD_CLICKED) {
+      if (!wait_for_unclick) {           // If not waiting for a debounce release:
+        wait_for_unclick = true;         //  Set debounce flag to ignore continous clicks
+        lcd_clicked = !wait_for_user;    //  Keep the click if not waiting for a user-click
+        wait_for_user = false;           //  Any click clears wait for user
+        lcd_quick_feedback();            //  Always make a click sound
+      }
+    }
+    else wait_for_unclick = false;
+  #endif
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
 
@@ -2691,7 +2674,7 @@ void lcd_update() {
       #endif // REPRAPWORLD_KEYPAD
 
       bool encoderPastThreshold = (abs(encoderDiff) >= ENCODER_PULSES_PER_STEP);
-      if (encoderPastThreshold || LCD_CLICKED) {
+      if (encoderPastThreshold || lcd_clicked) {
         if (encoderPastThreshold) {
           int32_t encoderMultiplier = 1;
 
@@ -2757,7 +2740,7 @@ void lcd_update() {
       }
 
       #if ENABLED(ULTIPANEL)
-        #define CURRENTSCREEN() (*currentScreen)()
+        #define CURRENTSCREEN() (*currentScreen)(), lcd_clicked = false
       #else
         #define CURRENTSCREEN() lcd_status_screen()
       #endif
@@ -3019,8 +3002,6 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
       return true;
     #endif
   }
-
-  bool lcd_clicked() { return LCD_CLICKED; }
 
 #endif // ULTIPANEL
 

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -30,12 +30,7 @@
   #define BUTTON_EXISTS(BN) (defined(BTN_## BN) && BTN_## BN >= 0)
   #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
 
-  extern int preheatHotendTemp1,
-             preheatBedTemp1,
-             preheatFanSpeed1,
-             preheatHotendTemp2,
-             preheatBedTemp2,
-             preheatFanSpeed2;
+  extern int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
 
   int lcd_strlen(const char* s);
   int lcd_strlen_P(const char* s);

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -30,6 +30,13 @@
   #define BUTTON_EXISTS(BN) (defined(BTN_## BN) && BTN_## BN >= 0)
   #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
 
+  extern int preheatHotendTemp1,
+             preheatBedTemp1,
+             preheatFanSpeed1,
+             preheatHotendTemp2,
+             preheatBedTemp2,
+             preheatFanSpeed2;
+
   int lcd_strlen(const char* s);
   int lcd_strlen_P(const char* s);
   void lcd_update();
@@ -65,32 +72,7 @@
   #define LCD_TIMEOUT_TO_STATUS 15000
 
   #if ENABLED(ULTIPANEL)
-    extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
-    void lcd_buttons_update();
-    void lcd_quick_feedback(); // Audible feedback for a button click - could also be visual
 
-    #if ENABLED(FILAMENT_CHANGE_FEATURE)
-      void lcd_filament_change_show_message(FilamentChangeMessage message);
-    #endif // FILAMENT_CHANGE_FEATURE
-
-  #else
-    FORCE_INLINE void lcd_buttons_update() {}
-  #endif
-
-  extern int preheatHotendTemp1,
-             preheatBedTemp1,
-             preheatFanSpeed1,
-             preheatHotendTemp2,
-             preheatBedTemp2,
-             preheatFanSpeed2;
-
-  #if ENABLED(FILAMENT_LCD_DISPLAY)
-    extern millis_t previous_lcd_status_ms;
-  #endif
-
-  bool lcd_blink();
-
-  #if ENABLED(ULTIPANEL)
     #define BLEN_A 0
     #define BLEN_B 1
     // Encoder click is directly connected
@@ -101,7 +83,26 @@
     #define EN_A (_BV(BLEN_A))
     #define EN_B (_BV(BLEN_B))
     #define EN_C (_BV(BLEN_C))
+
+    extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
+    void lcd_buttons_update();
+    void lcd_quick_feedback(); // Audible feedback for a button click - could also be visual
+
+    #if ENABLED(FILAMENT_CHANGE_FEATURE)
+      void lcd_filament_change_show_message(FilamentChangeMessage message);
+    #endif // FILAMENT_CHANGE_FEATURE
+
+  #else
+
+    inline void lcd_buttons_update() {}
+
   #endif
+
+  #if ENABLED(FILAMENT_LCD_DISPLAY)
+    extern millis_t previous_lcd_status_ms;
+  #endif
+
+  bool lcd_blink();
 
   #if ENABLED(REPRAPWORLD_KEYPAD) // is also ULTIPANEL and NEWPANEL
 
@@ -153,18 +154,18 @@
   #endif
 
 #else //no LCD
-  FORCE_INLINE void lcd_update() {}
-  FORCE_INLINE void lcd_init() {}
-  FORCE_INLINE bool lcd_hasstatus() { return false; }
-  FORCE_INLINE void lcd_setstatus(const char* message, const bool persist=false) {UNUSED(message); UNUSED(persist);}
-  FORCE_INLINE void lcd_setstatuspgm(const char* message, const uint8_t level=0) {UNUSED(message); UNUSED(level);}
-  FORCE_INLINE void lcd_buttons_update() {}
-  FORCE_INLINE void lcd_reset_alert_level() {}
-  FORCE_INLINE bool lcd_detected(void) { return true; }
+  inline void lcd_update() {}
+  inline void lcd_init() {}
+  inline bool lcd_hasstatus() { return false; }
+  inline void lcd_setstatus(const char* message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
+  inline void lcd_setstatuspgm(const char* message, const uint8_t level=0) { UNUSED(message); UNUSED(level); }
+  inline void lcd_buttons_update() {}
+  inline void lcd_reset_alert_level() {}
+  inline bool lcd_detected(void) { return true; }
 
   #define LCD_MESSAGEPGM(x) NOOP
   #define LCD_ALERTMESSAGEPGM(x) NOOP
 
-#endif //ULTRA_LCD
+#endif // ULTRA_LCD
 
-#endif //ULTRALCD_H
+#endif // ULTRALCD_H

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -68,8 +68,6 @@
     extern volatile uint8_t buttons;  //the last checked buttons in a bit array.
     void lcd_buttons_update();
     void lcd_quick_feedback(); // Audible feedback for a button click - could also be visual
-    bool lcd_clicked();
-    void lcd_ignore_click(bool b=true);
 
     #if ENABLED(FILAMENT_CHANGE_FEATURE)
       void lcd_filament_change_show_message(FilamentChangeMessage message);
@@ -79,12 +77,12 @@
     FORCE_INLINE void lcd_buttons_update() {}
   #endif
 
-  extern int preheatHotendTemp1;
-  extern int preheatBedTemp1;
-  extern int preheatFanSpeed1;
-  extern int preheatHotendTemp2;
-  extern int preheatBedTemp2;
-  extern int preheatFanSpeed2;
+  extern int preheatHotendTemp1,
+             preheatBedTemp1,
+             preheatFanSpeed1,
+             preheatHotendTemp2,
+             preheatBedTemp2,
+             preheatFanSpeed2;
 
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     extern millis_t previous_lcd_status_ms;
@@ -150,6 +148,8 @@
     #define LCD_CLICKED ((buttons & EN_C) || (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1))
   #elif ENABLED(NEWPANEL)
     #define LCD_CLICKED (buttons & EN_C)
+  #else
+    #define LCD_CLICKED false
   #endif
 
 #else //no LCD


### PR DESCRIPTION
Addressing #5052
- The LCD loop sets the `lcd_clicked` flag in a single place
- The flag is `extern` and replaces `LCD_CLICKED` (direct button pin test)
- `M0`/`M1` is simplified
