### PR TITLE
TMC2130 "Silent StepStick" support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,16 @@ install:
   - sudo mv U8glib_Arduino /usr/local/share/arduino/libraries/U8glib
   #
   # Install: L6470 Stepper Motor Driver library
-  - git clone https://github.com/ameyer/Arduino-L6470.git
-  - sudo mv Arduino-L6470/L6470 /usr/local/share/arduino/libraries/L6470
+  # - git clone https://github.com/ameyer/Arduino-L6470.git
+  # - sudo mv Arduino-L6470/L6470 /usr/local/share/arduino/libraries/L6470
   #
   # Install: TMC26X Stepper Motor Controller library
-  - git clone https://github.com/trinamic/TMC26XStepper.git
-  - sudo mv TMC26XStepper /usr/local/share/arduino/libraries/TMC26XStepper
+  # - git clone https://github.com/trinamic/TMC26XStepper.git
+  # - sudo mv TMC26XStepper /usr/local/share/arduino/libraries/TMC26XStepper
+  #
+  # Install: TMC2130 Stepper Motor Controller library
+  - git clone https://github.com/MarlinFirmware/Trinamic_TMC2130.git
+  - sudo mv Trinamic_TMC2130/Trinamic_TMC2130 /usr/local/share/arduino/libraries/Trinamic_TMC2130
   #
 before_script:
   #
@@ -378,6 +382,12 @@ script:
   #
   - use_example_configs SCARA
   - opt_enable AUTO_BED_LEVELING_BILINEAR FIX_MOUNTED_PROBE USE_ZMIN_PLUG EEPROM_SETTINGS EEPROM_CHITCHAT ULTIMAKERCONTROLLER
+  - build_marlin
+  #
+  # TMC2130 Config
+  #
+  - restore_configs
+  - opt_enable_adv HAVE_TMC2130DRIVER X_IS_TMC2130 Y_IS_TMC2130 Z_IS_TMC2130 E0_IS_TMC2130
   - build_marlin
   #
   # tvrrug Config need to check board type for sanguino atmega644p

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,70 +964,77 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -756,10 +756,215 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
 

--- a/Marlin/Marlin.ino
+++ b/Marlin/Marlin.ino
@@ -67,6 +67,11 @@
   #include <TMC26XStepper.h>
 #endif
 
+#if ENABLED(HAVE_TMC2130DRIVER)
+  #include <SPI.h>
+  #include <Trinamic_TMC2130.h>
+#endif
+
 #if ENABLED(HAVE_L6470DRIVER)
   #include <SPI.h>
   #include <L6470.h>

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5884,45 +5884,6 @@ inline void gcode_M117() {
  */
 inline void gcode_M119() { endstops.M119(); }
 
-#if ENABLED(HAVE_TMC2130DRIVER)
-  /**
-   * M122: Output Trinamic TMC2130 status to serial output. Very bad formatting.
-   */
-  inline void gcode_M122() {
-    SERIAL_PROTOCOLLNPGM("REPORTING TMC2130 STATUS");
-    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(X_IS_TMC2130)
-      stepperX.read_STAT();
-      SERIAL_PROTOCOLLN("X-AXIS: ");
-      SERIAL_PROTOCOLLN((stepperX.isReset() ? "RESET " : "----- "));
-      SERIAL_PROTOCOLLN((stepperX.isError() ? "ERROR " : "----- "));
-      SERIAL_PROTOCOLLN((stepperX.isStallguard() ? "SLGRD " : "----- "));
-      SERIAL_PROTOCOLLN((stepperX.isStandstill() ? "STILL " : "----- "));
-      SERIAL_PROTOCOLLN((stepperX.debug()));
-      SERIAL_PROTOCOLLN("-----");
-    #endif
-    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Y_IS_TMC2130)
-      stepperY.read_STAT();
-      SERIAL_PROTOCOLLN("Y-AXIS: ");
-      SERIAL_PROTOCOLLN((stepperY.isReset() ? "RESET " : "----- "));
-      SERIAL_PROTOCOLLN((stepperY.isError() ? "ERROR " : "----- "));
-      SERIAL_PROTOCOLLN((stepperY.isStallguard() ? "SLGRD " : "----- "));
-      SERIAL_PROTOCOLLN((stepperY.isStandstill() ? "STILL " : "----- "));
-      SERIAL_PROTOCOLLN((stepperY.debug()));
-      SERIAL_PROTOCOLLN("-----");
-    #endif
-    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Z_IS_TMC2130)
-      stepperZ.read_STAT();
-      SERIAL_PROTOCOLLN("Z-AXIS: ");
-      SERIAL_PROTOCOLLN((stepperZ.isReset() ? "RESET " : "----- "));
-      SERIAL_PROTOCOLLN((stepperZ.isError() ? "ERROR " : "----- "));
-      SERIAL_PROTOCOLLN((stepperZ.isStallguard() ? "SLGRD " : "----- "));
-      SERIAL_PROTOCOLLN((stepperZ.isStandstill() ? "STILL " : "----- "));
-      SERIAL_PROTOCOLLN((stepperZ.debug()));
-      SERIAL_PROTOCOLLN("-----");
-    #endif
-  }
-#endif // HAVE_TMC2130DRIVER
-
 /**
  * M120: Enable endstops and set non-homing endstop state to "enabled"
  */
@@ -5932,6 +5893,58 @@ inline void gcode_M120() { endstops.enable_globally(true); }
  * M121: Disable endstops and set non-homing endstop state to "disabled"
  */
 inline void gcode_M121() { endstops.enable_globally(false); }
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  /**
+   * M122: Output Trinamic TMC2130 status to serial output. Very bad formatting.
+   */
+
+  static void tmc2130_report(Trinamic_TMC2130 &stepr, const char *name) {
+    stepr.read_STAT();
+    SERIAL_PROTOCOL(name);
+    SERIAL_PROTOCOL(": ");
+    stepr.isReset() ? SERIAL_PROTOCOLPGM("RESET ") : SERIAL_PROTOCOLPGM("----- ");
+    stepr.isError() ? SERIAL_PROTOCOLPGM("ERROR ") : SERIAL_PROTOCOLPGM("----- ");
+    stepr.isStallguard() ? SERIAL_PROTOCOLPGM("SLGRD ") : SERIAL_PROTOCOLPGM("----- ");
+    stepr.isStandstill() ? SERIAL_PROTOCOLPGM("STILL ") : SERIAL_PROTOCOLPGM("----- ");
+    SERIAL_PROTOCOLLN(stepr.debug());
+  }
+
+  inline void gcode_M122() {
+    SERIAL_PROTOCOLLNPGM("Reporting TMC2130 status");
+    #if ENABLED(X_IS_TMC2130)
+      tmc2130_report(stepperX, "X");
+    #endif
+    #if ENABLED(X2_IS_TMC2130)
+      tmc2130_report(stepperX2, "X2");
+    #endif
+    #if ENABLED(Y_IS_TMC2130)
+      tmc2130_report(stepperY, "Y");
+    #endif
+    #if ENABLED(Y2_IS_TMC2130)
+      tmc2130_report(stepperY2, "Y2");
+    #endif
+    #if ENABLED(Z_IS_TMC2130)
+      tmc2130_report(stepperZ, "Z");
+    #endif
+    #if ENABLED(Z2_IS_TMC2130)
+      tmc2130_report(stepperZ2, "Z2");
+    #endif
+    #if ENABLED(E0_IS_TMC2130)
+      tmc2130_report(stepperE0, "E0");
+    #endif
+    #if ENABLED(E1_IS_TMC2130)
+      tmc2130_report(stepperE1, "E1");
+    #endif
+    #if ENABLED(E2_IS_TMC2130)
+      tmc2130_report(stepperE2, "E2");
+    #endif
+    #if ENABLED(E3_IS_TMC2130)
+      tmc2130_report(stepperE3, "E3");
+    #endif
+  }
+#endif // HAVE_TMC2130DRIVER
 
 #if ENABLED(BLINKM)
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8090,23 +8090,23 @@ void process_next_command() {
       case 92: // M92: Set the steps-per-unit for one or more axes
         gcode_M92();
         break;
+      case 114: // M114: Report current position
+        gcode_M114();
+        break;
       case 115: // M115: Report capabilities
         gcode_M115();
         break;
       case 117: // M117: Set LCD message text, if possible
         gcode_M117();
         break;
-      case 114: // M114: Report current position
-        gcode_M114();
+      case 119: // M119: Report endstop states
+        gcode_M119();
         break;
       case 120: // M120: Enable endstops
         gcode_M120();
         break;
       case 121: // M121: Disable endstops
         gcode_M121();
-        break;
-      case 119: // M119: Report endstop states
-        gcode_M119();
         break;
 
       #if ENABLED(HAVE_TMC2130DRIVER)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5884,6 +5884,45 @@ inline void gcode_M117() {
  */
 inline void gcode_M119() { endstops.M119(); }
 
+#if ENABLED(HAVE_TMC2130DRIVER)
+  /**
+   * M122: Output Trinamic TMC2130 status to serial output. Very bad formatting.
+   */
+  inline void gcode_M122() {
+    SERIAL_PROTOCOLLNPGM("REPORTING TMC2130 STATUS");
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(X_IS_TMC2130)
+      stepperX.read_STAT();
+      SERIAL_PROTOCOLLN("X-AXIS: ");
+      SERIAL_PROTOCOLLN((stepperX.isReset() ? "RESET " : "----- "));
+      SERIAL_PROTOCOLLN((stepperX.isError() ? "ERROR " : "----- "));
+      SERIAL_PROTOCOLLN((stepperX.isStallguard() ? "SLGRD " : "----- "));
+      SERIAL_PROTOCOLLN((stepperX.isStandstill() ? "STILL " : "----- "));
+      SERIAL_PROTOCOLLN((stepperX.debug()));
+      SERIAL_PROTOCOLLN("-----");
+    #endif
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Y_IS_TMC2130)
+      stepperY.read_STAT();
+      SERIAL_PROTOCOLLN("Y-AXIS: ");
+      SERIAL_PROTOCOLLN((stepperY.isReset() ? "RESET " : "----- "));
+      SERIAL_PROTOCOLLN((stepperY.isError() ? "ERROR " : "----- "));
+      SERIAL_PROTOCOLLN((stepperY.isStallguard() ? "SLGRD " : "----- "));
+      SERIAL_PROTOCOLLN((stepperY.isStandstill() ? "STILL " : "----- "));
+      SERIAL_PROTOCOLLN((stepperY.debug()));
+      SERIAL_PROTOCOLLN("-----");
+    #endif
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Z_IS_TMC2130)
+      stepperZ.read_STAT();
+      SERIAL_PROTOCOLLN("Z-AXIS: ");
+      SERIAL_PROTOCOLLN((stepperZ.isReset() ? "RESET " : "----- "));
+      SERIAL_PROTOCOLLN((stepperZ.isError() ? "ERROR " : "----- "));
+      SERIAL_PROTOCOLLN((stepperZ.isStallguard() ? "SLGRD " : "----- "));
+      SERIAL_PROTOCOLLN((stepperZ.isStandstill() ? "STILL " : "----- "));
+      SERIAL_PROTOCOLLN((stepperZ.debug()));
+      SERIAL_PROTOCOLLN("-----");
+    #endif
+  }
+#endif // HAVE_TMC2130DRIVER
+
 /**
  * M120: Enable endstops and set non-homing endstop state to "enabled"
  */
