### PR TITLE
Fix formatting of SD print time hours above one day

### DIFF
--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -150,7 +150,7 @@ struct duration_t {
              m = uint16_t(this->minute() % 60UL);
     if (with_days) {
       uint16_t d = this->day();
-      sprintf_P(buffer, PSTR("%ud %02u:%02u"), d, h, m);
+      sprintf_P(buffer, PSTR("%ud %02u:%02u"), d, h % 24, m);
       return d >= 10 ? 8 : 7;
     }
     else if (h < 100) {


### PR DESCRIPTION
Fixes time strings when the SD print job is over one full day.
Currently you get something like 2d 49:00.
This changes it so that you'd instead see 2d 01:00.