### PR TITLE
Allow UART ISRs inside the stepper ISR

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -331,6 +331,14 @@ void Stepper::set_directions() {
 ISR(TIMER1_COMPA_vect) { Stepper::isr(); }
 
 void Stepper::isr() {
+  //Disable Timer0 ISRs and enable global ISR again to capture UART events (incoming chars)
+  #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
+    CBI(TIMSK0, OCIE0A); //estepper ISR
+  #endif
+  CBI(TIMSK0, OCIE0B); //Temperature ISR
+  DISABLE_STEPPER_DRIVER_INTERRUPT();
+  sei();
+  
   if (cleaning_buffer_counter) {
     current_block = NULL;
     planner.discard_current_block();
@@ -339,6 +347,12 @@ void Stepper::isr() {
     #endif
     cleaning_buffer_counter--;
     OCR1A = 200; // Run at max speed - 10 KHz
+    //re-enable ISRs
+    #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
+      SBI(TIMSK0, OCIE0A);
+    #endif
+    SBI(TIMSK0, OCIE0B);
+    ENABLE_STEPPER_DRIVER_INTERRUPT();
     return;
   }
 
@@ -368,6 +382,11 @@ void Stepper::isr() {
         if (current_block->steps[Z_AXIS] > 0) {
           enable_z();
           OCR1A = 2000; // Run at slow speed - 1 KHz
+          #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
+            SBI(TIMSK0, OCIE0A);
+          #endif
+          SBI(TIMSK0, OCIE0B);
+          ENABLE_STEPPER_DRIVER_INTERRUPT();
           return;
         }
       #endif
@@ -378,6 +397,11 @@ void Stepper::isr() {
     }
     else {
       OCR1A = 2000; // Run at slow speed - 1 KHz
+      #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
+        SBI(TIMSK0, OCIE0A);
+      #endif
+      SBI(TIMSK0, OCIE0B);
+      ENABLE_STEPPER_DRIVER_INTERRUPT();
       return;
     }
   }
@@ -402,10 +426,6 @@ void Stepper::isr() {
   // Take multiple steps per interrupt (For high speed moves)
   bool all_steps_done = false;
   for (int8_t i = 0; i < step_loops; i++) {
-    #ifndef USBCON
-      customizedSerial.checkRx(); // Check for serial chars.
-    #endif
-
     #if ENABLED(LIN_ADVANCE)
 
       counter_E += current_block->steps[E_AXIS];
@@ -694,6 +714,11 @@ void Stepper::isr() {
     current_block = NULL;
     planner.discard_current_block();
   }
+  #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
+    SBI(TIMSK0, OCIE0A);
+  #endif
+  SBI(TIMSK0, OCIE0B);
+  ENABLE_STEPPER_DRIVER_INTERRUPT();
 }
 
 #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1489,6 +1489,9 @@ void Temperature::set_current_temp_raw() {
 ISR(TIMER0_COMPB_vect) { Temperature::isr(); }
 
 void Temperature::isr() {
+  //Allow UART and stepper ISRs
+  CBI(TIMSK0, OCIE0B); //Disable Temperature ISR
+  sei();
 
   static uint8_t temp_count = 0;
   static TempState temp_state = StartupDelay;
@@ -1940,4 +1943,6 @@ void Temperature::isr() {
       if (!endstop_monitor_count) endstop_monitor();  // report changes in endstop status
     }
   #endif
+  
+  SBI(TIMSK0, OCIE0B); //re-enable Temperature ISR
 }


### PR DESCRIPTION
If the stepper ISR takes too long, chars are lost which leads to serial communication errors like "Line number not +1" or "Wrong checksum". In worst case, the printer can even do crazy moves.

With this change, UART interrupts are handled inside the stepper ISR. This way, no chars should be lost.

In reality, with this PR I can print at 250000baud with only few single errors during communication. Without it, printing at 250000baud is completely impossible for me. But in fact there are error messages, so the next step would be to find out what (maybe other ISRs) takes too long. The PR is also likely not disabling all ISRs of all possible features, for example servo probe things. Therefore see it as a draft so volunteers can test it and throw in their statements.