@@ -8056,6 +8095,12 @@ void process_next_command() {
       case 119: // M119: Report endstop states
         gcode_M119();
         break;
+
+      #if ENABLED(HAVE_TMC2130DRIVER)
+        case 122: // M122: Diagnose, used to debug TMC2130
+          gcode_M122();
+          break;
+      #endif
 
       #if ENABLED(ULTIPANEL)
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -803,11 +803,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -718,54 +718,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -976,7 +977,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -988,64 +990,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -769,12 +769,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -798,11 +798,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -764,12 +764,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -713,54 +713,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -971,7 +972,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -983,64 +985,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -962,7 +963,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -974,64 +976,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -756,12 +756,222 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -789,11 +789,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -758,12 +758,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -792,11 +792,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -707,54 +707,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -965,7 +966,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -977,64 +979,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -758,12 +758,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -792,11 +792,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -707,54 +707,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -965,7 +966,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -977,64 +979,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -758,12 +758,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -792,11 +792,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -707,54 +707,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -965,7 +966,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -977,64 +979,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -712,54 +712,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -970,7 +971,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -982,64 +984,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -797,11 +797,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -763,12 +763,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -758,12 +758,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -792,11 +792,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -707,54 +707,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -965,7 +966,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -977,64 +979,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -790,11 +790,8 @@
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
-    // you can define global settings here, but you still need
-    // to configure the tmc2130.init() method manually in the file
-    //
-    // stepper_indirection.cpp
+    // If you've enabled TMC2130_ADVANCED_CONFIGURATION, define global settings below.
+    // Enabled settings will be automatically applied to all axes specified above.
     //
     // Please read the TMC2130 datasheet:
     // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -705,54 +705,55 @@
 #if ENABLED(HAVE_TMCDRIVER)
 
   //#define X_IS_TMC
-  #define X_MAX_CURRENT 1000  //in mA
-  #define X_SENSE_RESISTOR 91 //in mOhms
-  #define X_MICROSTEPS 16     //number of microsteps
-
   //#define X2_IS_TMC
-  #define X2_MAX_CURRENT 1000  //in mA
-  #define X2_SENSE_RESISTOR 91 //in mOhms
-  #define X2_MICROSTEPS 16     //number of microsteps
-
   //#define Y_IS_TMC
-  #define Y_MAX_CURRENT 1000  //in mA
-  #define Y_SENSE_RESISTOR 91 //in mOhms
-  #define Y_MICROSTEPS 16     //number of microsteps
-
   //#define Y2_IS_TMC
-  #define Y2_MAX_CURRENT 1000  //in mA
-  #define Y2_SENSE_RESISTOR 91 //in mOhms
-  #define Y2_MICROSTEPS 16     //number of microsteps
-
   //#define Z_IS_TMC
-  #define Z_MAX_CURRENT 1000  //in mA
-  #define Z_SENSE_RESISTOR 91 //in mOhms
-  #define Z_MICROSTEPS 16     //number of microsteps
-
   //#define Z2_IS_TMC
-  #define Z2_MAX_CURRENT 1000  //in mA
-  #define Z2_SENSE_RESISTOR 91 //in mOhms
-  #define Z2_MICROSTEPS 16     //number of microsteps
-
   //#define E0_IS_TMC
-  #define E0_MAX_CURRENT 1000  //in mA
-  #define E0_SENSE_RESISTOR 91 //in mOhms
-  #define E0_MICROSTEPS 16     //number of microsteps
-
   //#define E1_IS_TMC
-  #define E1_MAX_CURRENT 1000  //in mA
-  #define E1_SENSE_RESISTOR 91 //in mOhms
-  #define E1_MICROSTEPS 16     //number of microsteps
-
   //#define E2_IS_TMC
-  #define E2_MAX_CURRENT 1000  //in mA
-  #define E2_SENSE_RESISTOR 91 //in mOhms
-  #define E2_MICROSTEPS 16     //number of microsteps
-
   //#define E3_IS_TMC
-  #define E3_MAX_CURRENT 1000  //in mA
-  #define E3_SENSE_RESISTOR 91 //in mOhms
-  #define E3_MICROSTEPS 16     //number of microsteps
+
+  #define X_MAX_CURRENT     1000 // in mA
+  #define X_SENSE_RESISTOR    91 // in mOhms
+  #define X_MICROSTEPS        16 // number of microsteps
+
+  #define X2_MAX_CURRENT    1000
+  #define X2_SENSE_RESISTOR   91
+  #define X2_MICROSTEPS       16
+
+  #define Y_MAX_CURRENT     1000
+  #define Y_SENSE_RESISTOR    91
+  #define Y_MICROSTEPS        16
+
+  #define Y2_MAX_CURRENT    1000
+  #define Y2_SENSE_RESISTOR   91
+  #define Y2_MICROSTEPS       16
+
+  #define Z_MAX_CURRENT     1000
+  #define Z_SENSE_RESISTOR    91
+  #define Z_MICROSTEPS        16
+
+  #define Z2_MAX_CURRENT    1000
+  #define Z2_SENSE_RESISTOR   91
+  #define Z2_MICROSTEPS       16
+
+  #define E0_MAX_CURRENT    1000
+  #define E0_SENSE_RESISTOR   91
+  #define E0_MICROSTEPS       16
+
+  #define E1_MAX_CURRENT    1000
+  #define E1_SENSE_RESISTOR   91
+  #define E1_MICROSTEPS       16
+
+  #define E2_MAX_CURRENT    1000
+  #define E2_SENSE_RESISTOR   91
+  #define E2_MICROSTEPS       16
+
+  #define E3_MAX_CURRENT    1000
+  #define E3_SENSE_RESISTOR   91
+  #define E3_MICROSTEPS       16
 
 #endif
 
@@ -963,7 +964,8 @@
 
 #endif // HAVE_TMC2130DRIVER
 
-// @section l6470
+// @section L6470
+
 
 /**
  * Enable this section if you have L6470 motor drivers.
@@ -975,64 +977,65 @@
 #if ENABLED(HAVE_L6470DRIVER)
 
   //#define X_IS_L6470
-  #define X_MICROSTEPS 16     //number of microsteps
-  #define X_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define X2_IS_L6470
-  #define X2_MICROSTEPS 16     //number of microsteps
-  #define X2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define X2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define X2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y_IS_L6470
-  #define Y_MICROSTEPS 16     //number of microsteps
-  #define Y_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Y2_IS_L6470
-  #define Y2_MICROSTEPS 16     //number of microsteps
-  #define Y2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Y2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Y2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z_IS_L6470
-  #define Z_MICROSTEPS 16     //number of microsteps
-  #define Z_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define Z2_IS_L6470
-  #define Z2_MICROSTEPS 16     //number of microsteps
-  #define Z2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define Z2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define Z2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E0_IS_L6470
-  #define E0_MICROSTEPS 16     //number of microsteps
-  #define E0_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E0_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E0_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E1_IS_L6470
-  #define E1_MICROSTEPS 16     //number of microsteps
-  #define E1_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E1_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E1_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E2_IS_L6470
-  #define E2_MICROSTEPS 16     //number of microsteps
-  #define E2_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E2_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E2_STALLCURRENT 1500 //current in mA where the driver will detect a stall
-
   //#define E3_IS_L6470
-  #define E3_MICROSTEPS 16     //number of microsteps
-  #define E3_K_VAL 50          // 0 - 255, Higher values, are higher power. Be careful not to go too high
-  #define E3_OVERCURRENT 2000  //maxc current in mA. If the current goes over this value, the driver will switch off
-  #define E3_STALLCURRENT 1500 //current in mA where the driver will detect a stall
+
+  #define X_MICROSTEPS      16 // number of microsteps
+  #define X_K_VAL           50 // 0 - 255, Higher values, are higher power. Be careful not to go too high
+  #define X_OVERCURRENT   2000 // maxc current in mA. If the current goes over this value, the driver will switch off
+  #define X_STALLCURRENT  1500 // current in mA where the driver will detect a stall
+
+  #define X2_MICROSTEPS     16
+  #define X2_K_VAL          50
+  #define X2_OVERCURRENT  2000
+  #define X2_STALLCURRENT 1500
+
+  #define Y_MICROSTEPS      16
+  #define Y_K_VAL           50
+  #define Y_OVERCURRENT   2000
+  #define Y_STALLCURRENT  1500
+
+  #define Y2_MICROSTEPS     16
+  #define Y2_K_VAL          50
+  #define Y2_OVERCURRENT  2000
+  #define Y2_STALLCURRENT 1500
+
+  #define Z_MICROSTEPS      16
+  #define Z_K_VAL           50
+  #define Z_OVERCURRENT   2000
+  #define Z_STALLCURRENT  1500
+
+  #define Z2_MICROSTEPS     16
+  #define Z2_K_VAL          50
+  #define Z2_OVERCURRENT  2000
+  #define Z2_STALLCURRENT 1500
+
+  #define E0_MICROSTEPS     16
+  #define E0_K_VAL          50
+  #define E0_OVERCURRENT  2000
+  #define E0_STALLCURRENT 1500
+
+  #define E1_MICROSTEPS     16
+  #define E1_K_VAL          50
+  #define E1_OVERCURRENT  2000
+  #define E1_STALLCURRENT 1500
+
+  #define E2_MICROSTEPS     16
+  #define E2_K_VAL          50
+  #define E2_OVERCURRENT  2000
+  #define E2_STALLCURRENT 1500
+
+  #define E3_MICROSTEPS     16
+  #define E3_K_VAL          50
+  #define E3_OVERCURRENT  2000
+  #define E3_STALLCURRENT 1500
 
 #endif
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -756,12 +756,223 @@
 
 #endif
 
-/******************************************************************************\
- * enable this section if you have L6470  motor drivers.
- * you need to import the L6470 library into the Arduino IDE for this
- ******************************************************************************/
+// @section TMC2130
+
+
+/**
+ * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
+ *
+ * To use TMC2130 drivers in SPI mode, you'll also need the TMC2130 Arduino library
+ * (https://github.com/makertum/Trinamic_TMC2130).
+ *
+ * To use TMC2130 stepper drivers in SPI mode connect your SPI2130 pins to
+ * the hardware SPI interface on your board and define the required CS pins
+ * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
+ */
+
+//#define HAVE_TMC2130DRIVER
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  //#define TMC2130_ADVANCED_CONFIGURATION
+
+  // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
+  //#define X_IS_TMC2130
+  //#define X2_IS_TMC2130
+  //#define Y_IS_TMC2130
+  //#define Y2_IS_TMC2130
+  //#define Z_IS_TMC2130
+  //#define Z2_IS_TMC2130
+  //#define E0_IS_TMC2130
+  //#define E1_IS_TMC2130
+  //#define E2_IS_TMC2130
+  //#define E3_IS_TMC2130
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    // If you have enabled TMC2130_ADVANCED_CONFIGURATION,
+    // you can define global settings here, but you still need
+    // to configure the tmc2130.init() method manually in the file
+    //
+    // stepper_indirection.cpp
+    //
+    // Please read the TMC2130 datasheet:
+    // http://www.trinamic.com/_articles/products/integrated-circuits/tmc2130/_datasheet/TMC2130_datasheet.pdf
+    // All settings here have the same (sometimes cryptic) names as in the datasheet.
+    //
+    // The following, uncommented settings are only suggestion.
+
+    /* GENERAL CONFIGURATION */
+
+    //#define GLOBAL_EN_PWM_MODE        0
+    #define GLOBAL_I_SCALE_ANALOG     1 // [0,1] 0: Normal, 1: AIN
+    //#define GLOBAL_INTERNAL_RSENSE    0 // [0,1] 0: Normal, 1: Internal
+    #define GLOBAL_EN_PWM_MODE        0 // [0,1] 0: Normal, 1: stealthChop with velocity threshold
+    //#define GLOBAL_ENC_COMMUTATION    0 // [0,1]
+    #define GLOBAL_SHAFT              0 // [0,1] 0: normal, 1: invert
+    //#define GLOBAL_DIAG0_ERROR        0 // [0,1]
+    //#define GLOBAL_DIAG0_OTPW         0 // [0,1]
+    //#define GLOBAL_DIAG0_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_STALL        0 // [0,1]
+    //#define GLOBAL_DIAG1_INDEX        0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG1_ONSTATE      0 // [0,1]
+    //#define GLOBAL_DIAG0_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_DIAG1_INT_PUSHPULL 0 // [0,1]
+    //#define GLOBAL_SMALL_HYSTERESIS   0 // [0,1]
+    //#define GLOBAL_STOP_ENABLE        0 // [0,1]
+    //#define GLOBAL_DIRECT_MODE        0 // [0,1]
+
+    /* VELOCITY-DEPENDENT DRIVE FEATURES */
+
+    #define GLOBAL_IHOLD             22 // [0-31] 0: min, 31: max
+    #define GLOBAL_IRUN              31 // [0-31] 0: min, 31: max
+    #define GLOBAL_IHOLDDELAY        15 // [0-15] 0: min, 15: about 4 seconds
+    //#define GLOBAL_TPOWERDOWN         0 // [0-255] 0: min, 255: about 4 seconds
+    //#define GLOBAL_TPWMTHRS           0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    //#define GLOBAL_TCOOLTHRS          0 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+    #define GLOBAL_THIGH             10 // [0-1048576] e.g. 20 corresponds with 2000 steps/s
+
+    /* SPI MODE CONFIGURATION */
+
+    //#define GLOBAL_XDIRECT            0
+
+    /* DCSTEP MINIMUM VELOCITY */
+
+    //#define GLOBAL_VDCMIN             0
+
+    /* MOTOR DRIVER CONFIGURATION*/
+
+    //#define GLOBAL_DEDGE              0
+    //#define GLOBAL_DISS2G             0
+    #define GLOBAL_INTPOL             1 // 0: off 1: 256 microstep interpolation
+    #define GLOBAL_MRES              16 // number of microsteps
+    #define GLOBAL_SYNC               1 // [0-15]
+    #define GLOBAL_VHIGHCHM           1 // [0,1] 0: normal, 1: high velocity stepper mode
+    #define GLOBAL_VHIGHFS            0 // [0,1] 0: normal, 1: switch to full steps for high velocities
+    // #define GLOBAL_VSENSE            0 // [0,1] 0: normal, 1: high sensitivity (not recommended)
+    #define GLOBAL_TBL                1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define GLOBAL_CHM                0 // [0,1] 0: spreadCycle, 1: Constant off time with fast decay time.
+    //#define GLOBAL_RNDTF              0
+    //#define GLOBAL_DISFDCC            0
+    //#define GLOBAL_FD                 0
+    //#define GLOBAL_HEND               0
+    //#define GLOBAL_HSTRT              0
+    #define GLOBAL_TOFF              10 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    //#define GLOBAL_SFILT              0
+    //#define GLOBAL_SGT                0
+    //#define GLOBAL_SEIMIN             0
+    //#define GLOBAL_SEDN               0
+    //#define GLOBAL_SEMAX              0
+    //#define GLOBAL_SEUP               0
+    //#define GLOBAL_SEMIN              0
+
+    //#define GLOBAL_DC_TIME            0
+    //#define GLOBAL_DC_SG              0
+
+    //#define GLOBAL_FREEWHEEL          0
+    //#define GLOBAL_PWM_SYMMETRIC      0
+    //#define GLOBAL_PWM_AUTOSCALE      0
+    //#define GLOBAL_PWM_FREQ           0
+    //#define GLOBAL_PWM_GRAD           0
+    //#define GLOBAL_PWM_AMPL           0
+
+    //#define GLOBAL_ENCM_CTRL          0
+
+  #else
+
+    #define X_IHOLD          31 // [0-31] 0: min, 31: max
+    #define X_IRUN           31 // [0-31] 0: min, 31: max
+    #define X_IHOLDDELAY     15 // [0-15] 0: min, 15: about 4 seconds
+    #define X_I_SCALE_ANALOG  1 // 0: Normal, 1: AIN
+    #define X_MRES           16 // number of microsteps
+    #define X_TBL             1 // 0-3: set comparator blank time to 16, 24, 36 or 54 clocks, 1 or 2 is recommended
+    #define X_TOFF            8 // 0: driver disable, 1: use only with TBL>2, 2-15: off time setting during slow decay phase
+
+    #define X2_IHOLD         31
+    #define X2_IRUN          31
+    #define X2_IHOLDDELAY    15
+    #define X2_I_SCALE_ANALOG 1
+    #define X2_MRES          16
+    #define X2_TBL            1
+    #define X2_TOFF           8
+
+    #define Y_IHOLD          31
+    #define Y_IRUN           31
+    #define Y_IHOLDDELAY     15
+    #define Y_I_SCALE_ANALOG  1
+    #define Y_MRES           16
+    #define Y_TBL             1
+    #define Y_TOFF            8
+
+    #define Y2_IHOLD         31
+    #define Y2_IRUN          31
+    #define Y2_IHOLDDELAY    15
+    #define Y2_I_SCALE_ANALOG 1
+    #define Y2_MRES          16
+    #define Y2_TBL            1
+    #define Y2_TOFF           8
+
+    #define Z_IHOLD          31
+    #define Z_IRUN           31
+    #define Z_IHOLDDELAY     15
+    #define Z_I_SCALE_ANALOG  1
+    #define Z_MRES           16
+    #define Z_TBL             1
+    #define Z_TOFF            8
+
+    #define Z2_IHOLD         31
+    #define Z2_IRUN          31
+    #define Z2_IHOLDDELAY    15
+    #define Z2_I_SCALE_ANALOG 1
+    #define Z2_MRES          16
+    #define Z2_TBL            1
+    #define Z2_TOFF           8
+
+    #define E0_IHOLD         31
+    #define E0_IRUN          31
+    #define E0_IHOLDDELAY    15
+    #define E0_I_SCALE_ANALOG 1
+    #define E0_MRES          16
+    #define E0_TBL            1
+    #define E0_TOFF           8
+
+    #define E1_IHOLD         31
+    #define E1_IRUN          31
+    #define E1_IHOLDDELAY    15
+    #define E1_I_SCALE_ANALOG 1
+    #define E1_MRES          16
+    #define E1_TBL            1
+    #define E1_TOFF           8
+
+    #define E2_IHOLD         31
+    #define E2_IRUN          31
+    #define E2_IHOLDDELAY    15
+    #define E2_I_SCALE_ANALOG 1
+    #define E2_MRES          16
+    #define E2_TBL            1
+    #define E2_TOFF           8
+
+    #define E3_IHOLD         31
+    #define E3_IRUN          31
+    #define E3_IHOLDDELAY    15
+    #define E3_I_SCALE_ANALOG 1
+    #define E3_MRES          16
+    #define E3_TBL            1
+    #define E3_TOFF           8
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
 
 // @section l6470
+
+/**
+ * Enable this section if you have L6470 motor drivers.
+ * You need to import the L6470 library into the Arduino IDE for this.
+ * (https://github.com/ameyer/Arduino-L6470)
+ */
 
 //#define HAVE_L6470DRIVER
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -93,22 +93,27 @@
 #define X_STEP_PIN         54
 #define X_DIR_PIN          55
 #define X_ENABLE_PIN       38
+#define X_CS_PIN           53
 
 #define Y_STEP_PIN         60
 #define Y_DIR_PIN          61
 #define Y_ENABLE_PIN       56
+#define Y_CS_PIN           49
 
 #define Z_STEP_PIN         46
 #define Z_DIR_PIN          48
 #define Z_ENABLE_PIN       62
+#define Z_CS_PIN           40
 
 #define E0_STEP_PIN        26
 #define E0_DIR_PIN         28
 #define E0_ENABLE_PIN      24
+#define E0_CS_PIN          42
 
 #define E1_STEP_PIN        36
 #define E1_DIR_PIN         34
 #define E1_ENABLE_PIN      30
+#define E1_CS_PIN          44
 
 //
 // Temperature Sensors

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -784,6 +784,11 @@ void Stepper::init() {
     tmc_init();
   #endif
 
+  // Init TMC2130 Steppers
+  #if ENABLED(HAVE_TMC2130DRIVER)
+    tmc2130_init();
+  #endif
+
   // Init L6470 Steppers
   #if ENABLED(HAVE_L6470DRIVER)
     L6470_init();

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -127,6 +127,272 @@ void tmc_init() {
 }
 #endif
 
+#if ENABLED(HAVE_TMC2130DRIVER)
+  #include <SPI.h>
+  #include <Trinamic_TMC2130.h>
+#endif
+
+// Stepper objects of TMC2310 steppers used
+#if ENABLED(X_IS_TMC2130)
+  Trinamic_TMC2130 stepperX(X_CS_PIN);
+#endif
+#if ENABLED(X2_IS_TMC2130)
+  Trinamic_TMC2130 stepperX2(X2_CS_PIN);
+#endif
+#if ENABLED(Y_IS_TMC2130)
+  Trinamic_TMC2130 stepperY(Y_CS_PIN);
+#endif
+#if ENABLED(Y2_IS_TMC2130)
+  Trinamic_TMC2130 stepperY2(Y2_CS_PINR);
+#endif
+#if ENABLED(Z_IS_TMC2130)
+  Trinamic_TMC2130 stepperZ(Z_CS_PIN);
+#endif
+#if ENABLED(Z2_IS_TMC2130)
+  Trinamic_TMC2130 stepperZ2(Z2_CS_PIN);
+#endif
+#if ENABLED(E0_IS_TMC2130)
+  Trinamic_TMC2130 stepperE0(E0_CS_PIN);
+#endif
+#if ENABLED(E1_IS_TMC2130)
+  Trinamic_TMC2130 stepperE1(E1_CS_PIN);
+#endif
+#if ENABLED(E2_IS_TMC2130)
+  Trinamic_TMC2130 stepperE2(E2_CS_PIN);
+#endif
+#if ENABLED(E3_IS_TMC2130)
+  Trinamic_TMC2130 stepperE3(E3_CS_PIN);
+#endif
+
+#if ENABLED(HAVE_TMC2130DRIVER)
+
+  #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
+
+    void tmc2130_init() {
+
+      // If you've enabled TMC2130_ADVANCED_CONFIGURATION configure your
+      // steppers manually here. The ENABLED(XYZ_IS_TMC2130) is optional,
+
+      #if ENABLED(X_IS_TMC2130)
+        stepperX.init();
+        stepperX.set_I_scale_analog(GLOBAL_I_SCALE_ANALOG);
+        //stepperX.set_internal_Rsense(GLOBAL_INTERNAL_RSENSE);
+        stepperX.set_en_pwm_mode(GLOBAL_EN_PWM_MODE);
+        //stepperX.set_enc_commutation(GLOBAL_ENC_COMMUTATION);
+        stepperX.set_shaft(GLOBAL_SHAFT);
+        //stepperX.set_diag0_error(GLOBAL_DIAG0_ERROR);
+        //stepperX.set_diag0_otpw(GLOBAL_DIAG0_OTPW);
+        //stepperX.set_diag0_stall(GLOBAL_DIAG0_STALL);
+        //stepperX.set_diag1_stall(GLOBAL_DIAG1_STALL);
+        //stepperX.set_diag1_index(GLOBAL_DIAG1_INDEX);
+        //stepperX.set_diag1_onstate(GLOBAL_DIAG1_ONSTATE);
+        //stepperX.set_diag1_steps_skipped(GLOBAL_DIAG1_ONSTATE);
+        //stepperX.set_diag0_int_pushpull(GLOBAL_DIAG0_INT_PUSHPULL);
+        //stepperX.set_diag1_int_pushpull(GLOBAL_DIAG1_INT_PUSHPULL);
+        //stepperX.set_small_hysteresis(GLOBAL_SMALL_HYSTERESIS);
+        //stepperX.set_stop_enable(GLOBAL_STOP_ENABLE);
+        //stepperX.set_direct_mode(GLOBAL_DIRECT_MODE);
+
+        stepperX.set_IHOLD_IRUN(GLOBAL_IHOLD,GLOBAL_IRUN,GLOBAL_IHOLDDELAY);
+        //stepperX.set_TPOWERDOWN(GLOBAL_TPOWERDOWN);
+        //stepperX.set_TPWMTHRS(GLOBAL_TPWMTHRS);
+        //stepperX.set_TCOOLTHRS(GLOBAL_TCOOLTHRS);
+        stepperX.set_THIGH(GLOBAL_THIGH);
+        //stepperX.set_XDIRECT(GLOBAL_XDIRECT);
+        //stepperX.set_VDCMIN(GLOBAL_VDCMIN);
+
+        //stepperX.set_dedge(GLOBAL_DEDGE);
+        //stepperX.set_diss2g(GLOBAL_DISS2G);
+        stepperX.set_intpol(GLOBAL_INTPOL);
+        stepperX.set_mres(GLOBAL_MRES);
+        stepperX.set_sync(GLOBAL_SYNC);
+        stepperX.set_vhighchm(GLOBAL_VHIGHCHM);
+        stepperX.set_vhighfs(GLOBAL_VHIGHFS);
+        //stepperX.set_vsense(GLOBAL_VSENSE);
+        stepperX.set_tbl(GLOBAL_TBL);
+        stepperX.set_chm(GLOBAL_CHM);
+        //stepperX.set_rndtf(GLOBAL_RNDTF);
+        //stepperX.set_disfdcc(GLOBAL_DISFDCC);
+        //stepperX.set_fd(GLOBAL_FD);
+        //stepperX.set_hend(GLOBAL_HEND);
+        //stepperX.set_hstrt(GLOBAL_HSTRT);
+        stepperX.set_toff(GLOBAL_TOFF);
+
+        //stepperX.set_sfilt(GLOBAL_SFILT);
+        //stepperX.set_sgt(GLOBAL_SGT);
+        //stepperX.set_seimin(GLOBAL_SEIMIN);
+        //stepperX.set_sedn(GLOBAL_SEDN);
+        //stepperX.set_semax(GLOBAL_SEMAX);
+        //stepperX.set_seup(GLOBAL_SEUP);
+        //stepperX.set_semin(GLOBAL_SEMIN);
+
+        //stepperX.set_DCCTRL(GLOBAL_DC_TIME, GLOBAL_DC_SG);
+
+        //stepperX.set_freewheel(GLOBAL_FREEWHEEL);
+        //stepperX.set_pwm_symmetric(GLOBAL_PWM_SYMMETRIC);
+        //stepperX.set_pwm_autoscale(GLOBAL_PWM_AUTOSCALE);
+        //stepperX.set_pwm_freq(GLOBAL_PWM_FREQ);
+        //stepperX.set_PWM_GRAD(GLOBAL_PWM_GRAD);
+        //stepperX.set_PWM_AMPL(GLOBAL_PWM_AMPL);
+
+        //stepperX.set_ENCM_CTRL(GLOBAL_ENCM_CTRL);
+      #endif
+
+      #if ENABLED(Y_IS_TMC2130)
+        stepperY.init();
+        stepperY.set_I_scale_analog(GLOBAL_I_SCALE_ANALOG);
+        //stepperY.set_internal_Rsense(GLOBAL_INTERNAL_RSENSE);
+        stepperY.set_en_pwm_mode(GLOBAL_EN_PWM_MODE);
+        //stepperY.set_enc_commutation(GLOBAL_ENC_COMMUTATION);
+        stepperY.set_shaft(GLOBAL_SHAFT);
+        //stepperY.set_diag0_error(GLOBAL_DIAG0_ERROR);
+        //stepperY.set_diag0_otpw(GLOBAL_DIAG0_OTPW);
+        //stepperY.set_diag0_stall(GLOBAL_DIAG0_STALL);
+        //stepperY.set_diag1_stall(GLOBAL_DIAG1_STALL);
+        //stepperY.set_diag1_index(GLOBAL_DIAG1_INDEX);
+        //stepperY.set_diag1_onstate(GLOBAL_DIAG1_ONSTATE);
+        //stepperY.set_diag1_steps_skipped(GLOBAL_DIAG1_ONSTATE);
+        //stepperY.set_diag0_int_pushpull(GLOBAL_DIAG0_INT_PUSHPULL);
+        //stepperY.set_diag1_int_pushpull(GLOBAL_DIAG1_INT_PUSHPULL);
+        //stepperY.set_small_hysteresis(GLOBAL_SMALL_HYSTERESIS);
+        //stepperY.set_stop_enable(GLOBAL_STOP_ENABLE);
+        //stepperY.set_direct_mode(GLOBAL_DIRECT_MODE);
+
+        stepperY.set_IHOLD_IRUN(GLOBAL_IHOLD,GLOBAL_IRUN,GLOBAL_IHOLDDELAY);
+        //stepperY.set_TPOWERDOWN(GLOBAL_TPOWERDOWN);
+        //stepperY.set_TPWMTHRS(GLOBAL_TPWMTHRS);
+        //stepperY.set_TCOOLTHRS(GLOBAL_TCOOLTHRS);
+        stepperY.set_THIGH(GLOBAL_THIGH);
+        //stepperY.set_XDIRECT(GLOBAL_XDIRECT);
+        //stepperY.set_VDCMIN(GLOBAL_VDCMIN);
+
+        //stepperY.set_dedge(GLOBAL_DEDGE);
+        //stepperY.set_diss2g(GLOBAL_DISS2G);
+        stepperY.set_intpol(GLOBAL_INTPOL);
+        stepperY.set_mres(GLOBAL_MRES);
+        stepperY.set_sync(GLOBAL_SYNC);
+        stepperY.set_vhighchm(GLOBAL_VHIGHCHM);
+        stepperY.set_vhighfs(GLOBAL_VHIGHFS);
+        //stepperY.set_vsense(GLOBAL_VSENSE);
+        stepperY.set_tbl(GLOBAL_TBL);
+        stepperY.set_chm(GLOBAL_CHM);
+        //stepperY.set_rndtf(GLOBAL_RNDTF);
+        //stepperY.set_disfdcc(GLOBAL_DISFDCC);
+        //stepperY.set_fd(GLOBAL_FD);
+        //stepperY.set_hend(GLOBAL_HEND);
+        //stepperY.set_hstrt(GLOBAL_HSTRT);
+        stepperY.set_toff(GLOBAL_TOFF);
+
+        //stepperY.set_sfilt(GLOBAL_SFILT);
+        //stepperY.set_sgt(GLOBAL_SGT);
+        //stepperY.set_seimin(GLOBAL_SEIMIN);
+        //stepperY.set_sedn(GLOBAL_SEDN);
+        //stepperY.set_semax(GLOBAL_SEMAX);
+        //stepperY.set_seup(GLOBAL_SEUP);
+        //stepperY.set_semin(GLOBAL_SEMIN);
+
+        //stepperY.set_DCCTRL(GLOBAL_DC_TIME, GLOBAL_DC_SG);
+
+        //stepperY.set_freewheel(GLOBAL_FREEWHEEL);
+        //stepperY.set_pwm_symmetric(GLOBAL_PWM_SYMMETRIC);
+        //stepperY.set_pwm_autoscale(GLOBAL_PWM_AUTOSCALE);
+        //stepperY.set_pwm_freq(GLOBAL_PWM_FREQ);
+        //stepperY.set_PWM_GRAD(GLOBAL_PWM_GRAD);
+        //stepperY.set_PWM_AMPL(GLOBAL_PWM_AMPL);
+
+        //stepperY.set_ENCM_CTRL(GLOBAL_ENCM_CTRL);
+      #endif
+    }
+
+  #else // !TMC2130_ADVANCED_CONFIGURATION
+
+    void tmc2130_init() {
+      #if ENABLED(X_IS_TMC2130)
+        stepperX.init();
+        stepperX.set_mres(X_MRES);
+        stepperX.set_IHOLD_IRUN(X_IHOLD,X_IRUN,X_IHOLDDELAY);
+        stepperX.set_I_scale_analog(X_ISCALE);
+        stepperX.set_tbl(X_TBL);
+        stepperX.set_toff(X_TOFF);
+      #endif
+      #if ENABLED(X2_IS_TMC2130)
+        stepperX2.init();
+        stepperX2.set_mres(X2_MRES);
+        stepperX2.set_IHOLD_IRUN(X2_IHOLD,X2_IRUN,X2_IHOLDDELAY);
+        stepperX2.set_I_scale_analog(X2_ISCALE);
+        stepperX2.set_tbl(X2_TBL);
+        stepperX2.set_toff(X2_TOFF);
+      #endif
+      #if ENABLED(Y_IS_TMC2130)
+        stepperY.init();
+        stepperY.set_mres(Y_MRES);
+        stepperY.set_IHOLD_IRUN(Y_IHOLD,Y_IRUN,Y_IHOLDDELAY);
+        stepperY.set_I_scale_analog(Y_ISCALE);
+        stepperY.set_tbl(Y_TBL);
+        stepperY.set_toff(Y_TOFF);
+      #endif
+      #if ENABLED(Y2_IS_TMC2130)
+        stepperY2.init();
+        stepperY2.set_mres(Y2_MRES);
+        stepperY2.set_IHOLD_IRUN(Y2_IHOLD,Y2_IRUN,Y2_IHOLDDELAY);
+        stepperY2.set_I_scale_analog(Y2_ISCALE);
+        stepperY2.set_tbl(Y2_TBL);
+        stepperY2.set_toff(Y2_TOFF);
+      #endif
+      #if ENABLED(Z_IS_TMC2130)
+        stepperZ.init();
+        stepperZ.set_mres(Z_MRES);
+        stepperZ.set_IHOLD_IRUN(Z_IHOLD,Z_IRUN,Z_IHOLDDELAY);
+        stepperZ.set_I_scale_analog(Z_ISCALE);
+        stepperZ.set_tbl(Z_TBL);
+        stepperZ.set_toff(Z_TOFF);
+      #endif
+      #if ENABLED(Z2_IS_TMC2130)
+        stepperZ2.init();
+        stepperZ2.set_mres(Z2_MRES);
+        stepperZ2.set_IHOLD_IRUN(Z2_IHOLD,Z2_IRUN,Z2_IHOLDDELAY);
+        stepperZ2.set_I_scale_analog(Z2_ISCALE);
+        stepperZ2.set_tbl(Z2_TBL);
+        stepperZ2.set_toff(Z2_TOFF);
+      #endif
+      #if ENABLED(E0_IS_TMC2130)
+        stepperE0.init();
+        stepperE0.set_mres(E0_MRES);
+        stepperE0.set_IHOLD_IRUN(E0_IHOLD,E0_IRUN,E0_IHOLDDELAY);
+        stepperE0.set_I_scale_analog(E0_ISCALE);
+        stepperE0.set_tbl(E0_TBL);
+        stepperE0.set_toff(E0_TOFF);
+      #endif
+      #if ENABLED(E1_IS_TMC2130)
+        stepperE1.init();
+        stepperE1.set_mres(E1_MRES);
+        stepperE1.set_IHOLD_IRUN(E1_IHOLD,E1_IRUN,E1_IHOLDDELAY);
+        stepperE1.set_I_scale_analog(E1_ISCALE);
+        stepperE1.set_tbl(E1_TBL);
+        stepperE1.set_toff(E1_TOFF);
+      #endif
+      #if ENABLED(E2_IS_TMC2130)
+        stepperE2.init();
+        stepperE2.set_mres(E2_MRES);
+        stepperE2.set_IHOLD_IRUN(E2_IHOLD,E2_IRUN,E2_IHOLDDELAY);
+        stepperE2.set_I_scale_analog(E2_ISCALE);
+        stepperE2.set_tbl(E2_TBL);
+        stepperE2.set_toff(E2_TOFF);
+      #endif
+      #if ENABLED(E3_IS_TMC2130)
+        stepperE3.init();
+        stepperE3.set_mres(E3_MRES);
+        stepperE3.set_IHOLD_IRUN(E3_IHOLD,E3_IRUN,E3_IHOLDDELAY);
+        stepperE3.set_I_scale_analog(E3_ISCALE);
+        stepperE3.set_tbl(E3_TBL);
+        stepperE3.set_toff(E3_TOFF);
+      #endif
+    }
+
+  #endif // TMC2130_ADVANCED_CONFIGURATION
+
+#endif // HAVE_TMC2130DRIVER
+
 // L6470 Driver objects and inits
 
 #if ENABLED(HAVE_L6470DRIVER)

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -128,268 +128,424 @@ void tmc_init() {
 #endif
 
 #if ENABLED(HAVE_TMC2130DRIVER)
+
   #include <SPI.h>
   #include <Trinamic_TMC2130.h>
-#endif
-
-// Stepper objects of TMC2310 steppers used
-#if ENABLED(X_IS_TMC2130)
-  Trinamic_TMC2130 stepperX(X_CS_PIN);
-#endif
-#if ENABLED(X2_IS_TMC2130)
-  Trinamic_TMC2130 stepperX2(X2_CS_PIN);
-#endif
-#if ENABLED(Y_IS_TMC2130)
-  Trinamic_TMC2130 stepperY(Y_CS_PIN);
-#endif
-#if ENABLED(Y2_IS_TMC2130)
-  Trinamic_TMC2130 stepperY2(Y2_CS_PINR);
-#endif
-#if ENABLED(Z_IS_TMC2130)
-  Trinamic_TMC2130 stepperZ(Z_CS_PIN);
-#endif
-#if ENABLED(Z2_IS_TMC2130)
-  Trinamic_TMC2130 stepperZ2(Z2_CS_PIN);
-#endif
-#if ENABLED(E0_IS_TMC2130)
-  Trinamic_TMC2130 stepperE0(E0_CS_PIN);
-#endif
-#if ENABLED(E1_IS_TMC2130)
-  Trinamic_TMC2130 stepperE1(E1_CS_PIN);
-#endif
-#if ENABLED(E2_IS_TMC2130)
-  Trinamic_TMC2130 stepperE2(E2_CS_PIN);
-#endif
-#if ENABLED(E3_IS_TMC2130)
-  Trinamic_TMC2130 stepperE3(E3_CS_PIN);
-#endif
-
-#if ENABLED(HAVE_TMC2130DRIVER)
 
   #if ENABLED(TMC2130_ADVANCED_CONFIGURATION)
 
-    void tmc2130_init() {
+    #ifdef GLOBAL_I_SCALE_ANALOG
+      #define _2130_set_I_scale_analog(A) stepper##A.set_I_scale_analog(GLOBAL_I_SCALE_ANALOG)
+    #else
+      #define _2130_set_I_scale_analog(A) NOOP
+    #endif
+    #ifdef GLOBAL_INTERNAL_RSENSE
+      #define _2130_set_internal_Rsense(A) stepper##A.set_internal_Rsense(GLOBAL_INTERNAL_RSENSE)
+    #else
+      #define _2130_set_internal_Rsense(A) NOOP
+    #endif
+    #ifdef GLOBAL_EN_PWM_MODE
+      #define _2130_set_en_pwm_mode(A) stepper##A.set_en_pwm_mode(GLOBAL_EN_PWM_MODE)
+    #else
+      #define _2130_set_en_pwm_mode(A) NOOP
+    #endif
+    #ifdef GLOBAL_ENC_COMMUTATION
+      #define _2130_set_enc_commutation(A) stepper##A.set_enc_commutation(GLOBAL_ENC_COMMUTATION)
+    #else
+      #define _2130_set_enc_commutation(A) NOOP
+    #endif
+    #ifdef GLOBAL_SHAFT
+      #define _2130_set_shaft(A) stepper##A.set_shaft(GLOBAL_SHAFT)
+    #else
+      #define _2130_set_shaft(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG0_ERROR
+      #define _2130_set_diag0_error(A) stepper##A.set_diag0_error(GLOBAL_DIAG0_ERROR)
+    #else
+      #define _2130_set_diag0_error(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG0_OTPW
+      #define _2130_set_diag0_otpw(A) stepper##A.set_diag0_otpw(GLOBAL_DIAG0_OTPW)
+    #else
+      #define _2130_set_diag0_otpw(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG0_STALL
+      #define _2130_set_diag0_stall(A) stepper##A.set_diag0_stall(GLOBAL_DIAG0_STALL)
+    #else
+      #define _2130_set_diag0_stall(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG1_STALL
+      #define _2130_set_diag1_stall(A) stepper##A.set_diag1_stall(GLOBAL_DIAG1_STALL)
+    #else
+      #define _2130_set_diag1_stall(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG1_INDEX
+      #define _2130_set_diag1_index(A) stepper##A.set_diag1_index(GLOBAL_DIAG1_INDEX)
+    #else
+      #define _2130_set_diag1_index(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG1_ONSTATE
+      #define _2130_set_diag1_onstate(A) stepper##A.set_diag1_onstate(GLOBAL_DIAG1_ONSTATE)
+    #else
+      #define _2130_set_diag1_onstate(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG1_ONSTATE
+      #define _2130_set_diag1_steps_skipped(A) stepper##A.set_diag1_steps_skipped(GLOBAL_DIAG1_ONSTATE)
+    #else
+      #define _2130_set_diag1_steps_skipped(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG0_INT_PUSHPULL
+      #define _2130_set_diag0_int_pushpull(A) stepper##A.set_diag0_int_pushpull(GLOBAL_DIAG0_INT_PUSHPULL)
+    #else
+      #define _2130_set_diag0_int_pushpull(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIAG1_INT_PUSHPULL
+      #define _2130_set_diag1_int_pushpull(A) stepper##A.set_diag1_int_pushpull(GLOBAL_DIAG1_INT_PUSHPULL)
+    #else
+      #define _2130_set_diag1_int_pushpull(A) NOOP
+    #endif
+    #ifdef GLOBAL_SMALL_HYSTERESIS
+      #define _2130_set_small_hysteresis(A) stepper##A.set_small_hysteresis(GLOBAL_SMALL_HYSTERESIS)
+    #else
+      #define _2130_set_small_hysteresis(A) NOOP
+    #endif
+    #ifdef GLOBAL_STOP_ENABLE
+      #define _2130_set_stop_enable(A) stepper##A.set_stop_enable(GLOBAL_STOP_ENABLE)
+    #else
+      #define _2130_set_stop_enable(A) NOOP
+    #endif
+    #ifdef GLOBAL_DIRECT_MODE
+      #define _2130_set_direct_mode(A) stepper##A.set_direct_mode(GLOBAL_DIRECT_MODE)
+    #else
+      #define _2130_set_direct_mode(A) NOOP
+    #endif
+    #if defined(GLOBAL_IHOLD) && defined(GLOBAL_IRUN) && defined(GLOBAL_IHOLDDELAY)
+      #define _2130_set_IHOLD_IRUN(A) stepper##A.set_IHOLD_IRUN(GLOBAL_IHOLD, GLOBAL_IRUN, GLOBAL_IHOLDDELAY)
+    #else
+      #define _2130_set_IHOLD_IRUN(A) NOOP
+    #endif
+    #ifdef GLOBAL_TPOWERDOWN
+      #define _2130_set_TPOWERDOWN(A) stepper##A.set_TPOWERDOWN(GLOBAL_TPOWERDOWN)
+    #else
+      #define _2130_set_TPOWERDOWN(A) NOOP
+    #endif
+    #ifdef GLOBAL_TPWMTHRS
+      #define _2130_set_TPWMTHRS(A) stepper##A.set_TPWMTHRS(GLOBAL_TPWMTHRS)
+    #else
+      #define _2130_set_TPWMTHRS(A) NOOP
+    #endif
+    #ifdef GLOBAL_TCOOLTHRS
+      #define _2130_set_TCOOLTHRS(A) stepper##A.set_TCOOLTHRS(GLOBAL_TCOOLTHRS)
+    #else
+      #define _2130_set_TCOOLTHRS(A) NOOP
+    #endif
+    #ifdef GLOBAL_THIGH
+      #define _2130_set_THIGH(A) stepper##A.set_THIGH(GLOBAL_THIGH)
+    #else
+      #define _2130_set_THIGH(A) NOOP
+    #endif
+    #ifdef GLOBAL_XDIRECT
+      #define _2130_set_XDIRECT(A) stepper##A.set_XDIRECT(GLOBAL_XDIRECT)
+    #else
+      #define _2130_set_XDIRECT(A) NOOP
+    #endif
+    #ifdef GLOBAL_VDCMIN
+      #define _2130_set_VDCMIN(A) stepper##A.set_VDCMIN(GLOBAL_VDCMIN)
+    #else
+      #define _2130_set_VDCMIN(A) NOOP
+    #endif
+    #ifdef GLOBAL_DEDGE
+      #define _2130_set_dedge(A) stepper##A.set_dedge(GLOBAL_DEDGE)
+    #else
+      #define _2130_set_dedge(A) NOOP
+    #endif
+    #ifdef GLOBAL_DISS2G
+      #define _2130_set_diss2g(A) stepper##A.set_diss2g(GLOBAL_DISS2G)
+    #else
+      #define _2130_set_diss2g(A) NOOP
+    #endif
+    #ifdef GLOBAL_INTPOL
+      #define _2130_set_intpol(A) stepper##A.set_intpol(GLOBAL_INTPOL)
+    #else
+      #define _2130_set_intpol(A) NOOP
+    #endif
+    #ifdef GLOBAL_MRES
+      #define _2130_set_mres(A) stepper##A.set_mres(GLOBAL_MRES)
+    #else
+      #define _2130_set_mres(A) NOOP
+    #endif
+    #ifdef GLOBAL_SYNC
+      #define _2130_set_sync(A) stepper##A.set_sync(GLOBAL_SYNC)
+    #else
+      #define _2130_set_sync(A) NOOP
+    #endif
+    #ifdef GLOBAL_VHIGHCHM
+      #define _2130_set_vhighchm(A) stepper##A.set_vhighchm(GLOBAL_VHIGHCHM)
+    #else
+      #define _2130_set_vhighchm(A) NOOP
+    #endif
+    #ifdef GLOBAL_VHIGHFS
+      #define _2130_set_vhighfs(A) stepper##A.set_vhighfs(GLOBAL_VHIGHFS)
+    #else
+      #define _2130_set_vhighfs(A) NOOP
+    #endif
+    #ifdef GLOBAL_VSENSE
+      #define _2130_set_vsense(A) stepper##A.set_vsense(GLOBAL_VSENSE)
+    #else
+      #define _2130_set_vsense(A) NOOP
+    #endif
+    #ifdef GLOBAL_TBL
+      #define _2130_set_tbl(A) stepper##A.set_tbl(GLOBAL_TBL)
+    #else
+      #define _2130_set_tbl(A) NOOP
+    #endif
+    #ifdef GLOBAL_CHM
+      #define _2130_set_chm(A) stepper##A.set_chm(GLOBAL_CHM)
+    #else
+      #define _2130_set_chm(A) NOOP
+    #endif
+    #ifdef GLOBAL_RNDTF
+      #define _2130_set_rndtf(A) stepper##A.set_rndtf(GLOBAL_RNDTF)
+    #else
+      #define _2130_set_rndtf(A) NOOP
+    #endif
+    #ifdef GLOBAL_DISFDCC
+      #define _2130_set_disfdcc(A) stepper##A.set_disfdcc(GLOBAL_DISFDCC)
+    #else
+      #define _2130_set_disfdcc(A) NOOP
+    #endif
+    #ifdef GLOBAL_FD
+      #define _2130_set_fd(A) stepper##A.set_fd(GLOBAL_FD)
+    #else
+      #define _2130_set_fd(A) NOOP
+    #endif
+    #ifdef GLOBAL_HEND
+      #define _2130_set_hend(A) stepper##A.set_hend(GLOBAL_HEND)
+    #else
+      #define _2130_set_hend(A) NOOP
+    #endif
+    #ifdef GLOBAL_HSTRT
+      #define _2130_set_hstrt(A) stepper##A.set_hstrt(GLOBAL_HSTRT)
+    #else
+      #define _2130_set_hstrt(A) NOOP
+    #endif
+    #ifdef GLOBAL_TOFF
+      #define _2130_set_toff(A) stepper##A.set_toff(GLOBAL_TOFF)
+    #else
+      #define _2130_set_toff(A) NOOP
+    #endif
+    #ifdef GLOBAL_SFILT
+      #define _2130_set_sfilt(A) stepper##A.set_sfilt(GLOBAL_SFILT)
+    #else
+      #define _2130_set_sfilt(A) NOOP
+    #endif
+    #ifdef GLOBAL_SGT
+      #define _2130_set_sgt(A) stepper##A.set_sgt(GLOBAL_SGT)
+    #else
+      #define _2130_set_sgt(A) NOOP
+    #endif
+    #ifdef GLOBAL_SEIMIN
+      #define _2130_set_seimin(A) stepper##A.set_seimin(GLOBAL_SEIMIN)
+    #else
+      #define _2130_set_seimin(A) NOOP
+    #endif
+    #ifdef GLOBAL_SEDN
+      #define _2130_set_sedn(A) stepper##A.set_sedn(GLOBAL_SEDN)
+    #else
+      #define _2130_set_sedn(A) NOOP
+    #endif
+    #ifdef GLOBAL_SEMAX
+      #define _2130_set_semax(A) stepper##A.set_semax(GLOBAL_SEMAX)
+    #else
+      #define _2130_set_semax(A) NOOP
+    #endif
+    #ifdef GLOBAL_SEUP
+      #define _2130_set_seup(A) stepper##A.set_seup(GLOBAL_SEUP)
+    #else
+      #define _2130_set_seup(A) NOOP
+    #endif
+    #ifdef GLOBAL_SEMIN
+      #define _2130_set_semin(A) stepper##A.set_semin(GLOBAL_SEMIN)
+    #else
+      #define _2130_set_semin(A) NOOP
+    #endif
+    #if defined(GLOBAL_DC_TIME) && defined(GLOBAL_DC_SG)
+      #define _2130_set_DCCTRL(A) stepper##A.set_DCCTRL(GLOBAL_DC_TIME, GLOBAL_DC_SG)
+    #else
+      #define _2130_set_DCCTRL(A) NOOP
+    #endif
+    #ifdef GLOBAL_FREEWHEEL
+      #define _2130_set_freewheel(A) stepper##A.set_freewheel(GLOBAL_FREEWHEEL)
+    #else
+      #define _2130_set_freewheel(A) NOOP
+    #endif
+    #ifdef GLOBAL_PWM_SYMMETRIC
+      #define _2130_set_pwm_symmetric(A) stepper##A.set_pwm_symmetric(GLOBAL_PWM_SYMMETRIC)
+    #else
+      #define _2130_set_pwm_symmetric(A) NOOP
+    #endif
+    #ifdef GLOBAL_PWM_AUTOSCALE
+      #define _2130_set_pwm_autoscale(A) stepper##A.set_pwm_autoscale(GLOBAL_PWM_AUTOSCALE)
+    #else
+      #define _2130_set_pwm_autoscale(A) NOOP
+    #endif
+    #ifdef GLOBAL_PWM_FREQ
+      #define _2130_set_pwm_freq(A) stepper##A.set_pwm_freq(GLOBAL_PWM_FREQ)
+    #else
+      #define _2130_set_pwm_freq(A) NOOP
+    #endif
+    #ifdef GLOBAL_PWM_GRAD
+      #define _2130_set_PWM_GRAD(A) stepper##A.set_PWM_GRAD(GLOBAL_PWM_GRAD)
+    #else
+      #define _2130_set_PWM_GRAD(A) NOOP
+    #endif
+    #ifdef GLOBAL_PWM_AMPL
+      #define _2130_set_PWM_AMPL(A) stepper##A.set_PWM_AMPL(GLOBAL_PWM_AMPL)
+    #else
+      #define _2130_set_PWM_AMPL(A) NOOP
+    #endif
+    #ifdef GLOBAL_ENCM_CTRL
+      #define _2130_set_ENCM_CTRL(A) stepper##A.set_ENCM_CTRL(GLOBAL_ENCM_CTRL)
+    #else
+      #define _2130_set_ENCM_CTRL(A) NOOP
+    #endif
 
-      // If you've enabled TMC2130_ADVANCED_CONFIGURATION configure your
-      // steppers manually here. The ENABLED(XYZ_IS_TMC2130) is optional,
-
-      #if ENABLED(X_IS_TMC2130)
-        stepperX.init();
-        stepperX.set_I_scale_analog(GLOBAL_I_SCALE_ANALOG);
-        //stepperX.set_internal_Rsense(GLOBAL_INTERNAL_RSENSE);
-        stepperX.set_en_pwm_mode(GLOBAL_EN_PWM_MODE);
-        //stepperX.set_enc_commutation(GLOBAL_ENC_COMMUTATION);
-        stepperX.set_shaft(GLOBAL_SHAFT);
-        //stepperX.set_diag0_error(GLOBAL_DIAG0_ERROR);
-        //stepperX.set_diag0_otpw(GLOBAL_DIAG0_OTPW);
-        //stepperX.set_diag0_stall(GLOBAL_DIAG0_STALL);
-        //stepperX.set_diag1_stall(GLOBAL_DIAG1_STALL);
-        //stepperX.set_diag1_index(GLOBAL_DIAG1_INDEX);
-        //stepperX.set_diag1_onstate(GLOBAL_DIAG1_ONSTATE);
-        //stepperX.set_diag1_steps_skipped(GLOBAL_DIAG1_ONSTATE);
-        //stepperX.set_diag0_int_pushpull(GLOBAL_DIAG0_INT_PUSHPULL);
-        //stepperX.set_diag1_int_pushpull(GLOBAL_DIAG1_INT_PUSHPULL);
-        //stepperX.set_small_hysteresis(GLOBAL_SMALL_HYSTERESIS);
-        //stepperX.set_stop_enable(GLOBAL_STOP_ENABLE);
-        //stepperX.set_direct_mode(GLOBAL_DIRECT_MODE);
-
-        stepperX.set_IHOLD_IRUN(GLOBAL_IHOLD,GLOBAL_IRUN,GLOBAL_IHOLDDELAY);
-        //stepperX.set_TPOWERDOWN(GLOBAL_TPOWERDOWN);
-        //stepperX.set_TPWMTHRS(GLOBAL_TPWMTHRS);
-        //stepperX.set_TCOOLTHRS(GLOBAL_TCOOLTHRS);
-        stepperX.set_THIGH(GLOBAL_THIGH);
-        //stepperX.set_XDIRECT(GLOBAL_XDIRECT);
-        //stepperX.set_VDCMIN(GLOBAL_VDCMIN);
-
-        //stepperX.set_dedge(GLOBAL_DEDGE);
-        //stepperX.set_diss2g(GLOBAL_DISS2G);
-        stepperX.set_intpol(GLOBAL_INTPOL);
-        stepperX.set_mres(GLOBAL_MRES);
-        stepperX.set_sync(GLOBAL_SYNC);
-        stepperX.set_vhighchm(GLOBAL_VHIGHCHM);
-        stepperX.set_vhighfs(GLOBAL_VHIGHFS);
-        //stepperX.set_vsense(GLOBAL_VSENSE);
-        stepperX.set_tbl(GLOBAL_TBL);
-        stepperX.set_chm(GLOBAL_CHM);
-        //stepperX.set_rndtf(GLOBAL_RNDTF);
-        //stepperX.set_disfdcc(GLOBAL_DISFDCC);
-        //stepperX.set_fd(GLOBAL_FD);
-        //stepperX.set_hend(GLOBAL_HEND);
-        //stepperX.set_hstrt(GLOBAL_HSTRT);
-        stepperX.set_toff(GLOBAL_TOFF);
-
-        //stepperX.set_sfilt(GLOBAL_SFILT);
-        //stepperX.set_sgt(GLOBAL_SGT);
-        //stepperX.set_seimin(GLOBAL_SEIMIN);
-        //stepperX.set_sedn(GLOBAL_SEDN);
-        //stepperX.set_semax(GLOBAL_SEMAX);
-        //stepperX.set_seup(GLOBAL_SEUP);
-        //stepperX.set_semin(GLOBAL_SEMIN);
-
-        //stepperX.set_DCCTRL(GLOBAL_DC_TIME, GLOBAL_DC_SG);
-
-        //stepperX.set_freewheel(GLOBAL_FREEWHEEL);
-        //stepperX.set_pwm_symmetric(GLOBAL_PWM_SYMMETRIC);
-        //stepperX.set_pwm_autoscale(GLOBAL_PWM_AUTOSCALE);
-        //stepperX.set_pwm_freq(GLOBAL_PWM_FREQ);
-        //stepperX.set_PWM_GRAD(GLOBAL_PWM_GRAD);
-        //stepperX.set_PWM_AMPL(GLOBAL_PWM_AMPL);
-
-        //stepperX.set_ENCM_CTRL(GLOBAL_ENCM_CTRL);
-      #endif
-
-      #if ENABLED(Y_IS_TMC2130)
-        stepperY.init();
-        stepperY.set_I_scale_analog(GLOBAL_I_SCALE_ANALOG);
-        //stepperY.set_internal_Rsense(GLOBAL_INTERNAL_RSENSE);
-        stepperY.set_en_pwm_mode(GLOBAL_EN_PWM_MODE);
-        //stepperY.set_enc_commutation(GLOBAL_ENC_COMMUTATION);
-        stepperY.set_shaft(GLOBAL_SHAFT);
-        //stepperY.set_diag0_error(GLOBAL_DIAG0_ERROR);
-        //stepperY.set_diag0_otpw(GLOBAL_DIAG0_OTPW);
-        //stepperY.set_diag0_stall(GLOBAL_DIAG0_STALL);
-        //stepperY.set_diag1_stall(GLOBAL_DIAG1_STALL);
-        //stepperY.set_diag1_index(GLOBAL_DIAG1_INDEX);
-        //stepperY.set_diag1_onstate(GLOBAL_DIAG1_ONSTATE);
-        //stepperY.set_diag1_steps_skipped(GLOBAL_DIAG1_ONSTATE);
-        //stepperY.set_diag0_int_pushpull(GLOBAL_DIAG0_INT_PUSHPULL);
-        //stepperY.set_diag1_int_pushpull(GLOBAL_DIAG1_INT_PUSHPULL);
-        //stepperY.set_small_hysteresis(GLOBAL_SMALL_HYSTERESIS);
-        //stepperY.set_stop_enable(GLOBAL_STOP_ENABLE);
-        //stepperY.set_direct_mode(GLOBAL_DIRECT_MODE);
-
-        stepperY.set_IHOLD_IRUN(GLOBAL_IHOLD,GLOBAL_IRUN,GLOBAL_IHOLDDELAY);
-        //stepperY.set_TPOWERDOWN(GLOBAL_TPOWERDOWN);
-        //stepperY.set_TPWMTHRS(GLOBAL_TPWMTHRS);
-        //stepperY.set_TCOOLTHRS(GLOBAL_TCOOLTHRS);
-        stepperY.set_THIGH(GLOBAL_THIGH);
-        //stepperY.set_XDIRECT(GLOBAL_XDIRECT);
-        //stepperY.set_VDCMIN(GLOBAL_VDCMIN);
-
-        //stepperY.set_dedge(GLOBAL_DEDGE);
-        //stepperY.set_diss2g(GLOBAL_DISS2G);
-        stepperY.set_intpol(GLOBAL_INTPOL);
-        stepperY.set_mres(GLOBAL_MRES);
-        stepperY.set_sync(GLOBAL_SYNC);
-        stepperY.set_vhighchm(GLOBAL_VHIGHCHM);
-        stepperY.set_vhighfs(GLOBAL_VHIGHFS);
-        //stepperY.set_vsense(GLOBAL_VSENSE);
-        stepperY.set_tbl(GLOBAL_TBL);
-        stepperY.set_chm(GLOBAL_CHM);
-        //stepperY.set_rndtf(GLOBAL_RNDTF);
-        //stepperY.set_disfdcc(GLOBAL_DISFDCC);
-        //stepperY.set_fd(GLOBAL_FD);
-        //stepperY.set_hend(GLOBAL_HEND);
-        //stepperY.set_hstrt(GLOBAL_HSTRT);
-        stepperY.set_toff(GLOBAL_TOFF);
-
-        //stepperY.set_sfilt(GLOBAL_SFILT);
-        //stepperY.set_sgt(GLOBAL_SGT);
-        //stepperY.set_seimin(GLOBAL_SEIMIN);
-        //stepperY.set_sedn(GLOBAL_SEDN);
-        //stepperY.set_semax(GLOBAL_SEMAX);
-        //stepperY.set_seup(GLOBAL_SEUP);
-        //stepperY.set_semin(GLOBAL_SEMIN);
-
-        //stepperY.set_DCCTRL(GLOBAL_DC_TIME, GLOBAL_DC_SG);
-
-        //stepperY.set_freewheel(GLOBAL_FREEWHEEL);
-        //stepperY.set_pwm_symmetric(GLOBAL_PWM_SYMMETRIC);
-        //stepperY.set_pwm_autoscale(GLOBAL_PWM_AUTOSCALE);
-        //stepperY.set_pwm_freq(GLOBAL_PWM_FREQ);
-        //stepperY.set_PWM_GRAD(GLOBAL_PWM_GRAD);
-        //stepperY.set_PWM_AMPL(GLOBAL_PWM_AMPL);
-
-        //stepperY.set_ENCM_CTRL(GLOBAL_ENCM_CTRL);
-      #endif
-    }
+    #define _TMC2130_INIT(A) do{ \
+      stepper##A.init(); \
+      _2130_set_I_scale_analog(A); \
+      _2130_set_internal_Rsense(A); \
+      _2130_set_en_pwm_mode(A); \
+      _2130_set_enc_commutation(A); \
+      _2130_set_shaft(A); \
+      _2130_set_diag0_error(A); \
+      _2130_set_diag0_otpw(A); \
+      _2130_set_diag0_stall(A); \
+      _2130_set_diag1_stall(A); \
+      _2130_set_diag1_index(A); \
+      _2130_set_diag1_onstate(A); \
+      _2130_set_diag1_steps_skipped(A); \
+      _2130_set_diag0_int_pushpull(A); \
+      _2130_set_diag1_int_pushpull(A); \
+      _2130_set_small_hysteresis(A); \
+      _2130_set_stop_enable(A); \
+      _2130_set_direct_mode(A); \
+      _2130_set_IHOLD_IRUN(A); \
+      _2130_set_TPOWERDOWN(A); \
+      _2130_set_TPWMTHRS(A); \
+      _2130_set_TCOOLTHRS(A); \
+      _2130_set_THIGH(A); \
+      _2130_set_XDIRECT(A); \
+      _2130_set_VDCMIN(A); \
+      _2130_set_dedge(A); \
+      _2130_set_diss2g(A); \
+      _2130_set_intpol(A); \
+      _2130_set_mres(A); \
+      _2130_set_sync(A); \
+      _2130_set_vhighchm(A); \
+      _2130_set_vhighfs(A); \
+      _2130_set_vsense(A); \
+      _2130_set_tbl(A); \
+      _2130_set_chm(A); \
+      _2130_set_rndtf(A); \
+      _2130_set_disfdcc(A); \
+      _2130_set_fd(A); \
+      _2130_set_hend(A); \
+      _2130_set_hstrt(A); \
+      _2130_set_toff(A); \
+      _2130_set_sfilt(A); \
+      _2130_set_sgt(A); \
+      _2130_set_seimin(A); \
+      _2130_set_sedn(A); \
+      _2130_set_semax(A); \
+      _2130_set_seup(A); \
+      _2130_set_semin(A); \
+      _2130_set_DCCTRL(A); \
+      _2130_set_freewheel(A); \
+      _2130_set_pwm_symmetric(A); \
+      _2130_set_pwm_autoscale(A); \
+      _2130_set_pwm_freq(A); \
+      _2130_set_PWM_GRAD(A); \
+      _2130_set_PWM_AMPL(A); \
+      _2130_set_ENCM_CTRL(A); \
+    } while(0)
 
   #else // !TMC2130_ADVANCED_CONFIGURATION
 
-    void tmc2130_init() {
-      #if ENABLED(X_IS_TMC2130)
-        stepperX.init();
-        stepperX.set_mres(X_MRES);
-        stepperX.set_IHOLD_IRUN(X_IHOLD,X_IRUN,X_IHOLDDELAY);
-        stepperX.set_I_scale_analog(X_ISCALE);
-        stepperX.set_tbl(X_TBL);
-        stepperX.set_toff(X_TOFF);
-      #endif
-      #if ENABLED(X2_IS_TMC2130)
-        stepperX2.init();
-        stepperX2.set_mres(X2_MRES);
-        stepperX2.set_IHOLD_IRUN(X2_IHOLD,X2_IRUN,X2_IHOLDDELAY);
-        stepperX2.set_I_scale_analog(X2_ISCALE);
-        stepperX2.set_tbl(X2_TBL);
-        stepperX2.set_toff(X2_TOFF);
-      #endif
-      #if ENABLED(Y_IS_TMC2130)
-        stepperY.init();
-        stepperY.set_mres(Y_MRES);
-        stepperY.set_IHOLD_IRUN(Y_IHOLD,Y_IRUN,Y_IHOLDDELAY);
-        stepperY.set_I_scale_analog(Y_ISCALE);
-        stepperY.set_tbl(Y_TBL);
-        stepperY.set_toff(Y_TOFF);
-      #endif
-      #if ENABLED(Y2_IS_TMC2130)
-        stepperY2.init();
-        stepperY2.set_mres(Y2_MRES);
-        stepperY2.set_IHOLD_IRUN(Y2_IHOLD,Y2_IRUN,Y2_IHOLDDELAY);
-        stepperY2.set_I_scale_analog(Y2_ISCALE);
-        stepperY2.set_tbl(Y2_TBL);
-        stepperY2.set_toff(Y2_TOFF);
-      #endif
-      #if ENABLED(Z_IS_TMC2130)
-        stepperZ.init();
-        stepperZ.set_mres(Z_MRES);
-        stepperZ.set_IHOLD_IRUN(Z_IHOLD,Z_IRUN,Z_IHOLDDELAY);
-        stepperZ.set_I_scale_analog(Z_ISCALE);
-        stepperZ.set_tbl(Z_TBL);
-        stepperZ.set_toff(Z_TOFF);
-      #endif
-      #if ENABLED(Z2_IS_TMC2130)
-        stepperZ2.init();
-        stepperZ2.set_mres(Z2_MRES);
-        stepperZ2.set_IHOLD_IRUN(Z2_IHOLD,Z2_IRUN,Z2_IHOLDDELAY);
-        stepperZ2.set_I_scale_analog(Z2_ISCALE);
-        stepperZ2.set_tbl(Z2_TBL);
-        stepperZ2.set_toff(Z2_TOFF);
-      #endif
-      #if ENABLED(E0_IS_TMC2130)
-        stepperE0.init();
-        stepperE0.set_mres(E0_MRES);
-        stepperE0.set_IHOLD_IRUN(E0_IHOLD,E0_IRUN,E0_IHOLDDELAY);
-        stepperE0.set_I_scale_analog(E0_ISCALE);
-        stepperE0.set_tbl(E0_TBL);
-        stepperE0.set_toff(E0_TOFF);
-      #endif
-      #if ENABLED(E1_IS_TMC2130)
-        stepperE1.init();
-        stepperE1.set_mres(E1_MRES);
-        stepperE1.set_IHOLD_IRUN(E1_IHOLD,E1_IRUN,E1_IHOLDDELAY);
-        stepperE1.set_I_scale_analog(E1_ISCALE);
-        stepperE1.set_tbl(E1_TBL);
-        stepperE1.set_toff(E1_TOFF);
-      #endif
-      #if ENABLED(E2_IS_TMC2130)
-        stepperE2.init();
-        stepperE2.set_mres(E2_MRES);
-        stepperE2.set_IHOLD_IRUN(E2_IHOLD,E2_IRUN,E2_IHOLDDELAY);
-        stepperE2.set_I_scale_analog(E2_ISCALE);
-        stepperE2.set_tbl(E2_TBL);
-        stepperE2.set_toff(E2_TOFF);
-      #endif
-      #if ENABLED(E3_IS_TMC2130)
-        stepperE3.init();
-        stepperE3.set_mres(E3_MRES);
-        stepperE3.set_IHOLD_IRUN(E3_IHOLD,E3_IRUN,E3_IHOLDDELAY);
-        stepperE3.set_I_scale_analog(E3_ISCALE);
-        stepperE3.set_tbl(E3_TBL);
-        stepperE3.set_toff(E3_TOFF);
-      #endif
-    }
+    #define _TMC2130_INIT(A) do{ \
+      stepper##A.init(); \
+      stepper##A.set_mres(A##_MRES); \
+      stepper##A.set_IHOLD_IRUN(A##_IHOLD, A##_IRUN, A##_IHOLDDELAY); \
+      stepper##A.set_I_scale_analog(A##_I_SCALE_ANALOG); \
+      stepper##A.set_tbl(A##_TBL); \
+      stepper##A.set_toff(A##_TOFF); \
+    } while(0)
 
   #endif // TMC2130_ADVANCED_CONFIGURATION
+
+  // Stepper objects of TMC2310 steppers used
+  #if ENABLED(X_IS_TMC2130)
+    Trinamic_TMC2130 stepperX(X_CS_PIN);
+  #endif
+  #if ENABLED(X2_IS_TMC2130)
+    Trinamic_TMC2130 stepperX2(X2_CS_PIN);
+  #endif
+  #if ENABLED(Y_IS_TMC2130)
+    Trinamic_TMC2130 stepperY(Y_CS_PIN);
+  #endif
+  #if ENABLED(Y2_IS_TMC2130)
+    Trinamic_TMC2130 stepperY2(Y2_CS_PINR);
+  #endif
+  #if ENABLED(Z_IS_TMC2130)
+    Trinamic_TMC2130 stepperZ(Z_CS_PIN);
+  #endif
+  #if ENABLED(Z2_IS_TMC2130)
+    Trinamic_TMC2130 stepperZ2(Z2_CS_PIN);
+  #endif
+  #if ENABLED(E0_IS_TMC2130)
+    Trinamic_TMC2130 stepperE0(E0_CS_PIN);
+  #endif
+  #if ENABLED(E1_IS_TMC2130)
+    Trinamic_TMC2130 stepperE1(E1_CS_PIN);
+  #endif
+  #if ENABLED(E2_IS_TMC2130)
+    Trinamic_TMC2130 stepperE2(E2_CS_PIN);
+  #endif
+  #if ENABLED(E3_IS_TMC2130)
+    Trinamic_TMC2130 stepperE3(E3_CS_PIN);
+  #endif
+
+  void tmc2130_init() {
+    #if ENABLED(X_IS_TMC2130)
+      _TMC2130_INIT(X);
+    #endif
+    #if ENABLED(X2_IS_TMC2130)
+      _TMC2130_INIT(X2);
+    #endif
+    #if ENABLED(Y_IS_TMC2130)
+      _TMC2130_INIT(Y);
+    #endif
+    #if ENABLED(Y2_IS_TMC2130)
+      _TMC2130_INIT(Y2);
+    #endif
+    #if ENABLED(Z_IS_TMC2130)
+      _TMC2130_INIT(Z);
+    #endif
+    #if ENABLED(Z2_IS_TMC2130)
+      _TMC2130_INIT(Z2);
+    #endif
+    #if ENABLED(E0_IS_TMC2130)
+      _TMC2130_INIT(E0);
+    #endif
+    #if ENABLED(E1_IS_TMC2130)
+      _TMC2130_INIT(E1);
+    #endif
+    #if ENABLED(E2_IS_TMC2130)
+      _TMC2130_INIT(E2);
+    #endif
+    #if ENABLED(E3_IS_TMC2130)
+      _TMC2130_INIT(E3);
+    #endif
+  }
 
 #endif // HAVE_TMC2130DRIVER
 

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -45,88 +45,88 @@
 
 #include "MarlinConfig.h"
 
+//
+// TMC26X Driver objects and inits
+//
 #if ENABLED(HAVE_TMCDRIVER)
+
   #include <SPI.h>
   #include <TMC26XStepper.h>
-#endif
 
-// Stepper objects of TMC steppers used
-#if ENABLED(X_IS_TMC)
-  TMC26XStepper stepperX(200, X_ENABLE_PIN, X_STEP_PIN, X_DIR_PIN, X_MAX_CURRENT, X_SENSE_RESISTOR);
-#endif
-#if ENABLED(X2_IS_TMC)
-  TMC26XStepper stepperX2(200, X2_ENABLE_PIN, X2_STEP_PIN, X2_DIR_PIN, X2_MAX_CURRENT, X2_SENSE_RESISTOR);
-#endif
-#if ENABLED(Y_IS_TMC)
-  TMC26XStepper stepperY(200, Y_ENABLE_PIN, Y_STEP_PIN, Y_DIR_PIN, Y_MAX_CURRENT, Y_SENSE_RESISTOR);
-#endif
-#if ENABLED(Y2_IS_TMC)
-  TMC26XStepper stepperY2(200, Y2_ENABLE_PIN, Y2_STEP_PIN, Y2_DIR_PIN, Y2_MAX_CURRENT, Y2_SENSE_RESISTOR);
-#endif
-#if ENABLED(Z_IS_TMC)
-  TMC26XStepper stepperZ(200, Z_ENABLE_PIN, Z_STEP_PIN, Z_DIR_PIN, Z_MAX_CURRENT, Z_SENSE_RESISTOR);
-#endif
-#if ENABLED(Z2_IS_TMC)
-  TMC26XStepper stepperZ2(200, Z2_ENABLE_PIN, Z2_STEP_PIN, Z2_DIR_PIN, Z2_MAX_CURRENT, Z2_SENSE_RESISTOR);
-#endif
-#if ENABLED(E0_IS_TMC)
-  TMC26XStepper stepperE0(200, E0_ENABLE_PIN, E0_STEP_PIN, E0_DIR_PIN, E0_MAX_CURRENT, E0_SENSE_RESISTOR);
-#endif
-#if ENABLED(E1_IS_TMC)
-  TMC26XStepper stepperE1(200, E1_ENABLE_PIN, E1_STEP_PIN, E1_DIR_PIN, E1_MAX_CURRENT, E1_SENSE_RESISTOR);
-#endif
-#if ENABLED(E2_IS_TMC)
-  TMC26XStepper stepperE2(200, E2_ENABLE_PIN, E2_STEP_PIN, E2_DIR_PIN, E2_MAX_CURRENT, E2_SENSE_RESISTOR);
-#endif
-#if ENABLED(E3_IS_TMC)
-  TMC26XStepper stepperE3(200, E3_ENABLE_PIN, E3_STEP_PIN, E3_DIR_PIN, E3_MAX_CURRENT, E3_SENSE_RESISTOR);
-#endif
-
-#if ENABLED(HAVE_TMCDRIVER)
-void tmc_init() {
   #if ENABLED(X_IS_TMC)
-    stepperX.setMicrosteps(X_MICROSTEPS);
-    stepperX.start();
+    TMC26XStepper stepperX(200, X_ENABLE_PIN, X_STEP_PIN, X_DIR_PIN, X_MAX_CURRENT, X_SENSE_RESISTOR);
   #endif
   #if ENABLED(X2_IS_TMC)
-    stepperX2.setMicrosteps(X2_MICROSTEPS);
-    stepperX2.start();
+    TMC26XStepper stepperX2(200, X2_ENABLE_PIN, X2_STEP_PIN, X2_DIR_PIN, X2_MAX_CURRENT, X2_SENSE_RESISTOR);
   #endif
   #if ENABLED(Y_IS_TMC)
-    stepperY.setMicrosteps(Y_MICROSTEPS);
-    stepperY.start();
+    TMC26XStepper stepperY(200, Y_ENABLE_PIN, Y_STEP_PIN, Y_DIR_PIN, Y_MAX_CURRENT, Y_SENSE_RESISTOR);
   #endif
   #if ENABLED(Y2_IS_TMC)
-    stepperY2.setMicrosteps(Y2_MICROSTEPS);
-    stepperY2.start();
+    TMC26XStepper stepperY2(200, Y2_ENABLE_PIN, Y2_STEP_PIN, Y2_DIR_PIN, Y2_MAX_CURRENT, Y2_SENSE_RESISTOR);
   #endif
   #if ENABLED(Z_IS_TMC)
-    stepperZ.setMicrosteps(Z_MICROSTEPS);
-    stepperZ.start();
+    TMC26XStepper stepperZ(200, Z_ENABLE_PIN, Z_STEP_PIN, Z_DIR_PIN, Z_MAX_CURRENT, Z_SENSE_RESISTOR);
   #endif
   #if ENABLED(Z2_IS_TMC)
-    stepperZ2.setMicrosteps(Z2_MICROSTEPS);
-    stepperZ2.start();
+    TMC26XStepper stepperZ2(200, Z2_ENABLE_PIN, Z2_STEP_PIN, Z2_DIR_PIN, Z2_MAX_CURRENT, Z2_SENSE_RESISTOR);
   #endif
   #if ENABLED(E0_IS_TMC)
-    stepperE0.setMicrosteps(E0_MICROSTEPS);
-    stepperE0.start();
+    TMC26XStepper stepperE0(200, E0_ENABLE_PIN, E0_STEP_PIN, E0_DIR_PIN, E0_MAX_CURRENT, E0_SENSE_RESISTOR);
   #endif
   #if ENABLED(E1_IS_TMC)
-    stepperE1.setMicrosteps(E1_MICROSTEPS);
-    stepperE1.start();
+    TMC26XStepper stepperE1(200, E1_ENABLE_PIN, E1_STEP_PIN, E1_DIR_PIN, E1_MAX_CURRENT, E1_SENSE_RESISTOR);
   #endif
   #if ENABLED(E2_IS_TMC)
-    stepperE2.setMicrosteps(E2_MICROSTEPS);
-    stepperE2.start();
+    TMC26XStepper stepperE2(200, E2_ENABLE_PIN, E2_STEP_PIN, E2_DIR_PIN, E2_MAX_CURRENT, E2_SENSE_RESISTOR);
   #endif
   #if ENABLED(E3_IS_TMC)
-    stepperE3.setMicrosteps(E3_MICROSTEPS);
-    stepperE3.start();
+    TMC26XStepper stepperE3(200, E3_ENABLE_PIN, E3_STEP_PIN, E3_DIR_PIN, E3_MAX_CURRENT, E3_SENSE_RESISTOR);
   #endif
-}
-#endif
 
+  #define _TMC_INIT(A) do{ \
+    stepper##A.setMicrosteps(A##_MICROSTEPS);
+    stepper##A.start();
+  } while(0)
+
+  void tmc_init() {
+    #if ENABLED(X_IS_TMC)
+      _TMC_INIT(X);
+    #endif
+    #if ENABLED(X2_IS_TMC)
+      _TMC_INIT(X2);
+    #endif
+    #if ENABLED(Y_IS_TMC)
+      _TMC_INIT(Y);
+    #endif
+    #if ENABLED(Y2_IS_TMC)
+      _TMC_INIT(Y2);
+    #endif
+    #if ENABLED(Z_IS_TMC)
+      _TMC_INIT(Z);
+    #endif
+    #if ENABLED(Z2_IS_TMC)
+      _TMC_INIT(Z2);
+    #endif
+    #if ENABLED(E0_IS_TMC)
+      _TMC_INIT(E0);
+    #endif
+    #if ENABLED(E1_IS_TMC)
+      _TMC_INIT(E1);
+    #endif
+    #if ENABLED(E2_IS_TMC)
+      _TMC_INIT(E2);
+    #endif
+    #if ENABLED(E3_IS_TMC)
+      _TMC_INIT(E3);
+    #endif
+  }
+
+#endif // HAVE_TMCDRIVER
+
+//
+// TMC2130 Driver objects and inits
+//
 #if ENABLED(HAVE_TMC2130DRIVER)
 
   #include <SPI.h>
