### PR TITLE
Add delta_tower_angle_trim

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -630,7 +630,7 @@
   #endif
 
   /**
-   * Delta radius/rod trimmers
+   * Delta radius/rod trimmers/angle trimmers
    */
   #if ENABLED(DELTA)
     #ifndef DELTA_RADIUS_TRIM_TOWER_1
@@ -650,6 +650,15 @@
     #endif
     #ifndef DELTA_DIAGONAL_ROD_TRIM_TOWER_3
       #define DELTA_DIAGONAL_ROD_TRIM_TOWER_3 0.0
+    #endif
+    #ifndef DELTA_TOWER_ANGLE_TRIM_1
+      #define DELTA_TOWER_ANGLE_TRIM_1 0.0
+    #endif
+    #ifndef DELTA_TOWER_ANGLE_TRIM_2
+      #define DELTA_TOWER_ANGLE_TRIM_2 0.0
+    #endif
+    #ifndef DELTA_TOWER_ANGLE_TRIM_3
+      #define DELTA_TOWER_ANGLE_TRIM_3 0.0
     #endif
   #endif
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -332,12 +332,8 @@ float code_value_temp_diff();
                delta_radius,
                delta_diagonal_rod,
                delta_segments_per_second,
-               delta_diagonal_rod_trim_tower_1,
-               delta_diagonal_rod_trim_tower_2,
-               delta_diagonal_rod_trim_tower_3,
-               delta_tower_angle_trim_1,
-               delta_tower_angle_trim_2,
-               delta_tower_angle_trim_3,
+               delta_diagonal_rod_trim[ABC],
+               delta_tower_angle_trim[ABC],
                delta_clip_start_height;
   void recalc_delta_settings(float radius, float diagonal_rod);
 #elif IS_SCARA

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -335,6 +335,9 @@ float code_value_temp_diff();
                delta_diagonal_rod_trim_tower_1,
                delta_diagonal_rod_trim_tower_2,
                delta_diagonal_rod_trim_tower_3,
+               delta_tower_angle_trim_1,
+               delta_tower_angle_trim_2,
+               delta_tower_angle_trim_3,
                delta_clip_start_height;
   void recalc_delta_settings(float radius, float diagonal_rod);
 #elif IS_SCARA

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -564,12 +564,15 @@ static uint8_t target_extruder;
 
   // these are the default values, can be overriden with M665
   float delta_radius = DELTA_RADIUS,
