### PR TITLE
Set DAC current defaults

### DIFF
--- a/Marlin/pins_RIGIDBOARD_V2.h
+++ b/Marlin/pins_RIGIDBOARD_V2.h
@@ -44,3 +44,4 @@
 #define DAC_STEPPER_GAIN     1 // value of 1 here sets gain of 2
 #define DAC_DISABLE_PIN     42 // set low to enable DAC
 #define DAC_OR_ADDRESS    0x01
+#define DAC_STEPPER_DEFLT { 70, 80, 90, 80 } // Default values for drive strength percent

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -49,7 +49,7 @@
 
   bool dac_present = false;
   const uint8_t dac_order[NUM_AXIS] = DAC_STEPPER_ORDER;
-  uint16_t dac_channel_pct[XYZE];
+  uint16_t dac_channel_pct[XYZE] = DAC_STEPPER_DFLT;
 
   int dac_init() {
     #if PIN_EXISTS(DAC_DISABLE)
@@ -64,6 +64,11 @@
 
     mcp4728_setVref_all(DAC_STEPPER_VREF);
     mcp4728_setGain_all(DAC_STEPPER_GAIN);
+    
+    if (mcp4728_getDrvPct(0) < 1 || mcp4728_getDrvPct(1) < 1 || mcp4728_getDrvPct(2) < 1 || mcp4728_getDrvPct(3) < 1 ) {
+      mcp4728_setDrvPct(dac_channel_pct);
+      mcp4728_eepromWrite();
+    }
 
     return 0;
   }


### PR DESCRIPTION
These tweaks allow the firmware to set defaults to the dac stepper values in the case where the values are empty.