### PR TITLE
No space after X: or A: in M114 output

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -133,8 +133,8 @@
 #define MSG_INVALID_SOLENOID                "Invalid solenoid"
 #define MSG_ERR_NO_THERMISTORS              "No thermistors - no temperature"
 #define MSG_M115_REPORT                     "FIRMWARE_NAME:Marlin " DETAILED_BUILD_VERSION " SOURCE_CODE_URL:" SOURCE_CODE_URL " PROTOCOL_VERSION:" PROTOCOL_VERSION " MACHINE_TYPE:" MACHINE_NAME " EXTRUDER_COUNT:" STRINGIFY(EXTRUDERS) " UUID:" MACHINE_UUID
-#define MSG_COUNT_X                         " Count X: "
-#define MSG_COUNT_A                         " Count A: "
+#define MSG_COUNT_X                         " Count X:"
+#define MSG_COUNT_A                         " Count A:"
 #define MSG_ERR_KILLED                      "Printer halted. kill() called!"
 #define MSG_ERR_STOPPED                     "Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)"
 #define MSG_BUSY_PROCESSING                 "busy: processing"


### PR DESCRIPTION
I hope the host developers are using robust string comparison. 😁 