### PR TITLE
Move Z last in tool-change for SWITCHING_EXTRUDER

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -848,7 +848,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1063,7 +1063,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -45,7 +45,7 @@
 #
 #   make ARDUINO_VERSION=10609 AVR_TOOLS_PATH=/root/arduino/hardware/tools/avr/bin/ \
 #   HARDWARE_MOTHERBOARD=33 ARDUINO_INSTALL_DIR=/root/arduino upload
-# 
+#
 # If uploading doesn't work try adding the parameter "AVRDUDE_PROGRAMMER=wiring" or
 # start upload manually (using stk500) like so:
 #
@@ -69,7 +69,7 @@ AVR_TOOLS_PATH ?=
 #Programmer configuration
 UPLOAD_RATE        ?= 57600
 AVRDUDE_PROGRAMMER ?= arduino
-# on most linuxes this will be /dev/ttyACM0 or /dev/ttyACM1 
+# on most linuxes this will be /dev/ttyACM0 or /dev/ttyACM1
 UPLOAD_PORT        ?= /dev/ttyUSB0
 
 #Directory used to build files in, contains all the build files, from object files to the final hex file

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7883,6 +7883,7 @@ inline void gcode_M999() {
   inline void move_extruder_servo(uint8_t e) {
     const int angles[2] = SWITCHING_EXTRUDER_SERVO_ANGLES;
     MOVE_SERVO(SWITCHING_EXTRUDER_SERVO_NR, angles[e]);
+    delay(500);
   }
 #endif
 
@@ -8029,25 +8030,15 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
           #if ENABLED(SWITCHING_EXTRUDER)
             // <0 if the new nozzle is higher, >0 if lower. A bigger raise when lower.
-            float z_diff = hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder],
-                  z_raise = 0.3 + (z_diff > 0.0 ? z_diff : 0.0);
+            const float z_diff = hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder],
+                        z_raise = 0.3 + (z_diff > 0.0 ? z_diff : 0.0);
 
             // Always raise by some amount (destination copied from current_position earlier)
-            float save_Z = destination[Z_AXIS];  // save Z for later on
-            destination[Z_AXIS] += z_raise;
-            planner.buffer_line_kinematic(destination, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
+            current_position[Z_AXIS] += z_raise;
+            planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
             stepper.synchronize();
 
             move_extruder_servo(active_extruder);
-            delay(500);
-
-            // Move back down, if needed
-            if (z_raise != z_diff) {
-              destination[Z_AXIS] = current_position[Z_AXIS] + z_diff;
-              planner.buffer_line_kinematic(destination, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
-              stepper.synchronize();
-            }
-            destination[Z_AXIS] = save_Z;  // restore original Z position so the 'Move to the "old position"' is correct
           #endif
 
           /**
@@ -8098,12 +8089,12 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             #endif
 
             // Adjustments to the current position
-            float xydiff[2] = { offset_vec.x, offset_vec.y };
+            const float xydiff[2] = { offset_vec.x, offset_vec.y };
             current_position[Z_AXIS] += offset_vec.z;
 
           #else // !ABL_PLANAR
 
-            float xydiff[2] = {
+            const float xydiff[2] = {
               hotend_offset[X_AXIS][tmp_extruder] - hotend_offset[X_AXIS][active_extruder],
               hotend_offset[Y_AXIS][tmp_extruder] - hotend_offset[Y_AXIS][active_extruder]
             };
@@ -8169,6 +8160,15 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #endif
           prepare_move_to_destination();
         }
+
+        #if ENABLED(SWITCHING_EXTRUDER)
+          // Move back down, if needed. (Including when the new tool is higher.)
+          if (z_raise != z_diff) {
+            destination[Z_AXIS] += z_diff;
+            feedrate_mm_s = planner.max_feedrate_mm_s[Z_AXIS];
+            prepare_move_to_destination();
+          }
+        #endif
 
       } // (tmp_extruder != active_extruder)
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -828,7 +828,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1043,7 +1043,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -858,7 +858,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1073,7 +1073,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -853,7 +853,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1068,7 +1068,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration_adv.h
@@ -850,7 +850,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1065,7 +1065,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -847,7 +847,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1062,7 +1062,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -847,7 +847,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1062,7 +1062,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -852,7 +852,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1067,7 +1067,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -847,7 +847,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1062,7 +1062,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -845,7 +845,7 @@
    * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
    * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
    * Adjusting starts from X/Y/Z/E_MAX_CURRENT but will not increase over AUTO_ADJUST_MAX
-   */ 
+   */
   //#define AUTOMATIC_CURRENT_CONTROL
   #define CURRENT_STEP          50  // [mA]
   #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
@@ -1060,7 +1060,7 @@
  * with DEFAULT_NOMINAL_FILAMENT_DIA as the default diameter.
  *
  * M200 D0 to disable, M200 Dn to set a new diameter.
- */ 
+ */
 //#define VOLUMETRIC_DEFAULT_ON
 
 /**

--- a/Marlin/pinsDebug_Teensyduino.h
+++ b/Marlin/pinsDebug_Teensyduino.h
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
- 
+
 //
 //  some of the pin mapping functions of the Teensduino extension to the Arduino IDE
 //  do not function the same as the other Arduino extensions

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -64,7 +64,7 @@
 
     mcp4728_setVref_all(DAC_STEPPER_VREF);
     mcp4728_setGain_all(DAC_STEPPER_GAIN);
-    
+
     if (mcp4728_getDrvPct(0) < 1 || mcp4728_getDrvPct(1) < 1 || mcp4728_getDrvPct(2) < 1 || mcp4728_getDrvPct(3) < 1 ) {
       mcp4728_setDrvPct(dac_channel_pct);
       mcp4728_eepromWrite();

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1491,7 +1491,7 @@ void Temperature::isr() {
   // at the end of its run, potentially causing re-entry. This flag prevents it.
   if (in_temp_isr) return;
   in_temp_isr = true;
-  
+
   // Allow UART and stepper ISRs
   CBI(TIMSK0, OCIE0B); //Disable Temperature ISR
   sei();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -428,7 +428,7 @@ uint16_t max_display_update_time = 0;
         }
         else if (screen == lcd_status_screen && currentScreen == lcd_main_menu && PENDING(millis(), doubleclick_expire_ms))
           screen = lcd_babystep_z;
-      #endif 
+      #endif
 
       currentScreen = screen;
       encoderPosition = encoder;


### PR DESCRIPTION
Moving Z back down last reduces the chance of a collision with the printed object. As a side-effect, it also corrects the problem of a bad Z position after tool-change with the `SWITCHING_EXTRUDER`. The code is altered to use `prepare_move_to_destination` so that `current_position` will also be updated by the move.

Reference: #6021