### PR TITLE
MENU_HOLLOW_FRAME for the menu screens

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -215,6 +215,10 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
     #define ENCODER_PULSES_PER_STEP 1
   #endif
 
+  #ifndef TALL_FONT_CORRECTION
+    #define TALL_FONT_CORRECTION 0
+  #endif
+
   /**
    * START_SCREEN_OR_MENU generates init code for a screen or menu
    *
@@ -238,7 +242,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
 
   #define SCREEN_OR_MENU_LOOP() \
     int8_t _menuLineNr = encoderTopLine, _thisItemNr; \
-    for (int8_t _lcdLineNr = 0; _lcdLineNr < LCD_HEIGHT; _lcdLineNr++, _menuLineNr++) { \
+    for (int8_t _lcdLineNr = 0; _lcdLineNr < LCD_HEIGHT - TALL_FONT_CORRECTION; _lcdLineNr++, _menuLineNr++) { \
       _thisItemNr = 0
 
   /**
@@ -249,7 +253,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
    *               Scroll as-needed to keep the selected line in view.
    */
   #define START_SCREEN() \
-    START_SCREEN_OR_MENU(LCD_HEIGHT); \
+    START_SCREEN_OR_MENU(LCD_HEIGHT - TALL_FONT_CORRECTION); \
     encoderTopLine = encoderLine; \
     bool _skipStatic = false; \
     SCREEN_OR_MENU_LOOP()
@@ -257,8 +261,8 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
   #define START_MENU() \
     START_SCREEN_OR_MENU(1); \
     NOMORE(encoderTopLine, encoderLine); \
