### PR TITLE
Adjust probe_pt() terminal output to respect probe z-offset

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2208,7 +2208,7 @@ static void clean_up_after_endstop_or_probe_move() {
       SERIAL_PROTOCOLPGM(" Y: ");
       SERIAL_PROTOCOL_F(y, 3);
       SERIAL_PROTOCOLPGM(" Z: ");
-      SERIAL_PROTOCOL_F(measured_z, 3);
+      SERIAL_PROTOCOL_F(measured_z + zprobe_zoffset, 3);
       SERIAL_EOL;
     }
 


### PR DESCRIPTION
`probe_pt()` does not take the probe z-offset into account when reporting probed z-heights. This causes `probe_pt()` and  `print_bilinear_leveling_grid()` to report different values which can make correlating the two outputs difficult if, e.g., the bed origin is in the back-right instead of the front-left of the printer and the report by `print_bilinear_leveling_grid()` is mirrored.

This change only affects the terminal output of `probe_pt()` to respect the probe z-offset if the printer has a probe. The internal values passed around between functions is not changed.

Another approach would be to undo the probe z-offset correction inside `print_bilinear_leveling_grid()` by changing [Marlin_main.cpp@L2441](https://github.com/MarlinFirmware/Marlin/blob/RCBugFix/Marlin/Marlin_main.cpp#L2441) from

`float offset = bed_level_grid[x][y];`

to 

`float offset = bed_level_grid[x][y] - zprobe_zoffset;`