### PR TITLE
Soft pwm enhancement

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1394,6 +1394,12 @@
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
 
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
+
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.
 // Otherwise the RED led is on. There is 1C hysteresis.

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1508,7 +1508,7 @@ void Temperature::isr() {
       static uint8_t state_heater_ ## n = 0; \
       static uint8_t state_timer_heater_ ## n = 0
   #else
-    #define ISR_STATICS(n) static uint8_t soft_pwm_ ## n
+    #define ISR_STATICS(n) static uint8_t soft_pwm_ ## n = 0
   #endif
 
   // Statics per heater
@@ -1531,43 +1531,56 @@ void Temperature::isr() {
   #endif
 
   #if DISABLED(SLOW_PWM_HEATERS)
+    #if ENABLED(SOFT_PWM_DITHER)
+      const uint8_t pwm_mask = _BV(SOFT_PWM_SCALE) - 1;
+    #else
+      const uint8_t pwm_mask = 0;
+    #endif
     /**
      * Standard PWM modulation
      */
     if (pwm_count >= 127) {
-      pwm_count = 0;
-      soft_pwm_0 = soft_pwm[0];
-      WRITE_HEATER_0(soft_pwm_0 > 0 ? HIGH : LOW);
+      pwm_count -= 127;
+      soft_pwm_0 &= pwm_mask;
+      soft_pwm_0 += soft_pwm[0];
+      WRITE_HEATER_0(soft_pwm_0 > pwm_mask ? HIGH : LOW);
       #if HOTENDS > 1
-        soft_pwm_1 = soft_pwm[1];
-        WRITE_HEATER_1(soft_pwm_1 > 0 ? HIGH : LOW);
+        soft_pwm_1 &= pwm_mask;
+        soft_pwm_1 += soft_pwm[1];
+        WRITE_HEATER_1(soft_pwm_1 > pwm_mask ? HIGH : LOW);
         #if HOTENDS > 2
-          soft_pwm_2 = soft_pwm[2];
-          WRITE_HEATER_2(soft_pwm_2 > 0 ? HIGH : LOW);
+          soft_pwm_2 &= pwm_mask;
+          soft_pwm_2 += soft_pwm[2];
+          WRITE_HEATER_2(soft_pwm_2 > pwm_mask ? HIGH : LOW);
           #if HOTENDS > 3
-            soft_pwm_3 = soft_pwm[3];
-            WRITE_HEATER_3(soft_pwm_3 > 0 ? HIGH : LOW);
+            soft_pwm_3 &= pwm_mask;
+            soft_pwm_3 += soft_pwm[3];
+            WRITE_HEATER_3(soft_pwm_3 > pwm_mask ? HIGH : LOW);
           #endif
         #endif
       #endif
 
       #if HAS_HEATER_BED
-        soft_pwm_BED = soft_pwm_bed;
-        WRITE_HEATER_BED(soft_pwm_BED > 0 ? HIGH : LOW);
+        soft_pwm_BED &= pwm_mask;
+        soft_pwm_BED += soft_pwm_bed;
+        WRITE_HEATER_BED(soft_pwm_BED > pwm_mask ? HIGH : LOW);
       #endif
 
       #if ENABLED(FAN_SOFT_PWM)
         #if HAS_FAN0
-          soft_pwm_fan[0] = fanSpeedSoftPwm[0] >> 1;
-          WRITE_FAN(soft_pwm_fan[0] > 0 ? HIGH : LOW);
+          soft_pwm_fan[0] &= pwm_mask;
+          soft_pwm_fan[0] += fanSpeedSoftPwm[0] >> 1;
+          WRITE_FAN(soft_pwm_fan[0] > pwm_mask ? HIGH : LOW);
         #endif
         #if HAS_FAN1
-          soft_pwm_fan[1] = fanSpeedSoftPwm[1] >> 1;
-          WRITE_FAN1(soft_pwm_fan[1] > 0 ? HIGH : LOW);
+          soft_pwm_fan[1] &= pwm_mask;
+          soft_pwm_fan[1] += fanSpeedSoftPwm[1] >> 1;
+          WRITE_FAN1(soft_pwm_fan[1] > pwm_mask ? HIGH : LOW);
         #endif
         #if HAS_FAN2
-          soft_pwm_fan[2] = fanSpeedSoftPwm[2] >> 1;
-          WRITE_FAN2(soft_pwm_fan[2] > 0 ? HIGH : LOW);
+          soft_pwm_fan[2] &= pwm_mask;
+          soft_pwm_fan[2] += fanSpeedSoftPwm[2] >> 1;
+          WRITE_FAN2(soft_pwm_fan[2] > pwm_mask ? HIGH : LOW);
         #endif
       #endif
     }

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1586,33 +1586,34 @@ void Temperature::isr() {
         #endif
       #endif
     }
-
-    if (soft_pwm_0 <= pwm_count_tmp) WRITE_HEATER_0(0);
-    #if HOTENDS > 1
-      if (soft_pwm_1 <= pwm_count_tmp) WRITE_HEATER_1(0);
+    else {
+      if (soft_pwm_0 <= pwm_count_tmp) WRITE_HEATER_0(0);
+      #if HOTENDS > 1
+        if (soft_pwm_1 <= pwm_count_tmp) WRITE_HEATER_1(0);
+      #endif
       #if HOTENDS > 2
         if (soft_pwm_2 <= pwm_count_tmp) WRITE_HEATER_2(0);
-        #if HOTENDS > 3
-          if (soft_pwm_3 <= pwm_count_tmp) WRITE_HEATER_3(0);
+      #endif
+      #if HOTENDS > 3
+        if (soft_pwm_3 <= pwm_count_tmp) WRITE_HEATER_3(0);
+      #endif
+
+      #if HAS_HEATER_BED
+        if (soft_pwm_BED <= pwm_count_tmp) WRITE_HEATER_BED(0);
+      #endif
+
+      #if ENABLED(FAN_SOFT_PWM)
+        #if HAS_FAN0
+          if (soft_pwm_fan[0] <= pwm_count_tmp) WRITE_FAN(0);
+        #endif
+        #if HAS_FAN1
+          if (soft_pwm_fan[1] <= pwm_count_tmp) WRITE_FAN1(0);
+        #endif
+        #if HAS_FAN2
+          if (soft_pwm_fan[2] <= pwm_count_tmp) WRITE_FAN2(0);
         #endif
       #endif
-    #endif
-
-    #if HAS_HEATER_BED
-      if (soft_pwm_BED <= pwm_count_tmp) WRITE_HEATER_BED(0);
-    #endif
-
-    #if ENABLED(FAN_SOFT_PWM)
-      #if HAS_FAN0
-        if (soft_pwm_fan[0] <= pwm_count_tmp) WRITE_FAN(0);
-      #endif
-      #if HAS_FAN1
-        if (soft_pwm_fan[1] <= pwm_count_tmp) WRITE_FAN1(0);
-      #endif
-      #if HAS_FAN2
-        if (soft_pwm_fan[2] <= pwm_count_tmp) WRITE_FAN2(0);
-      #endif
-    #endif
+    }
 
     // SOFT_PWM_SCALE to frequency:
     //

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1534,7 +1534,8 @@ void Temperature::isr() {
     /**
      * Standard PWM modulation
      */
-    if (pwm_count == 0) {
+    if (pwm_count >= 127) {
+      pwm_count = 0;
       soft_pwm_0 = soft_pwm[0];
       WRITE_HEATER_0(soft_pwm_0 > 0 ? HIGH : LOW);
       #if HOTENDS > 1
@@ -1571,30 +1572,30 @@ void Temperature::isr() {
       #endif
     }
 
-    if (soft_pwm_0 < pwm_count) WRITE_HEATER_0(0);
+    if (soft_pwm_0 <= pwm_count) WRITE_HEATER_0(0);
     #if HOTENDS > 1
-      if (soft_pwm_1 < pwm_count) WRITE_HEATER_1(0);
+      if (soft_pwm_1 <= pwm_count) WRITE_HEATER_1(0);
       #if HOTENDS > 2
-        if (soft_pwm_2 < pwm_count) WRITE_HEATER_2(0);
+        if (soft_pwm_2 <= pwm_count) WRITE_HEATER_2(0);
         #if HOTENDS > 3
-          if (soft_pwm_3 < pwm_count) WRITE_HEATER_3(0);
+          if (soft_pwm_3 <= pwm_count) WRITE_HEATER_3(0);
         #endif
       #endif
     #endif
 
     #if HAS_HEATER_BED
-      if (soft_pwm_BED < pwm_count) WRITE_HEATER_BED(0);
+      if (soft_pwm_BED <= pwm_count) WRITE_HEATER_BED(0);
     #endif
 
     #if ENABLED(FAN_SOFT_PWM)
       #if HAS_FAN0
-        if (soft_pwm_fan[0] < pwm_count) WRITE_FAN(0);
+        if (soft_pwm_fan[0] <= pwm_count) WRITE_FAN(0);
       #endif
       #if HAS_FAN1
-        if (soft_pwm_fan[1] < pwm_count) WRITE_FAN1(0);
+        if (soft_pwm_fan[1] <= pwm_count) WRITE_FAN1(0);
       #endif
       #if HAS_FAN2
-        if (soft_pwm_fan[2] < pwm_count) WRITE_FAN2(0);
+        if (soft_pwm_fan[2] <= pwm_count) WRITE_FAN2(0);
       #endif
     #endif
 
@@ -1607,7 +1608,6 @@ void Temperature::isr() {
     // 4:                /  8 = 122.0703 Hz
     // 5:                /  4 = 244.1406 Hz
     pwm_count += _BV(SOFT_PWM_SCALE);
-    pwm_count &= 0x7F;
 
   #else // SLOW_PWM_HEATERS
 
@@ -1681,7 +1681,8 @@ void Temperature::isr() {
     #endif
 
     #if ENABLED(FAN_SOFT_PWM)
-      if (pwm_count == 0) {
+      if (pwm_count >= 127) {
+        pwm_count = 0;
         #if HAS_FAN0
           soft_pwm_fan[0] = fanSpeedSoftPwm[0] >> 1;
           WRITE_FAN(soft_pwm_fan[0] > 0 ? HIGH : LOW);
@@ -1696,13 +1697,13 @@ void Temperature::isr() {
         #endif
       }
       #if HAS_FAN0
-        if (soft_pwm_fan[0] < pwm_count) WRITE_FAN(0);
+        if (soft_pwm_fan[0] <= pwm_count) WRITE_FAN(0);
       #endif
       #if HAS_FAN1
-        if (soft_pwm_fan[1] < pwm_count) WRITE_FAN1(0);
+        if (soft_pwm_fan[1] <= pwm_count) WRITE_FAN1(0);
       #endif
       #if HAS_FAN2
-        if (soft_pwm_fan[2] < pwm_count) WRITE_FAN2(0);
+        if (soft_pwm_fan[2] <= pwm_count) WRITE_FAN2(0);
       #endif
     #endif //FAN_SOFT_PWM
 
@@ -1715,10 +1716,10 @@ void Temperature::isr() {
     // 4:                /  8 = 122.0703 Hz
     // 5:                /  4 = 244.1406 Hz
     pwm_count += _BV(SOFT_PWM_SCALE);
-    pwm_count &= 0x7F;
 
-    // increment slow_pwm_count only every 64 pwm_count (e.g., every 8s)
-    if ((pwm_count % 64) == 0) {
+    // increment slow_pwm_count only every 64th pwm_count,
+    // i.e. yielding a PWM frequency of 16/128 Hz (8s).
+    if (((pwm_count >> SOFT_PWM_SCALE) % 64) == 0) {
       slow_pwm_count++;
       slow_pwm_count &= 0x7f;
 

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1499,6 +1499,8 @@ void Temperature::isr() {
   static uint8_t temp_count = 0;
   static TempState temp_state = StartupDelay;
   static uint8_t pwm_count = _BV(SOFT_PWM_SCALE);
+  /* avoid multiple loads of pwm_count */
+  uint8_t pwm_count_tmp = pwm_count;
 
   // Static members for each heater
   #if ENABLED(SLOW_PWM_HEATERS)
@@ -1539,8 +1541,8 @@ void Temperature::isr() {
     /**
      * Standard PWM modulation
      */
-    if (pwm_count >= 127) {
-      pwm_count -= 127;
+    if (pwm_count_tmp >= 127) {
+      pwm_count_tmp -= 127;
       soft_pwm_0 &= pwm_mask;
       soft_pwm_0 += soft_pwm[0];
       WRITE_HEATER_0(soft_pwm_0 > pwm_mask ? HIGH : LOW);
@@ -1585,30 +1587,30 @@ void Temperature::isr() {
       #endif
     }
 
-    if (soft_pwm_0 <= pwm_count) WRITE_HEATER_0(0);
+    if (soft_pwm_0 <= pwm_count_tmp) WRITE_HEATER_0(0);
     #if HOTENDS > 1
-      if (soft_pwm_1 <= pwm_count) WRITE_HEATER_1(0);
+      if (soft_pwm_1 <= pwm_count_tmp) WRITE_HEATER_1(0);
       #if HOTENDS > 2
-        if (soft_pwm_2 <= pwm_count) WRITE_HEATER_2(0);
+        if (soft_pwm_2 <= pwm_count_tmp) WRITE_HEATER_2(0);
         #if HOTENDS > 3
-          if (soft_pwm_3 <= pwm_count) WRITE_HEATER_3(0);
+          if (soft_pwm_3 <= pwm_count_tmp) WRITE_HEATER_3(0);
         #endif
       #endif
     #endif
 
     #if HAS_HEATER_BED
-      if (soft_pwm_BED <= pwm_count) WRITE_HEATER_BED(0);
+      if (soft_pwm_BED <= pwm_count_tmp) WRITE_HEATER_BED(0);
     #endif
 
     #if ENABLED(FAN_SOFT_PWM)
       #if HAS_FAN0
-        if (soft_pwm_fan[0] <= pwm_count) WRITE_FAN(0);
+        if (soft_pwm_fan[0] <= pwm_count_tmp) WRITE_FAN(0);
       #endif
       #if HAS_FAN1
-        if (soft_pwm_fan[1] <= pwm_count) WRITE_FAN1(0);
+        if (soft_pwm_fan[1] <= pwm_count_tmp) WRITE_FAN1(0);
       #endif
       #if HAS_FAN2
-        if (soft_pwm_fan[2] <= pwm_count) WRITE_FAN2(0);
+        if (soft_pwm_fan[2] <= pwm_count_tmp) WRITE_FAN2(0);
       #endif
     #endif
 
@@ -1620,7 +1622,7 @@ void Temperature::isr() {
     // 3:                / 16 =  61.0352 Hz
     // 4:                /  8 = 122.0703 Hz
     // 5:                /  4 = 244.1406 Hz
-    pwm_count += _BV(SOFT_PWM_SCALE);
+    pwm_count = pwm_count_tmp + _BV(SOFT_PWM_SCALE);
 
   #else // SLOW_PWM_HEATERS
 
@@ -1694,8 +1696,8 @@ void Temperature::isr() {
     #endif
 
     #if ENABLED(FAN_SOFT_PWM)
-      if (pwm_count >= 127) {
-        pwm_count = 0;
+      if (pwm_count_tmp >= 127) {
+        pwm_count_tmp = 0;
         #if HAS_FAN0
           soft_pwm_fan[0] = fanSpeedSoftPwm[0] >> 1;
           WRITE_FAN(soft_pwm_fan[0] > 0 ? HIGH : LOW);
@@ -1710,13 +1712,13 @@ void Temperature::isr() {
         #endif
       }
       #if HAS_FAN0
-        if (soft_pwm_fan[0] <= pwm_count) WRITE_FAN(0);
+        if (soft_pwm_fan[0] <= pwm_count_tmp) WRITE_FAN(0);
       #endif
       #if HAS_FAN1
-        if (soft_pwm_fan[1] <= pwm_count) WRITE_FAN1(0);
+        if (soft_pwm_fan[1] <= pwm_count_tmp) WRITE_FAN1(0);
       #endif
       #if HAS_FAN2
-        if (soft_pwm_fan[2] <= pwm_count) WRITE_FAN2(0);
+        if (soft_pwm_fan[2] <= pwm_count_tmp) WRITE_FAN2(0);
       #endif
     #endif //FAN_SOFT_PWM
 
@@ -1728,7 +1730,7 @@ void Temperature::isr() {
     // 3:                / 16 =  61.0352 Hz
     // 4:                /  8 = 122.0703 Hz
     // 5:                /  4 = 244.1406 Hz
-    pwm_count += _BV(SOFT_PWM_SCALE);
+    pwm_count = pwm_count_tmp + _BV(SOFT_PWM_SCALE);
 
     // increment slow_pwm_count only every 64th pwm_count,
     // i.e. yielding a PWM frequency of 16/128 Hz (8s).


### PR DESCRIPTION
Includes fix for #6003: For low duty cyles, the actual duty cycle is larger than wanted

Supersedes #5997
Dithering allows to mitigate the resolution loss caused by the scaling.
