### PR TITLE
M355 status report : no case light

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7593,6 +7593,7 @@ inline void gcode_M907() {
     digitalWrite(CASE_LIGHT_PIN, case_light_on != INVERT_CASE_LIGHT ? HIGH : LOW);
     analogWrite(CASE_LIGHT_PIN, case_light_on != INVERT_CASE_LIGHT ? case_light_brightness : 0);
   }
+#endif // HAS_CASE_LIGHT
 
   /**
    * M355: Turn case lights on/off and set brightness
@@ -7601,12 +7602,17 @@ inline void gcode_M907() {
    *   P<byte>  Set case light brightness (PWM pin required)
    */
   inline void gcode_M355() {
+#if HAS_CASE_LIGHT
     if (code_seen('P')) case_light_brightness = code_value_byte();
     if (code_seen('S')) case_light_on = code_value_bool();
     update_case_light();
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM("Case lights ");
     case_light_on ? SERIAL_ECHOLNPGM("on") : SERIAL_ECHOLNPGM("off");
+#else
+	SERIAL_ECHO_START;
+	SERIAL_ECHOLNPGM(MSG_LIGHTS_NONE);
+#endif // HAS_CASE_LIGHT
   }
 
 #endif // HAS_CASE_LIGHT
@@ -8750,13 +8756,9 @@ void process_next_command() {
 
       #endif // HAS_MICROSTEPS
 
-      #if HAS_CASE_LIGHT
-
         case 355: // M355 Turn case lights on/off
           gcode_M355();
           break;
-
-      #endif // HAS_CASE_LIGHT
 
       case 999: // M999: Restart after being Stopped
         gcode_M999();

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -511,6 +511,9 @@
 #ifndef MSG_LIGHTS_OFF
   #define MSG_LIGHTS_OFF                      _UxGT("Case light off")
 #endif
+#ifndef MSG_LIGHTS_NONE
+#define MSG_LIGHTS_NONE                       _UxGT("No case light")
+#endif
 
 #if LCD_WIDTH >= 20
   #ifndef MSG_INFO_PRINT_COUNT

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -193,6 +193,7 @@
 #define MSG_INFO_PROTOCOL                   _UxGT("Protocole")
 #define MSG_LIGHTS_ON                       _UxGT("Allumer boitier")
 #define MSG_LIGHTS_OFF                      _UxGT("Eteindre boitier")
+#define MSG_LIGHTS_NONE                     _UxGT("Pas de lumiere boitier")
 
 #if LCD_WIDTH >= 20
   #define MSG_INFO_PRINT_COUNT              _UxGT("Nbre impressions")

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -193,7 +193,6 @@
 #define MSG_INFO_PROTOCOL                   _UxGT("Protocole")
 #define MSG_LIGHTS_ON                       _UxGT("Allumer boitier")
 #define MSG_LIGHTS_OFF                      _UxGT("Eteindre boitier")
-#define MSG_LIGHTS_NONE                     _UxGT("Pas de lumiere boitier")
 
 #if LCD_WIDTH >= 20
   #define MSG_INFO_PRINT_COUNT              _UxGT("Nbre impressions")


### PR DESCRIPTION
As seen in http://www.reprap.org/wiki/G-Code#M355:_Turn_case_lights_on.2Foff

A call to `M355` when there is no case lights may echo "No case lights"
