### PR TITLE
Add autotemp capabilities to M104

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5078,6 +5078,10 @@ inline void gcode_M104() {
 
     if (code_value_temp_abs() > thermalManager.degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
   }
+  
+  #if ENABLED(AUTOTEMP)
+    planner.autotemp_M104();
+  #endif
 }
 
 #if HAS_TEMP_HOTEND || HAS_TEMP_BED

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5080,7 +5080,7 @@ inline void gcode_M104() {
   }
   
   #if ENABLED(AUTOTEMP)
-    planner.autotemp_M104();
+    planner.autotemp_M104_M109();
   #endif
 }
 
@@ -5277,7 +5277,7 @@ inline void gcode_M109() {
   }
 
   #if ENABLED(AUTOTEMP)
-    planner.autotemp_M109();
+    planner.autotemp_M104_M109();
   #endif
 
   #if TEMP_RESIDENCY_TIME > 0

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1366,6 +1366,13 @@ void Planner::refresh_positioning() {
     if (code_seen('S')) autotemp_min = code_value_temp_abs();
     if (code_seen('B')) autotemp_max = code_value_temp_abs();
   }
+  
+  void Planner::autotemp_M104() {
+    autotemp_enabled = code_seen('F');
+    if (autotemp_enabled) autotemp_factor = code_value_temp_diff();
+    if (code_seen('S')) autotemp_min = code_value_temp_abs();
+    if (code_seen('B')) autotemp_max = code_value_temp_abs();
+  }
 
 #endif
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1360,14 +1360,7 @@ void Planner::refresh_positioning() {
 
 #if ENABLED(AUTOTEMP)
 
-  void Planner::autotemp_M109() {
-    autotemp_enabled = code_seen('F');
-    if (autotemp_enabled) autotemp_factor = code_value_temp_diff();
-    if (code_seen('S')) autotemp_min = code_value_temp_abs();
-    if (code_seen('B')) autotemp_max = code_value_temp_abs();
-  }
-  
-  void Planner::autotemp_M104() {
+  void Planner::autotemp_M104_M109() {
     autotemp_enabled = code_seen('F');
     if (autotemp_enabled) autotemp_factor = code_value_temp_diff();
     if (code_seen('S')) autotemp_min = code_value_temp_abs();

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -372,8 +372,7 @@ class Planner {
       static float autotemp_factor;
       static bool autotemp_enabled;
       static void getHighESpeed();
-      static void autotemp_M109();
-      static void autotemp_M104();
+      static void autotemp_M104_M109();
     #endif
 
   private:

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -373,6 +373,7 @@ class Planner {
       static bool autotemp_enabled;
       static void getHighESpeed();
       static void autotemp_M109();
+      static void autotemp_M104();
     #endif
 
   private:


### PR DESCRIPTION
This allows M104 to pass the F and B parameters to set autotemp parameters similar to M109