### PR TITLE
Enable and disable power supply automatically

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -221,6 +221,11 @@
   #endif
   #define HAS_POWER_SWITCH (POWER_SUPPLY > 0 && PIN_EXISTS(PS_ON))
 
+  // Default to 30 seconds timeout
+  #ifndef POWER_TIMEOUT
+    #define POWER_TIMEOUT 30
+  #endif
+
   /**
    * Temp Sensor defines
    */

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -196,11 +196,17 @@
   // Enable this option to leave the PSU off at startup.
   // Power to steppers and heaters will need to be turned on with M80.
   #define PS_DEFAULT_OFF
-  #define FAN_NEEDS_POWER
-  #define AUTO_FAN_NEEDS_POWER
-  #define CONTROLLERFAN_NEEDS_POWER
 
-  #define POWER_TIMEOUT 30
+  //#define AUTO_POWER_CONTROL        // Enable automatic control of the PS_ON pin
+  #if ENABLED(AUTO_POWER_CONTROL)
+    #define FAN_NEEDS_POWER
+    #define AUTO_FAN_NEEDS_POWER
+    #define CONTROLLERFAN_NEEDS_POWER
+
+    #define POWER_TIMEOUT 30
+  #endif
+
+
 #endif
 
 // @section temperature

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -195,7 +195,12 @@
 #if POWER_SUPPLY > 0
   // Enable this option to leave the PSU off at startup.
   // Power to steppers and heaters will need to be turned on with M80.
-  //#define PS_DEFAULT_OFF
+  #define PS_DEFAULT_OFF
+  //#define FAN_NEEDS_POWER
+  #define AUTO_FAN_NEEDS_POWER
+  #define CONTROLLERFAN_NEEDS_POWER
+
+  #define POWER_TIMEOUT 30
 #endif
 
 // @section temperature

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -196,7 +196,7 @@
   // Enable this option to leave the PSU off at startup.
   // Power to steppers and heaters will need to be turned on with M80.
   #define PS_DEFAULT_OFF
-  //#define FAN_NEEDS_POWER
+  #define FAN_NEEDS_POWER
   #define AUTO_FAN_NEEDS_POWER
   #define CONTROLLERFAN_NEEDS_POWER
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -370,7 +370,9 @@ float code_value_temp_diff();
   extern int fanSpeeds[FAN_COUNT];
 #endif
 
-extern int controllerFanSpeed;
+#if HAS_CONTROLLERFAN
+  extern int controllerFanSpeed;
+#endif
 extern int autoFanSpeeds[HOTENDS];
 
 #if ENABLED(BARICUDA)

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -39,7 +39,6 @@
 #include "types.h"
 #include "fastio.h"
 #include "utility.h"
-#include "power.h"
 
 
 #ifdef USBCON
@@ -123,35 +122,35 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 #endif
 
 #if HAS_X2_ENABLE
-  #define  enable_x() do{ powerManager.power_on(); X_ENABLE_WRITE( X_ENABLE_ON); X2_ENABLE_WRITE( X_ENABLE_ON); }while(0)
+  #define  enable_x() do{ X_ENABLE_WRITE( X_ENABLE_ON); X2_ENABLE_WRITE( X_ENABLE_ON); }while(0)
   #define disable_x() do{ X_ENABLE_WRITE(!X_ENABLE_ON); X2_ENABLE_WRITE(!X_ENABLE_ON); axis_known_position[X_AXIS] = false; }while(0)
 #elif HAS_X_ENABLE
-  #define  enable_x() do{ powerManager.power_on(); X_ENABLE_WRITE( X_ENABLE_ON); }while(0)
+  #define  enable_x() X_ENABLE_WRITE( X_ENABLE_ON)
   #define disable_x() do{ X_ENABLE_WRITE(!X_ENABLE_ON); axis_known_position[X_AXIS] = false; }while(0)
 #else
-  #define  enable_x() powerManager.power_on()
+  #define  enable_x() NOOP
   #define disable_x() NOOP
 #endif
 
 #if HAS_Y2_ENABLE
