### PR TITLE
Make HOTEND_LOOP more consistent, let compiler optimize it

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -787,8 +787,6 @@ void Config_ResetDefault() {
   #if ENABLED(PIDTEMP)
     #if ENABLED(PID_PARAMS_PER_HOTEND) && HOTENDS > 1
       HOTEND_LOOP()
-    #else
-      int e = 0; UNUSED(e); // only need to write once
     #endif
     {
       PID_PARAM(Kp, e) = DEFAULT_Kp;

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -731,7 +731,7 @@ void Temperature::manage_heater() {
       }
     #endif
 
-  } // Hotends Loop
+  } // HOTEND_LOOP
 
   #if HAS_AUTO_FAN
     if (ELAPSED(ms, next_auto_fan_check_ms)) { // only need to check fan state very infrequently
@@ -885,9 +885,8 @@ void Temperature::updateTemperaturesFromRawValues() {
   #if ENABLED(HEATER_0_USES_MAX6675)
     current_temperature_raw[0] = read_max6675();
   #endif
-  HOTEND_LOOP() {
+  HOTEND_LOOP()
     current_temperature[e] = Temperature::analog2temp(current_temperature_raw[e], e);
-  }
   current_temperature_bed = Temperature::analog2tempBed(current_temperature_bed_raw);
   #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
     redundant_temperature = Temperature::analog2temp(redundant_temperature_raw, 1);
@@ -939,15 +938,7 @@ void Temperature::init() {
   #endif
 
   // Finish init of mult hotend arrays
-  HOTEND_LOOP() {
-    // populate with the first value
-    maxttemp[e] = maxttemp[0];
-    #if ENABLED(PIDTEMP)
-      #if ENABLED(PID_EXTRUSION_SCALING)
-        last_e_position = 0;
-      #endif
-    #endif //PIDTEMP
-  }
+  HOTEND_LOOP() maxttemp[e] = maxttemp[0];
 
   #if ENABLED(PIDTEMP) && ENABLED(PID_EXTRUSION_SCALING)
     last_e_position = 0;

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -40,12 +40,12 @@
   #define SOFT_PWM_SCALE 0
 #endif
 
+#define HOTEND_LOOP() for (int8_t e = 0; e < HOTENDS; e++)
+
 #if HOTENDS == 1
-  #define HOTEND_LOOP() const int8_t e = 0;
   #define HOTEND_INDEX  0
   #define EXTRUDER_IDX  0
 #else
-  #define HOTEND_LOOP() for (int8_t e = 0; e < HOTENDS; e++)
   #define HOTEND_INDEX  e
   #define EXTRUDER_IDX  active_extruder
 #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1403,7 +1403,7 @@ KeepDrawing:
     // Cooldown
     //
     bool has_heat = false;
-    HOTEND_LOOP() if (thermalManager.target_temperature[HOTEND_INDEX]) { has_heat = true; }
+    HOTEND_LOOP() if (thermalManager.target_temperature[HOTEND_INDEX]) { has_heat = true; break; }
     #if HAS_TEMP_BED
       if (thermalManager.target_temperature_bed) has_heat = true;
     #endif


### PR DESCRIPTION
Save ~100 bytes in the generated binary. Allows the compiler to do loop optimization and commands like `break` to always work as expected.