### PR TITLE
Double Click of Encoder Wheel Jumps to Z-BabyStepping

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1127,6 +1127,14 @@
 
 
 /**
+ * Double Clicking of LCD Panel's Encoder Wheel while at the Status Screen will jump
+ * to the Z-BabyStepping menu.
+ */
+//#define DOUBLE_CLICK_JUMPS_TO_Z_BABYSTEPPING
+#define DOUBLE_CLICK_TIME_WINDOW 1250   // How quickly the double click must be done.
+
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1131,7 +1131,10 @@
  * to the Z-BabyStepping menu.
  */
 //#define DOUBLE_CLICK_JUMPS_TO_Z_BABYSTEPPING
-#define DOUBLE_CLICK_TIME_WINDOW 1250   // How quickly the double click must be done.
+#define DOUBLE_CLICK_TIME_WINDOW 1250   // How quickly the double click must be done in miliseconds.
+                                        // Please notice this time must be a little bit longer than what
+                                        // is actually desired because there is some latency in detecting a
+                                        // change in LCD Panel Button Status.
 
 
 /**

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -49,6 +49,12 @@ int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2
   millis_t previous_lcd_status_ms = 0;
 #endif
 
+#if ENABLED(BABYSTEPPING)
+  long babysteps_done = 0;
+  millis_t status_screen_click_time = 0;
+  static void lcd_babystep_z();
+#endif
+
 uint8_t lcd_status_message_level;
 char lcd_status_message[3 * (LCD_WIDTH) + 1] = WELCOME_MSG; // worst case is kana with up to 3*LCD_WIDTH+1
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -417,21 +417,21 @@ uint16_t max_display_update_time = 0;
    * General function to go directly to a screen
    */
   void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0) {
-  #ifdef DOUBLE_CLICK_JUMPS_TO_Z_BABYSTEPPING
-  #if ENABLED(BABYSTEPPING)
-    if (currentScreen==lcd_status_screen && screen==lcd_main_menu)	// We are in leaving the status screen to goto the main_menu 
-      status_screen_click_time = millis();				// screen.  Mark the time so we know how quick the user is
-									// pressing buttons.
-    if (currentScreen==lcd_main_menu)  {
-      if ( screen==lcd_status_screen && status_screen_click_time+DOUBLE_CLICK_TIME_WINDOW>millis() ) {
-        lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
-        status_screen_click_time = 0;
-        lcd_babystep_z();
-        return;
-      }
-    }
-  #endif
-  #endif
+    #ifdef DOUBLE_CLICK_JUMPS_TO_Z_BABYSTEPPING
+      #if ENABLED(BABYSTEPPING) 
+        if (currentScreen==lcd_status_screen && screen==lcd_main_menu)  // We are in leaving the status screen to goto the main_menu  
+          status_screen_click_time = millis();       // screen.  Mark the time so we know how quick the user is 
+                     // pressing buttons. 
+        if (currentScreen==lcd_main_menu)  { 
+          if ( screen==lcd_status_screen && status_screen_click_time+DOUBLE_CLICK_TIME_WINDOW>millis() ) { 
+            lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; 
+            status_screen_click_time = 0; 
+            lcd_babystep_z(); 
+          return; 
+          } 
+        } 
+      #endif 
+    #endif 
     if (currentScreen != screen) {
       currentScreen = screen;
       encoderPosition = encoder;


### PR DESCRIPTION
This change to ultralcd.cpp allows quick and easy access to the Z-BabyStepping via a double click of the LCD Panel's Encoder Wheel.     This is very helpful when starting a print and trying to get the first layer to adhere properly.

I have a fair amount of test time on this change within the UBL branch.   But once we get a little more test time on it in RCBugFix it may be worth while to broaden its scope.   Instead of jumping to Z-BabyStepping, it maybe possible the user wants to use a double click to do a G28 to home the printer or to do a PLA Bed Preheat.  With a simple change, we can use the double click to invoke what ever important function the user wants.

But...   First, we should get some test time on the change!

Incidentally...  The LCD Panel screens used to time out after 15 seconds and revert back to the status screen.   The Z-BabyStep screen used to go back to Status if nothing is changed for 15 seconds.  That no longer happens.   Something has changed in the LCD code that is keeping that from happening.   But this change is independent of all that.  You can terminate the Z-BabyStepping with a single click.