-    if (encoderLine >= encoderTopLine + LCD_HEIGHT) { \
-      encoderTopLine = encoderLine - (LCD_HEIGHT - 1); \
+    if (encoderLine >= encoderTopLine + LCD_HEIGHT - TALL_FONT_CORRECTION) { \
+      encoderTopLine = encoderLine - (LCD_HEIGHT - TALL_FONT_CORRECTION - 1); \
     } \
     bool _skipStatic = true; \
     SCREEN_OR_MENU_LOOP()

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -508,13 +508,14 @@ static void lcd_implementation_status_screen() {
 
   // Enable to save many cycles by drawing a hollow frame
   #define XYZ_HOLLOW_FRAME
+  #define MENU_HOLLOW_FRAME
 
   #if ENABLED(XYZ_HOLLOW_FRAME)
     #define XYZ_FRAME_TOP 29
     #define XYZ_FRAME_HEIGHT INFO_FONT_HEIGHT + 3
   #else
     #define XYZ_FRAME_TOP 30
-    #define XYZ_FRAME_HEIGHT INFO_FONT_HEIGHT + 2
+    #define XYZ_FRAME_HEIGHT INFO_FONT_HEIGHT + 1
   #endif
 
   // Before homing the axis letters are blinking 'X' <-> '?'.
@@ -569,13 +570,13 @@ static void lcd_implementation_status_screen() {
   // Feedrate
   //
 
-  if (PAGE_CONTAINS(50 - INFO_FONT_HEIGHT, 49)) {
+  if (PAGE_CONTAINS(51 - INFO_FONT_HEIGHT, 49)) {
     lcd_setFont(FONT_MENU);
-    u8g.setPrintPos(3, 49);
+    u8g.setPrintPos(3, 50);
     lcd_print(LCD_STR_FEEDRATE[0]);
 
     lcd_setFont(FONT_STATUSMENU);
-    u8g.setPrintPos(12, 49);
+    u8g.setPrintPos(12, 50);
     lcd_print(itostr3(feedrate_percentage));
     u8g.print('%');
   }
@@ -584,7 +585,7 @@ static void lcd_implementation_status_screen() {
   // Status line
   //
 
-  #define STATUS_BASELINE (54 + INFO_FONT_HEIGHT)
+  #define STATUS_BASELINE (55 + INFO_FONT_HEIGHT)
 
   if (PAGE_CONTAINS(STATUS_BASELINE + 1 - INFO_FONT_HEIGHT, STATUS_BASELINE)) {
     u8g.setPrintPos(0, STATUS_BASELINE);
@@ -613,19 +614,26 @@ static void lcd_implementation_status_screen() {
   // Set the colors for a menu item based on whether it is selected
   static void lcd_implementation_mark_as_selected(const uint8_t row, const bool isSelected) {
 
-    row_y1 = row * (DOG_CHAR_HEIGHT) + 1;
-    row_y2 = row_y1 + (DOG_CHAR_HEIGHT) - 1;
+    row_y1 = row * (DOG_CHAR_HEIGHT + 2 * (TALL_FONT_CORRECTION)) + 1;
+    row_y2 = row_y1 + (DOG_CHAR_HEIGHT + 2 * (TALL_FONT_CORRECTION)) - 1;
 
-    if (!PAGE_CONTAINS(row_y1 + 2 - (TALL_FONT_CORRECTION), row_y2 + 2 - (TALL_FONT_CORRECTION))) return;
+    if (!PAGE_CONTAINS(row_y1 + 1, row_y1 + 1 + DOG_CHAR_HEIGHT + 2 * (TALL_FONT_CORRECTION))) return;
 
     if (isSelected) {
-      u8g.setColorIndex(1);  // black on white
-      u8g.drawBox(0, row_y1 + 2 - (TALL_FONT_CORRECTION), LCD_PIXEL_WIDTH, DOG_CHAR_HEIGHT);
-      u8g.setColorIndex(0);  // following text must be white on black
+      #if ENABLED(MENU_HOLLOW_FRAME)
+        u8g.drawHLine(0, row_y1 + 1, LCD_PIXEL_WIDTH);
+        u8g.drawHLine(0, row_y1 + 1 + DOG_CHAR_HEIGHT + 2 * (TALL_FONT_CORRECTION), LCD_PIXEL_WIDTH);
+      #else
+        u8g.setColorIndex(1); // black on white
+        u8g.drawBox(0, row_y1 + 2, LCD_PIXEL_WIDTH, DOG_CHAR_HEIGHT - 1 + 2 * (TALL_FONT_CORRECTION));
+        u8g.setColorIndex(0); // white on black
+      #endif
     }
-    else {
-      u8g.setColorIndex(1); // unmarked text is black on white
-    }
+    #if DISABLED(MENU_HOLLOW_FRAME)
+      else {
+        u8g.setColorIndex(1); // unmarked text is black on white
+      }
+    #endif
     u8g.setPrintPos((START_COL) * (DOG_CHAR_WIDTH), row_y2);
   }
 


### PR DESCRIPTION
Simmilar to XYZ_HOLLOW_FRAME, now
MENU_HOLLOW_FRAME for the menu screens and
some pixel shifting to optimize the look with tall fonts. (cn)

![picture 16](https://cloud.githubusercontent.com/assets/211931/20642900/9f96c6aa-b41b-11e6-8b9a-6f50ad0c0fcf.jpg)
![picture 18](https://cloud.githubusercontent.com/assets/211931/20642903/a68366c6-b41b-11e6-8433-2004b61712b7.jpg)
![picture 17](https://cloud.githubusercontent.com/assets/211931/20642904/ad18d408-b41b-11e6-89fd-8245d5aa4a90.jpg)
![picture 19](https://cloud.githubusercontent.com/assets/211931/20642905/b0ab4a24-b41b-11e6-89ed-da646aa8dc42.jpg)
![picture 25](https://cloud.githubusercontent.com/assets/211931/20642906/b70e594c-b41b-11e6-975b-eaeca76e5319.jpg)
![picture 24](https://cloud.githubusercontent.com/assets/211931/20642907/b9a14e44-b41b-11e6-85bd-817f343ff982.jpg)
![picture 22](https://cloud.githubusercontent.com/assets/211931/20642908/bc467142-b41b-11e6-9274-ba31af1153b5.jpg)
![picture 23](https://cloud.githubusercontent.com/assets/211931/20642910/be7ac328-b41b-11e6-965e-18a383e58cfd.jpg)

