### PR TITLE
Correction made to pins_RIGIDBOARD.h file to enable the speaker when using smart controllers

### DIFF
--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -125,7 +125,7 @@
 #elif ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
 
   #undef BEEPER_PIN
-  #define BEEPER_PIN -1
+  #define BEEPER_PIN 37
 
   #undef  SD_DETECT_PIN
   #define SD_DETECT_PIN 22


### PR DESCRIPTION
Changed the pin# for the speaker from disabled (-1) to pin 37 to enable use of the built in speaker when using the `REPRAP_DISCOUNT_SMART_CONTROLLER` derivatives instead of the proprietary Rigidbot_panel controller.

Arduino equivalent pin D37 is what has been recommended for sometime in the Rigidbot wiki entry for installing these displays. http://rigidtalk.com/wiki/index.php?title=LCD_Smart_Controller

Tested and working on both my Rigidbots for several months with RC8