### PR TITLE
Use safe_delay to ensure watchdog reset

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6023,7 +6023,7 @@ inline void gcode_M81() {
       fanSpeeds[0] = 0;
     #endif
   #endif
-  delay(1000); // Wait 1 second before switching off
+  safe_delay(1000); // Wait 1 second before switching off
   #if HAS_SUICIDE
     stepper.synchronize();
     suicide();
@@ -7589,7 +7589,7 @@ inline void gcode_M503() {
     // Synchronize steppers and then disable extruders steppers for manual filament changing
     stepper.synchronize();
     disable_e_steppers();
-    delay(100);
+    safe_delay(100);
 
     millis_t nozzle_timeout = millis() + (millis_t)(FILAMENT_CHANGE_NOZZLE_TIMEOUT) * 1000L;
     bool nozzle_timed_out = false;
@@ -8112,7 +8112,7 @@ inline void gcode_M999() {
   inline void move_extruder_servo(uint8_t e) {
     const int angles[2] = SWITCHING_EXTRUDER_SERVO_ANGLES;
     MOVE_SERVO(SWITCHING_EXTRUDER_SERVO_NR, angles[e]);
-    delay(500);
+    safe_delay(500);
   }
 #endif
 

--- a/Marlin/UBL_Bed_Leveling.cpp
+++ b/Marlin/UBL_Bed_Leveling.cpp
@@ -183,7 +183,7 @@
         #if TX_BUFFER_SIZE>0
           MYSERIAL.flushTX();
         #endif
-        delay(15);
+        safe_delay(15);
       }
       
       SERIAL_ECHOPAIR("(", UBL_MESH_NUM_X_POINTS - 1);
@@ -193,20 +193,20 @@
       SERIAL_ECHOPAIR("(", UBL_MESH_MIN_X);
       SERIAL_ECHOPAIR(",", UBL_MESH_MAX_Y);
       SERIAL_CHAR(')');
-      delay(15);
+      safe_delay(15);
 
       for (i = 0; i < UBL_MESH_NUM_X_POINTS - 1; i++) {
         SERIAL_ECHOPGM("            ");
         #if TX_BUFFER_SIZE>0
           MYSERIAL.flushTX();
         #endif
-        delay(15);
+        safe_delay(15);
       }
 
       SERIAL_ECHOPAIR("(", UBL_MESH_MAX_X);
       SERIAL_ECHOPAIR(",", UBL_MESH_MAX_Y);
       SERIAL_ECHOLNPGM(")");
-      delay(15);
+      safe_delay(15);
     }
 
     for (j = UBL_MESH_NUM_Y_POINTS - 1; j >= 0; j--) {
@@ -234,7 +234,7 @@
         #if TX_BUFFER_SIZE>0
           MYSERIAL.flushTX();
         #endif
-        delay(15);
+        safe_delay(15);
         if (map_type==0) {
           if (i == current_xi && j == current_yi) // is the nozzle here? if so, finish marking the number
             SERIAL_CHAR(']');
@@ -260,7 +260,7 @@
         #if TX_BUFFER_SIZE>0
           MYSERIAL.flushTX();
         #endif
-        delay(15);
+        safe_delay(15);
       }
       SERIAL_ECHOPAIR("(", int(UBL_MESH_MAX_X));
       SERIAL_ECHOPAIR(",", int(UBL_MESH_MIN_Y));
@@ -276,7 +276,7 @@
         #if TX_BUFFER_SIZE>0
           MYSERIAL.flushTX();
         #endif
-        delay(15);
+        safe_delay(15);
       }
       SERIAL_ECHOPAIR("(", UBL_MESH_NUM_X_POINTS-1);
       SERIAL_ECHOPAIR(",", 0);

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -497,8 +497,7 @@
           SERIAL_ECHOLNPGM("Checking G29 has control of LCD Panel:");
           wait_for_user = true;
           while (wait_for_user) {
-            idle();
-            delay(250);
+            safe_delay(250);
             SERIAL_ECHO((int)ubl_encoderDiff);
             ubl_encoderDiff = 0;
             SERIAL_EOL;
@@ -644,7 +643,7 @@
           }
         }
         ubl_has_control_of_lcd_panel = false;
-        delay(20); // We don't want any switch noise.
+        safe_delay(20); // We don't want any switch noise.
 
         ubl.state.z_offset = measured_z;
 
@@ -734,7 +733,7 @@
         }
         ubl_has_control_of_lcd_panel = false;
         restore_ubl_active_state_and_leave();
-        delay(50);  // Debounce the Encoder wheel
+        safe_delay(50);  // Debounce the Encoder wheel
         return;
       }
 
@@ -1113,7 +1112,7 @@
     else
       SERIAL_PROTOCOLPGM("In");
     SERIAL_PROTOCOLLNPGM("ctive.\n");
