### PR TITLE
Remove useless line from stepper ISR

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -343,7 +343,6 @@ void Stepper::isr() {
     // Anything in the buffer?
     current_block = planner.get_current_block();
     if (current_block) {
-      SBI(current_block->flag, BLOCK_BIT_BUSY);
       trapezoid_generator_reset();
 
       // Initialize Bresenham counters to 1/2 the ceiling


### PR DESCRIPTION
This is a small one, but every time I was working on the stepper file it bothers me, especialy as it's inside an ISR:
The flag is already set inside planner.get_current_block(), there is no need to set it again.