-        delta_tower1_x = -SIN_60 * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
-        delta_tower1_y = -COS_60 * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
-        delta_tower2_x =  SIN_60 * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
-        delta_tower2_y = -COS_60 * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
-        delta_tower3_x = 0,                                                    // back middle tower
-        delta_tower3_y = (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
+        delta_tower_angle_trim_1 = DELTA_TOWER_ANGLE_TRIM_1,
+        delta_tower_angle_trim_2 = DELTA_TOWER_ANGLE_TRIM_2,
+        delta_tower_angle_trim_3 = DELTA_TOWER_ANGLE_TRIM_3,
+        delta_tower1_x = -sin( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
+        delta_tower1_y = -cos( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
+        delta_tower2_x =  sin( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
+        delta_tower2_y = -cos( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
+        delta_tower3_x = -sin( (     delta_tower_angle_trim_3) * PI/180),                                                    // back middle tower
+        delta_tower3_y =  cos( (     delta_tower_angle_trim_3) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
         delta_diagonal_rod = DELTA_DIAGONAL_ROD,
         delta_diagonal_rod_trim_tower_1 = DELTA_DIAGONAL_ROD_TRIM_TOWER_1,
         delta_diagonal_rod_trim_tower_2 = DELTA_DIAGONAL_ROD_TRIM_TOWER_2,
@@ -6337,6 +6340,9 @@ inline void gcode_M205() {
     if (code_seen('A')) delta_diagonal_rod_trim_tower_1 = code_value_linear_units();
     if (code_seen('B')) delta_diagonal_rod_trim_tower_2 = code_value_linear_units();
     if (code_seen('C')) delta_diagonal_rod_trim_tower_3 = code_value_linear_units();
+    if (code_seen('I')) delta_tower_angle_trim_1 = code_value_linear_units();
+    if (code_seen('J')) delta_tower_angle_trim_2 = code_value_linear_units();
+    if (code_seen('K')) delta_tower_angle_trim_3 = code_value_linear_units();
     recalc_delta_settings(delta_radius, delta_diagonal_rod);
   }
   /**
@@ -9140,12 +9146,12 @@ void ok_to_send() {
    * settings have been changed (e.g., by M665).
    */
   void recalc_delta_settings(float radius, float diagonal_rod) {
-    delta_tower1_x = -SIN_60 * (radius + DELTA_RADIUS_TRIM_TOWER_1);  // front left tower
-    delta_tower1_y = -COS_60 * (radius + DELTA_RADIUS_TRIM_TOWER_1);
-    delta_tower2_x =  SIN_60 * (radius + DELTA_RADIUS_TRIM_TOWER_2);  // front right tower
-    delta_tower2_y = -COS_60 * (radius + DELTA_RADIUS_TRIM_TOWER_2);
-    delta_tower3_x = 0.0;                                             // back middle tower
-    delta_tower3_y = (radius + DELTA_RADIUS_TRIM_TOWER_3);
+    delta_tower1_x = -sin( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
+    delta_tower1_y = -cos( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
+    delta_tower2_x =  sin( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
+    delta_tower2_y = -cos( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
+    delta_tower3_x = -sin( (     delta_tower_angle_trim_3) * PI/180),                                              // back middle tower
+    delta_tower3_y =  cos( (     delta_tower_angle_trim_3) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
     delta_diagonal_rod_2_tower_1 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_1);
     delta_diagonal_rod_2_tower_2 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_2);
     delta_diagonal_rod_2_tower_3 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_3);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -185,7 +185,7 @@
  * M503 - Print the current settings (in memory): "M503 S<verbose>". S0 specifies compact output.
  * M540 - Enable/disable SD card abort on endstop hit: "M540 S<state>". (Requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
  * M600 - Pause for filament change: "M600 X<pos> Y<pos> Z<raise> E<first_retract> L<later_retract>". (Requires FILAMENT_CHANGE_FEATURE)
- * M665 - Set delta configurations: "M665 L<diagonal rod> R<delta radius> S<segments/s>" (Requires DELTA)
+ * M665 - Set delta configurations: "M665 L<diagonal rod> R<delta radius> S<segments/s> A<rod A trim mm> B<rod B trim mm> C<rod C trim mm> I<tower A trim angle> J<tower B trim angle> K<tower C trim angle>" (Requires DELTA)
  * M666 - Set delta endstop adjustment. (Requires DELTA)
  * M605 - Set dual x-carriage movement mode: "M605 S<mode> [X<x_offset>] [R<temp_offset>]". (Requires DUAL_X_CARRIAGE)
  * M851 - Set Z probe's Z offset in current units. (Negative = below the nozzle.)
@@ -556,9 +556,6 @@ static uint8_t target_extruder;
 
 #if ENABLED(DELTA)
 
-  #define SIN_60 0.8660254037844386
-  #define COS_60 0.5
-
   float delta[ABC],
         endstop_adj[ABC] = { 0 };
 
@@ -567,12 +564,12 @@ static uint8_t target_extruder;
         delta_tower_angle_trim_1 = DELTA_TOWER_ANGLE_TRIM_1,
         delta_tower_angle_trim_2 = DELTA_TOWER_ANGLE_TRIM_2,
         delta_tower_angle_trim_3 = DELTA_TOWER_ANGLE_TRIM_3,
-        delta_tower1_x = -sin( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
-        delta_tower1_y = -cos( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
-        delta_tower2_x =  sin( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
-        delta_tower2_y = -cos( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
-        delta_tower3_x = -sin( (     delta_tower_angle_trim_3) * PI/180),                                                    // back middle tower
-        delta_tower3_y =  cos( (     delta_tower_angle_trim_3) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
+        delta_tower1_x = -sin(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
+        delta_tower1_y = -cos(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
+        delta_tower2_x =  sin(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
+        delta_tower2_y = -cos(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
+        delta_tower3_x = -sin(RADIANS(     delta_tower_angle_trim_3)),                                                    // back middle tower
+        delta_tower3_y =  cos(RADIANS(     delta_tower_angle_trim_3)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
         delta_diagonal_rod = DELTA_DIAGONAL_ROD,
         delta_diagonal_rod_trim_tower_1 = DELTA_DIAGONAL_ROD_TRIM_TOWER_1,
         delta_diagonal_rod_trim_tower_2 = DELTA_DIAGONAL_ROD_TRIM_TOWER_2,
@@ -9146,12 +9143,12 @@ void ok_to_send() {
    * settings have been changed (e.g., by M665).
    */
   void recalc_delta_settings(float radius, float diagonal_rod) {
-    delta_tower1_x = -sin( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
-    delta_tower1_y = -cos( (60 - delta_tower_angle_trim_1) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
-    delta_tower2_x =  sin( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
-    delta_tower2_y = -cos( (60 + delta_tower_angle_trim_2) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
-    delta_tower3_x = -sin( (     delta_tower_angle_trim_3) * PI/180),                                              // back middle tower
-    delta_tower3_y =  cos( (     delta_tower_angle_trim_3) * PI/180) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
+    delta_tower1_x = -sin(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
+    delta_tower1_y = -cos(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
+    delta_tower2_x =  sin(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
+    delta_tower2_y = -cos(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
+    delta_tower3_x = -sin(RADIANS(     delta_tower_angle_trim_3)),                                              // back middle tower
+    delta_tower3_y =  cos(RADIANS(     delta_tower_angle_trim_3)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
     delta_diagonal_rod_2_tower_1 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_1);
     delta_diagonal_rod_2_tower_2 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_2);
     delta_diagonal_rod_2_tower_3 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_3);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -559,25 +559,15 @@ static uint8_t target_extruder;
   float delta[ABC],
         endstop_adj[ABC] = { 0 };
 
-  // these are the default values, can be overriden with M665
-  float delta_radius = DELTA_RADIUS,
-        delta_tower_angle_trim_1 = DELTA_TOWER_ANGLE_TRIM_1,
-        delta_tower_angle_trim_2 = DELTA_TOWER_ANGLE_TRIM_2,
-        delta_tower_angle_trim_3 = DELTA_TOWER_ANGLE_TRIM_3,
-        delta_tower1_x = -sin(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
-        delta_tower1_y = -cos(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
-        delta_tower2_x =  sin(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
-        delta_tower2_y = -cos(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
-        delta_tower3_x = -sin(RADIANS(     delta_tower_angle_trim_3)),                                                    // back middle tower
-        delta_tower3_y =  cos(RADIANS(     delta_tower_angle_trim_3)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
-        delta_diagonal_rod = DELTA_DIAGONAL_ROD,
-        delta_diagonal_rod_trim_tower_1 = DELTA_DIAGONAL_ROD_TRIM_TOWER_1,
-        delta_diagonal_rod_trim_tower_2 = DELTA_DIAGONAL_ROD_TRIM_TOWER_2,
-        delta_diagonal_rod_trim_tower_3 = DELTA_DIAGONAL_ROD_TRIM_TOWER_3,
-        delta_diagonal_rod_2_tower_1 = sq(delta_diagonal_rod + delta_diagonal_rod_trim_tower_1),
-        delta_diagonal_rod_2_tower_2 = sq(delta_diagonal_rod + delta_diagonal_rod_trim_tower_2),
-        delta_diagonal_rod_2_tower_3 = sq(delta_diagonal_rod + delta_diagonal_rod_trim_tower_3),
-        delta_segments_per_second = DELTA_SEGMENTS_PER_SECOND,
+  // These values are loaded or reset at boot time when setup() calls
+  // Config_RetrieveSettings(), which calls recalc_delta_settings().
+  float delta_radius,
+        delta_tower_angle_trim[ABC],
+        delta_tower[ABC][2],
+        delta_diagonal_rod,
+        delta_diagonal_rod_trim[ABC],
+        delta_diagonal_rod_2_tower[ABC],
+        delta_segments_per_second,
         delta_clip_start_height = Z_MAX_POS;
 
   float delta_safe_distance_from_top();
@@ -6334,12 +6324,12 @@ inline void gcode_M205() {
     if (code_seen('L')) delta_diagonal_rod = code_value_linear_units();
     if (code_seen('R')) delta_radius = code_value_linear_units();
     if (code_seen('S')) delta_segments_per_second = code_value_float();
-    if (code_seen('A')) delta_diagonal_rod_trim_tower_1 = code_value_linear_units();
-    if (code_seen('B')) delta_diagonal_rod_trim_tower_2 = code_value_linear_units();
-    if (code_seen('C')) delta_diagonal_rod_trim_tower_3 = code_value_linear_units();
-    if (code_seen('I')) delta_tower_angle_trim_1 = code_value_linear_units();
-    if (code_seen('J')) delta_tower_angle_trim_2 = code_value_linear_units();
-    if (code_seen('K')) delta_tower_angle_trim_3 = code_value_linear_units();
+    if (code_seen('A')) delta_diagonal_rod_trim[A_AXIS] = code_value_linear_units();
+    if (code_seen('B')) delta_diagonal_rod_trim[B_AXIS] = code_value_linear_units();
+    if (code_seen('C')) delta_diagonal_rod_trim[C_AXIS] = code_value_linear_units();
+    if (code_seen('I')) delta_tower_angle_trim[A_AXIS] = code_value_linear_units();
+    if (code_seen('J')) delta_tower_angle_trim[B_AXIS] = code_value_linear_units();
+    if (code_seen('K')) delta_tower_angle_trim[C_AXIS] = code_value_linear_units();
     recalc_delta_settings(delta_radius, delta_diagonal_rod);
   }
   /**
@@ -9143,15 +9133,15 @@ void ok_to_send() {
    * settings have been changed (e.g., by M665).
    */
   void recalc_delta_settings(float radius, float diagonal_rod) {
-    delta_tower1_x = -sin(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
-    delta_tower1_y = -cos(RADIANS(60 - delta_tower_angle_trim_1)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
-    delta_tower2_x =  sin(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
-    delta_tower2_y = -cos(RADIANS(60 + delta_tower_angle_trim_2)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
-    delta_tower3_x = -sin(RADIANS(     delta_tower_angle_trim_3)),                                              // back middle tower
-    delta_tower3_y =  cos(RADIANS(     delta_tower_angle_trim_3)) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
-    delta_diagonal_rod_2_tower_1 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_1);
-    delta_diagonal_rod_2_tower_2 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_2);
-    delta_diagonal_rod_2_tower_3 = sq(diagonal_rod + delta_diagonal_rod_trim_tower_3);
+    delta_tower[A_AXIS][X_AXIS] = -sin(RADIANS(60 - delta_tower_angle_trim[A_AXIS])) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1), // front left tower
+    delta_tower[A_AXIS][Y_AXIS] = -cos(RADIANS(60 - delta_tower_angle_trim[A_AXIS])) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_1),
+    delta_tower[B_AXIS][X_AXIS] =  sin(RADIANS(60 + delta_tower_angle_trim[B_AXIS])) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2), // front right tower
+    delta_tower[B_AXIS][Y_AXIS] = -cos(RADIANS(60 + delta_tower_angle_trim[B_AXIS])) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_2),
+    delta_tower[C_AXIS][X_AXIS] = -sin(RADIANS(     delta_tower_angle_trim[C_AXIS])) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3), // back middle tower
+    delta_tower[C_AXIS][Y_AXIS] =  cos(RADIANS(     delta_tower_angle_trim[C_AXIS])) * (delta_radius + DELTA_RADIUS_TRIM_TOWER_3),
+    delta_diagonal_rod_2_tower[A_AXIS] = sq(diagonal_rod + delta_diagonal_rod_trim[A_AXIS]);
+    delta_diagonal_rod_2_tower[B_AXIS] = sq(diagonal_rod + delta_diagonal_rod_trim[B_AXIS]);
+    delta_diagonal_rod_2_tower[C_AXIS] = sq(diagonal_rod + delta_diagonal_rod_trim[C_AXIS]);
   }
 
   #if ENABLED(DELTA_FAST_SQRT)
@@ -9201,17 +9191,17 @@ void ok_to_send() {
    */
 
   // Macro to obtain the Z position of an individual tower
-  #define DELTA_Z(T) raw[Z_AXIS] + _SQRT(    \
-    delta_diagonal_rod_2_tower_##T - HYPOT2( \
-        delta_tower##T##_x - raw[X_AXIS],    \
-        delta_tower##T##_y - raw[Y_AXIS]     \
-      )                                      \
+  #define DELTA_Z(T) raw[Z_AXIS] + _SQRT(     \
+    delta_diagonal_rod_2_tower[T] - HYPOT2(   \
+        delta_tower[T][X_AXIS] - raw[X_AXIS], \
+        delta_tower[T][Y_AXIS] - raw[Y_AXIS]  \
+      )                                       \
     )
 
   #define DELTA_RAW_IK() do {   \
-    delta[A_AXIS] = DELTA_Z(1); \
-    delta[B_AXIS] = DELTA_Z(2); \
-    delta[C_AXIS] = DELTA_Z(3); \
+    delta[A_AXIS] = DELTA_Z(A_AXIS); \
+    delta[B_AXIS] = DELTA_Z(B_AXIS); \
+    delta[C_AXIS] = DELTA_Z(C_AXIS); \
   } while(0)
 
   #define DELTA_LOGICAL_IK() do {      \
@@ -9281,7 +9271,7 @@ void ok_to_send() {
    */
   void forward_kinematics_DELTA(float z1, float z2, float z3) {
     // Create a vector in old coordinates along x axis of new coordinate
-    float p12[3] = { delta_tower2_x - delta_tower1_x, delta_tower2_y - delta_tower1_y, z2 - z1 };
+    float p12[3] = { delta_tower[B_AXIS][X_AXIS] - delta_tower[A_AXIS][X_AXIS], delta_tower[B_AXIS][Y_AXIS] - delta_tower[A_AXIS][Y_AXIS], z2 - z1 };
 
     // Get the Magnitude of vector.
     float d = sqrt( sq(p12[0]) + sq(p12[1]) + sq(p12[2]) );
@@ -9290,7 +9280,7 @@ void ok_to_send() {
     float ex[3] = { p12[0] / d, p12[1] / d, p12[2] / d };
 
     // Get the vector from the origin of the new system to the third point.
-    float p13[3] = { delta_tower3_x - delta_tower1_x, delta_tower3_y - delta_tower1_y, z3 - z1 };
+    float p13[3] = { delta_tower[C_AXIS][X_AXIS] - delta_tower[A_AXIS][X_AXIS], delta_tower[C_AXIS][Y_AXIS] - delta_tower[A_AXIS][Y_AXIS], z3 - z1 };
 
     // Use the dot product to find the component of this vector on the X axis.
     float i = ex[0] * p13[0] + ex[1] * p13[1] + ex[2] * p13[2];
@@ -9318,15 +9308,15 @@ void ok_to_send() {
 
     // We now have the d, i and j values defined in Wikipedia.
     // Plug them into the equations defined in Wikipedia for Xnew, Ynew and Znew
-    float Xnew = (delta_diagonal_rod_2_tower_1 - delta_diagonal_rod_2_tower_2 + sq(d)) / (d * 2),
-          Ynew = ((delta_diagonal_rod_2_tower_1 - delta_diagonal_rod_2_tower_3 + HYPOT2(i, j)) / 2 - i * Xnew) / j,
-          Znew = sqrt(delta_diagonal_rod_2_tower_1 - HYPOT2(Xnew, Ynew));
+    float Xnew = (delta_diagonal_rod_2_tower[A_AXIS] - delta_diagonal_rod_2_tower[B_AXIS] + sq(d)) / (d * 2),
+          Ynew = ((delta_diagonal_rod_2_tower[A_AXIS] - delta_diagonal_rod_2_tower[C_AXIS] + HYPOT2(i, j)) / 2 - i * Xnew) / j,
+          Znew = sqrt(delta_diagonal_rod_2_tower[A_AXIS] - HYPOT2(Xnew, Ynew));
 
     // Start from the origin of the old coordinates and add vectors in the
     // old coords that represent the Xnew, Ynew and Znew to find the point
     // in the old system.
-    cartes[X_AXIS] = delta_tower1_x + ex[0] * Xnew + ey[0] * Ynew - ez[0] * Znew;
-    cartes[Y_AXIS] = delta_tower1_y + ex[1] * Xnew + ey[1] * Ynew - ez[1] * Znew;
+    cartes[X_AXIS] = delta_tower[A_AXIS][X_AXIS] + ex[0] * Xnew + ey[0] * Ynew - ez[0] * Znew;
+    cartes[Y_AXIS] = delta_tower[A_AXIS][Y_AXIS] + ex[1] * Xnew + ey[1] * Ynew - ez[1] * Znew;
     cartes[Z_AXIS] =             z1 + ex[2] * Xnew + ey[2] * Ynew - ez[2] * Znew;
   }
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -84,17 +84,17 @@
  *  308  G29 L F   bilinear_start                  (int x2)
  *  312            bed_level_grid[][]              (float x9, up to float x256) +988
  *
- * DELTA (if deltabot):                            48 bytes
- *  348  M666 XYZ  endstop_adj                     (float x3)
- *  360  M665 R    delta_radius                    (float)
- *  364  M665 L    delta_diagonal_rod              (float)
- *  368  M665 S    delta_segments_per_second       (float)
- *  372  M665 A    delta_diagonal_rod_trim_tower_1 (float)
- *  376  M665 B    delta_diagonal_rod_trim_tower_2 (float)
- *  380  M665 C    delta_diagonal_rod_trim_tower_3 (float)
- *  384  M665 I    delta_tower_angle_trim_1        (float)
- *  388  M665 J    delta_tower_angle_trim_2        (float)
- *  392  M665 K    delta_tower_angle_trim_3        (float)
+ * DELTA (if deltabot):                             48 bytes
+ *  348  M666 XYZ  endstop_adj                      (float x3)
+ *  360  M665 R    delta_radius                     (float)
+ *  364  M665 L    delta_diagonal_rod               (float)
+ *  368  M665 S    delta_segments_per_second        (float)
+ *  372  M665 A    delta_diagonal_rod_trim[A]       (float)
+ *  376  M665 B    delta_diagonal_rod_trim[B]       (float)
+ *  380  M665 C    delta_diagonal_rod_trim[C]       (float)
+ *  384  M665 I    delta_tower_angle_trim[A]        (float)
+ *  388  M665 J    delta_tower_angle_trim[B]        (float)
+ *  392  M665 K    delta_tower_angle_trim[C]        (float)
  *
  * Z_DUAL_ENDSTOPS (if not deltabot):              48 bytes
  *  348  M666 Z    z_endstop_adj                   (float)
@@ -357,14 +357,10 @@ void Config_Postprocess() {
       EEPROM_WRITE(delta_radius);              // 1 float
       EEPROM_WRITE(delta_diagonal_rod);        // 1 float
       EEPROM_WRITE(delta_segments_per_second); // 1 float
-      EEPROM_WRITE(delta_diagonal_rod_trim_tower_1);  // 1 float
-      EEPROM_WRITE(delta_diagonal_rod_trim_tower_2);  // 1 float
-      EEPROM_WRITE(delta_diagonal_rod_trim_tower_3);  // 1 float
-      EEPROM_WRITE(delta_tower_angle_trim_1); // 1 float
-      EEPROM_WRITE(delta_tower_angle_trim_2); // 1 float
-      EEPROM_WRITE(delta_tower_angle_trim_3); // 1 float
+      EEPROM_WRITE(delta_diagonal_rod_trim);   // 3 floats
+      EEPROM_WRITE(delta_tower_angle_trim);    // 3 floats
     #elif ENABLED(Z_DUAL_ENDSTOPS)
-      EEPROM_WRITE(z_endstop_adj);            // 1 float
+      EEPROM_WRITE(z_endstop_adj);             // 1 float
       dummy = 0.0f;
       for (uint8_t q = 11; q--;) EEPROM_WRITE(dummy);
     #else
@@ -681,16 +677,12 @@ void Config_Postprocess() {
         }
 
       #if ENABLED(DELTA)
-        EEPROM_READ(endstop_adj);                // 3 floats
-        EEPROM_READ(delta_radius);               // 1 float
-        EEPROM_READ(delta_diagonal_rod);         // 1 float
-        EEPROM_READ(delta_segments_per_second);  // 1 float
-        EEPROM_READ(delta_diagonal_rod_trim_tower_1);  // 1 float
-        EEPROM_READ(delta_diagonal_rod_trim_tower_2);  // 1 float
-        EEPROM_READ(delta_diagonal_rod_trim_tower_3);  // 1 float
-        EEPROM_READ(delta_tower_angle_trim_1); // 1 float
-        EEPROM_READ(delta_tower_angle_trim_2); // 1 float
-        EEPROM_READ(delta_tower_angle_trim_3); // 1 float
+        EEPROM_READ(endstop_adj);               // 3 floats
+        EEPROM_READ(delta_radius);              // 1 float
+        EEPROM_READ(delta_diagonal_rod);        // 1 float
+        EEPROM_READ(delta_segments_per_second); // 1 float
+        EEPROM_READ(delta_diagonal_rod_trim);   // 3 floats
+        EEPROM_READ(delta_tower_angle_trim);    // 3 floats
       #elif ENABLED(Z_DUAL_ENDSTOPS)
         EEPROM_READ(z_endstop_adj);
         dummy = 0.0f;
@@ -909,19 +901,15 @@ void Config_ResetDefault() {
   #endif
 
   #if ENABLED(DELTA)
-    const float adj[ABC] = DELTA_ENDSTOP_ADJ;
-    endstop_adj[A_AXIS] = adj[A_AXIS];
-    endstop_adj[B_AXIS] = adj[B_AXIS];
-    endstop_adj[C_AXIS] = adj[C_AXIS];
+    const float adj[ABC] = DELTA_ENDSTOP_ADJ,
+                drt[ABC] = { DELTA_DIAGONAL_ROD_TRIM_TOWER_1, DELTA_DIAGONAL_ROD_TRIM_TOWER_2, DELTA_DIAGONAL_ROD_TRIM_TOWER_3 },
+                dta[ABC] = { DELTA_TOWER_ANGLE_TRIM_1, DELTA_TOWER_ANGLE_TRIM_2, DELTA_TOWER_ANGLE_TRIM_3 };
+    COPY(endstop_adj, adj);
     delta_radius = DELTA_RADIUS;
     delta_diagonal_rod = DELTA_DIAGONAL_ROD;
     delta_segments_per_second = DELTA_SEGMENTS_PER_SECOND;
-    delta_diagonal_rod_trim_tower_1 = DELTA_DIAGONAL_ROD_TRIM_TOWER_1;
-    delta_diagonal_rod_trim_tower_2 = DELTA_DIAGONAL_ROD_TRIM_TOWER_2;
-    delta_diagonal_rod_trim_tower_3 = DELTA_DIAGONAL_ROD_TRIM_TOWER_3;
-    delta_tower_angle_trim_1 = DELTA_TOWER_ANGLE_TRIM_1;
-    delta_tower_angle_trim_2 = DELTA_TOWER_ANGLE_TRIM_2;
-    delta_tower_angle_trim_3 = DELTA_TOWER_ANGLE_TRIM_3;
+    COPY(delta_diagonal_rod_trim, drt);
+    COPY(delta_tower_angle_trim, dta);
   #elif ENABLED(Z_DUAL_ENDSTOPS)
     z_endstop_adj = 0;
   #endif
@@ -1198,12 +1186,12 @@ void Config_ResetDefault() {
       SERIAL_ECHOPAIR("  M665 L", delta_diagonal_rod);
       SERIAL_ECHOPAIR(" R", delta_radius);
       SERIAL_ECHOPAIR(" S", delta_segments_per_second);
-      SERIAL_ECHOPAIR(" A", delta_diagonal_rod_trim_tower_1);
-      SERIAL_ECHOPAIR(" B", delta_diagonal_rod_trim_tower_2);
-      SERIAL_ECHOPAIR(" C", delta_diagonal_rod_trim_tower_3);
-      SERIAL_ECHOPAIR(" I", delta_tower_angle_trim_1);
-      SERIAL_ECHOPAIR(" J", delta_tower_angle_trim_2);
-      SERIAL_ECHOPAIR(" K", delta_tower_angle_trim_3);
+      SERIAL_ECHOPAIR(" A", delta_diagonal_rod_trim[A_AXIS]);
+      SERIAL_ECHOPAIR(" B", delta_diagonal_rod_trim[B_AXIS]);
+      SERIAL_ECHOPAIR(" C", delta_diagonal_rod_trim[C_AXIS]);
+      SERIAL_ECHOPAIR(" I", delta_tower_angle_trim[A_AXIS]);
+      SERIAL_ECHOPAIR(" J", delta_tower_angle_trim[B_AXIS]);
+      SERIAL_ECHOPAIR(" K", delta_tower_angle_trim[C_AXIS]);
       SERIAL_EOL;
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       CONFIG_ECHO_START;

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,13 +36,13 @@
  *
  */
 
-#define EEPROM_VERSION "V30"
+#define EEPROM_VERSION "V31"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
 
 /**
- * V30 EEPROM Layout:
+ * V31 EEPROM Layout:
  *
  *  100  Version                                   (char x4)
  *  104  EEPROM Checksum                           (uint16_t)
@@ -96,55 +96,56 @@
  *  388  M665 J    delta_tower_angle_trim_2        (float)
  *  392  M665 K    delta_tower_angle_trim_3        (float)
  *
- * Z_DUAL_ENDSTOPS:                                4 bytes
- *  384  M666 Z    z_endstop_adj                   (float)
+ * Z_DUAL_ENDSTOPS (if not deltabot):              48 bytes
+ *  348  M666 Z    z_endstop_adj                   (float)
+ *  ---            dummy data                      (float x11)
  *
  * ULTIPANEL:                                      6 bytes
- *  388  M145 S0 H lcd_preheat_hotend_temp         (int x2)
- *  392  M145 S0 B lcd_preheat_bed_temp            (int x2)
- *  396  M145 S0 F lcd_preheat_fan_speed           (int x2)
+ *  396  M145 S0 H lcd_preheat_hotend_temp         (int x2)
+ *  400  M145 S0 B lcd_preheat_bed_temp            (int x2)
+ *  404  M145 S0 F lcd_preheat_fan_speed           (int x2)
  *
  * PIDTEMP:                                        66 bytes
- *  400  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]  (float x4)
- *  416  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]  (float x4)
- *  432  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]  (float x4)
- *  448  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]  (float x4)
- *  464  M301 L        lpq_len                     (int)
+ *  408  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]  (float x4)
+ *  424  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]  (float x4)
+ *  440  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]  (float x4)
+ *  456  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]  (float x4)
+ *  472  M301 L        lpq_len                     (int)
  *
- * PIDTEMPBED:
- *  466  M304 PID  thermalManager.bedKp, thermalManager.bedKi, thermalManager.bedKd (float x3)
+ * PIDTEMPBED:                                      12 bytes
+ *  474  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
  *
  * DOGLCD:                                          2 bytes
- *  478  M250 C    lcd_contrast                     (int)
+ *  486  M250 C    lcd_contrast                     (int)
  *
  * FWRETRACT:                                       29 bytes
- *  480  M209 S    autoretract_enabled              (bool)
- *  481  M207 S    retract_length                   (float)
- *  485  M207 W    retract_length_swap              (float)
- *  489  M207 F    retract_feedrate_mm_s            (float)
- *  493  M207 Z    retract_zlift                    (float)
- *  497  M208 S    retract_recover_length           (float)
- *  501  M208 W    retract_recover_length_swap      (float)
- *  505  M208 F    retract_recover_feedrate_mm_s    (float)
+ *  488  M209 S    autoretract_enabled              (bool)
+ *  489  M207 S    retract_length                   (float)
+ *  493  M207 W    retract_length_swap              (float)
+ *  497  M207 F    retract_feedrate_mm_s            (float)
+ *  501  M207 Z    retract_zlift                    (float)
+ *  505  M208 S    retract_recover_length           (float)
+ *  509  M208 W    retract_recover_length_swap      (float)
+ *  513  M208 F    retract_recover_feedrate_mm_s    (float)
  *
  * Volumetric Extrusion:                            17 bytes
- *  509  M200 D    volumetric_enabled               (bool)
- *  510  M200 T D  filament_size                    (float x4) (T0..3)
+ *  517  M200 D    volumetric_enabled               (bool)
+ *  518  M200 T D  filament_size                    (float x4) (T0..3)
  *
- * TMC2130:                                         20 bytes
- *  526  M906 X    TMC2130  X-stepper current       (uint16_t)
- *  528  M906 Y    TMC2130  Y-stepper current       (uint16_t)
- *  530  M906 Z    TMC2130  Z-stepper current       (uint16_t)
- *  532  M906 X2   TMC2130 X2-stepper current       (uint16_t)
- *  534  M906 Y2   TMC2130 Y2-stepper current       (uint16_t)
- *  536  M906 Z2   TMC2130 Z2-stepper current       (uint16_t)
- *  538  M906 E0   TMC2130 E0-stepper current       (uint16_t)
- *  540  M906 E1   TMC2130 E1-stepper current       (uint16_t)
- *  542  M906 E2   TMC2130 E2-stepper current       (uint16_t)
- *  544  M906 E3   TMC2130 E3-stepper current       (uint16_t)
+ * TMC2130 Stepper Current:                         20 bytes
+ *  534  M906 X    stepperX current                 (uint16_t)
+ *  536  M906 Y    stepperY current                 (uint16_t)
+ *  538  M906 Z    stepperZ current                 (uint16_t)
+ *  540  M906 X2   stepperX2 current                (uint16_t)
+ *  542  M906 Y2   stepperY2 current                (uint16_t)
+ *  544  M906 Z2   stepperZ2 current                (uint16_t)
+ *  546  M906 E0   stepperE0 current                (uint16_t)
+ *  548  M906 E1   stepperE1 current                (uint16_t)
+ *  550  M906 E2   stepperE2 current                (uint16_t)
+ *  552  M906 E3   stepperE3 current                (uint16_t)
  *
- *  546                                Minimum end-point
- * 1867 (546 + 36 + 9 + 288 + 988)     Maximum end-point
+ *  554                                Minimum end-point
+ * 1875 (554 + 36 + 9 + 288 + 988)     Maximum end-point
  *
  */
 #include "Marlin.h"
@@ -365,10 +366,10 @@ void Config_Postprocess() {
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       EEPROM_WRITE(z_endstop_adj);            // 1 float
       dummy = 0.0f;
-      for (uint8_t q = 8; q--;) EEPROM_WRITE(dummy);
+      for (uint8_t q = 11; q--;) EEPROM_WRITE(dummy);
     #else
       dummy = 0.0f;
-      for (uint8_t q = 9; q--;) EEPROM_WRITE(dummy);
+      for (uint8_t q = 12; q--;) EEPROM_WRITE(dummy);
     #endif
 
     #if DISABLED(ULTIPANEL)
@@ -693,10 +694,10 @@ void Config_Postprocess() {
       #elif ENABLED(Z_DUAL_ENDSTOPS)
         EEPROM_READ(z_endstop_adj);
         dummy = 0.0f;
-        for (uint8_t q=8; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=11; q--;) EEPROM_READ(dummy);
       #else
         dummy = 0.0f;
-        for (uint8_t q=9; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=12; q--;) EEPROM_READ(dummy);
       #endif
 
       #if DISABLED(ULTIPANEL)
@@ -1191,7 +1192,7 @@ void Config_ResetDefault() {
       SERIAL_EOL;
       CONFIG_ECHO_START;
       if (!forReplay) {
-        SERIAL_ECHOLNPGM("Delta settings: L=diagonal_rod, R=radius, S=segments_per_second, ABC=diagonal_rod_trim_tower_[123], IJK=tower_angle_trim[123]");
+        SERIAL_ECHOLNPGM("Delta settings: L=diagonal rod, R=radius, S=segments-per-second, ABC=diagonal rod trim, IJK=tower angle trim");
         CONFIG_ECHO_START;
       }
       SERIAL_ECHOPAIR("  M665 L", delta_diagonal_rod);

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -84,7 +84,7 @@
  *  308  G29 L F   bilinear_start                  (int x2)
  *  312            bed_level_grid[][]              (float x9, up to float x256) +988
  *
- * DELTA (if deltabot):                            36 bytes
+ * DELTA (if deltabot):                            48 bytes
  *  348  M666 XYZ  endstop_adj                     (float x3)
  *  360  M665 R    delta_radius                    (float)
  *  364  M665 L    delta_diagonal_rod              (float)
@@ -92,6 +92,9 @@
  *  372  M665 A    delta_diagonal_rod_trim_tower_1 (float)
  *  376  M665 B    delta_diagonal_rod_trim_tower_2 (float)
  *  380  M665 C    delta_diagonal_rod_trim_tower_3 (float)
+ *  384  M665 I    delta_tower_angle_trim_1        (float)
+ *  388  M665 J    delta_tower_angle_trim_2        (float)
+ *  392  M665 K    delta_tower_angle_trim_3        (float)
  *
  * Z_DUAL_ENDSTOPS:                                4 bytes
  *  384  M666 Z    z_endstop_adj                   (float)
@@ -356,6 +359,9 @@ void Config_Postprocess() {
       EEPROM_WRITE(delta_diagonal_rod_trim_tower_1);  // 1 float
       EEPROM_WRITE(delta_diagonal_rod_trim_tower_2);  // 1 float
       EEPROM_WRITE(delta_diagonal_rod_trim_tower_3);  // 1 float
+      EEPROM_WRITE(delta_tower_angle_trim_1); // 1 float
+      EEPROM_WRITE(delta_tower_angle_trim_2); // 1 float
+      EEPROM_WRITE(delta_tower_angle_trim_3); // 1 float
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       EEPROM_WRITE(z_endstop_adj);            // 1 float
       dummy = 0.0f;
@@ -681,6 +687,9 @@ void Config_Postprocess() {
         EEPROM_READ(delta_diagonal_rod_trim_tower_1);  // 1 float
         EEPROM_READ(delta_diagonal_rod_trim_tower_2);  // 1 float
         EEPROM_READ(delta_diagonal_rod_trim_tower_3);  // 1 float
+        EEPROM_READ(delta_tower_angle_trim_1); // 1 float
+        EEPROM_READ(delta_tower_angle_trim_2); // 1 float
+        EEPROM_READ(delta_tower_angle_trim_3); // 1 float
       #elif ENABLED(Z_DUAL_ENDSTOPS)
         EEPROM_READ(z_endstop_adj);
         dummy = 0.0f;
@@ -909,6 +918,9 @@ void Config_ResetDefault() {
     delta_diagonal_rod_trim_tower_1 = DELTA_DIAGONAL_ROD_TRIM_TOWER_1;
     delta_diagonal_rod_trim_tower_2 = DELTA_DIAGONAL_ROD_TRIM_TOWER_2;
     delta_diagonal_rod_trim_tower_3 = DELTA_DIAGONAL_ROD_TRIM_TOWER_3;
+    delta_tower_angle_trim_1 = DELTA_TOWER_ANGLE_TRIM_1;
+    delta_tower_angle_trim_2 = DELTA_TOWER_ANGLE_TRIM_2;
+    delta_tower_angle_trim_3 = DELTA_TOWER_ANGLE_TRIM_3;
   #elif ENABLED(Z_DUAL_ENDSTOPS)
     z_endstop_adj = 0;
   #endif
@@ -1179,7 +1191,7 @@ void Config_ResetDefault() {
       SERIAL_EOL;
       CONFIG_ECHO_START;
       if (!forReplay) {
-        SERIAL_ECHOLNPGM("Delta settings: L=diagonal_rod, R=radius, S=segments_per_second, ABC=diagonal_rod_trim_tower_[123]");
+        SERIAL_ECHOLNPGM("Delta settings: L=diagonal_rod, R=radius, S=segments_per_second, ABC=diagonal_rod_trim_tower_[123], IJK=tower_angle_trim[123]");
         CONFIG_ECHO_START;
       }
       SERIAL_ECHOPAIR("  M665 L", delta_diagonal_rod);
@@ -1188,6 +1200,9 @@ void Config_ResetDefault() {
       SERIAL_ECHOPAIR(" A", delta_diagonal_rod_trim_tower_1);
       SERIAL_ECHOPAIR(" B", delta_diagonal_rod_trim_tower_2);
       SERIAL_ECHOPAIR(" C", delta_diagonal_rod_trim_tower_3);
+      SERIAL_ECHOPAIR(" I", delta_tower_angle_trim_1);
+      SERIAL_ECHOPAIR(" J", delta_tower_angle_trim_2);
+      SERIAL_ECHOPAIR(" K", delta_tower_angle_trim_3);
       SERIAL_EOL;
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       CONFIG_ECHO_START;


### PR DESCRIPTION
Rebase, squash, and patch of #5976

----
See issue #5914 
Added a parameter to correct for tower angle error on delta printers.
Tuning is done with the M665-code.

----
Additionally, this PR converts the delta live parameters to arrays.