### PR TITLE
Megatronics 3.0 has no SD-Card detect

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -78,6 +78,7 @@
 #define BOARD_MEGATRONICS_2     701  // Megatronics v2.0
 #define BOARD_MINITRONICS       702  // Minitronics v1.0/1.1
 #define BOARD_MEGATRONICS_3     703  // Megatronics v3.0
+#define BOARD_MEGATRONICS_31    704  // Megatronics v3.1
 #define BOARD_OMCA_A            90   // Alpha OMCA board
 #define BOARD_OMCA              91   // Final OMCA board
 #define BOARD_RAMBO             301  // Rambo

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -133,6 +133,9 @@
   #include "pins_MEGATRONICS_2.h"
 #elif MB(MEGATRONICS_3)
   #include "pins_MEGATRONICS_3.h"
+#elif MB(MEGATRONICS_31)
+  #define MEGATRONICS_31
+  #include "pins_MEGATRONICS_3.h" 
 #elif MB(OMCA_A)
   #include "pins_OMCA_A.h"
 #elif MB(OMCA)

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -28,8 +28,6 @@
   #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define MEGATRONICS_31
-
 #if ENABLED(MEGATRONICS_31)
   #define BOARD_NAME       "Megatronics v3.1"
 #else


### PR DESCRIPTION
SD-Card detection only implemented in Megatronics 3.1. So it is necessary to split it into different boards.