-  #define  enable_y() do{ powerManager.power_on(); Y_ENABLE_WRITE( Y_ENABLE_ON); Y2_ENABLE_WRITE(Y_ENABLE_ON); }while(0)
+  #define  enable_y() do{ Y_ENABLE_WRITE( Y_ENABLE_ON); Y2_ENABLE_WRITE(Y_ENABLE_ON); }while(0)
   #define disable_y() do{ Y_ENABLE_WRITE(!Y_ENABLE_ON); Y2_ENABLE_WRITE(!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }while(0)
 #elif HAS_Y_ENABLE
-  #define  enable_y() do{ powerManager.power_on(); Y_ENABLE_WRITE( Y_ENABLE_ON); }while(0)
+  #define  enable_y() Y_ENABLE_WRITE( Y_ENABLE_ON)
   #define disable_y() do{ Y_ENABLE_WRITE(!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }while(0)
 #else
-  #define  enable_y() powerManager.power_on()
+  #define  enable_y() NOOP
   #define disable_y() NOOP
 #endif
 
 #if HAS_Z2_ENABLE
-  #define  enable_z() do{ powerManager.power_on(); Z_ENABLE_WRITE( Z_ENABLE_ON); Z2_ENABLE_WRITE(Z_ENABLE_ON); }while(0)
+  #define  enable_z() do{ Z_ENABLE_WRITE( Z_ENABLE_ON); Z2_ENABLE_WRITE(Z_ENABLE_ON); }while(0)
   #define disable_z() do{ Z_ENABLE_WRITE(!Z_ENABLE_ON); Z2_ENABLE_WRITE(!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }while(0)
 #elif HAS_Z_ENABLE
-  #define  enable_z() do{ powerManager.power_on(); Z_ENABLE_WRITE( Z_ENABLE_ON); }while(0)
+  #define  enable_z() Z_ENABLE_WRITE( Z_ENABLE_ON)
   #define disable_z() do{ Z_ENABLE_WRITE(!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }while(0)
 #else
-  #define  enable_z() powerManager.power_on()
+  #define  enable_z() NOOP
   #define disable_z() NOOP
 #endif
 
@@ -161,53 +160,53 @@ void manage_inactivity(bool ignore_stepper_queue = false);
    * Mixing steppers synchronize their enable (and direction) together
    */
   #if MIXING_STEPPERS > 3
-    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); E3_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); E3_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); E2_ENABLE_WRITE(!E_ENABLE_ON); E3_ENABLE_WRITE(!E_ENABLE_ON); }
   #elif MIXING_STEPPERS > 2
-    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); E2_ENABLE_WRITE(!E_ENABLE_ON); }
   #else
-    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); }
   #endif
-  #define  enable_e1() powerManager.power_on()
+  #define  enable_e1() NOOP
   #define disable_e1() NOOP
-  #define  enable_e2() powerManager.power_on()
+  #define  enable_e2() NOOP
   #define disable_e2() NOOP
-  #define  enable_e3() powerManager.power_on()
+  #define  enable_e3() NOOP
   #define disable_e3() NOOP
 
 #else // !MIXING_EXTRUDER
 
   #if HAS_E0_ENABLE
-    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() E0_ENABLE_WRITE( E_ENABLE_ON)
     #define disable_e0() E0_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e0() powerManager.power_on()
+    #define  enable_e0() NOOP
     #define disable_e0() NOOP
   #endif
 
   #if E_STEPPERS > 1 && HAS_E1_ENABLE
-    #define  enable_e1() { powerManager.power_on() E1_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e1() E1_ENABLE_WRITE( E_ENABLE_ON)
     #define disable_e1() E1_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e1() powerManager.power_on()
+    #define  enable_e1() NOOP
     #define disable_e1() NOOP
   #endif
 
   #if E_STEPPERS > 2 && HAS_E2_ENABLE
-    #define  enable_e2() { powerManager.power_on(); E2_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e2() E2_ENABLE_WRITE( E_ENABLE_ON)
     #define disable_e2() E2_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e2() powerManager.power_on()
+    #define  enable_e2() NOOP
     #define disable_e2() NOOP
   #endif
 
   #if E_STEPPERS > 3 && HAS_E3_ENABLE
