### PR TITLE
LIN_ADVANCE: Add option to fix E/D ratio

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -589,6 +589,30 @@
 
 #if ENABLED(LIN_ADVANCE)
   #define LIN_ADVANCE_K 75
+  
+  /**
+   * Some Slicers produce gcode with randomly jumping extrusion widths from time to time, for example within one perimeter of 0.4mm a single segment of 0.05mm width.
+   * While this is harmless for normal printing (the fluid nature of the filament will close this very, very tiny gap), it will screw up the LIN_ADVANCE pressure adaption.
+   * 
+   * In this case, you can use LIN_ADVANCE_E_D_RATIO to lock the ratio between extrusion length and distance traveled to a fixed value.
+   * Note that using a fixed ratio will lead to wrong nozzle pressures if your slicer is using variable widths or layer heights within one print!
+   * This is only the default value after printer power on, it can be overwritten in start-gcode using for example "M905 W0.4 H0.2 D1.75" where:
+   * - W is the extrusion width in mm
+   * - H is the layer height in mm
+   * - D is the filament diameter in mm
+   * 
+   * See Marlin documentation for start-gcode examples.
+   * 0 means auto-detect ratio based on given gcode G1 print moves.
+   * 
+   * Slicers known to work with auto-detection, including variable gap fill or layer height feature (0):
+   * Slic3r
+   * Prusa Slic3r
+   * 
+   * Slicers known to produce faulty gcode in the meaning of LIN_ADVANCE, therefore needing a fixed ratio:
+   * Cura
+   */
+  #define LIN_ADVANCE_E_D_RATIO 0 // Enter your calculated ratio (or 0) here according to the folmula W * H / ((D / 2)^2 * PI)
+                                  // For example 0.4 * 0.2 / ((1.75 / 2)^2 * PI) = 0.033260135
 #endif
 
 // @section leveling

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7601,7 +7601,41 @@ inline void gcode_M503() {
    */
   inline void gcode_M905() {
     stepper.synchronize();
-    planner.advance_M905(code_seen('K') ? code_value_float() : -1.0);
+    
+    float newD = -1;
+    float newW = -1;
+    float newH = -1;
+    
+    if (code_seen('K')) {
+      float newK = code_value_float();
+      if (newK >= 0.0)
+        planner.set_extruder_advance_k(newK);
+    }
+
+    SERIAL_ECHO_START;
+    SERIAL_ECHOPAIR("Advance factor: ", planner.get_extruder_advance_k());
+    SERIAL_EOL;
+    
+    if (code_seen('D'))
+      newD = code_value_float();
+    if (code_seen('W'))
+      newW = code_value_float();
+    if (code_seen('H'))
+      newH = code_value_float();
+
+    if (newD > 0 && newW > 0 && newH > 0) {
+      float E_D_ratio = newW * newH / (sq(newD / 2) * M_PI);
+      planner.set_E_D_ratio(E_D_ratio);
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPAIR("E/D ratio: ", E_D_ratio);
+      SERIAL_EOL;
+    }
+    else if (newD != -1 || newW != -1 || newH != -1) {
+      planner.set_E_D_ratio(0);
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPGM("E/D ratio: Automatic");
+      SERIAL_EOL;
+    }
   }
 #endif
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -210,6 +210,7 @@ class Planner {
     #if ENABLED(LIN_ADVANCE)
       static float position_float[NUM_AXIS];
       static float extruder_advance_k;
+      static float E_D_ratio;
     #endif
 
     #if ENABLED(ULTRA_LCD)
@@ -266,7 +267,9 @@ class Planner {
     #endif
 
     #if ENABLED(LIN_ADVANCE)
-      void advance_M905(const float &k);
+      static void set_extruder_advance_k(const float &k) { extruder_advance_k = k; };
+      static float get_extruder_advance_k() { return extruder_advance_k; };
+      static void set_E_D_ratio(const float &ratio) { E_D_ratio = ratio; };
     #endif
 
     /**


### PR DESCRIPTION
This is a small modification to `LIN_ADVANCE` to have a work around for slicers producing buggy gcode as noticed in #5699.
This PR can be merged after:
- Confirmation that the description given in Configuration_adv.h is understandable.
- Modification from Configuration_adv.h is copied to ever printer configuration (after finishing the point above).
- @psavva has confirmed it is not longer crashing at reasonable print speeds.

After this is merged I have to add some lines to the Marlin documentation.