### PR TITLE
User defined thermistor tables

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -248,7 +248,12 @@
  *   998 : Dummy Table that ALWAYS reads 25°C or the temperature defined below.
  *   999 : Dummy Table that ALWAYS reads 100°C or the temperature defined below.
  *
- * :{ '0': "Not used", '1':"100k / 4.7k - EPCOS", '2':"200k / 4.7k - ATC Semitec 204GT-2", '3':"Mendel-parts / 4.7k", '4':"10k !! do not use for a hotend. Bad resolution at high temp. !!", '5':"100K / 4.7k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '6':"100k / 4.7k EPCOS - Not as accurate as Table 1", '7':"100k / 4.7k Honeywell 135-104LAG-J01", '8':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT", '9':"100k / 4.7k GE Sensing AL03006-58.2K-97-G1", '10':"100k / 4.7k RS 198-961", '11':"100k / 4.7k beta 3950 1%", '12':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT (calibrated for Makibox hot bed)", '13':"100k Hisens 3950  1% up to 300°C for hotend 'Simple ONE ' & hotend 'All In ONE'", '20':"PT100 (Ultimainboard V2.x)", '51':"100k / 1k - EPCOS", '52':"200k / 1k - ATC Semitec 204GT-2", '55':"100k / 1k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '60':"100k Maker's Tool Works Kapton Bed Thermistor beta=3950", '66':"Dyze Design 4.7M High Temperature thermistor", '70':"the 100K thermistor found in the bq Hephestos 2", '71':"100k / 4.7k Honeywell 135-104LAF-J01", '147':"Pt100 / 4.7k", '1047':"Pt1000 / 4.7k", '110':"Pt100 / 1k (non-standard)", '1010':"Pt1000 / 1k (non standard)", '-3':"Thermocouple + MAX31855 (only for sensor 0)", '-2':"Thermocouple + MAX6675 (only for sensor 0)", '-1':"Thermocouple + AD595",'998':"Dummy 1", '999':"Dummy 2" }
+ *          User defined thermistor tables:
+ *  9997 : User defined thermistor table 0 defined in USER_THERMISTORTABLE0
+ *  9998 : User defined thermistor table 1 defined in USER_THERMISTORTABLE1
+ *  9999 : User defined thermistor table 2 defined in USER_THERMISTORTABLE2
+ *
+ * :{ '0': "Not used", '1':"100k / 4.7k - EPCOS", '2':"200k / 4.7k - ATC Semitec 204GT-2", '3':"Mendel-parts / 4.7k", '4':"10k !! do not use for a hotend. Bad resolution at high temp. !!", '5':"100K / 4.7k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '6':"100k / 4.7k EPCOS - Not as accurate as Table 1", '7':"100k / 4.7k Honeywell 135-104LAG-J01", '8':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT", '9':"100k / 4.7k GE Sensing AL03006-58.2K-97-G1", '10':"100k / 4.7k RS 198-961", '11':"100k / 4.7k beta 3950 1%", '12':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT (calibrated for Makibox hot bed)", '13':"100k Hisens 3950  1% up to 300°C for hotend 'Simple ONE ' & hotend 'All In ONE'", '20':"PT100 (Ultimainboard V2.x)", '51':"100k / 1k - EPCOS", '52':"200k / 1k - ATC Semitec 204GT-2", '55':"100k / 1k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '60':"100k Maker's Tool Works Kapton Bed Thermistor beta=3950", '66':"Dyze Design 4.7M High Temperature thermistor", '70':"the 100K thermistor found in the bq Hephestos 2", '71':"100k / 4.7k Honeywell 135-104LAF-J01", '147':"Pt100 / 4.7k", '1047':"Pt1000 / 4.7k", '110':"Pt100 / 1k (non-standard)", '1010':"Pt1000 / 1k (non standard)", '-3':"Thermocouple + MAX31855 (only for sensor 0)", '-2':"Thermocouple + MAX6675 (only for sensor 0)", '-1':"Thermocouple + AD595",'998':"Dummy 1", '999':"Dummy 2", '9997':"User 0"'9998':"User 1", '9999':"User 2" }
  */
 #define TEMP_SENSOR_0 1
 #define TEMP_SENSOR_1 0
