### PR TITLE
UBL additional cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ script:
   # Test a simple build of AUTO_BED_LEVELING_UBL
   #
   - restore_configs
-  - opt_enable AUTO_BED_LEVELING_UBL FIX_MOUNTED_PROBE EEPROM_SETTINGS G3D_PANEL
+  - opt_enable AUTO_BED_LEVELING_UBL UBL_G26_MESH_EDITING FIX_MOUNTED_PROBE EEPROM_SETTINGS G3D_PANEL
   - build_marlin
   #
   # Test a Sled Z Probe

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -862,7 +862,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -113,6 +113,7 @@
    *   Y #  Y coordinate  Specify the starting location of the drawing activity.
    */
 
+  extern bool g26_debug_flag;
   extern bool ubl_has_control_of_lcd_panel;
   extern float feedrate;
   //extern bool relative_mode;
@@ -171,8 +172,7 @@
 
   int8_t prime_flag = 0;
 
-  bool keep_heaters_on = false,
-       g26_debug_flag = false;
+  bool keep_heaters_on = false;
 
   /**
    * G26: Mesh Validation Pattern generation.

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -26,7 +26,7 @@
 
 #include "MarlinConfig.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
+#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
 
   #include "Marlin.h"
   #include "Configuration.h"
@@ -896,4 +896,4 @@
     return UBL_OK;
   }
 
-#endif // AUTO_BED_LEVELING_UBL && UBL_MESH_EDIT_ENABLED
+#endif // AUTO_BED_LEVELING_UBL && UBL_G26_MESH_EDITING

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -38,7 +38,7 @@
 
   #define EXTRUSION_MULTIPLIER 1.0    // This is too much clutter for the main Configuration.h file  But
   #define RETRACTION_MULTIPLIER 1.0   // some user have expressed an interest in being able to customize
-  #define NOZZLE 0.3                  // these numbers for thier printer so they don't need to type all
+  #define NOZZLE 0.3                  // these numbers for their printer so they don't need to type all
   #define FILAMENT 1.75               // the options every time they do a Mesh Validation Print.
   #define LAYER_HEIGHT 0.2
   #define PRIME_LENGTH 10.0           // So, we put these number in an easy to find and change place.
@@ -113,10 +113,7 @@
    *   Y #  Y coordinate  Specify the starting location of the drawing activity.
    */
 
-  extern bool g26_debug_flag;
-  extern bool ubl_has_control_of_lcd_panel;
   extern float feedrate;
-  //extern bool relative_mode;
   extern Planner planner;
   //#if ENABLED(ULTRA_LCD)
     extern char lcd_status_message[];
@@ -197,12 +194,10 @@
       set_current_to_destination();
     }
 
-    ubl_has_control_of_lcd_panel = true; // Take control of the LCD Panel!
+    ubl.has_control_of_lcd_panel = true; // Take control of the LCD Panel!
     if (turn_on_heaters())     // Turn on the heaters, leave the command if anything
       goto LEAVE;              // has gone wrong.
 
-    axis_relative_modes[E_AXIS] = false;    // Get things setup so we can take control of the
-    //relative_mode = false;                  // planner and stepper motors!
     current_position[E_AXIS] = 0.0;
     sync_plan_position_e();
 
@@ -232,7 +227,7 @@
     move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 0.0);
     move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], ooze_amount);
 
