### PR TITLE
Fix auto_report_temperatures()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5235,6 +5235,7 @@ inline void gcode_M105() {
     if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
       next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
       print_heaterstates();
+      SERIAL_EOL;
     }
   }
 


### PR DESCRIPTION
The `auto_report_temperatures` needs a linefeed to be recognized by Repetier Host.