### PR TITLE
Optimize buffer_line by calculating before wait-for-free-block

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -763,6 +763,12 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
       enable_z();
     }
     if (block->steps[Y_AXIS]) enable_y();
+  #elif ENABLED(COREYZ)
+    if (block->steps[B_AXIS] || block->steps[C_AXIS]) {
+      enable_y();
+      enable_z();
+    }
+    if (block->steps[X_AXIS]) enable_x();
   #else
     if (block->steps[X_AXIS]) enable_x();
     if (block->steps[Y_AXIS]) enable_y();

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -594,12 +594,6 @@ void Planner::check_axes_activity() {
  *  extruder    - target extruder
  */
 void Planner::_buffer_line(const float &a, const float &b, const float &c, const float &e, float fr_mm_s, const uint8_t extruder) {
-  // Calculate the buffer head after we push this byte
-  int next_buffer_head = next_block_index(block_buffer_head);
-
-  // If the buffer is full: good! That means we are well ahead of the robot.
-  // Rest here until there is room in the buffer.
-  while (block_buffer_tail == next_buffer_head) idle();
 
   // The target position of the tool in absolute steps
   // Calculate target position in absolute steps
@@ -661,6 +655,13 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
       #endif
     }
   #endif
+
+  // Calculate the buffer head after we push this byte
+  int next_buffer_head = next_block_index(block_buffer_head);
+
+  // If the buffer is full: good! That means we are well ahead of the robot.
+  // Rest here until there is room in the buffer.
+  while (block_buffer_tail == next_buffer_head) idle();
 
   // Prepare to set up new block
   block_t* block = &block_buffer[block_buffer_head];

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -74,53 +74,54 @@ enum BlockFlag {
  */
 typedef struct {
 
+  uint8_t flag;                             // Block flags (See BlockFlag enum above)
+
   unsigned char active_extruder;            // The extruder to move (if E move)
 
-  // Fields used by the bresenham algorithm for tracing the line
-  long steps[NUM_AXIS];                     // Step count along each axis
-  unsigned long step_event_count;           // The number of step events required to complete this block
+  // Fields used by the Bresenham algorithm for tracing the line
+  int32_t steps[NUM_AXIS];                  // Step count along each axis
+  uint32_t step_event_count;                // The number of step events required to complete this block
 
   #if ENABLED(MIXING_EXTRUDER)
-    unsigned long mix_event_count[MIXING_STEPPERS]; // Scaled step_event_count for the mixing steppers
+    uint32_t mix_event_count[MIXING_STEPPERS]; // Scaled step_event_count for the mixing steppers
   #endif
 
-  long accelerate_until,                    // The index of the step event on which to stop acceleration
-       decelerate_after,                    // The index of the step event on which to start decelerating
-       acceleration_rate;                   // The acceleration rate used for acceleration calculation
+  int32_t accelerate_until,                 // The index of the step event on which to stop acceleration
+          decelerate_after,                 // The index of the step event on which to start decelerating
+          acceleration_rate;                // The acceleration rate used for acceleration calculation
 
-  unsigned char direction_bits;             // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
+  uint8_t direction_bits;                   // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
 
   // Advance extrusion
   #if ENABLED(LIN_ADVANCE)
     bool use_advance_lead;
-    int e_speed_multiplier8; // Factorised by 2^8 to avoid float
+    int16_t e_speed_multiplier8; // Factorised by 2^8 to avoid float
   #elif ENABLED(ADVANCE)
-    long advance_rate;
-    volatile long initial_advance;
-    volatile long final_advance;
+    int32_t advance_rate;
+    volatile int32_t initial_advance;
+    volatile int32_t final_advance;
     float advance;
   #endif
 
   // Fields used by the motion planner to manage acceleration
-  float nominal_speed,                          // The nominal speed for this block in mm/sec
-        entry_speed,                            // Entry speed at previous-current junction in mm/sec
-        max_entry_speed,                        // Maximum allowable junction entry speed in mm/sec
-        millimeters,                            // The total travel of this block in mm
-        acceleration;                           // acceleration mm/sec^2
-  uint8_t flag;                                 // Block flags (See BlockFlag enum above)
+  float nominal_speed,                      // The nominal speed for this block in mm/sec
+        entry_speed,                        // Entry speed at previous-current junction in mm/sec
+        max_entry_speed,                    // Maximum allowable junction entry speed in mm/sec
+        millimeters,                        // The total travel of this block in mm
+        acceleration;                       // acceleration mm/sec^2
 
   // Settings for the trapezoid generator
-  uint32_t nominal_rate,                        // The nominal step rate for this block in step_events/sec
-           initial_rate,                        // The jerk-adjusted step rate at start of block
-           final_rate,                          // The minimal rate at exit
-           acceleration_steps_per_s2;           // acceleration steps/sec^2
+  uint32_t nominal_rate,                    // The nominal step rate for this block in step_events/sec
+           initial_rate,                    // The jerk-adjusted step rate at start of block
+           final_rate,                      // The minimal rate at exit
+           acceleration_steps_per_s2;       // acceleration steps/sec^2
 
   #if FAN_COUNT > 0
-    unsigned long fan_speed[FAN_COUNT];
+    uint32_t fan_speed[FAN_COUNT];
   #endif
 
   #if ENABLED(BARICUDA)
-    unsigned long valve_pressure, e_to_p_pressure;
+    uint32_t valve_pressure, e_to_p_pressure;
   #endif
 
 } block_t;

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -344,7 +344,7 @@ void Stepper::isr() {
     // Anything in the buffer?
     current_block = planner.get_current_block();
     if (current_block) {
-      current_block->busy = true;
+      SBI(current_block->flag, BLOCK_BIT_BUSY);
       trapezoid_generator_reset();
 
       // Initialize Bresenham counters to 1/2 the ceiling


### PR DESCRIPTION
This optimization of `buffer_line` moves the wait-for-buffer test farther down so that calculations that don't need to write to the block can occur ahead of time. This saves lots of time because the calculations will already have been done when the block finally becomes available. Significantly more time may be saved by doing other expensive calculations earlier also.
