### PR TITLE
OLD_SLOWDOWN does nothing, so remove it

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -929,24 +929,18 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   int moves_queued = movesplanned();
 
   // Slow down when the buffer starts to empty, rather than wait at the corner for a buffer refill
-  #if ENABLED(OLD_SLOWDOWN) || ENABLED(SLOWDOWN)
-    bool mq = moves_queued > 1 && moves_queued < (BLOCK_BUFFER_SIZE) / 2;
-    #if ENABLED(OLD_SLOWDOWN)
-      if (mq) fr_mm_s *= 2.0 * moves_queued / (BLOCK_BUFFER_SIZE);
-    #endif
-    #if ENABLED(SLOWDOWN)
-      //  segment time im micro seconds
-      unsigned long segment_time = lround(1000000.0/inverse_mm_s);
-      if (mq) {
-        if (segment_time < min_segment_time) {
-          // buffer is draining, add extra time.  The amount of time added increases if the buffer is still emptied more.
-          inverse_mm_s = 1000000.0 / (segment_time + lround(2 * (min_segment_time - segment_time) / moves_queued));
-          #ifdef XY_FREQUENCY_LIMIT
-            segment_time = lround(1000000.0 / inverse_mm_s);
-          #endif
-        }
+  #if ENABLED(SLOWDOWN)
+    // Segment time im micro seconds
+    unsigned long segment_time = lround(1000000.0 / inverse_mm_s);
+    if (moves_queued > 1 && moves_queued < (BLOCK_BUFFER_SIZE) / 2) {
+      if (segment_time < min_segment_time) {
+        // buffer is draining, add extra time.  The amount of time added increases if the buffer is still emptied more.
+        inverse_mm_s = 1000000.0 / (segment_time + lround(2 * (min_segment_time - segment_time) / moves_queued));
+        #ifdef XY_FREQUENCY_LIMIT
+          segment_time = lround(1000000.0 / inverse_mm_s);
+        #endif
       }
-    #endif
+    }
   #endif
 
   block->nominal_speed = block->millimeters * inverse_mm_s; // (mm/sec) Always > 0


### PR DESCRIPTION
The `fr_mm_s` modified by `OLD_SLOWDOWN` is simply never used, and it's been this way [since at least Marlin 1.0.2](https://github.com/MarlinFirmware/Marlin/blob/1.0.x/Marlin/planner.cpp#L760).

Possibly the intent was to modify the variable ahead of the line:
```cpp
float inverse_mm_s = fr_mm_s * inverse_millimeters;
```

This PR removes the obsolete code associated with `OLD_SLOWDOWN` and reformats the `SLOWDOWN` code block.