@@ -549,119 +549,86 @@ void tmc_init() {
 
 #endif // HAVE_TMC2130DRIVER
 
+//
 // L6470 Driver objects and inits
-
+//
 #if ENABLED(HAVE_L6470DRIVER)
+
   #include <SPI.h>
   #include <L6470.h>
-#endif
 
-// L6470 Stepper objects
-#if ENABLED(X_IS_L6470)
-  L6470 stepperX(X_ENABLE_PIN);
-#endif
-#if ENABLED(X2_IS_L6470)
-  L6470 stepperX2(X2_ENABLE_PIN);
-#endif
-#if ENABLED(Y_IS_L6470)
-  L6470 stepperY(Y_ENABLE_PIN);
-#endif
-#if ENABLED(Y2_IS_L6470)
-  L6470 stepperY2(Y2_ENABLE_PIN);
-#endif
-#if ENABLED(Z_IS_L6470)
-  L6470 stepperZ(Z_ENABLE_PIN);
-#endif
-#if ENABLED(Z2_IS_L6470)
-  L6470 stepperZ2(Z2_ENABLE_PIN);
-#endif
-#if ENABLED(E0_IS_L6470)
-  L6470 stepperE0(E0_ENABLE_PIN);
-#endif
-#if ENABLED(E1_IS_L6470)
-  L6470 stepperE1(E1_ENABLE_PIN);
-#endif
-#if ENABLED(E2_IS_L6470)
-  L6470 stepperE2(E2_ENABLE_PIN);
-#endif
-#if ENABLED(E3_IS_L6470)
-  L6470 stepperE3(E3_ENABLE_PIN);
-#endif
-
-
-// init routine
-#if ENABLED(HAVE_L6470DRIVER)
-void L6470_init() {
+  // L6470 Stepper objects
   #if ENABLED(X_IS_L6470)
-    stepperX.init(X_K_VAL);
-    stepperX.softFree();
-    stepperX.setMicroSteps(X_MICROSTEPS);
-    stepperX.setOverCurrent(X_OVERCURRENT); //set overcurrent protection
-    stepperX.setStallCurrent(X_STALLCURRENT);
+    L6470 stepperX(X_ENABLE_PIN);
   #endif
   #if ENABLED(X2_IS_L6470)
-    stepperX2.init(X2_K_VAL);
-    stepperX2.softFree();
-    stepperX2.setMicroSteps(X2_MICROSTEPS);
-    stepperX2.setOverCurrent(X2_OVERCURRENT); //set overcurrent protection
-    stepperX2.setStallCurrent(X2_STALLCURRENT);
+    L6470 stepperX2(X2_ENABLE_PIN);
   #endif
   #if ENABLED(Y_IS_L6470)
-    stepperY.init(Y_K_VAL);
-    stepperY.softFree();
-    stepperY.setMicroSteps(Y_MICROSTEPS);
-    stepperY.setOverCurrent(Y_OVERCURRENT); //set overcurrent protection
-    stepperY.setStallCurrent(Y_STALLCURRENT);
+    L6470 stepperY(Y_ENABLE_PIN);
   #endif
   #if ENABLED(Y2_IS_L6470)
-    stepperY2.init(Y2_K_VAL);
-    stepperY2.softFree();
-    stepperY2.setMicroSteps(Y2_MICROSTEPS);
-    stepperY2.setOverCurrent(Y2_OVERCURRENT); //set overcurrent protection
-    stepperY2.setStallCurrent(Y2_STALLCURRENT);
+    L6470 stepperY2(Y2_ENABLE_PIN);
   #endif
   #if ENABLED(Z_IS_L6470)
-    stepperZ.init(Z_K_VAL);
-    stepperZ.softFree();
-    stepperZ.setMicroSteps(Z_MICROSTEPS);
-    stepperZ.setOverCurrent(Z_OVERCURRENT); //set overcurrent protection
-    stepperZ.setStallCurrent(Z_STALLCURRENT);
+    L6470 stepperZ(Z_ENABLE_PIN);
   #endif
   #if ENABLED(Z2_IS_L6470)
-    stepperZ2.init(Z2_K_VAL);
-    stepperZ2.softFree();
-    stepperZ2.setMicroSteps(Z2_MICROSTEPS);
-    stepperZ2.setOverCurrent(Z2_OVERCURRENT); //set overcurrent protection
-    stepperZ2.setStallCurrent(Z2_STALLCURRENT);
+    L6470 stepperZ2(Z2_ENABLE_PIN);
   #endif
   #if ENABLED(E0_IS_L6470)
-    stepperE0.init(E0_K_VAL);
-    stepperE0.softFree();
-    stepperE0.setMicroSteps(E0_MICROSTEPS);
-    stepperE0.setOverCurrent(E0_OVERCURRENT); //set overcurrent protection
-    stepperE0.setStallCurrent(E0_STALLCURRENT);
+    L6470 stepperE0(E0_ENABLE_PIN);
   #endif
   #if ENABLED(E1_IS_L6470)
-    stepperE1.init(E1_K_VAL);
-    stepperE1.softFree();
-    stepperE1.setMicroSteps(E1_MICROSTEPS);
-    stepperE1.setOverCurrent(E1_OVERCURRENT); //set overcurrent protection
-    stepperE1.setStallCurrent(E1_STALLCURRENT);
+    L6470 stepperE1(E1_ENABLE_PIN);
   #endif
   #if ENABLED(E2_IS_L6470)
-    stepperE2.init(E2_K_VAL);
-    stepperE2.softFree();
-    stepperE2.setMicroSteps(E2_MICROSTEPS);
-    stepperE2.setOverCurrent(E2_OVERCURRENT); //set overcurrent protection
-    stepperE2.setStallCurrent(E2_STALLCURRENT);
+    L6470 stepperE2(E2_ENABLE_PIN);
   #endif
   #if ENABLED(E3_IS_L6470)
-    stepperE3.init(E3_K_VAL);
-    stepperE3.softFree();
-    stepperE3.setMicroSteps(E3_MICROSTEPS);
-    stepperE3.setOverCurrent(E3_OVERCURRENT); //set overcurrent protection
-    stepperE3.setStallCurrent(E3_STALLCURRENT);
+    L6470 stepperE3(E3_ENABLE_PIN);
   #endif
-}
-#endif
+
+  #define _L6470_INIT(A) do{ \
+    stepper##A.init(A##_K_VAL); \
+    stepper##A.softFree(); \
+    stepper##A.setMicroSteps(A##_MICROSTEPS); \
+    stepper##A.setOverCurrent(A##_OVERCURRENT); \
+    stepper##A.setStallCurrent(A##_STALLCURRENT); \
+  } while(0)
+
+  void L6470_init() {
+    #if ENABLED(X_IS_L6470)
+      _L6470_INIT(X);
+    #endif
+    #if ENABLED(X2_IS_L6470)
+      _L6470_INIT(X2);
+    #endif
+    #if ENABLED(Y_IS_L6470)
+      _L6470_INIT(Y);
+    #endif
+    #if ENABLED(Y2_IS_L6470)
+      _L6470_INIT(Y2);
+    #endif
+    #if ENABLED(Z_IS_L6470)
+      _L6470_INIT(Z);
+    #endif
+    #if ENABLED(Z2_IS_L6470)
+      _L6470_INIT(Z2);
+    #endif
+    #if ENABLED(E0_IS_L6470)
+      _L6470_INIT(E0);
+    #endif
+    #if ENABLED(E1_IS_L6470)
+      _L6470_INIT(E1);
+    #endif
+    #if ENABLED(E2_IS_L6470)
+      _L6470_INIT(E2);
+    #endif
+    #if ENABLED(E3_IS_L6470)
+      _L6470_INIT(E3);
+    #endif
+  }
+
+#endif // HAVE_L6470DRIVER
 

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -53,6 +53,13 @@
   void tmc_init();
 #endif
 
