### PR TITLE
Show decimal for small numbers in ftostr4sign

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -435,6 +435,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -430,6 +430,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -424,6 +424,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -424,6 +424,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -424,6 +424,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -429,6 +429,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -424,6 +424,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -422,6 +422,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// On the Info Screen, display XY with one decimal place when possible
+//#define LCD_DECIMAL_SMALL_XY
+
 #if ENABLED(SDSUPPORT)
 
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -129,29 +129,22 @@ void safe_delay(millis_t ms) {
     return conv;
   }
 
-  // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
-  char *ftostr4sign(const float& fx) { 
-    int x = fx * 10, xx = abs(x);
-    bool ispos = x >= 0,
-         isten = xx >= 100,
-         ishun = xx >= 1000;
-    if (!isten || (ispos && !ishun)) {
-      // 12.3, _1.2, -1.2
-      conv[0] = ispos ? (isten ? DIGIMOD(xx, 100) : ' ') : '-';
+  #if ENABLED(LCD_DECIMAL_SMALL_XY)
+
+    // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
+    char *ftostr4sign(const float& fx) {
+      int x = fx * 10;
+      if (x <= -100 || x >= 1000) return itostr4sign((int)fx);
+      int xx = abs(x);
+      conv[0] = x < 0 ? '-' : (xx >= 100 ? DIGIMOD(xx, 100) : ' ');
       conv[1] = DIGIMOD(xx, 10);
       conv[2] = '.';
       conv[3] = DIGIMOD(xx, 1);
+      conv[4] = '\0';
+      return conv;
     }
-    else {
-      // 1234, _123, -123, _-12
-      conv[0] = ispos ? (xx >= 10000 ? DIGIMOD(xx, 10000) : ' ') : (ishun ? '-' : ' ');
-      conv[1] = ishun ? DIGIMOD(xx, 1000) : '-';
-      conv[2] = DIGIMOD(xx, 100);
-      conv[3] = DIGIMOD(xx, 10);
-    }
-    conv[4] = '\0';
-    return conv;
-  }
+
+  #endif // LCD_DECIMAL_SMALL_XY
 
   // Convert float to fixed-length string with +123.4 / -123.4 format
   char* ftostr41sign(const float& x) {

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -129,6 +129,30 @@ void safe_delay(millis_t ms) {
     return conv;
   }
 
+  // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
+  char *ftostr4sign(const float& fx) { 
+    int x = fx * 10, xx = abs(x);
+    bool ispos = x >= 0,
+         isten = xx >= 100,
+         ishun = xx >= 1000;
+    if (!isten || (ispos && !ishun)) {
+      // 12.3, _1.2, -1.2
+      conv[0] = ispos ? (isten ? DIGIMOD(xx, 100) : ' ') : '-';
+      conv[1] = DIGIMOD(xx, 10);
+      conv[2] = '.';
+      conv[3] = DIGIMOD(xx, 1);
+    }
+    else {
+      // 1234, _123, -123, _-12
+      conv[0] = ispos ? (xx >= 10000 ? DIGIMOD(xx, 10000) : ' ') : (ishun ? '-' : ' ');
+      conv[1] = ishun ? DIGIMOD(xx, 1000) : '-';
+      conv[2] = DIGIMOD(xx, 100);
+      conv[3] = DIGIMOD(xx, 10);
+    }
+    conv[4] = '\0';
+    return conv;
+  }
+
   // Convert float to fixed-length string with +123.4 / -123.4 format
   char* ftostr41sign(const float& x) {
     int xx = x * 10;

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -74,25 +74,32 @@ void safe_delay(millis_t ms) {
     return str;
   }
 
-  // Convert signed int to rj string with _123, -123, _-12, or __-1 format
+  // Convert signed int to rj string with 1234, _123, -123, _-12, or __-1 format
   char *itostr4sign(const int& x) {
-    int xx = abs(x), sign = 0;
-    if (xx >= 100) {
+    int xx = abs(x);
+    if (x >= 1000) {
+      conv[0] = DIGIMOD(xx, 1000);
       conv[1] = DIGIMOD(xx, 100);
       conv[2] = DIGIMOD(xx, 10);
     }
     else {
-      conv[0] = ' ';
-      if (xx >= 10) {
-        sign = 1;
+      if (xx >= 100) {
+        conv[0] = x < 0 ? '-' : ' ';
+        conv[1] = DIGIMOD(xx, 100);
         conv[2] = DIGIMOD(xx, 10);
       }
       else {
-        conv[1] = ' ';
-        sign = 2;
+        conv[0] = ' ';
+        if (xx >= 10) {
+          conv[1] = x < 0 ? '-' : ' ';
+          conv[2] = DIGIMOD(xx, 10);
+        }
+        else {
+          conv[1] = ' ';
+          conv[2] = x < 0 ? '-' : ' ';
+        }
       }
     }
-    conv[sign] = x < 0 ? '-' : ' ';
     conv[3] = DIGIMOD(xx, 1);
     conv[4] = '\0';
     return conv;

--- a/Marlin/utility.h
+++ b/Marlin/utility.h
@@ -69,8 +69,13 @@ void safe_delay(millis_t ms);
   // Convert float to rj string with 123 or -12 format
   FORCE_INLINE char *ftostr3(const float& x) { return itostr3((int)x); }
 
-  // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
-  char *ftostr4sign(const float& fx);
+  #if ENABLED(LCD_DECIMAL_SMALL_XY)
+    // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
+    char *ftostr4sign(const float& fx);
+  #else
+    // Convert float to rj string with 1234, _123, -123, __12, _-12, ___1, or __-1 format
+    FORCE_INLINE char *ftostr4sign(const float& x) { return itostr4sign((int)x); }
+  #endif
 
 #endif // ULTRA_LCD
 

--- a/Marlin/utility.h
+++ b/Marlin/utility.h
@@ -69,8 +69,8 @@ void safe_delay(millis_t ms);
   // Convert float to rj string with 123 or -12 format
   FORCE_INLINE char *ftostr3(const float& x) { return itostr3((int)x); }
 
-  // Convert float to rj string with _123, -123, _-12, or __-1 format
-  FORCE_INLINE char *ftostr4sign(const float& x) { return itostr4sign((int)x); }
+  // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
+  char *ftostr4sign(const float& fx);
 
 #endif // ULTRA_LCD
 


### PR DESCRIPTION
Cleanup of #5337

Implemented as an optional feature because it can make the display less readable.

Also:
- Minor rewrite of `itostr4sign`