### PR TITLE
Fix LCD prepare menu when heating

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1403,7 +1403,7 @@ KeepDrawing:
     // Cooldown
     //
     bool has_heat = false;
-    HOTEND_LOOP() if (thermalManager.target_temperature[e]) { has_heat = true; break; }
+    HOTEND_LOOP() if (thermalManager.target_temperature[e]) has_heat = true;
     #if HAS_TEMP_BED
       if (thermalManager.target_temperature_bed) has_heat = true;
     #endif


### PR DESCRIPTION
When iheat the hotend or preheat PLA, ABS or temperature control the prepare menu becomes empty.
I deleted the break and now it works perfectly.
It seems to me as strange thing, but for some reason the break not only comes from the HOTEND_LOOP, but the routine itself.
Sorry for english!