-    delay(50);
+    safe_delay(50);
 
     if (ubl.state.eeprom_storage_slot == -1)
       SERIAL_PROTOCOLPGM("No Mesh Loaded.");
@@ -1123,7 +1122,7 @@
       SERIAL_PROTOCOLPGM(" Loaded.");
     }
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       SERIAL_PROTOCOLPAIR("g29_correction_fade_height : ", ubl.state.g29_correction_fade_height);
@@ -1133,13 +1132,13 @@
     SERIAL_PROTOCOLPGM("z_offset: ");
     SERIAL_PROTOCOL_F(ubl.state.z_offset, 6);
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     SERIAL_PROTOCOLPGM("X-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < UBL_MESH_NUM_X_POINTS; i++) {
       SERIAL_PROTOCOL_F( ubl.map_x_index_to_bed_location(i), 1);
       SERIAL_PROTOCOLPGM("  ");
-      delay(50);
+      safe_delay(50);
     }
     SERIAL_EOL;
 
@@ -1147,7 +1146,7 @@
     for (uint8_t i = 0; i < UBL_MESH_NUM_Y_POINTS; i++) {
       SERIAL_PROTOCOL_F( ubl.map_y_index_to_bed_location(i), 1);
       SERIAL_PROTOCOLPGM("  ");
-      delay(50);
+      safe_delay(50);
     }
     SERIAL_EOL;
 
@@ -1156,13 +1155,13 @@
       SERIAL_PROTOCOLLNPAIR("  state:", READ(KILL_PIN));
     #endif
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("ubl_state_at_invocation :", ubl_state_at_invocation);
     SERIAL_EOL;
     SERIAL_PROTOCOLLNPAIR("ubl_state_recursion_chk :", ubl_state_recursion_chk);
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
     SERIAL_PROTOCOLPGM("Free EEPROM space starts at: 0x");
     prt_hex_word(ubl_eeprom_start);
     SERIAL_EOL;
@@ -1170,42 +1169,42 @@
     SERIAL_PROTOCOLPGM("end of EEPROM              : ");
     prt_hex_word(E2END);
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("sizeof(ubl) :  ", (int)sizeof(ubl));
     SERIAL_EOL;
     SERIAL_PROTOCOLLNPAIR("z_value[][] size: ", (int)sizeof(z_values));
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     SERIAL_PROTOCOLPGM("EEPROM free for UBL: 0x");
     prt_hex_word(k);
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     SERIAL_PROTOCOLPGM("EEPROM can hold 0x");
     prt_hex_word(k / sizeof(z_values));
     SERIAL_PROTOCOLLNPGM(" meshes.\n");
-    delay(50);
+    safe_delay(50);
 
     SERIAL_PROTOCOLPGM("sizeof(ubl.state) :");
     prt_hex_word(sizeof(ubl.state));
 
     SERIAL_PROTOCOLPAIR("\nUBL_MESH_NUM_X_POINTS  ", UBL_MESH_NUM_X_POINTS);
     SERIAL_PROTOCOLPAIR("\nUBL_MESH_NUM_Y_POINTS  ", UBL_MESH_NUM_Y_POINTS);
-    delay(50);
+    safe_delay(50);
     SERIAL_PROTOCOLPAIR("\nUBL_MESH_MIN_X         ", UBL_MESH_MIN_X);
     SERIAL_PROTOCOLPAIR("\nUBL_MESH_MIN_Y         ", UBL_MESH_MIN_Y);
-    delay(50);
+    safe_delay(50);
     SERIAL_PROTOCOLPAIR("\nUBL_MESH_MAX_X         ", UBL_MESH_MAX_X);
     SERIAL_PROTOCOLPAIR("\nUBL_MESH_MAX_Y         ", UBL_MESH_MAX_Y);
-    delay(50);
+    safe_delay(50);
     SERIAL_PROTOCOLPGM("\nMESH_X_DIST        ");
     SERIAL_PROTOCOL_F(MESH_X_DIST, 6);
     SERIAL_PROTOCOLPGM("\nMESH_Y_DIST        ");
     SERIAL_PROTOCOL_F(MESH_Y_DIST, 6);
     SERIAL_EOL;
-    delay(50);
+    safe_delay(50);
 
     if (!ubl.sanity_check())
       SERIAL_PROTOCOLLNPGM("Unified Bed Leveling sanity checks passed.");
@@ -1408,7 +1407,7 @@
         }
       }
 
-      delay(20);                       // We don't want any switch noise.
+      safe_delay(20);                       // We don't want any switch noise.
 
       z_values[location.x_index][location.y_index] = new_z;
 


### PR DESCRIPTION
We should use `safe_delay()` instead of `delay()` because it makes sure everything continues to run and watchdog gets reset.