### PR TITLE
Patch long_move()

### DIFF
--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -393,7 +393,7 @@ class Planner {
 
     #if ENABLED(ENSURE_SMOOTH_MOVES)
       static bool long_move() {
-          if (blocks_queued()) {
+          if (blocks_queued() && block_buffer_runtime_us) {
             return block_buffer_runtime_us > (LCD_UPDATE_THRESHOLD) * 1000UL + (MIN_BLOCK_TIME) * 3000UL;
           }
           else


### PR DESCRIPTION
While the last move in the planner_buffer is running
its duration is already subtracted from `block_buffer_runtime_us`.

When this move is over we'll have a stop anyway.