### PR TITLE
Update Bilinear Grid with Probe Height Changes

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -567,6 +567,10 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  #define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -567,8 +567,9 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
 #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-  #define UPDATE_GRID_WITH_PROBE_HEIGHT
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
 #endif
 
 // @section extras

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7233,6 +7233,16 @@ inline void gcode_M503() {
     if (code_seen('Z')) {
       float value = code_value_axis_units(Z_AXIS);
       if (Z_PROBE_OFFSET_RANGE_MIN <= value && value <= Z_PROBE_OFFSET_RANGE_MAX) {
+        #if ENABLED(UPDATE_GRID_WITH_PROBE_HEIGHT)
+          float height_difference = (value - zprobe_zoffset);
+          for (uint8_t x = 0; x < ABL_GRID_MAX_POINTS_X; x++)
+            for (uint8_t y = 0; y < ABL_GRID_MAX_POINTS_Y; y++)
+              bed_level_grid[x][y] += height_difference;
+          #if ENABLED(ABL_BILINEAR_SUBDIVISION)
+            bed_level_virt_prepare();
+            bed_level_virt_interpolate();
+          #endif
+        #endif
         zprobe_zoffset = value;
         SERIAL_ECHO(zprobe_zoffset);
       }

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -550,6 +550,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -580,6 +580,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -575,6 +575,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/biv2.5/Configuration_adv.h
@@ -569,6 +569,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -569,6 +569,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -569,6 +569,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -574,6 +574,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -569,6 +569,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -567,6 +567,11 @@
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #endif
 
+// Update Bilinear grid with probe height changes
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  //#define UPDATE_GRID_WITH_PROBE_HEIGHT
+#endif
+
 // @section extras
 
 // Arc interpretation settings:


### PR DESCRIPTION
I change nozzles a lot, causing me to have to change my probe height.  Measuring a 9x9 grid every change becomes boring fast, especially since the bed hasn't changed, only the height offset has.

All this does is if enabled (disabled by default), the grid will be updated with the height difference.