-    #define  enable_e3() { powerManager.power_on(); E3_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e3() E3_ENABLE_WRITE( E_ENABLE_ON)
     #define disable_e3() E3_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e3() powerManager.power_on()
+    #define  enable_e3() NOOP
     #define disable_e3() NOOP
   #endif
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -39,6 +39,7 @@
 #include "types.h"
 #include "fastio.h"
 #include "utility.h"
+#include "power.h"
 
 
 #ifdef USBCON
@@ -122,35 +123,35 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 #endif
 
 #if HAS_X2_ENABLE
-  #define  enable_x() do{ X_ENABLE_WRITE( X_ENABLE_ON); X2_ENABLE_WRITE( X_ENABLE_ON); }while(0)
+  #define  enable_x() do{ powerManager.power_on(); X_ENABLE_WRITE( X_ENABLE_ON); X2_ENABLE_WRITE( X_ENABLE_ON); }while(0)
   #define disable_x() do{ X_ENABLE_WRITE(!X_ENABLE_ON); X2_ENABLE_WRITE(!X_ENABLE_ON); axis_known_position[X_AXIS] = false; }while(0)
 #elif HAS_X_ENABLE
-  #define  enable_x() X_ENABLE_WRITE( X_ENABLE_ON)
+  #define  enable_x() do{ powerManager.power_on(); X_ENABLE_WRITE( X_ENABLE_ON); }while(0)
   #define disable_x() do{ X_ENABLE_WRITE(!X_ENABLE_ON); axis_known_position[X_AXIS] = false; }while(0)
 #else
-  #define  enable_x() NOOP
+  #define  enable_x() powerManager.power_on()
   #define disable_x() NOOP
 #endif
 
 #if HAS_Y2_ENABLE
-  #define  enable_y() do{ Y_ENABLE_WRITE( Y_ENABLE_ON); Y2_ENABLE_WRITE(Y_ENABLE_ON); }while(0)
+  #define  enable_y() do{ powerManager.power_on(); Y_ENABLE_WRITE( Y_ENABLE_ON); Y2_ENABLE_WRITE(Y_ENABLE_ON); }while(0)
   #define disable_y() do{ Y_ENABLE_WRITE(!Y_ENABLE_ON); Y2_ENABLE_WRITE(!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }while(0)
 #elif HAS_Y_ENABLE
-  #define  enable_y() Y_ENABLE_WRITE( Y_ENABLE_ON)
+  #define  enable_y() do{ powerManager.power_on(); Y_ENABLE_WRITE( Y_ENABLE_ON); }while(0)
   #define disable_y() do{ Y_ENABLE_WRITE(!Y_ENABLE_ON); axis_known_position[Y_AXIS] = false; }while(0)
 #else
-  #define  enable_y() NOOP
+  #define  enable_y() powerManager.power_on()
   #define disable_y() NOOP
 #endif
 
 #if HAS_Z2_ENABLE
-  #define  enable_z() do{ Z_ENABLE_WRITE( Z_ENABLE_ON); Z2_ENABLE_WRITE(Z_ENABLE_ON); }while(0)
+  #define  enable_z() do{ powerManager.power_on(); Z_ENABLE_WRITE( Z_ENABLE_ON); Z2_ENABLE_WRITE(Z_ENABLE_ON); }while(0)
   #define disable_z() do{ Z_ENABLE_WRITE(!Z_ENABLE_ON); Z2_ENABLE_WRITE(!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }while(0)
 #elif HAS_Z_ENABLE
-  #define  enable_z() Z_ENABLE_WRITE( Z_ENABLE_ON)
+  #define  enable_z() do{ powerManager.power_on(); Z_ENABLE_WRITE( Z_ENABLE_ON); }while(0)
   #define disable_z() do{ Z_ENABLE_WRITE(!Z_ENABLE_ON); axis_known_position[Z_AXIS] = false; }while(0)
 #else
-  #define  enable_z() NOOP
+  #define  enable_z() powerManager.power_on()
   #define disable_z() NOOP
 #endif
 
@@ -160,53 +161,53 @@ void manage_inactivity(bool ignore_stepper_queue = false);
    * Mixing steppers synchronize their enable (and direction) together
    */
   #if MIXING_STEPPERS > 3
