### PR TITLE
Display a message for EEPROM version mismatch

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -458,13 +458,16 @@ void Config_Postprocess() {
     uint16_t stored_checksum;
     EEPROM_READ(stored_checksum);
 
-    //  SERIAL_ECHOPAIR("Version: [", version);
-    //  SERIAL_ECHOPAIR("] Stored version: [", stored_ver);
-    //  SERIAL_CHAR(']');
-    //  SERIAL_EOL;
-
     // Version has to match or defaults are used
     if (strncmp(version, stored_ver, 3) != 0) {
+      if (stored_ver[0] != 'V') {
+        stored_ver[0] = '?';
+        stored_ver[1] = '\0';
+      }
+      SERIAL_ECHO_START;
+      SERIAL_ECHOPGM("EEPROM version mismatch ");
+      SERIAL_ECHOPAIR("(EEPROM=", stored_ver);
+      SERIAL_ECHOLNPGM(" Marlin=" EEPROM_VERSION ")");
       Config_ResetDefault();
     }
     else {


### PR DESCRIPTION
When the EEPROM needs to be initialized or updated after upgrading Marlin, the only message given is "Hardcoded Default Settings Loaded," and this is often overlooked. This PR adds an error message for version mismatch, to give a more visible indication that the EEPROM settings are not being loaded, and giving the reason why.

Based on suggestion #5903.