-    ubl_has_control_of_lcd_panel = true; // Take control of the LCD Panel!
+    ubl.has_control_of_lcd_panel = true; // Take control of the LCD Panel!
     //debug_current_and_destination((char*)"Starting G26 Mesh Validation Pattern.");
 
     /**
@@ -292,7 +287,7 @@
         xi = location.x_index;  // Just to shrink the next few lines and make them easier to understand
         yi = location.y_index;
 
-        if (g26_debug_flag) {
+        if (ubl.g26_debug_flag) {
           SERIAL_ECHOPAIR("   Doing circle at: (xi=", xi);
           SERIAL_ECHOPAIR(", yi=", yi);
           SERIAL_CHAR(')');
@@ -346,7 +341,7 @@
             ye = constrain(ye, Y_MIN_POS + 1, Y_MAX_POS - 1);
           #endif
 
-          //if (g26_debug_flag) {
+          //if (ubl.g26_debug_flag) {
           //  char ccc, *cptr, seg_msg[50], seg_num[10];
           //  strcpy(seg_msg, "   segment: ");
           //  strcpy(seg_num, "    \n");
@@ -364,7 +359,7 @@
         //if (lcd_init_counter > 10) {
         //  lcd_init_counter = 0;
         //  lcd_init(); // Some people's LCD Displays are locking up.  This might help them
-        //  ubl_has_control_of_lcd_panel = true;     // Make sure UBL still is controlling the LCD Panel
+        //  ubl.has_control_of_lcd_panel = true;     // Make sure UBL still is controlling the LCD Panel
         //}
 
         //debug_current_and_destination((char*)"Looking for lines to connect.");
@@ -394,7 +389,7 @@
     move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 0); // Move back to the starting position
     //debug_current_and_destination((char*)"done doing X/Y move.");
 
-    ubl_has_control_of_lcd_panel = false;     // Give back control of the LCD Panel!
+    ubl.has_control_of_lcd_panel = false;     // Give back control of the LCD Panel!
 
     if (!keep_heaters_on) {
       #if HAS_TEMP_BED
@@ -479,7 +474,7 @@
               ex = constrain(ex, X_MIN_POS + 1, X_MAX_POS - 1);
               ey = constrain(ey, Y_MIN_POS + 1, Y_MAX_POS - 1);
 
-              if (g26_debug_flag) {
+              if (ubl.g26_debug_flag) {
                 SERIAL_ECHOPAIR(" Connecting with horizontal line (sx=", sx);
                 SERIAL_ECHOPAIR(", sy=", sy);
                 SERIAL_ECHOPAIR(") -> (ex=", ex);
@@ -516,7 +511,7 @@
                 ex = constrain(ex, X_MIN_POS + 1, X_MAX_POS - 1);
                 ey = constrain(ey, Y_MIN_POS + 1, Y_MAX_POS - 1);
 
-                if (g26_debug_flag) {
+                if (ubl.g26_debug_flag) {
                   SERIAL_ECHOPAIR(" Connecting with vertical line (sx=", sx);
                   SERIAL_ECHOPAIR(", sy=", sy);
                   SERIAL_ECHOPAIR(") -> (ex=", ex);
@@ -541,10 +536,10 @@
 
     bool has_xy_component = (x != current_position[X_AXIS] || y != current_position[Y_AXIS]); // Check if X or Y is involved in the movement.
 
-    //if (g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to()  has_xy_component:", (int)has_xy_component);
+    //if (ubl.g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to()  has_xy_component:", (int)has_xy_component);
 
     if (z != last_z) {
-      //if (g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to()  changing Z to ", (int)z);
+      //if (ubl.g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to()  changing Z to ", (int)z);
 
       last_z = z;
       feed_value = planner.max_feedrate_mm_s[Z_AXIS]/(3.0);  // Base the feed rate off of the configured Z_AXIS feed rate
@@ -559,24 +554,24 @@
       stepper.synchronize();
       set_destination_to_current();
 
-      //if (g26_debug_flag) debug_current_and_destination((char*)" in move_to() done with Z move");
+      //if (ubl.g26_debug_flag) debug_current_and_destination((char*)" in move_to() done with Z move");
     }
 
     // Check if X or Y is involved in the movement.
     // Yes: a 'normal' movement. No: a retract() or un_retract()
     feed_value = has_xy_component ? PLANNER_XY_FEEDRATE() / 10.0 : planner.max_feedrate_mm_s[E_AXIS] / 1.5;
 
-    if (g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to() feed_value for XY:", feed_value);
+    if (ubl.g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to() feed_value for XY:", feed_value);
 
     destination[X_AXIS] = x;
     destination[Y_AXIS] = y;
     destination[E_AXIS] += e_delta;
 
-    //if (g26_debug_flag) debug_current_and_destination((char*)" in move_to() doing last move");
+    //if (ubl.g26_debug_flag) debug_current_and_destination((char*)" in move_to() doing last move");
 
     ubl_line_to_destination(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], feed_value, 0);
 
-    //if (g26_debug_flag) debug_current_and_destination((char*)" in move_to() after last move");
+    //if (ubl.g26_debug_flag) debug_current_and_destination((char*)" in move_to() after last move");
 
     stepper.synchronize();
     set_destination_to_current();
@@ -586,9 +581,9 @@
   void retract_filament() {
     if (!g26_retracted) { // Only retract if we are not already retracted!
       g26_retracted = true;
-      //if (g26_debug_flag) SERIAL_ECHOLNPGM(" Decided to do retract.");
+      //if (ubl.g26_debug_flag) SERIAL_ECHOLNPGM(" Decided to do retract.");
       move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], -1.0 * retraction_multiplier);
-      //if (g26_debug_flag) SERIAL_ECHOLNPGM(" Retraction done.");
+      //if (ubl.g26_debug_flag) SERIAL_ECHOLNPGM(" Retraction done.");
     }
   }
 
@@ -596,7 +591,7 @@
     if (g26_retracted) { // Only un-retract if we are retracted.
       move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 1.2 * retraction_multiplier);
       g26_retracted = false;
-      //if (g26_debug_flag) SERIAL_ECHOLNPGM(" unretract done.");
+      //if (ubl.g26_debug_flag) SERIAL_ECHOLNPGM(" unretract done.");
     }
   }
 
@@ -633,7 +628,7 @@
     // On very small lines we don't do the optimization because it just isn't worth it.
     //
     if (dist_end < dist_start && (SIZE_OF_INTERSECTION_CIRCLES) < abs(line_length)) {
-      //if (g26_debug_flag) SERIAL_ECHOLNPGM("  Reversing start and end of print_line_from_here_to_there()");
+      //if (ubl.g26_debug_flag) SERIAL_ECHOLNPGM("  Reversing start and end of print_line_from_here_to_there()");
       print_line_from_here_to_there(ex, ey, ez, sx, sy, sz);
       return;
     }
@@ -642,7 +637,7 @@
 
     if (dist_start > 2.0) {
       retract_filament();
-      //if (g26_debug_flag) SERIAL_ECHOLNPGM("  filament retracted.");
+      //if (ubl.g26_debug_flag) SERIAL_ECHOLNPGM("  filament retracted.");
     }
     move_to(sx, sy, sz, 0.0); // Get to the starting point with no extrusion
 
@@ -650,7 +645,7 @@
 
     un_retract_filament();
 
-    //if (g26_debug_flag) {
+    //if (ubl.g26_debug_flag) {
     //  SERIAL_ECHOLNPGM("  doing printing move.");
     //  debug_current_and_destination((char*)"doing final move_to() inside print_line_from_here_to_there()");
     //}
@@ -810,7 +805,7 @@
           lcd_setstatuspgm(PSTR("G26 Heating Bed."), 99);
           lcd_quick_feedback();
       #endif
-          ubl_has_control_of_lcd_panel = true;
+          ubl.has_control_of_lcd_panel = true;
           thermalManager.setTargetBed(bed_temp);
           while (abs(thermalManager.degBed() - bed_temp) > 3) {
             if (ubl_lcd_clicked()) return exit_from_g26();

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -265,8 +265,8 @@
         location = find_closest_circle_to_print(x_pos, y_pos); // Find the closest Mesh Intersection to where we are now.
 
       if (location.x_index >= 0 && location.y_index >= 0) {
-        circle_x = ubl.map_x_index_to_bed_location(location.x_index);
-        circle_y = ubl.map_y_index_to_bed_location(location.y_index);
+        circle_x = ubl.mesh_index_to_xpos[location.x_index];
+        circle_y = ubl.mesh_index_to_ypos[location.y_index];
 
         // Let's do a couple of quick sanity checks.  We can pull this code out later if we never see it catch a problem
         #ifdef DELTA
@@ -415,8 +415,8 @@
     for (uint8_t i = 0; i < UBL_MESH_NUM_X_POINTS; i++) {
       for (uint8_t j = 0; j < UBL_MESH_NUM_Y_POINTS; j++) {
         if (!is_bit_set(circle_flags, i, j)) {
-          mx = ubl.map_x_index_to_bed_location(i);  // We found a circle that needs to be printed
-          my = ubl.map_y_index_to_bed_location(j);
+          mx = ubl.mesh_index_to_xpos[i];  // We found a circle that needs to be printed
+          my = ubl.mesh_index_to_ypos[j];
 
           dx = X - mx;        // Get the distance to this intersection
           dy = Y - my;
@@ -461,11 +461,11 @@
               // We found two circles that need a horizontal line to connect them
               // Print it!
               //
-              sx = ubl.map_x_index_to_bed_location(i);
+              sx = ubl.mesh_index_to_xpos[i];
               sx = sx + SIZE_OF_INTERSECTION_CIRCLES - SIZE_OF_CROSS_HAIRS; // get the right edge of the circle
-              sy = ubl.map_y_index_to_bed_location(j);
+              sy = ubl.mesh_index_to_ypos[j];
 
-              ex = ubl.map_x_index_to_bed_location(i + 1);
+              ex = ubl.mesh_index_to_xpos[i + 1];
               ex = ex - SIZE_OF_INTERSECTION_CIRCLES + SIZE_OF_CROSS_HAIRS; // get the left edge of the circle
               ey = sy;
 
@@ -498,12 +498,12 @@
                 // We found two circles that need a vertical line to connect them
                 // Print it!
                 //
-                sx = ubl.map_x_index_to_bed_location(i);
-                sy = ubl.map_y_index_to_bed_location(j);
+                sx = ubl.mesh_index_to_xpos[i];
+                sy = ubl.mesh_index_to_ypos[j];
                 sy = sy + SIZE_OF_INTERSECTION_CIRCLES - SIZE_OF_CROSS_HAIRS; // get the top edge of the circle
 
                 ex = sx;
-                ey = ubl.map_y_index_to_bed_location(j + 1);
+                ey = ubl.mesh_index_to_ypos[j + 1];
                 ey = ey - SIZE_OF_INTERSECTION_CIRCLES + SIZE_OF_CROSS_HAIRS; // get the bottom edge of the circle
 
                 sx = constrain(sx, X_MIN_POS + 1, X_MAX_POS - 1);             // This keeps us from bumping the endstops

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -76,10 +76,10 @@ void gcode_M100() {
       // We want to start and end the dump on a nice 16 byte boundry even though
       // the values we are using are not 16 byte aligned.
       //
-      SERIAL_ECHOPAIR("\nbss_end : ", hex_word((uint16_t)ptr));
+      SERIAL_ECHOPAIR("\nbss_end : 0x", hex_word((uint16_t)ptr));
       ptr = (char*)((uint32_t)ptr & 0xfff0);
       sp = top_of_stack();
-      SERIAL_ECHOLNPAIR("\nStack Pointer : ", hex_word((uint16_t)sp));
+      SERIAL_ECHOLNPAIR("\nStack Pointer : 0x", hex_word((uint16_t)sp));
       sp = (char*)((uint32_t)sp | 0x000f);
       n = sp - ptr;
       //

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -430,4 +430,8 @@ void do_blocking_move_to_x(const float &x, const float &fr_mm_s=0.0);
 void do_blocking_move_to_z(const float &z, const float &fr_mm_s=0.0);
 void do_blocking_move_to_xy(const float &x, const float &y, const float &fr_mm_s=0.0);
 
+#if ENABLED(Z_PROBE_ALLEN_KEY) || ENABLED(Z_PROBE_SLED) || HAS_PROBING_PROCEDURE || HOTENDS > 1 || ENABLED(NOZZLE_CLEAN_FEATURE) || ENABLED(NOZZLE_PARK_FEATURE)
+  bool axis_unhomed_error(const bool x, const bool y, const bool z);
+#endif
+
 #endif //MARLIN_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3221,7 +3221,7 @@ inline void gcode_G4() {
    */
   inline void gcode_G12() {
     // Don't allow nozzle cleaning without homing first
-    if (axis_unhomed_error(true, true, true)) { return; }
+    if (axis_unhomed_error(true, true, true)) return;
 
     const uint8_t pattern = code_seen('P') ? code_value_ushort() : 0,
                   strokes = code_seen('S') ? code_value_ushort() : NOZZLE_CLEAN_STROKES,

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5344,7 +5344,7 @@ inline void gcode_M42() {
 
 #endif // Z_MIN_PROBE_REPEATABILITY_TEST
 
-#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
+#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
 
   inline void gcode_M49() {
     ubl.g26_debug_flag = !ubl.g26_debug_flag;
@@ -5352,7 +5352,7 @@ inline void gcode_M42() {
     serialprintPGM(ubl.g26_debug_flag ? PSTR("on.") : PSTR("off."));
   }
 
-#endif // AUTO_BED_LEVELING_UBL && UBL_MESH_EDIT_ENABLED
+#endif // AUTO_BED_LEVELING_UBL && UBL_G26_MESH_EDITING
 
 /**
  * M75: Start print timer
@@ -8601,7 +8601,7 @@ void process_next_command() {
           break;
       #endif // INCH_MODE_SUPPORT
 
-      #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
+      #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
         case 26: // G26: Mesh Validation Pattern generation
           gcode_G26();
           break;
@@ -8617,7 +8617,7 @@ void process_next_command() {
         gcode_G28();
         break;
 
-      #if PLANNER_LEVELING && !ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
+      #if PLANNER_LEVELING && !ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
         case 29: // G29 Detailed Z probe, probes the bed at 3 or more points,
                  // or provides access to the UBL System if enabled.
           gcode_G29();
@@ -8733,11 +8733,11 @@ void process_next_command() {
           break;
       #endif // Z_MIN_PROBE_REPEATABILITY_TEST
 
-      #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
+      #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
         case 49: // M49: Turn on or off G26 debug flag for verbose output
           gcode_M49();
           break;
-      #endif // AUTO_BED_LEVELING_UBL && UBL_MESH_EDIT_ENABLED
+      #endif // AUTO_BED_LEVELING_UBL && UBL_G26_MESH_EDITING
 
       case 75: // M75: Start print timer
         gcode_M75(); break;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -299,11 +299,13 @@
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "UBL.h"
   unified_bed_leveling ubl;
-#define UBL_MESH_VALID !(   z_values[0][0] == z_values[0][1] && z_values[0][1] == z_values[0][2] \
-                         && z_values[1][0] == z_values[1][1] && z_values[1][1] == z_values[1][2] \
-                         && z_values[2][0] == z_values[2][1] && z_values[2][1] == z_values[2][2] \
-                         && z_values[0][0] == 0 && z_values[1][0] == 0 && z_values[2][0] == 0    \
-                         || isnan(z_values[0][0]))
+  #define UBL_MESH_VALID !( ( z_values[0][0] == z_values[0][1] && z_values[0][1] == z_values[0][2] \
+                           && z_values[1][0] == z_values[1][1] && z_values[1][1] == z_values[1][2] \
+                           && z_values[2][0] == z_values[2][1] && z_values[2][1] == z_values[2][2] \
+                           && z_values[0][0] == 0 && z_values[1][0] == 0 && z_values[2][0] == 0 )  \
+                           || isnan(z_values[0][0]))
+  extern bool g26_debug_flag;
+  extern int ubl_eeprom_start;
 #endif
 
 bool Running = true;
@@ -7213,10 +7215,54 @@ void quickstop_stepper() {
    *       S[bool]   Turns leveling on or off
    *       Z[height] Sets the Z fade height (0 or none to disable)
    *       V[bool]   Verbose - Print the leveling grid
+   *
+   *       L[index]  Load UBL mesh from index (0 is default)
    */
   inline void gcode_M420() {
-    bool to_enable = false;
 
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      // L to load a mesh from the EEPROM
+      if (code_seen('L')) {
+        const int8_t storage_slot = code_has_value() ? code_value_int() : ubl.state.eeprom_storage_slot;
+        const int16_t j = (UBL_LAST_EEPROM_INDEX - ubl.eeprom_start) / sizeof(z_values);
+        if (storage_slot < 0 || storage_slot >= j || ubl.eeprom_start <= 0) {
+          SERIAL_PROTOCOLLNPGM("?EEPROM storage not available for use.\n");
+          return;
+        }
+        ubl.load_mesh(Storage_Slot);
+        ubl.state.eeprom_storage_slot = Storage_Slot;
+        if (Storage_Slot != ubl.state.eeprom_storage_slot)
+          ubl.store_state();
+        ubl.display_map(0);  // Right now, we only support one type of map
+        SERIAL_ECHOLNPAIR("UBL_MESH_VALID =  ", UBL_MESH_VALID);
+        SERIAL_ECHOLNPAIR("eeprom_storage_slot = ", ubl.state.eeprom_storage_slot);
+      }
+    #endif // AUTO_BED_LEVELING_UBL
+
+    // V to print the matrix or mesh
+    if (code_seen('V')) {
+      #if ABL_PLANAR
+        planner.bed_level_matrix.debug("Bed Level Correction Matrix:");
+      #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
+        if (bilinear_grid_spacing[X_AXIS]) {
+          print_bilinear_leveling_grid();
+          #if ENABLED(ABL_BILINEAR_SUBDIVISION)
+            bed_level_virt_print();
+          #endif
+        }
+      #elif ENABLED(AUTO_BED_LEVELING_UBL)
+        ubl.display_map(0);  // Currently only supports one map type
+        SERIAL_ECHOLNPAIR("UBL_MESH_VALID =  ", UBL_MESH_VALID);
+        SERIAL_ECHOLNPAIR("eeprom_storage_slot = ", ubl.state.eeprom_storage_slot);
+      #elif ENABLED(MESH_BED_LEVELING)
+        if (mbl.has_mesh()) {
+          SERIAL_ECHOLNPGM("Mesh Bed Level data:");
+          mbl_mesh_report();
+        }
+      #endif
+    }
+
+    bool to_enable = false;
     if (code_seen('S')) {
       to_enable = code_value_bool();
       set_bed_leveling_enabled(to_enable);
@@ -7243,28 +7289,6 @@ void quickstop_stepper() {
 
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPAIR("Bed Leveling ", new_status ? MSG_ON : MSG_OFF);
-
-    // V to print the matrix or mesh
-    if (code_seen('V')) {
-      #if ABL_PLANAR
-        planner.bed_level_matrix.debug("Bed Level Correction Matrix:");
-      #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
-        if (bilinear_grid_spacing[X_AXIS]) {
-          print_bilinear_leveling_grid();
-          #if ENABLED(ABL_BILINEAR_SUBDIVISION)
-            bed_level_virt_print();
-          #endif
-        }
-      #elif ENABLED(AUTO_BED_LEVELING_UBL)
-        ubl.display_map(0);  // Right now, we only support one type of map
-      #elif ENABLED(MESH_BED_LEVELING)
-        if (mbl.has_mesh()) {
-          SERIAL_ECHOLNPGM("Mesh Bed Level data:");
-          mbl_mesh_report();
-        }
-      #endif
-    }
-
   }
 #endif
 
@@ -8595,7 +8619,7 @@ void process_next_command() {
         gcode_G28();
         break;
 
-      #if PLANNER_LEVELING
+      #if PLANNER_LEVELING && !ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
         case 29: // G29 Detailed Z probe, probes the bed at 3 or more points,
                  // or provides access to the UBL System if enabled.
           gcode_G29();

--- a/Marlin/UBL.h
+++ b/Marlin/UBL.h
@@ -81,11 +81,6 @@
     #define MESH_X_DIST ((float(UBL_MESH_MAX_X) - float(UBL_MESH_MIN_X)) / (float(UBL_MESH_NUM_X_POINTS) - 1.0))
     #define MESH_Y_DIST ((float(UBL_MESH_MAX_Y) - float(UBL_MESH_MIN_Y)) / (float(UBL_MESH_NUM_Y_POINTS) - 1.0))
 
-    #if ENABLED(UBL_MESH_EDIT_ENABLED)
-      extern bool g26_debug_flag;
-    #else
-      constexpr bool g26_debug_flag = false;
-    #endif
     extern float last_specified_z;
     extern float fade_scaling_factor_for_current_height;
     extern float z_values[UBL_MESH_NUM_X_POINTS][UBL_MESH_NUM_Y_POINTS];
@@ -339,7 +334,6 @@
     }; // class unified_bed_leveling
 
     extern unified_bed_leveling ubl;
-    extern int ubl_eeprom_start;
 
     #define UBL_LAST_EEPROM_INDEX (E2END - sizeof(unified_bed_leveling::state))
 

--- a/Marlin/UBL.h
+++ b/Marlin/UBL.h
@@ -39,7 +39,6 @@
 
     enum MeshPointType { INVALID, REAL, SET_IN_BITMAP };
 
-    bool axis_unhomed_error(bool, bool, bool);
     void dump(char * const str, const float &f);
     bool ubl_lcd_clicked();
     void probe_entire_mesh(const float&, const float&, const bool, const bool, const bool);
@@ -78,275 +77,273 @@
 
     enum MBLStatus { MBL_STATUS_NONE = 0, MBL_STATUS_HAS_MESH_BIT = 0, MBL_STATUS_ACTIVE_BIT = 1 };
 
-    #define MESH_X_DIST ((float(UBL_MESH_MAX_X) - float(UBL_MESH_MIN_X)) / (float(UBL_MESH_NUM_X_POINTS) - 1.0))
-    #define MESH_Y_DIST ((float(UBL_MESH_MAX_Y) - float(UBL_MESH_MIN_Y)) / (float(UBL_MESH_NUM_Y_POINTS) - 1.0))
+    #define MESH_X_DIST (float(UBL_MESH_MAX_X - (UBL_MESH_MIN_X)) / float(UBL_MESH_NUM_X_POINTS - 1))
+    #define MESH_Y_DIST (float(UBL_MESH_MAX_Y - (UBL_MESH_MIN_Y)) / float(UBL_MESH_NUM_Y_POINTS - 1))
 
-    extern float mesh_index_to_x_location[UBL_MESH_NUM_X_POINTS + 1]; // +1 just because of paranoia that we might end up on the
-    extern float mesh_index_to_y_location[UBL_MESH_NUM_Y_POINTS + 1]; // the last Mesh Line and that is the start of a whole new cell
+    typedef struct {
+      bool active = false;
+      float z_offset = 0.0;
+      int8_t eeprom_storage_slot = -1,
+             n_x = UBL_MESH_NUM_X_POINTS,
+             n_y = UBL_MESH_NUM_Y_POINTS;
+
+      float mesh_x_min = UBL_MESH_MIN_X,
+            mesh_y_min = UBL_MESH_MIN_Y,
+            mesh_x_max = UBL_MESH_MAX_X,
+            mesh_y_max = UBL_MESH_MAX_Y,
+            mesh_x_dist = MESH_X_DIST,
+            mesh_y_dist = MESH_Y_DIST;
+
+      #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+        float g29_correction_fade_height = 10.0,
+              g29_fade_height_multiplier = 1.0 / 10.0; // It's cheaper to do a floating point multiply than divide,
+                                                       // so keep this value and its reciprocal.
+      #else
+        const float g29_correction_fade_height = 10.0,
+                    g29_fade_height_multiplier = 1.0 / 10.0;
+      #endif
+
+      // If you change this struct, adjust TOTAL_STRUCT_SIZE
+
+      #define TOTAL_STRUCT_SIZE 40 // Total size of the above fields
+
+      // padding provides space to add state variables without
+      // changing the location of data structures in the EEPROM.
+      // This is for compatibility with future versions to keep
+      // users from having to regenerate their mesh data.
+      unsigned char padding[64 - TOTAL_STRUCT_SIZE];
+
+    } ubl_state;
 
     class unified_bed_leveling {
       private:
 
-      float last_specified_z,
-            fade_scaling_factor_for_current_height;
+        static float last_specified_z,
+                     fade_scaling_factor_for_current_height;
 
       public:
 
-      float z_values[UBL_MESH_NUM_X_POINTS][UBL_MESH_NUM_Y_POINTS];
+        static ubl_state state, pre_initialized;
 
-      bool g26_debug_flag = false,
-           has_control_of_lcd_panel = false;
+        static float z_values[UBL_MESH_NUM_X_POINTS][UBL_MESH_NUM_Y_POINTS],
+                     mesh_index_to_xpos[UBL_MESH_NUM_X_POINTS + 1], // +1 safety margin for now, until determinism prevails
+                     mesh_index_to_ypos[UBL_MESH_NUM_Y_POINTS + 1];
 
-      int8_t eeprom_start = -1;
+        static bool g26_debug_flag,
+                    has_control_of_lcd_panel;
 
-      volatile int encoder_diff; // Volatile because it's changed at interrupt time.
+        static int8_t eeprom_start;
 
-      struct ubl_state {
-        bool active = false;
-        float z_offset = 0.0;
-        int8_t eeprom_storage_slot = -1,
-               n_x = UBL_MESH_NUM_X_POINTS,
-               n_y = UBL_MESH_NUM_Y_POINTS;
+        static volatile int encoder_diff; // Volatile because it's changed at interrupt time.
 
-        float mesh_x_min = UBL_MESH_MIN_X,
-              mesh_y_min = UBL_MESH_MIN_Y,
-              mesh_x_max = UBL_MESH_MAX_X,
-              mesh_y_max = UBL_MESH_MAX_Y,
-              mesh_x_dist = MESH_X_DIST,
-              mesh_y_dist = MESH_Y_DIST;
+        unified_bed_leveling();
 
-        #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-          float g29_correction_fade_height = 10.0,
-                g29_fade_height_multiplier = 1.0 / 10.0; // It's cheaper to do a floating point multiply than divide,
-                                                         // so keep this value and its reciprocal.
-        #else
-          const float g29_correction_fade_height = 10.0,
-                      g29_fade_height_multiplier = 1.0 / 10.0;
-        #endif
+        static void display_map(const int);
 
-        // If you change this struct, adjust TOTAL_STRUCT_SIZE
+        static void reset();
+        static void invalidate();
 
-        #define TOTAL_STRUCT_SIZE 43 // Total size of the above fields
+        static void store_state();
+        static void load_state();
+        static void store_mesh(const int16_t);
+        static void load_mesh(const int16_t);
 
-        // padding provides space to add state variables without
-        // changing the location of data structures in the EEPROM.
-        // This is for compatibility with future versions to keep
-        // users from having to regenerate their mesh data.
-        unsigned char padding[64 - TOTAL_STRUCT_SIZE];
+        static bool sanity_check();
 
-      } state, pre_initialized;
+        static FORCE_INLINE void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
 
-      unified_bed_leveling();
+        static int8_t get_cell_index_x(const float &x) {
+          const int8_t cx = (x - (UBL_MESH_MIN_X)) * (1.0 / (MESH_X_DIST));
+          return constrain(cx, 0, (UBL_MESH_NUM_X_POINTS) - 1);   // -1 is appropriate if we want all movement to the X_MAX
+        }                                                         // position. But with this defined this way, it is possible
+                                                                  // to extrapolate off of this point even further out. Probably
+                                                                  // that is OK because something else should be keeping that from
+                                                                  // happening and should not be worried about at this level.
+        static int8_t get_cell_index_y(const float &y) {
+          const int8_t cy = (y - (UBL_MESH_MIN_Y)) * (1.0 / (MESH_Y_DIST));
+          return constrain(cy, 0, (UBL_MESH_NUM_Y_POINTS) - 1);   // -1 is appropriate if we want all movement to the Y_MAX
+        }                                                         // position. But with this defined this way, it is possible
+                                                                  // to extrapolate off of this point even further out. Probably
+                                                                  // that is OK because something else should be keeping that from
+                                                                  // happening and should not be worried about at this level.
 
-      void display_map(const int);
-
-      void reset();
-      void invalidate();
-
-      void store_state();
-      void load_state();
-      void store_mesh(const int16_t);
-      void load_mesh(const int16_t);
-
-      bool sanity_check();
-
-      FORCE_INLINE static float map_x_index_to_bed_location(const int8_t i) { return ((float) UBL_MESH_MIN_X) + (((float) MESH_X_DIST) * (float) i); };
-      FORCE_INLINE static float map_y_index_to_bed_location(const int8_t i) { return ((float) UBL_MESH_MIN_Y) + (((float) MESH_Y_DIST) * (float) i); };
-
-      FORCE_INLINE void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
-
-      static int8_t get_cell_index_x(const float &x) {
-        const int8_t cx = (x - (UBL_MESH_MIN_X)) * (1.0 / (MESH_X_DIST));
-        return constrain(cx, 0, (UBL_MESH_NUM_X_POINTS) - 1);   // -1 is appropriate if we want all movement to the X_MAX
-      }                                                         // position. But with this defined this way, it is possible
-                                                                // to extrapolate off of this point even further out. Probably
-                                                                // that is OK because something else should be keeping that from
-                                                                // happening and should not be worried about at this level.
-      static int8_t get_cell_index_y(const float &y) {
-        const int8_t cy = (y - (UBL_MESH_MIN_Y)) * (1.0 / (MESH_Y_DIST));
-        return constrain(cy, 0, (UBL_MESH_NUM_Y_POINTS) - 1);   // -1 is appropriate if we want all movement to the Y_MAX
-      }                                                         // position. But with this defined this way, it is possible
-                                                                // to extrapolate off of this point even further out. Probably
-                                                                // that is OK because something else should be keeping that from
-                                                                // happening and should not be worried about at this level.
-
-      static int8_t find_closest_x_index(const float &x) {
-        const int8_t px = (x - (UBL_MESH_MIN_X) + (MESH_X_DIST) * 0.5) * (1.0 / (MESH_X_DIST));
-        return (px >= 0 && px < (UBL_MESH_NUM_X_POINTS)) ? px : -1;
-      }
-
-      static int8_t find_closest_y_index(const float &y) {
-        const int8_t py = (y - (UBL_MESH_MIN_Y) + (MESH_Y_DIST) * 0.5) * (1.0 / (MESH_Y_DIST));
-        return (py >= 0 && py < (UBL_MESH_NUM_Y_POINTS)) ? py : -1;
-      }
-
-      /**
-       *                           z2   --|
-       *                 z0        |      |
-       *                  |        |      + (z2-z1)
-       *   z1             |        |      |
-       * ---+-------------+--------+--  --|
-       *   a1            a0        a2
-       *    |<---delta_a---------->|
-       *
-       *  calc_z0 is the basis for all the Mesh Based correction. It is used to
-       *  find the expected Z Height at a position between two known Z-Height locations.
-       *
-       *  It is fairly expensive with its 4 floating point additions and 2 floating point
-       *  multiplications.
-       */
-      static FORCE_INLINE float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
-        const float delta_z = (z2 - z1),
-                    delta_a = (a0 - a1) / (a2 - a1);
-        return z1 + delta_a * delta_z;
-      }
-
-      /**
-       * get_z_correction_at_Y_intercept(float x0, int x1_i, int yi) only takes
-       * three parameters. It assumes the x0 point is on a Mesh line denoted by yi. In theory
-       * we could use get_cell_index_x(float x) to obtain the 2nd parameter x1_i but any code calling
-       * the get_z_correction_along_vertical_mesh_line_at_specific_X routine  will already have
-       * the X index of the x0 intersection available and we don't want to perform any extra floating
-       * point operations.
-       */
-      inline float get_z_correction_along_horizontal_mesh_line_at_specific_X(const float &x0, const int x1_i, const int yi) {
-        if (x1_i < 0 || yi < 0 || x1_i >= UBL_MESH_NUM_X_POINTS || yi >= UBL_MESH_NUM_Y_POINTS) {
-          SERIAL_ECHOPAIR("? in get_z_correction_along_horizontal_mesh_line_at_specific_X(x0=", x0);
-          SERIAL_ECHOPAIR(",x1_i=", x1_i);
-          SERIAL_ECHOPAIR(",yi=", yi);
-          SERIAL_CHAR(')');
-          SERIAL_EOL;
-          return NAN;
+        static int8_t find_closest_x_index(const float &x) {
+          const int8_t px = (x - (UBL_MESH_MIN_X) + (MESH_X_DIST) * 0.5) * (1.0 / (MESH_X_DIST));
+          return (px >= 0 && px < (UBL_MESH_NUM_X_POINTS)) ? px : -1;
         }
 
-        const float xratio = (RAW_X_POSITION(x0) - mesh_index_to_x_location[x1_i]) * (1.0 / (MESH_X_DIST)),
-                    z1 = z_values[x1_i][yi],
-                    z2 = z_values[x1_i + 1][yi],
-                    dz = (z2 - z1);
-
-        return z1 + xratio * dz;
-      }
-
-      //
-      // See comments above for get_z_correction_along_horizontal_mesh_line_at_specific_X
-      //
-      inline float get_z_correction_along_vertical_mesh_line_at_specific_Y(const float &y0, const int xi, const int y1_i) {
-        if (xi < 0 || y1_i < 0 || xi >= UBL_MESH_NUM_X_POINTS || y1_i >= UBL_MESH_NUM_Y_POINTS) {
-          SERIAL_ECHOPAIR("? in get_z_correction_along_vertical_mesh_line_at_specific_X(y0=", y0);
-          SERIAL_ECHOPAIR(", x1_i=", xi);
-          SERIAL_ECHOPAIR(", yi=", y1_i);
-          SERIAL_CHAR(')');
-          SERIAL_EOL;
-          return NAN;
+        static int8_t find_closest_y_index(const float &y) {
+          const int8_t py = (y - (UBL_MESH_MIN_Y) + (MESH_Y_DIST) * 0.5) * (1.0 / (MESH_Y_DIST));
+          return (py >= 0 && py < (UBL_MESH_NUM_Y_POINTS)) ? py : -1;
         }
 
-        const float yratio = (RAW_Y_POSITION(y0) - mesh_index_to_y_location[y1_i]) * (1.0 / (MESH_Y_DIST)),
-                    z1 = z_values[xi][y1_i],
-                    z2 = z_values[xi][y1_i + 1],
-                    dz = (z2 - z1);
-
-        return z1 + yratio * dz;
-      }
-
-      /**
-       * This is the generic Z-Correction. It works anywhere within a Mesh Cell. It first
-       * does a linear interpolation along both of the bounding X-Mesh-Lines to find the
-       * Z-Height at both ends. Then it does a linear interpolation of these heights based
-       * on the Y position within the cell.
-       */
-      float get_z_correction(const float &x0, const float &y0) const {
-        const int8_t cx = get_cell_index_x(RAW_X_POSITION(x0)),
-                     cy = get_cell_index_y(RAW_Y_POSITION(y0));
-
-        if (cx < 0 || cy < 0 || cx >= UBL_MESH_NUM_X_POINTS || cy >= UBL_MESH_NUM_Y_POINTS) {
-
-          SERIAL_ECHOPAIR("? in get_z_correction(x0=", x0);
-          SERIAL_ECHOPAIR(", y0=", y0);
-          SERIAL_CHAR(')');
-          SERIAL_EOL;
-
-          #if ENABLED(ULTRA_LCD)
-            strcpy(lcd_status_message, "get_z_correction() indexes out of range.");
-            lcd_quick_feedback();
-          #endif
-          return 0.0; // this used to return state.z_offset
+        /**
+         *                           z2   --|
+         *                 z0        |      |
+         *                  |        |      + (z2-z1)
+         *   z1             |        |      |
+         * ---+-------------+--------+--  --|
+         *   a1            a0        a2
+         *    |<---delta_a---------->|
+         *
+         *  calc_z0 is the basis for all the Mesh Based correction. It is used to
+         *  find the expected Z Height at a position between two known Z-Height locations.
+         *
+         *  It is fairly expensive with its 4 floating point additions and 2 floating point
+         *  multiplications.
+         */
+        static FORCE_INLINE float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
+          const float delta_z = (z2 - z1),
+                      delta_a = (a0 - a1) / (a2 - a1);
+          return z1 + delta_a * delta_z;
         }
 
-        const float z1 = calc_z0(RAW_X_POSITION(x0),
-                      map_x_index_to_bed_location(cx), z_values[cx][cy],
-                      map_x_index_to_bed_location(cx + 1), z_values[cx + 1][cy]),
-                    z2 = calc_z0(RAW_X_POSITION(x0),
-                      map_x_index_to_bed_location(cx), z_values[cx][cy + 1],
-                      map_x_index_to_bed_location(cx + 1), z_values[cx + 1][cy + 1]);
-              float z0 = calc_z0(RAW_Y_POSITION(y0),
-                  map_y_index_to_bed_location(cy), z1,
-                  map_y_index_to_bed_location(cy + 1), z2);
-
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(MESH_ADJUST)) {
-            SERIAL_ECHOPAIR(" raw get_z_correction(", x0);
-            SERIAL_CHAR(',')
-            SERIAL_ECHO(y0);
-            SERIAL_ECHOPGM(") = ");
-            SERIAL_ECHO_F(z0, 6);
-          }
-        #endif
-
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(MESH_ADJUST)) {
-            SERIAL_ECHOPGM(" >>>---> ");
-            SERIAL_ECHO_F(z0, 6);
+        /**
+         * get_z_correction_at_Y_intercept(float x0, int x1_i, int yi) only takes
+         * three parameters. It assumes the x0 point is on a Mesh line denoted by yi. In theory
+         * we could use get_cell_index_x(float x) to obtain the 2nd parameter x1_i but any code calling
+         * the get_z_correction_along_vertical_mesh_line_at_specific_X routine  will already have
+         * the X index of the x0 intersection available and we don't want to perform any extra floating
+         * point operations.
+         */
+        static inline float get_z_correction_along_horizontal_mesh_line_at_specific_X(const float &x0, const int x1_i, const int yi) {
+          if (x1_i < 0 || yi < 0 || x1_i >= UBL_MESH_NUM_X_POINTS || yi >= UBL_MESH_NUM_Y_POINTS) {
+            SERIAL_ECHOPAIR("? in get_z_correction_along_horizontal_mesh_line_at_specific_X(x0=", x0);
+            SERIAL_ECHOPAIR(",x1_i=", x1_i);
+            SERIAL_ECHOPAIR(",yi=", yi);
+            SERIAL_CHAR(')');
             SERIAL_EOL;
+            return NAN;
           }
-        #endif
 
-        if (isnan(z0)) { // if part of the Mesh is undefined, it will show up as NAN
-          z0 = 0.0;      // in ubl.z_values[][] and propagate through the
-                         // calculations. If our correction is NAN, we throw it out
-                         // because part of the Mesh is undefined and we don't have the
-                         // information we need to complete the height correction.
+          const float xratio = (RAW_X_POSITION(x0) - mesh_index_to_xpos[x1_i]) * (1.0 / (MESH_X_DIST)),
+                      z1 = z_values[x1_i][yi],
+                      z2 = z_values[x1_i + 1][yi],
+                      dz = (z2 - z1);
+
+          return z1 + xratio * dz;
+        }
+
+        //
+        // See comments above for get_z_correction_along_horizontal_mesh_line_at_specific_X
+        //
+        static inline float get_z_correction_along_vertical_mesh_line_at_specific_Y(const float &y0, const int xi, const int y1_i) {
+          if (xi < 0 || y1_i < 0 || xi >= UBL_MESH_NUM_X_POINTS || y1_i >= UBL_MESH_NUM_Y_POINTS) {
+            SERIAL_ECHOPAIR("? in get_z_correction_along_vertical_mesh_line_at_specific_X(y0=", y0);
+            SERIAL_ECHOPAIR(", x1_i=", xi);
+            SERIAL_ECHOPAIR(", yi=", y1_i);
+            SERIAL_CHAR(')');
+            SERIAL_EOL;
+            return NAN;
+          }
+
+          const float yratio = (RAW_Y_POSITION(y0) - mesh_index_to_ypos[y1_i]) * (1.0 / (MESH_Y_DIST)),
+                      z1 = z_values[xi][y1_i],
+                      z2 = z_values[xi][y1_i + 1],
+                      dz = (z2 - z1);
+
+          return z1 + yratio * dz;
+        }
+
+        /**
+         * This is the generic Z-Correction. It works anywhere within a Mesh Cell. It first
+         * does a linear interpolation along both of the bounding X-Mesh-Lines to find the
+         * Z-Height at both ends. Then it does a linear interpolation of these heights based
+         * on the Y position within the cell.
+         */
+        static float get_z_correction(const float &x0, const float &y0) {
+          const int8_t cx = get_cell_index_x(RAW_X_POSITION(x0)),
+                       cy = get_cell_index_y(RAW_Y_POSITION(y0));
+
+          if (cx < 0 || cy < 0 || cx >= UBL_MESH_NUM_X_POINTS || cy >= UBL_MESH_NUM_Y_POINTS) {
+
+            SERIAL_ECHOPAIR("? in get_z_correction(x0=", x0);
+            SERIAL_ECHOPAIR(", y0=", y0);
+            SERIAL_CHAR(')');
+            SERIAL_EOL;
+
+            #if ENABLED(ULTRA_LCD)
+              strcpy(lcd_status_message, "get_z_correction() indexes out of range.");
+              lcd_quick_feedback();
+            #endif
+            return 0.0; // this used to return state.z_offset
+          }
+
+          const float z1 = calc_z0(RAW_X_POSITION(x0),
+                        mesh_index_to_xpos[cx], z_values[cx][cy],
+                        mesh_index_to_xpos[cx + 1], z_values[cx + 1][cy]),
+                      z2 = calc_z0(RAW_X_POSITION(x0),
+                        mesh_index_to_xpos[cx], z_values[cx][cy + 1],
+                        mesh_index_to_xpos[cx + 1], z_values[cx + 1][cy + 1]);
+                float z0 = calc_z0(RAW_Y_POSITION(y0),
+                    mesh_index_to_ypos[cy], z1,
+                    mesh_index_to_ypos[cy + 1], z2);
 
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(MESH_ADJUST)) {
-              SERIAL_ECHOPAIR("??? Yikes!  NAN in get_z_correction(", x0);
-              SERIAL_CHAR(',');
+              SERIAL_ECHOPAIR(" raw get_z_correction(", x0);
+              SERIAL_CHAR(',')
               SERIAL_ECHO(y0);
-              SERIAL_CHAR(')');
+              SERIAL_ECHOPGM(") = ");
+              SERIAL_ECHO_F(z0, 6);
+            }
+          #endif
+
+          #if ENABLED(DEBUG_LEVELING_FEATURE)
+            if (DEBUGGING(MESH_ADJUST)) {
+              SERIAL_ECHOPGM(" >>>---> ");
+              SERIAL_ECHO_F(z0, 6);
               SERIAL_EOL;
             }
           #endif
-        }
-        return z0; // there used to be a +state.z_offset on this line
-      }
 
-      /**
-       * This routine is used to scale the Z correction depending upon the current nozzle height. It is
-       * optimized for speed. It avoids floating point operations by checking if the requested scaling
-       * factor is going to be the same as the last time the function calculated a value. If so, it just
-       * returns it.
-       *
-       * It returns a scaling factor of 1.0 if UBL is inactive.
-       * It returns a scaling factor of 0.0 if Z is past the specified 'Fade Height'
-       */
-      #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+          if (isnan(z0)) { // if part of the Mesh is undefined, it will show up as NAN
+            z0 = 0.0;      // in ubl.z_values[][] and propagate through the
+                           // calculations. If our correction is NAN, we throw it out
+                           // because part of the Mesh is undefined and we don't have the
+                           // information we need to complete the height correction.
 
-        FORCE_INLINE float fade_scaling_factor_for_z(const float &lz) {
-          const float rz = RAW_Z_POSITION(lz);
-          if (last_specified_z != rz) {
-            last_specified_z = rz;
-            fade_scaling_factor_for_current_height =
-              state.active && rz < state.g29_correction_fade_height
-                ? 1.0 - (rz * state.g29_fade_height_multiplier)
-                : 0.0;
+            #if ENABLED(DEBUG_LEVELING_FEATURE)
+              if (DEBUGGING(MESH_ADJUST)) {
+                SERIAL_ECHOPAIR("??? Yikes!  NAN in get_z_correction(", x0);
+                SERIAL_CHAR(',');
+                SERIAL_ECHO(y0);
+                SERIAL_CHAR(')');
+                SERIAL_EOL;
+              }
+            #endif
           }
-          return fade_scaling_factor_for_current_height;
+          return z0; // there used to be a +state.z_offset on this line
         }
 
-      #else
+        /**
+         * This routine is used to scale the Z correction depending upon the current nozzle height. It is
+         * optimized for speed. It avoids floating point operations by checking if the requested scaling
+         * factor is going to be the same as the last time the function calculated a value. If so, it just
+         * returns it.
+         *
+         * It returns a scaling factor of 1.0 if UBL is inactive.
+         * It returns a scaling factor of 0.0 if Z is past the specified 'Fade Height'
+         */
+        #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
-        static constexpr float fade_scaling_factor_for_z(const float &lz) { UNUSED(lz); return 1.0; }
+          FORCE_INLINE float fade_scaling_factor_for_z(const float &lz) {
+            const float rz = RAW_Z_POSITION(lz);
+            if (last_specified_z != rz) {
+              last_specified_z = rz;
+              fade_scaling_factor_for_current_height =
+                state.active && rz < state.g29_correction_fade_height
+                  ? 1.0 - (rz * state.g29_fade_height_multiplier)
+                  : 0.0;
+            }
+            return fade_scaling_factor_for_current_height;
+          }
 
-      #endif
+        #else
+
+          static constexpr float fade_scaling_factor_for_z(const float &lz) { UNUSED(lz); return 1.0; }
+
+        #endif
 
     }; // class unified_bed_leveling
 
@@ -355,5 +352,4 @@
     #define UBL_LAST_EEPROM_INDEX (E2END - sizeof(unified_bed_leveling::state))
 
   #endif // AUTO_BED_LEVELING_UBL
-
 #endif // UNIFIED_BED_LEVELING_H

--- a/Marlin/UBL_Bed_Leveling.cpp
+++ b/Marlin/UBL_Bed_Leveling.cpp
@@ -27,6 +27,7 @@
 
   #include "UBL.h"
   #include "hex_print_routines.h"
+  extern int ubl_eeprom_start;
 
   /**
    * These support functions allow the use of large bit arrays of flags that take very

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -22,7 +22,7 @@
 
 #include "MarlinConfig.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
+#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
   //#include "vector_3.h"
   //#include "qr_solve.h"
 

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -750,8 +750,8 @@
       location = find_closest_mesh_point_of_type(INVALID, lx, ly, 1, NULL, do_furthest );  // the '1' says we want the location to be relative to the probe
       if (location.x_index >= 0 && location.y_index >= 0) {
 
-        const float rawx = ubl.map_x_index_to_bed_location(location.x_index),
-                    rawy = ubl.map_y_index_to_bed_location(location.y_index);
+        const float rawx = ubl.mesh_index_to_xpos[location.x_index],
+                    rawy = ubl.mesh_index_to_ypos[location.y_index];
 
         // TODO: Change to use `position_is_reachable` (for SCARA-compatibility)
         if (rawx < (MIN_PROBE_X) || rawx > (MAX_PROBE_X) || rawy < (MIN_PROBE_Y) || rawy > (MAX_PROBE_Y)) {
@@ -900,8 +900,8 @@
       // It doesn't matter if the probe can't reach the NAN location. This is a manual probe.
       if (location.x_index < 0 && location.y_index < 0) continue;
 
-      const float rawx = ubl.map_x_index_to_bed_location(location.x_index),
-                  rawy = ubl.map_y_index_to_bed_location(location.y_index);
+      const float rawx = ubl.mesh_index_to_xpos[location.x_index],
+                  rawy = ubl.mesh_index_to_ypos[location.y_index];
 
       // TODO: Change to use `position_is_reachable` (for SCARA-compatibility)
       if (rawx < (X_MIN_POS) || rawx > (X_MAX_POS) || rawy < (Y_MIN_POS) || rawy > (Y_MAX_POS)) {
@@ -1137,7 +1137,7 @@
 
     SERIAL_PROTOCOLPGM("X-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < UBL_MESH_NUM_X_POINTS; i++) {
-      SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(ubl.map_x_index_to_bed_location(i)), 1);
+      SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(ubl.mesh_index_to_xpos[i]), 1);
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(50);
     }
@@ -1145,7 +1145,7 @@
 
     SERIAL_PROTOCOLPGM("Y-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < UBL_MESH_NUM_Y_POINTS; i++) {
-      SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(ubl.map_y_index_to_bed_location(i)), 1);
+      SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(ubl.mesh_index_to_ypos[i]), 1);
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(50);
     }
@@ -1283,8 +1283,8 @@
 
           // We only get here if we found a Mesh Point of the specified type
 
-          const float rawx = ubl.map_x_index_to_bed_location(i), // Check if we can probe this mesh location
-                      rawy = ubl.map_y_index_to_bed_location(j);
+          const float rawx = ubl.mesh_index_to_xpos[i], // Check if we can probe this mesh location
+                      rawy = ubl.mesh_index_to_ypos[j];
 
           // If using the probe as the reference there are some unreachable locations.
           // Prune them from the list and ignore them till the next Phase (manual nozzle probing).
@@ -1350,8 +1350,8 @@
       bit_clear(not_done, location.x_index, location.y_index);  // Mark this location as 'adjusted' so we will find a
                                                                 // different location the next time through the loop
 
-      const float rawx = ubl.map_x_index_to_bed_location(location.x_index),
-                  rawy = ubl.map_y_index_to_bed_location(location.y_index);
+      const float rawx = ubl.mesh_index_to_xpos[location.x_index],
+                  rawy = ubl.mesh_index_to_ypos[location.y_index];
 
       // TODO: Change to use `position_is_reachable` (for SCARA-compatibility)
       if (rawx < (X_MIN_POS) || rawx > (X_MAX_POS) || rawy < (Y_MIN_POS) || rawy > (Y_MAX_POS)) { // In theory, we don't need this check.

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -65,8 +65,6 @@
   #define SIZE_OF_LITTLE_RAISE 0
   #define BIG_RAISE_NOT_NEEDED 0
   extern void lcd_quick_feedback();
-  extern int ubl_eeprom_start;
-  extern volatile int ubl_encoderDiff; // This is volatile because it is getting changed at interrupt time.
 
   /**
    *   G29: Unified Bed Leveling by Roxy
@@ -146,7 +144,7 @@
    *   P0    Phase 0    Zero Mesh Data and turn off the Mesh Compensation System. This reverts the
    *                    3D Printer to the same state it was in before the Unified Bed Leveling Compensation
    *                    was turned on. Setting the entire Mesh to Zero is a special case that allows
-   *                    a subsequent G or T leveling operation for backward compatability.
+   *                    a subsequent G or T leveling operation for backward compatibility.
    *
    *   P1    Phase 1    Invalidate entire Mesh and continue with automatic generation of the Mesh data using
    *                    the Z-Probe. Depending upon the values of DELTA_PROBEABLE_RADIUS and
@@ -299,13 +297,9 @@
    *   this is going to be helpful to the users!)
    *
    *   The foundation of this Bed Leveling System is built on Epatel's Mesh Bed Leveling code. A big
-   *   'Thanks!' to him and the creators of 3-Point and Grid Based leveling. Combining thier contributions
+   *   'Thanks!' to him and the creators of 3-Point and Grid Based leveling. Combining their contributions
    *   we now have the functionality and features of all three systems combined.
    */
-
-  int ubl_eeprom_start = -1;
-  bool ubl_has_control_of_lcd_panel = false;
-  volatile int8_t ubl_encoderDiff = 0; // Volatile because it's changed by Temperature ISR button update
 
   // The simple parameter flags and values are 'static' so parameter parsing can be in a support routine.
   static int g29_verbose_level, phase_value = -1, repetition_cnt,
@@ -318,8 +312,8 @@
   #endif
 
   void gcode_G29() {
-    SERIAL_PROTOCOLLNPAIR("ubl_eeprom_start=", ubl_eeprom_start);
-    if (ubl_eeprom_start < 0) {
+    SERIAL_PROTOCOLLNPAIR("ubl.eeprom_start=", ubl.eeprom_start);
+    if (ubl.eeprom_start < 0) {
       SERIAL_PROTOCOLLNPGM("?You need to enable your EEPROM and initialize it");
       SERIAL_PROTOCOLLNPGM("with M502, M500, M501 in that order.\n");
       return;
@@ -340,7 +334,7 @@
           SERIAL_PROTOCOLLNPGM("Entire Mesh invalidated.\n");
           break;            // No more invalid Mesh Points to populate
         }
-        z_values[location.x_index][location.y_index] = NAN;
+        ubl.z_values[location.x_index][location.y_index] = NAN;
       }
       SERIAL_PROTOCOLLNPGM("Locations invalidated.\n");
     }
@@ -359,21 +353,21 @@
             for (uint8_t y = 0; y < UBL_MESH_NUM_Y_POINTS; y++) { // a poorly calibrated Delta.
               const float p1 = 0.5 * (UBL_MESH_NUM_X_POINTS) - x,
                           p2 = 0.5 * (UBL_MESH_NUM_Y_POINTS) - y;
-              z_values[x][y] += 2.0 * HYPOT(p1, p2);
+              ubl.z_values[x][y] += 2.0 * HYPOT(p1, p2);
             }
           }
           break;
         case 1:
           for (uint8_t x = 0; x < UBL_MESH_NUM_X_POINTS; x++) {  // Create a diagonal line several Mesh cells thick that is raised
-            z_values[x][x] += 9.999;
-            z_values[x][x + (x < UBL_MESH_NUM_Y_POINTS - 1) ? 1 : -1] += 9.999; // We want the altered line several mesh points thick
+            ubl.z_values[x][x] += 9.999;
+            ubl.z_values[x][x + (x < UBL_MESH_NUM_Y_POINTS - 1) ? 1 : -1] += 9.999; // We want the altered line several mesh points thick
           }
           break;
         case 2:
           // Allow the user to specify the height because 10mm is a little extreme in some cases.
           for (uint8_t x = (UBL_MESH_NUM_X_POINTS) / 3; x < 2 * (UBL_MESH_NUM_X_POINTS) / 3; x++)   // Create a rectangular raised area in
             for (uint8_t y = (UBL_MESH_NUM_Y_POINTS) / 3; y < 2 * (UBL_MESH_NUM_Y_POINTS) / 3; y++) // the center of the bed
-              z_values[x][y] += code_seen('C') ? ubl_constant : 9.99;
+              ubl.z_values[x][y] += code_seen('C') ? ubl_constant : 9.99;
           break;
       }
     }
@@ -395,17 +389,18 @@
         return;
       }
       switch (phase_value) {
-        //
-        // Zero Mesh Data
-        //
         case 0:
+          //
+          // Zero Mesh Data
+          //
           ubl.reset();
           SERIAL_PROTOCOLLNPGM("Mesh zeroed.\n");
           break;
-        //
-        // Invalidate Entire Mesh and Automatically Probe Mesh in areas that can be reached by the probe
-        //
+
         case 1:
+          //
+          // Invalidate Entire Mesh and Automatically Probe Mesh in areas that can be reached by the probe
+          //
           if (!code_seen('C') ) {
             ubl.invalidate();
             SERIAL_PROTOCOLLNPGM("Mesh invalidated. Probing mesh.\n");
@@ -419,10 +414,11 @@
           probe_entire_mesh(x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER,
                             code_seen('O') || code_seen('M'), code_seen('E'), code_seen('U'));
           break;
-        //
-        // Manually Probe Mesh in areas that can't be reached by the probe
-        //
+
         case 2: {
+          //
+          // Manually Probe Mesh in areas that can't be reached by the probe
+          //
           SERIAL_PROTOCOLLNPGM("Manually probing unreachable mesh locations.\n");
           do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
           if (!x_flag && !y_flag) {      // use a good default location for the path
@@ -455,24 +451,24 @@
 
         } break;
 
-        //
-        // Populate invalid Mesh areas with a constant
-        //
         case 3: {
+          //
+          // Populate invalid Mesh areas with a constant
+          //
           const float height = code_seen('C') ? ubl_constant : 0.0;
           // If no repetition is specified, do the whole Mesh
           if (!repeat_flag) repetition_cnt = 9999;
           while (repetition_cnt--) {
             const mesh_index_pair location = find_closest_mesh_point_of_type(INVALID, x_pos, y_pos, 0, NULL, false); // The '0' says we want to use the nozzle's position
             if (location.x_index < 0) break; // No more invalid Mesh Points to populate
-            z_values[location.x_index][location.y_index] = height;
+            ubl.z_values[location.x_index][location.y_index] = height;
           }
         } break;
 
-        //
-        // Fine Tune (Or Edit) the Mesh
-        //
         case 4:
+          //
+          // Fine Tune (i.e., Edit) the Mesh
+          //
           fine_tune_mesh(x_pos, y_pos, code_seen('O') || code_seen('M'));
           break;
         case 5:
@@ -487,16 +483,16 @@
           SERIAL_ECHO_START;
           SERIAL_ECHOLNPGM("Checking G29 has control of LCD Panel:");
           KEEPALIVE_STATE(PAUSED_FOR_USER);
-          ubl_has_control_of_lcd_panel++;
+          ubl.has_control_of_lcd_panel++;
           while (!ubl_lcd_clicked()) {
             safe_delay(250);
-            if (ubl_encoderDiff) {
-              SERIAL_ECHOLN((int)ubl_encoderDiff);
-              ubl_encoderDiff = 0;
+            if (ubl.encoder_diff) {
+              SERIAL_ECHOLN((int)ubl.encoder_diff);
+              ubl.encoder_diff = 0;
             }
           }
           SERIAL_ECHOLNPGM("G29 giving back control of LCD Panel.");
-          ubl_has_control_of_lcd_panel = false;
+          ubl.has_control_of_lcd_panel = false;
           KEEPALIVE_STATE(IN_HANDLER);
           break;
 
@@ -508,9 +504,9 @@
           wait_for_user = true;
           while (wait_for_user) {
             safe_delay(250);
-            if (ubl_encoderDiff) {
-              SERIAL_ECHOLN((int)ubl_encoderDiff);
-              ubl_encoderDiff = 0;
+            if (ubl.encoder_diff) {
+              SERIAL_ECHOLN((int)ubl.encoder_diff);
+              ubl.encoder_diff = 0;
             }
           }
           SERIAL_ECHOLNPGM("G29 giving back control of LCD Panel.");
@@ -562,9 +558,9 @@
     if (code_seen('L')) {     // Load Current Mesh Data
       storage_slot = code_has_value() ? code_value_int() : ubl.state.eeprom_storage_slot;
 
-      const int16_t j = (UBL_LAST_EEPROM_INDEX - ubl_eeprom_start) / sizeof(z_values);
+      const int16_t j = (UBL_LAST_EEPROM_INDEX - ubl.eeprom_start) / sizeof(ubl.z_values);
 
-      if (storage_slot < 0 || storage_slot >= j || ubl_eeprom_start <= 0) {
+      if (storage_slot < 0 || storage_slot >= j || ubl.eeprom_start <= 0) {
         SERIAL_PROTOCOLLNPGM("?EEPROM storage not available for use.\n");
         return;
       }
@@ -586,19 +582,19 @@
         SERIAL_ECHOLNPGM("G29 I 999");              // host in a form it can be reconstructed on a different machine
         for (uint8_t x = 0; x < UBL_MESH_NUM_X_POINTS; x++)
           for (uint8_t y = 0;  y < UBL_MESH_NUM_Y_POINTS; y++)
-            if (!isnan(z_values[x][y])) {
+            if (!isnan(ubl.z_values[x][y])) {
               SERIAL_ECHOPAIR("M421 I ", x);
               SERIAL_ECHOPAIR(" J ", y);
               SERIAL_ECHOPGM(" Z ");
-              SERIAL_ECHO_F(z_values[x][y], 6);
+              SERIAL_ECHO_F(ubl.z_values[x][y], 6);
               SERIAL_EOL;
             }
         return;
       }
 
-      const int16_t j = (UBL_LAST_EEPROM_INDEX - ubl_eeprom_start) / sizeof(z_values);
+      const int16_t j = (UBL_LAST_EEPROM_INDEX - ubl.eeprom_start) / sizeof(ubl.z_values);
 
-      if (storage_slot < 0 || storage_slot >= j || ubl_eeprom_start <= 0) {
+      if (storage_slot < 0 || storage_slot >= j || ubl.eeprom_start <= 0) {
         SERIAL_PROTOCOLLNPGM("?EEPROM storage not available for use.\n");
         SERIAL_PROTOCOLLNPAIR("?Use 0 to ", j - 1);
         goto LEAVE;
@@ -622,7 +618,7 @@
         save_ubl_active_state_and_disable();
         //measured_z = probe_pt(x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER, ProbeDeployAndStow, g29_verbose_level);
 
-        ubl_has_control_of_lcd_panel++;     // Grab the LCD Hardware
+        ubl.has_control_of_lcd_panel++;     // Grab the LCD Hardware
         measured_z = 1.5;
         do_blocking_move_to_z(measured_z);  // Get close to the bed, but leave some space so we don't damage anything
                                             // The user is not going to be locking in a new Z-Offset very often so
@@ -638,7 +634,7 @@
           do_blocking_move_to_z(measured_z);
         } while (!ubl_lcd_clicked());
 
-        ubl_has_control_of_lcd_panel++;   // There is a race condition for the Encoder Wheel getting clicked.
+        ubl.has_control_of_lcd_panel++;   // There is a race condition for the Encoder Wheel getting clicked.
                                           // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune)
                                           // or here. So, until we are done looking for a long Encoder Wheel Press,
                                           // we need to take control of the panel
@@ -658,7 +654,7 @@
             goto LEAVE;
           }
         }
-        ubl_has_control_of_lcd_panel = false;
+        ubl.has_control_of_lcd_panel = false;
         safe_delay(20); // We don't want any switch noise.
 
         ubl.state.z_offset = measured_z;
@@ -675,7 +671,7 @@
       lcd_quick_feedback();
     #endif
 
-    ubl_has_control_of_lcd_panel = false;
+    ubl.has_control_of_lcd_panel = false;
   }
 
   void find_mean_mesh_height() {
@@ -687,8 +683,8 @@
     n = 0;
     for (x = 0; x < UBL_MESH_NUM_X_POINTS; x++)
       for (y = 0; y < UBL_MESH_NUM_Y_POINTS; y++)
-        if (!isnan(z_values[x][y])) {
-          sum += z_values[x][y];
+        if (!isnan(ubl.z_values[x][y])) {
+          sum += ubl.z_values[x][y];
           n++;
         }
 
@@ -699,8 +695,8 @@
     //
     for (x = 0; x < UBL_MESH_NUM_X_POINTS; x++)
       for (y = 0; y < UBL_MESH_NUM_Y_POINTS; y++)
-        if (!isnan(z_values[x][y])) {
-          difference = (z_values[x][y] - mean);
+        if (!isnan(ubl.z_values[x][y])) {
+          difference = (ubl.z_values[x][y] - mean);
           sum_of_diff_squared += difference * difference;
         }
 
@@ -717,15 +713,15 @@
     if (c_flag)
       for (x = 0; x < UBL_MESH_NUM_X_POINTS; x++)
         for (y = 0; y < UBL_MESH_NUM_Y_POINTS; y++)
-          if (!isnan(z_values[x][y]))
-            z_values[x][y] -= mean + ubl_constant;
+          if (!isnan(ubl.z_values[x][y]))
+            ubl.z_values[x][y] -= mean + ubl_constant;
   }
 
   void shift_mesh_height() {
     for (uint8_t x = 0; x < UBL_MESH_NUM_X_POINTS; x++)
       for (uint8_t y = 0; y < UBL_MESH_NUM_Y_POINTS; y++)
-        if (!isnan(z_values[x][y]))
-          z_values[x][y] += ubl_constant;
+        if (!isnan(ubl.z_values[x][y]))
+          ubl.z_values[x][y] += ubl_constant;
   }
 
   /**
@@ -735,7 +731,7 @@
   void probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest) {
     mesh_index_pair location;
 
-    ubl_has_control_of_lcd_panel++;
+    ubl.has_control_of_lcd_panel++;
     save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
     DEPLOY_PROBE();
 
@@ -745,7 +741,7 @@
         lcd_quick_feedback();
         STOW_PROBE();
         while (ubl_lcd_clicked()) idle();
-        ubl_has_control_of_lcd_panel = false;
+        ubl.has_control_of_lcd_panel = false;
         restore_ubl_active_state_and_leave();
         safe_delay(50);  // Debounce the Encoder wheel
         return;
@@ -761,11 +757,11 @@
         if (rawx < (MIN_PROBE_X) || rawx > (MAX_PROBE_X) || rawy < (MIN_PROBE_Y) || rawy > (MAX_PROBE_Y)) {
           SERIAL_ERROR_START;
           SERIAL_ERRORLNPGM("Attempt to probe off the bed.");
-          ubl_has_control_of_lcd_panel = false;
+          ubl.has_control_of_lcd_panel = false;
           goto LEAVE;
         }
         const float measured_z = probe_pt(LOGICAL_X_POSITION(rawx), LOGICAL_Y_POSITION(rawy), stow_probe, g29_verbose_level);
-        z_values[location.x_index][location.y_index] = measured_z + zprobe_zoffset;
+        ubl.z_values[location.x_index][location.y_index] = measured_z + zprobe_zoffset;
       }
 
       if (do_ubl_mesh_map) ubl.display_map(map_type);
@@ -842,7 +838,7 @@
     for (i = 0; i < UBL_MESH_NUM_X_POINTS; i++) {
       for (j = 0; j < UBL_MESH_NUM_Y_POINTS; j++) {
         c = -((normal.x * (UBL_MESH_MIN_X + i * (MESH_X_DIST)) + normal.y * (UBL_MESH_MIN_Y + j * (MESH_Y_DIST))) - d);
-        z_values[i][j] += c;
+        ubl.z_values[i][j] += c;
       }
     }
     return normal;
@@ -852,9 +848,9 @@
     KEEPALIVE_STATE(PAUSED_FOR_USER);
     while (!ubl_lcd_clicked()) {     // we need the loop to move the nozzle based on the encoder wheel here!
       idle();
-      if (ubl_encoderDiff) {
-        do_blocking_move_to_z(current_position[Z_AXIS] + 0.01 * float(ubl_encoderDiff));
-        ubl_encoderDiff = 0;
+      if (ubl.encoder_diff) {
+        do_blocking_move_to_z(current_position[Z_AXIS] + 0.01 * float(ubl.encoder_diff));
+        ubl.encoder_diff = 0;
       }
     }
     KEEPALIVE_STATE(IN_HANDLER);
@@ -863,7 +859,7 @@
 
   float measure_business_card_thickness(const float &in_height) {
 
-    ubl_has_control_of_lcd_panel++;
+    ubl.has_control_of_lcd_panel++;
     save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
 
     SERIAL_PROTOCOLLNPGM("Place Shim Under Nozzle and Perform Measurement.");
@@ -873,7 +869,7 @@
 
     const float z1 = use_encoder_wheel_to_measure_point();
     do_blocking_move_to_z(current_position[Z_AXIS] + SIZE_OF_LITTLE_RAISE);
-    ubl_has_control_of_lcd_panel = false;
+    ubl.has_control_of_lcd_panel = false;
 
     SERIAL_PROTOCOLLNPGM("Remove Shim and Measure Bed Height.");
     const float z2 = use_encoder_wheel_to_measure_point();
@@ -890,7 +886,7 @@
 
   void manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map) {
 
-    ubl_has_control_of_lcd_panel++;
+    ubl.has_control_of_lcd_panel++;
     save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
     do_blocking_move_to_z(z_clearance);
     do_blocking_move_to_xy(lx, ly);
@@ -911,7 +907,7 @@
       if (rawx < (X_MIN_POS) || rawx > (X_MAX_POS) || rawy < (Y_MIN_POS) || rawy > (Y_MAX_POS)) {
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM("Attempt to probe off the bed.");
-        ubl_has_control_of_lcd_panel = false;
+        ubl.has_control_of_lcd_panel = false;
         goto LEAVE;
       }
 
@@ -931,13 +927,13 @@
       last_y = yProbe;
 
       KEEPALIVE_STATE(PAUSED_FOR_USER);
-      ubl_has_control_of_lcd_panel = true;
+      ubl.has_control_of_lcd_panel = true;
 
       while (!ubl_lcd_clicked()) {     // we need the loop to move the nozzle based on the encoder wheel here!
         idle();
-        if (ubl_encoderDiff) {
-          do_blocking_move_to_z(current_position[Z_AXIS] + float(ubl_encoderDiff) / 100.0);
-          ubl_encoderDiff = 0;
+        if (ubl.encoder_diff) {
+          do_blocking_move_to_z(current_position[Z_AXIS] + float(ubl.encoder_diff) / 100.0);
+          ubl.encoder_diff = 0;
         }
       }
 
@@ -949,17 +945,17 @@
           do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
           lcd_quick_feedback();
           while (ubl_lcd_clicked()) idle();
-          ubl_has_control_of_lcd_panel = false;
+          ubl.has_control_of_lcd_panel = false;
           KEEPALIVE_STATE(IN_HANDLER);
           restore_ubl_active_state_and_leave();
           return;
         }
       }
 
-      z_values[location.x_index][location.y_index] = current_position[Z_AXIS] - card_thickness;
+      ubl.z_values[location.x_index][location.y_index] = current_position[Z_AXIS] - card_thickness;
       if (g29_verbose_level > 2) {
         SERIAL_PROTOCOLPGM("Mesh Point Measured at: ");
-        SERIAL_PROTOCOL_F(z_values[location.x_index][location.y_index], 6);
+        SERIAL_PROTOCOL_F(ubl.z_values[location.x_index][location.y_index], 6);
         SERIAL_EOL;
       }
     } while (location.x_index >= 0 && location.y_index >= 0);
@@ -1110,7 +1106,7 @@
    * good to have the extra information. Soon... we prune this to just a few items
    */
   void g29_what_command() {
-    const uint16_t k = E2END - ubl_eeprom_start;
+    const uint16_t k = E2END - ubl.eeprom_start;
 
     SERIAL_PROTOCOLPGM("Unified Bed Leveling System Version 1.00 ");
     if (ubl.state.active)  
@@ -1167,21 +1163,21 @@
     SERIAL_PROTOCOLLNPAIR("ubl_state_recursion_chk :", ubl_state_recursion_chk);
     SERIAL_EOL;
     safe_delay(50);
-    SERIAL_PROTOCOLLNPAIR("Free EEPROM space starts at: 0x", hex_word(ubl_eeprom_start));
+    SERIAL_PROTOCOLLNPAIR("Free EEPROM space starts at: 0x", hex_word(ubl.eeprom_start));
 
-    SERIAL_PROTOCOLLNPAIR("end of EEPROM              : ", hex_word(E2END));
+    SERIAL_PROTOCOLLNPAIR("end of EEPROM              : 0x", hex_word(E2END));
     safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("sizeof(ubl) :  ", (int)sizeof(ubl));
     SERIAL_EOL;
-    SERIAL_PROTOCOLLNPAIR("z_value[][] size: ", (int)sizeof(z_values));
+    SERIAL_PROTOCOLLNPAIR("z_value[][] size: ", (int)sizeof(ubl.z_values));
     SERIAL_EOL;
     safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("EEPROM free for UBL: 0x", hex_word(k));
     safe_delay(50);
 
-    SERIAL_PROTOCOLPAIR("EEPROM can hold ", k / sizeof(z_values));
+    SERIAL_PROTOCOLPAIR("EEPROM can hold ", k / sizeof(ubl.z_values));
     SERIAL_PROTOCOLLNPGM(" meshes.\n");
     safe_delay(50);
 
@@ -1245,9 +1241,9 @@
     }
     storage_slot = code_value_int();
 
-    int16_t j = (UBL_LAST_EEPROM_INDEX - ubl_eeprom_start) / sizeof(tmp_z_values);
+    int16_t j = (UBL_LAST_EEPROM_INDEX - ubl.eeprom_start) / sizeof(tmp_z_values);
 
-    if (storage_slot < 0 || storage_slot > j || ubl_eeprom_start <= 0) {
+    if (storage_slot < 0 || storage_slot > j || ubl.eeprom_start <= 0) {
       SERIAL_PROTOCOLLNPGM("?EEPROM storage not available for use.\n");
       return;
     }
@@ -1256,12 +1252,12 @@
     eeprom_read_block((void *)&tmp_z_values, (void *)j, sizeof(tmp_z_values));
 
     SERIAL_ECHOPAIR("Subtracting Mesh ", storage_slot);
-    SERIAL_PROTOCOLLNPAIR(" loaded from EEPROM address ", hex_word(j)); // Soon, we can remove the extra clutter of printing
+    SERIAL_PROTOCOLLNPAIR(" loaded from EEPROM address 0x", hex_word(j)); // Soon, we can remove the extra clutter of printing
                                                                         // the address in the EEPROM where the Mesh is stored.
 
     for (uint8_t x = 0; x < UBL_MESH_NUM_X_POINTS; x++)
       for (uint8_t y = 0; y < UBL_MESH_NUM_Y_POINTS; y++)
-        z_values[x][y] = z_values[x][y] - tmp_z_values[x][y];
+        ubl.z_values[x][y] -= tmp_z_values[x][y];
   }
 
   mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType type, const float &lx, const float &ly, const bool probe_as_reference, unsigned int bits[16], bool far_flag) {
@@ -1280,8 +1276,8 @@
     for (uint8_t i = 0; i < UBL_MESH_NUM_X_POINTS; i++) {
       for (uint8_t j = 0; j < UBL_MESH_NUM_Y_POINTS; j++) {
 
-        if ( (type == INVALID && isnan(z_values[i][j]))  // Check to see if this location holds the right thing
-          || (type == REAL && !isnan(z_values[i][j]))
+        if ( (type == INVALID && isnan(ubl.z_values[i][j]))  // Check to see if this location holds the right thing
+          || (type == REAL && !isnan(ubl.z_values[i][j]))
           || (type == SET_IN_BITMAP && is_bit_set(bits, i, j))
         ) {
 
@@ -1308,7 +1304,7 @@
           if (far_flag) {                                           // If doing the far_flag action, we want to be as far as possible
             for (uint8_t k = 0; k < UBL_MESH_NUM_X_POINTS; k++) {   // from the starting point and from any other probed points.  We
               for (uint8_t l = 0; l < UBL_MESH_NUM_Y_POINTS; l++) { // want the next point spread out and filling in any blank spaces
-                if (!isnan(z_values[k][l])) {                       // in the mesh. So we add in some of the distance to every probed
+                if (!isnan(ubl.z_values[k][l])) {                       // in the mesh. So we add in some of the distance to every probed
                   distance += sq(i - k) * (MESH_X_DIST) * .05       // point we can find.
                             + sq(j - l) * (MESH_Y_DIST) * .05;
                 }
@@ -1361,19 +1357,19 @@
       if (rawx < (X_MIN_POS) || rawx > (X_MAX_POS) || rawy < (Y_MIN_POS) || rawy > (Y_MAX_POS)) { // In theory, we don't need this check.
         SERIAL_ERROR_START;
         SERIAL_ERRORLNPGM("Attempt to edit off the bed."); // This really can't happen, but do the check for now
-        ubl_has_control_of_lcd_panel = false;
+        ubl.has_control_of_lcd_panel = false;
         goto FINE_TUNE_EXIT;
       }
 
       do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);    // Move the nozzle to where we are going to edit
       do_blocking_move_to_xy(LOGICAL_X_POSITION(rawx), LOGICAL_Y_POSITION(rawy));
-      float new_z = z_values[location.x_index][location.y_index];
+      float new_z = ubl.z_values[location.x_index][location.y_index];
       
       round_off = (int32_t)(new_z * 1000.0);    // we chop off the last digits just to be clean. We are rounding to the
       new_z = float(round_off) / 1000.0;
 
       KEEPALIVE_STATE(PAUSED_FOR_USER);
-      ubl_has_control_of_lcd_panel = true;
+      ubl.has_control_of_lcd_panel = true;
 
       lcd_implementation_clear();
       lcd_mesh_edit_setup(new_z);
@@ -1385,7 +1381,7 @@
 
       lcd_return_to_status();
 
-      ubl_has_control_of_lcd_panel = true; // There is a race condition for the Encoder Wheel getting clicked.
+      ubl.has_control_of_lcd_panel = true; // There is a race condition for the Encoder Wheel getting clicked.
                                            // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune)
                                            // or here.
 
@@ -1406,7 +1402,7 @@
 
       safe_delay(20);                       // We don't want any switch noise.
 
-      z_values[location.x_index][location.y_index] = new_z;
+      ubl.z_values[location.x_index][location.y_index] = new_z;
 
       lcd_implementation_clear();
 
@@ -1414,7 +1410,7 @@
 
     FINE_TUNE_EXIT:
 
-    ubl_has_control_of_lcd_panel = false;
+    ubl.has_control_of_lcd_panel = false;
     KEEPALIVE_STATE(IN_HANDLER);
 
     if (do_ubl_mesh_map) ubl.display_map(map_type);

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -22,7 +22,7 @@
 
 #include "MarlinConfig.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL)
+#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_MESH_EDIT_ENABLED)
   //#include "vector_3.h"
   //#include "qr_solve.h"
 
@@ -39,7 +39,10 @@
   void lcd_return_to_status();
   bool lcd_clicked();
   void lcd_implementation_clear();
-
+  void lcd_mesh_edit_setup(float initial);
+  float lcd_mesh_edit();
+  void lcd_z_offset_edit_setup(float);
+  float lcd_z_offset_edit();
   extern float meshedit_done;
   extern long babysteps_done;
   extern float code_value_float();
@@ -62,6 +65,8 @@
   #define SIZE_OF_LITTLE_RAISE 0
   #define BIG_RAISE_NOT_NEEDED 0
   extern void lcd_quick_feedback();
+  extern int ubl_eeprom_start;
+  extern volatile int ubl_encoderDiff; // This is volatile because it is getting changed at interrupt time.
 
   /**
    *   G29: Unified Bed Leveling by Roxy

--- a/Marlin/UBL_line_to_destination.cpp
+++ b/Marlin/UBL_line_to_destination.cpp
@@ -32,12 +32,11 @@
   extern float destination[XYZE];
   extern void set_current_to_destination();
   extern float destination[];
-  bool g26_debug_flag = false;
   void debug_current_and_destination(char *title) {
 
     // if the title message starts with a '!' it is so important, we are going to
     // ignore the status of the g26_debug_flag
-    if (*title != '!' && !g26_debug_flag) return;
+    if (*title != '!' && !ubl.g26_debug_flag) return;
 
     const float de = destination[E_AXIS] - current_position[E_AXIS];
 
@@ -122,7 +121,7 @@
               cell_dest_xi  = ubl.get_cell_index_x(RAW_X_POSITION(x_end)),
               cell_dest_yi  = ubl.get_cell_index_y(RAW_Y_POSITION(y_end));
 
-    if (g26_debug_flag) {
+    if (ubl.g26_debug_flag) {
       SERIAL_ECHOPGM(" ubl_line_to_destination(xe=");
       SERIAL_ECHO(x_end);
       SERIAL_ECHOPGM(", ye=");
@@ -151,7 +150,7 @@
         planner.buffer_line(x_end, y_end, z_end + ubl.state.z_offset, e_end, feed_rate, extruder);
         set_current_to_destination();
 
-        if (g26_debug_flag)
+        if (ubl.g26_debug_flag)
           debug_current_and_destination((char*)"out of bounds in ubl_line_to_destination()");
 
         return;
@@ -213,7 +212,7 @@
 
       planner.buffer_line(x_end, y_end, z_end + z0 + ubl.state.z_offset, e_end, feed_rate, extruder);
 
-      if (g26_debug_flag)
+      if (ubl.g26_debug_flag)
         debug_current_and_destination((char*)"FINAL_MOVE in ubl_line_to_destination()");
 
       set_current_to_destination();
@@ -340,7 +339,7 @@
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
-      if (g26_debug_flag)
+      if (ubl.g26_debug_flag)
         debug_current_and_destination((char*)"vertical move done in ubl_line_to_destination()");
 
       //
@@ -425,7 +424,7 @@
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
-      if (g26_debug_flag)
+      if (ubl.g26_debug_flag)
         debug_current_and_destination((char*)"horizontal move done in ubl_line_to_destination()");
 
       if (current_position[X_AXIS] != x_end || current_position[Y_AXIS] != y_end)
@@ -564,7 +563,7 @@
       }
     }
 
-    if (g26_debug_flag)
+    if (ubl.g26_debug_flag)
       debug_current_and_destination((char*)"generic move done in ubl_line_to_destination()");
 
     if (current_position[0] != x_end || current_position[1] != y_end)

--- a/Marlin/UBL_line_to_destination.cpp
+++ b/Marlin/UBL_line_to_destination.cpp
@@ -167,16 +167,16 @@
        * to create a 1-over number for us. That will allow us to do a floating point multiply instead of a floating point divide.
        */
 
-      const float xratio = (RAW_X_POSITION(x_end) - mesh_index_to_x_location[cell_dest_xi]) * (1.0 / (MESH_X_DIST)),
-                  z1 = z_values[cell_dest_xi    ][cell_dest_yi    ] + xratio *
-                      (z_values[cell_dest_xi + 1][cell_dest_yi    ] - z_values[cell_dest_xi][cell_dest_yi    ]),
-                  z2 = z_values[cell_dest_xi    ][cell_dest_yi + 1] + xratio *
-                      (z_values[cell_dest_xi + 1][cell_dest_yi + 1] - z_values[cell_dest_xi][cell_dest_yi + 1]);
+      const float xratio = (RAW_X_POSITION(x_end) - ubl.mesh_index_to_xpos[cell_dest_xi]) * (1.0 / (MESH_X_DIST)),
+                  z1 = ubl.z_values[cell_dest_xi    ][cell_dest_yi    ] + xratio *
+                      (ubl.z_values[cell_dest_xi + 1][cell_dest_yi    ] - ubl.z_values[cell_dest_xi][cell_dest_yi    ]),
+                  z2 = ubl.z_values[cell_dest_xi    ][cell_dest_yi + 1] + xratio *
+                      (ubl.z_values[cell_dest_xi + 1][cell_dest_yi + 1] - ubl.z_values[cell_dest_xi][cell_dest_yi + 1]);
 
       // we are done with the fractional X distance into the cell. Now with the two Z-Heights we have calculated, we
       // are going to apply the Y-Distance into the cell to interpolate the final Z correction.
 
-      const float yratio = (RAW_Y_POSITION(y_end) - mesh_index_to_y_location[cell_dest_yi]) * (1.0 / (MESH_Y_DIST));
+      const float yratio = (RAW_Y_POSITION(y_end) - ubl.mesh_index_to_ypos[cell_dest_yi]) * (1.0 / (MESH_Y_DIST));
 
       float z0 = z1 + (z2 - z1) * yratio;
 
@@ -274,7 +274,7 @@
       current_yi += down_flag;  // Line is heading down, we just want to go to the bottom
       while (current_yi != cell_dest_yi + down_flag) {
         current_yi += dyi;
-        const float next_mesh_line_y = LOGICAL_Y_POSITION(mesh_index_to_y_location[current_yi]);
+        const float next_mesh_line_y = LOGICAL_Y_POSITION(ubl.mesh_index_to_ypos[current_yi]);
 
         /**
          * inf_m_flag? the slope of the line is infinite, we won't do the calculations
@@ -316,7 +316,7 @@
          */
         if (isnan(z0)) z0 = 0.0;
 
-        const float y = LOGICAL_Y_POSITION(mesh_index_to_y_location[current_yi]);
+        const float y = LOGICAL_Y_POSITION(ubl.mesh_index_to_ypos[current_yi]);
 
         /**
          * Without this check, it is possible for the algorithm to generate a zero length move in the case
@@ -365,7 +365,7 @@
                                 // edge of this cell for the first move.
       while (current_xi != cell_dest_xi + left_flag) {
         current_xi += dxi;
-        const float next_mesh_line_x = LOGICAL_X_POSITION(mesh_index_to_x_location[current_xi]),
+        const float next_mesh_line_x = LOGICAL_X_POSITION(ubl.mesh_index_to_xpos[current_xi]),
                     y = m * next_mesh_line_x + c;   // Calculate X at the next Y mesh line
 
         float z0 = ubl.get_z_correction_along_vertical_mesh_line_at_specific_Y(y, current_xi, current_yi);
@@ -401,7 +401,7 @@
          */
         if (isnan(z0)) z0 = 0.0;
 
-        const float x = LOGICAL_X_POSITION(mesh_index_to_x_location[current_xi]);
+        const float x = LOGICAL_X_POSITION(ubl.mesh_index_to_xpos[current_xi]);
 
         /**
          * Without this check, it is possible for the algorithm to generate a zero length move in the case
@@ -451,8 +451,8 @@
 
     while (xi_cnt > 0 || yi_cnt > 0) {
 
-      const float next_mesh_line_x = LOGICAL_X_POSITION(mesh_index_to_x_location[current_xi + dxi]),
-                  next_mesh_line_y = LOGICAL_Y_POSITION(mesh_index_to_y_location[current_yi + dyi]),
+      const float next_mesh_line_x = LOGICAL_X_POSITION(ubl.mesh_index_to_xpos[current_xi + dxi]),
+                  next_mesh_line_y = LOGICAL_Y_POSITION(ubl.mesh_index_to_ypos[current_yi + dyi]),
                   y = m * next_mesh_line_x + c,   // Calculate Y at the next X mesh line
                   x = (next_mesh_line_y - c) / m; // Calculate X at the next Y mesh line    (we don't have to worry
                                                   // about m being equal to 0.0  If this was the case, we would have

--- a/Marlin/UBL_line_to_destination.cpp
+++ b/Marlin/UBL_line_to_destination.cpp
@@ -31,7 +31,8 @@
 
   extern float destination[XYZE];
   extern void set_current_to_destination();
-
+  extern float destination[];
+  bool g26_debug_flag = false;
   void debug_current_and_destination(char *title) {
 
     // if the title message starts with a '!' it is so important, we are going to
@@ -314,7 +315,7 @@
          * because part of the Mesh is undefined and we don't have the
          * information we need to complete the height correction.
          */
-        if (isnan(z0)) z0 = 0.0;     
+        if (isnan(z0)) z0 = 0.0;
 
         const float y = LOGICAL_Y_POSITION(mesh_index_to_y_location[current_yi]);
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -166,7 +166,6 @@
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "UBL.h"
-  int ubl_eeprom_start = -1;
 #endif
 
 #if ENABLED(ABL_BILINEAR_SUBDIVISION)
@@ -847,7 +846,7 @@ void Config_Postprocess() {
       }
 
       #if ENABLED(AUTO_BED_LEVELING_UBL)
-        ubl_eeprom_start = (eeprom_index + 32) & 0xFFF8; // Pad the end of configuration data so it
+        ubl.eeprom_start = (eeprom_index + 32) & 0xFFF8; // Pad the end of configuration data so it
                                                          // can float up or down a little bit without
                                                          // disrupting the Unified Bed Leveling data
         ubl.load_state();
@@ -1233,7 +1232,7 @@ void Config_ResetDefault() {
         SERIAL_ECHO_F(ubl.state.z_offset, 6);
         SERIAL_EOL;
 
-        SERIAL_ECHOPAIR("EEPROM can hold ", (int)((UBL_LAST_EEPROM_INDEX - ubl_eeprom_start) / sizeof(z_values)));
+        SERIAL_ECHOPAIR("EEPROM can hold ", (int)((UBL_LAST_EEPROM_INDEX - ubl.eeprom_start) / sizeof(ubl.z_values)));
         SERIAL_ECHOLNPGM(" meshes.\n");
 
         SERIAL_ECHOLNPGM("UBL_MESH_NUM_X_POINTS  " STRINGIFY(UBL_MESH_NUM_X_POINTS));

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -166,6 +166,7 @@
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "UBL.h"
+  int ubl_eeprom_start = -1;
 #endif
 
 #if ENABLED(ABL_BILINEAR_SUBDIVISION)

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -863,7 +863,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -846,7 +846,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -846,7 +846,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -855,7 +855,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -857,7 +857,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -892,7 +892,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -863,7 +863,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -863,7 +863,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -863,7 +863,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -862,7 +862,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -878,7 +878,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -884,7 +884,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -855,7 +855,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -863,7 +863,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
@@ -968,7 +968,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -954,7 +954,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -958,7 +958,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -957,7 +957,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -967,7 +967,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -866,7 +866,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -859,7 +859,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  //#define UBL_G26_MESH_EDITING    // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -124,8 +124,7 @@ uint16_t max_display_update_time = 0;
   int32_t lastEncoderMovementMillis;
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
-    extern bool ubl_has_control_of_lcd_panel;
-    extern int8_t ubl_encoderDiff;
+    #include "UBL.h"
   #endif
 
   #if HAS_POWER_SWITCH
@@ -860,9 +859,9 @@ void kill_screen(const char* lcd_msg) {
 
     static void _lcd_mesh_fine_tune(const char* msg) {
       defer_return_to_status = true;
-      if (ubl_encoderDiff) {
-        ubl_encoderPosition = (ubl_encoderDiff > 0) ? 1 : -1;
-        ubl_encoderDiff = 0;
+      if (ubl.encoder_diff) {
+        ubl_encoderPosition = (ubl.encoder_diff > 0) ? 1 : -1;
+        ubl.encoder_diff = 0;
 
         mesh_edit_accumulator += float(ubl_encoderPosition) * 0.005 / 2.0;
         mesh_edit_value = mesh_edit_accumulator;
@@ -3206,7 +3205,7 @@ void lcd_update() {
     lcd_buttons_update();
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      const bool UBL_CONDITION = !ubl_has_control_of_lcd_panel;
+      const bool UBL_CONDITION = !ubl.has_control_of_lcd_panel;
     #else
       constexpr bool UBL_CONDITION = true;
     #endif
@@ -3622,8 +3621,8 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
         case encrot3: ENCODER_SPIN(encrot2, encrot0); break;
       }
       #if ENABLED(AUTO_BED_LEVELING_UBL)
-        if (ubl_has_control_of_lcd_panel) {
-          ubl_encoderDiff = encoderDiff;    // Make the encoder's rotation available to G29's Mesh Editor
+        if (ubl.has_control_of_lcd_panel) {
+          ubl.encoder_diff = encoderDiff;    // Make the encoder's rotation available to G29's Mesh Editor
           encoderDiff = 0;                  // We are going to lie to the LCD Panel and claim the encoder
                                             // wheel has not turned.
         }


### PR DESCRIPTION
Some changes by @Bob-the-Kuhn from #6086, plus additional fixes.

- Various patches to formatting, trailing whitespace, spelling, etc.
- Convert data and methods in `class unified_bed_leveling` to `static` to reduce code size and calling overhead.
- Make `G26` compatible with workspace offsets.
- Disable `G26` by default

[Concise diff](https://github.com/MarlinFirmware/Marlin/pull/6174/files?w=1)