### PR TITLE
Remove SIMULATE_ROMFONT from language files

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -25,7 +25,7 @@
 
 #include "MarlinConfig.h"
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
+// Define SIMULATE_ROMFONT to see what is seen on the character-based display defined in Configuration.h
 //#define SIMULATE_ROMFONT
 
 // Fallback if no language is set. DON'T CHANGE

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -31,8 +31,6 @@
 #ifndef LANGUAGE_KANA_H
 #define LANGUAGE_KANA_H
 
-// Define SIMULATE_ROMFONT to see what is seen on the character based display defined in Configuration.h
-#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_KANA
 
 // 片仮名表示定義

--- a/Marlin/language_tr.h
+++ b/Marlin/language_tr.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_TR_H
 #define LANGUAGE_TR_H
 
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_TR
 
 #define WELCOME_MSG                         MACHINE_NAME " haz\xfdr."                                    //hazır.

--- a/Marlin/language_tr_utf8.h
+++ b/Marlin/language_tr_utf8.h
@@ -30,7 +30,6 @@
 #ifndef LANGUAGE_TR_UTF_H
 #define LANGUAGE_TR_UTF_H
 
-//#define SIMULATE_ROMFONT
 #define DISPLAY_CHARSET_ISO10646_TR
 
 #define WELCOME_MSG                         MACHINE_NAME " hazır."                                       //hazır.


### PR DESCRIPTION
For language maintainers, if you need to use `SIMULATE_ROMFONT` it is in `language.h`.