### PR TITLE
Enhance findMissingTranslations, format the output

### DIFF
--- a/buildroot/share/scripts/findMissingTranslations.sh
+++ b/buildroot/share/scripts/findMissingTranslations.sh
@@ -1,14 +1,42 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# findMissingTranslations.sh
+#
+# Locate all language strings needing an update based on English
+#
+# Usage: findMissingTranslations.sh [language codes]
+#
+# If no language codes are specified then all languages will be checked
+#
 IGNORE_DEFINES="LANGUAGE_EN_H MAPPER_NON SIMULATE_ROMFONT DISPLAY_CHARSET_ISO10646_1 MSG_X MSG_Y MSG_Z MSG_E MSG_H1 MSG_H2 MSG_H3 MSG_H4 MSG_MOVE_E1 MSG_MOVE_E2 MSG_MOVE_E3 MSG_MOVE_E4 MSG_N1 MSG_N2 MSG_N3 MSG_N4 MSG_DIAM_E1 MSG_DIAM_E2 MSG_DIAM_E3 MSG_DIAM_E4 MSG_E1 MSG_E2 MSG_E3 MSG_E4"
 
-for i in `awk '/#define/{print $2}' language_en.h`; do
-  for j in `ls language_*.h | grep -v language_en.h`; do
-    t=$(grep -c "${i}" ${j})
-    if [ "$t" -eq 0 ]; then
+[ -d "Marlin" ] && cd "Marlin"
+
+LANG="$@"
+FILES=$(ls language_*.h | grep -v language_en.h | sed -E 's/language_([^\.]+)\.h/\1/')
+declare -A STRING_MAP
+
+echo -n "Building list of missing strings..."
+
+for i in $(awk '/#define/{print $2}' language_en.h); do
+  LANG_LIST=""
+  for j in $FILES; do
+    [[ $j == "test" ]] && continue
+    [[ -n $LANG && ! "${j}" =~ $LANG ]] && continue
+    t=$(grep -c "define ${i} " language_${j}.h)
+    if [[ $t -eq 0 ]]; then
       for k in ${IGNORE_DEFINES}; do
-        [ "${k}" == "${i}" ] && continue 2;
+        [[ $k == $i ]] && continue 2
       done
-      echo "${j},${i}"
+      LANG_LIST="$LANG_LIST $j"
     fi
   done
+  [[ -z $LANG_LIST ]] && continue
+  STRING_MAP["$i"]="$LANG_LIST"
+done
+
+echo
+
+for K in $( printf "%s\n" "${!STRING_MAP[@]}" | sort ); do
+  printf "%-35s :%s\n" "$K" "${STRING_MAP[$K]}"
 done


### PR DESCRIPTION
- Use `+#!/usr/bin/env bash` for bash invocation
- `cd` into the `Marlin` folder, if needed
- Allow language codes to be specified in the command-line
- Build the list of strings and languages as a keyed array
- Speed up by compiling the language list just once
- Fix bug missing names that are substrings of other names
- Output in a more readable format

Example:
```
$ buildroot/share/scripts/findMissingTranslations.sh de uk el
Building list of missing strings...
MSG_CONTROL_RETRACT_RECOVERF        :  uk
MSG_SELECT                          :  el
MSG_LIGHTS_ON                       :  el
MSG_FIRST                           :  el
MSG_SHORT_HOUR                      :  el
MSG_ERR_MINTEMP_BED                 :  uk
MSG_ERR_REDUNDANT_TEMP              :  uk
MSG_FILAMENT_CHANGE_OPTION_HEADER   :  el
MSG_BLTOUCH_SELFTEST                :  de el
MSG_CONTROL_RETRACT_ZLIFT           :  uk
MSG_CONTROL_RETRACT_RECOVER_SWAP    :  uk
MSG_INFO_PRINT_FILAMENT             :  el
MSG_DAC_PERCENT                     :  de el
MSG_SHORT_DAY                       :  el
MSG_DAC_EEPROM_WRITE                :  de el
MSG_CONTROL_RETRACT                 :  uk
MSG_AUTORETRACT                     :  uk
MSG_ERR_Z_HOMING                    :  el
MSG_ERR_MINTEMP                     :  uk
MSG_CONTROL_RETRACTF                :  uk
MSG_BLTOUCH_RESET                   :  de el
MSG_DRIVE_STRENGTH                  :  de el
MSG_SHORT_MINUTE                    :  el
MSG_ERR_MAXTEMP                     :  uk
MSG_INFO_PRINT_LONGEST              :  el
MSG_ERR_MAXTEMP_BED                 :  uk
MSG_CONTROL_RETRACT_RECOVER         :  uk
MSG_CONTROL_RETRACT_SWAP            :  uk
MSG_LIGHTS_OFF                      :  el
```