### PR TITLE
Fix compile without ENABLE_LEVELING_FADE_HEIGHT

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -552,6 +552,8 @@ void Planner::check_axes_activity() {
       }
       else
         z_fade_factor = 1.0;
+    #else
+        constexpr float z_fade_factor = 1.0;
     #endif
 
     #if ENABLED(MESH_BED_LEVELING)


### PR DESCRIPTION
Addressing https://github.com/MarlinFirmware/Marlin/pull/5299#issuecomment-264079836

Fix compile errors when `ENABLE_LEVELING_FADE_HEIGHT` is disabled.