### PR TITLE
Show Filament Width on LCD when SD is disabled

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -224,6 +224,10 @@
     #define LCD_STR_SPECIAL_MAX '\x09'
     // Maximum here is 0x1f because 0x20 is ' ' (space) and the normal charsets begin.
     // Better stay below 0x10 because DISPLAY_CHARSET_HD44780_WESTERN begins here.
+
+    // Symbol characters
+    #define LCD_STR_FILAM_DIA   "\xf8"
+    #define LCD_STR_FILAM_MUL   "\xa4"
   #else
     /* Custom characters defined in the first 8 characters of the LCD */
     #define LCD_STR_BEDTEMP     "\x00"  // Print only as a char. This will have 'unexpected' results when used in a string!

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -47,7 +47,7 @@ extern float zprobe_zoffset;
 
 int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
 
-#if ENABLED(FILAMENT_LCD_DISPLAY)
+#if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
   millis_t previous_lcd_status_ms = 0;
 #endif
 
@@ -547,7 +547,7 @@ void lcd_status_screen() {
   #if ENABLED(ULTIPANEL)
 
     if (lcd_clicked) {
-      #if ENABLED(FILAMENT_LCD_DISPLAY)
+      #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
         previous_lcd_status_ms = millis();  // get status message to show up for a while
       #endif
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
@@ -3456,7 +3456,7 @@ void lcd_finishstatus(bool persist=false) {
   #endif
   lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
 
-  #if ENABLED(FILAMENT_LCD_DISPLAY)
+  #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
     previous_lcd_status_ms = millis();  //get status message to show up for a while
   #endif
 }

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -93,7 +93,7 @@
 
   #endif
 
-  #if ENABLED(FILAMENT_LCD_DISPLAY)
+  #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
     extern millis_t previous_lcd_status_ms;
   #endif
 

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -535,12 +535,19 @@ static void lcd_implementation_status_screen() {
   // When everything is ok you see a constant 'X'.
 
   static char xstring[5], ystring[5], zstring[7];
+  #if ENABLED(FILAMENT_LCD_DISPLAY) && DISABLED(SDSUPPORT)
+    static char wstring[5], mstring[4];
+  #endif
 
   // At the first page, regenerate the XYZ strings
   if (page.page == 0) {
     strcpy(xstring, ftostr4sign(current_position[X_AXIS]));
     strcpy(ystring, ftostr4sign(current_position[Y_AXIS]));
     strcpy(zstring, ftostr52sp(current_position[Z_AXIS] + 0.00001));
+    #if ENABLED(FILAMENT_LCD_DISPLAY) && DISABLED(SDSUPPORT)
+      strcpy(wstring, ftostr12ns(filament_width_meas));
+      strcpy(mstring, itostr3(100.0 * volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]));
+    #endif
   }
 
   if (PAGE_CONTAINS(XYZ_FRAME_TOP, XYZ_FRAME_TOP + XYZ_FRAME_HEIGHT - 1)) {
@@ -591,6 +598,22 @@ static void lcd_implementation_status_screen() {
     u8g.setPrintPos(12, 50);
     lcd_print(itostr3(feedrate_percentage));
     u8g.print('%');
+
+    //
+    // Filament sensor display if SD is disabled
+    //
+    #if DISABLED(SDSUPPORT) && ENABLED(FILAMENT_LCD_DISPLAY)
+      u8g.setPrintPos(56, 50);
+      lcd_print(wstring);
+      u8g.setPrintPos(102, 50);
+      lcd_print(mstring);
+      u8g.print('%');
+      lcd_setFont(FONT_MENU);
+      u8g.setPrintPos(47, 50);
+      lcd_print(LCD_STR_FILAM_DIA);
+      u8g.setPrintPos(93, 50);
+      lcd_print(LCD_STR_FILAM_MUL);
+    #endif
   }
 
   //
@@ -602,19 +625,21 @@ static void lcd_implementation_status_screen() {
   if (PAGE_CONTAINS(STATUS_BASELINE + 1 - INFO_FONT_HEIGHT, STATUS_BASELINE)) {
     u8g.setPrintPos(0, STATUS_BASELINE);
 
-    #if DISABLED(FILAMENT_LCD_DISPLAY)
-      lcd_print(lcd_status_message);
-    #else
+    #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
       if (PENDING(millis(), previous_lcd_status_ms + 5000UL)) {  //Display both Status message line and Filament display on the last line
         lcd_print(lcd_status_message);
       }
       else {
-        lcd_printPGM(PSTR("dia:"));
+        lcd_printPGM(PSTR(LCD_STR_FILAM_DIA));
+        u8g.print(':');
         lcd_print(ftostr12ns(filament_width_meas));
-        lcd_printPGM(PSTR(" factor:"));
+        lcd_printPGM(PSTR("  " LCD_STR_FILAM_MUL));
+        u8g.print(':');
         lcd_print(itostr3(100.0 * volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]));
         u8g.print('%');
       }
+    #else
+      lcd_print(lcd_status_message);
     #endif
   }
 }

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -396,7 +396,7 @@ void lcd_print(char c) { charset_mapper(c); }
   void lcd_erase_line(const int line) {
     lcd.setCursor(0, line);
     for (uint8_t i = LCD_WIDTH + 1; --i;)
-      lcd_print(' ');
+      lcd.print(' ');
   }
 
   // Scroll the PSTR 'text' in a 'len' wide field for 'time' milliseconds at position col,line
@@ -775,14 +775,12 @@ static void lcd_implementation_status_screen() {
 
   #if ENABLED(LCD_PROGRESS_BAR)
 
-    if (card.isFileOpen()) {
-      // Draw the progress bar if the message has shown long enough
-      // or if there is no message set.
-      if (ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0])
-        return lcd_draw_progress_bar(card.percentDone());
-    } //card.isFileOpen
+    // Draw the progress bar if the message has shown long enough
+    // or if there is no message set.
+    if (card.isFileOpen() && ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0])
+      return lcd_draw_progress_bar(card.percentDone());
 
-  #elif ENABLED(FILAMENT_LCD_DISPLAY)
+  #elif ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
 
     // Show Filament Diameter and Volumetric Multiplier %
     // After allowing lcd_status_message to show for 5 seconds
@@ -795,7 +793,7 @@ static void lcd_implementation_status_screen() {
       return;
     }
 
-  #endif // FILAMENT_LCD_DISPLAY
+  #endif // FILAMENT_LCD_DISPLAY && SDSUPPORT
 
   lcd_print(lcd_status_message);
 }


### PR DESCRIPTION
Rebase, cleanup of #5614, showing the filament width in the space where SD is normally displayed.