### PR TITLE
Simplify long_move()

### DIFF
--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -393,11 +393,11 @@ class Planner {
 
     #if ENABLED(ENSURE_SMOOTH_MOVES)
       static bool long_move() {
-          if (blocks_queued() && block_buffer_runtime_us) {
-            return block_buffer_runtime_us > (LCD_UPDATE_THRESHOLD) * 1000UL + (MIN_BLOCK_TIME) * 3000UL;
-          }
-          else
-            return true;
+        if (block_buffer_runtime_us) {
+          return block_buffer_runtime_us > (LCD_UPDATE_THRESHOLD) * 1000UL + (MIN_BLOCK_TIME) * 3000UL;
+        }
+        else
+          return true;
       }
       
       static void clear_block_buffer_runtime(){


### PR DESCRIPTION
We are not really interested in, if there are blocks.
All information we need is in `block_buffer_runtime_us`.

(https://github.com/MarlinFirmware/Marlin/pull/5438#discussion_r91627807)