### PR TITLE
Menu entry for toggling case light

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -225,8 +225,9 @@
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
 // Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-//#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
+//#define CASE_LIGHT_PIN 11         // M355 S1 or M355 S0 to switch On / Off
+//#define CASE_LIGHT_DEFAULT_ON     // Uncomment to set default state to on
+//#define MENU_ITEM_CASE_LIGHT      // Uncomment to have a Case Light On / Off entry in main menu
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7231,9 +7231,8 @@ inline void gcode_M907() {
   inline void gcode_M355() {
     static bool case_light_on
       #if ENABLED(CASE_LIGHT_DEFAULT_ON)
-        = true
-        caselight=true
-       #else
+        = true;
+      #else
       ;
     #endif
     static uint8_t case_light_brightness = 255;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -524,6 +524,16 @@ static uint8_t target_extruder;
   ;
 #endif
 
+#if ENABLED(ULTIPANEL) && HAS_CASE_LIGHT
+  bool caselight =
+    #if ENABLED(CASE_LIGHT_DEFAULT_ON)
+      true
+    #else
+      false
+    #endif
+  ;
+#endif
+
 #if ENABLED(DELTA)
 
   #define SIN_60 0.8660254037844386

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7232,13 +7232,16 @@ inline void gcode_M907() {
     static bool case_light_on
       #if ENABLED(CASE_LIGHT_DEFAULT_ON)
         = true
-      #else
-    ;
+        caselight=true
+       #else
+      ;
     #endif
     static uint8_t case_light_brightness = 255;
     if (code_seen('P')) case_light_brightness = code_value_byte();
     if (code_seen('S')) {
       case_light_on = code_value_bool();
+       if (case_light_on == 0) caselight = false;
+       if (case_light_on == 1) caselight = true;
       digitalWrite(CASE_LIGHT_PIN, case_light_on ? HIGH : LOW);
       analogWrite(CASE_LIGHT_PIN, case_light_on ? case_light_brightness : 0);
     }

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -184,6 +184,8 @@
 #define MSG_INFO_EXTRUDERS                  "Extruders"
 #define MSG_INFO_BAUDRATE                   "Baud"
 #define MSG_INFO_PROTOCOL                   "Protokol"
+#define MSG_LIGHTS_ON                       "Gehäuse Licht an"
+#define MSG_LIGHTS_OFF                      "Gehäuse Licht aus"
 
 #if LCD_WIDTH > 19
   #define MSG_INFO_PRINT_COUNT              "Gesamte Drucke"

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -487,6 +487,12 @@
 #ifndef MSG_INFO_PROTOCOL
   #define MSG_INFO_PROTOCOL                   "Protocol"
 #endif
+#ifndef MSG_LIGHTS_ON
+  #define MSG_LIGHTS_ON                       "Case light on"
+#endif
+#ifndef MSG_LIGHTS_OFF
+  #define MSG_LIGHTS_OFF                      "Case light off"
+#endif
 
 #if LCD_WIDTH > 19
   #ifndef MSG_INFO_PRINT_COUNT

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -110,6 +110,9 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
   #if HAS_POWER_SWITCH
     extern bool powersupply;
   #endif
+  #if HAS_CASE_LIGHT
+    extern bool caselight;
+  #endif
   const float manual_feedrate_mm_m[] = MANUAL_FEEDRATE;
   static void lcd_main_menu();
   static void lcd_tune_menu();
@@ -580,7 +583,15 @@ void kill_screen(const char* lcd_msg) {
   static void lcd_main_menu() {
     START_MENU();
     MENU_BACK(MSG_WATCH);
-
+    //
+    // Switch case light on/off
+    //
+    #if HAS_CASE_LIGHT && ENABLED(MENU_ITEM_CASE_LIGHT)
+      if (caselight)
+        MENU_ITEM(gcode, MSG_LIGHTS_OFF, PSTR("M355 S0"));       
+      else
+        MENU_ITEM(gcode, MSG_LIGHTS_ON, PSTR("M355 S1"));
+    #endif
     #if ENABLED(BLTOUCH)
       if (!endstops.z_probe_enabled && TEST_BLTOUCH())
         MENU_ITEM(gcode, MSG_BLTOUCH_RESET, PSTR("M280 P" STRINGIFY(Z_ENDSTOP_SERVO_NR) " S" STRINGIFY(BLTOUCH_RESET)));


### PR DESCRIPTION
Referenced to this #5194 i implemented a (definable) Menu entry on the main screen to toggle the case lights. I had this long before the `#define CASE_LIGHT_PIN 4` and always found it extremely useful to be able to switch off the case light from by LCD. The host is shut down most of the time, so if `#define CASE_LIGHT_DEFAULT_ON` is enabled there is no way to switch of the case light if the printer is printing for 20 hours.