### PR TITLE
Hot end indicator to the heating message on the lcd display.

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5308,7 +5308,7 @@ inline void gcode_M104() {
       }
     #endif
 
-    if (code_value_temp_abs() > thermalManager.degHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
+    if (code_value_temp_abs() > thermalManager.degHotend(target_extruder)) status_printf(0,"E%i %s",target_extruder+1, MSG_HEATING);
   }
 
   #if ENABLED(AUTOTEMP)
@@ -5506,7 +5506,7 @@ inline void gcode_M109() {
       else print_job_timer.start();
     #endif
 
-    if (thermalManager.isHeatingHotend(target_extruder)) LCD_MESSAGEPGM(MSG_HEATING);
+    if (thermalManager.isHeatingHotend(target_extruder)) status_printf(0,"E%i %s",target_extruder+1, MSG_HEATING);
   }
 
   #if ENABLED(AUTOTEMP)

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3272,6 +3272,17 @@ void lcd_setstatuspgm(const char* const message, uint8_t level) {
   lcd_finishstatus(level > 0);
 }
 
+void status_printf(uint8_t level, const char *Status, ...){
+  if (level < lcd_status_message_level) return;
+  lcd_status_message_level = level;
+  va_list args;
+  va_start(args, Status);
+  vsnprintf(lcd_status_message, 3 * (LCD_WIDTH), Status, args);
+  va_end(args);
+  lcd_finishstatus(level > 0);
+}
+
+
 void lcd_setalertstatuspgm(const char* const message) {
   lcd_setstatuspgm(message, 1);
   #if ENABLED(ULTIPANEL)

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -39,6 +39,7 @@
   bool lcd_hasstatus();
   void lcd_setstatus(const char* message, const bool persist=false);
   void lcd_setstatuspgm(const char* message, const uint8_t level=0);
+  void status_printf(uint8_t level, const char *Status, ...);
   void lcd_setalertstatuspgm(const char* message);
   void lcd_reset_alert_level();
   void lcd_kill_screen();
@@ -153,6 +154,7 @@
   inline bool lcd_hasstatus() { return false; }
   inline void lcd_setstatus(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
   inline void lcd_setstatuspgm(const char* const message, const uint8_t level=0) { UNUSED(message); UNUSED(level); }
+  inline void status_printf(uint8_t level, const char *Status, ...){ UNUSED(level); UNUSED(Status); };
   inline void lcd_buttons_update() {}
   inline void lcd_reset_alert_level() {}
   inline bool lcd_detected() { return true; }


### PR DESCRIPTION
I thought I would give it a go at contributing to Marlin.  I will start with something simple to see how painful or painless the process is before I submit something more significant.

This code came about as I was writing a GCode script for my dual extrusion printer.  The firmware wasn't listing which hot end it was currently heating.  So I added a printf style function and indicator to which hot end was heating.  The indicator is "Ex " where x is the hot number starting at 1.  So in my case it would say "E1 Heating..." for extruder 1 and "E2 Heating..." for extruder 2.  It should prepend the string "Ex " to any supported language file that defines MSG_HEATING. 
 
Changes: 
Added the function status_printf used to print messages to the status line of a lcd display.
Added a hot end indicator to the heating message which is displayed on the status line of a lcd display.

-Robert