### PR TITLE
Endstop interrupt refinement

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -359,6 +359,11 @@ void Stepper::isr() {
 
       step_events_completed = 0;
 
+      #if ENABLED(ENDSTOP_INTERRUPTS_FEATURE)
+        e_hit = 2; // Needed for the case an endstop is already triggered before the new move begins.
+                   // No 'change' can be detected.
+      #endif
+
       #if ENABLED(Z_LATE_ENABLE)
         if (current_block->steps[Z_AXIS] > 0) {
           enable_z();


### PR DESCRIPTION
At the start of a move, check if the endstops are already triggered.
The 'change' interrupts will not see a change if already triggered.