+// TMC130 drivers have STEP/DIR/ENABLE on normal pins
+#if ENABLED(HAVE_TMC2130DRIVER)
+  #include <SPI.h>
+  #include <Trinamic_TMC2130.h>
+  void tmc2130_init();
+#endif
+
 // L6470 has STEP on normal pins, but DIR/ENABLE via SPI
 #if ENABLED(HAVE_L6470DRIVER)
   #include <SPI.h>
@@ -76,6 +83,9 @@
     #define X_ENABLE_WRITE(STATE) stepperX.setEnabled(STATE)
     #define X_ENABLE_READ stepperX.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(X_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperX;
+    #endif
     #define X_ENABLE_INIT SET_OUTPUT(X_ENABLE_PIN)
     #define X_ENABLE_WRITE(STATE) WRITE(X_ENABLE_PIN,STATE)
     #define X_ENABLE_READ READ(X_ENABLE_PIN)
@@ -104,6 +114,9 @@
     #define Y_ENABLE_WRITE(STATE) stepperY.setEnabled(STATE)
     #define Y_ENABLE_READ stepperY.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Y_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperY;
+    #endif
     #define Y_ENABLE_INIT SET_OUTPUT(Y_ENABLE_PIN)
     #define Y_ENABLE_WRITE(STATE) WRITE(Y_ENABLE_PIN,STATE)
     #define Y_ENABLE_READ READ(Y_ENABLE_PIN)
