### PR TITLE
Better alignment of elapsed print time

### DIFF
--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -145,15 +145,22 @@ struct duration_t {
    *  99:59
    *  11d 12:33
    */
-  void toDigital(char *buffer, bool with_days=false) const {
+  uint8_t toDigital(char *buffer, bool with_days=false) const {
     uint16_t h = uint16_t(this->hour()),
              m = uint16_t(this->minute() % 60UL);
-    if (with_days)
-      sprintf_P(buffer, PSTR("%ud %02u:%02u"), this->day(), h, m);
-    else if (h < 100)
+    if (with_days) {
+      uint16_t d = this->day();
+      sprintf_P(buffer, PSTR("%ud %02u:%02u"), d, h, m);
+      return d >= 10 ? 8 : 7;
+    }
+    else if (h < 100) {
       sprintf_P(buffer, PSTR("%02u:%02u"), h % 24, m);
-    else
+      return 5;
+    }
+    else {
       sprintf_P(buffer, PSTR("%u:%02u"), h, m);
+      return 6;
+    }
   }
 };
 

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -452,8 +452,14 @@ static void lcd_implementation_status_screen() {
     // Progress bar frame
     //
 
-    if (PAGE_CONTAINS(49, 52 - (TALL_FONT_CORRECTION)))
-      u8g.drawFrame(54, 49, 73, 4 - (TALL_FONT_CORRECTION));  // 49-52 (or 49-51)
+    #define PROGRESS_BAR_X 54
+    #define PROGRESS_BAR_WIDTH (LCD_PIXEL_WIDTH - PROGRESS_BAR_X)
+
+    if (PAGE_CONTAINS(49, 52 - (TALL_FONT_CORRECTION)))       // 49-52 (or 49-51)
+      u8g.drawFrame(
+        PROGRESS_BAR_X, 49,
+        PROGRESS_BAR_WIDTH, 4 - (TALL_FONT_CORRECTION)
+      );
 
     if (IS_SD_PRINTING) {
 
@@ -461,8 +467,11 @@ static void lcd_implementation_status_screen() {
       // Progress bar solid part
       //
 
-      if (PAGE_CONTAINS(50, 51 - (TALL_FONT_CORRECTION)))
-        u8g.drawBox(55, 50, (unsigned int)(71 * card.percentDone() * 0.01), 2 - (TALL_FONT_CORRECTION));
+      if (PAGE_CONTAINS(50, 51 - (TALL_FONT_CORRECTION)))     // 50-51 (or just 50)
+        u8g.drawBox(
+          PROGRESS_BAR_X + 1, 50,
+          (unsigned int)((PROGRESS_BAR_WIDTH - 2) * card.percentDone() * 0.01), 2 - (TALL_FONT_CORRECTION)
+        );
 
       //
       // SD Percent Complete
@@ -483,9 +492,9 @@ static void lcd_implementation_status_screen() {
     //
 
     #if DISABLED(DOGM_SD_PERCENT)
-      #define SD_DURATION_X 71
+      #define SD_DURATION_X (PROGRESS_BAR_X + (PROGRESS_BAR_WIDTH / 2) - len * (DOG_CHAR_WIDTH / 2))
     #else
-      #define SD_DURATION_X 89
+      #define SD_DURATION_X (LCD_PIXEL_WIDTH - len * DOG_CHAR_WIDTH)
     #endif
 
     if (PAGE_CONTAINS(41, 48)) {
@@ -493,9 +502,8 @@ static void lcd_implementation_status_screen() {
       char buffer[10];
       duration_t elapsed = print_job_timer.duration();
       bool has_days = (elapsed.value > 60*60*24L);
-      elapsed.toDigital(buffer, has_days);
-
-      u8g.setPrintPos(SD_DURATION_X + (has_days ? 0 : 9), 48);
+      uint8_t len = elapsed.toDigital(buffer, has_days);
+      u8g.setPrintPos(SD_DURATION_X, 48);
       lcd_print(buffer);
     }
 
@@ -749,11 +757,12 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* const pstr, const char* const value=NULL) {
-    const uint8_t labellen = lcd_strlen_P(pstr), vallen = lcd_strlen(value);
-    uint8_t lcd_width, char_width,
-            rows = (labellen > LCD_WIDTH - 2 - vallen) ? 2 : 1;
+    const uint8_t labellen = lcd_strlen_P(pstr),
+                  vallen = lcd_strlen(value),
+                  rows = (labellen > LCD_WIDTH - 2 - vallen) ? 2 : 1;
 
     #if ENABLED(USE_BIG_EDIT_FONT)
+      uint8_t lcd_width, char_width;
       if (labellen <= LCD_WIDTH_EDIT - 1) {
         if (labellen >= LCD_WIDTH_EDIT - vallen) rows = 2;
         lcd_width = LCD_WIDTH_EDIT + 1;
@@ -766,8 +775,8 @@ static void lcd_implementation_status_screen() {
         lcd_setFont(FONT_MENU);
       }
     #else
-      lcd_width = LCD_WIDTH - (START_COL);
-      char_width = DOG_CHAR_WIDTH;
+      constexpr uint8_t lcd_width = LCD_WIDTH - (START_COL),
+                        char_width = DOG_CHAR_WIDTH;
     #endif
 
     // Center either one or two rows

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -733,12 +733,12 @@ static void lcd_implementation_status_screen() {
 
     #endif // LCD_WIDTH >= 20 && SDSUPPORT
 
-    lcd.setCursor(LCD_WIDTH - 6, 2);
-    lcd.print(LCD_STR_CLOCK[0]);
-
     char buffer[10];
     duration_t elapsed = print_job_timer.duration();
-    elapsed.toDigital(buffer);
+    uint8_t len = elapsed.toDigital(buffer);
+
+    lcd.setCursor(LCD_WIDTH - len - 1, 2);
+    lcd.print(LCD_STR_CLOCK[0]);
     lcd_print(buffer);
 
   #endif // LCD_HEIGHT > 3


### PR DESCRIPTION
As requested by @jbrazio —
When showing SD percentage, right-justify the print time. When SD percentage is not shown center the print time above the progress bar. On character displays, simply right-justify the print time.