### PR TITLE
Fix DIRECT_MIXING_IN_G1 to preserve the previous mix

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2672,16 +2672,26 @@ static void homeaxis(AxisEnum axis) {
 
   #if ENABLED(DIRECT_MIXING_IN_G1)
     // Get mixing parameters from the GCode
-    // Factors that are left out are set to 0
     // The total "must" be 1.0 (but it will be normalized)
+    // If no mix factors are given, the old mix is preserved
     void gcode_get_mix() {
       const char* mixing_codes = "ABCDHI";
-      for (int i = 0; i < MIXING_STEPPERS; i++) {
-        float v = code_seen(mixing_codes[i]) ? code_value_float() : 0.0;
-        NOLESS(v, 0.0);
-        mixing_factor[i] = RECIPROCAL(v);
+      byte mix_bits = 0;
+      for (uint8_t i = 0; i < MIXING_STEPPERS; i++) {
+        if (code_seen(mixing_codes[i])) {
+          SBI(mix_bits, i);
+          float v = code_value_float();
+          NOLESS(v, 0.0);
+          mixing_factor[i] = RECIPROCAL(v);
+        }
       }
-      normalize_mix();
+      // If any mixing factors were included, clear the rest
+      // If none were included, preserve the last mix
+      if (mix_bits) {
+        for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
+          if (!TEST(mix_bits, i)) mixing_factor[i] = 0.0;
+        normalize_mix();
+      }
     }
   #endif
 


### PR DESCRIPTION
Addressing https://github.com/MarlinFirmware/Marlin/pull/3655#issuecomment-250030216

Currently if you omit mix factors in `G1` when using `DIRECT_MIXING_IN_G1` the mix gets cleared, effectively disabling extrusion. This PR changes the behavior so that if any mix factors are included, it specifies a whole new mix, but if no mix factors are included, the previous mix is preserved.