### PR TITLE
Travis badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Proposed patches should be submitted as a Pull Request against the [RCBugFix](ht
 Please test this firmware and inform us if it misbehaves in any way. Volunteers are standing by!
 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224)
-[![Travis Build Status](https://travis-ci.org/MarlinFirmware/MarlinDev.svg)](https://travis-ci.org/MarlinFirmware/MarlinDev)
+[![Travis Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg)](https://travis-ci.org/MarlinFirmware/Marlin)
 
 ##### [RepRap.org Wiki Page](http://reprap.org/wiki/Marlin)
 


### PR DESCRIPTION
We probably don't want to see Badge pointing to MarlinDev anymore.

Also Coverity Scan hasn't been updated since Aug 08, maybe pointing to Dev repo as well? https://scan.coverity.com/projects/2224