### PR TITLE
Have bed leveling status output current status, not requested status

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7043,7 +7043,13 @@ void quickstop_stepper() {
     }
 
     SERIAL_ECHO_START;
-    SERIAL_ECHOLNPAIR("Bed Leveling ", to_enable ? MSG_ON : MSG_OFF);
+    SERIAL_ECHOLNPAIR("Bed Leveling ", 
+#if ENABLED(MESH_BED_LEVELING)
+      mbl.active()
+#else
+      planner.abl_enabled
+#endif
+      ? MSG_ON : MSG_OFF);
 
     // V to print the matrix or mesh
     if (code_seen('V')) {


### PR DESCRIPTION
Wouldn't it be better to show the outcome instead of the request?

Also this fixes `M420 V` always stating ABL is off when it is not.