### PR TITLE
Adjust Z if bed leveling is enabled

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9363,14 +9363,19 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
       // For non-interpolated delta calculate every segment
       for (uint16_t s = segments + 1; --s;) {
         DELTA_NEXT(segment_distance[i]);
-        planner.buffer_line_kinematic(DELTA_VAR, _feedrate_mm_s, active_extruder);
+        DELTA_IK();
+        ADJUST_DELTA(DELTA_VAR); // Adjust Z if bed leveling is enabled
+        planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], DELTA_VAR[E_AXIS], _feedrate_mm_s, active_extruder);
       }
 
     #endif
 
     // Since segment_distance is only approximate,
     // the final move must be to the exact destination.
-    planner.buffer_line_kinematic(ltarget, _feedrate_mm_s, active_extruder);
+    memcpy(DELTA_VAR, ltarget, sizeof(DELTA_VAR));
+    DELTA_IK();
+    ADJUST_DELTA(DELTA_VAR); // Adjust Z if bed leveling is enabled
+    planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], DELTA_VAR[E_AXIS], _feedrate_mm_s, active_extruder);
     return true;
   }
 


### PR DESCRIPTION
Lost if not active USE_DELTA_IK_INTERPOLATION

I hope I have made mistakes, but if it is not active USE_DELTA_IK_INTERPOLATION does ADJUST_DELTA and therefore levels the plane with the bilinear.
Scott can verify if it is correct !!!