### PR TITLE
Retract head on pause resume feature add

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -759,6 +759,7 @@
   #define FILAMENT_CHANGE_NUMBER_OF_ALERT_BEEPS  5L  // Number of alert beeps before printer goes quiet
   #define FILAMENT_CHANGE_NO_STEPPER_TIMEOUT         // Enable to have stepper motors hold position during filament change
                                                      // even if it takes longer than DEFAULT_STEPPER_DEACTIVE_TIME.
+  #define RB_PAUSE_RESUME                       //Currently dependent on filament change feature
 #endif
 
 // @section tmc

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -608,11 +608,18 @@ void kill_screen(const char* lcd_msg) {
     void lcd_sdcard_pause() {
       card.pauseSDPrint();
       print_job_timer.pause();
+      #if ENABLED(RB_PAUSE_RESUME)
+        enqueue_and_echo_commands_P(PSTR("M125"));
+      #endif 
     }
 
     void lcd_sdcard_resume() {
-      card.startFileprint();
-      print_job_timer.start();
+      #if ENABLED(RB_PAUSE_RESUME)
+        enqueue_and_echo_commands_P(PSTR("M24"));
+      #else 
+        card.startFileprint();
+        print_job_timer.start();
+      #endif 
     }
 
     void lcd_sdcard_stop() {


### PR DESCRIPTION
The Rigidbot has a really nice feature that moves the head up and away from the part when pause is called. This prevents a big blob from forming on the print and enables the user to move the printer around while the printer is paused and still have the printer return where it left off on resume. There may still need to be a check in case the steppers turn off during the pause so that it homes xy before continuing...