### PR TITLE
Fix empty Prepare menu

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1403,7 +1403,7 @@ KeepDrawing:
     // Cooldown
     //
     bool has_heat = false;
-    HOTEND_LOOP() if (thermalManager.target_temperature[e]) { has_heat = true; break; }
+    HOTEND_LOOP() if (thermalManager.target_temperature[HOTEND_INDEX]) { has_heat = true; }
     #if HAS_TEMP_BED
       if (thermalManager.target_temperature_bed) has_heat = true;
     #endif


### PR DESCRIPTION
Fixes the blank prepare menu error.  When using a single hotend, there is no for loop, so having a break statement would exit the function.  While not great coding practice, its alright to loop all the hotends to check for heat.

The other option would be to add a
```c
#if HOTENDS > 1
 break;
#endif
```
but I'll leave that up to @thinkyhead or whoever merges this.

I also renamed e to the index macro.