@@ -259,6 +264,11 @@
 // Dummy thermistor constant temperature readings, for use with 998 and 999
 #define DUMMY_THERMISTOR_998_VALUE 25
 #define DUMMY_THERMISTOR_999_VALUE 100
+
+//User defined thermistor tables 9997, 9998 and 9999
+//#define USER_THERMISTORTABLE0 {}
+//#define USER_THERMISTORTABLE1 {}
+//#define USER_THERMISTORTABLE2 {}
 
 // Use temp sensor 1 as a redundant sensor with sensor 0. If the readings
 // from the two sensors differ too much the print will be aborted.

--- a/Marlin/thermistornames.h
+++ b/Marlin/thermistornames.h
@@ -94,4 +94,12 @@
 #elif THERMISTOR_ID == 999
   #define THERMISTOR_NAME "Dummy 2"
 
+//User defined thermistors
+#elif THERMISTOR_ID == 9997
+  #define THERMISTOR_NAME "User 0"
+#elif THERMISTOR_ID == 9998
+  #define THERMISTOR_NAME "User 1"
+#elif THERMISTOR_ID == 9999
+  #define THERMISTOR_NAME "User 2"
+
 #endif // THERMISTOR_ID

--- a/Marlin/thermistortable_9997.h
+++ b/Marlin/thermistortable_9997.h
@@ -1,0 +1,31 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// User-defined table 0.
+#ifndef USER_THERMISTORTABLE0
+  #error "Table must be defined using USER_THERMISTORTABLE0 in Configuration.h"
+#endif
+
+const short temptable_9997[][2] PROGMEM = USER_THERMISTORTABLE0 ;
+
+
+

--- a/Marlin/thermistortable_9998.h
+++ b/Marlin/thermistortable_9998.h
@@ -1,0 +1,31 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// User-defined table 1.
+#ifndef USER_THERMISTORTABLE1
+  #error "Table must be defined using USER_THERMISTORTABLE1 in Configuration.h"
+#endif
+
+const short temptable_9998[][2] PROGMEM = USER_THERMISTORTABLE1 ;
+
+
+

--- a/Marlin/thermistortable_9999.h
+++ b/Marlin/thermistortable_9999.h
@@ -1,0 +1,31 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// User-defined table 2.
+#ifndef USER_THERMISTORTABLE2
+  #error "Table must be defined using USER_THERMISTORTABLE2 in Configuration.h"
+#endif
+
+const short temptable_9999[][2] PROGMEM = USER_THERMISTORTABLE2 ;
+
+
+

--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -118,11 +118,20 @@
 #if ANY_THERMISTOR_IS(1047) // Pt1000 with 4k7 pullup
   #include "thermistortable_1047.h"
 #endif
-#if ANY_THERMISTOR_IS(998) // User-defined table 1
+#if ANY_THERMISTOR_IS(998) // Dummy table 1
   #include "thermistortable_998.h"
 #endif
-#if ANY_THERMISTOR_IS(999) // User-defined table 2
+#if ANY_THERMISTOR_IS(999) // Dummy table 2
   #include "thermistortable_999.h"
+#endif
+#if ANY_THERMISTOR_IS(9997) // User-defined table 0
+  #include "thermistortable_9997.h"
+#endif
+#if ANY_THERMISTOR_IS(9998) // User-defined table 1
+  #include "thermistortable_9998.h"
+#endif
+#if ANY_THERMISTOR_IS(9999) // User-defined table 2
+  #include "thermistortable_9999.h"
 #endif
 
 #define _TT_NAME(_N) temptable_ ## _N


### PR DESCRIPTION
Support for user defined thermistor tables.
There are 3 user tables (no. 9997, 9998 and 9999) and you may define them in Configuration.h using variables USER_THERMISTORTABLE0, USER_THERMISTORTABLE1 and USER_THERMISTORTABLE2.