-    #define  enable_e0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); E3_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); E3_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); E2_ENABLE_WRITE(!E_ENABLE_ON); E3_ENABLE_WRITE(!E_ENABLE_ON); }
   #elif MIXING_STEPPERS > 2
-    #define  enable_e0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); E2_ENABLE_WRITE(!E_ENABLE_ON); }
   #else
-    #define  enable_e0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); }
+    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); }
   #endif
-  #define  enable_e1() NOOP
+  #define  enable_e1() powerManager.power_on()
   #define disable_e1() NOOP
-  #define  enable_e2() NOOP
+  #define  enable_e2() powerManager.power_on()
   #define disable_e2() NOOP
-  #define  enable_e3() NOOP
+  #define  enable_e3() powerManager.power_on()
   #define disable_e3() NOOP
 
 #else // !MIXING_EXTRUDER
 
   #if HAS_E0_ENABLE
-    #define  enable_e0() E0_ENABLE_WRITE( E_ENABLE_ON)
+    #define  enable_e0() { powerManager.power_on(); E0_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e0() E0_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e0() NOOP
+    #define  enable_e0() powerManager.power_on()
     #define disable_e0() NOOP
   #endif
 
   #if E_STEPPERS > 1 && HAS_E1_ENABLE
-    #define  enable_e1() E1_ENABLE_WRITE( E_ENABLE_ON)
+    #define  enable_e1() { powerManager.power_on() E1_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e1() E1_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e1() NOOP
+    #define  enable_e1() powerManager.power_on()
     #define disable_e1() NOOP
   #endif
 
   #if E_STEPPERS > 2 && HAS_E2_ENABLE
-    #define  enable_e2() E2_ENABLE_WRITE( E_ENABLE_ON)
+    #define  enable_e2() { powerManager.power_on(); E2_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e2() E2_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e2() NOOP
+    #define  enable_e2() powerManager.power_on()
     #define disable_e2() NOOP
   #endif
 
   #if E_STEPPERS > 3 && HAS_E3_ENABLE
-    #define  enable_e3() E3_ENABLE_WRITE( E_ENABLE_ON)
+    #define  enable_e3() { powerManager.power_on(); E3_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_e3() E3_ENABLE_WRITE(!E_ENABLE_ON)
   #else
-    #define  enable_e3() NOOP
+    #define  enable_e3() powerManager.power_on()
     #define disable_e3() NOOP
   #endif
 
@@ -369,6 +370,9 @@ float code_value_temp_diff();
 #if FAN_COUNT > 0
   extern int fanSpeeds[FAN_COUNT];
 #endif
