### PR TITLE
Bl touch m119

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -348,6 +348,7 @@
     #define Z_SERVO_ANGLES { BLTOUCH_DEPLOY, BLTOUCH_STOW }
 
     #define BLTOUCH_DEPLOY    10
+    #define BLTOUCH_M119      60
     #define BLTOUCH_STOW      90
     #define BLTOUCH_SELFTEST 120
     #define BLTOUCH_RESET    160

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -553,6 +553,7 @@
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
 //#define BLTOUCH
+#define BLTOUCH_M119_MODE   // removes minimum feedrate limitation
 
 // Z Servo Probe, such as an endstop switch on a rotating arm.
 //#define Z_ENDSTOP_SERVO_NR 0

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -388,7 +388,7 @@ int feedrate_percentage = 100, saved_feedrate_percentage,
     flow_percentage[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100);
 
 bool axis_relative_modes[] = AXIS_RELATIVE_MODES,
-     volumetric_enabled = 
+     volumetric_enabled =
       #if ENABLED(VOLUMETRIC_DEFAULT_ON)
         true
       #else
@@ -1989,6 +1989,7 @@ static void clean_up_after_endstop_or_probe_move() {
   #if ENABLED(BLTOUCH)
     FORCE_INLINE void set_bltouch_deployed(const bool &deploy) {
       servo[Z_ENDSTOP_SERVO_NR].move(deploy ? BLTOUCH_DEPLOY : BLTOUCH_STOW);
+      if (deploy && ENABLED(BLTOUCH_M119_MODE)) servo[Z_ENDSTOP_SERVO_NR].move(BLTOUCH_M119);
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) {
           SERIAL_ECHOPAIR("set_bltouch_deployed(", deploy);
@@ -3902,7 +3903,7 @@ inline void gcode_G28() {
    *  R  Set the Right limit of the probing grid
    *
    * Parameters with BILINEAR only:
-   * 
+   *
    *  Z  Supply an additional Z probe offset
    *
    * Global Parameters:


### PR DESCRIPTION
Not ready for prime time.  I have to do a lot more testing before this is ready to be taken seriously.

There appears to be an easy way to put the BLTouch into the "M119" mode.  In that mode it acts like a traditional endstop in that, when triggered, the signal goes active & stays active until stowed.  None of the 5mS pulse b%^#.