### PR TITLE
Clean up and finish #5887

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1128,17 +1128,12 @@
  */
 //#define EXTENDED_CAPABILITIES_REPORT
 
-
 /**
- * Double Clicking of LCD Panel's Encoder Wheel while at the Status Screen will jump
- * to the Z-BabyStepping menu.
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
  */
-//#define DOUBLE_CLICK_JUMPS_TO_Z_BABYSTEPPING
-#define DOUBLE_CLICK_TIME_WINDOW 1250   // How quickly the double click must be done in miliseconds.
-                                        // Please notice this time must be a little bit longer than what
-                                        // is actually desired because there is some latency in detecting a
-                                        // change in LCD Panel Button Status.
-
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
 
 /**
  * Volumetric extrusion default state

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -1109,6 +1109,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -1139,6 +1139,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -1134,6 +1134,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -1128,6 +1128,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -1128,6 +1128,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -1133,6 +1133,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -1128,6 +1128,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -1126,6 +1126,13 @@
 //#define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Double-click the Encoder button on the Status Screen for Z Babystepping.
+ */
+//#define DOUBLECLICK_FOR_Z_BABYSTEPPING
+#define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.
+                                        // Note: You may need to add extra time to mitigate controller latency.
+
+/**
  * Volumetric extrusion default state
  * Activate to make volumetric extrusion the default method,
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.


### PR DESCRIPTION
- Shorten configuration option names
- Use `ENABLED` macro for the option
- Apply new options to all configurations
- Simplify implementation, use `PENDING` macro for reliability
- Apply coding standards (see Wiki)