+
+extern int controllerFanSpeed;
+extern int autoFanSpeeds[HOTENDS];
 
 #if ENABLED(BARICUDA)
   extern int baricuda_valve_pressure;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10117,6 +10117,9 @@ void calculate_volumetric_multipliers() {
 }
 
 void enable_all_steppers() {
+#if ENABLED(AUTO_POWER_CONTROL)
+  powerManager.power_on();
+#endif
   enable_x();
   enable_y();
   enable_z();

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -70,6 +70,10 @@
   #include "mesh_bed_leveling.h"
 #endif
 
+# if ENABLED(AUTO_POWER_CONTROL)
+  #include "power.h"
+#endif
+
 Planner planner;
 
   // public:
@@ -834,6 +838,11 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
   block->active_extruder = extruder;
 
+  #if ENABLED(AUTO_POWER_CONTROL)
+    if (block->steps[X_AXIS] || block->steps[Y_AXIS] || block->steps[Z_AXIS])
+        powerManager.power_on();
+  #endif
+
   //enable active axes
   #if CORE_IS_XY
     if (block->steps[A_AXIS] || block->steps[B_AXIS]) {
@@ -865,6 +874,9 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
   // Enable extruder(s)
   if (esteps) {
+    #if ENABLED(AUTO_POWER_CONTROL)
+      powerManager.power_on();
+    #endif
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER) // Enable only the selected extruder
 

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -92,7 +92,6 @@ void Power::check() {
         nextPowerCheck = ms + 2500UL;
 
         if (this->is_power_needed()) {
-            this->lastPowerOn = ms;
             this->power_on();
         } else {
             if (!this->lastPowerOn || ELAPSED(ms, this->lastPowerOn + (POWER_TIMEOUT) * 1000UL)) this->power_off();

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -24,10 +24,11 @@
  * power.cpp - temperature control
  */
 
-#include "power.h"
 #include "temperature.h"
 #include "stepper_indirection.h"
-#include "Marlin.h"
+#include "power.h"
+
+millis_t Power::lastPowerOn;
 
 bool Power::is_power_needed() {
 #if ENABLED(FAN_NEEDS_POWER)
@@ -85,17 +86,16 @@ bool Power::is_power_needed() {
 
 void Power::check() {
 #if (POWER_SUPPLY > 0) && ENABLED(AUTO_POWER_CONTROL)
-    static millis_t lastPowerOn = 0;
     static millis_t nextPowerCheck = 0;
     millis_t ms = millis();
     if (ELAPSED(ms, nextPowerCheck)) {
         nextPowerCheck = ms + 2500UL;
 
         if (this->is_power_needed()) {
-            lastPowerOn = ms;
+            this->lastPowerOn = ms;
             this->power_on();
         } else {
-            if (!lastPowerOn || ELAPSED(ms, lastPowerOn + (POWER_TIMEOUT) * 1000UL)) this->power_off();
+            if (!this->lastPowerOn || ELAPSED(ms, this->lastPowerOn + (POWER_TIMEOUT) * 1000UL)) this->power_off();
         }
     }
 #endif
@@ -103,6 +103,7 @@ void Power::check() {
 
 void Power::power_on() {
 #if (POWER_SUPPLY > 0)
+    this->lastPowerOn = millis();
     OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE);
 #endif
 }

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -84,7 +84,7 @@ bool Power::is_power_needed() {
 }
 
 void Power::check() {
-#if (POWER_SUPPLY > 0)
+#if (POWER_SUPPLY > 0) && ENABLED(AUTO_POWER_CONTROL)
     static millis_t lastPowerOn = 0;
     static millis_t nextPowerCheck = 0;
     millis_t ms = millis();

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -1,0 +1,88 @@
+//
+// Created by christopher on 20.02.17.
+//
+
+#include "power.h"
+#include "temperature.h"
+#include "stepper_indirection.h"
+#include "Marlin.h"
+#include "MarlinConfig.h"
+#include "ultralcd.h"
+
+void Power::check() {
+  bool powerNeeded = false;
+  static millis_t lastPowerOn = 0;
+  static millis_t nextPowerCheck = 0;
+  millis_t ms = millis();
+  if (ELAPSED(ms, nextPowerCheck)) {
+    nextPowerCheck = ms + 2500UL;
+
+#if ENABLED(FAN_NEEDS_POWER)
+    for (uint8_t i = 0; i < FAN_COUNT; i++) {
+      if (fanSpeeds[i] > 0) {
+        powerNeeded = true;
+      }
+    }
+#endif
+
+#if ENABLED(AUTO_FAN_NEEDS_POWER)
+    for (uint8_t i = 0; i < HOTENDS; i++) {
+      if (autoFanSpeeds[i] > 0) {
+        powerNeeded = true;
+      }
+    }
+#endif
+
+#if ENABLED(CONTROLLERFAN_NEEDS_POWER)
+    if (controllerFanSpeed > 0) {
+      powerNeeded = true;
+    }
+#endif
+
+    if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON ||
+        thermalManager.soft_pwm_bed > 0
+        || E0_ENABLE_READ == E_ENABLE_ON // If any of the drivers are enabled...
+#if E_STEPPERS > 1
+      || E1_ENABLE_READ == E_ENABLE_ON
+#if HAS_X2_ENABLE
+              || X2_ENABLE_READ == X_ENABLE_ON
+#endif
+#if E_STEPPERS > 2
+              || E2_ENABLE_READ == E_ENABLE_ON
+#if E_STEPPERS > 3
+                || E3_ENABLE_READ == E_ENABLE_ON
+#endif
+#endif
+#endif
+            ) {
+      powerNeeded = true;
+    }
+
+    for (uint8_t i = 0; i < HOTENDS; i++) {
+      if (thermalManager.target_temperature[i] > 0) {
+        powerNeeded = true;
+      }
+    }
+
+    if (thermalManager.target_temperature_bed > 0) {
+      powerNeeded = true;
+    }
+
+    if (powerNeeded) {
+      lastPowerOn = ms;
+      this->power_on();
+    } else {
+      if (!lastPowerOn || ELAPSED(ms, lastPowerOn + (POWER_TIMEOUT) * 1000UL)) this->power_off();
+    }
+  }
+}
+
+void Power::power_on() {
+  OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE);
+}
+
+void Power::power_off() {
+  OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+}
+
+

--- a/Marlin/power.h
+++ b/Marlin/power.h
@@ -1,6 +1,28 @@
-//
-// Created by christopher on 20.02.17.
-//
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * power.h - power control
+ */
 
 #ifndef POWER_H
 #define POWER_H
@@ -10,6 +32,8 @@ public:
     void check();
     void power_on();
     void power_off();
+private:
+    bool is_power_needed();
 };
 
 extern Power powerManager;

--- a/Marlin/power.h
+++ b/Marlin/power.h
@@ -1,0 +1,16 @@
+//
+// Created by christopher on 20.02.17.
+//
+
+#ifndef POWER_H
+#define POWER_H
+
+class Power {
+public:
+    void check();
+    void power_on();
+    void power_off();
+};
+
+extern Power powerManager;
+#endif //POWER_H

--- a/Marlin/power.h
+++ b/Marlin/power.h
@@ -27,12 +27,15 @@
 #ifndef POWER_H
 #define POWER_H
 
+#include "Marlin.h"
+
 class Power {
 public:
     void check();
     void power_on();
     void power_off();
 private:
+    static millis_t lastPowerOn;
     bool is_power_needed();
 };
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -479,6 +479,7 @@ int Temperature::getHeaterPower(int heater) {
       int8_t pin = fanPin[f];
       if (pin >= 0 && !TEST(fanDone, fanBit[f])) {
         uint8_t newFanSpeed = TEST(fanState, fanBit[f]) ? EXTRUDER_AUTO_FAN_SPEED : 0;
+        autoFanSpeeds[f] = newFanSpeed;
         // this idiom allows both digital and PWM fan outputs (see M42 handling).
         digitalWrite(pin, newFanSpeed);
         analogWrite(pin, newFanSpeed);

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -29,6 +29,7 @@
 
 #include "planner.h"
 #include "thermistortables.h"
+#include "power.h"
 
 #include "MarlinConfig.h"
 
@@ -324,6 +325,9 @@ class Temperature {
         else if (target_temperature[HOTEND_INDEX] == 0.0f)
           start_preheat_time(HOTEND_INDEX);
       #endif
+      #if ENABLED(AUTO_POWER_CONTROL)
+        powerManager.power_on();
+      #endif
       target_temperature[HOTEND_INDEX] = celsius;
       #if ENABLED(THERMAL_PROTECTION_HOTENDS) && WATCH_TEMP_PERIOD > 0
         start_watching_heater(HOTEND_INDEX);
@@ -331,6 +335,9 @@ class Temperature {
     }
 
     static void setTargetBed(const float& celsius) {
+      #if ENABLED(AUTO_POWER_CONTROL)
+        powerManager.power_on();
+      #endif
       target_temperature_bed = celsius;
       #if ENABLED(THERMAL_PROTECTION_BED) && WATCH_BED_TEMP_PERIOD > 0
         start_watching_bed();


### PR DESCRIPTION
I use an ATX power supply for my printer and wanted it to only be powered on when there's actually a need for 12V. 

There's a new loop which checks for active steppers, active fans or active heaters.
Steppers are enabled instantly, to avoid missed steps.
Heaters and fans rely on the check() loop.

If nothing is left which needs 12V power PS_ON gets disabled after a predefined timeout.

Since this is my first contribution and I never developed for a microcontroller before I'm quite sure I did a lot wrong and there's a lot to improve.
