### PR TITLE
Optimize handling of block_buffer_runtime()

### DIFF
--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -395,10 +395,16 @@ class Planner {
 
     #if ENABLED(ULTRA_LCD)
 
-      static millis_t block_buffer_runtime() {
+      static uint16_t block_buffer_runtime() {
         CRITICAL_SECTION_START
           millis_t bbru = block_buffer_runtime_us;
         CRITICAL_SECTION_END
+        // To translate µs to ms a division by 1000 would be required.
+        // We introduce 2.4% error here by dividing by 1024.
+        // Doesn't matter because block_buffer_runtime_us is already too small an estimation.
+        bbru >>= 10;
+        // limit to about a minute.
+        NOMORE(bbru, 0xfffful);
         return bbru;
       }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -64,7 +64,7 @@ void lcd_status_screen();
 millis_t next_lcd_update_ms;
 
 uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to draw, decrements after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
-millis_t max_display_update_time = 0;
+uint16_t max_display_update_time = 0;
 
 #if ENABLED(DOGLCD)
   bool drawing_screen = false;
@@ -2978,12 +2978,13 @@ void lcd_update() {
       lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
     }
 
-    millis_t bbr = planner.block_buffer_runtime();
+    // then we want to use 1/2 of the time only.
+    uint16_t bbr2 = planner.block_buffer_runtime() >> 1;
 
     #if ENABLED(DOGLCD)
-      if ((lcdDrawUpdate || drawing_screen) && (!bbr || (bbr > 2 * max_display_update_time * 1000)))
+      if ((lcdDrawUpdate || drawing_screen) && (!bbr2 || (bbr2 > max_display_update_time)))
     #else
-      if (lcdDrawUpdate && (!bbr || (bbr > 2 * max_display_update_time * 1000)))
+      if (lcdDrawUpdate && (!bbr2 || (bbr2 > max_display_update_time)))
     #endif
     {
       #if ENABLED(DOGLCD)


### PR DESCRIPTION
millis_t is long - divisions take for ever.

Return a kind of millisecond instead of microsecond -
divided by 1024 instead of 1000 for speed. (-2.4% error)

That does not matter because block_buffer_runtime is
already a too short estimation.
Shrink the return-type.