### PR TITLE
Fix MAKRPANEL assignments

### DIFF
--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -121,10 +121,6 @@
 //
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
 
-  // No buzzer installed
-  #define BEEPER_PIN -1
-
-  // LCD Pins
   #if ENABLED(DOGLCD)
 
     #if ENABLED(U8GLIB_ST7920) // SPI GLCD 12864 ST7920 ( like [www.digole.com] ) For Melzi V2.0
@@ -137,7 +133,7 @@
         // Marlin so this can be used for BEEPER_PIN. You can use this pin
         // with M42 instead of BEEPER_PIN.
         #define BEEPER_PIN      27
-      #else         // Sanguinololu 1.3
+      #else        // Sanguinololu 1.3
         #define LCD_PINS_RS      4
         #define LCD_PINS_ENABLE 17
         #define LCD_PINS_D4     30
@@ -149,8 +145,19 @@
     #else // DOGM SPI LCD Support
 
       #define DOGLCD_A0         30
-      #define DOGLCD_CS         29
       #define LCD_CONTRAST       1
+
+      #if ENABLED(MAKRPANEL)
+
+        #define BEEPER_PIN      29
+        #define DOGLCD_CS       17
+        #define LCD_BACKLIGHT_PIN 28 // PA3
+
+      #else // !MAKRPANEL
+
+        #define DOGLCD_CS       29
+
+      #endif
 
     #endif
 
@@ -160,7 +167,7 @@
     //#define LCD_SCREEN_ROT_180
     //#define LCD_SCREEN_ROT_270
 
-  #else // !DOGLCD - Standard Hitachi LCD controller
+  #else // !DOGLCD
 
     #define LCD_PINS_RS          4
     #define LCD_PINS_ENABLE     17
@@ -171,9 +178,9 @@
 
   #endif // !DOGLCD
 
-  //The encoder and click button
   #define BTN_EN1               11
   #define BTN_EN2               10
+
   #if ENABLED(LCD_I2C_PANELOLU2)
     #if IS_MELZI
       #define BTN_ENC           29
@@ -181,33 +188,11 @@
     #else
       #define BTN_ENC           30
     #endif
-  #else
+  #else  // !Panelolu2
     #define BTN_ENC             16
     #define LCD_SDSS            28 // Smart Controller SD card reader rather than the Melzi
-  #endif // Panelolu2
+  #endif // !Panelolu2
 
   #define SD_DETECT_PIN         -1
 
-#elif ENABLED(MAKRPANEL)
-
-  #define BEEPER_PIN            29
-
-  // Pins for DOGM SPI LCD Support
-  #define DOGLCD_A0             30
-  #define DOGLCD_CS             17
-  #define LCD_BACKLIGHT_PIN     28 // backlight LED on PA3
-  // GLCD features
-  #define LCD_CONTRAST           1
-  // Uncomment screen orientation
-  #define LCD_SCREEN_ROT_0
-  //#define LCD_SCREEN_ROT_90
-  //#define LCD_SCREEN_ROT_180
-  //#define LCD_SCREEN_ROT_270
-  //The encoder and click button
-  #define BTN_EN1               11
-  #define BTN_EN2               10
-  #define BTN_ENC               16
-
-  #define SD_DETECT_PIN         -1
-
-#endif // MAKRPANEL
+#endif // ULTRA_LCD && NEWPANEL


### PR DESCRIPTION
Addressing #5773

`MAKRPANEL` is a `DOGLCD` + `ULTRA_LCD` + `NEWPANEL`, so customize its pins within
that block.