@@ -132,6 +145,9 @@
     #define Z_ENABLE_WRITE(STATE) stepperZ.setEnabled(STATE)
     #define Z_ENABLE_READ stepperZ.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Z_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperZ;
+    #endif
     #define Z_ENABLE_INIT SET_OUTPUT(Z_ENABLE_PIN)
     #define Z_ENABLE_WRITE(STATE) WRITE(Z_ENABLE_PIN,STATE)
     #define Z_ENABLE_READ READ(Z_ENABLE_PIN)
@@ -161,6 +177,9 @@
       #define X2_ENABLE_WRITE(STATE) stepperX2.setEnabled(STATE)
       #define X2_ENABLE_READ stepperX2.isEnabled()
     #else
+      #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(X2_IS_TMC2130)
+        extern Trinamic_TMC2130 stepperX2;
+      #endif
       #define X2_ENABLE_INIT SET_OUTPUT(X2_ENABLE_PIN)
       #define X2_ENABLE_WRITE(STATE) WRITE(X2_ENABLE_PIN,STATE)
       #define X2_ENABLE_READ READ(X2_ENABLE_PIN)
@@ -191,6 +210,9 @@
       #define Y2_ENABLE_WRITE(STATE) stepperY2.setEnabled(STATE)
       #define Y2_ENABLE_READ stepperY2.isEnabled()
     #else
