### PR TITLE
Disable SD Detect for K8400

### DIFF
--- a/Marlin/pins_K8400.h
+++ b/Marlin/pins_K8400.h
@@ -65,3 +65,4 @@
 //
 #undef PS_ON_PIN
 #undef KILL_PIN
+#undef SD_DETECT_PIN


### PR DESCRIPTION
As already mentioned in #5045, the SD_DETECT_PIN is, by default, not connected on the Vellemann K8400. The pin configurations included with Marlin should work with the corresponding printers without the need of a modification like this.