### PR TITLE
Make block_buffer_runtime_us volatile

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -146,7 +146,7 @@ float Planner::previous_speed[NUM_AXIS],
 #endif
 
 #if ENABLED(ENSURE_SMOOTH_MOVES)
-  uint32_t Planner::block_buffer_runtime_us = 0;
+  volatile uint32_t Planner::block_buffer_runtime_us = 0;
 #endif
 
 /**
@@ -1007,7 +1007,9 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
       segment_time = (MIN_BLOCK_TIME) * 1000UL;
     }
     block->segment_time = segment_time;
-    block_buffer_runtime_us += segment_time;
+    CRITICAL_SECTION_START
+      block_buffer_runtime_us += segment_time;
+    CRITICAL_SECTION_END
   #endif
 
   block->nominal_speed = block->millimeters * inverse_mm_s; // (mm/sec) Always > 0

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -215,7 +215,7 @@ class Planner {
     #endif
 
     #if ENABLED(ENSURE_SMOOTH_MOVES)
-      static uint32_t block_buffer_runtime_us; //Theoretical block buffer runtime in µs
+      volatile static uint32_t block_buffer_runtime_us; //Theoretical block buffer runtime in µs
     #endif
 
   public:
@@ -387,21 +387,26 @@ class Planner {
         SBI(block->flag, BLOCK_BIT_BUSY);
         return block;
       }
-      else
+      else {
+        #if ENABLED(ENSURE_SMOOTH_MOVES)
+          clear_block_buffer_runtime(); // paranoia. Buffer is empty now - so reset accumulated time to zero.
+        #endif
         return NULL;
+      }
     }
 
     #if ENABLED(ENSURE_SMOOTH_MOVES)
       static bool long_move() {
-        if (block_buffer_runtime_us) {
-          return block_buffer_runtime_us > (LCD_UPDATE_THRESHOLD) * 1000UL + (MIN_BLOCK_TIME) * 3000UL;
-        }
-        else
-          return true;
+        CRITICAL_SECTION_START
+          uint32_t bbru = block_buffer_runtime_us;
+        CRITICAL_SECTION_END
+        return !bbru || bbru > (LCD_UPDATE_THRESHOLD) * 1000UL + (MIN_BLOCK_TIME) * 3000UL;
       }
       
       static void clear_block_buffer_runtime(){
-        block_buffer_runtime_us = 0;
+        CRITICAL_SECTION_START
+          block_buffer_runtime_us = 0;
+        CRITICAL_SECTION_END
       }
     #endif
 


### PR DESCRIPTION
`block_buffer_runtime_us` is mangled in the planner and in the stepper-ISR.
So it needs to be volatile and interrupt protected.

When the stepper-ISR is not interrupt protected anymore we have to scan it for variables shared with other interrupts - and if so, to protect them.