+      #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Y2_IS_TMC2130)
+        extern Trinamic_TMC2130 stepperY2;
+      #endif
       #define Y2_ENABLE_INIT SET_OUTPUT(Y2_ENABLE_PIN)
       #define Y2_ENABLE_WRITE(STATE) WRITE(Y2_ENABLE_PIN,STATE)
       #define Y2_ENABLE_READ READ(Y2_ENABLE_PIN)
@@ -221,6 +243,9 @@
       #define Z2_ENABLE_WRITE(STATE) stepperZ2.setEnabled(STATE)
       #define Z2_ENABLE_READ stepperZ2.isEnabled()
     #else
+      #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(Z2_IS_TMC2130)
+        extern Trinamic_TMC2130 stepperZ2;
+      #endif
       #define Z2_ENABLE_INIT SET_OUTPUT(Z2_ENABLE_PIN)
       #define Z2_ENABLE_WRITE(STATE) WRITE(Z2_ENABLE_PIN,STATE)
       #define Z2_ENABLE_READ READ(Z2_ENABLE_PIN)
@@ -250,6 +275,9 @@
     #define E0_ENABLE_WRITE(STATE) stepperE0.setEnabled(STATE)
     #define E0_ENABLE_READ stepperE0.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(E0_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperE0;
+    #endif
     #define E0_ENABLE_INIT SET_OUTPUT(E0_ENABLE_PIN)
     #define E0_ENABLE_WRITE(STATE) WRITE(E0_ENABLE_PIN,STATE)
     #define E0_ENABLE_READ READ(E0_ENABLE_PIN)
