### PR TITLE
Drop "static" keyword in ultralcd.cpp function declarations

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -59,7 +59,7 @@ char lcd_status_message[3 * (LCD_WIDTH) + 1] = WELCOME_MSG; // worst case is kan
 #endif
 
 // The main status screen
-static void lcd_status_screen();
+void lcd_status_screen();
 
 millis_t next_lcd_update_ms;
 
@@ -111,53 +111,53 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     extern bool powersupply;
   #endif
   const float manual_feedrate_mm_m[] = MANUAL_FEEDRATE;
-  static void lcd_main_menu();
-  static void lcd_tune_menu();
-  static void lcd_prepare_menu();
-  static void lcd_move_menu();
-  static void lcd_control_menu();
-  static void lcd_control_temperature_menu();
-  static void lcd_control_temperature_preheat_pla_settings_menu();
-  static void lcd_control_temperature_preheat_abs_settings_menu();
-  static void lcd_control_motion_menu();
-  static void lcd_control_volumetric_menu();
+  void lcd_main_menu();
+  void lcd_tune_menu();
+  void lcd_prepare_menu();
+  void lcd_move_menu();
+  void lcd_control_menu();
+  void lcd_control_temperature_menu();
+  void lcd_control_temperature_preheat_pla_settings_menu();
+  void lcd_control_temperature_preheat_abs_settings_menu();
+  void lcd_control_motion_menu();
+  void lcd_control_volumetric_menu();
 
   #if ENABLED(DAC_STEPPER_CURRENT)
-    static void dac_driver_commit();
-    static void dac_driver_getValues();
-    static void lcd_dac_menu();
-    static void lcd_dac_write_eeprom();
+    void dac_driver_commit();
+    void dac_driver_getValues();
+    void lcd_dac_menu();
+    void lcd_dac_write_eeprom();
   #endif
 
   #if ENABLED(LCD_INFO_MENU)
     #if ENABLED(PRINTCOUNTER)
-      static void lcd_info_stats_menu();
+      void lcd_info_stats_menu();
     #endif
-    static void lcd_info_thermistors_menu();
-    static void lcd_info_board_menu();
-    static void lcd_info_menu();
+    void lcd_info_thermistors_menu();
+    void lcd_info_board_menu();
+    void lcd_info_menu();
   #endif // LCD_INFO_MENU
 
   #if ENABLED(FILAMENT_CHANGE_FEATURE)
-    static void lcd_filament_change_option_menu();
-    static void lcd_filament_change_init_message();
-    static void lcd_filament_change_unload_message();
-    static void lcd_filament_change_insert_message();
-    static void lcd_filament_change_load_message();
-    static void lcd_filament_change_extrude_message();
-    static void lcd_filament_change_resume_message();
+    void lcd_filament_change_option_menu();
+    void lcd_filament_change_init_message();
+    void lcd_filament_change_unload_message();
+    void lcd_filament_change_insert_message();
+    void lcd_filament_change_load_message();
+    void lcd_filament_change_extrude_message();
+    void lcd_filament_change_resume_message();
   #endif
 
   #if HAS_LCD_CONTRAST
-    static void lcd_set_contrast();
+    void lcd_set_contrast();
   #endif
 
   #if ENABLED(FWRETRACT)
-    static void lcd_control_retract_menu();
+    void lcd_control_retract_menu();
   #endif
 
   #if ENABLED(DELTA_CALIBRATION_MENU)
-    static void lcd_delta_calibrate_menu();
+    void lcd_delta_calibrate_menu();
   #endif
 
   #if ENABLED(MANUAL_BED_LEVELING)
@@ -169,35 +169,35 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
 
   // Different types of actions that can be used in menu items.
   #define menu_action_back(dummy) _menu_action_back()
