### PR TITLE
Correct computation of bilinear z-offset

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8883,16 +8883,15 @@ void ok_to_send() {
           ratio_y = y / ABL_BG_SPACING(Y_AXIS);
 
     // Whole units for the grid line indices. Constrained within bounds.
-    const int gridx = constrain(floor(ratio_x), 0, ABL_BG_POINTS_X - 1),
-              gridy = constrain(floor(ratio_y), 0, ABL_BG_POINTS_Y - 1),
+    const int gridx = constrain(floor(ratio_x), 0, ABL_BG_POINTS_X - 2),
+              gridy = constrain(floor(ratio_y), 0, ABL_BG_POINTS_Y - 2),
               nextx = min(gridx + 1, ABL_BG_POINTS_X - 1),
               nexty = min(gridy + 1, ABL_BG_POINTS_Y - 1);
 
-    // Subtract whole to get the ratio within the grid box
+    // Subtract whole to get the ratio relative to the grid box. Values less than 0 or
+    // greater than 1 (i.e. outside of the probed area) will result in an interpolation
+    // based on the closest grid box.
     ratio_x -= gridx; ratio_y -= gridy;
-
-    // Never less than 0.0. (Over 1.0 is fine due to previous contraints.)
-    NOLESS(ratio_x, 0); NOLESS(ratio_y, 0);
 
     // Z at the box corners
     const float z1 = ABL_BG_GRID(gridx, gridy),  // left-front


### PR DESCRIPTION
In the computation of the Z-Offset for the bilinear leveling, the current algorithm had several issues. First, gridx/y and nextx/y could be equal, resulting in the use of an edge instead of the four corners of a box. Second, limiting ratio_x/y to greater than 0 resulted in the offset being estimated for portions of the bed outside of probe area only in the portions where x/y are greater than the probe area, but not when x/y are less than the probe area.