### PR TITLE
Implements REPROBE and REWIPE, using Nozzle::clean()

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -545,10 +545,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -981,13 +994,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1000,6 +1013,7 @@
 //                       |________|_________|_________|
 //                           T1        T2        T3
 //
+//
 // Caveats: End point Z should use the same value as Start point Z.
 //
 // Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
@@ -1008,8 +1022,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -429,8 +429,13 @@
   #else
     #define COUNT_PROBE_6 COUNT_PROBE_5
   #endif
-  #if COUNT_PROBE_6 > 1
-    #error "Please enable only one probe: FIX_MOUNTED_PROBE, Z Servo, BLTOUCH, Z_PROBE_ALLEN_KEY, or Z_PROBE_SLED."
+  #if ENABLED(NOZZLE_PROBE)
+    #define COUNT_PROBE_7 INCREMENT(COUNT_PROBE_6)
+  #else
+    #define COUNT_PROBE_7 COUNT_PROBE_6
+  #endif
+  #if COUNT_PROBE_7 > 1
+    #error "Please enable only one probe: FIX_MOUNTED_PROBE, NOZZLE_PROBE, Z Servo, BLTOUCH, Z_PROBE_ALLEN_KEY, or Z_PROBE_SLED."
   #endif
 
   /**
@@ -439,6 +444,26 @@
   #if ENABLED(Z_PROBE_SLED) && ENABLED(DELTA)
     #error "You cannot use Z_PROBE_SLED with DELTA."
   #endif
+
+  /**
+   * Nozzle-conductivity probe dependencies
+   */
+  #if ENABLED(NOZZLE_PROBE)
+    #ifndef PROBE_FAIL_HEIGHT
+      #error "You must define a failure height to use NOZZLE_PROBE."
+    #endif
+    #if ENABLED(REWIPE) // || ENABLED(PREWIPE)
+      #ifndef NOZZLE_CLEAN_FEATURE
+        #error "Your nozzle probe settings require a wipe pad, but none is defined."
+      #endif
+    #endif
+
+    #if ENABLED(HOMING_Z_WITH_PROBE)
+      #error "Cannot safely use NOZZLE_PROBE to home Z-axis. Change Z_HOME_DIR or enable a seperate Z-min probe."
+    #endif
+  #endif
+
+
 
   /**
    * NUM_SERVOS is required for a Z servo probe

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -545,10 +545,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -981,13 +994,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1008,8 +1021,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -528,10 +528,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -964,13 +977,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -991,8 +1004,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -528,10 +528,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -964,13 +977,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -991,8 +1004,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -537,10 +537,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -973,13 +986,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1000,8 +1013,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -539,10 +539,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 #define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -975,13 +988,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1002,8 +1015,11 @@
 #define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { X_MIN_POS + 10, Y_MAX_POS - 9, (Z_MIN_POS + 0.5)}

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -574,10 +574,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -1010,13 +1023,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1037,8 +1050,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -545,10 +545,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -981,13 +994,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1008,8 +1021,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -545,10 +545,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -981,13 +994,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1008,8 +1021,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -545,10 +545,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -981,13 +994,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1008,8 +1021,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -544,10 +544,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -980,13 +993,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1007,8 +1020,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -560,10 +560,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -996,13 +1009,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1023,8 +1036,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -566,10 +566,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -1002,13 +1015,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1029,8 +1042,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -537,10 +537,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -973,13 +986,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -992,6 +1005,7 @@
 //                       |________|_________|_________|
 //                           T1        T2        T3
 //
+//
 // Caveats: End point Z should use the same value as Start point Z.
 //
 // Attention: This is an EXPERIMENTAL feature, in the future the G-code arguments
@@ -1000,8 +1014,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -545,10 +545,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -981,13 +994,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1008,8 +1021,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -590,10 +590,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -1068,13 +1081,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1095,8 +1108,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -590,10 +590,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -1071,13 +1084,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1098,8 +1111,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -584,10 +584,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -1070,13 +1083,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1097,8 +1110,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -596,10 +596,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 #define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -1074,13 +1087,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1101,8 +1114,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -548,10 +548,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -984,13 +997,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1011,8 +1024,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -541,10 +541,23 @@
 //
 
 // A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
-// For example an inductive probe, or a setup that uses the nozzle to probe.
-// An inductive probe must be deactivated to go below
-// its trigger-point if hardware endstops are active.
+// For example an inductive probe. An inductive probe must be deactivated to go
+// below its trigger-point if hardware endstops are active.
 //#define FIX_MOUNTED_PROBE
+
+// A Nozzle Probe sense conductivity between the bed and nozzle. Allows for
+// automatic recleaning of nozzles to ensure successful probing.
+// Must be Z-homed before leveling, to know when a probe has failed.
+//#define NOZZLE_PROBE
+#if ENABLED(NOZZLE_PROBE)
+  #define PROBE_FAIL_HEIGHT  -10    //probe will fail this far below the expected probe point
+  #define REPROBE_ATTEMPTS   1      //Maximum number of retries per point. Set to 0 to make one attempt
+  //#define REWIPE                  //Uncomment to rewipe nozzle between attempts. NOZZLE_CLEAN_FEATURE
+                                    //must be setup.
+  #if ENABLED(REWIPE)
+    #define REWIPE_PATTERN   1      //The rewipe pattern to use, as defined in the "Clean Nozzle" section.
+  #endif                            //Currently only 0=stroke 1=triangles
+#endif
 
 // The BLTouch probe emulates a servo probe.
 // The default connector is SERVO 0. Set Z_ENDSTOP_SERVO_NR below to override.
@@ -977,13 +990,13 @@
 //
 // Available list of patterns:
 //   P0: This is the default pattern, this process requires a sponge type
-//       material at a fixed bed location, the cleaning process is based on
-//       "strokes" i.e. back-and-forth movements between the starting and end
-//       points.
+//       material at a fixed bed location. S defines "strokes" i.e.
+//       back-and-forth movements between the starting and end points.
 //
 //   P1: This starts a zig-zag pattern between (X0, Y0) and (X1, Y1), "T"
 //       defines the number of zig-zag triangles to be done. "S" defines the
-//       number of strokes aka one back-and-forth movement. As an example
+//       number of strokes aka one back-and-forth movement. Zig-zags will
+//       be performed in whichever dimension is smallest. As an example,
 //       sending "G12 P1 S1 T3" will execute:
 //
 //          --
@@ -1004,8 +1017,11 @@
 //#define NOZZLE_CLEAN_FEATURE
 
 #if ENABLED(NOZZLE_CLEAN_FEATURE)
-  // Number of pattern repetitions
+  // Default number of pattern repetitions
   #define NOZZLE_CLEAN_STROKES  12
+  
+  // Default number of triangles
+  #define NOZZLE_CLEAN_TRIANGLES  3
 
   // Specify positions as { X, Y, Z }
   #define NOZZLE_CLEAN_START_POINT { 30, 30, (Z_MIN_POS + 1)}

--- a/Marlin/nozzle.h
+++ b/Marlin/nozzle.h
@@ -26,6 +26,14 @@
 #include "Marlin.h"
 #include "point_t.h"
 
+#if ENABLED(NOZZLE_CLEAN_FEATURE)
+  constexpr float nozzle_clean_start_point[4] = NOZZLE_CLEAN_START_POINT,
+                  nozzle_clean_end_point[4] = NOZZLE_CLEAN_END_POINT,
+                  nozzle_clean_length = fabs(nozzle_clean_start_point[X_AXIS] - nozzle_clean_end_point[X_AXIS]), //abs x size of wipe pad
+                  nozzle_clean_height = fabs(nozzle_clean_start_point[Y_AXIS] - nozzle_clean_end_point[Y_AXIS]); //abs y size of wipe pad
+  constexpr bool NOZZLE_CLEAN_HORIZONTAL = nozzle_clean_length >= nozzle_clean_height; //whether to zig-zag horizontally or vertically
+#endif //NOZZLE_CLEAN_FEATURE
+
 /**
  * @brief Nozzle class
  *
@@ -92,8 +100,8 @@ class Nozzle {
       __attribute__((unused)) uint8_t const &objects
     ) __attribute__((optimize ("Os"))) {
       #if ENABLED(NOZZLE_CLEAN_FEATURE)
-        float A = fabs(end.y - start.y); // [twice the] Amplitude
-        float P = fabs(end.x - start.x) / (objects << 1); // Period
+        float A = NOZZLE_CLEAN_HORIZONTAL ? nozzle_clean_height : nozzle_clean_length; // [twice the] Amplitude
+        float P = ( NOZZLE_CLEAN_HORIZONTAL ? nozzle_clean_length : nozzle_clean_height ) / (objects << 1); // Period
 
         // Don't allow impossible triangles
         if (A <= 0.0f || P <= 0.0f ) return;
@@ -110,16 +118,16 @@ class Nozzle {
 
         for (uint8_t j = 0; j < strokes; j++) {
           for (uint8_t i = 0; i < (objects << 1); i++) {
-            float const x = start.x + i * P;
-            float const y = start.y + (A/P) * (P - fabs(fmod((i*P), (2*P)) - P));
+            float const x = start.x + ( NOZZLE_CLEAN_HORIZONTAL ? i * P : (A/P) * (P - fabs(fmod((i*P), (2*P)) - P)) );
+            float const y = start.y + (!NOZZLE_CLEAN_HORIZONTAL ? i * P : (A/P) * (P - fabs(fmod((i*P), (2*P)) - P)) );
 
             do_blocking_move_to_xy(x, y);
             if (i == 0) do_blocking_move_to_z(start.z);
           }
 
           for (int i = (objects << 1); i > -1; i--) {
-            float const x = start.x + i * P;
-            float const y = start.y + (A/P) * (P - fabs(fmod((i*P), (2*P)) - P));
+            float const x = start.x + ( NOZZLE_CLEAN_HORIZONTAL ? i * P : (A/P) * (P - fabs(fmod((i*P), (2*P)) - P)) );
+            float const y = start.y + (!NOZZLE_CLEAN_HORIZONTAL ? i * P : (A/P) * (P - fabs(fmod((i*P), (2*P)) - P)) );
 
             do_blocking_move_to_xy(x, y);
           }


### PR DESCRIPTION
Implements the features described here: https://github.com/MarlinFirmware/Marlin/pull/3553

Logic works as follows:
-setup_for_endstop_or_probe_move() resets a global variable "attempt" to count probe attempts
-do_probe_move now returns bool. If the endstop is triggered before the end of the move, true/success is returned.
-attempt_probe now sits in between run_z_probe and do_probe_move. run_z_probe still controls fast/slow bumps, but attempt_probe now loops do_probe_move until success or failure, rewiping in-between if defined.

This PR also fixes a few bugs I found in functions that implement probe_pt, where both probe_pt and the caller function account for XY probe offset, causing the probe to be off in the opposite direction.

Please let me know if this fits the criteria discussed in the last PR, or what I need to change.