### PR TITLE
Fix type conversion issue with echo_command

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -796,7 +796,7 @@ extern "C" {
   extern void digipot_i2c_init();
 #endif
 
-inline void echo_command(char * const cmd) {
+inline void echo_command(const char* cmd) {
   SERIAL_ECHO_START;
   SERIAL_ECHOPAIR(MSG_ENQUEUEING, cmd);
   SERIAL_CHAR('"');


### PR DESCRIPTION
With the the current definition of echo_command I cannot compile RCBugFix (Arduino IDE 1.8.1) with the error "invalid conversion from 'const char*' to 'char*'".  This change resolves that.