### PR TITLE
Fix BUG set_position_mm

### DIFF
--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -348,13 +348,7 @@ class Planner {
     static void set_position_mm_kinematic(const float position[NUM_AXIS]);
     static void set_position_mm(const AxisEnum axis, const float &v);
     static FORCE_INLINE void set_z_position_mm(const float &z) { set_position_mm(Z_AXIS, z); }
-    static FORCE_INLINE void set_e_position_mm(const float &e) {
-      set_position_mm(AxisEnum(E_AXIS
-        #if ENABLED(DISTINCT_E_FACTORS)
-          + active_extruder
-        #endif
-      ), e);
-    }
+    static FORCE_INLINE void set_e_position_mm(const float &e) { set_position_mm(AxisEnum(E_AXIS), e); }
 
     /**
      * Sync from the stepper positions. (e.g., after an interrupted move)


### PR DESCRIPTION
Set postion must have E_AXIS and not E_AXIS + active_extruder.

set_position_mm have Axisenum axis for variable
If call it with E_AXIS + active_extruder axis could be 4 or 5 or 6 that are X_HEAD Y_HEAD or Z_HEAD. More in 'routine is position [axis] which is defined as an array NUM_AXIS, then axis can not be greater than 3.