### PR TITLE
Add autotemp capabilities to M104

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5089,6 +5089,10 @@ inline void gcode_M104() {
 
     if (code_value_temp_abs() > thermalManager.degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
   }
+  
+  #if ENABLED(AUTOTEMP)
+    planner.autotemp_M104_M109();
+  #endif
 }
 
 #if HAS_TEMP_HOTEND || HAS_TEMP_BED
@@ -5284,7 +5288,7 @@ inline void gcode_M109() {
   }
 
   #if ENABLED(AUTOTEMP)
-    planner.autotemp_M109();
+    planner.autotemp_M104_M109();
   #endif
 
   #if TEMP_RESIDENCY_TIME > 0

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1360,7 +1360,7 @@ void Planner::refresh_positioning() {
 
 #if ENABLED(AUTOTEMP)
 
-  void Planner::autotemp_M109() {
+  void Planner::autotemp_M104_M109() {
     autotemp_enabled = code_seen('F');
     if (autotemp_enabled) autotemp_factor = code_value_temp_diff();
     if (code_seen('S')) autotemp_min = code_value_temp_abs();

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -372,7 +372,7 @@ class Planner {
       static float autotemp_factor;
       static bool autotemp_enabled;
       static void getHighESpeed();
-      static void autotemp_M109();
+      static void autotemp_M104_M109();
     #endif
 
   private:


### PR DESCRIPTION
This allows M104 to pass the F and B parameters to enable autotemp as well.

Squash of #5223