### PR TITLE
Board A4JP should be SCOOVO_X9H

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -83,7 +83,7 @@
 #define BOARD_OMCA              91   // Final OMCA board
 #define BOARD_RAMBO             301  // Rambo
 #define BOARD_MINIRAMBO         302  // Mini-Rambo
-#define BOARD_AJ4P              303  // AJ4P
+#define BOARD_SCOOVO_X9H        303  // abee Scoovo X9H
 #define BOARD_MEGACONTROLLER    310  // Mega controller
 #define BOARD_ELEFU_3           21   // Elefu Ra Board (v3)
 #define BOARD_5DPRINT           88   // 5DPrint D8 Driver Board

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -166,8 +166,8 @@
   #include "pins_MEGACONTROLLER.h"
 #elif MB(BQ_ZUM_MEGA_3D)
   #include "pins_BQ_ZUM_MEGA_3D.h"
-#elif MB(AJ4P)
-  #include "pins_AJ4P.h"
+#elif MB(SCOOVO_X9H)
+  #include "pins_SCOOVO_X9H.h"
 #elif MB(MKS_13)
   #include "pins_MKS_13.h"
 #elif MB(SAINSMART_2IN1)

--- a/Marlin/pins_SCOOVO_X9H.h
+++ b/Marlin/pins_SCOOVO_X9H.h
@@ -21,20 +21,16 @@
  */
 
 /************************************************
- * Rambo pin assignments MODIFIED FOR A4JP
+ * Rambo pin assignments MODIFIED FOR Scoovo X9H
  ************************************************/
 
 #ifndef __AVR_ATmega2560__
   #error "Oops!  Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define BOARD_NAME "AJ4P"
+#define BOARD_NAME "Scoovo X9H"
 
 #define LARGE_FLASH true
-
-/************************************************
- * Rambo pin assignments old
- ************************************************/
 
 //
 // Servos


### PR DESCRIPTION
Based on #6134. Rename the board to the product name, no longer based on the original fork name.