### PR TITLE
UBL - add rectangular probing for G29 P1 (replaces PR #6132)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -862,8 +862,9 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
-
+  #define UBL_CIRCULAR_PROBING          // circular probing starting at mesh point nearest nozzle
+  //#define UBL_RECTANGULAR_PROBING     // probe grid linearly
+  #define UBL_MESH_EDIT_ENABLED     // Enable G29 & G26 mesh editing
 #elif ENABLED(MESH_BED_LEVELING)
 
   //===========================================================================


### PR DESCRIPTION
This is cloned from PR #6132.

Example configurations will be updated later.

Below are copies from PR #6132

----

I was tired of waiting for the circular probing so I grabbed the bilinear G29 probing code & combined it with the existing G29 P1 code.
I added flags to the Configuration.h files to control which one get (compiled in).

----

Just uploaded a much improved version.  

The main improvement was adding a UBL specific "is_reacheable" routine.  It is used to determine if the probed point is within the mesh limits and if the probe point is reachable.  If both are true then the point is probed.

Handles both rectangular and circular beds.

Handles situations where the travel limits are wider than the mesh area.

Rectangular:
1. assumes the travel area is set by the X_MIN_POS ... defines 
2. assumes the mesh area is set by the UBL_MESH_MIN_X ... defines
3. assumes the UBL_MESH_INSET has already been incorporated into the UBL_MESH_MIN_X ... defines

Circular:
1. assumes DELTA_RADIUS minus UBL_MESH_INSET is the same as the UBL_MESH_MIN_X ... defines
2. assumes travel area is the same as DELTA_RADIUS unless DELTA_TRAVEL_RADIUS is defined.  DELTA_TRAVEL_RADIUS is something I just made up.

The rectangular & circular assumptions can be easily modified.  Let me know what makes sense.

----

Speed - G29 P1 - 9x9 grid includes G28
Rectangular probing:  4:26
Circular probing: 6:26

This is only a 30% reduction in time.  **Is it worth pursuing this PR?**

----

The circular bed is placed within a rectangular grid.  Do we need to mark the points outside the bed so that they're not used when doing manual probing?

Right now the routine just leaves them as NAN.  There's a convenient place for code to mark these points as special.