@@ -278,6 +306,9 @@
     #define E1_ENABLE_WRITE(STATE) stepperE1.setEnabled(STATE)
     #define E1_ENABLE_READ stepperE1.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(E1_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperE1;
+    #endif
     #define E1_ENABLE_INIT SET_OUTPUT(E1_ENABLE_PIN)
     #define E1_ENABLE_WRITE(STATE) WRITE(E1_ENABLE_PIN,STATE)
     #define E1_ENABLE_READ READ(E1_ENABLE_PIN)
@@ -306,6 +337,9 @@
     #define E2_ENABLE_WRITE(STATE) stepperE2.setEnabled(STATE)
     #define E2_ENABLE_READ stepperE2.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(E2_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperE2;
+    #endif
     #define E2_ENABLE_INIT SET_OUTPUT(E2_ENABLE_PIN)
     #define E2_ENABLE_WRITE(STATE) WRITE(E2_ENABLE_PIN,STATE)
     #define E2_ENABLE_READ READ(E2_ENABLE_PIN)
@@ -334,6 +368,9 @@
     #define E3_ENABLE_WRITE(STATE) stepperE3.setEnabled(STATE)
     #define E3_ENABLE_READ stepperE3.isEnabled()
   #else
+    #if ENABLED(HAVE_TMC2130DRIVER) && ENABLED(E3_IS_TMC2130)
+      extern Trinamic_TMC2130 stepperE3;
+    #endif
     #define E3_ENABLE_INIT SET_OUTPUT(E3_ENABLE_PIN)
     #define E3_ENABLE_WRITE(STATE) WRITE(E3_ENABLE_PIN,STATE)
     #define E3_ENABLE_READ READ(E3_ENABLE_PIN)


### PR DESCRIPTION
Derived from the fork https://github.com/makertum/Marlin by @makertum

- Integrate support for TMC2130 as with other SPI / i2c stepper drivers
- Use conditional macros so users need not edit `stepper_indirection.cpp`
- Use macros to reduce code for TMC26X and L6470 also
- Indent related settings values in `Configuration_adv.h`