### PR TITLE
Proposed fix to M84 and safe Stepper timeout defaults

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -357,10 +357,10 @@
 // Steppers will shut down DEFAULT_STEPPER_DEACTIVE_TIME seconds after the last move when DISABLE_INACTIVE_? is true.
 // Time can be set by M18 and M84.
 #define DEFAULT_STEPPER_DEACTIVE_TIME 120
-#define DISABLE_INACTIVE_X true
-#define DISABLE_INACTIVE_Y true
-#define DISABLE_INACTIVE_Z true  // set to false if the nozzle will fall down on your printed part when print has finished.
-#define DISABLE_INACTIVE_E true
+#define DISABLE_INACTIVE_X false
+#define DISABLE_INACTIVE_Y false
+#define DISABLE_INACTIVE_Z false  // set to false if the nozzle will fall down on your printed part when print has finished.
+#define DISABLE_INACTIVE_E false
 
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -457,7 +457,7 @@ static int serial_count = 0;
 // Inactivity shutdown
 millis_t previous_cmd_ms = 0;
 static millis_t max_inactive_time = 0;
-static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
+millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
 
 // Print Job Timer
 #if ENABLED(PRINTCOUNTER)


### PR DESCRIPTION
This is the associated proposed PR for Issue #6147 

2 Edits.

Proposed Solution for Problem 1:
File `Configuration_adv.h` change "true" to "false" for lines 360-363:
```cpp
#define DISABLE_INACTIVE_X false
#define DISABLE_INACTIVE_Y false
#define DISABLE_INACTIVE_Z false // set to false if the nozzle will fall down on your printed part when print has finished.
#define DISABLE_INACTIVE_E false
```
Justification: Marlin 1.0.2-2 Has these vars as well and they are FALSE, thus keeping the motors on as expected. This is the known and right thing to do, given the stable branch's choices. M18/M84 is expected to disable steppers, and is an expected command to initiate when that is the desired result.


Proposed solution for Problem 2:
File marlin_main.cpp remove STATIC keyword
460: millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;

Justification: C++ Static keyword. When included modifying a variable, and as global scope, the variable can no longer be referenced other than by the initial declaration. In the case of the default Marlin RCBugFix, the number is 120 seconds. Giving any M84 S## defaults to 120 seconds as per static keyword.

I also noticed this behavior as well in Marlin 1.0.2-2, with a similar STATIC declaration. However, since motors do not disable by default in Stable, did not notice it earlier.
