### PR TITLE
Printer Stats / Completed prints line doesn't fit in display (when german)

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2011,7 +2011,7 @@ void kill_screen(const char* lcd_msg) {
 
         START_SCREEN();                                                                                // 12345678901234567890
         STATIC_ITEM(MSG_INFO_PRINT_COUNT ": ", false, false, itostr3left(stats.totalPrints));          // Print Count: 999
-        STATIC_ITEM(MSG_INFO_COMPLETED_PRINTS"  : ", false, false, itostr3left(stats.finishedPrints)); // Completed  : 666
+        STATIC_ITEM(MSG_INFO_COMPLETED_PRINTS": ", false, false, itostr3left(stats.finishedPrints)); // Completed  : 666
 
         duration_t elapsed = stats.printTime;
         elapsed.toString(buffer);


### PR DESCRIPTION
I think the below picture says it all :)
![20161109_220217_resized](https://cloud.githubusercontent.com/assets/20832276/20154606/68ad7ca2-a6c8-11e6-9913-65b13a721d0f.jpg)
