### PR TITLE
'PENDING'->'ELAPSED' for CHDK

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9942,8 +9942,8 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     #endif
   }
 
-  #ifdef CHDK // Check if pin should be set to LOW after M240 set it to HIGH
-    if (chdkActive && PENDING(ms, chdkHigh + CHDK_DELAY)) {
+ #ifdef CHDK // Check if pin should be set to LOW after M240 set it to HIGH
+    if (chdkActive && ELAPSED(ms, chdkHigh + CHDK_DELAY)) {
       chdkActive = false;
       WRITE(CHDK, LOW);
     }


### PR DESCRIPTION
In the "Configuration_adv.h" the comment of the CHDK_DELAY says: 

`#define CHDK_DELAY 50 //How long in ms the pin should stay HIGH before going LOW again`

so I've changed the check from "PENDING" to "ELAPSED".

Thank you