### PR TITLE
Fix submenu hotend status display

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -634,7 +634,7 @@ static void lcd_implementation_status_screen() {
 
       u8g.setPrintPos(LCD_PIXEL_WIDTH - 11 * (DOG_CHAR_WIDTH), row_y2);
       lcd_print('E');
-      lcd_print((char)('0' + active_extruder));
+      lcd_print((char)('1' + active_extruder));
       lcd_print(' ');
       lcd_print(itostr3(thermalManager.degHotend(active_extruder)));
       lcd_print('/');

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -807,7 +807,7 @@ static void lcd_implementation_status_screen() {
     static void lcd_implementation_hotend_status(const uint8_t row) {
       if (row < LCD_HEIGHT) {
         lcd.setCursor(LCD_WIDTH - 9, row);
-        lcd.print(LCD_STR_THERMOMETER[active_extruder]);
+        lcd.print(LCD_STR_THERMOMETER[0]);
         lcd.print(itostr3(thermalManager.degHotend(active_extruder)));
         lcd.print('/');
         lcd.print(itostr3(thermalManager.degTargetHotend(active_extruder)));


### PR DESCRIPTION
The first hotend was displaying as "E0" instead of "E1".
On character displays the thermometer wasn't displayed correctly for `active_extruder` > 0.

Reference: https://github.com/MarlinFirmware/Marlin/pull/5948#issuecomment-284123003