-  static void _menu_action_back();
-  static void menu_action_submenu(screenFunc_t data);
-  static void menu_action_gcode(const char* pgcode);
-  static void menu_action_function(screenFunc_t data);
-  static void menu_action_setting_edit_bool(const char* pstr, bool* ptr);
-  static void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
-  static void menu_action_setting_edit_float3(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_float32(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_float43(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_float5(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_float51(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_float52(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_float62(const char* pstr, float* ptr, float minValue, float maxValue);
-  static void menu_action_setting_edit_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue);
-  static void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float3(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float32(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float43(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float5(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float51(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float52(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_float62(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  static void menu_action_setting_edit_callback_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue, screenFunc_t callbackFunc);
+  void _menu_action_back();
+  void menu_action_submenu(screenFunc_t data);
+  void menu_action_gcode(const char* pgcode);
+  void menu_action_function(screenFunc_t data);
+  void menu_action_setting_edit_bool(const char* pstr, bool* ptr);
+  void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
+  void menu_action_setting_edit_float3(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_float32(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_float43(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_float5(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_float51(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_float52(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_float62(const char* pstr, float* ptr, float minValue, float maxValue);
+  void menu_action_setting_edit_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue);
+  void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float3(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float32(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float43(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float5(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float51(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float52(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_float62(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue, screenFunc_t callbackFunc);
 
   #if ENABLED(SDSUPPORT)
-    static void lcd_sdcard_menu();
-    static void menu_action_sdfile(const char* filename, char* longFilename);
-    static void menu_action_sddirectory(const char* filename, char* longFilename);
+    void lcd_sdcard_menu();
+    void menu_action_sdfile(const char* filename, char* longFilename);
+    void menu_action_sddirectory(const char* filename, char* longFilename);
   #endif
 
   /* Helper macros for menus */
@@ -391,7 +391,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
   /**
    * General function to go directly to a screen
    */
-  static void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0) {
+  void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0) {
     if (currentScreen != screen) {
       currentScreen = screen;
       encoderPosition = encoder;
@@ -408,7 +408,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     }
   }
 
-  static void lcd_return_to_status() { lcd_goto_screen(lcd_status_screen); }
+  void lcd_return_to_status() { lcd_goto_screen(lcd_status_screen); }
 
   inline void lcd_save_previous_menu() {
     if (screen_history_depth < COUNT(screen_history)) {
@@ -418,7 +418,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     }
   }
 
-  static void lcd_goto_previous_menu() {
+  void lcd_goto_previous_menu() {
     if (screen_history_depth > 0) {
       --screen_history_depth;
       lcd_goto_screen(
@@ -439,7 +439,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
  * This is very display-dependent, so the lcd implementation draws this.
  */
 
-static void lcd_status_screen() {
+void lcd_status_screen() {
 
   #if ENABLED(ULTIPANEL)
     ENCODER_DIRECTION_NORMAL();
@@ -549,17 +549,17 @@ void kill_screen(const char* lcd_msg) {
 
   #if ENABLED(SDSUPPORT)
 
-    static void lcd_sdcard_pause() {
+    void lcd_sdcard_pause() {
       card.pauseSDPrint();
       print_job_timer.pause();
     }
 
-    static void lcd_sdcard_resume() {
+    void lcd_sdcard_resume() {
       card.startFileprint();
       print_job_timer.start();
     }
 
-    static void lcd_sdcard_stop() {
+    void lcd_sdcard_stop() {
       card.stopSDPrint();
       clear_command_queue();
       quickstop_stepper();
@@ -579,7 +579,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
 
-  static void lcd_main_menu() {
+  void lcd_main_menu() {
     START_MENU();
     MENU_BACK(MSG_WATCH);
 
@@ -649,7 +649,7 @@ void kill_screen(const char* lcd_msg) {
 
     long babysteps_done = 0;
 
-    static void _lcd_babystep(const AxisEnum axis, const char* msg) {
+    void _lcd_babystep(const AxisEnum axis, const char* msg) {
       if (lcd_clicked) { defer_return_to_status = false; return lcd_goto_previous_menu(); }
       ENCODER_DIRECTION_NORMAL();
       if (encoderPosition) {
@@ -666,13 +666,13 @@ void kill_screen(const char* lcd_msg) {
     }
 
     #if ENABLED(BABYSTEP_XY)
-      static void _lcd_babystep_x() { _lcd_babystep(X_AXIS, PSTR(MSG_BABYSTEPPING_X)); }
-      static void _lcd_babystep_y() { _lcd_babystep(Y_AXIS, PSTR(MSG_BABYSTEPPING_Y)); }
-      static void lcd_babystep_x() { lcd_goto_screen(_lcd_babystep_x); babysteps_done = 0; defer_return_to_status = true; }
-      static void lcd_babystep_y() { lcd_goto_screen(_lcd_babystep_y); babysteps_done = 0; defer_return_to_status = true; }
+      void _lcd_babystep_x() { _lcd_babystep(X_AXIS, PSTR(MSG_BABYSTEPPING_X)); }
+      void _lcd_babystep_y() { _lcd_babystep(Y_AXIS, PSTR(MSG_BABYSTEPPING_Y)); }
+      void lcd_babystep_x() { lcd_goto_screen(_lcd_babystep_x); babysteps_done = 0; defer_return_to_status = true; }
+      void lcd_babystep_y() { lcd_goto_screen(_lcd_babystep_y); babysteps_done = 0; defer_return_to_status = true; }
     #endif
-    static void _lcd_babystep_z() { _lcd_babystep(Z_AXIS, PSTR(MSG_BABYSTEPPING_Z)); }
-    static void lcd_babystep_z() { lcd_goto_screen(_lcd_babystep_z); babysteps_done = 0; defer_return_to_status = true; }
+    void _lcd_babystep_z() { _lcd_babystep(Z_AXIS, PSTR(MSG_BABYSTEPPING_Z)); }
+    void lcd_babystep_z() { lcd_goto_screen(_lcd_babystep_z); babysteps_done = 0; defer_return_to_status = true; }
 
   #endif //BABYSTEPPING
 
@@ -718,7 +718,7 @@ void kill_screen(const char* lcd_msg) {
   #endif
 
   #if ENABLED(FILAMENT_CHANGE_FEATURE)
-    static void lcd_enqueue_filament_change() {
+    void lcd_enqueue_filament_change() {
       lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_INIT);
       enqueue_and_echo_commands_P(PSTR("M600"));
     }
@@ -729,7 +729,7 @@ void kill_screen(const char* lcd_msg) {
    * "Tune" submenu
    *
    */
-  static void lcd_tune_menu() {
+  void lcd_tune_menu() {
     START_MENU();
 
     //
@@ -851,13 +851,13 @@ void kill_screen(const char* lcd_msg) {
    *
    */
   #if ENABLED(DAC_STEPPER_CURRENT)
-    static void dac_driver_getValues() { LOOP_XYZE(i) driverPercent[i] = dac_current_get_percent((AxisEnum)i); }
+    void dac_driver_getValues() { LOOP_XYZE(i) driverPercent[i] = dac_current_get_percent((AxisEnum)i); }
 
-    static void dac_driver_commit() { dac_current_set_percents(driverPercent); }
+    void dac_driver_commit() { dac_current_set_percents(driverPercent); }
 
-    static void dac_driver_eeprom_write() { dac_commit_eeprom(); }
+    void dac_driver_eeprom_write() { dac_commit_eeprom(); }
 
-    static void lcd_dac_menu() {
+    void lcd_dac_menu() {
       dac_driver_getValues();
       START_MENU();    
       MENU_BACK(MSG_CONTROL);
@@ -945,7 +945,7 @@ void kill_screen(const char* lcd_msg) {
 
   #if TEMP_SENSOR_0 != 0 && (TEMP_SENSOR_1 != 0 || TEMP_SENSOR_2 != 0 || TEMP_SENSOR_3 != 0 || TEMP_SENSOR_BED != 0)
 
-    static void lcd_preheat_pla_menu() {
+    void lcd_preheat_pla_menu() {
       START_MENU();
       MENU_BACK(MSG_PREPARE);
       #if HOTENDS == 1
@@ -967,7 +967,7 @@ void kill_screen(const char* lcd_msg) {
       END_MENU();
     }
 
-    static void lcd_preheat_abs_menu() {
+    void lcd_preheat_abs_menu() {
       START_MENU();
       MENU_BACK(MSG_PREPARE);
       #if HOTENDS == 1
@@ -1001,7 +1001,7 @@ void kill_screen(const char* lcd_msg) {
 
   #if ENABLED(SDSUPPORT) && ENABLED(MENU_ADDAUTOSTART)
 
-    static void lcd_autostart_sd() {
+    void lcd_autostart_sd() {
       card.autostart_index = 0;
       card.setroot();
       card.checkautostart(true);
@@ -1036,9 +1036,9 @@ void kill_screen(const char* lcd_msg) {
       stepper.synchronize();
     }
 
-    static void _lcd_level_goto_next_point();
+    void _lcd_level_goto_next_point();
 
-    static void _lcd_level_bed_done() {
+    void _lcd_level_bed_done() {
       if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_DONE));
       lcdDrawUpdate =
         #if ENABLED(DOGLCD)
@@ -1052,7 +1052,7 @@ void kill_screen(const char* lcd_msg) {
     /**
      * Step 7: Get the Z coordinate, then goto next point or exit
      */
-    static void _lcd_level_bed_get_z() {
+    void _lcd_level_bed_get_z() {
       ENCODER_DIRECTION_NORMAL();
 
       // Encoder wheel adjusts the Z position
@@ -1114,7 +1114,7 @@ void kill_screen(const char* lcd_msg) {
     /**
      * Step 6: Display "Next point: 1 / 9" while waiting for move to finish
      */
-    static void _lcd_level_bed_moving() {
+    void _lcd_level_bed_moving() {
       if (lcdDrawUpdate) {
         char msg[10];
         sprintf_P(msg, PSTR("%i / %u"), (int)(_lcd_level_bed_position + 1), (MESH_NUM_X_POINTS) * (MESH_NUM_Y_POINTS));
@@ -1133,7 +1133,7 @@ void kill_screen(const char* lcd_msg) {
     /**
      * Step 5: Initiate a move to the next point
      */
-    static void _lcd_level_goto_next_point() {
+    void _lcd_level_goto_next_point() {
       // Set the menu to display ahead of blocking call
       lcd_goto_screen(_lcd_level_bed_moving);
 
@@ -1150,7 +1150,7 @@ void kill_screen(const char* lcd_msg) {
      * Step 4: Display "Click to Begin", wait for click
      *         Move to the first probe position
      */
-    static void _lcd_level_bed_homing_done() {
+    void _lcd_level_bed_homing_done() {
       if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_WAITING));
       if (lcd_clicked) {
         _lcd_level_bed_position = 0;
@@ -1167,7 +1167,7 @@ void kill_screen(const char* lcd_msg) {
     /**
      * Step 3: Display "Homing XYZ" - Wait for homing to finish
      */
-    static void _lcd_level_bed_homing() {
+    void _lcd_level_bed_homing() {
       if (lcdDrawUpdate) lcd_implementation_drawedit(PSTR(MSG_LEVEL_BED_HOMING), NULL);
       lcdDrawUpdate =
         #if ENABLED(DOGLCD)
@@ -1183,7 +1183,7 @@ void kill_screen(const char* lcd_msg) {
     /**
      * Step 2: Continue Bed Leveling...
      */
-    static void _lcd_level_bed_continue() {
+    void _lcd_level_bed_continue() {
       defer_return_to_status = true;
       axis_homed[X_AXIS] = axis_homed[Y_AXIS] = axis_homed[Z_AXIS] = false;
       mbl.reset();
@@ -1194,7 +1194,7 @@ void kill_screen(const char* lcd_msg) {
     /**
      * Step 1: MBL entry-point: "Cancel" or "Level Bed"
      */
-    static void lcd_level_bed() {
+    void lcd_level_bed() {
       START_MENU();
       MENU_BACK(MSG_LEVEL_BED_CANCEL);
       MENU_ITEM(submenu, MSG_LEVEL_BED, _lcd_level_bed_continue);
@@ -1209,7 +1209,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
 
-  static void lcd_prepare_menu() {
+  void lcd_prepare_menu() {
     START_MENU();
 
     //
@@ -1304,7 +1304,7 @@ void kill_screen(const char* lcd_msg) {
 
   #if ENABLED(DELTA_CALIBRATION_MENU)
 
-    static void _goto_tower_pos(const float &a) {
+    void _goto_tower_pos(const float &a) {
       do_blocking_move_to(
         a < 0 ? X_HOME_POS : sin(a) * -(DELTA_PRINTABLE_RADIUS),
         a < 0 ? Y_HOME_POS : cos(a) *  (DELTA_PRINTABLE_RADIUS),
@@ -1312,12 +1312,12 @@ void kill_screen(const char* lcd_msg) {
       );
     }
 
-    static void _goto_tower_x() { _goto_tower_pos(RADIANS(120)); }
-    static void _goto_tower_y() { _goto_tower_pos(RADIANS(240)); }
-    static void _goto_tower_z() { _goto_tower_pos(0); }
-    static void _goto_center()  { _goto_tower_pos(-1); }
+    void _goto_tower_x() { _goto_tower_pos(RADIANS(120)); }
+    void _goto_tower_y() { _goto_tower_pos(RADIANS(240)); }
+    void _goto_tower_z() { _goto_tower_pos(0); }
+    void _goto_center()  { _goto_tower_pos(-1); }
 
-    static void lcd_delta_calibrate_menu() {
+    void lcd_delta_calibrate_menu() {
       START_MENU();
       MENU_BACK(MSG_MAIN);
       MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
@@ -1365,7 +1365,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
 
-  static void _lcd_move_xyz(const char* name, AxisEnum axis) {
+  void _lcd_move_xyz(const char* name, AxisEnum axis) {
     if (lcd_clicked) { return lcd_goto_previous_menu(); }
     ENCODER_DIRECTION_NORMAL();
     if (encoderPosition) {
@@ -1398,10 +1398,10 @@ void kill_screen(const char* lcd_msg) {
     }
     if (lcdDrawUpdate) lcd_implementation_drawedit(name, ftostr41sign(current_position[axis]));
   }
-  static void lcd_move_x() { _lcd_move_xyz(PSTR(MSG_MOVE_X), X_AXIS); }
-  static void lcd_move_y() { _lcd_move_xyz(PSTR(MSG_MOVE_Y), Y_AXIS); }
-  static void lcd_move_z() { _lcd_move_xyz(PSTR(MSG_MOVE_Z), Z_AXIS); }
-  static void _lcd_move_e(
+  void lcd_move_x() { _lcd_move_xyz(PSTR(MSG_MOVE_X), X_AXIS); }
+  void lcd_move_y() { _lcd_move_xyz(PSTR(MSG_MOVE_Y), Y_AXIS); }
+  void lcd_move_z() { _lcd_move_xyz(PSTR(MSG_MOVE_Z), Z_AXIS); }
+  void _lcd_move_e(
     #if E_MANUAL > 1
       int8_t eindex=-1
     #endif
@@ -1438,14 +1438,14 @@ void kill_screen(const char* lcd_msg) {
     }
   }
 
-  static void lcd_move_e() { _lcd_move_e(); }
+  void lcd_move_e() { _lcd_move_e(); }
   #if E_MANUAL > 1
-    static void lcd_move_e0() { _lcd_move_e(0); }
-    static void lcd_move_e1() { _lcd_move_e(1); }
+    void lcd_move_e0() { _lcd_move_e(0); }
+    void lcd_move_e1() { _lcd_move_e(1); }
     #if E_MANUAL > 2
-      static void lcd_move_e2() { _lcd_move_e(2); }
+      void lcd_move_e2() { _lcd_move_e(2); }
       #if E_MANUAL > 3
-        static void lcd_move_e3() { _lcd_move_e(3); }
+        void lcd_move_e3() { _lcd_move_e(3); }
       #endif
     #endif
   #endif
@@ -1462,7 +1462,7 @@ void kill_screen(const char* lcd_msg) {
     #define _MOVE_XYZ_ALLOWED true
   #endif
 
-  static void _lcd_move_menu_axis() {
+  void _lcd_move_menu_axis() {
     START_MENU();
     MENU_BACK(MSG_MOVE_AXIS);
 
@@ -1496,15 +1496,15 @@ void kill_screen(const char* lcd_msg) {
     END_MENU();
   }
 
-  static void lcd_move_menu_10mm() {
+  void lcd_move_menu_10mm() {
     move_menu_scale = 10.0;
     _lcd_move_menu_axis();
   }
-  static void lcd_move_menu_1mm() {
+  void lcd_move_menu_1mm() {
     move_menu_scale = 1.0;
     _lcd_move_menu_axis();
   }
-  static void lcd_move_menu_01mm() {
+  void lcd_move_menu_01mm() {
     move_menu_scale = 0.1;
     _lcd_move_menu_axis();
   }
@@ -1515,7 +1515,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
 
-  static void lcd_move_menu() {
+  void lcd_move_menu() {
     START_MENU();
     MENU_BACK(MSG_PREPARE);
 
@@ -1534,7 +1534,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
 
-  static void lcd_control_menu() {
+  void lcd_control_menu() {
     START_MENU();
     MENU_BACK(MSG_MAIN);
     MENU_ITEM(submenu, MSG_TEMPERATURE, lcd_control_temperature_menu);
@@ -1577,7 +1577,7 @@ void kill_screen(const char* lcd_msg) {
       int autotune_temp_bed = 70;
     #endif
 
-    static void _lcd_autotune(int e) {
+    void _lcd_autotune(int e) {
       char cmd[30];
       sprintf_P(cmd, PSTR("M303 U1 E%i S%i"), e,
         #if HAS_PID_FOR_BOTH
@@ -1643,7 +1643,7 @@ void kill_screen(const char* lcd_msg) {
    * "Control" > "Temperature" submenu
    *
    */
-  static void lcd_control_temperature_menu() {
+  void lcd_control_temperature_menu() {
     START_MENU();
 
     //
@@ -1774,7 +1774,7 @@ void kill_screen(const char* lcd_msg) {
     END_MENU();
   }
 
-  static void _lcd_control_temperature_preheat_settings_menu(uint8_t material) {
+  void _lcd_control_temperature_preheat_settings_menu(uint8_t material) {
     START_MENU();
     MENU_BACK(MSG_TEMPERATURE);
     MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &lcd_preheat_fan_speed[material], 0, 255);
@@ -1795,24 +1795,24 @@ void kill_screen(const char* lcd_msg) {
    * "Temperature" > "Preheat PLA conf" submenu
    *
    */
-  static void lcd_control_temperature_preheat_pla_settings_menu() { _lcd_control_temperature_preheat_settings_menu(0); }
+  void lcd_control_temperature_preheat_pla_settings_menu() { _lcd_control_temperature_preheat_settings_menu(0); }
 
   /**
    *
    * "Temperature" > "Preheat ABS conf" submenu
    *
    */
-  static void lcd_control_temperature_preheat_abs_settings_menu() { _lcd_control_temperature_preheat_settings_menu(1); }
+  void lcd_control_temperature_preheat_abs_settings_menu() { _lcd_control_temperature_preheat_settings_menu(1); }
 
-  static void _reset_acceleration_rates() { planner.reset_acceleration_rates(); }
-  static void _planner_refresh_positioning() { planner.refresh_positioning(); }
+  void _reset_acceleration_rates() { planner.reset_acceleration_rates(); }
+  void _planner_refresh_positioning() { planner.refresh_positioning(); }
 
   /**
    *
    * "Control" > "Motion" submenu
    *
    */
-  static void lcd_control_motion_menu() {
+  void lcd_control_motion_menu() {
     START_MENU();
     MENU_BACK(MSG_CONTROL);
     #if HAS_BED_PROBE
@@ -1858,7 +1858,7 @@ void kill_screen(const char* lcd_msg) {
    * "Control" > "Filament" submenu
    *
    */
-  static void lcd_control_volumetric_menu() {
+  void lcd_control_volumetric_menu() {
     START_MENU();
     MENU_BACK(MSG_CONTROL);
 
@@ -1888,7 +1888,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
   #if HAS_LCD_CONTRAST
-    static void lcd_set_contrast() {
+    void lcd_set_contrast() {
       if (lcd_clicked) { return lcd_goto_previous_menu(); }
       ENCODER_DIRECTION_NORMAL();
       if (encoderPosition) {
@@ -1915,7 +1915,7 @@ void kill_screen(const char* lcd_msg) {
    */
   #if ENABLED(FWRETRACT)
 
-    static void lcd_control_retract_menu() {
+    void lcd_control_retract_menu() {
       START_MENU();
       MENU_BACK(MSG_CONTROL);
       MENU_ITEM_EDIT(bool, MSG_AUTORETRACT, &autoretract_enabled);
@@ -1938,13 +1938,13 @@ void kill_screen(const char* lcd_msg) {
   #if ENABLED(SDSUPPORT)
 
     #if !PIN_EXISTS(SD_DETECT)
-      static void lcd_sd_refresh() {
+      void lcd_sd_refresh() {
         card.initsd();
         encoderTopLine = 0;
       }
     #endif
 
-    static void lcd_sd_updir() {
+    void lcd_sd_updir() {
       card.updir();
       encoderTopLine = 0;
     }
@@ -2001,7 +2001,7 @@ void kill_screen(const char* lcd_msg) {
        * About Printer > Statistics submenu
        *
        */
-      static void lcd_info_stats_menu() {
+      void lcd_info_stats_menu() {
         if (lcd_clicked) { return lcd_goto_previous_menu(); }
 
         char buffer[21];
@@ -2035,7 +2035,7 @@ void kill_screen(const char* lcd_msg) {
      * About Printer > Thermistors
      *
      */
-    static void lcd_info_thermistors_menu() {
+    void lcd_info_thermistors_menu() {
       if (lcd_clicked) { return lcd_goto_previous_menu(); }
       START_SCREEN();
       #define THERMISTOR_ID TEMP_SENSOR_0
@@ -2087,7 +2087,7 @@ void kill_screen(const char* lcd_msg) {
      * About Printer > Board Info
      *
      */
-    static void lcd_info_board_menu() {
+    void lcd_info_board_menu() {
       if (lcd_clicked) { return lcd_goto_previous_menu(); }
       START_SCREEN();
       STATIC_ITEM(BOARD_NAME, true, true);                           // MyPrinterController
@@ -2108,7 +2108,7 @@ void kill_screen(const char* lcd_msg) {
      * About Printer > Printer Info
      *
      */
-    static void lcd_info_printer_menu() {
+    void lcd_info_printer_menu() {
       if (lcd_clicked) { return lcd_goto_previous_menu(); }
       START_SCREEN();
       STATIC_ITEM(MSG_MARLIN, true, true);                             // Marlin
@@ -2125,7 +2125,7 @@ void kill_screen(const char* lcd_msg) {
      * "About Printer" submenu
      *
      */
-    static void lcd_info_menu() {
+    void lcd_info_menu() {
       START_MENU();
       MENU_BACK(MSG_MAIN);
       MENU_ITEM(submenu, MSG_INFO_PRINTER_MENU, lcd_info_printer_menu);        // Printer Info >
@@ -2140,16 +2140,16 @@ void kill_screen(const char* lcd_msg) {
 
   #if ENABLED(FILAMENT_CHANGE_FEATURE)
 
-    static void lcd_filament_change_resume_print() {
+    void lcd_filament_change_resume_print() {
       filament_change_menu_response = FILAMENT_CHANGE_RESPONSE_RESUME_PRINT;
       lcd_goto_screen(lcd_status_screen);
     }
 
-    static void lcd_filament_change_extrude_more() {
+    void lcd_filament_change_extrude_more() {
       filament_change_menu_response = FILAMENT_CHANGE_RESPONSE_EXTRUDE_MORE;
     }
 
-    static void lcd_filament_change_option_menu() {
+    void lcd_filament_change_option_menu() {
       START_MENU();
       #if LCD_HEIGHT > 2
         STATIC_ITEM(MSG_FILAMENT_CHANGE_OPTION_HEADER, true, false);
@@ -2159,7 +2159,7 @@ void kill_screen(const char* lcd_msg) {
       END_MENU();
     }
 
-    static void lcd_filament_change_init_message() {
+    void lcd_filament_change_init_message() {
       START_SCREEN();
       STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, true, true);
       STATIC_ITEM(MSG_FILAMENT_CHANGE_INIT_1);
@@ -2172,7 +2172,7 @@ void kill_screen(const char* lcd_msg) {
       END_SCREEN();
     }
 
-    static void lcd_filament_change_unload_message() {
+    void lcd_filament_change_unload_message() {
       START_SCREEN();
       STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, true, true);
       STATIC_ITEM(MSG_FILAMENT_CHANGE_UNLOAD_1);
@@ -2185,7 +2185,7 @@ void kill_screen(const char* lcd_msg) {
       END_SCREEN();
     }
 
-    static void lcd_filament_change_insert_message() {
+    void lcd_filament_change_insert_message() {
       START_SCREEN();
       STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, true, true);
       STATIC_ITEM(MSG_FILAMENT_CHANGE_INSERT_1);
@@ -2198,7 +2198,7 @@ void kill_screen(const char* lcd_msg) {
       END_SCREEN();
     }
 
-    static void lcd_filament_change_load_message() {
+    void lcd_filament_change_load_message() {
       START_SCREEN();
       STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, true, true);
       STATIC_ITEM(MSG_FILAMENT_CHANGE_LOAD_1);
@@ -2211,7 +2211,7 @@ void kill_screen(const char* lcd_msg) {
       END_SCREEN();
     }
 
-    static void lcd_filament_change_extrude_message() {
+    void lcd_filament_change_extrude_message() {
       START_SCREEN();
       STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, true, true);
       STATIC_ITEM(MSG_FILAMENT_CHANGE_EXTRUDE_1);
@@ -2224,7 +2224,7 @@ void kill_screen(const char* lcd_msg) {
       END_SCREEN();
     }
 
-    static void lcd_filament_change_resume_message() {
+    void lcd_filament_change_resume_message() {
       START_SCREEN();
       STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, true, true);
       STATIC_ITEM(MSG_FILAMENT_CHANGE_RESUME_1);
@@ -2281,9 +2281,9 @@ void kill_screen(const char* lcd_msg) {
    *   bool _menu_edit_int3();
    *   void menu_edit_int3(); // edit int (interactively)
    *   void menu_edit_callback_int3(); // edit int (interactively) with callback on completion
-   *   static void _menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
-   *   static void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
-   *   static void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callback); // edit int with callback
+   *   void _menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
+   *   void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
+   *   void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callback); // edit int with callback
    *
    * You can then use one of the menu macros to present the edit interface:
    *   MENU_ITEM_EDIT(int3, MSG_SPEED, &feedrate_percentage, 10, 999)
@@ -2311,7 +2311,7 @@ void kill_screen(const char* lcd_msg) {
     } \
     void menu_edit_ ## _name () { _menu_edit_ ## _name(); } \
     void menu_edit_callback_ ## _name () { if (_menu_edit_ ## _name ()) (*callbackFunc)(); } \
-    static void _menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
+    void _menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
       lcd_save_previous_menu(); \
       \
       lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; \
@@ -2322,11 +2322,11 @@ void kill_screen(const char* lcd_msg) {
       maxEditValue = maxValue * scale - minEditValue; \
       encoderPosition = (*ptr) * scale - minEditValue; \
     } \
-    static void menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
+    void menu_action_setting_edit_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue) { \
       _menu_action_setting_edit_ ## _name(pstr, ptr, minValue, maxValue); \
       currentScreen = menu_edit_ ## _name; \
     }\
-    static void menu_action_setting_edit_callback_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue, screenFunc_t callback) { \
+    void menu_action_setting_edit_callback_ ## _name (const char* pstr, _type* ptr, _type minValue, _type maxValue, screenFunc_t callback) { \
       _menu_action_setting_edit_ ## _name(pstr, ptr, minValue, maxValue); \
       currentScreen = menu_edit_callback_ ## _name; \
       callbackFunc = callback; \
@@ -2348,7 +2348,7 @@ void kill_screen(const char* lcd_msg) {
    *
    */
   #if ENABLED(REPRAPWORLD_KEYPAD)
-    static void _reprapworld_keypad_move(AxisEnum axis, int dir) {
+    void _reprapworld_keypad_move(AxisEnum axis, int dir) {
       move_menu_scale = REPRAPWORLD_KEYPAD_MOVE_STEP;
       encoderPosition = dir;
       switch (axis) {
@@ -2358,14 +2358,14 @@ void kill_screen(const char* lcd_msg) {
         default: break;
       }
     }
-    static void reprapworld_keypad_move_z_up()    { _reprapworld_keypad_move(Z_AXIS,  1); }
-    static void reprapworld_keypad_move_z_down()  { _reprapworld_keypad_move(Z_AXIS, -1); }
-    static void reprapworld_keypad_move_x_left()  { _reprapworld_keypad_move(X_AXIS, -1); }
-    static void reprapworld_keypad_move_x_right() { _reprapworld_keypad_move(X_AXIS,  1); }
-    static void reprapworld_keypad_move_y_up()    { _reprapworld_keypad_move(Y_AXIS, -1); }
-    static void reprapworld_keypad_move_y_down()  { _reprapworld_keypad_move(Y_AXIS,  1); }
-    static void reprapworld_keypad_move_home()    { enqueue_and_echo_commands_P(PSTR("G28")); } // move all axes home and wait
-    static void reprapworld_keypad_move_menu()    { lcd_goto_screen(lcd_move_menu); }
+    void reprapworld_keypad_move_z_up()    { _reprapworld_keypad_move(Z_AXIS,  1); }
+    void reprapworld_keypad_move_z_down()  { _reprapworld_keypad_move(Z_AXIS, -1); }
+    void reprapworld_keypad_move_x_left()  { _reprapworld_keypad_move(X_AXIS, -1); }
+    void reprapworld_keypad_move_x_right() { _reprapworld_keypad_move(X_AXIS,  1); }
+    void reprapworld_keypad_move_y_up()    { _reprapworld_keypad_move(Y_AXIS, -1); }
+    void reprapworld_keypad_move_y_down()  { _reprapworld_keypad_move(Y_AXIS,  1); }
+    void reprapworld_keypad_move_home()    { enqueue_and_echo_commands_P(PSTR("G28")); } // move all axes home and wait
+    void reprapworld_keypad_move_menu()    { lcd_goto_screen(lcd_move_menu); }
   #endif // REPRAPWORLD_KEYPAD
 
   /**
@@ -2402,20 +2402,20 @@ void kill_screen(const char* lcd_msg) {
    * Menu actions
    *
    */
-  static void _menu_action_back() { lcd_goto_previous_menu(); }
-  static void menu_action_submenu(screenFunc_t func) { lcd_save_previous_menu(); lcd_goto_screen(func); }
-  static void menu_action_gcode(const char* pgcode) { enqueue_and_echo_commands_P(pgcode); }
-  static void menu_action_function(screenFunc_t func) { (*func)(); }
+  void _menu_action_back() { lcd_goto_previous_menu(); }
+  void menu_action_submenu(screenFunc_t func) { lcd_save_previous_menu(); lcd_goto_screen(func); }
+  void menu_action_gcode(const char* pgcode) { enqueue_and_echo_commands_P(pgcode); }
+  void menu_action_function(screenFunc_t func) { (*func)(); }
 
   #if ENABLED(SDSUPPORT)
 
-    static void menu_action_sdfile(const char* filename, char* longFilename) {
+    void menu_action_sdfile(const char* filename, char* longFilename) {
       UNUSED(longFilename);
       card.openAndPrintFile(filename);
       lcd_return_to_status();
     }
 
-    static void menu_action_sddirectory(const char* filename, char* longFilename) {
+    void menu_action_sddirectory(const char* filename, char* longFilename) {
       UNUSED(longFilename);
       card.chdir(filename);
       encoderPosition = 0;
@@ -2423,8 +2423,8 @@ void kill_screen(const char* lcd_msg) {
 
   #endif //SDSUPPORT
 
-  static void menu_action_setting_edit_bool(const char* pstr, bool* ptr) {UNUSED(pstr); *ptr = !(*ptr); }
-  static void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callback) {
+  void menu_action_setting_edit_bool(const char* pstr, bool* ptr) {UNUSED(pstr); *ptr = !(*ptr); }
+  void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callback) {
     menu_action_setting_edit_bool(pstr, ptr);
     (*callback)();
   }


### PR DESCRIPTION
All `ultralcd.cpp` functions are private to this compilation unit, so there's no extra benefit in declaring them as `static`. Since the compiler throws unnecessary warnings for unused `static` functions, to eliminate these warnings the simplest thing is to declare them without the `static` keyword. The final code output is unaffected by this change.

Reference #5273