### PR TITLE
pimp-AUTO_REPORT_TEMPERATURES

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -396,6 +396,10 @@ extern uint8_t active_extruder;
   extern float mixing_factor[MIXING_STEPPERS];
 #endif
 
+#if ENABLED(AUTO_REPORT_TEMPERATURES) && (HAS_TEMP_HOTEND || HAS_TEMP_BED)
+  extern uint8_t auto_report_temp_interval;
+#endif
+
 void calculate_volumetric_multipliers();
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5151,11 +5151,11 @@ inline void gcode_M105() {
 
 #if ENABLED(AUTO_REPORT_TEMPERATURES) && (HAS_TEMP_HOTEND || HAS_TEMP_BED)
 
-  static uint8_t auto_report_temp_interval;
+  uint8_t auto_report_temp_interval = 0;
   static millis_t next_temp_report_ms;
 
   /**
-   * M155: Set temperature auto-report interval. M155 S<seconds>
+   * M155: Set temperature auto-report interval. M155 S<seconds>. S0 = off.
    */
   inline void gcode_M155() {
     if (code_seen('S')) {
@@ -5169,6 +5169,7 @@ inline void gcode_M105() {
     if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
       next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
       print_heaterstates();
+      SERIAL_EOL;
     }
   }
 
@@ -5305,7 +5306,9 @@ inline void gcode_M109() {
     now = millis();
     if (ELAPSED(now, next_temp_ms)) { //Print temp & remaining time every 1s while waiting
       next_temp_ms = now + 1000UL;
-      print_heaterstates();
+      #if DISABLED(AUTO_REPORT_TEMPERATURES)
+        print_heaterstates();
+      #endif
       #if TEMP_RESIDENCY_TIME > 0
         SERIAL_PROTOCOLPGM(" W:");
         if (residency_start_ms) {
@@ -5424,7 +5427,9 @@ inline void gcode_M109() {
       now = millis();
       if (ELAPSED(now, next_temp_ms)) { //Print Temp Reading every 1 second while heating up.
         next_temp_ms = now + 1000UL;
-        print_heaterstates();
+        #if DISABLED(AUTO_REPORT_TEMPERATURES)
+          print_heaterstates();
+        #endif
         #if TEMP_BED_RESIDENCY_TIME > 0
           SERIAL_PROTOCOLPGM(" W:");
           if (residency_start_ms) {
@@ -5806,7 +5811,7 @@ inline void gcode_M115() {
 
     // PROGRESS (M530 S L, M531 <file>, M532 X L)
     SERIAL_PROTOCOLPGM("Cap:");
-    SERIAL_PROTOCOLPGM("PROGRESS:0");
+    SERIAL_PROTOCOLLNPGM("PROGRESS:0");
 
     // AUTOLEVEL (G29)
     SERIAL_PROTOCOLPGM("Cap:");

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -367,17 +367,19 @@ uint8_t Temperature::soft_pwm[HOTENDS];
         SERIAL_PROTOCOLLNPGM(MSG_PID_TEMP_TOO_HIGH);
         return;
       }
-      // Every 2 seconds...
-      if (ELAPSED(ms, temp_ms + 2000UL)) {
-        #if HAS_TEMP_HOTEND || HAS_TEMP_BED
-          print_heaterstates();
-          SERIAL_EOL;
-        #endif
-
+      #if ENABLED(AUTO_REPORT_TEMPERATURES)
+        if (auto_report_temp_interval && ELAPSED(ms, temp_ms + 1000UL * auto_report_temp_interval))
+      #else
+        // Every 2 seconds...
+        if (ELAPSED(ms, temp_ms + 2000UL))
+      #endif
+      {
+        print_heaterstates();
+        SERIAL_EOL;
         temp_ms = ms;
-      } // every 2 seconds
+      }
       // Over 2 minutes?
-      if (((ms - t1) + (ms - t2)) > (10L * 60L * 1000L * 2L)) {
+      if (((ms - t1) + (ms - t2)) > (10UL * 60UL * 1000UL * 2UL)) {
         SERIAL_PROTOCOLLNPGM(MSG_PID_TIMEOUT);
         return;
       }


### PR DESCRIPTION
Add a '\n' at the end of auto report.
Avoid multiple reports during M109/190/303.
Add a '\n' behind report of 'PROGRESS' capability.

Following up to #5188 