### PR TITLE
Reset watchdog in SD init to prevent reboot

### DIFF
--- a/Marlin/Sd2Card.cpp
+++ b/Marlin/Sd2Card.cpp
@@ -31,6 +31,10 @@
 #if ENABLED(SDSUPPORT)
 #include "Sd2Card.h"
 
+#if ENABLED(USE_WATCHDOG)
+  #include "watchdog.h"
+#endif
+
 //------------------------------------------------------------------------------
 #if DISABLED(SOFTWARE_SPI)
   // functions for hardware SPI
@@ -298,6 +302,12 @@ bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   // 16-bit init start time allows over a minute
   uint16_t t0 = (uint16_t)millis();
   uint32_t arg;
+
+  // If init takes more than 4s it could trigger
+  // watchdog leading to a reboot loop.
+  #if ENABLED(USE_WATCHDOG)
+    watchdog_reset();
+  #endif
 
   // set pin modes
   pinMode(chipSelectPin_, OUTPUT);


### PR DESCRIPTION
If the watchdog is enabled and bootscreen + sd card checks take too long the program may hang at boot time because of the reset loop. We have this happen all the time with the Anet board if no SD card is inserted.

Tweaked version of #5679