### PR TITLE
Report EEPROM data size, not final index

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9455,7 +9455,9 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
       // For non-interpolated delta calculate every segment
       for (uint16_t s = segments + 1; --s;) {
         DELTA_NEXT(segment_distance[i]);
-        planner.buffer_line_kinematic(DELTA_VAR, _feedrate_mm_s, active_extruder);
+        DELTA_IK();
+        ADJUST_DELTA(DELTA_VAR); // Adjust Z if bed leveling is enabled
+        planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], DELTA_VAR[E_AXIS], _feedrate_mm_s, active_extruder);
       }
 
     #endif

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -240,6 +240,7 @@ void Config_Postprocess() {
 
     const uint8_t esteppers = E_STEPPERS;
     EEPROM_WRITE(esteppers);
+
     EEPROM_WRITE(planner.axis_steps_per_mm);
     EEPROM_WRITE(planner.max_feedrate_mm_s);
     EEPROM_WRITE(planner.max_acceleration_mm_per_s2);
@@ -439,7 +440,7 @@ void Config_Postprocess() {
 
       // Report storage size
       SERIAL_ECHO_START;
-      SERIAL_ECHOPAIR("Settings Stored (", eeprom_size);
+      SERIAL_ECHOPAIR("Settings Stored (", eeprom_size - (EEPROM_OFFSET));
       SERIAL_ECHOLNPGM(" bytes)");
     }
   }
@@ -680,7 +681,7 @@ void Config_Postprocess() {
           Config_Postprocess();
           SERIAL_ECHO_START;
           SERIAL_ECHO(version);
-          SERIAL_ECHOPAIR(" stored settings retrieved (", eeprom_index);
+          SERIAL_ECHOPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
           SERIAL_ECHOLNPGM(" bytes)");
         }
       }

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -238,7 +238,7 @@ void Config_Postprocess() {
 
     eeprom_checksum = 0; // clear before first "real data"
 
-    const uint8_t esteppers = E_STEPPERS;
+    const uint8_t esteppers = COUNT(planner.axis_steps_per_mm) - XYZ;
     EEPROM_WRITE(esteppers);
 
     EEPROM_WRITE(planner.axis_steps_per_mm);

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1372,16 +1372,16 @@ void Planner::_set_position_mm(const float &a, const float &b, const float &c, c
 
 void Planner::set_position_mm_kinematic(const float position[NUM_AXIS]) {
   #if PLANNER_LEVELING
-    float pos[XYZ] = { position[X_AXIS], position[Y_AXIS], position[Z_AXIS] };
-    apply_leveling(pos);
+    float lpos[XYZ] = { position[X_AXIS], position[Y_AXIS], position[Z_AXIS] };
+    apply_leveling(lpos);
   #else
-    const float * const pos = position;
+    const float * const lpos = position;
   #endif
   #if IS_KINEMATIC
-    inverse_kinematics(pos);
+    inverse_kinematics(lpos);
     _set_position_mm(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], position[E_AXIS]);
   #else
-    _set_position_mm(pos[X_AXIS], pos[Y_AXIS], pos[Z_AXIS], position[E_AXIS]);
+    _set_position_mm(lpos[X_AXIS], lpos[Y_AXIS], lpos[Z_AXIS], position[E_AXIS]);
   #endif
 }
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -308,22 +308,22 @@ class Planner {
      * The target is cartesian, it's translated to delta/scara if
      * needed.
      *
-     *  target   - x,y,z,e CARTESIAN target in mm
+     *  ltarget  - x,y,z,e CARTESIAN target in mm
      *  fr_mm_s  - (target) speed of the move (mm/s)
      *  extruder - target extruder
      */
-    static FORCE_INLINE void buffer_line_kinematic(const float target[XYZE], const float &fr_mm_s, const uint8_t extruder) {
+    static FORCE_INLINE void buffer_line_kinematic(const float ltarget[XYZE], const float &fr_mm_s, const uint8_t extruder) {
       #if PLANNER_LEVELING
-        float pos[XYZ] = { target[X_AXIS], target[Y_AXIS], target[Z_AXIS] };
-        apply_leveling(pos);
+        float lpos[XYZ] = { ltarget[X_AXIS], ltarget[Y_AXIS], ltarget[Z_AXIS] };
+        apply_leveling(lpos);
       #else
-        const float * const pos = target;
+        const float * const lpos = ltarget;
       #endif
       #if IS_KINEMATIC
-        inverse_kinematics(pos);
-        _buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], target[E_AXIS], fr_mm_s, extruder);
+        inverse_kinematics(lpos);
+        _buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], ltarget[E_AXIS], fr_mm_s, extruder);
       #else
-        _buffer_line(pos[X_AXIS], pos[Y_AXIS], pos[Z_AXIS], target[E_AXIS], fr_mm_s, extruder);
+        _buffer_line(lpos[X_AXIS], lpos[Y_AXIS], lpos[Z_AXIS], ltarget[E_AXIS], fr_mm_s, extruder);
       #endif
     }
 


### PR DESCRIPTION
The EEPROM reports the last index written, but since it starts at 100, it overstates the data written by 100 bytes. This PR corrects the output.