### PR TITLE
reduce UBL RAM usage & another BLTouch retry location

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -883,7 +883,8 @@
     #define MBL_Z_STEP 0.025     // Step size while manually probing Z axis.
   #endif
 
-#endif // BED_LEVELING
+#endif  // BED_LEVELING
+
 
 /**
  * Commands to execute at the end of G29 probing.

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -113,6 +113,7 @@
    *   Y #  Y coordinate  Specify the starting location of the drawing activity.
    */
 
+  extern bool g26_Debug_flag;
   extern bool ubl_has_control_of_lcd_panel;
   extern float feedrate;
   //extern bool relative_mode;
@@ -173,12 +174,11 @@
 
   int8_t prime_flag = 0;
 
-  bool keep_heaters_on = false,
-       g26_debug_flag = false;
+  bool keep_heaters_on = false;
 
   /**
    * G26: Mesh Validation Pattern generation.
-   * 
+   *
    * Used to interactively edit UBL's Mesh by placing the
    * nozzle in a problem area and doing a G29 P4 R command.
    */
@@ -274,7 +274,7 @@
         xi = location.x_index;  // Just to shrink the next few lines and make them easier to understand
         yi = location.y_index;
 
-        if (g26_debug_flag) {
+        if (g26_Debug_flag) {
           SERIAL_ECHOPGM("   Doing circle at: (xi=");
           SERIAL_ECHO(xi);
           SERIAL_ECHOPGM(", yi=");
@@ -339,7 +339,7 @@
             ye = constrain(ye, Y_MIN_POS + 1, Y_MAX_POS - 1);
           #endif
 
-          if (g26_debug_flag) {
+          if (g26_Debug_flag) {
             char ccc, *cptr, seg_msg[50], seg_num[10];
             strcpy(seg_msg, "   segment: ");
             strcpy(seg_num, "    \n");
@@ -472,7 +472,7 @@
               ex = constrain(ex, X_MIN_POS + 1, X_MAX_POS - 1);
               ey = constrain(ey, Y_MIN_POS + 1, Y_MAX_POS - 1);
 
-              if (g26_debug_flag) {
+              if (g26_Debug_flag) {
                 SERIAL_ECHOPGM(" Connecting with horizontal line (sx=");
                 SERIAL_ECHO(sx);
                 SERIAL_ECHOPGM(", sy=");
@@ -512,7 +512,7 @@
                 ex = constrain(ex, X_MIN_POS + 1, X_MAX_POS - 1);
                 ey = constrain(ey, Y_MIN_POS + 1, Y_MAX_POS - 1);
 
-                if (g26_debug_flag) {
+                if (g26_Debug_flag) {
                   SERIAL_ECHOPGM(" Connecting with vertical line (sx=");
                   SERIAL_ECHO(sx);
                   SERIAL_ECHOPGM(", sy=");
@@ -540,14 +540,14 @@
 
     bool has_xy_component = (x != current_position[X_AXIS] || y != current_position[Y_AXIS]); // Check if X or Y is involved in the movement.
 
-    if (g26_debug_flag) {
+    if (g26_Debug_flag) {
       SERIAL_ECHOPAIR("in move_to()  has_xy_component:", (int)has_xy_component);
       SERIAL_EOL;
     }
 
     if (z != last_z) {
 
-      if (g26_debug_flag) {
+      if (g26_Debug_flag) {
         SERIAL_ECHOPAIR("in move_to()  changing Z to ", (int)z);
         SERIAL_EOL;
       }
@@ -564,7 +564,7 @@
       stepper.synchronize();
       set_destination_to_current();
 
-      if (g26_debug_flag)
+      if (g26_Debug_flag)
         debug_current_and_destination((char*)" in move_to() done with Z move");
     }
 
@@ -572,7 +572,7 @@
     // Yes: a 'normal' movement. No: a retract() or un_retract()
     feed_value = has_xy_component ? PLANNER_XY_FEEDRATE() / 10.0 : planner.max_feedrate_mm_s[E_AXIS] / 1.5;
 
-    if (g26_debug_flag) {
+    if (g26_Debug_flag) {
       SERIAL_ECHOPAIR("in move_to() feed_value for XY:", feed_value);
       SERIAL_EOL;
     }
@@ -581,12 +581,12 @@
     destination[Y_AXIS] = y;
     destination[E_AXIS] += e_delta;
 
-    if (g26_debug_flag)
+    if (g26_Debug_flag)
       debug_current_and_destination((char*)" in move_to() doing last move");
 
     ubl_line_to_destination(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feed_value, 0);
 
-    if (g26_debug_flag)
+    if (g26_Debug_flag)
       debug_current_and_destination((char*)" in move_to() after last move");
 
     stepper.synchronize();
@@ -596,9 +596,9 @@
   void retract_filament() {
     if (!g26_retracted) { // Only retract if we are not already retracted!
       g26_retracted = true;
-      if (g26_debug_flag) SERIAL_ECHOLNPGM(" Decided to do retract.");
+      if (g26_Debug_flag) SERIAL_ECHOLNPGM(" Decided to do retract.");
       move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], -1.0 * retraction_multiplier);
-      if (g26_debug_flag) SERIAL_ECHOLNPGM(" Retraction done.");
+      if (g26_Debug_flag) SERIAL_ECHOLNPGM(" Retraction done.");
     }
   }
 
@@ -606,7 +606,7 @@
     if (g26_retracted) { // Only un-retract if we are retracted.
       move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 1.2 * retraction_multiplier);
       g26_retracted = false;
-      if (g26_debug_flag) SERIAL_ECHOLNPGM(" unretract done.");
+      if (g26_Debug_flag) SERIAL_ECHOLNPGM(" unretract done.");
     }
   }
 
@@ -645,7 +645,7 @@
     // On very small lines we don't do the optimization because it just isn't worth it.
     //
     if (dist_end < dist_start && (SIZE_OF_INTERSECTION_CIRCLES) < abs(Line_Length)) {
-      if (g26_debug_flag)
+      if (g26_Debug_flag)
         SERIAL_ECHOLNPGM("  Reversing start and end of print_line_from_here_to_there()");
       print_line_from_here_to_there(ex, ey, ez, sx, sy, sz);
       return;
@@ -655,7 +655,7 @@
 
     if (dist_start > 2.0) {
       retract_filament();
-      if (g26_debug_flag)
+      if (g26_Debug_flag)
         SERIAL_ECHOLNPGM("  filament retracted.");
     }
     move_to(sx, sy, sz, 0.0); // Get to the starting point with no extrusion
@@ -663,7 +663,7 @@
     float e_pos_delta = Line_Length * g26_e_axis_feedrate * extrusion_multiplier;
 
     un_retract_filament();
-    if (g26_debug_flag) {
+    if (g26_Debug_flag) {
       SERIAL_ECHOLNPGM("  doing printing move.");
       debug_current_and_destination((char*)"doing final move_to() inside print_line_from_here_to_there()");
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -299,11 +299,13 @@
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "UBL.h"
   unified_bed_leveling ubl;
-#define UBL_MESH_VALID !(   z_values[0][0] == z_values[0][1] && z_values[0][1] == z_values[0][2] \
-                         && z_values[1][0] == z_values[1][1] && z_values[1][1] == z_values[1][2] \
-                         && z_values[2][0] == z_values[2][1] && z_values[2][1] == z_values[2][2] \
-                         && z_values[0][0] == 0 && z_values[1][0] == 0 && z_values[2][0] == 0    \
-                         || isnan(z_values[0][0]))
+  #define UBL_MESH_VALID !(   z_values[0][0] == z_values[0][1] && z_values[0][1] == z_values[0][2] \
+                           && z_values[1][0] == z_values[1][1] && z_values[1][1] == z_values[1][2] \
+                           && z_values[2][0] == z_values[2][1] && z_values[2][1] == z_values[2][2] \
+                           && z_values[0][0] == 0 && z_values[1][0] == 0 && z_values[2][0] == 0    \
+                           || isnan(z_values[0][0]))
+  extern bool g26_Debug_flag;
+  extern int ubl_eeprom_start;
 #endif
 
 bool Running = true;
@@ -5360,7 +5362,7 @@ inline void gcode_M42() {
 
   inline void gcode_M49() {
     SERIAL_PROTOCOLPGM("UBL Debug Flag turned ");
-    if ((g26_debug_flag = !g26_debug_flag))
+    if ((g26_Debug_flag = !g26_Debug_flag))
       SERIAL_PROTOCOLLNPGM("on.");
     else
       SERIAL_PROTOCOLLNPGM("off.");
@@ -7225,8 +7227,58 @@ void quickstop_stepper() {
    *       S[bool]   Turns leveling on or off
    *       Z[height] Sets the Z fade height (0 or none to disable)
    *       V[bool]   Verbose - Print the leveling grid
+   *
+   *       L[index]  Load UBL mesh from index (0 is default)
    */
   inline void gcode_M420() {
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      //
+      // Load a Mesh from the EEPROM
+      //
+
+      if (code_seen('L')) {     // Load Current Mesh Data
+        uint8_t Storage_Slot = code_has_value() ? code_value_int() : ubl.state.eeprom_storage_slot;
+
+        int k = E2END - sizeof(ubl.state);
+        int j = (k - ubl_eeprom_start) / sizeof(z_values);
+
+        if (Storage_Slot < 0 || Storage_Slot >= j || ubl_eeprom_start <= 0) {
+          SERIAL_PROTOCOLLNPGM("?EEPROM storage not available for use.\n");
+          return;
+        }
+        ubl.load_mesh(Storage_Slot);
+        ubl.state.eeprom_storage_slot = Storage_Slot;
+        if (Storage_Slot != ubl.state.eeprom_storage_slot)
+          ubl.store_state();
+        ubl.display_map(0);  // Right now, we only support one type of map
+        SERIAL_ECHOLNPAIR("UBL_MESH_VALID =  ", UBL_MESH_VALID);
+        SERIAL_ECHOLNPAIR("eeprom_storage_slot = ", ubl.state.eeprom_storage_slot);
+      }
+
+    #endif
+
+    // V to print the matrix or mesh
+    if (code_seen('V')) {
+      #if ABL_PLANAR
+        planner.bed_level_matrix.debug("Bed Level Correction Matrix:");
+      #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
+        if (bilinear_grid_spacing[X_AXIS]) {
+          print_bilinear_leveling_grid();
+          #if ENABLED(ABL_BILINEAR_SUBDIVISION)
+            bed_level_virt_print();
+          #endif
+        }
+      #elif ENABLED(AUTO_BED_LEVELING_UBL)
+        ubl.display_map(0);  // Right now, we only support one type of map
+        SERIAL_ECHOLNPAIR("UBL_MESH_VALID =  ", UBL_MESH_VALID);
+        SERIAL_ECHOLNPAIR("eeprom_storage_slot = ", ubl.state.eeprom_storage_slot);
+      #elif ENABLED(MESH_BED_LEVELING)
+        if (mbl.has_mesh()) {
+          SERIAL_ECHOLNPGM("Mesh Bed Level data:");
+          mbl_mesh_report();
+        }
+      #endif
+    }
     bool to_enable = false;
 
     if (code_seen('S')) {
@@ -7255,28 +7307,6 @@ void quickstop_stepper() {
 
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPAIR("Bed Leveling ", new_status ? MSG_ON : MSG_OFF);
-
-    // V to print the matrix or mesh
-    if (code_seen('V')) {
-      #if ABL_PLANAR
-        planner.bed_level_matrix.debug("Bed Level Correction Matrix:");
-      #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
-        if (bilinear_grid_spacing[X_AXIS]) {
-          print_bilinear_leveling_grid();
-          #if ENABLED(ABL_BILINEAR_SUBDIVISION)
-            bed_level_virt_print();
-          #endif
-        }
-      #elif ENABLED(AUTO_BED_LEVELING_UBL)
-        ubl.display_map(0);  // Right now, we only support one type of map
-      #elif ENABLED(MESH_BED_LEVELING)
-        if (mbl.has_mesh()) {
-          SERIAL_ECHOLNPGM("Mesh Bed Level data:");
-          mbl_mesh_report();
-        }
-      #endif
-    }
-
   }
 #endif
 
@@ -8591,7 +8621,7 @@ void process_next_command() {
         gcode_G28();
         break;
 
-      #if PLANNER_LEVELING
+      #if PLANNER_LEVELING && !ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
         case 29: // G29 Detailed Z probe, probes the bed at 3 or more points,
                  // or provides access to the UBL System if enabled.
           gcode_G29();
@@ -8708,7 +8738,7 @@ void process_next_command() {
       #endif // Z_MIN_PROBE_REPEATABILITY_TEST
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
-        case 49: // M49: Turn on or off g26_debug_flag for verbose output
+        case 49: // M49: Turn on or off g26_Debug_flag for verbose output
           gcode_M49();
           break;
       #endif // AUTO_BED_LEVELING_UBL && UBL_MESH_EDIT_ENABLED
@@ -10672,7 +10702,7 @@ void kill(const char* lcd_msg) {
 
   thermalManager.disable_all_heaters();
   disable_all_steppers();
-            
+
   #if ENABLED(ULTRA_LCD)
     kill_screen(lcd_msg);
   #else
@@ -10681,7 +10711,7 @@ void kill(const char* lcd_msg) {
 
   _delay_ms(250); // Wait a short time
   cli(); // Stop interrupts
-            
+
   _delay_ms(250); //Wait to ensure all interrupts routines stopped
   thermalManager.disable_all_heaters(); //turn off heaters again
 

--- a/Marlin/UBL.h
+++ b/Marlin/UBL.h
@@ -81,11 +81,6 @@
     #define MESH_X_DIST ((float(UBL_MESH_MAX_X) - float(UBL_MESH_MIN_X)) / (float(UBL_MESH_NUM_X_POINTS) - 1.0))
     #define MESH_Y_DIST ((float(UBL_MESH_MAX_Y) - float(UBL_MESH_MIN_Y)) / (float(UBL_MESH_NUM_Y_POINTS) - 1.0))
 
-    #if ENABLED(UBL_MESH_EDIT_ENABLED)
-      extern bool g26_debug_flag;
-    #else
-      constexpr bool g26_debug_flag = false;
-    #endif
     extern float last_specified_z;
     extern float fade_scaling_factor_for_current_height;
     extern float z_values[UBL_MESH_NUM_X_POINTS][UBL_MESH_NUM_Y_POINTS];
@@ -339,7 +334,6 @@
     }; // class unified_bed_leveling
 
     extern unified_bed_leveling ubl;
-    extern int ubl_eeprom_start;
 
     #define UBL_LAST_EEPROM_INDEX (E2END - sizeof(unified_bed_leveling::state))
 

--- a/Marlin/UBL_Bed_Leveling.cpp
+++ b/Marlin/UBL_Bed_Leveling.cpp
@@ -27,6 +27,7 @@
 
   #include "UBL.h"
   #include "hex_print_routines.h"
+  extern int ubl_eeprom_start;
 
   /**
    * These support functions allow the use of large bit arrays of flags that take very

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -22,7 +22,7 @@
 
 #include "MarlinConfig.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL)
+#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
   //#include "vector_3.h"
   //#include "qr_solve.h"
 
@@ -39,7 +39,10 @@
   void lcd_return_to_status();
   bool lcd_clicked();
   void lcd_implementation_clear();
-
+  void lcd_mesh_edit_setup(float inital);
+  float lcd_mesh_edit();
+  void lcd_z_offset_edit_setup(float);
+  float lcd_z_offset_edit();
   extern float meshedit_done;
   extern long babysteps_done;
   extern float code_value_float();
@@ -62,6 +65,8 @@
   #define SIZE_OF_LITTLE_RAISE 0
   #define BIG_RAISE_NOT_NEEDED 0
   extern void lcd_quick_feedback();
+  extern int ubl_eeprom_start;
+  extern volatile int G29_encoderDiff; // This is volatile because it is getting changed at interrupt time.
 
   /**
    *   G29: Unified Bed Leveling by Roxy
@@ -291,9 +296,8 @@
    *   we now have the functionality and features of all three systems combined.
    */
 
-  int ubl_eeprom_start = -1;
-  bool ubl_has_control_of_lcd_panel = false;
-  volatile uint8_t ubl_encoderDiff = 0; // Volatile because it's changed by Temperature ISR button update
+  extern bool ubl_has_control_of_lcd_panel;
+  extern volatile uint8_t ubl_encoderDiff; // Volatile because it's changed by Temperature ISR button update
 
   // The simple parameter flags and values are 'static' so parameter parsing can be in a support routine.
   static int g29_verbose_level = 0, phase_value = -1, repetition_cnt = 1,

--- a/Marlin/UBL_line_to_destination.cpp
+++ b/Marlin/UBL_line_to_destination.cpp
@@ -31,12 +31,13 @@
 
   extern float destination[XYZE];
   extern void set_current_to_destination();
-
+  extern float destination[];
+  bool g26_Debug_flag = false;
   void debug_current_and_destination(char *title) {
 
     // if the title message starts with a '!' it is so important, we are going to
-    // ignore the status of the g26_debug_flag
-    if (*title != '!' && !g26_debug_flag) return;
+    // ignore the status of the g26_Debug_flag
+    if (*title != '!' && !g26_Debug_flag) return;
 
     const float de = destination[E_AXIS] - current_position[E_AXIS];
 
@@ -121,7 +122,7 @@
               cell_dest_xi  = ubl.get_cell_index_x(RAW_X_POSITION(x_end)),
               cell_dest_yi  = ubl.get_cell_index_y(RAW_Y_POSITION(y_end));
 
-    if (g26_debug_flag) {
+    if (g26_Debug_flag) {
       SERIAL_ECHOPGM(" ubl_line_to_destination(xe=");
       SERIAL_ECHO(x_end);
       SERIAL_ECHOPGM(", ye=");
@@ -150,13 +151,14 @@
         planner.buffer_line(x_end, y_end, z_end + ubl.state.z_offset, e_end, feed_rate, extruder);
         set_current_to_destination();
 
-        if (g26_debug_flag)
+        if (g26_Debug_flag)
           debug_current_and_destination((char*)"out of bounds in ubl_line_to_destination()");
 
         return;
       }
 
       FINAL_MOVE:
+
 
       /**
        * Optimize some floating point operations here. We could call float get_z_correction(float x0, float y0) to
@@ -212,7 +214,7 @@
 
       planner.buffer_line(x_end, y_end, z_end + z0 + ubl.state.z_offset, e_end, feed_rate, extruder);
 
-      if (g26_debug_flag)
+      if (g26_Debug_flag)
         debug_current_and_destination((char*)"FINAL_MOVE in ubl_line_to_destination()");
 
       set_current_to_destination();
@@ -276,6 +278,7 @@
         current_yi += dyi;
         const float next_mesh_line_y = LOGICAL_Y_POSITION(mesh_index_to_y_location[current_yi]);
 
+
         /**
          * inf_m_flag? the slope of the line is infinite, we won't do the calculations
          * else, we know the next X is the same so we can recover and continue!
@@ -314,7 +317,7 @@
          * because part of the Mesh is undefined and we don't have the
          * information we need to complete the height correction.
          */
-        if (isnan(z0)) z0 = 0.0;     
+        if (isnan(z0)) z0 = 0.0;
 
         const float y = LOGICAL_Y_POSITION(mesh_index_to_y_location[current_yi]);
 
@@ -339,7 +342,7 @@
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
-      if (g26_debug_flag)
+      if (g26_Debug_flag)
         debug_current_and_destination((char*)"vertical move done in ubl_line_to_destination()");
 
       //
@@ -424,7 +427,7 @@
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
-      if (g26_debug_flag)
+      if (g26_Debug_flag)
         debug_current_and_destination((char*)"horizontal move done in ubl_line_to_destination()");
 
       if (current_position[X_AXIS] != x_end || current_position[Y_AXIS] != y_end)
@@ -488,6 +491,7 @@
 
         z0 *= ubl.fade_scaling_factor_for_z(z_end);
 
+
         /**
          * If part of the Mesh is undefined, it will show up as NAN
          * in z_values[][] and propagate through the
@@ -515,6 +519,7 @@
         // Yes!  Crossing a X Mesh Line next
         //
         float z0 = ubl.get_z_correction_along_vertical_mesh_line_at_specific_Y(y, current_xi + dxi, current_yi - down_flag);
+
 
         /**
          * Debug code to use non-optimized get_z_correction() and to do a sanity check
@@ -563,7 +568,8 @@
       }
     }
 
-    if (g26_debug_flag)
+
+    if (g26_Debug_flag)
       debug_current_and_destination((char*)"generic move done in ubl_line_to_destination()");
 
     if (current_position[0] != x_end || current_position[1] != y_end)

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -166,6 +166,7 @@
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "UBL.h"
+  int ubl_eeprom_start = -1;
 #endif
 
 #if ENABLED(ABL_BILINEAR_SUBDIVISION)

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -232,7 +232,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1425,6 +1425,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1408,6 +1408,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1408,6 +1408,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -234,7 +234,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1417,6 +1417,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1419,6 +1419,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -251,7 +251,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1459,6 +1459,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1425,6 +1425,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1425,6 +1425,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1425,6 +1425,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -234,7 +234,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1426,6 +1426,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -263,7 +263,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1440,6 +1440,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1446,6 +1446,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -234,7 +234,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1417,6 +1417,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1425,6 +1425,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1530,6 +1530,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1515,6 +1515,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1519,6 +1519,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -235,7 +235,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1518,6 +1518,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1528,6 +1528,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1428,6 +1428,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -231,7 +231,7 @@
  *    60 : 100k Maker's Tool Works Kapton Bed Thermistor beta=3950
  *    66 : 4.7M High Temperature thermistor from Dyze Design
  *    70 : the 100K thermistor found in the bq Hephestos 2
- *    75 : 100k Generic Silicon Heat Pad typically a NTC 100K MGB18-104F39050L32 thermistor
+ *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.
  *                              (but gives greater accuracy and more stable PID)
@@ -1421,6 +1421,12 @@
 // However, control resolution will be halved for each increment;
 // at zero value, there are 128 effective control positions.
 #define SOFT_PWM_SCALE 0
+
+// If SOFT_PWM_SCALE is set to a value higher than 0, dithering can
+// be used to mitigate the associated resolution loss. If enabled,
+// some of the PWM cycles are stretched so on average the wanted
+// duty cycle is attained.
+//#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
 // If all hotends and bed temperature and temperature setpoint are < 54C then the BLUE led is on.

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -125,7 +125,8 @@ uint16_t max_display_update_time = 0;
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
     extern bool ubl_has_control_of_lcd_panel;
-    extern uint8_t ubl_encoderDiff;
+    volatile uint8_t ubl_encoderDiff = 0; // Volatile because it's changed by Temperature ISR button update
+    bool ubl_has_control_of_lcd_panel = false;
   #endif
 
   #if HAS_POWER_SWITCH


### PR DESCRIPTION
@Roxy-3D  & @thinkyhead - I wanted to get this out in front of you in case there's something here that's of immediate interest.  If not then I'll just close this PR.

The idea is to reduce UBL RAM usage by enabling the mesh editing tools only when they're needed.

I added a flag to configuration.h to control the enable/disable.

The definitions of 4 or 5 variables were affected.  I moved the base definitions to files that were always enabled and made the others EXTERN.

I also had to move one function to another file.

----

I can't figure out why I'm getting a multiple definition error for G26_Debug_flag.  it's defined one place and is an extern the only other place it's used.

I'll work on it more tomorrow.

----

I also found another place where we need to have BLTouch retries and that the BLTouch needs a longer delay to see if the error condition stays fixed.  Unfortunately the delay can be multiple seconds long so I just capped it at 1.5.


