### PR TITLE
Case light menu (3rd attempt)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -530,6 +530,16 @@ static uint8_t target_extruder;
   ;
 #endif
 
+#if ENABLED(ULTIPANEL) && HAS_CASE_LIGHT
+  bool case_light_on =
+    #if ENABLED(CASE_LIGHT_DEFAULT_ON)
+      true
+    #else
+      false
+    #endif
+  ;
+#endif
+
 #if ENABLED(DELTA)
 
   #define SIN_60 0.8660254037844386
@@ -7225,11 +7235,6 @@ inline void gcode_M907() {
    *   P<byte>  Set case light brightness (PWM pin required)
    */
   inline void gcode_M355() {
-    static bool case_light_on
-      #if ENABLED(CASE_LIGHT_DEFAULT_ON)
-        = true
-      #endif
-    ;
     static uint8_t case_light_brightness = 255;
     if (code_seen('P')) case_light_brightness = code_value_byte();
     if (code_seen('S')) {

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -184,6 +184,8 @@
 #define MSG_INFO_EXTRUDERS                  "Extruders"
 #define MSG_INFO_BAUDRATE                   "Baud"
 #define MSG_INFO_PROTOCOL                   "Protokol"
+#define MSG_LIGHTS_ON                       "Gehäuse Licht an"
+#define MSG_LIGHTS_OFF                      "Gehäuse Licht aus"
 
 #if LCD_WIDTH >= 20
   #define MSG_INFO_PRINT_COUNT              "Gesamte Drucke"

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -487,6 +487,12 @@
 #ifndef MSG_INFO_PROTOCOL
   #define MSG_INFO_PROTOCOL                   "Protocol"
 #endif
+#ifndef MSG_LIGHTS_ON
+  #define MSG_LIGHTS_ON                       "Case light on"
+#endif
+#ifndef MSG_LIGHTS_OFF
+  #define MSG_LIGHTS_OFF                      "Case light off"
+#endif
 
 #if LCD_WIDTH >= 20
   #ifndef MSG_INFO_PRINT_COUNT

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -110,6 +110,9 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
   #if HAS_POWER_SWITCH
     extern bool powersupply;
   #endif
+  #if HAS_CASE_LIGHT
+    extern bool case_light_on;
+  #endif
   const float manual_feedrate_mm_m[] = MANUAL_FEEDRATE;
   static void lcd_main_menu();
   static void lcd_tune_menu();
@@ -581,6 +584,16 @@ void kill_screen(const char* lcd_msg) {
     START_MENU();
     MENU_BACK(MSG_WATCH);
 
+    //
+    // Switch case light on/off
+    //
+    #if HAS_CASE_LIGHT && ENABLED(MENU_ITEM_CASE_LIGHT)
+      if (case_light_on == 0)
+        MENU_ITEM(gcode, MSG_LIGHTS_ON, PSTR("M355 S1"));
+      else
+        MENU_ITEM(gcode, MSG_LIGHTS_OFF, PSTR("M355 S0"));
+    #endif
+
     #if ENABLED(BLTOUCH)
       if (!endstops.z_probe_enabled && TEST_BLTOUCH())
         MENU_ITEM(gcode, MSG_BLTOUCH_RESET, PSTR("M280 P" STRINGIFY(Z_ENDSTOP_SERVO_NR) " S" STRINGIFY(BLTOUCH_RESET)));
@@ -857,7 +870,7 @@ void kill_screen(const char* lcd_msg) {
 
     static void lcd_dac_menu() {
       dac_driver_getValues();
-      START_MENU();    
+      START_MENU();
       MENU_BACK(MSG_CONTROL);
       MENU_ITEM_EDIT_CALLBACK(int3, MSG_X " " MSG_DAC_PERCENT, &driverPercent[X_AXIS], 0, 100, dac_driver_commit);
       MENU_ITEM_EDIT_CALLBACK(int3, MSG_Y " " MSG_DAC_PERCENT, &driverPercent[Y_AXIS], 0, 100, dac_driver_commit);
@@ -1547,7 +1560,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM(submenu, MSG_RETRACT, lcd_control_retract_menu);
     #endif
     #if ENABLED(DAC_STEPPER_CURRENT)
-      MENU_ITEM(submenu, MSG_DRIVE_STRENGTH, lcd_dac_menu); 
+      MENU_ITEM(submenu, MSG_DRIVE_STRENGTH, lcd_dac_menu);
     #endif
 
     #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
Github seems to be for Pros only :) 
Referenced to this #5194 (and this #5243 because i don't understand github) i implemented a (definable) Menu entry on the main screen to toggle the case lights. I had this long before the #define CASE_LIGHT_PIN 4 and always found it extremely useful to be able to switch off the case light from by LCD. The host is shut down most of the time, so if #define CASE_LIGHT_DEFAULT_ON is enabled there is no way to switch of the case light if the printer is printing for 20 hours.