### PR TITLE
Block lcd_update during short segments

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9539,7 +9539,11 @@ void idle(
     bool no_stepper_sleep/*=false*/
   #endif
 ) {
-  lcd_update();
+  #if ENABLED(BLOCK_LCD_ON_SHORT_MOVES)
+    if (planner.long_move()) lcd_update();
+  #else
+    lcd_update();
+  #endif
   host_keepalive();
   manage_inactivity(
     #if ENABLED(FILAMENT_CHANGE_FEATURE)

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -498,6 +498,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -500,6 +500,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -494,6 +494,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -494,6 +494,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -494,6 +494,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -499,6 +499,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -494,6 +494,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -492,6 +492,13 @@
   #define BABYSTEP_MULTIPLICATOR 1 //faster movements
 #endif
 
+// During short segments like in circles, the update of the LCD Display can take so long that the block buffer gets completely drained.
+// If that happens, the movement of the printer gets very jerky until a longer segment like a longer straight line allows the buffer
+// to be filled again. This small stops also effects print quality in a bad way.
+// Enable BLOCK_LCD_ON_SHORT_MOVES to update the LCD only when there is enough time during a move to do so.
+// Note that this means the display will not show actual values during this time and your printer will also not react to buttons pressed!
+//#define BLOCK_LCD_ON_SHORT_MOVES
+
 // @section extruder
 
 // extruder advance constant (s2/mm3)

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -932,6 +932,14 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
       }
     #endif
   #endif
+  
+  #if ENABLED(BLOCK_LCD_ON_SHORT_MOVES)
+    #if ENABLED(SLOWDOWN)
+      block->segment_time = segment_time;
+    #else
+      block->segment_time = lround(1000000.0/inverse_mm_s);
+    #endif
+  #endif
 
   block->nominal_speed = block->millimeters * inverse_mm_s; // (mm/sec) Always > 0
   block->nominal_rate = ceil(block->step_event_count * inverse_mm_s); // (step/sec) Always > 0

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -123,6 +123,10 @@ typedef struct {
   #if ENABLED(BARICUDA)
     uint32_t valve_pressure, e_to_p_pressure;
   #endif
+  
+  #if ENABLED(BLOCK_LCD_ON_SHORT_MOVES)
+    uint32_t segment_time;
+  #endif
 
 } block_t;
 
@@ -356,6 +360,17 @@ class Planner {
       else
         return NULL;
     }
+    
+    #if ENABLED(BLOCK_LCD_ON_SHORT_MOVES)
+      static bool long_move() {
+        if (blocks_queued()) {
+          block_t* block = &block_buffer[block_buffer_tail];
+          return (block->segment_time > 25000UL);
+        }
+        else
+          return true;
+      }
+    #endif
 
     #if ENABLED(AUTOTEMP)
       static float autotemp_max;


### PR DESCRIPTION
lcd_update can take so much time that the block buffer gets drained if there are only short segments. This leads to jerky printer movements for example in circles and a bad print quality.

This change implements a simple check: Only if the block currently executed is long enough, run lcd_update.
This also means the printer will not show actual values on the LCD nor will it respond to buttons pressed. But for normal printing, LCD and interaction are not necessary so this might be OK for most users.

Without increased block buffer size or other changes, this means I can print now circles with D=20mm at 60mm/s and more at full resolution without the printer stuttering - before I was used to do such things at 20mm/s perimeter speed.