### PR TITLE
`int` in place of `bool` saves several K of PROGMEM

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -122,12 +122,12 @@
   extern void set_destination_to_current();
   extern void set_current_to_destination();
   extern float code_value_float();
-  extern bool code_value_bool();
-  extern bool code_has_value();
+  extern BOOL code_value_bool();
+  extern BOOL code_has_value();
   extern void lcd_init();
   extern void lcd_setstatuspgm(const char* const message, uint8_t level);
   #define PLANNER_XY_FEEDRATE() (min(planner.max_feedrate_mm_s[X_AXIS], planner.max_feedrate_mm_s[Y_AXIS])) //bob
-  bool prepare_move_to_destination_cartesian();
+  BOOL prepare_move_to_destination_cartesian();
   void line_to_destination();
   void line_to_destination(float );
   void gcode_G28();
@@ -135,11 +135,11 @@
   void un_retract_filament(float where[XYZE]);
   void retract_filament(float where[XYZE]);
   void look_for_lines_to_connect();
-  bool parse_G26_parameters();
+  BOOL parse_G26_parameters();
   void move_to(const float&, const float&, const float&, const float&) ;
   void print_line_from_here_to_there(const float&, const float&, const float&, const float&, const float&, const float&);
-  bool turn_on_heaters();
-  bool prime_nozzle();
+  BOOL turn_on_heaters();
+  BOOL prime_nozzle();
   void chirp_at_user();
 
   static uint16_t circle_flags[16], horizontal_mesh_line_flags[16], vertical_mesh_line_flags[16], continue_with_closest = 0;
@@ -147,7 +147,7 @@
         random_deviation = 0.0,
         layer_height = LAYER_HEIGHT;
 
-  bool g26_retracted = false; // We keep track of the state of the nozzle to know if it
+  BOOL g26_retracted = false; // We keep track of the state of the nozzle to know if it
                               // is currently retracted or not.  This allows us to be
                               // less careful because mis-matched retractions and un-retractions
                               // won't leave us in a bad state.
@@ -167,7 +167,7 @@
 
   int8_t prime_flag = 0;
 
-  bool keep_heaters_on = false;
+  BOOL keep_heaters_on = false;
 
   /**
    * G26: Mesh Validation Pattern generation.
@@ -504,7 +504,7 @@
     float feed_value;
     static float last_z = -999.99;
 
-    bool has_xy_component = (x != current_position[X_AXIS] || y != current_position[Y_AXIS]); // Check if X or Y is involved in the movement.
+    BOOL has_xy_component = (x != current_position[X_AXIS] || y != current_position[Y_AXIS]); // Check if X or Y is involved in the movement.
 
     //if (ubl.g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to()  has_xy_component:", (int)has_xy_component);
 
@@ -622,7 +622,7 @@
    * parameters it made sense to turn them into static globals and get
    * this code out of sight of the main routine.
    */
-  bool parse_G26_parameters() {
+  BOOL parse_G26_parameters() {
 
     extrusion_multiplier  = EXTRUSION_MULTIPLIER;
     retraction_multiplier = RETRACTION_MULTIPLIER;
@@ -751,7 +751,7 @@
     return UBL_OK;
   }
 
-  bool exit_from_g26() {
+  BOOL exit_from_g26() {
     //strcpy(lcd_status_message, "Leaving G26"); // We can't do lcd_setstatus() without having it continue;
     lcd_reset_alert_level();
     lcd_setstatuspgm(PSTR("Leaving G26"));
@@ -763,7 +763,7 @@
    * Turn on the bed and nozzle heat and
    * wait for them to get up to temperature.
    */
-  bool turn_on_heaters() {
+  BOOL turn_on_heaters() {
     #if HAS_TEMP_BED
       #if ENABLED(ULTRA_LCD)
         if (bed_temp > 25) {
@@ -802,7 +802,7 @@
   /**
    * Prime the nozzle if needed. Return true on error.
    */
-  bool prime_nozzle() {
+  BOOL prime_nozzle() {
     float Total_Prime = 0.0;
 
     if (prime_flag == -1) {  // The user wants to control how much filament gets purged

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -57,7 +57,7 @@ char* top_of_stack();
 int how_many_E5s_are_here(char*);
 
 void gcode_M100() {
-  static bool m100_not_initialized = true;
+  static BOOL m100_not_initialized = true;
   char* sp, *ptr;
   int i, j, n;
   //

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -100,7 +100,7 @@ void serial_echopair_P(const char* s_P, unsigned int v);
 void serial_echopair_P(const char* s_P, unsigned long v);
 FORCE_INLINE void serial_echopair_P(const char* s_P, uint8_t v) { serial_echopair_P(s_P, (int)v); }
 FORCE_INLINE void serial_echopair_P(const char* s_P, uint16_t v) { serial_echopair_P(s_P, (int)v); }
-FORCE_INLINE void serial_echopair_P(const char* s_P, bool v) { serial_echopair_P(s_P, (int)v); }
+//FORCE_INLINE void serial_echopair_P(const char* s_P, BOOL v) { serial_echopair_P(s_P, (int)v); }
 FORCE_INLINE void serial_echopair_P(const char* s_P, void *v) { serial_echopair_P(s_P, (unsigned long)v); }
 
 // Things to write to serial from Program memory. Saves 400 to 2k of RAM.
@@ -110,14 +110,14 @@ FORCE_INLINE void serialprintPGM(const char* str) {
 
 void idle(
   #if ENABLED(FILAMENT_CHANGE_FEATURE)
-    bool no_stepper_sleep = false  // pass true to keep steppers from disabling on timeout
+    BOOL no_stepper_sleep = false  // pass true to keep steppers from disabling on timeout
   #endif
 );
 
-void manage_inactivity(bool ignore_stepper_queue = false);
+void manage_inactivity(BOOL ignore_stepper_queue = false);
 
 #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
-  extern bool extruder_duplication_enabled;
+  extern BOOL extruder_duplication_enabled;
 #endif
 
 #if HAS_X2_ENABLE
@@ -212,7 +212,7 @@ void manage_inactivity(bool ignore_stepper_queue = false);
 #endif // !MIXING_EXTRUDER
 
 #if ENABLED(G38_PROBE_TARGET)
-  extern bool G38_move,        // flag to tell the interrupt handler that a G38 command is being run
+  extern BOOL G38_move,        // flag to tell the interrupt handler that a G38 command is being run
               G38_endstop_hit; // flag from the interrupt handler to indicate if the endstop went active
 #endif
 
@@ -239,11 +239,11 @@ void quickstop_stepper();
 extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (DEBUG_## F))
 
-extern bool Running;
-inline bool IsRunning() { return  Running; }
-inline bool IsStopped() { return !Running; }
+extern BOOL Running;
+inline BOOL IsRunning() { return  Running; }
+inline BOOL IsStopped() { return !Running; }
 
-bool enqueue_and_echo_command(const char* cmd, bool say_ok=false); //put a single ASCII command at the end of the current buffer or return false when it is full
+BOOL enqueue_and_echo_command(const char* cmd, BOOL say_ok=false); //put a single ASCII command at the end of the current buffer or return false when it is full
 void enqueue_and_echo_commands_P(const char* cmd); //put one or many ASCII commands at the end of the current buffer, read from flash
 void clear_command_queue();
 
@@ -263,17 +263,17 @@ extern int feedrate_percentage;
 #define MMS_TO_MMM(MM_S) ((MM_S)*60.0)
 #define MMS_SCALED(MM_S) ((MM_S)*feedrate_percentage*0.01)
 
-extern bool axis_relative_modes[];
-extern bool volumetric_enabled;
+extern BOOL axis_relative_modes[];
+extern BOOL volumetric_enabled;
 extern int flow_percentage[EXTRUDERS]; // Extrusion factor for each extruder
 extern float filament_size[EXTRUDERS]; // cross-sectional area of filament (in millimeters), typically around 1.75 or 2.85, 0 disables the volumetric calculations for the extruder.
 extern float volumetric_multiplier[EXTRUDERS]; // reciprocal of cross-sectional area of filament (in square millimeters), stored this way to reduce computational burden in planner
-extern bool axis_known_position[XYZ]; // axis[n].is_known
-extern bool axis_homed[XYZ]; // axis[n].is_homed
-extern volatile bool wait_for_heatup;
+extern BOOL axis_known_position[XYZ]; // axis[n].is_known
+extern BOOL axis_homed[XYZ]; // axis[n].is_homed
+extern volatile BOOL wait_for_heatup;
 
 #if ENABLED(EMERGENCY_PARSER) || ENABLED(ULTIPANEL)
-  extern volatile bool wait_for_user;
+  extern volatile BOOL wait_for_user;
 #endif
 
 extern float current_position[NUM_AXIS];
@@ -307,7 +307,7 @@ extern float soft_endstop_min[XYZ];
 extern float soft_endstop_max[XYZ];
 
 #if HAS_SOFTWARE_ENDSTOPS
-  extern bool soft_endstops_enabled;
+  extern BOOL soft_endstops_enabled;
   void clamp_to_software_endstops(float target[XYZ]);
 #else
   #define soft_endstops_enabled false
@@ -319,7 +319,7 @@ extern float soft_endstop_max[XYZ];
 #endif
 
 // GCode support for external objects
-bool code_seen(char);
+BOOL code_seen(char);
 int code_value_int();
 float code_value_temp_abs();
 float code_value_temp_diff();
@@ -346,7 +346,7 @@ float code_value_temp_diff();
   extern int bilinear_grid_spacing[2], bilinear_start[2];
   extern float bed_level_grid[ABL_GRID_MAX_POINTS_X][ABL_GRID_MAX_POINTS_Y];
   float bilinear_z_offset(float logical[XYZ]);
-  void set_bed_leveling_enabled(bool enable=true);
+  void set_bed_leveling_enabled(BOOL enable=true);
 #endif
 
 #if PLANNER_LEVELING
@@ -378,7 +378,7 @@ float code_value_temp_diff();
 #endif
 
 #if ENABLED(FILAMENT_WIDTH_SENSOR)
-  extern bool filament_sensor;         // Flag that filament sensor readings should control extrusion
+  extern BOOL filament_sensor;         // Flag that filament sensor readings should control extrusion
   extern float filament_width_nominal, // Theoretical filament diameter i.e., 3.00 or 1.75
                filament_width_meas;    // Measured filament diameter
   extern int8_t measurement_delay[];   // Ring buffer to delay measurement
@@ -395,8 +395,8 @@ float code_value_temp_diff();
 #endif
 
 #if ENABLED(FWRETRACT)
-  extern bool autoretract_enabled;
-  extern bool retracted[EXTRUDERS]; // extruder[n].retracted
+  extern BOOL autoretract_enabled;
+  extern BOOL retracted[EXTRUDERS]; // extruder[n].retracted
   extern float retract_length, retract_length_swap, retract_feedrate_mm_s, retract_zlift;
   extern float retract_recover_length, retract_recover_length_swap, retract_recover_feedrate_mm_s;
 #endif
@@ -430,7 +430,7 @@ void do_blocking_move_to_z(const float &z, const float &fr_mm_s=0.0);
 void do_blocking_move_to_xy(const float &x, const float &y, const float &fr_mm_s=0.0);
 
 #if ENABLED(Z_PROBE_ALLEN_KEY) || ENABLED(Z_PROBE_SLED) || HAS_PROBING_PROCEDURE || HOTENDS > 1 || ENABLED(NOZZLE_CLEAN_FEATURE) || ENABLED(NOZZLE_PARK_FEATURE)
-  bool axis_unhomed_error(const bool x, const bool y, const bool z);
+  BOOL axis_unhomed_error(const BOOL x, const BOOL y, const BOOL z);
 #endif
 
 #endif //MARLIN_H

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -42,7 +42,7 @@
   ring_buffer_r rx_buffer  =  { { 0 }, 0, 0 };
   #if TX_BUFFER_SIZE > 0
     ring_buffer_t tx_buffer  =  { { 0 }, 0, 0 };
-    static bool _written;
+    static BOOL _written;
   #endif
 #endif
 
@@ -112,7 +112,7 @@ MarlinSerial::MarlinSerial() { }
 
 void MarlinSerial::begin(long baud) {
   uint16_t baud_setting;
-  bool useU2X = true;
+  BOOL useU2X = true;
 
   #if F_CPU == 16000000UL && SERIAL_PORT == 0
     // hard-coded exception for compatibility with the bootloader shipped
@@ -213,7 +213,7 @@ void MarlinSerial::flush(void) {
   void MarlinSerial::write(uint8_t c) {
     _written = true;
     CRITICAL_SECTION_START;
-      bool emty = (tx_buffer.head == tx_buffer.tail);
+      BOOL emty = (tx_buffer.head == tx_buffer.tail);
     CRITICAL_SECTION_END;
     // If the buffer and the data register is empty, just write the byte
     // to the data register and be done. This shortcut helps

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -292,7 +292,7 @@
 #endif
 
 #if ENABLED(G38_PROBE_TARGET)
-  bool G38_move = false,
+  BOOL G38_move = false,
        G38_endstop_hit = false;
 #endif
 
@@ -306,7 +306,7 @@
                            || isnan(ubl.z_values[0][0]))
 #endif
 
-bool Running = true;
+BOOL Running = true;
 
 uint8_t marlin_debug_flags = DEBUG_NONE;
 
@@ -335,7 +335,7 @@ float destination[XYZE] = { 0.0 };
  *   Flags that the position is known in each linear axis. Set when homed.
  *   Cleared whenever a stepper powers off, potentially losing its position.
  */
-bool axis_homed[XYZ] = { false }, axis_known_position[XYZ] = { false };
+BOOL axis_homed[XYZ] = { false }, axis_known_position[XYZ] = { false };
 
 /**
  * GCode line number handling. Hosts may opt to include line numbers when
@@ -397,7 +397,7 @@ static float feedrate_mm_s = MMM_TO_MMS(1500.0), saved_feedrate_mm_s;
 int feedrate_percentage = 100, saved_feedrate_percentage,
     flow_percentage[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100);
 
-bool axis_relative_modes[] = AXIS_RELATIVE_MODES,
+BOOL axis_relative_modes[] = AXIS_RELATIVE_MODES,
      volumetric_enabled =
       #if ENABLED(VOLUMETRIC_DEFAULT_ON)
         true
@@ -424,7 +424,7 @@ float filament_size[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(DEFAULT_NOMINAL_FILAMENT_DI
 
 // Software Endstops are based on the configured limits.
 #if HAS_SOFTWARE_ENDSTOPS
-  bool soft_endstops_enabled = true;
+  BOOL soft_endstops_enabled = true;
 #endif
 float soft_endstop_min[XYZ] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS },
       soft_endstop_max[XYZ] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
@@ -437,14 +437,14 @@ float soft_endstop_min[XYZ] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS },
 uint8_t active_extruder = 0;
 
 // Relative Mode. Enable with G91, disable with G90.
-static bool relative_mode = false;
+static BOOL relative_mode = false;
 
 // For M109 and M190, this flag may be cleared (by M108) to exit the wait loop
-volatile bool wait_for_heatup = true;
+volatile BOOL wait_for_heatup = true;
 
 // For M0/M1, this flag may be cleared (by M108) to exit the wait-for-user loop
 #if ENABLED(EMERGENCY_PARSER) || ENABLED(ULTIPANEL)
-  volatile bool wait_for_user = false;
+  volatile BOOL wait_for_user = false;
 #endif
 
 const char errormagic[] PROGMEM = "Error:";
@@ -535,9 +535,9 @@ static uint8_t target_extruder;
 
 #if ENABLED(FWRETRACT)
 
-  bool autoretract_enabled = false;
-  bool retracted[EXTRUDERS] = { false };
-  bool retracted_swap[EXTRUDERS] = { false };
+  BOOL autoretract_enabled = false;
+  BOOL retracted[EXTRUDERS] = { false };
+  BOOL retracted_swap[EXTRUDERS] = { false };
 
   float retract_length = RETRACT_LENGTH;
   float retract_length_swap = RETRACT_LENGTH_SWAP;
@@ -550,7 +550,7 @@ static uint8_t target_extruder;
 #endif // FWRETRACT
 
 #if ENABLED(ULTIPANEL) && HAS_POWER_SWITCH
-  bool powersupply =
+  BOOL powersupply =
     #if ENABLED(PS_DEFAULT_OFF)
       false
     #else
@@ -560,7 +560,7 @@ static uint8_t target_extruder;
 #endif
 
 #if HAS_CASE_LIGHT
-  bool case_light_on =
+  BOOL case_light_on =
     #if ENABLED(CASE_LIGHT_DEFAULT_ON)
       true
     #else
@@ -608,7 +608,7 @@ static uint8_t target_extruder;
 float cartes[XYZ] = { 0 };
 
 #if ENABLED(FILAMENT_WIDTH_SENSOR)
-  bool filament_sensor = false;  //M405 turns on filament_sensor control, M406 turns it off
+  BOOL filament_sensor = false;  //M405 turns on filament_sensor control, M406 turns it off
   float filament_width_nominal = DEFAULT_NOMINAL_FILAMENT_DIA,  // Nominal filament width. Change with M404
         filament_width_meas = DEFAULT_MEASURED_FILAMENT_DIA;    // Measured filament diameter
   int8_t measurement_delay[MAX_MEASUREMENT_DELAY + 1]; // Ring buffer to delayed measurement. Store extruder factor after subtracting 100
@@ -617,7 +617,7 @@ float cartes[XYZ] = { 0 };
 #endif
 
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  static bool filament_ran_out = false;
+  static BOOL filament_ran_out = false;
 #endif
 
 #if ENABLED(FILAMENT_CHANGE_FEATURE)
@@ -631,7 +631,7 @@ float cartes[XYZ] = { 0 };
   #endif
 #endif
 
-static bool send_ok[BUFSIZE];
+static BOOL send_ok[BUFSIZE];
 
 #if HAS_SERVOS
   Servo servo[NUM_SERVOS];
@@ -644,7 +644,7 @@ static bool send_ok[BUFSIZE];
 
 #ifdef CHDK
   millis_t chdkHigh = 0;
-  bool chdkActive = false;
+  BOOL chdkActive = false;
 #endif
 
 #if ENABLED(PID_EXTRUSION_SCALING)
@@ -704,7 +704,7 @@ void serial_echopair_P(const char* s_P, float v)         { serialprintPGM(s_P); 
 void serial_echopair_P(const char* s_P, double v)        { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_P(const char* s_P, unsigned long v) { serialprintPGM(s_P); SERIAL_ECHO(v); }
 
-void tool_change(const uint8_t tmp_extruder, const float fr_mm_s=0.0, bool no_move=false);
+void tool_change(const uint8_t tmp_extruder, const float fr_mm_s=0.0, BOOL no_move=false);
 static void report_current_position();
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -799,7 +799,7 @@ inline void echo_command(const char* cmd) {
  * Shove a command in RAM to the front of the main command queue.
  * Return true if the command is successfully added.
  */
-inline bool _shovecommand(const char* cmd, bool say_ok=false) {
+inline BOOL _shovecommand(const char* cmd, BOOL say_ok=false) {
   if (*cmd == ';' || commands_in_queue >= BUFSIZE) return false;
   cmd_queue_index_r = (cmd_queue_index_r + BUFSIZE - 1) % BUFSIZE; // Index of the previous slot
   commands_in_queue++;
@@ -812,7 +812,7 @@ inline bool _shovecommand(const char* cmd, bool say_ok=false) {
  * Shove a command to the front of the queue with Serial Echo
  * Return true if the command is successfully added.
  */
-bool shove_and_echo_command(const char* cmd, bool say_ok=false) {
+BOOL shove_and_echo_command(const char* cmd, BOOL say_ok=false) {
   if (_shovecommand(cmd, say_ok)) {
     echo_command(cmd);
     return true;
@@ -832,7 +832,7 @@ void shove_and_echo_command_now(const char* cmd) {
  * Inject the next "immediate" command, when possible, onto the front of the queue.
  * Return true if any immediate commands remain to inject.
  */
-static bool drain_injected_commands_P() {
+static BOOL drain_injected_commands_P() {
   if (injected_commands_P != NULL) {
     size_t i = 0;
     char c, cmd[30];
@@ -867,7 +867,7 @@ void clear_command_queue() {
 /**
  * Once a new command is in the ring buffer, call this to commit it
  */
-inline void _commit_command(bool say_ok) {
+inline void _commit_command(BOOL say_ok) {
   send_ok[cmd_queue_index_w] = say_ok;
   cmd_queue_index_w = (cmd_queue_index_w + 1) % BUFSIZE;
   commands_in_queue++;
@@ -878,7 +878,7 @@ inline void _commit_command(bool say_ok) {
  * Return true if the command was successfully added.
  * Return false for a full buffer, or if the 'command' is a comment.
  */
-inline bool _enqueuecommand(const char* cmd, bool say_ok=false) {
+inline BOOL _enqueuecommand(const char* cmd, BOOL say_ok=false) {
   if (*cmd == ';' || commands_in_queue >= BUFSIZE) return false;
   strcpy(command_queue[cmd_queue_index_w], cmd);
   _commit_command(say_ok);
@@ -888,7 +888,7 @@ inline bool _enqueuecommand(const char* cmd, bool say_ok=false) {
 /**
  * Enqueue with Serial Echo
  */
-bool enqueue_and_echo_command(const char* cmd, bool say_ok/*=false*/) {
+BOOL enqueue_and_echo_command(const char* cmd, BOOL say_ok/*=false*/) {
   if (_enqueuecommand(cmd, say_ok)) {
     echo_command(cmd);
     return true;
@@ -993,7 +993,7 @@ void servo_init() {
 
 #endif
 
-void gcode_line_error(const char* err, bool doFlush = true) {
+void gcode_line_error(const char* err, BOOL doFlush = true) {
   SERIAL_ERROR_START;
   serialprintPGM(err);
   SERIAL_ERRORLN(gcode_LastN);
@@ -1009,7 +1009,7 @@ void gcode_line_error(const char* err, bool doFlush = true) {
  */
 inline void get_serial_commands() {
   static char serial_line_buffer[MAX_CMD_SIZE];
-  static bool serial_comment_mode = false;
+  static BOOL serial_comment_mode = false;
 
   // If the command buffer is empty for too long,
   // send "wait" to indicate Marlin is still waiting.
@@ -1049,7 +1049,7 @@ inline void get_serial_commands() {
 
       if (npos) {
 
-        bool M110 = strstr_P(command, PSTR("M110")) != NULL;
+        BOOL M110 = strstr_P(command, PSTR("M110")) != NULL;
 
         if (M110) {
           char* n2pos = strchr(command + 4, 'N');
@@ -1150,7 +1150,7 @@ inline void get_serial_commands() {
    * can also interrupt buffering.
    */
   inline void get_sdcard_commands() {
-    static bool stop_buffering = false,
+    static BOOL stop_buffering = false,
                 sd_comment_mode = false;
 
     if (!card.sdprinting) return;
@@ -1165,7 +1165,7 @@ inline void get_serial_commands() {
     if (commands_in_queue == 0) stop_buffering = false;
 
     uint16_t sd_count = 0;
-    bool card_eof = card.eof();
+    BOOL card_eof = card.eof();
     while (commands_in_queue < BUFSIZE && !card_eof && !stop_buffering) {
       const int16_t n = card.get();
       char sd_char = (char)n;
@@ -1227,7 +1227,7 @@ void get_available_commands() {
   #endif
 }
 
-inline bool code_has_value() {
+inline BOOL code_has_value() {
   int i = 1;
   char c = seen_pointer[i];
   while (c == ' ') c = seen_pointer[++i];
@@ -1255,7 +1255,7 @@ inline uint16_t code_value_ushort() { return (uint16_t)strtoul(seen_pointer + 1,
 
 inline uint8_t code_value_byte() { return (uint8_t)(constrain(strtol(seen_pointer + 1, NULL, 10), 0, 255)); }
 
-inline bool code_value_bool() { return !code_has_value() || code_value_byte() > 0; }
+inline BOOL code_value_bool() { return !code_has_value() || code_value_byte() > 0; }
 
 #if ENABLED(INCH_MODE_SUPPORT)
   inline void set_input_linear_units(LinearUnit units) {
@@ -1322,7 +1322,7 @@ inline bool code_value_bool() { return !code_has_value() || code_value_byte() > 
 FORCE_INLINE millis_t code_value_millis() { return code_value_ulong(); }
 inline millis_t code_value_millis_from_seconds() { return code_value_float() * 1000; }
 
-bool code_seen(char code) {
+BOOL code_seen(char code) {
   seen_pointer = strchr(current_command_args, code);
   return (seen_pointer != NULL); // Return TRUE if the code-letter was found
 }
@@ -1332,7 +1332,7 @@ bool code_seen(char code) {
  *
  * Returns TRUE if the target is invalid
  */
-bool get_target_extruder_from_command(int code) {
+BOOL get_target_extruder_from_command(int code) {
   if (code_seen('T')) {
     if (code_value_byte() >= EXTRUDERS) {
       SERIAL_ECHO_START;
@@ -1350,7 +1350,7 @@ bool get_target_extruder_from_command(int code) {
 }
 
 #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
-  bool extruder_duplication_enabled = false; // Used in Dual X mode 2
+  BOOL extruder_duplication_enabled = false; // Used in Dual X mode 2
 #endif
 
 #if ENABLED(DUAL_X_CARRIAGE)
@@ -1373,7 +1373,7 @@ bool get_target_extruder_from_command(int code) {
   static int x_home_dir(const int extruder) { return extruder ? X2_HOME_DIR : X_HOME_DIR; }
 
   static float inactive_extruder_x_pos = X2_MAX_POS; // used in mode 0 & 1
-  static bool active_extruder_parked = false;        // used in mode 1 & 2
+  static BOOL active_extruder_parked = false;        // used in mode 1 & 2
   static float raised_parked_position[XYZE];         // used in mode 1
   static millis_t delayed_move_time = 0;             // used in mode 1
   static float duplicate_extruder_x_offset = DEFAULT_DUPLICATION_X_OFFSET; // used in mode 2
@@ -1809,8 +1809,8 @@ static void clean_up_after_endstop_or_probe_move() {
 #endif //HAS_BED_PROBE
 
 #if ENABLED(Z_PROBE_ALLEN_KEY) || ENABLED(Z_PROBE_SLED) || HAS_PROBING_PROCEDURE || HOTENDS > 1 || ENABLED(NOZZLE_CLEAN_FEATURE) || ENABLED(NOZZLE_PARK_FEATURE)
-  bool axis_unhomed_error(const bool x, const bool y, const bool z) {
-    const bool xx = x && !axis_homed[X_AXIS],
+  BOOL axis_unhomed_error(const BOOL x, const BOOL y, const BOOL z) {
+    const BOOL xx = x && !axis_homed[X_AXIS],
                yy = y && !axis_homed[Y_AXIS],
                zz = z && !axis_homed[Z_AXIS];
     if (xx || yy || zz) {
@@ -1848,7 +1848,7 @@ static void clean_up_after_endstop_or_probe_move() {
    * stow[in]     If false, move to MAX_X and engage the solenoid
    *              If true, move to MAX_X and release the solenoid
    */
-  static void dock_sled(bool stow) {
+  static void dock_sled(BOOL stow) {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR("dock_sled(", stow);
@@ -2045,7 +2045,7 @@ static void clean_up_after_endstop_or_probe_move() {
       safe_delay(375);
     }
 
-    void set_bltouch_deployed(const bool deploy) {
+    void set_bltouch_deployed(const BOOL deploy) {
       bltouch_command(deploy ? BLTOUCH_DEPLOY : BLTOUCH_STOW);
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) {
@@ -2058,7 +2058,7 @@ static void clean_up_after_endstop_or_probe_move() {
   #endif
 
   // returns false for ok and true for failure
-  bool set_probe_deployed(bool deploy) {
+  BOOL set_probe_deployed(BOOL deploy) {
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
@@ -2245,8 +2245,8 @@ static void clean_up_after_endstop_or_probe_move() {
   //   - Raise to the BETWEEN height
   // - Return the probed Z position
   //
-//float probe_pt(const float &x, const float &y, const bool stow = true, const int verbose_level = 1) {
-  float probe_pt(const float x, const float y, const bool stow, const int verbose_level) {
+//float probe_pt(const float &x, const float &y, const BOOL stow = true, const int verbose_level = 1) {
+  float probe_pt(const float x, const float y, const BOOL stow, const int verbose_level) {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR(">>> probe_pt(", x);
@@ -2310,7 +2310,7 @@ static void clean_up_after_endstop_or_probe_move() {
    * Disable: Current position = physical position
    *  Enable: Current position = "unleveled" physical position
    */
-  void set_bed_leveling_enabled(bool enable/*=true*/) {
+  void set_bed_leveling_enabled(BOOL enable/*=true*/) {
     #if ENABLED(MESH_BED_LEVELING)
 
       if (enable != mbl.active()) {
@@ -2326,9 +2326,9 @@ static void clean_up_after_endstop_or_probe_move() {
     #elif HAS_ABL && !ENABLED(AUTO_BED_LEVELING_UBL)
 
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-        const bool can_change = (!enable || (bilinear_grid_spacing[0] && bilinear_grid_spacing[1]));
+        const BOOL can_change = (!enable || (bilinear_grid_spacing[0] && bilinear_grid_spacing[1]));
       #else
-        constexpr bool can_change = true;
+        constexpr BOOL can_change = true;
       #endif
 
       if (can_change && enable != planner.abl_enabled) {
@@ -2650,7 +2650,7 @@ static void do_homing_move(const AxisEnum axis, float distance, float fr_mm_s=0.
   #endif
 
   #if HOMING_Z_WITH_PROBE && ENABLED(BLTOUCH)
-    const bool deploy_bltouch = (axis == Z_AXIS && distance < 0);
+    const BOOL deploy_bltouch = (axis == Z_AXIS && distance < 0);
     if (deploy_bltouch) set_bltouch_deployed(true);
   #endif
 
@@ -2765,7 +2765,7 @@ static void homeaxis(const AxisEnum axis) {
   #if ENABLED(Z_DUAL_ENDSTOPS)
     if (axis == Z_AXIS) {
       float adj = fabs(z_endstop_adj);
-      bool lockZ1;
+      BOOL lockZ1;
       if (axis_home_dir > 0) {
         adj = -adj;
         lockZ1 = (z_endstop_adj > 0);
@@ -2833,7 +2833,7 @@ static void homeaxis(const AxisEnum axis) {
 
 #if ENABLED(FWRETRACT)
 
-  void retract(const bool retracting, const bool swapping = false) {
+  void retract(const BOOL retracting, const BOOL swapping = false) {
 
     static float hop_height;
 
@@ -2998,9 +2998,9 @@ void unknown_command_error() {
 
 #endif //HOST_KEEPALIVE_FEATURE
 
-bool position_is_reachable(float target[XYZ]
+BOOL position_is_reachable(float target[XYZ]
   #if HAS_BED_PROBE
-    , bool by_probe=false
+    , BOOL by_probe=false
   #endif
 ) {
   float dx = RAW_X_POSITION(target[X_AXIS]),
@@ -3039,7 +3039,7 @@ bool position_is_reachable(float target[XYZ]
  */
 inline void gcode_G0_G1(
   #if IS_SCARA
-    bool fast_move=false
+    BOOL fast_move=false
   #endif
 ) {
   if (IsRunning()) {
@@ -3092,11 +3092,11 @@ inline void gcode_G0_G1(
  *    G3 X20 Y12 R14   ; CCW circle with r=14 ending at X20 Y12
  */
 #if ENABLED(ARC_SUPPORT)
-  inline void gcode_G2_G3(bool clockwise) {
+  inline void gcode_G2_G3(BOOL clockwise) {
     if (IsRunning()) {
 
       #if ENABLED(SF_ARC_FIX)
-        const bool relative_mode_backup = relative_mode;
+        const BOOL relative_mode_backup = relative_mode;
         relative_mode = true;
       #endif
 
@@ -3196,7 +3196,7 @@ inline void gcode_G4() {
    * G10 - Retract filament according to settings of M207
    * G11 - Recover filament according to settings of M208
    */
-  inline void gcode_G10_G11(bool doRetract=false) {
+  inline void gcode_G10_G11(BOOL doRetract=false) {
     #if EXTRUDERS > 1
       if (doRetract) {
         retracted_swap[active_extruder] = (code_seen('S') && code_value_bool()); // checks for swap retract argument
@@ -3503,9 +3503,9 @@ inline void gcode_G4() {
 #endif // Z_SAFE_HOMING
 
 #if ENABLED(PROBE_MANUALLY)
-  bool g29_in_progress = false;
+  BOOL g29_in_progress = false;
 #else
-  constexpr bool g29_in_progress = false;
+  constexpr BOOL g29_in_progress = false;
 #endif
 
 /**
@@ -3543,7 +3543,7 @@ inline void gcode_G28() {
   // Disable the leveling matrix before homing
   #if PLANNER_LEVELING
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      const bool bed_leveling_state_at_entry = ubl.state.active;
+      const BOOL bed_leveling_state_at_entry = ubl.state.active;
     #endif
     set_bed_leveling_enabled(false);
   #endif
@@ -3570,7 +3570,7 @@ inline void gcode_G28() {
 
   #else // NOT DELTA
 
-    const bool homeX = code_seen('X'), homeY = code_seen('Y'), homeZ = code_seen('Z'),
+    const BOOL homeX = code_seen('X'), homeY = code_seen('Y'), homeZ = code_seen('Z'),
                home_all_axis = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
 
     set_destination_to_current();
@@ -3801,7 +3801,7 @@ inline void gcode_G28() {
 
     static int mbl_probe_index = -1;
     #if HAS_SOFTWARE_ENDSTOPS
-      static bool enable_soft_endstops;
+      static BOOL enable_soft_endstops;
     #endif
 
     const MeshLevelingState state = code_seen('S') ? (MeshLevelingState)code_value_byte() : MeshReport;
@@ -4013,7 +4013,7 @@ inline void gcode_G28() {
 
     // G29 Q is also available if debugging
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      const bool query = code_seen('Q');
+      const BOOL query = code_seen('Q');
       const uint8_t old_debug_flags = marlin_debug_flags;
       if (query) marlin_debug_flags |= DEBUG_LEVELING;
       if (DEBUGGING(LEVELING)) {
@@ -4038,10 +4038,10 @@ inline void gcode_G28() {
 
     ABL_VAR int verbose_level, abl_probe_index;
     ABL_VAR float xProbe, yProbe, measured_z;
-    ABL_VAR bool dryrun, abl_should_enable;
+    ABL_VAR BOOL dryrun, abl_should_enable;
 
     #if HAS_SOFTWARE_ENDSTOPS
-      ABL_VAR bool enable_soft_endstops = true;
+      ABL_VAR BOOL enable_soft_endstops = true;
     #endif
 
     #if ABL_GRID
@@ -4056,7 +4056,7 @@ inline void gcode_G28() {
         ABL_VAR uint8_t abl_grid_points_x = ABL_GRID_MAX_POINTS_X,
                         abl_grid_points_y = ABL_GRID_MAX_POINTS_Y;
         ABL_VAR int abl2;
-        ABL_VAR bool do_topography_map;
+        ABL_VAR BOOL do_topography_map;
       #else // 3-point
         uint8_t constexpr abl_grid_points_x = ABL_GRID_MAX_POINTS_X,
                           abl_grid_points_y = ABL_GRID_MAX_POINTS_Y;
@@ -4190,7 +4190,7 @@ inline void gcode_G28() {
         front_probe_bed_position = code_seen('F') ? (int)code_value_axis_units(Y_AXIS) : LOGICAL_Y_POSITION(FRONT_PROBE_BED_POSITION);
         back_probe_bed_position = code_seen('B') ? (int)code_value_axis_units(Y_AXIS) : LOGICAL_Y_POSITION(BACK_PROBE_BED_POSITION);
 
-        const bool left_out_l = left_probe_bed_position < LOGICAL_X_POSITION(MIN_PROBE_X),
+        const BOOL left_out_l = left_probe_bed_position < LOGICAL_X_POSITION(MIN_PROBE_X),
                    left_out = left_out_l || left_probe_bed_position > right_probe_bed_position - (MIN_PROBE_EDGE),
                    right_out_r = right_probe_bed_position > LOGICAL_X_POSITION(MAX_PROBE_X),
                    right_out = right_out_r || right_probe_bed_position < left_probe_bed_position + MIN_PROBE_EDGE,
@@ -4375,7 +4375,7 @@ inline void gcode_G28() {
           PR_OUTER_VAR = abl_probe_index / PR_INNER_END;
           PR_INNER_VAR = abl_probe_index - (PR_OUTER_VAR * PR_INNER_END);
 
-          bool zig = (PR_OUTER_VAR & 1) != ((PR_OUTER_END) & 1);
+          BOOL zig = (PR_OUTER_VAR & 1) != ((PR_OUTER_END) & 1);
 
           if (zig) PR_INNER_VAR = (PR_INNER_END - 1) - PR_INNER_VAR;
 
@@ -4464,11 +4464,11 @@ inline void gcode_G28() {
     #else // !PROBE_MANUALLY
 
 
-      bool stow_probe_after_each = code_seen('E');
+      BOOL stow_probe_after_each = code_seen('E');
 
       #if ABL_GRID
 
-        bool zig = PR_OUTER_END & 1;  // Always end at RIGHT and BACK_PROBE_BED_POSITION
+        BOOL zig = PR_OUTER_END & 1;  // Always end at RIGHT and BACK_PROBE_BED_POSITION
 
         // Outer loop is Y with PROBE_Y_FIRST disabled
         for (uint8_t PR_OUTER_VAR = 0; PR_OUTER_VAR < PR_OUTER_END; PR_OUTER_VAR++) {
@@ -4810,7 +4810,7 @@ inline void gcode_G28() {
     float pos[XYZ] = { X_probe_location, Y_probe_location, LOGICAL_Z_POSITION(0) };
     if (!position_is_reachable(pos, true)) return;
 
-    bool stow = code_seen('S') ? code_value_bool() : true;
+    BOOL stow = code_seen('S') ? code_value_bool() : true;
 
     // Disable leveling so the planner won't mess with us
     #if PLANNER_LEVELING
@@ -4851,9 +4851,9 @@ inline void gcode_G28() {
 
 #if ENABLED(G38_PROBE_TARGET)
 
-  static bool G38_run_probe() {
+  static BOOL G38_run_probe() {
 
-    bool G38_pass_fail = false;
+    BOOL G38_pass_fail = false;
 
     // Get direction of move and retract
     float retract_mm[XYZ];
@@ -4914,7 +4914,7 @@ inline void gcode_G28() {
    *
    * Like G28 except uses Z min endstop for all axes
    */
-  inline void gcode_G38(bool is_38_2) {
+  inline void gcode_G38(BOOL is_38_2) {
     // Get X Y Z E F
     gcode_get_destination();
 
@@ -4941,7 +4941,7 @@ inline void gcode_G28() {
  * G92: Set current position to given X Y Z E
  */
 inline void gcode_G92() {
-  bool didXYZ = false,
+  BOOL didXYZ = false,
        didE = code_seen('E');
 
   if (!didE) stepper.synchronize();
@@ -4987,7 +4987,7 @@ inline void gcode_G92() {
     char* args = current_command_args;
 
     millis_t codenum = 0;
-    bool hasP = false, hasS = false;
+    BOOL hasP = false, hasS = false;
     if (code_seen('P')) {
       codenum = code_value_millis(); // milliseconds to wait
       hasP = codenum > 0;
@@ -5060,7 +5060,7 @@ inline void gcode_M17() {
 
 #if ENABLED(PARK_HEAD_ON_PAUSE)
   float resume_position[XYZE];
-  bool move_away_flag = false;
+  BOOL move_away_flag = false;
 
   inline void move_back_on_resume() {
     if (!move_away_flag) return;
@@ -5212,7 +5212,7 @@ inline void gcode_M31() {
     else
       namestartpos++; //to skip the '!'
 
-    bool call_procedure = code_seen('P') && (seen_pointer < namestartpos);
+    BOOL call_procedure = code_seen('P') && (seen_pointer < namestartpos);
 
     if (card.cardOK) {
       card.openFile(namestartpos, true, call_procedure);
@@ -5273,7 +5273,7 @@ inline void gcode_M31() {
 /**
  * Sensitive pin test for M42, M226
  */
-static bool pin_is_protected(uint8_t pin) {
+static BOOL pin_is_protected(uint8_t pin) {
   static const int sensitive_pins[] = SENSITIVE_PINS;
   for (uint8_t i = 0; i < COUNT(sensitive_pins); i++)
     if (sensitive_pins[i] == pin) return true;
@@ -5357,7 +5357,7 @@ inline void gcode_M42() {
       if (first_pin > NUM_DIGITAL_PINS - 1) return;
     }
 
-    const bool ignore_protection = code_seen('I') ? code_value_bool() : false;
+    const BOOL ignore_protection = code_seen('I') ? code_value_bool() : false;
 
     // Watch until click, M108, or reset
     if (code_seen('W') && code_value_bool()) { // watch digital pins
@@ -5427,7 +5427,7 @@ inline void gcode_M42() {
    */
   inline void gcode_M48() {
   #if ENABLED(AUTO_BED_LEVELING_UBL)
-  bool bed_leveling_state_at_entry=0;
+  BOOL bed_leveling_state_at_entry=0;
     bed_leveling_state_at_entry = ubl.state.active;
   #endif
 
@@ -5451,7 +5451,7 @@ inline void gcode_M42() {
     float  X_current = current_position[X_AXIS],
            Y_current = current_position[Y_AXIS];
 
-    bool stow_probe_after_each = code_seen('E');
+    BOOL stow_probe_after_each = code_seen('E');
 
     float X_probe_location = code_seen('X') ? code_value_axis_units(X_AXIS) : X_current + X_PROBE_OFFSET_FROM_EXTRUDER;
     #if DISABLED(DELTA)
@@ -5475,7 +5475,7 @@ inline void gcode_M42() {
       }
     #endif
 
-    bool seen_L = code_seen('L');
+    BOOL seen_L = code_seen('L');
     uint8_t n_legs = seen_L ? code_value_byte() : 0;
     if (n_legs > 15) {
       SERIAL_PROTOCOLLNPGM("?Number of legs in movement not plausible (0-15).");
@@ -5483,7 +5483,7 @@ inline void gcode_M42() {
     }
     if (n_legs == 1) n_legs = 2;
 
-    bool schizoid_flag = code_seen('S');
+    BOOL schizoid_flag = code_seen('S');
     if (schizoid_flag && !seen_L) n_legs = 7;
 
     /**
@@ -5496,7 +5496,7 @@ inline void gcode_M42() {
 
     // Disable bed level correction in M48 because we want the raw data when we probe
     #if HAS_ABL
-      const bool abl_was_enabled = planner.abl_enabled;
+      const BOOL abl_was_enabled = planner.abl_enabled;
       set_bed_leveling_enabled(false);
     #endif
 
@@ -5905,7 +5905,7 @@ inline void gcode_M109() {
     if (target_extruder != active_extruder) return;
   #endif
 
-  bool no_wait_for_cooling = code_seen('S');
+  BOOL no_wait_for_cooling = code_seen('S');
   if (no_wait_for_cooling || code_seen('R')) {
     thermalManager.setTargetHotend(code_value_temp_abs(), target_extruder);
     #if ENABLED(DUAL_X_CARRIAGE)
@@ -5948,7 +5948,7 @@ inline void gcode_M109() {
   #endif //TEMP_RESIDENCY_TIME > 0
 
   float theTarget = -1.0, old_temp = 9999.0;
-  bool wants_to_cool = false;
+  BOOL wants_to_cool = false;
   wait_for_heatup = true;
   millis_t now, next_temp_ms = 0, next_cool_check_ms = 0;
 
@@ -6037,7 +6037,7 @@ inline void gcode_M109() {
     if (DEBUGGING(DRYRUN)) return;
 
     LCD_MESSAGEPGM(MSG_BED_HEATING);
-    bool no_wait_for_cooling = code_seen('S');
+    BOOL no_wait_for_cooling = code_seen('S');
     if (no_wait_for_cooling || code_seen('R')) {
       thermalManager.setTargetBed(code_value_temp_abs());
       #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
@@ -6065,7 +6065,7 @@ inline void gcode_M109() {
     #endif //TEMP_BED_RESIDENCY_TIME > 0
 
     float theTarget = -1.0, old_temp = 9999.0;
-    bool wants_to_cool = false;
+    BOOL wants_to_cool = false;
     wait_for_heatup = true;
     millis_t now, next_temp_ms = 0, next_cool_check_ms = 0;
 
@@ -6362,7 +6362,7 @@ inline void gcode_M18_M84() {
     stepper_inactive_time = code_value_millis_from_seconds();
   }
   else {
-    bool all_axis = !((code_seen('X')) || (code_seen('Y')) || (code_seen('Z')) || (code_seen('E')));
+    BOOL all_axis = !((code_seen('X')) || (code_seen('Y')) || (code_seen('Z')) || (code_seen('E')));
     if (all_axis) {
       stepper.finish_and_disable();
     }
@@ -6558,7 +6558,7 @@ inline void gcode_M121() { endstops.enable_globally(false); }
   inline void gcode_M125() {
     if (move_away_flag) return; // already paused
 
-    const bool job_running = print_job_timer.isRunning();
+    const BOOL job_running = print_job_timer.isRunning();
 
     // there are blocks after this one, or sd printing
     move_away_flag = job_running || planner.blocks_queued()
@@ -7286,7 +7286,7 @@ inline void gcode_M226() {
    *       M302 S170 P1 ; set min extrude temp to 170 but leave disabled
    */
   inline void gcode_M302() {
-    bool seen_S = code_seen('S');
+    BOOL seen_S = code_seen('S');
     if (seen_S) {
       thermalManager.extrude_min_temp = code_value_temp_abs();
       thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0);
@@ -7317,7 +7317,7 @@ inline void gcode_M303() {
   #if HAS_PID_HEATING
     int e = code_seen('E') ? code_value_int() : 0;
     int c = code_seen('C') ? code_value_int() : 5;
-    bool u = code_seen('U') && code_value_bool();
+    BOOL u = code_seen('U') && code_value_bool();
 
     float temp = code_seen('S') ? code_value_temp_abs() : (e < 0 ? 70.0 : 150.0);
 
@@ -7337,7 +7337,7 @@ inline void gcode_M303() {
 
 #if ENABLED(MORGAN_SCARA)
 
-  bool SCARA_move_to_cal(uint8_t delta_a, uint8_t delta_b) {
+  BOOL SCARA_move_to_cal(uint8_t delta_a, uint8_t delta_b) {
     if (IsRunning()) {
       forward_kinematics_SCARA(delta_a, delta_b);
       destination[X_AXIS] = LOGICAL_X_POSITION(cartes[X_AXIS]);
@@ -7352,7 +7352,7 @@ inline void gcode_M303() {
   /**
    * M360: SCARA calibration: Move to cal-position ThetaA (0 deg calibration)
    */
-  inline bool gcode_M360() {
+  inline BOOL gcode_M360() {
     SERIAL_ECHOLNPGM(" Cal: Theta 0");
     return SCARA_move_to_cal(0, 120);
   }
@@ -7360,7 +7360,7 @@ inline void gcode_M303() {
   /**
    * M361: SCARA calibration: Move to cal-position ThetaB (90 deg calibration - steps per degree)
    */
-  inline bool gcode_M361() {
+  inline BOOL gcode_M361() {
     SERIAL_ECHOLNPGM(" Cal: Theta 90");
     return SCARA_move_to_cal(90, 130);
   }
@@ -7368,7 +7368,7 @@ inline void gcode_M303() {
   /**
    * M362: SCARA calibration: Move to cal-position PsiA (0 deg calibration)
    */
-  inline bool gcode_M362() {
+  inline BOOL gcode_M362() {
     SERIAL_ECHOLNPGM(" Cal: Psi 0");
     return SCARA_move_to_cal(60, 180);
   }
@@ -7376,7 +7376,7 @@ inline void gcode_M303() {
   /**
    * M363: SCARA calibration: Move to cal-position PsiB (90 deg calibration - steps per degree)
    */
-  inline bool gcode_M363() {
+  inline BOOL gcode_M363() {
     SERIAL_ECHOLNPGM(" Cal: Psi 90");
     return SCARA_move_to_cal(50, 90);
   }
@@ -7384,7 +7384,7 @@ inline void gcode_M303() {
   /**
    * M364: SCARA calibration: Move to cal-position PSIC (90 deg to Theta calibration position)
    */
-  inline bool gcode_M364() {
+  inline BOOL gcode_M364() {
     SERIAL_ECHOLNPGM(" Cal: Theta-Psi 90");
     return SCARA_move_to_cal(45, 135);
   }
@@ -7579,7 +7579,7 @@ void quickstop_stepper() {
       #endif
     }
 
-    bool to_enable = false;
+    BOOL to_enable = false;
     if (code_seen('S')) {
       to_enable = code_value_bool();
       set_bed_leveling_enabled(to_enable);
@@ -7589,7 +7589,7 @@ void quickstop_stepper() {
       if (code_seen('Z')) set_z_fade_height(code_value_linear_units());
     #endif
 
-    const bool new_status =
+    const BOOL new_status =
       #if ENABLED(MESH_BED_LEVELING)
         mbl.active()
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
@@ -7618,7 +7618,7 @@ void quickstop_stepper() {
   inline void gcode_M421() {
     int8_t px = 0, py = 0;
     float z = 0;
-    bool hasX, hasY, hasZ, hasI, hasJ;
+    BOOL hasX, hasY, hasZ, hasI, hasJ;
     if ((hasX = code_seen('X'))) px = mbl.probe_index_x(code_value_axis_units(X_AXIS));
     if ((hasY = code_seen('Y'))) py = mbl.probe_index_y(code_value_axis_units(Y_AXIS));
     if ((hasI = code_seen('I'))) px = code_value_axis_units(X_AXIS);
@@ -7658,7 +7658,7 @@ void quickstop_stepper() {
   inline void gcode_M421() {
     int8_t px = 0, py = 0;
     float z = 0;
-    bool hasI, hasJ, hasZ;
+    BOOL hasI, hasJ, hasZ;
     if ((hasI = code_seen('I'))) px = code_value_axis_units(X_AXIS);
     if ((hasJ = code_seen('J'))) py = code_value_axis_units(Y_AXIS);
     if ((hasZ = code_seen('Z'))) z = code_value_axis_units(Z_AXIS);
@@ -7697,7 +7697,7 @@ void quickstop_stepper() {
    *       Use M206 to set these values directly.
    */
   inline void gcode_M428() {
-    bool err = false;
+    BOOL err = false;
     LOOP_XYZ(i) {
       if (axis_homed[i]) {
         float base = (current_position[i] > (soft_endstop_min[i] + soft_endstop_max[i]) * 0.5) ? base_home_pos((AxisEnum)i) : 0,
@@ -7811,7 +7811,7 @@ inline void gcode_M503() {
 
 #if ENABLED(FILAMENT_CHANGE_FEATURE)
 
-  void filament_change_beep(const bool init=false) {
+  void filament_change_beep(const BOOL init=false) {
     static millis_t next_buzz = 0;
     static uint16_t runout_beep = 0;
 
@@ -7827,7 +7827,7 @@ inline void gcode_M503() {
     }
   }
 
-  static bool busy_doing_M600 = false;
+  static BOOL busy_doing_M600 = false;
 
   /**
    * M600: Pause for filament change
@@ -7852,7 +7852,7 @@ inline void gcode_M503() {
     busy_doing_M600 = true;  // Stepper Motors can't timeout when this is set
 
     // Pause the print job timer
-    const bool job_running = print_job_timer.isRunning();
+    const BOOL job_running = print_job_timer.isRunning();
 
     print_job_timer.pause();
 
@@ -7921,7 +7921,7 @@ inline void gcode_M503() {
     safe_delay(100);
 
     const millis_t nozzle_timeout = millis() + (millis_t)(FILAMENT_CHANGE_NOZZLE_TIMEOUT) * 1000UL;
-    bool nozzle_timed_out = false;
+    BOOL nozzle_timed_out = false;
     float temps[4];
 
     // Wait for filament insert by user and press button
@@ -8458,7 +8458,7 @@ inline void invalid_extruder_error(const uint8_t &e) {
  * Perform a tool-change, which may result in moving the
  * previous tool out of the way and the new tool into place.
  */
-void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool no_move/*=false*/) {
+void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, BOOL no_move/*=false*/) {
   #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
 
     if (tmp_extruder >= MIXING_VIRTUAL_TOOLS)
@@ -8837,7 +8837,7 @@ void process_next_command() {
   uint16_t codenum = 0; // define ahead of goto
 
   // Bail early if there's no code
-  bool code_is_good = NUMERIC(*cmd_ptr);
+  BOOL code_is_good = NUMERIC(*cmd_ptr);
   if (!code_is_good) goto ExitUnknownCommand;
 
   // Get and skip the code number
@@ -10093,7 +10093,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
    * This calls planner.buffer_line several times, adding
    * small incremental moves for DELTA or SCARA.
    */
-  inline bool prepare_kinematic_move_to(float ltarget[XYZE]) {
+  inline BOOL prepare_kinematic_move_to(float ltarget[XYZE]) {
 
     // Get the top feedrate of the move in the XY plane
     float _feedrate_mm_s = MMS_SCALED(feedrate_mm_s);
@@ -10209,7 +10209,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
    * Prepare a linear move in a Cartesian setup.
    * If Mesh Bed Leveling is enabled, perform a mesh move.
    */
-  inline bool prepare_move_to_destination_cartesian() {
+  inline BOOL prepare_move_to_destination_cartesian() {
     // Do not use feedrate_percentage for E or Z only moves
     if (current_position[X_AXIS] == destination[X_AXIS] && current_position[Y_AXIS] == destination[Y_AXIS]) {
       line_to_destination();
@@ -10248,7 +10248,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
   /**
    * Prepare a linear move in a dual X axis setup
    */
-  inline bool prepare_move_to_destination_dualx() {
+  inline BOOL prepare_move_to_destination_dualx() {
     if (active_extruder_parked) {
       switch (dual_x_carriage_mode) {
         case DXC_FULL_CONTROL_MODE:
@@ -10614,7 +10614,7 @@ void prepare_move_to_destination() {
 
 #if ENABLED(TEMP_STAT_LEDS)
 
-  static bool red_led = false;
+  static BOOL red_led = false;
   static millis_t next_status_led_update_ms = 0;
 
   void handle_status_leds(void) {
@@ -10627,7 +10627,7 @@ void prepare_move_to_destination() {
       HOTEND_LOOP() {
         max_temp = MAX3(max_temp, thermalManager.degHotend(e), thermalManager.degTargetHotend(e));
       }
-      bool new_led = (max_temp > 55.0) ? true : (max_temp < 54.0) ? false : red_led;
+      BOOL new_led = (max_temp > 55.0) ? true : (max_temp < 54.0) ? false : red_led;
       if (new_led != red_led) {
         red_led = new_led;
         #if PIN_EXISTS(STAT_LED_RED)
@@ -10756,7 +10756,7 @@ void disable_all_steppers() {
 
   void automatic_current_control(const TMC2130Stepper &st) {
     #if CURRENT_STEP > 0
-      const bool is_otpw = st.checkOT(), // Check otpw even if we don't adjust. Allows for flag inspection.
+      const BOOL is_otpw = st.checkOT(), // Check otpw even if we don't adjust. Allows for flag inspection.
                  is_otpw_triggered = st.getOTPW();
 
       if (!is_otpw && !is_otpw_triggered) {
@@ -10823,7 +10823,7 @@ void disable_all_steppers() {
  *  - Check if cooling fan needs to be switched on
  *  - Check if an idle but hot extruder needs filament extruded (EXTRUDER_RUNOUT_PREVENT)
  */
-void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
+void manage_inactivity(BOOL ignore_stepper_queue/*=false*/) {
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
     if ((IS_SD_PRINTING || print_job_timer.isRunning()) && (READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING))
@@ -10916,7 +10916,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
   #if ENABLED(EXTRUDER_RUNOUT_PREVENT)
     if (ELAPSED(ms, previous_cmd_ms + (EXTRUDER_RUNOUT_SECONDS) * 1000UL)
       && thermalManager.degHotend(active_extruder) > EXTRUDER_RUNOUT_MINTEMP) {
-      bool oldstatus;
+      BOOL oldstatus;
       #if ENABLED(SWITCHING_EXTRUDER)
         oldstatus = E0_ENABLE_READ;
         enable_e0();
@@ -11008,7 +11008,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
  */
 void idle(
   #if ENABLED(FILAMENT_CHANGE_FEATURE)
-    bool no_stepper_sleep/*=false*/
+    BOOL no_stepper_sleep/*=false*/
   #endif
 ) {
   lcd_update();

--- a/Marlin/Sd2Card.cpp
+++ b/Marlin/Sd2Card.cpp
@@ -242,7 +242,7 @@ void Sd2Card::chipSelectLow() {
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::erase(uint32_t firstBlock, uint32_t lastBlock) {
+BOOL Sd2Card::erase(uint32_t firstBlock, uint32_t lastBlock) {
   csd_t csd;
   if (!readCSD(&csd)) goto fail;
   // check for single block erase
@@ -281,7 +281,7 @@ fail:
  * \return The value one, true, is returned if single block erase is supported.
  * The value zero, false, is returned if single block erase is not supported.
  */
-bool Sd2Card::eraseSingleBlockEnable() {
+BOOL Sd2Card::eraseSingleBlockEnable() {
   csd_t csd;
   return readCSD(&csd) ? csd.v1.erase_blk_en : false;
 }
@@ -296,7 +296,7 @@ bool Sd2Card::eraseSingleBlockEnable() {
  * the value zero, false, is returned for failure.  The reason for failure
  * can be determined by calling errorCode() and errorData().
  */
-bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
+BOOL Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
   errorCode_ = type_ = 0;
   chipSelectPin_ = chipSelectPin;
   // 16-bit init start time allows over a minute
@@ -393,7 +393,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
+BOOL Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
   // use address if not SDHC card
   if (type() != SD_CARD_TYPE_SDHC) blockNumber <<= 9;
 
@@ -430,7 +430,7 @@ bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::readData(uint8_t* dst) {
+BOOL Sd2Card::readData(uint8_t* dst) {
   chipSelectLow();
   return readData(dst, 512);
 }
@@ -480,7 +480,7 @@ static uint16_t CRC_CCITT(const uint8_t* data, size_t n) {
 #endif
 
 //------------------------------------------------------------------------------
-bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
+BOOL Sd2Card::readData(uint8_t* dst, uint16_t count) {
   // wait for start block token
   uint16_t t0 = millis();
   while ((status_ = spiRec()) == 0XFF) {
@@ -523,7 +523,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 /** read CID or CSR register */
-bool Sd2Card::readRegister(uint8_t cmd, void* buf) {
+BOOL Sd2Card::readRegister(uint8_t cmd, void* buf) {
   uint8_t* dst = reinterpret_cast<uint8_t*>(buf);
   if (cardCommand(cmd, 0)) {
     error(SD_CARD_ERROR_READ_REG);
@@ -545,7 +545,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::readStart(uint32_t blockNumber) {
+BOOL Sd2Card::readStart(uint32_t blockNumber) {
   if (type() != SD_CARD_TYPE_SDHC) blockNumber <<= 9;
   if (cardCommand(CMD18, blockNumber)) {
     error(SD_CARD_ERROR_CMD18);
@@ -563,7 +563,7 @@ fail:
 * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::readStop() {
+BOOL Sd2Card::readStop() {
   chipSelectLow();
   if (cardCommand(CMD12, 0)) {
     error(SD_CARD_ERROR_CMD12);
@@ -588,7 +588,7 @@ fail:
  * \return The value one, true, is returned for success and the value zero,
  * false, is returned for an invalid value of \a sckRateID.
  */
-bool Sd2Card::setSckRate(uint8_t sckRateID) {
+BOOL Sd2Card::setSckRate(uint8_t sckRateID) {
   if (sckRateID > 6) {
     error(SD_CARD_ERROR_SCK_RATE);
     return false;
@@ -598,7 +598,7 @@ bool Sd2Card::setSckRate(uint8_t sckRateID) {
 }
 //------------------------------------------------------------------------------
 // wait for card to go not busy
-bool Sd2Card::waitNotBusy(uint16_t timeoutMillis) {
+BOOL Sd2Card::waitNotBusy(uint16_t timeoutMillis) {
   uint16_t t0 = millis();
   while (spiRec() != 0XFF) {
     if (((uint16_t)millis() - t0) >= timeoutMillis) goto fail;
@@ -616,7 +616,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::writeBlock(uint32_t blockNumber, const uint8_t* src) {
+BOOL Sd2Card::writeBlock(uint32_t blockNumber, const uint8_t* src) {
   // use address if not SDHC card
   if (type() != SD_CARD_TYPE_SDHC) blockNumber <<= 9;
   if (cardCommand(CMD24, blockNumber)) {
@@ -647,7 +647,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::writeData(const uint8_t* src) {
+BOOL Sd2Card::writeData(const uint8_t* src) {
   chipSelectLow();
   // wait for previous write to finish
   if (!waitNotBusy(SD_WRITE_TIMEOUT)) goto fail;
@@ -661,7 +661,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 // send one block of data for write block or write multiple blocks
-bool Sd2Card::writeData(uint8_t token, const uint8_t* src) {
+BOOL Sd2Card::writeData(uint8_t token, const uint8_t* src) {
   spiSendBlock(token, src);
 
   spiSend(0xff);  // dummy crc
@@ -689,7 +689,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::writeStart(uint32_t blockNumber, uint32_t eraseCount) {
+BOOL Sd2Card::writeStart(uint32_t blockNumber, uint32_t eraseCount) {
   // send pre-erase count
   if (cardAcmd(ACMD23, eraseCount)) {
     error(SD_CARD_ERROR_ACMD23);
@@ -713,7 +713,7 @@ fail:
 * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool Sd2Card::writeStop() {
+BOOL Sd2Card::writeStop() {
   chipSelectLow();
   if (!waitNotBusy(SD_WRITE_TIMEOUT)) goto fail;
   spiSend(STOP_TRAN_TOKEN);

--- a/Marlin/Sd2Card.h
+++ b/Marlin/Sd2Card.h
@@ -166,8 +166,8 @@ class Sd2Card {
   /** Construct an instance of Sd2Card. */
   Sd2Card() : errorCode_(SD_CARD_ERROR_INIT_NOT_CALLED), type_(0) {}
   uint32_t cardSize();
-  bool erase(uint32_t firstBlock, uint32_t lastBlock);
-  bool eraseSingleBlockEnable();
+  BOOL erase(uint32_t firstBlock, uint32_t lastBlock);
+  BOOL eraseSingleBlockEnable();
   /**
    *  Set SD error code.
    *  \param[in] code value for error code.
@@ -185,9 +185,9 @@ class Sd2Card {
    *
    * \return true for success or false for failure.
    */
-  bool init(uint8_t sckRateID = SPI_FULL_SPEED,
+  BOOL init(uint8_t sckRateID = SPI_FULL_SPEED,
             uint8_t chipSelectPin = SD_CHIP_SELECT_PIN);
-  bool readBlock(uint32_t block, uint8_t* dst);
+  BOOL readBlock(uint32_t block, uint8_t* dst);
   /**
    * Read a card's CID register. The CID contains card identification
    * information such as Manufacturer ID, Product name, Product serial
@@ -197,7 +197,7 @@ class Sd2Card {
    *
    * \return true for success or false for failure.
    */
-  bool readCID(cid_t* cid) {
+  BOOL readCID(cid_t* cid) {
     return readRegister(CMD10, cid);
   }
   /**
@@ -208,21 +208,21 @@ class Sd2Card {
    *
    * \return true for success or false for failure.
    */
-  bool readCSD(csd_t* csd) {
+  BOOL readCSD(csd_t* csd) {
     return readRegister(CMD9, csd);
   }
-  bool readData(uint8_t* dst);
-  bool readStart(uint32_t blockNumber);
-  bool readStop();
-  bool setSckRate(uint8_t sckRateID);
+  BOOL readData(uint8_t* dst);
+  BOOL readStart(uint32_t blockNumber);
+  BOOL readStop();
+  BOOL setSckRate(uint8_t sckRateID);
   /** Return the card type: SD V1, SD V2 or SDHC
    * \return 0 - SD V1, 1 - SD V2, or 3 - SDHC.
    */
   int type() const {return type_;}
-  bool writeBlock(uint32_t blockNumber, const uint8_t* src);
-  bool writeData(const uint8_t* src);
-  bool writeStart(uint32_t blockNumber, uint32_t eraseCount);
-  bool writeStop();
+  BOOL writeBlock(uint32_t blockNumber, const uint8_t* src);
+  BOOL writeData(const uint8_t* src);
+  BOOL writeStart(uint32_t blockNumber, uint32_t eraseCount);
+  BOOL writeStop();
  private:
   //----------------------------------------------------------------------------
   uint8_t chipSelectPin_;
@@ -237,13 +237,13 @@ class Sd2Card {
   }
   uint8_t cardCommand(uint8_t cmd, uint32_t arg);
 
-  bool readData(uint8_t* dst, uint16_t count);
-  bool readRegister(uint8_t cmd, void* buf);
+  BOOL readData(uint8_t* dst, uint16_t count);
+  BOOL readRegister(uint8_t cmd, void* buf);
   void chipSelectHigh();
   void chipSelectLow();
   void type(uint8_t value) {type_ = value;}
-  bool waitNotBusy(uint16_t timeoutMillis);
-  bool writeData(uint8_t token, const uint8_t* src);
+  BOOL waitNotBusy(uint16_t timeoutMillis);
+  BOOL writeData(uint8_t token, const uint8_t* src);
 };
 #endif  // Sd2Card_h
 

--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -38,7 +38,7 @@ SdBaseFile* SdBaseFile::cwd_ = 0;
 void (*SdBaseFile::dateTime_)(uint16_t* date, uint16_t* time) = 0;
 //------------------------------------------------------------------------------
 // add a cluster to a file
-bool SdBaseFile::addCluster() {
+BOOL SdBaseFile::addCluster() {
   if (!vol_->allocContiguous(1, &curCluster_)) goto fail;
 
   // if first cluster of file link to directory entry
@@ -54,7 +54,7 @@ bool SdBaseFile::addCluster() {
 //------------------------------------------------------------------------------
 // Add a cluster to a directory file and zero the cluster.
 // return with first block of cluster in the cache
-bool SdBaseFile::addDirCluster() {
+BOOL SdBaseFile::addDirCluster() {
   uint32_t block;
   // max folder size
   if (fileSize_ / sizeof(dir_t) >= 0XFFFF) goto fail;
@@ -97,8 +97,8 @@ fail:
  * the value zero, false, is returned for failure.
  * Reasons for failure include no file is open or an I/O error.
  */
-bool SdBaseFile::close() {
-  bool rtn = sync();
+BOOL SdBaseFile::close() {
+  BOOL rtn = sync();
   type_ = FAT_FILE_TYPE_CLOSED;
   return rtn;
 }
@@ -113,7 +113,7 @@ bool SdBaseFile::close() {
  * Reasons for failure include file is not contiguous, file has zero length
  * or an I/O error occurred.
  */
-bool SdBaseFile::contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock) {
+BOOL SdBaseFile::contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock) {
   // error if no blocks
   if (firstCluster_ == 0) goto fail;
 
@@ -153,7 +153,7 @@ fail:
  * directory is full or an I/O error.
  *
  */
-bool SdBaseFile::createContiguous(SdBaseFile* dirFile,
+BOOL SdBaseFile::createContiguous(SdBaseFile* dirFile,
                                   const char* path, uint32_t size) {
   uint32_t count;
   // don't allow zero length file
@@ -185,7 +185,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::dirEntry(dir_t* dir) {
+BOOL SdBaseFile::dirEntry(dir_t* dir) {
   dir_t* p;
   // make sure fields on SD are correct
   if (!sync()) goto fail;
@@ -228,7 +228,7 @@ void SdBaseFile::dirName(const dir_t& dir, char* name) {
  *
  * \return true if the file exists else false.
  */
-bool SdBaseFile::exists(const char* name) {
+BOOL SdBaseFile::exists(const char* name) {
   SdBaseFile file;
   return file.open(this, name, O_READ);
 }
@@ -283,7 +283,7 @@ int16_t SdBaseFile::fgets(char* str, int16_t num, char* delim) {
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::getFilename(char* name) {
+BOOL SdBaseFile::getFilename(char* name) {
   if (!isOpen()) return false;
 
   if (isRoot()) {
@@ -385,7 +385,7 @@ int8_t SdBaseFile::lsPrintNext(uint8_t flags, uint8_t indent) {
 }
 //------------------------------------------------------------------------------
 // format directory name field from a 8.3 name string
-bool SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
+BOOL SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
   uint8_t c;
   uint8_t n = 7;  // max index for part before dot
   uint8_t i = 0;
@@ -431,7 +431,7 @@ fail:
  * Reasons for failure include this file is already open, \a parent is not a
  * directory, \a path is invalid or already exists in \a parent.
  */
-bool SdBaseFile::mkdir(SdBaseFile* parent, const char* path, bool pFlag) {
+BOOL SdBaseFile::mkdir(SdBaseFile* parent, const char* path, BOOL pFlag) {
   uint8_t dname[11];
   SdBaseFile dir1, dir2;
   SdBaseFile* sub = &dir1;
@@ -464,7 +464,7 @@ fail:
   return false;
 }
 //------------------------------------------------------------------------------
-bool SdBaseFile::mkdir(SdBaseFile* parent, const uint8_t dname[11]) {
+BOOL SdBaseFile::mkdir(SdBaseFile* parent, const uint8_t dname[11]) {
   uint32_t block;
   dir_t d;
   dir_t* p;
@@ -532,7 +532,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::open(const char* path, uint8_t oflag) {
+BOOL SdBaseFile::open(const char* path, uint8_t oflag) {
   return open(cwd_, path, oflag);
 }
 //------------------------------------------------------------------------------
@@ -586,7 +586,7 @@ bool SdBaseFile::open(const char* path, uint8_t oflag) {
  * a directory, \a path is invalid, the file does not exist
  * or can't be opened in the access mode specified by oflag.
  */
-bool SdBaseFile::open(SdBaseFile* dirFile, const char* path, uint8_t oflag) {
+BOOL SdBaseFile::open(SdBaseFile* dirFile, const char* path, uint8_t oflag) {
   uint8_t dname[11];
   SdBaseFile dir1, dir2;
   SdBaseFile* parent = dirFile;
@@ -619,10 +619,10 @@ fail:
 }
 //------------------------------------------------------------------------------
 // open with filename in dname
-bool SdBaseFile::open(SdBaseFile* dirFile,
+BOOL SdBaseFile::open(SdBaseFile* dirFile,
                       const uint8_t dname[11], uint8_t oflag) {
-  bool emptyFound = false;
-  bool fileFound = false;
+  BOOL emptyFound = false;
+  BOOL fileFound = false;
   uint8_t index;
   dir_t* p;
 
@@ -713,7 +713,7 @@ fail:
  * See open() by path for definition of flags.
  * \return true for success or false for failure.
  */
-bool SdBaseFile::open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag) {
+BOOL SdBaseFile::open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag) {
   dir_t* p;
 
   vol_ = dirFile->vol_;
@@ -743,7 +743,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 // open a cached directory entry. Assumes vol_ is initialized
-bool SdBaseFile::openCachedEntry(uint8_t dirIndex, uint8_t oflag) {
+BOOL SdBaseFile::openCachedEntry(uint8_t dirIndex, uint8_t oflag) {
   // location of entry in cache
   dir_t* p = &vol_->cache()->dir[dirIndex];
 
@@ -795,7 +795,7 @@ fail:
  * See open() by path for definition of flags.
  * \return true for success or false for failure.
  */
-bool SdBaseFile::openNext(SdBaseFile* dirFile, uint8_t oflag) {
+BOOL SdBaseFile::openNext(SdBaseFile* dirFile, uint8_t oflag) {
   dir_t* p;
   uint8_t index;
 
@@ -836,7 +836,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::openParent(SdBaseFile* dir) {
+BOOL SdBaseFile::openParent(SdBaseFile* dir) {
   dir_t entry;
   dir_t* p;
   SdBaseFile file;
@@ -893,7 +893,7 @@ fail:
  * Reasons for failure include the file is already open, the FAT volume has
  * not been initialized or it a FAT12 volume.
  */
-bool SdBaseFile::openRoot(SdVolume* vol) {
+BOOL SdBaseFile::openRoot(SdVolume* vol) {
   // error if file is already open
   if (isOpen()) goto fail;
 
@@ -947,7 +947,7 @@ int SdBaseFile::peek() {
  * \param[in] printSlash Print '/' after directory names if true.
  */
 void SdBaseFile::printDirName(const dir_t& dir,
-                              uint8_t width, bool printSlash) {
+                              uint8_t width, BOOL printSlash) {
   uint8_t w = 0;
   for (uint8_t i = 0; i < 11; i++) {
     if (dir.name[i] == ' ')continue;
@@ -1018,7 +1018,7 @@ void SdBaseFile::printFatTime(uint16_t fatTime) {
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::printName() {
+BOOL SdBaseFile::printName() {
   char name[FILENAME_LENGTH];
   if (!getFilename(name)) return false;
   MYSERIAL.print(name);
@@ -1191,7 +1191,7 @@ fail:
  * Reasons for failure include the file read-only, is a directory,
  * or an I/O error occurred.
  */
-bool SdBaseFile::remove() {
+BOOL SdBaseFile::remove() {
   dir_t* d;
   // free any clusters - will fail if read-only or directory
   if (!truncate(0)) goto fail;
@@ -1230,7 +1230,7 @@ fail:
  * \a dirFile is not a directory, \a path is not found
  * or an I/O error occurred.
  */
-bool SdBaseFile::remove(SdBaseFile* dirFile, const char* path) {
+BOOL SdBaseFile::remove(SdBaseFile* dirFile, const char* path) {
   SdBaseFile file;
   if (!file.open(dirFile, path, O_WRITE)) goto fail;
   return file.remove();
@@ -1249,7 +1249,7 @@ fail:
  * Reasons for failure include \a dirFile is not open or is not a directory
  * file, newPath is invalid or already exists, or an I/O error occurs.
  */
-bool SdBaseFile::rename(SdBaseFile* dirFile, const char* newPath) {
+BOOL SdBaseFile::rename(SdBaseFile* dirFile, const char* newPath) {
   dir_t entry;
   uint32_t dirCluster = 0;
   SdBaseFile file;
@@ -1343,7 +1343,7 @@ fail:
  * Reasons for failure include the file is not a directory, is the root
  * directory, is not empty, or an I/O error occurred.
  */
-bool SdBaseFile::rmdir() {
+BOOL SdBaseFile::rmdir() {
   // must be open subdirectory
   if (!isSubDir()) goto fail;
 
@@ -1383,7 +1383,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::rmRfStar() {
+BOOL SdBaseFile::rmRfStar() {
   uint16_t index;
   SdBaseFile f;
   rewind();
@@ -1447,7 +1447,7 @@ SdBaseFile::SdBaseFile(const char* path, uint8_t oflag) {
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::seekSet(uint32_t pos) {
+BOOL SdBaseFile::seekSet(uint32_t pos) {
   uint32_t nCur;
   uint32_t nNew;
   // error if file not open or seek past end of file
@@ -1500,7 +1500,7 @@ void SdBaseFile::setpos(filepos_t* pos) {
  * Reasons for failure include a call to sync() before a file has been
  * opened or an I/O error.
  */
-bool SdBaseFile::sync() {
+BOOL SdBaseFile::sync() {
   // only allow open files and directories
   if (!isOpen()) goto fail;
 
@@ -1542,7 +1542,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::timestamp(SdBaseFile* file) {
+BOOL SdBaseFile::timestamp(SdBaseFile* file) {
   dir_t* d;
   dir_t dir;
 
@@ -1603,7 +1603,7 @@ fail:
  * \return The value one, true, is returned for success and
  * the value zero, false, is returned for failure.
  */
-bool SdBaseFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
+BOOL SdBaseFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
                            uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
   uint16_t dirDate;
   uint16_t dirTime;
@@ -1658,7 +1658,7 @@ fail:
  * Reasons for failure include file is read only, file is a directory,
  * \a length is greater than the current file size or an I/O error occurs.
  */
-bool SdBaseFile::truncate(uint32_t length) {
+BOOL SdBaseFile::truncate(uint32_t length) {
   uint32_t newPos;
   // error if not a normal file or read-only
   if (!isFile() || !(flags_ & O_WRITE)) goto fail;

--- a/Marlin/SdBaseFile.h
+++ b/Marlin/SdBaseFile.h
@@ -199,7 +199,7 @@ class SdBaseFile {
    * Set writeError to false before calling print() and/or write() and check
    * for true after calls to print() and/or write().
    */
-  bool writeError;
+  BOOL writeError;
   //----------------------------------------------------------------------------
   // helpers for stream classes
   /** get position for streams
@@ -211,9 +211,9 @@ class SdBaseFile {
    */
   void setpos(filepos_t* pos);
   //----------------------------------------------------------------------------
-  bool close();
-  bool contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock);
-  bool createContiguous(SdBaseFile* dirFile,
+  BOOL close();
+  BOOL contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock);
+  BOOL createContiguous(SdBaseFile* dirFile,
                         const char* path, uint32_t size);
   /** \return The current cluster number for a file or directory. */
   uint32_t curCluster() const {return curCluster_;}
@@ -254,70 +254,70 @@ class SdBaseFile {
   }
   /**  Cancel the date/time callback function. */
   static void dateTimeCallbackCancel() {dateTime_ = 0;}
-  bool dirEntry(dir_t* dir);
+  BOOL dirEntry(dir_t* dir);
   static void dirName(const dir_t& dir, char* name);
-  bool exists(const char* name);
+  BOOL exists(const char* name);
   int16_t fgets(char* str, int16_t num, char* delim = 0);
   /** \return The total number of bytes in a file or directory. */
   uint32_t fileSize() const {return fileSize_;}
   /** \return The first cluster number for a file or directory. */
   uint32_t firstCluster() const {return firstCluster_;}
-  bool getFilename(char* name);
+  BOOL getFilename(char* name);
   /** \return True if this is a directory else false. */
-  bool isDir() const {return type_ >= FAT_FILE_TYPE_MIN_DIR;}
+  BOOL isDir() const {return type_ >= FAT_FILE_TYPE_MIN_DIR;}
   /** \return True if this is a normal file else false. */
-  bool isFile() const {return type_ == FAT_FILE_TYPE_NORMAL;}
+  BOOL isFile() const {return type_ == FAT_FILE_TYPE_NORMAL;}
   /** \return True if this is an open file/directory else false. */
-  bool isOpen() const {return type_ != FAT_FILE_TYPE_CLOSED;}
+  BOOL isOpen() const {return type_ != FAT_FILE_TYPE_CLOSED;}
   /** \return True if this is a subdirectory else false. */
-  bool isSubDir() const {return type_ == FAT_FILE_TYPE_SUBDIR;}
+  BOOL isSubDir() const {return type_ == FAT_FILE_TYPE_SUBDIR;}
   /** \return True if this is the root directory. */
-  bool isRoot() const {
+  BOOL isRoot() const {
     return type_ == FAT_FILE_TYPE_ROOT_FIXED || type_ == FAT_FILE_TYPE_ROOT32;
   }
   void ls(uint8_t flags = 0, uint8_t indent = 0);
-  bool mkdir(SdBaseFile* dir, const char* path, bool pFlag = true);
+  BOOL mkdir(SdBaseFile* dir, const char* path, BOOL pFlag = true);
   // alias for backward compactability
-  bool makeDir(SdBaseFile* dir, const char* path) {
+  BOOL makeDir(SdBaseFile* dir, const char* path) {
     return mkdir(dir, path, false);
   }
-  bool open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag);
-  bool open(SdBaseFile* dirFile, const char* path, uint8_t oflag);
-  bool open(const char* path, uint8_t oflag = O_READ);
-  bool openNext(SdBaseFile* dirFile, uint8_t oflag);
-  bool openRoot(SdVolume* vol);
+  BOOL open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag);
+  BOOL open(SdBaseFile* dirFile, const char* path, uint8_t oflag);
+  BOOL open(const char* path, uint8_t oflag = O_READ);
+  BOOL openNext(SdBaseFile* dirFile, uint8_t oflag);
+  BOOL openRoot(SdVolume* vol);
   int peek();
   static void printFatDate(uint16_t fatDate);
   static void printFatTime(uint16_t fatTime);
-  bool printName();
+  BOOL printName();
   int16_t read();
   int16_t read(void* buf, uint16_t nbyte);
   int8_t readDir(dir_t* dir, char* longFilename);
-  static bool remove(SdBaseFile* dirFile, const char* path);
-  bool remove();
+  static BOOL remove(SdBaseFile* dirFile, const char* path);
+  BOOL remove();
   /** Set the file's current position to zero. */
   void rewind() {seekSet(0);}
-  bool rename(SdBaseFile* dirFile, const char* newPath);
-  bool rmdir();
+  BOOL rename(SdBaseFile* dirFile, const char* newPath);
+  BOOL rmdir();
   // for backward compatibility
-  bool rmDir() {return rmdir();}
-  bool rmRfStar();
+  BOOL rmDir() {return rmdir();}
+  BOOL rmRfStar();
   /** Set the files position to current position + \a pos. See seekSet().
    * \param[in] offset The new position in bytes from the current position.
    * \return true for success or false for failure.
    */
-  bool seekCur(int32_t offset) {
+  BOOL seekCur(int32_t offset) {
     return seekSet(curPosition_ + offset);
   }
   /** Set the files position to end-of-file + \a offset. See seekSet().
    * \param[in] offset The new position in bytes from end-of-file.
    * \return true for success or false for failure.
    */
-  bool seekEnd(int32_t offset = 0) {return seekSet(fileSize_ + offset);}
-  bool seekSet(uint32_t pos);
-  bool sync();
-  bool timestamp(SdBaseFile* file);
-  bool timestamp(uint8_t flag, uint16_t year, uint8_t month, uint8_t day,
+  BOOL seekEnd(int32_t offset = 0) {return seekSet(fileSize_ + offset);}
+  BOOL seekSet(uint32_t pos);
+  BOOL sync();
+  BOOL timestamp(SdBaseFile* file);
+  BOOL timestamp(uint8_t flag, uint16_t year, uint8_t month, uint8_t day,
                  uint8_t hour, uint8_t minute, uint8_t second);
   /** Type of file.  You should use isFile() or isDir() instead of type()
    * if possible.
@@ -325,7 +325,7 @@ class SdBaseFile {
    * \return The file or directory type.
    */
   uint8_t type() const {return type_;}
-  bool truncate(uint32_t size);
+  BOOL truncate(uint32_t size);
   /** \return SdVolume that contains this file. */
   SdVolume* volume() const {return vol_;}
   int16_t write(const void* buf, uint16_t nbyte);
@@ -356,43 +356,43 @@ class SdBaseFile {
   SdVolume* vol_;           // volume where file is located
 
   /** experimental don't use */
-  bool openParent(SdBaseFile* dir);
+  BOOL openParent(SdBaseFile* dir);
   // private functions
-  bool addCluster();
-  bool addDirCluster();
+  BOOL addCluster();
+  BOOL addDirCluster();
   dir_t* cacheDirEntry(uint8_t action);
   int8_t lsPrintNext(uint8_t flags, uint8_t indent);
-  static bool make83Name(const char* str, uint8_t* name, const char** ptr);
-  bool mkdir(SdBaseFile* parent, const uint8_t dname[11]);
-  bool open(SdBaseFile* dirFile, const uint8_t dname[11], uint8_t oflag);
-  bool openCachedEntry(uint8_t cacheIndex, uint8_t oflags);
+  static BOOL make83Name(const char* str, uint8_t* name, const char** ptr);
+  BOOL mkdir(SdBaseFile* parent, const uint8_t dname[11]);
+  BOOL open(SdBaseFile* dirFile, const uint8_t dname[11], uint8_t oflag);
+  BOOL openCachedEntry(uint8_t cacheIndex, uint8_t oflags);
   dir_t* readDirCache();
   //------------------------------------------------------------------------------
   // to be deleted
   static void printDirName(const dir_t& dir,
-                           uint8_t width, bool printSlash);
+                           uint8_t width, BOOL printSlash);
   //------------------------------------------------------------------------------
   // Deprecated functions  - suppress cpplint warnings with NOLINT comment
 #if ALLOW_DEPRECATED_FUNCTIONS && !defined(DOXYGEN)
  public:
   /** \deprecated Use:
-   * bool contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock);
+   * BOOL contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock);
    * \param[out] bgnBlock the first block address for the file.
    * \param[out] endBlock the last  block address for the file.
    * \return true for success or false for failure.
    */
-  bool contiguousRange(uint32_t& bgnBlock, uint32_t& endBlock) {  // NOLINT
+  BOOL contiguousRange(uint32_t& bgnBlock, uint32_t& endBlock) {  // NOLINT
     return contiguousRange(&bgnBlock, &endBlock);
   }
   /** \deprecated Use:
-    * bool createContiguous(SdBaseFile* dirFile,
+    * BOOL createContiguous(SdBaseFile* dirFile,
     *   const char* path, uint32_t size)
     * \param[in] dirFile The directory where the file will be created.
     * \param[in] path A path with a valid DOS 8.3 file name.
     * \param[in] size The desired file size.
     * \return true for success or false for failure.
     */
-  bool createContiguous(SdBaseFile& dirFile,  // NOLINT
+  BOOL createContiguous(SdBaseFile& dirFile,  // NOLINT
                         const char* path, uint32_t size) {
     return createContiguous(&dirFile, path, size);
   }
@@ -406,23 +406,23 @@ class SdBaseFile {
     oldDateTime_ = dateTime;
     dateTime_ = dateTime ? oldToNew : 0;
   }
-  /** \deprecated Use: bool dirEntry(dir_t* dir);
+  /** \deprecated Use: BOOL dirEntry(dir_t* dir);
    * \param[out] dir Location for return of the file's directory entry.
    * \return true for success or false for failure.
    */
-  bool dirEntry(dir_t& dir) {return dirEntry(&dir);}  // NOLINT
+  BOOL dirEntry(dir_t& dir) {return dirEntry(&dir);}  // NOLINT
   /** \deprecated Use:
-   * bool mkdir(SdBaseFile* dir, const char* path);
+   * BOOL mkdir(SdBaseFile* dir, const char* path);
    * \param[in] dir An open SdFat instance for the directory that will contain
    * the new directory.
    * \param[in] path A path with a valid 8.3 DOS name for the new directory.
    * \return true for success or false for failure.
    */
-  bool mkdir(SdBaseFile& dir, const char* path) {  // NOLINT
+  BOOL mkdir(SdBaseFile& dir, const char* path) {  // NOLINT
     return mkdir(&dir, path);
   }
   /** \deprecated Use:
-   * bool open(SdBaseFile* dirFile, const char* path, uint8_t oflag);
+   * BOOL open(SdBaseFile* dirFile, const char* path, uint8_t oflag);
    * \param[in] dirFile An open SdFat instance for the directory containing the
    * file to be opened.
    * \param[in] path A path with a valid 8.3 DOS name for the file.
@@ -430,7 +430,7 @@ class SdBaseFile {
    * OR of flags O_READ, O_WRITE, O_TRUNC, and O_SYNC.
    * \return true for success or false for failure.
    */
-  bool open(SdBaseFile& dirFile, // NOLINT
+  BOOL open(SdBaseFile& dirFile, // NOLINT
             const char* path, uint8_t oflag) {
     return open(&dirFile, path, oflag);
   }
@@ -440,11 +440,11 @@ class SdBaseFile {
    * \param[in] path A path with a valid 8.3 DOS name for a file to be opened.
    * \return true for success or false for failure.
    */
-  bool open(SdBaseFile& dirFile, const char* path) {  // NOLINT
+  BOOL open(SdBaseFile& dirFile, const char* path) {  // NOLINT
     return open(dirFile, path, O_RDWR);
   }
   /** \deprecated Use:
-   * bool open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag);
+   * BOOL open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag);
    * \param[in] dirFile An open SdFat instance for the directory.
    * \param[in] index The \a index of the directory entry for the file to be
    * opened.  The value for \a index is (directory file position)/32.
@@ -452,14 +452,14 @@ class SdBaseFile {
    * OR of flags O_READ, O_WRITE, O_TRUNC, and O_SYNC.
    * \return true for success or false for failure.
    */
-  bool open(SdBaseFile& dirFile, uint16_t index, uint8_t oflag) {  // NOLINT
+  BOOL open(SdBaseFile& dirFile, uint16_t index, uint8_t oflag) {  // NOLINT
     return open(&dirFile, index, oflag);
   }
-  /** \deprecated Use: bool openRoot(SdVolume* vol);
+  /** \deprecated Use: BOOL openRoot(SdVolume* vol);
    * \param[in] vol The FAT volume containing the root directory to be opened.
    * \return true for success or false for failure.
    */
-  bool openRoot(SdVolume& vol) {return openRoot(&vol);}  // NOLINT
+  BOOL openRoot(SdVolume& vol) {return openRoot(&vol);}  // NOLINT
   /** \deprecated Use: int8_t readDir(dir_t* dir);
    * \param[out] dir The dir_t struct that will receive the data.
    * \return bytes read for success zero for eof or -1 for failure.
@@ -471,7 +471,7 @@ class SdBaseFile {
    * \param[in] path The name of the file to be removed.
    * \return true for success or false for failure.
    */
-  static bool remove(SdBaseFile& dirFile, const char* path) {  // NOLINT
+  static BOOL remove(SdBaseFile& dirFile, const char* path) {  // NOLINT
     return remove(&dirFile, path);
   }
   //------------------------------------------------------------------------------

--- a/Marlin/SdVolume.cpp
+++ b/Marlin/SdVolume.cpp
@@ -36,12 +36,12 @@
   uint32_t SdVolume::cacheBlockNumber_;  // current block number
   cache_t  SdVolume::cacheBuffer_;       // 512 byte cache for Sd2Card
   Sd2Card* SdVolume::sdCard_;            // pointer to SD card object
-  bool     SdVolume::cacheDirty_;        // cacheFlush() will write block if true
+  BOOL     SdVolume::cacheDirty_;        // cacheFlush() will write block if true
   uint32_t SdVolume::cacheMirrorBlock_;  // mirror  block for second FAT
 #endif  // USE_MULTIPLE_CARDS
 //------------------------------------------------------------------------------
 // find a contiguous group of clusters
-bool SdVolume::allocContiguous(uint32_t count, uint32_t* curCluster) {
+BOOL SdVolume::allocContiguous(uint32_t count, uint32_t* curCluster) {
   // start of group
   uint32_t bgnCluster;
   // end of group
@@ -50,7 +50,7 @@ bool SdVolume::allocContiguous(uint32_t count, uint32_t* curCluster) {
   uint32_t fatEnd = clusterCount_ + 1;
 
   // flag to save place to start next search
-  bool setStart;
+  BOOL setStart;
 
   // set search start cluster
   if (*curCluster) {
@@ -114,7 +114,7 @@ fail:
   return false;
 }
 //------------------------------------------------------------------------------
-bool SdVolume::cacheFlush() {
+BOOL SdVolume::cacheFlush() {
   if (cacheDirty_) {
     if (!sdCard_->writeBlock(cacheBlockNumber_, cacheBuffer_.data)) {
       goto fail;
@@ -133,7 +133,7 @@ fail:
   return false;
 }
 //------------------------------------------------------------------------------
-bool SdVolume::cacheRawBlock(uint32_t blockNumber, bool dirty) {
+BOOL SdVolume::cacheRawBlock(uint32_t blockNumber, BOOL dirty) {
   if (cacheBlockNumber_ != blockNumber) {
     if (!cacheFlush()) goto fail;
     if (!sdCard_->readBlock(blockNumber, cacheBuffer_.data)) goto fail;
@@ -146,7 +146,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 // return the size in bytes of a cluster chain
-bool SdVolume::chainSize(uint32_t cluster, uint32_t* size) {
+BOOL SdVolume::chainSize(uint32_t cluster, uint32_t* size) {
   uint32_t s = 0;
   do {
     if (!fatGet(cluster, &cluster)) goto fail;
@@ -159,7 +159,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 // Fetch a FAT entry
-bool SdVolume::fatGet(uint32_t cluster, uint32_t* value) {
+BOOL SdVolume::fatGet(uint32_t cluster, uint32_t* value) {
   uint32_t lba;
   if (cluster > (clusterCount_ + 1)) goto fail;
   if (FAT12_SUPPORT && fatType_ == 12) {
@@ -202,7 +202,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 // Store a FAT entry
-bool SdVolume::fatPut(uint32_t cluster, uint32_t value) {
+BOOL SdVolume::fatPut(uint32_t cluster, uint32_t value) {
   uint32_t lba;
   // error if reserved cluster
   if (cluster < 2) goto fail;
@@ -263,7 +263,7 @@ fail:
 }
 //------------------------------------------------------------------------------
 // free a cluster chain
-bool SdVolume::freeChain(uint32_t cluster) {
+BOOL SdVolume::freeChain(uint32_t cluster) {
   uint32_t next;
 
   // clear free cluster location
@@ -334,7 +334,7 @@ int32_t SdVolume::freeClusterCount() {
  * failure include not finding a valid partition, not finding a valid
  * FAT file system in the specified partition or an I/O error.
  */
-bool SdVolume::init(Sd2Card* dev, uint8_t part) {
+BOOL SdVolume::init(Sd2Card* dev, uint8_t part) {
   uint32_t totalBlocks;
   uint32_t volumeStartBlock = 0;
   fat32_boot_t* fbs;

--- a/Marlin/SdVolume.h
+++ b/Marlin/SdVolume.h
@@ -89,8 +89,8 @@ class SdVolume {
    * failure include not finding a valid partition, not finding a valid
    * FAT file system or an I/O error.
    */
-  bool init(Sd2Card* dev) { return init(dev, 1) ? true : init(dev, 0);}
-  bool init(Sd2Card* dev, uint8_t part);
+  BOOL init(Sd2Card* dev) { return init(dev, 1) ? true : init(dev, 0);}
+  BOOL init(Sd2Card* dev, uint8_t part);
 
   // inline functions that return volume info
   /** \return The volume's cluster size in blocks. */
@@ -125,28 +125,28 @@ class SdVolume {
    * \param[out] v value of entry
    * \return true for success or false for failure
    */
-  bool dbgFat(uint32_t n, uint32_t* v) {return fatGet(n, v);}
+  BOOL dbgFat(uint32_t n, uint32_t* v) {return fatGet(n, v);}
   //------------------------------------------------------------------------------
  private:
   // Allow SdBaseFile access to SdVolume private data.
   friend class SdBaseFile;
 
   // value for dirty argument in cacheRawBlock to indicate read from cache
-  static bool const CACHE_FOR_READ = false;
+  static BOOL const CACHE_FOR_READ = false;
   // value for dirty argument in cacheRawBlock to indicate write to cache
-  static bool const CACHE_FOR_WRITE = true;
+  static BOOL const CACHE_FOR_WRITE = true;
 
 #if USE_MULTIPLE_CARDS
   cache_t cacheBuffer_;        // 512 byte cache for device blocks
   uint32_t cacheBlockNumber_;  // Logical number of block in the cache
   Sd2Card* sdCard_;            // Sd2Card object for cache
-  bool cacheDirty_;            // cacheFlush() will write block if true
+  BOOL cacheDirty_;            // cacheFlush() will write block if true
   uint32_t cacheMirrorBlock_;  // block number for mirror FAT
 #else  // USE_MULTIPLE_CARDS
   static cache_t cacheBuffer_;        // 512 byte cache for device blocks
   static uint32_t cacheBlockNumber_;  // Logical number of block in the cache
   static Sd2Card* sdCard_;            // Sd2Card object for cache
-  static bool cacheDirty_;            // cacheFlush() will write block if true
+  static BOOL cacheDirty_;            // cacheFlush() will write block if true
   static uint32_t cacheMirrorBlock_;  // block number for mirror FAT
 #endif  // USE_MULTIPLE_CARDS
   uint32_t allocSearchStart_;   // start cluster for alloc search
@@ -161,7 +161,7 @@ class SdVolume {
   uint16_t rootDirEntryCount_;  // number of entries in FAT16 root dir
   uint32_t rootDirStart_;       // root start block for FAT16, cluster for FAT32
   //----------------------------------------------------------------------------
-  bool allocContiguous(uint32_t count, uint32_t* curCluster);
+  BOOL allocContiguous(uint32_t count, uint32_t* curCluster);
   uint8_t blockOfCluster(uint32_t position) const {
     return (position >> 9) & (blocksPerCluster_ - 1);
   }
@@ -174,51 +174,51 @@ class SdVolume {
   cache_t* cache() {return &cacheBuffer_;}
   uint32_t cacheBlockNumber() {return cacheBlockNumber_;}
 #if USE_MULTIPLE_CARDS
-  bool cacheFlush();
-  bool cacheRawBlock(uint32_t blockNumber, bool dirty);
+  BOOL cacheFlush();
+  BOOL cacheRawBlock(uint32_t blockNumber, BOOL dirty);
 #else  // USE_MULTIPLE_CARDS
-  static bool cacheFlush();
-  static bool cacheRawBlock(uint32_t blockNumber, bool dirty);
+  static BOOL cacheFlush();
+  static BOOL cacheRawBlock(uint32_t blockNumber, BOOL dirty);
 #endif  // USE_MULTIPLE_CARDS
   // used by SdBaseFile write to assign cache to SD location
-  void cacheSetBlockNumber(uint32_t blockNumber, bool dirty) {
+  void cacheSetBlockNumber(uint32_t blockNumber, BOOL dirty) {
     cacheDirty_ = dirty;
     cacheBlockNumber_  = blockNumber;
   }
   void cacheSetDirty() {cacheDirty_ |= CACHE_FOR_WRITE;}
-  bool chainSize(uint32_t beginCluster, uint32_t* size);
-  bool fatGet(uint32_t cluster, uint32_t* value);
-  bool fatPut(uint32_t cluster, uint32_t value);
-  bool fatPutEOC(uint32_t cluster) {
+  BOOL chainSize(uint32_t beginCluster, uint32_t* size);
+  BOOL fatGet(uint32_t cluster, uint32_t* value);
+  BOOL fatPut(uint32_t cluster, uint32_t value);
+  BOOL fatPutEOC(uint32_t cluster) {
     return fatPut(cluster, 0x0FFFFFFF);
   }
-  bool freeChain(uint32_t cluster);
-  bool isEOC(uint32_t cluster) const {
+  BOOL freeChain(uint32_t cluster);
+  BOOL isEOC(uint32_t cluster) const {
     if (FAT12_SUPPORT && fatType_ == 12) return  cluster >= FAT12EOC_MIN;
     if (fatType_ == 16) return cluster >= FAT16EOC_MIN;
     return  cluster >= FAT32EOC_MIN;
   }
-  bool readBlock(uint32_t block, uint8_t* dst) {
+  BOOL readBlock(uint32_t block, uint8_t* dst) {
     return sdCard_->readBlock(block, dst);
   }
-  bool writeBlock(uint32_t block, const uint8_t* dst) {
+  BOOL writeBlock(uint32_t block, const uint8_t* dst) {
     return sdCard_->writeBlock(block, dst);
   }
   //------------------------------------------------------------------------------
   // Deprecated functions  - suppress cpplint warnings with NOLINT comment
 #if ALLOW_DEPRECATED_FUNCTIONS && !defined(DOXYGEN)
  public:
-  /** \deprecated Use: bool SdVolume::init(Sd2Card* dev);
+  /** \deprecated Use: BOOL SdVolume::init(Sd2Card* dev);
    * \param[in] dev The SD card where the volume is located.
    * \return true for success or false for failure.
    */
-  bool init(Sd2Card& dev) {return init(&dev);}  // NOLINT
-  /** \deprecated Use: bool SdVolume::init(Sd2Card* dev, uint8_t vol);
+  BOOL init(Sd2Card& dev) {return init(&dev);}  // NOLINT
+  /** \deprecated Use: BOOL SdVolume::init(Sd2Card* dev, uint8_t vol);
    * \param[in] dev The SD card where the volume is located.
    * \param[in] part The partition to be used.
    * \return true for success or false for failure.
    */
-  bool init(Sd2Card& dev, uint8_t part) {  // NOLINT
+  BOOL init(Sd2Card& dev, uint8_t part) {  // NOLINT
     return init(&dev, part);
   }
 #endif  // ALLOW_DEPRECATED_FUNCTIONS

--- a/Marlin/UBL.h
+++ b/Marlin/UBL.h
@@ -40,24 +40,24 @@
     enum MeshPointType { INVALID, REAL, SET_IN_BITMAP };
 
     void dump(char * const str, const float &f);
-    bool ubl_lcd_clicked();
-    void probe_entire_mesh(const float&, const float&, const bool, const bool, const bool);
+    BOOL ubl_lcd_clicked();
+    void probe_entire_mesh(const float&, const float&, const BOOL, const BOOL, const BOOL);
     void debug_current_and_destination(char *title);
     void ubl_line_to_destination(const float&, uint8_t);
-    void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
+    void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const BOOL);
     vector_3 tilt_mesh_based_on_3pts(const float&, const float&, const float&);
     float measure_business_card_thickness(const float&);
-    mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, unsigned int[16], bool);
+    mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const BOOL, unsigned int[16], BOOL);
     void find_mean_mesh_height();
     void shift_mesh_height();
-    bool g29_parameter_parsing();
+    BOOL g29_parameter_parsing();
     void g29_what_command();
     void g29_eeprom_dump();
     void g29_compare_current_mesh_to_stored_mesh();
-    void fine_tune_mesh(const float&, const float&, const bool);
+    void fine_tune_mesh(const float&, const float&, const BOOL);
     void bit_clear(uint16_t bits[16], uint8_t x, uint8_t y);
     void bit_set(uint16_t bits[16], uint8_t x, uint8_t y);
-    bool is_bit_set(uint16_t bits[16], uint8_t x, uint8_t y);
+    BOOL is_bit_set(uint16_t bits[16], uint8_t x, uint8_t y);
     char *ftostr43sign(const float&, char);
 
     void gcode_G26();
@@ -81,7 +81,7 @@
     #define MESH_Y_DIST (float(UBL_MESH_MAX_Y - (UBL_MESH_MIN_Y)) / float(UBL_MESH_NUM_Y_POINTS - 1))
 
     typedef struct {
-      bool active = false;
+      BOOL active = false;
       float z_offset = 0.0;
       int8_t eeprom_storage_slot = -1,
              n_x = UBL_MESH_NUM_X_POINTS,
@@ -129,7 +129,7 @@
                      mesh_index_to_xpos[UBL_MESH_NUM_X_POINTS + 1], // +1 safety margin for now, until determinism prevails
                      mesh_index_to_ypos[UBL_MESH_NUM_Y_POINTS + 1];
 
-        static bool g26_debug_flag,
+        static BOOL g26_debug_flag,
                     has_control_of_lcd_panel;
 
         static int8_t eeprom_start;
@@ -148,7 +148,7 @@
         static void store_mesh(const int16_t);
         static void load_mesh(const int16_t);
 
-        static bool sanity_check();
+        static BOOL sanity_check();
 
         static FORCE_INLINE void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
 

--- a/Marlin/UBL_Bed_Leveling.cpp
+++ b/Marlin/UBL_Bed_Leveling.cpp
@@ -36,7 +36,7 @@
    */
   void bit_clear(uint16_t bits[16], uint8_t x, uint8_t y) { CBI(bits[y], x); }
   void bit_set(uint16_t bits[16], uint8_t x, uint8_t y) { SBI(bits[y], x); }
-  bool is_bit_set(uint16_t bits[16], uint8_t x, uint8_t y) { return TEST(bits[y], x); }
+  BOOL is_bit_set(uint16_t bits[16], uint8_t x, uint8_t y) { return TEST(bits[y], x); }
 
   static void serial_echo_xy(const uint16_t x, const uint16_t y) {
     SERIAL_CHAR('(');
@@ -65,7 +65,7 @@
         unified_bed_leveling::mesh_index_to_xpos[UBL_MESH_NUM_X_POINTS + 1], // +1 safety margin for now, until determinism prevails
         unified_bed_leveling::mesh_index_to_ypos[UBL_MESH_NUM_Y_POINTS + 1];
 
-  bool unified_bed_leveling::g26_debug_flag = false,
+  BOOL unified_bed_leveling::g26_debug_flag = false,
        unified_bed_leveling::has_control_of_lcd_panel = false;
 
   int8_t unified_bed_leveling::eeprom_start = -1;
@@ -173,7 +173,7 @@
 
   void unified_bed_leveling::display_map(const int map_type) {
 
-    const bool map0 = map_type == 0;
+    const BOOL map0 = map_type == 0;
 
     if (map0) {
       SERIAL_PROTOCOLLNPGM("\nBed Topography Report:\n");
@@ -196,7 +196,7 @@
 
     for (uint8_t j = UBL_MESH_NUM_Y_POINTS - 1; j >= 0; j--) {
       for (uint8_t i = 0; i < UBL_MESH_NUM_X_POINTS; i++) {
-        const bool is_current = i == current_xi && j == current_yi;
+        const BOOL is_current = i == current_xi && j == current_yi;
 
         // is the nozzle here? then mark the number
         if (map0) SERIAL_CHAR(is_current ? '[' : ' ');
@@ -243,7 +243,7 @@
     }
   }
 
-  bool unified_bed_leveling::sanity_check() {
+  BOOL unified_bed_leveling::sanity_check() {
     uint8_t error_flag = 0;
 
     if (state.n_x != UBL_MESH_NUM_X_POINTS) {

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -37,7 +37,7 @@
 
   void lcd_babystep_z();
   void lcd_return_to_status();
-  bool lcd_clicked();
+  BOOL lcd_clicked();
   void lcd_implementation_clear();
   void lcd_mesh_edit_setup(float initial);
   float lcd_mesh_edit();
@@ -46,13 +46,13 @@
   extern float meshedit_done;
   extern long babysteps_done;
   extern float code_value_float();
-  extern bool code_value_bool();
-  extern bool code_has_value();
-  extern float probe_pt(float x, float y, bool, int);
-  extern bool set_probe_deployed(bool);
+  extern BOOL code_value_bool();
+  extern BOOL code_has_value();
+  extern float probe_pt(float x, float y, BOOL, int);
+  extern BOOL set_probe_deployed(BOOL);
   #define DEPLOY_PROBE() set_probe_deployed(true)
   #define STOW_PROBE() set_probe_deployed(false)
-  bool ProbeStay = true;
+  BOOL ProbeStay = true;
 
   constexpr float ubl_3_point_1_X = UBL_PROBE_PT_1_X,
                   ubl_3_point_1_Y = UBL_PROBE_PT_1_Y,
@@ -303,11 +303,11 @@
   // The simple parameter flags and values are 'static' so parameter parsing can be in a support routine.
   static int g29_verbose_level, phase_value = -1, repetition_cnt,
              storage_slot = 0, map_type; //unlevel_value = -1;
-  static bool repeat_flag, c_flag, x_flag, y_flag;
+  static BOOL repeat_flag, c_flag, x_flag, y_flag;
   static float x_pos, y_pos, measured_z, card_thickness = 0.0, ubl_constant = 0.0;
 
   #if ENABLED(ULTRA_LCD)
-    void lcd_setstatus(const char* message, bool persist);
+    void lcd_setstatus(const char* message, BOOL persist);
   #endif
 
   void gcode_G29() {
@@ -734,7 +734,7 @@
    * Probe all invalidated locations of the mesh that can be reached by the probe.
    * This attempts to fill in locations closest to the nozzle's start location first.
    */
-  void probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest) {
+  void probe_entire_mesh(const float &lx, const float &ly, const BOOL do_ubl_mesh_map, const BOOL stow_probe, BOOL do_furthest) {
     mesh_index_pair location;
 
     ubl.has_control_of_lcd_panel++;
@@ -890,7 +890,7 @@
     return abs(z1 - z2);
   }
 
-  void manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map) {
+  void manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &card_thickness, const BOOL do_ubl_mesh_map) {
 
     ubl.has_control_of_lcd_panel++;
     save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
@@ -975,7 +975,7 @@
     do_blocking_move_to_xy(lx, ly);
   }
 
-  bool g29_parameter_parsing() {
+  BOOL g29_parameter_parsing() {
     #if ENABLED(ULTRA_LCD)
       lcd_setstatus("Doing G29 UBL !", true);
       lcd_quick_feedback();
@@ -1266,7 +1266,7 @@
         ubl.z_values[x][y] -= tmp_z_values[x][y];
   }
 
-  mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType type, const float &lx, const float &ly, const bool probe_as_reference, unsigned int bits[16], bool far_flag) {
+  mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType type, const float &lx, const float &ly, const BOOL probe_as_reference, unsigned int bits[16], BOOL far_flag) {
     float distance, closest = far_flag ? -99999.99 : 99999.99;
     mesh_index_pair return_val;
 
@@ -1331,7 +1331,7 @@
     return return_val;
   }
 
-  void fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map) {
+  void fine_tune_mesh(const float &lx, const float &ly, const BOOL do_ubl_mesh_map) {
     mesh_index_pair location;
     uint16_t not_done[16];
     int32_t round_off;

--- a/Marlin/UBL_line_to_destination.cpp
+++ b/Marlin/UBL_line_to_destination.cpp
@@ -241,7 +241,7 @@
      * component is larger. We use the biggest of the two to preserve precision.
      */
 
-    const bool use_x_dist = adx > ady;
+    const BOOL use_x_dist = adx > ady;
 
     float on_axis_distance = use_x_dist ? dx : dy,
           e_position = end[E_AXIS] - start[E_AXIS],
@@ -255,7 +255,7 @@
     const float m = dy / dx,
                 c = start[Y_AXIS] - m * start[X_AXIS];
 
-    const bool inf_normalized_flag = NEAR_ZERO(on_axis_distance),
+    const BOOL inf_normalized_flag = NEAR_ZERO(on_axis_distance),
                inf_m_flag = NEAR_ZERO(dx);
 
     /**

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -91,7 +91,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
       createFilename(lfilename, p);
 
       // Allocate enough stack space for the full path to a folder, trailing slash, and nul
-      bool prepend_is_empty = (prepend[0] == '\0');
+      BOOL prepend_is_empty = (prepend[0] == '\0');
       int len = (prepend_is_empty ? 1 : strlen(prepend)) + strlen(lfilename) + 1 + 1;
       char path[len];
 
@@ -319,7 +319,7 @@ void CardReader::getAbsFilename(char *t) {
     t[0] = 0;
 }
 
-void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
+void CardReader::openFile(char* name, BOOL read, BOOL push_current/*=false*/) {
 
   if (!cardOK) return;
 
@@ -527,7 +527,7 @@ void CardReader::write_command(char *buf) {
   }
 }
 
-void CardReader::checkautostart(bool force) {
+void CardReader::checkautostart(BOOL force) {
   if (!force && (!autostart_stilltocheck || ELAPSED(millis(), next_autostart_ms)))
     return;
 
@@ -546,7 +546,7 @@ void CardReader::checkautostart(bool force) {
 
   root.rewind();
 
-  bool found = false;
+  BOOL found = false;
   while (root.readDir(p, NULL) > 0) {
     for (int8_t i = 0; i < (int8_t)strlen((char*)p.name); i++) p.name[i] = tolower(p.name[i]);
     if (p.name[9] != '~' && strncmp((char*)p.name, autoname, 5) == 0) {
@@ -560,7 +560,7 @@ void CardReader::checkautostart(bool force) {
     autostart_index++;
 }
 
-void CardReader::closefile(bool store_location) {
+void CardReader::closefile(BOOL store_location) {
   file.sync();
   file.close();
   saving = logging = false;
@@ -749,7 +749,7 @@ void CardReader::updir() {
 
         // Bubble Sort
         for (uint16_t i = fileCnt; --i;) {
-          bool didSwap = false;
+          BOOL didSwap = false;
           for (uint16_t j = 0; j < i; ++j) {
             const uint16_t o1 = sort_order[j], o2 = sort_order[j + 1];
 
@@ -780,7 +780,7 @@ void CardReader::updir() {
               getfilename(o1);
               strcpy(name1, LONGEST_FILENAME); // save (or getfilename below will trounce it)
               #if HAS_FOLDER_SORTING
-                bool dir1 = filenameIsDir;
+                BOOL dir1 = filenameIsDir;
               #endif
               getfilename(o2);
               char *name2 = LONGEST_FILENAME; // use the string in-place

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -43,11 +43,11 @@ public:
   //files auto[0-9].g on the sd card are performed in a row
   //this is to delay autostart and hence the initialisaiton of the sd card to some seconds after the normal init, so the device is available quick after a reset
 
-  void checkautostart(bool x);
-  void openFile(char* name, bool read, bool push_current=false);
+  void checkautostart(BOOL x);
+  void openFile(char* name, BOOL read, BOOL push_current=false);
   void openLogFile(char* name);
   void removeFile(char* name);
-  void closefile(bool store_location=false);
+  void closefile(BOOL store_location=false);
   void release();
   void openAndPrintFile(const char *name);
   void startFileprint();
@@ -73,22 +73,22 @@ public:
     void presort();
     void getfilename_sorted(const uint16_t nr);
     #if ENABLED(SDSORT_GCODE)
-      FORCE_INLINE void setSortOn(bool b) { sort_alpha = b; presort(); }
+      FORCE_INLINE void setSortOn(BOOL b) { sort_alpha = b; presort(); }
       FORCE_INLINE void setSortFolders(int i) { sort_folders = i; presort(); }
-      //FORCE_INLINE void setSortReverse(bool b) { sort_reverse = b; }
+      //FORCE_INLINE void setSortReverse(BOOL b) { sort_reverse = b; }
     #endif
   #endif
 
   FORCE_INLINE void pauseSDPrint() { sdprinting = false; }
-  FORCE_INLINE bool isFileOpen() { return file.isOpen(); }
-  FORCE_INLINE bool eof() { return sdpos >= filesize; }
+  FORCE_INLINE BOOL isFileOpen() { return file.isOpen(); }
+  FORCE_INLINE BOOL eof() { return sdpos >= filesize; }
   FORCE_INLINE int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
   FORCE_INLINE void setIndex(long index) { sdpos = index; file.seekSet(index); }
   FORCE_INLINE uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
   FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
 
 public:
-  bool saving, logging, sdprinting, cardOK, filenameIsDir;
+  BOOL saving, logging, sdprinting, cardOK, filenameIsDir;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   int autostart_index;
 private:
@@ -99,9 +99,9 @@ private:
   #if ENABLED(SDCARD_SORT_ALPHA)
     uint16_t sort_count;        // Count of sorted items in the current directory
     #if ENABLED(SDSORT_GCODE)
-      bool sort_alpha;          // Flag to enable / disable the feature
+      BOOL sort_alpha;          // Flag to enable / disable the feature
       int sort_folders;         // Flag to enable / disable folder sorting
-      //bool sort_reverse;      // Flag to enable / disable reverse sorting
+      //BOOL sort_reverse;      // Flag to enable / disable reverse sorting
     #endif
 
     // By default the sort index is static
@@ -152,7 +152,7 @@ private:
   uint32_t sdpos;
 
   millis_t next_autostart_ms;
-  bool autostart_stilltocheck; //the sd start is delayed, because otherwise the serial cannot answer fast enought to make contact with the hostsoftware.
+  BOOL autostart_stilltocheck; //the sd start is delayed, because otherwise the serial cannot answer fast enought to make contact with the hostsoftware.
 
   LsAction lsAction; //stored for recursion.
   uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.

--- a/Marlin/circularqueue.h
+++ b/Marlin/circularqueue.h
@@ -83,7 +83,7 @@ class CircularQueue {
      * @param   item Item to be added to the queue
      * @return  true if the operation was successful
      */
-    bool enqueue(T const &item) {
+    BOOL enqueue(T const &item) {
       if (this->isFull()) return false;
 
       this->buffer.queue[this->buffer.tail] = item;
@@ -100,7 +100,7 @@ class CircularQueue {
      * @details Returns true if there are no items on the queue, false otherwise.
      * @return  true if queue is empty
      */
-    bool isEmpty() {
+    BOOL isEmpty() {
       return this->buffer.count == 0;
     }
 
@@ -109,7 +109,7 @@ class CircularQueue {
      * @details Returns true if the queue is full, false otherwise.
      * @return  true if queue is full
      */
-    bool isFull() {
+    BOOL isFull() {
       return this->buffer.count == this->buffer.size;
     }
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,13 +36,13 @@
  *
  */
 
-#define EEPROM_VERSION "V31"
+#define EEPROM_VERSION "V32"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
 
 /**
- * V31 EEPROM Layout:
+ * V32 EEPROM Layout:
  *
  *  100  Version                                   (char x4)
  *  104  EEPROM Checksum                           (uint16_t)
@@ -64,88 +64,88 @@
  *  195  M206 XYZ  home_offset (float x3)
  *  207  M218 XYZ  hotend_offset (float x3 per additional hotend)
  *
- * Mesh bed leveling:
- *  219  M420 S    from mbl.status (bool)
- *  220            mbl.z_offset (float)
- *  224            MESH_NUM_X_POINTS (uint8 as set in firmware)
- *  225            MESH_NUM_Y_POINTS (uint8 as set in firmware)
- *  226 G29 S3 XYZ z_values[][] (float x9, by default, up to float x 81) +288
+ * Mesh bed leveling:                               56 bytes
+ *  219  M420 S    from mbl.status                  (BOOL)
+ *  221            mbl.z_offset                     (float)
+ *  225            MESH_NUM_X_POINTS                (uint8_t)
+ *  226            MESH_NUM_Y_POINTS                (uint8_t)
+ *  227 G29 S3 XYZ z_values[][]                     (float x9, up to float x 81) +288
  *
  * AUTO BED LEVELING
- *  262  M851      zprobe_zoffset (float)
+ *  263  M851      zprobe_zoffset (float)
  *
- * ABL_PLANAR (or placeholder):                    36 bytes
- *  266            planner.bed_level_matrix        (matrix_3x3 = float x9)
+ * ABL_PLANAR (or placeholder):                     36 bytes
+ *  267            planner.bed_level_matrix         (matrix_3x3 = float x9)
  *
- * AUTO_BED_LEVELING_BILINEAR (or placeholder):    47 bytes
- *  302            ABL_GRID_MAX_POINTS_X           (uint8_t)
- *  303            ABL_GRID_MAX_POINTS_Y           (uint8_t)
- *  304            bilinear_grid_spacing           (int x2)   from G29: (B-F)/X, (R-L)/Y
- *  308  G29 L F   bilinear_start                  (int x2)
- *  312            bed_level_grid[][]              (float x9, up to float x256) +988
+ * AUTO_BED_LEVELING_BILINEAR (or placeholder):     47 bytes
+ *  303            ABL_GRID_MAX_POINTS_X            (uint8_t)
+ *  304            ABL_GRID_MAX_POINTS_Y            (uint8_t)
+ *  305            bilinear_grid_spacing            (int x2)
+ *  309  G29 L F   bilinear_start                   (int x2)
+ *  313            bed_level_grid[][]               (float x9, up to float x256) +988
  *
  * DELTA (if deltabot):                             48 bytes
- *  348  M666 XYZ  endstop_adj                      (float x3)
- *  360  M665 R    delta_radius                     (float)
- *  364  M665 L    delta_diagonal_rod               (float)
- *  368  M665 S    delta_segments_per_second        (float)
- *  372  M665 A    delta_diagonal_rod_trim[A]       (float)
- *  376  M665 B    delta_diagonal_rod_trim[B]       (float)
- *  380  M665 C    delta_diagonal_rod_trim[C]       (float)
- *  384  M665 I    delta_tower_angle_trim[A]        (float)
- *  388  M665 J    delta_tower_angle_trim[B]        (float)
- *  392  M665 K    delta_tower_angle_trim[C]        (float)
+ *  349  M666 XYZ  endstop_adj                      (float x3)
+ *  361  M665 R    delta_radius                     (float)
+ *  365  M665 L    delta_diagonal_rod               (float)
+ *  369  M665 S    delta_segments_per_second        (float)
+ *  373  M665 A    delta_diagonal_rod_trim[A]       (float)
+ *  377  M665 B    delta_diagonal_rod_trim[B]       (float)
+ *  381  M665 C    delta_diagonal_rod_trim[C]       (float)
+ *  385  M665 I    delta_tower_angle_trim[A]        (float)
+ *  389  M665 J    delta_tower_angle_trim[B]        (float)
+ *  393  M665 K    delta_tower_angle_trim[C]        (float)
  *
  * Z_DUAL_ENDSTOPS (if not deltabot):              48 bytes
- *  348  M666 Z    z_endstop_adj                   (float)
+ *  349  M666 Z    z_endstop_adj                   (float)
  *  ---            dummy data                      (float x11)
  *
  * ULTIPANEL:                                      6 bytes
- *  396  M145 S0 H lcd_preheat_hotend_temp         (int x2)
- *  400  M145 S0 B lcd_preheat_bed_temp            (int x2)
- *  404  M145 S0 F lcd_preheat_fan_speed           (int x2)
+ *  397  M145 S0 H lcd_preheat_hotend_temp         (int x2)
+ *  401  M145 S0 B lcd_preheat_bed_temp            (int x2)
+ *  405  M145 S0 F lcd_preheat_fan_speed           (int x2)
  *
  * PIDTEMP:                                        66 bytes
- *  408  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]  (float x4)
- *  424  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]  (float x4)
- *  440  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]  (float x4)
- *  456  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]  (float x4)
- *  472  M301 L        lpq_len                     (int)
+ *  409  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]  (float x4)
+ *  425  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]  (float x4)
+ *  441  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]  (float x4)
+ *  457  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]  (float x4)
+ *  473  M301 L        lpq_len                     (int)
  *
  * PIDTEMPBED:                                      12 bytes
- *  474  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
+ *  475  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
  *
  * DOGLCD:                                          2 bytes
- *  486  M250 C    lcd_contrast                     (int)
+ *  487  M250 C    lcd_contrast                     (int)
  *
- * FWRETRACT:                                       29 bytes
- *  488  M209 S    autoretract_enabled              (bool)
- *  489  M207 S    retract_length                   (float)
- *  493  M207 W    retract_length_swap              (float)
- *  497  M207 F    retract_feedrate_mm_s            (float)
- *  501  M207 Z    retract_zlift                    (float)
- *  505  M208 S    retract_recover_length           (float)
- *  509  M208 W    retract_recover_length_swap      (float)
- *  513  M208 F    retract_recover_feedrate_mm_s    (float)
+ * FWRETRACT:                                       30 bytes
+ *  489  M209 S    autoretract_enabled              (BOOL)
+ *  491  M207 S    retract_length                   (float)
+ *  495  M207 W    retract_length_swap              (float)
+ *  499  M207 F    retract_feedrate_mm_s            (float)
+ *  503  M207 Z    retract_zlift                    (float)
+ *  507  M208 S    retract_recover_length           (float)
+ *  511  M208 W    retract_recover_length_swap      (float)
+ *  515  M208 F    retract_recover_feedrate_mm_s    (float)
  *
- * Volumetric Extrusion:                            17 bytes
- *  517  M200 D    volumetric_enabled               (bool)
- *  518  M200 T D  filament_size                    (float x4) (T0..3)
+ * Volumetric Extrusion:                            18 bytes
+ *  519  M200 D    volumetric_enabled               (BOOL)
+ *  521  M200 T D  filament_size                    (float x4) (T0..3)
  *
  * TMC2130 Stepper Current:                         20 bytes
- *  534  M906 X    stepperX current                 (uint16_t)
- *  536  M906 Y    stepperY current                 (uint16_t)
- *  538  M906 Z    stepperZ current                 (uint16_t)
- *  540  M906 X2   stepperX2 current                (uint16_t)
- *  542  M906 Y2   stepperY2 current                (uint16_t)
- *  544  M906 Z2   stepperZ2 current                (uint16_t)
- *  546  M906 E0   stepperE0 current                (uint16_t)
- *  548  M906 E1   stepperE1 current                (uint16_t)
- *  550  M906 E2   stepperE2 current                (uint16_t)
- *  552  M906 E3   stepperE3 current                (uint16_t)
+ *  537  M906 X    stepperX current                 (uint16_t)
+ *  539  M906 Y    stepperY current                 (uint16_t)
+ *  541  M906 Z    stepperZ current                 (uint16_t)
+ *  543  M906 X2   stepperX2 current                (uint16_t)
+ *  545  M906 Y2   stepperY2 current                (uint16_t)
+ *  547  M906 Z2   stepperZ2 current                (uint16_t)
+ *  549  M906 E0   stepperE0 current                (uint16_t)
+ *  551  M906 E1   stepperE1 current                (uint16_t)
+ *  553  M906 E2   stepperE2 current                (uint16_t)
+ *  555  M906 E3   stepperE3 current                (uint16_t)
  *
- *  554                                Minimum end-point
- * 1875 (554 + 36 + 9 + 288 + 988)     Maximum end-point
+ *  557                                Minimum end-point
+ * 1878 (557 + 36 + 9 + 288 + 988)     Maximum end-point
  *
  */
 #include "Marlin.h"
@@ -206,7 +206,7 @@ void Config_Postprocess() {
   uint16_t eeprom_checksum;
   const char version[4] = EEPROM_VERSION;
 
-  bool eeprom_write_error;
+  BOOL eeprom_write_error;
 
   void _EEPROM_writeData(int &pos, const uint8_t* value, uint16_t size) {
     if (eeprom_write_error) return;
@@ -229,7 +229,7 @@ void Config_Postprocess() {
       value++;
     };
   }
-  bool eeprom_read_error;
+  BOOL eeprom_read_error;
   void _EEPROM_readData(int &pos, uint8_t* value, uint16_t size) {
     do {
       uint8_t c = eeprom_read_byte((unsigned char*)pos);
@@ -250,7 +250,7 @@ void Config_Postprocess() {
   /**
    * M500 - Store Configuration
    */
-  bool Config_StoreSettings() {
+  BOOL Config_StoreSettings() {
     float dummy = 0.0f;
     char ver[4] = "000";
 
@@ -295,7 +295,7 @@ void Config_Postprocess() {
     #if ENABLED(MESH_BED_LEVELING)
       // Compile time test that sizeof(mbl.z_values) is as expected
       typedef char c_assert[(sizeof(mbl.z_values) == (MESH_NUM_X_POINTS) * (MESH_NUM_Y_POINTS) * sizeof(dummy)) ? 1 : -1];
-      const bool leveling_is_on = TEST(mbl.status, MBL_STATUS_HAS_MESH_BIT);
+      const BOOL leveling_is_on = TEST(mbl.status, MBL_STATUS_HAS_MESH_BIT);
       const uint8_t mesh_num_x = MESH_NUM_X_POINTS, mesh_num_y = MESH_NUM_Y_POINTS;
       EEPROM_WRITE(leveling_is_on);
       EEPROM_WRITE(mbl.z_offset);
@@ -304,7 +304,7 @@ void Config_Postprocess() {
       EEPROM_WRITE(mbl.z_values);
     #else
       // For disabled MBL write a default mesh
-      const bool leveling_is_on = false;
+      const BOOL leveling_is_on = false;
       dummy = 0.0f;
       const uint8_t mesh_num_x = 3, mesh_num_y = 3;
       EEPROM_WRITE(leveling_is_on);
@@ -551,7 +551,7 @@ void Config_Postprocess() {
   /**
    * M501 - Retrieve Configuration
    */
-  bool Config_RetrieveSettings() {
+  BOOL Config_RetrieveSettings() {
 
     EEPROM_START();
     eeprom_read_error = false; // If set EEPROM_READ won't write into RAM
@@ -621,7 +621,7 @@ void Config_Postprocess() {
       // Mesh (Manual) Bed Leveling
       //
 
-      bool leveling_is_on;
+      BOOL leveling_is_on;
       uint8_t mesh_num_x, mesh_num_y;
       EEPROM_READ(leveling_is_on);
       EEPROM_READ(dummy);
@@ -857,7 +857,7 @@ void Config_Postprocess() {
 
         if (!ubl.sanity_check()) {
           int tmp_mesh;                                // We want to preserve whether the UBL System is Active
-          bool tmp_active;                             // If it is, we want to preserve the Mesh that is being used.
+          BOOL tmp_active;                             // If it is, we want to preserve the Mesh that is being used.
           tmp_mesh = ubl.state.eeprom_storage_slot;
           tmp_active = ubl.state.active;
           SERIAL_ECHOLNPGM("\nInitializing Bed Leveling State to current firmware settings.\n");
@@ -892,7 +892,7 @@ void Config_Postprocess() {
 
 #else // !EEPROM_SETTINGS
 
-  bool Config_StoreSettings() {
+  BOOL Config_StoreSettings() {
     SERIAL_ERROR_START;
     SERIAL_ERRORLNPGM("EEPROM disabled");
     return false;
@@ -1081,7 +1081,7 @@ void Config_ResetDefault() {
   /**
    * M503 - Print Configuration
    */
-  void Config_PrintSettings(bool forReplay) {
+  void Config_PrintSettings(BOOL forReplay) {
     // Always have this function, even with EEPROM_SETTINGS disabled, the current values will be shown
 
     CONFIG_ECHO_START;

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -26,18 +26,18 @@
 #include "MarlinConfig.h"
 
 void Config_ResetDefault();
-bool Config_StoreSettings();
+BOOL Config_StoreSettings();
 
 #if DISABLED(DISABLE_M503)
-  void Config_PrintSettings(bool forReplay=false);
+  void Config_PrintSettings(BOOL forReplay=false);
 #else
-  FORCE_INLINE void Config_PrintSettings(bool forReplay=false) {}
+  FORCE_INLINE void Config_PrintSettings(BOOL forReplay=false) {}
 #endif
 
 #if ENABLED(EEPROM_SETTINGS)
-  bool Config_RetrieveSettings();
+  BOOL Config_RetrieveSettings();
 #else
-  FORCE_INLINE bool Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); return true; }
+  FORCE_INLINE BOOL Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); return true; }
 #endif
 
 #endif //CONFIGURATION_STORE_H

--- a/Marlin/duration_t.h
+++ b/Marlin/duration_t.h
@@ -51,7 +51,7 @@ struct duration_t {
    * @param value The number of seconds to compare to
    * @return True if both durations are equal
    */
-  bool operator==(const uint32_t &value) const {
+  BOOL operator==(const uint32_t &value) const {
     return (this->value == value);
   }
 
@@ -62,7 +62,7 @@ struct duration_t {
    * @param value The number of seconds to compare to
    * @return False if both durations are equal
    */
-  bool operator!=(const uint32_t &value) const {
+  BOOL operator!=(const uint32_t &value) const {
     return ! this->operator==(value);
   }
 
@@ -145,7 +145,7 @@ struct duration_t {
    *  99:59
    *  11d 12:33
    */
-  uint8_t toDigital(char *buffer, bool with_days=false) const {
+  uint8_t toDigital(char *buffer, BOOL with_days=false) const {
     uint16_t h = uint16_t(this->hour()),
              m = uint16_t(this->minute() % 60UL);
     if (with_days) {

--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -38,7 +38,7 @@ Endstops endstops;
 
 // public:
 
-bool  Endstops::enabled = true,
+BOOL  Endstops::enabled = true,
       Endstops::enabled_globally =
         #if ENABLED(ENDSTOPS_ALWAYS_ON_DEFAULT)
           (true)
@@ -57,7 +57,7 @@ volatile char Endstops::endstop_hit_bits; // use X_MIN, Y_MIN, Z_MIN and Z_MIN_P
     Endstops::old_endstop_bits = 0;
 
 #if HAS_BED_PROBE
-  volatile bool Endstops::z_probe_enabled = false;
+  volatile BOOL Endstops::z_probe_enabled = false;
 #endif
 
 /**

--- a/Marlin/endstops.h
+++ b/Marlin/endstops.h
@@ -33,7 +33,7 @@ class Endstops {
 
   public:
 
-    static bool enabled, enabled_globally;
+    static BOOL enabled, enabled_globally;
     static volatile char endstop_hit_bits; // use X_MIN, Y_MIN, Z_MIN and Z_MIN_PROBE as BIT value
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
@@ -66,10 +66,10 @@ class Endstops {
     static void M119();
 
     // Enable / disable endstop checking globally
-    static void enable_globally(bool onoff=true) { enabled_globally = enabled = onoff; }
+    static void enable_globally(BOOL onoff=true) { enabled_globally = enabled = onoff; }
 
     // Enable / disable endstop checking
-    static void enable(bool onoff=true) { enabled = onoff; }
+    static void enable(BOOL onoff=true) { enabled = onoff; }
 
     // Disable / Enable endstops based on ENSTOPS_ONLY_FOR_HOMING and global enable
     static void not_homing() { enabled = enabled_globally; }
@@ -79,8 +79,8 @@ class Endstops {
 
     // Enable / disable endstop z-probe checking
     #if HAS_BED_PROBE
-      static volatile bool z_probe_enabled;
-      static void enable_z_probe(bool onoff=true) { z_probe_enabled = onoff; }
+      static volatile BOOL z_probe_enabled;
+      static void enable_z_probe(BOOL onoff=true) { z_probe_enabled = onoff; }
     #endif
 
   private:

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -44,7 +44,7 @@
 */
 
 /// Read a pin
-#define _READ(IO) ((bool)(DIO ## IO ## _RPORT & MASK(DIO ## IO ## _PIN)))
+#define _READ(IO) ((BOOL)(DIO ## IO ## _RPORT & MASK(DIO ## IO ## _PIN)))
 /// write to a pin
 // On some boards pins > 0x100 are used. These are not converted to atomic actions. An critical section is needed.
 

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -57,12 +57,12 @@
 
     static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[py][px] = z; }
 
-    static bool active()                       { return TEST(status, MBL_STATUS_ACTIVE_BIT); }
-    static void set_active(const bool onOff)   { onOff ? SBI(status, MBL_STATUS_ACTIVE_BIT) : CBI(status, MBL_STATUS_ACTIVE_BIT); }
-    static bool has_mesh()                     { return TEST(status, MBL_STATUS_HAS_MESH_BIT); }
-    static void set_has_mesh(const bool onOff) { onOff ? SBI(status, MBL_STATUS_HAS_MESH_BIT) : CBI(status, MBL_STATUS_HAS_MESH_BIT); }
-    static bool reactivate()                   { bool b = TEST(status, MBL_STATUS_REACTIVATE_BIT); CBI(status, MBL_STATUS_REACTIVATE_BIT); return b; }
-    static void set_reactivate(const bool onOff) { onOff ? SBI(status, MBL_STATUS_REACTIVATE_BIT) : CBI(status, MBL_STATUS_REACTIVATE_BIT); }
+    static BOOL active()                       { return TEST(status, MBL_STATUS_ACTIVE_BIT); }
+    static void set_active(const BOOL onOff)   { onOff ? SBI(status, MBL_STATUS_ACTIVE_BIT) : CBI(status, MBL_STATUS_ACTIVE_BIT); }
+    static BOOL has_mesh()                     { return TEST(status, MBL_STATUS_HAS_MESH_BIT); }
+    static void set_has_mesh(const BOOL onOff) { onOff ? SBI(status, MBL_STATUS_HAS_MESH_BIT) : CBI(status, MBL_STATUS_HAS_MESH_BIT); }
+    static BOOL reactivate()                   { BOOL b = TEST(status, MBL_STATUS_REACTIVATE_BIT); CBI(status, MBL_STATUS_REACTIVATE_BIT); return b; }
+    static void set_reactivate(const BOOL onOff) { onOff ? SBI(status, MBL_STATUS_REACTIVATE_BIT) : CBI(status, MBL_STATUS_REACTIVATE_BIT); }
 
     static inline void zigzag(const int8_t index, int8_t &px, int8_t &py) {
       px = index % (MESH_NUM_X_POINTS);

--- a/Marlin/nozzle.h
+++ b/Marlin/nozzle.h
@@ -31,7 +31,7 @@
                   nozzle_clean_end_point[4] = NOZZLE_CLEAN_END_POINT,
                   nozzle_clean_length = fabs(nozzle_clean_start_point[X_AXIS] - nozzle_clean_end_point[X_AXIS]), //abs x size of wipe pad
                   nozzle_clean_height = fabs(nozzle_clean_start_point[Y_AXIS] - nozzle_clean_end_point[Y_AXIS]); //abs y size of wipe pad
-  constexpr bool nozzle_clean_horizontal = nozzle_clean_length >= nozzle_clean_height; //whether to zig-zag horizontally or vertically
+  constexpr BOOL nozzle_clean_horizontal = nozzle_clean_length >= nozzle_clean_height; //whether to zig-zag horizontally or vertically
 #endif //NOZZLE_CLEAN_FEATURE
 
 /**

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -22,7 +22,7 @@
 
 #include "macros.h"
 
-bool endstop_monitor_flag = false;
+BOOL endstop_monitor_flag = false;
 
 #if !defined(TIMER1B)    // working with Teensyduino extension so need to re-define some things
   #include "pinsDebug_Teensyduino.h"
@@ -47,7 +47,7 @@ int digitalRead_mod(int8_t pin) { // same as digitalRead except the PWM stop sec
 /**
  * Report pin name for a given fastio digital pin index
  */
-static bool report_pin_name(int8_t pin, bool &pin_is_analog) {
+static BOOL report_pin_name(int8_t pin, BOOL &pin_is_analog) {
 
   char buffer[30];   // for the sprintf statements
   pin_is_analog = false;   // default to digital pin
@@ -676,7 +676,7 @@ static bool report_pin_name(int8_t pin, bool &pin_is_analog) {
  * Print a pin's PWM status.
  * Return true if it's currently a PWM pin.
  */
-static bool pwm_status(uint8_t pin) {
+static BOOL pwm_status(uint8_t pin) {
   char buffer[20];   // for the sprintf statements
 
   switch(digitalPinToTimer(pin)) {
@@ -899,7 +899,7 @@ static void pwm_details(uint8_t pin) {
 inline void report_pin_state(int8_t pin) {
   SERIAL_ECHO((int)pin);
   SERIAL_CHAR(' ');
-  bool dummy;
+  BOOL dummy;
   if (report_pin_name(pin, dummy)) {
     if (pin_is_protected(pin))
       SERIAL_ECHOPGM(" (protected)");
@@ -917,10 +917,10 @@ inline void report_pin_state(int8_t pin) {
   SERIAL_EOL;
 }
 
-bool get_pinMode(int8_t pin) { return *portModeRegister(digitalPinToPort(pin)) & digitalPinToBitMask(pin); }
+BOOL get_pinMode(int8_t pin) { return *portModeRegister(digitalPinToPort(pin)) & digitalPinToBitMask(pin); }
 
 // pretty report with PWM info
-inline void report_pin_state_extended(int8_t pin, bool ignore) {
+inline void report_pin_state_extended(int8_t pin, BOOL ignore) {
 
   char buffer[30];   // for the sprintf statements
 
@@ -929,7 +929,7 @@ inline void report_pin_state_extended(int8_t pin, bool ignore) {
   SERIAL_ECHO(buffer);
 
   // report pin name
-  bool analog_pin;
+  BOOL analog_pin;
   report_pin_name(pin, analog_pin);
 
   // report pin state

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -101,7 +101,7 @@ float Planner::min_feedrate_mm_s,
       Planner::min_travel_feedrate_mm_s;
 
 #if HAS_ABL
-  bool Planner::abl_enabled = false; // Flag that auto bed leveling is enabled
+  BOOL Planner::abl_enabled = false; // Flag that auto bed leveling is enabled
 #endif
 
 #if ABL_PLANAR
@@ -117,7 +117,7 @@ float Planner::min_feedrate_mm_s,
   float Planner::autotemp_max = 250,
         Planner::autotemp_min = 210,
         Planner::autotemp_factor = 0.1;
-  bool Planner::autotemp_enabled = false;
+  BOOL Planner::autotemp_enabled = false;
 #endif
 
 // private:
@@ -1240,7 +1240,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
     // then the machine is not coasting anymore and the safe entry / exit velocities shall be used.
 
     // The junction velocity will be shared between successive segments. Limit the junction velocity to their minimum.
-    bool prev_speed_larger = previous_nominal_speed > block->nominal_speed;
+    BOOL prev_speed_larger = previous_nominal_speed > block->nominal_speed;
     float smaller_speed_factor = prev_speed_larger ? (block->nominal_speed / previous_nominal_speed) : (previous_nominal_speed / block->nominal_speed);
     // Pick the smaller of the nominal speeds. Higher speed shall not be achieved at the junction during coasting.
     vmax_junction = prev_speed_larger ? block->nominal_speed : previous_nominal_speed;

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -94,7 +94,7 @@ typedef struct {
 
   // Advance extrusion
   #if ENABLED(LIN_ADVANCE)
-    bool use_advance_lead;
+    BOOL use_advance_lead;
     uint32_t abs_adv_steps_multiplier8; // Factorised by 2^8 to avoid float
   #elif ENABLED(ADVANCE)
     int32_t advance_rate;
@@ -160,7 +160,7 @@ class Planner {
                  min_travel_feedrate_mm_s;
 
     #if HAS_ABL
-      static bool abl_enabled;            // Flag that bed leveling is enabled
+      static BOOL abl_enabled;            // Flag that bed leveling is enabled
       static matrix_3x3 bed_level_matrix; // Transform to compensate for bed level
     #endif
 
@@ -242,7 +242,7 @@ class Planner {
      */
     static uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block_buffer_tail + BLOCK_BUFFER_SIZE); }
 
-    static bool is_full() { return (block_buffer_tail == BLOCK_MOD(block_buffer_head + 1)); }
+    static BOOL is_full() { return (block_buffer_tail == BLOCK_MOD(block_buffer_head + 1)); }
 
     #if PLANNER_LEVELING && DISABLED(AUTO_BED_LEVELING_UBL)
 
@@ -358,7 +358,7 @@ class Planner {
     /**
      * Does the buffer have any blocks queued?
      */
-    static bool blocks_queued() { return (block_buffer_head != block_buffer_tail); }
+    static BOOL blocks_queued() { return (block_buffer_head != block_buffer_tail); }
 
     /**
      * "Discards" the block and "releases" the memory.
@@ -415,7 +415,7 @@ class Planner {
 
     #if ENABLED(AUTOTEMP)
       static float autotemp_min, autotemp_max, autotemp_factor;
-      static bool autotemp_enabled;
+      static BOOL autotemp_enabled;
       static void getHighESpeed();
       static void autotemp_M104_M109();
     #endif

--- a/Marlin/planner_bezier.cpp
+++ b/Marlin/planner_bezier.cpp
@@ -131,7 +131,7 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
 
     // First try to reduce the step in order to make it sufficiently
     // close to a linear interpolation.
-    bool did_reduce = false;
+    BOOL did_reduce = false;
     float new_t = t + step;
     NOMORE(new_t, 1.0);
     float new_pos0 = eval_bezier(position[X_AXIS], first0, second0, target[X_AXIS], new_t);

--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -38,7 +38,7 @@ millis_t PrintCounter::deltaDuration() {
   return this->lastDuration - tmp;
 }
 
-bool PrintCounter::isLoaded() {
+BOOL PrintCounter::isLoaded() {
   return this->loaded;
 }
 
@@ -174,12 +174,12 @@ void PrintCounter::tick() {
 }
 
 // @Override
-bool PrintCounter::start() {
+BOOL PrintCounter::start() {
   #if ENABLED(DEBUG_PRINTCOUNTER)
     PrintCounter::debug(PSTR("start"));
   #endif
 
-  bool paused = this->isPaused();
+  BOOL paused = this->isPaused();
 
   if (super::start()) {
     if (!paused) {
@@ -192,7 +192,7 @@ bool PrintCounter::start() {
 }
 
 // @Override
-bool PrintCounter::stop() {
+BOOL PrintCounter::stop() {
   #if ENABLED(DEBUG_PRINTCOUNTER)
     PrintCounter::debug(PSTR("stop"));
   #endif

--- a/Marlin/printcounter.h
+++ b/Marlin/printcounter.h
@@ -83,7 +83,7 @@ class PrintCounter: public Stopwatch {
      * @details If set to true it indicates if the statistical data was already
      * loaded from the EEPROM.
      */
-    bool loaded = false;
+    BOOL loaded = false;
 
   protected:
     /**
@@ -103,9 +103,9 @@ class PrintCounter: public Stopwatch {
     /**
      * @brief Checks if Print Statistics has been loaded
      * @details Returns true if the statistical data has been loaded.
-     * @return bool
+     * @return BOOL
      */
-    bool isLoaded();
+    BOOL isLoaded();
 
     /**
      * @brief Increments the total filament used
@@ -157,8 +157,8 @@ class PrintCounter: public Stopwatch {
     /**
      * The following functions are being overridden
      */
-    bool start();
-    bool stop();
+    BOOL start();
+    BOOL stop();
     void reset();
 
     #if ENABLED(DEBUG_PRINTCOUNTER)

--- a/Marlin/servo.cpp
+++ b/Marlin/servo.cpp
@@ -227,7 +227,7 @@ static void finISR(timer16_Sequence_t timer) {
   #endif
 }
 
-static bool isTimerActive(timer16_Sequence_t timer) {
+static BOOL isTimerActive(timer16_Sequence_t timer) {
   // returns true if any servo is active on this timer
   for (uint8_t channel = 0; channel < SERVOS_PER_TIMER; channel++) {
     if (SERVO(timer, channel).Pin.isActive)
@@ -305,7 +305,7 @@ int Servo::readMicroseconds() {
   return (this->servoIndex == INVALID_SERVO) ? 0 : ticksToUs(servo_info[this->servoIndex].ticks) + TRIM_DURATION;
 }
 
-bool Servo::attached() { return servo_info[this->servoIndex].Pin.isActive; }
+BOOL Servo::attached() { return servo_info[this->servoIndex].Pin.isActive; }
 
 void Servo::move(int value) {
   if (this->attach(0) >= 0) {

--- a/Marlin/servo.h
+++ b/Marlin/servo.h
@@ -70,6 +70,7 @@
 #define servo_h
 
 #include <inttypes.h>
+#include "types.h"
 
 /**
  * Defines for 16 bit timers used with  Servo library
@@ -150,7 +151,7 @@ class Servo {
                                        // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY, then detach
     int read();                        // returns current pulse width as an angle between 0 and 180 degrees
     int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
-    bool attached();                   // return true if this servo is attached, otherwise false
+    BOOL attached();                   // return true if this servo is attached, otherwise false
 
   private:
     uint8_t servoIndex;               // index into the channel data for this servo

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -65,11 +65,11 @@ Stepper stepper; // Singleton
 block_t* Stepper::current_block = NULL;  // A pointer to the block currently being traced
 
 #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
-  bool Stepper::abort_on_endstop_hit = false;
+  BOOL Stepper::abort_on_endstop_hit = false;
 #endif
 
 #if ENABLED(Z_DUAL_ENDSTOPS)
-  bool Stepper::performing_homing = false;
+  BOOL Stepper::performing_homing = false;
 #endif
 
 // private:
@@ -78,8 +78,8 @@ unsigned char Stepper::last_direction_bits = 0;        // The next stepping-bits
 unsigned int Stepper::cleaning_buffer_counter = 0;
 
 #if ENABLED(Z_DUAL_ENDSTOPS)
-  bool Stepper::locked_z_motor = false;
-  bool Stepper::locked_z2_motor = false;
+  BOOL Stepper::locked_z_motor = false;
+  BOOL Stepper::locked_z2_motor = false;
 #endif
 
 long Stepper::counter_X = 0,
@@ -460,7 +460,7 @@ void Stepper::isr() {
   #endif
 
   // Take multiple steps per interrupt (For high speed moves)
-  bool all_steps_done = false;
+  BOOL all_steps_done = false;
   for (int8_t i = 0; i < step_loops; i++) {
     #if ENABLED(LIN_ADVANCE)
 
@@ -476,7 +476,7 @@ void Stepper::isr() {
 
       #if ENABLED(MIXING_EXTRUDER)
         // Step mixing steppers proportionally
-        const bool dir = motor_direction(E_AXIS);
+        const BOOL dir = motor_direction(E_AXIS);
         MIXING_STEPPERS_LOOP(j) {
           counter_m[j] += current_block->steps[E_AXIS];
           if (counter_m[j] > 0) {
@@ -501,7 +501,7 @@ void Stepper::isr() {
       #if ENABLED(MIXING_EXTRUDER)
 
         // Step mixing steppers proportionally
-        const bool dir = motor_direction(E_AXIS);
+        const BOOL dir = motor_direction(E_AXIS);
         MIXING_STEPPERS_LOOP(j) {
           counter_m[j] += current_block->steps[E_AXIS];
           if (counter_m[j] > 0) {
@@ -1259,7 +1259,7 @@ void Stepper::report_positions() {
 
   // MUST ONLY BE CALLED BY AN ISR,
   // No other ISR should ever interrupt this!
-  void Stepper::babystep(const AxisEnum axis, const bool direction) {
+  void Stepper::babystep(const AxisEnum axis, const BOOL direction) {
     cli();
     uint8_t old_dir;
     #if STEP_PULSE_CYCLES > CYCLES_EATEN_BY_BABYSTEP
@@ -1290,7 +1290,7 @@ void Stepper::report_positions() {
 
         #else // DELTA
 
-          bool z_direction = direction ^ BABYSTEP_INVERT_Z;
+          BOOL z_direction = direction ^ BABYSTEP_INVERT_Z;
 
           enable_x();
           enable_y();

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -84,11 +84,11 @@ class Stepper {
     static block_t* current_block;  // A pointer to the block currently being traced
 
     #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
-      static bool abort_on_endstop_hit;
+      static BOOL abort_on_endstop_hit;
     #endif
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      static bool performing_homing;
+      static BOOL performing_homing;
     #endif
 
   private:
@@ -97,7 +97,7 @@ class Stepper {
     static unsigned int cleaning_buffer_counter;
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      static bool locked_z_motor, locked_z2_motor;
+      static BOOL locked_z_motor, locked_z2_motor;
     #endif
 
     // Counter variables for the Bresenham line tracer
@@ -240,7 +240,7 @@ class Stepper {
     //
     // The direction of a single motor
     //
-    static FORCE_INLINE bool motor_direction(AxisEnum axis) { return TEST(last_direction_bits, axis); }
+    static FORCE_INLINE BOOL motor_direction(AxisEnum axis) { return TEST(last_direction_bits, axis); }
 
     #if HAS_DIGIPOTSS || HAS_MOTOR_CURRENT_PWM
       static void digitalPotWrite(int address, int value);
@@ -254,13 +254,13 @@ class Stepper {
     #endif
 
     #if ENABLED(Z_DUAL_ENDSTOPS)
-      static FORCE_INLINE void set_homing_flag(bool state) { performing_homing = state; }
-      static FORCE_INLINE void set_z_lock(bool state) { locked_z_motor = state; }
-      static FORCE_INLINE void set_z2_lock(bool state) { locked_z2_motor = state; }
+      static FORCE_INLINE void set_homing_flag(BOOL state) { performing_homing = state; }
+      static FORCE_INLINE void set_z_lock(BOOL state) { locked_z_motor = state; }
+      static FORCE_INLINE void set_z2_lock(BOOL state) { locked_z2_motor = state; }
     #endif
 
     #if ENABLED(BABYSTEPPING)
-      static void babystep(const AxisEnum axis, const bool direction); // perform a short step with a single stepper motor, outside of any convention
+      static void babystep(const AxisEnum axis, const BOOL direction); // perform a short step with a single stepper motor, outside of any convention
     #endif
 
     static inline void kill_current_block() {

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -47,7 +47,7 @@
 
   #include "stepper_dac.h"
 
-  bool dac_present = false;
+  BOOL dac_present = false;
   const uint8_t dac_order[NUM_AXIS] = DAC_STEPPER_ORDER;
   uint16_t dac_channel_pct[XYZE] = DAC_STEPPER_DFLT;
 

--- a/Marlin/stopwatch.cpp
+++ b/Marlin/stopwatch.cpp
@@ -27,7 +27,7 @@ Stopwatch::Stopwatch() {
   this->reset();
 }
 
-bool Stopwatch::stop() {
+BOOL Stopwatch::stop() {
   #if ENABLED(DEBUG_STOPWATCH)
     Stopwatch::debug(PSTR("stop"));
   #endif
@@ -40,7 +40,7 @@ bool Stopwatch::stop() {
   else return false;
 }
 
-bool Stopwatch::pause() {
+BOOL Stopwatch::pause() {
   #if ENABLED(DEBUG_STOPWATCH)
     Stopwatch::debug(PSTR("pause"));
   #endif
@@ -53,7 +53,7 @@ bool Stopwatch::pause() {
   else return false;
 }
 
-bool Stopwatch::start() {
+BOOL Stopwatch::start() {
   #if ENABLED(DEBUG_STOPWATCH)
     Stopwatch::debug(PSTR("start"));
   #endif
@@ -80,11 +80,11 @@ void Stopwatch::reset() {
   this->accumulator = 0;
 }
 
-bool Stopwatch::isRunning() {
+BOOL Stopwatch::isRunning() {
   return (this->state == RUNNING) ? true : false;
 }
 
-bool Stopwatch::isPaused() {
+BOOL Stopwatch::isPaused() {
   return (this->state == PAUSED) ? true : false;
 }
 

--- a/Marlin/stopwatch.h
+++ b/Marlin/stopwatch.h
@@ -58,7 +58,7 @@ class Stopwatch {
      * no timer is currently running.
      * @return true is method was successful
      */
-    bool stop();
+    BOOL stop();
 
     /**
      * @brief Pause the stopwatch
@@ -66,7 +66,7 @@ class Stopwatch {
      * no timer is currently running.
      * @return true is method was successful
      */
-    bool pause();
+    BOOL pause();
 
     /**
      * @brief Starts the stopwatch
@@ -74,7 +74,7 @@ class Stopwatch {
      * timer is already running.
      * @return true is method was successful
      */
-    bool start();
+    BOOL start();
 
     /**
      * @brief Resets the stopwatch
@@ -87,14 +87,14 @@ class Stopwatch {
      * @details Returns true if the timer is currently running, false otherwise.
      * @return true if stopwatch is running
      */
-    bool isRunning();
+    BOOL isRunning();
 
     /**
      * @brief Checks if the timer is paused
      * @details Returns true if the timer is currently paused, false otherwise.
      * @return true if stopwatch is paused
      */
-    bool isPaused();
+    BOOL isPaused();
 
     /**
      * @brief Gets the running time

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -115,7 +115,7 @@ uint8_t Temperature::soft_pwm_bed;
 #endif
 
 #if ENABLED(PREVENT_COLD_EXTRUSION)
-  bool Temperature::allow_cold_extrude = false;
+  BOOL Temperature::allow_cold_extrude = false;
   float Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
 #endif
 
@@ -126,7 +126,7 @@ uint8_t Temperature::soft_pwm_bed;
   float Temperature::redundant_temperature = 0.0;
 #endif
 
-volatile bool Temperature::temp_meas_ready = false;
+volatile BOOL Temperature::temp_meas_ready = false;
 
 #if ENABLED(PIDTEMP)
   float Temperature::temp_iState[HOTENDS] = { 0 },
@@ -143,7 +143,7 @@ volatile bool Temperature::temp_meas_ready = false;
   #endif
 
   float Temperature::pid_error[HOTENDS];
-  bool Temperature::pid_reset[HOTENDS];
+  BOOL Temperature::pid_reset[HOTENDS];
 #endif
 
 #if ENABLED(PIDTEMPBED)
@@ -202,10 +202,10 @@ uint8_t Temperature::soft_pwm[HOTENDS];
 
 #if HAS_PID_HEATING
 
-  void Temperature::PID_autotune(float temp, int hotend, int ncycles, bool set_result/*=false*/) {
+  void Temperature::PID_autotune(float temp, int hotend, int ncycles, BOOL set_result/*=false*/) {
     float input = 0.0;
     int cycles = 0;
-    bool heating = true;
+    BOOL heating = true;
 
     millis_t temp_ms = millis(), t1 = temp_ms, t2 = temp_ms;
     long t_high = 0, t_low = 0;
@@ -493,7 +493,7 @@ int Temperature::getHeaterPower(int heater) {
 // Temperature Error Handlers
 //
 void Temperature::_temp_error(int e, const char* serial_msg, const char* lcd_msg) {
-  static bool killed = false;
+  static BOOL killed = false;
   if (IsRunning()) {
     SERIAL_ERROR_START;
     serialprintPGM(serial_msg);
@@ -1488,7 +1488,7 @@ void Temperature::set_current_temp_raw() {
  */
 ISR(TIMER0_COMPB_vect) { Temperature::isr(); }
 
-volatile bool Temperature::in_temp_isr = false;
+volatile BOOL Temperature::in_temp_isr = false;
 
 void Temperature::isr() {
   // The stepper ISR can interrupt this ISR. When it does it re-enables this ISR
@@ -1953,7 +1953,7 @@ void Temperature::isr() {
   #endif //BABYSTEPPING
 
   #if ENABLED(PINS_DEBUGGING)
-    extern bool endstop_monitor_flag;
+    extern BOOL endstop_monitor_flag;
     // run the endstop monitor at 15Hz
     static uint8_t endstop_monitor_count = 16;  // offset this check from the others
     if (endstop_monitor_flag) {

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -61,7 +61,7 @@ class Temperature {
                  current_temperature_bed_raw,
                  target_temperature_bed;
 
-    static volatile bool in_temp_isr;
+    static volatile BOOL in_temp_isr;
 
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
       static float redundant_temperature;
@@ -124,16 +124,16 @@ class Temperature {
     #endif
 
     #if ENABLED(PREVENT_COLD_EXTRUSION)
-      static bool allow_cold_extrude;
+      static BOOL allow_cold_extrude;
       static float extrude_min_temp;
-      static bool tooColdToExtrude(uint8_t e) {
+      static BOOL tooColdToExtrude(uint8_t e) {
         #if HOTENDS == 1
           UNUSED(e);
         #endif
         return allow_cold_extrude ? false : degHotend(HOTEND_INDEX) < extrude_min_temp;
       }
     #else
-      static bool tooColdToExtrude(uint8_t e) { UNUSED(e); return false; }
+      static BOOL tooColdToExtrude(uint8_t e) { UNUSED(e); return false; }
     #endif
 
   private:
@@ -143,7 +143,7 @@ class Temperature {
       static float redundant_temperature;
     #endif
 
-    static volatile bool temp_meas_ready;
+    static volatile BOOL temp_meas_ready;
 
     #if ENABLED(PIDTEMP)
       static float temp_iState[HOTENDS],
@@ -160,7 +160,7 @@ class Temperature {
       #endif
 
       static float pid_error[HOTENDS];
-      static bool pid_reset[HOTENDS];
+      static BOOL pid_reset[HOTENDS];
     #endif
 
     #if ENABLED(PIDTEMPBED)
@@ -248,7 +248,7 @@ class Temperature {
      * Preheating hotends
      */
     #ifdef MILLISECONDS_PREHEAT_TIME
-      static bool is_preheating(uint8_t e) {
+      static BOOL is_preheating(uint8_t e) {
         #if HOTENDS == 1
           UNUSED(e);
         #endif
@@ -337,21 +337,21 @@ class Temperature {
       #endif
     }
 
-    static bool isHeatingHotend(uint8_t e) {
+    static BOOL isHeatingHotend(uint8_t e) {
       #if HOTENDS == 1
         UNUSED(e);
       #endif
       return target_temperature[HOTEND_INDEX] > current_temperature[HOTEND_INDEX];
     }
-    static bool isHeatingBed() { return target_temperature_bed > current_temperature_bed; }
+    static BOOL isHeatingBed() { return target_temperature_bed > current_temperature_bed; }
 
-    static bool isCoolingHotend(uint8_t e) {
+    static BOOL isCoolingHotend(uint8_t e) {
       #if HOTENDS == 1
         UNUSED(e);
       #endif
       return target_temperature[HOTEND_INDEX] < current_temperature[HOTEND_INDEX];
     }
-    static bool isCoolingBed() { return target_temperature_bed < current_temperature_bed; }
+    static BOOL isCoolingBed() { return target_temperature_bed < current_temperature_bed; }
 
     /**
      * The software PWM power for a heater
@@ -367,7 +367,7 @@ class Temperature {
      * Perform auto-tuning for hotend or bed in response to M303
      */
     #if HAS_PID_HEATING
-      static void PID_autotune(float temp, int hotend, int ncycles, bool set_result=false);
+      static void PID_autotune(float temp, int hotend, int ncycles, BOOL set_result=false);
     #endif
 
     /**

--- a/Marlin/twibus.cpp
+++ b/Marlin/twibus.cpp
@@ -110,7 +110,7 @@ void TWIBus::echobuffer(const char prefix[], uint8_t adr) {
   SERIAL_EOL;
 }
 
-bool TWIBus::request(const uint8_t bytes) {
+BOOL TWIBus::request(const uint8_t bytes) {
   if (!this->addr) return false;
 
   #if ENABLED(DEBUG_TWIBUS)

--- a/Marlin/twibus.h
+++ b/Marlin/twibus.h
@@ -163,7 +163,7 @@ class TWIBus {
      * @param bytes the number of bytes to request
      * @return status of the request: true=success, false=fail
      */
-    bool request(const uint8_t bytes);
+    BOOL request(const uint8_t bytes);
 
     /**
      * @brief Capture data from the bus into the buffer.

--- a/Marlin/types.h
+++ b/Marlin/types.h
@@ -24,5 +24,6 @@
 #define __TYPES_H__
 
 typedef unsigned long millis_t;
+typedef unsigned int BOOL;
 
 #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -73,7 +73,7 @@ uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to 
 uint16_t max_display_update_time = 0;
 
 #if ENABLED(DOGLCD)
-  bool drawing_screen = false;
+  BOOL drawing_screen = false;
   #define LCDVIEW_KEEP_REDRAWING LCDVIEW_CALL_REDRAW_NEXT
 #else
   #define LCDVIEW_KEEP_REDRAWING LCDVIEW_REDRAW_NOW
@@ -118,7 +118,7 @@ uint16_t max_display_update_time = 0;
     #define manual_move_e_index 0
   #endif
 
-  bool encoderRateMultiplierEnabled;
+  BOOL encoderRateMultiplierEnabled;
   int32_t lastEncoderMovementMillis;
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -126,7 +126,7 @@ uint16_t max_display_update_time = 0;
   #endif
 
   #if HAS_POWER_SWITCH
-    extern bool powersupply;
+    extern BOOL powersupply;
   #endif
 
   const float manual_feedrate_mm_m[] = MANUAL_FEEDRATE;
@@ -194,7 +194,7 @@ uint16_t max_display_update_time = 0;
   void menu_action_submenu(screenFunc_t data);
   void menu_action_gcode(const char* pgcode);
   void menu_action_function(screenFunc_t data);
-  void menu_action_setting_edit_bool(const char* pstr, bool* ptr);
+  void menu_action_setting_edit_BOOL(const char* pstr, BOOL* ptr);
   void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
   void menu_action_setting_edit_float3(const char* pstr, float* ptr, float minValue, float maxValue);
   void menu_action_setting_edit_float32(const char* pstr, float* ptr, float minValue, float maxValue);
@@ -204,7 +204,7 @@ uint16_t max_display_update_time = 0;
   void menu_action_setting_edit_float52(const char* pstr, float* ptr, float minValue, float maxValue);
   void menu_action_setting_edit_float62(const char* pstr, float* ptr, float minValue, float maxValue);
   void menu_action_setting_edit_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue);
-  void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_callback_BOOL(const char* pstr, BOOL* ptr, screenFunc_t callbackFunc);
   void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callbackFunc);
   void menu_action_setting_edit_callback_float3(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
   void menu_action_setting_edit_callback_float32(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
@@ -273,7 +273,7 @@ uint16_t max_display_update_time = 0;
   #define START_SCREEN() \
     START_SCREEN_OR_MENU(LCD_HEIGHT - (TALL_FONT_CORRECTION)); \
     encoderTopLine = encoderLine; \
-    bool _skipStatic = false; \
+    BOOL _skipStatic = false; \
     SCREEN_OR_MENU_LOOP()
 
   #define START_MENU() \
@@ -283,7 +283,7 @@ uint16_t max_display_update_time = 0;
     if (encoderLine >= encoderTopLine + LCD_HEIGHT - (TALL_FONT_CORRECTION)) { \
       encoderTopLine = encoderLine - (LCD_HEIGHT - (TALL_FONT_CORRECTION) - 1); \
     } \
-    bool _skipStatic = true; \
+    BOOL _skipStatic = true; \
     SCREEN_OR_MENU_LOOP()
 
   /**
@@ -331,7 +331,7 @@ uint16_t max_display_update_time = 0;
   #define MENU_BACK(LABEL) MENU_ITEM(back, LABEL, 0)
 
   // Used to print static text with no visible cursor.
-  // Parameters: label [, bool center [, bool invert [, char *value] ] ]
+  // Parameters: label [, BOOL center [, BOOL invert [, char *value] ] ]
   #define STATIC_ITEM(LABEL, ...) \
     if (_menuLineNr == _thisItemNr) { \
       if (_skipStatic && encoderLine <= _thisItemNr) { \
@@ -405,10 +405,10 @@ uint16_t max_display_update_time = 0;
 
   menuPosition screen_history[10];
   uint8_t screen_history_depth = 0;
-  bool screen_changed;
+  BOOL screen_changed;
 
   // LCD and menu clicks
-  bool lcd_clicked, wait_for_unclick, defer_return_to_status, no_reentrance;
+  BOOL lcd_clicked, wait_for_unclick, defer_return_to_status, no_reentrance;
 
   // Variables used when editing values.
   const char* editLabel;
@@ -637,7 +637,7 @@ void kill_screen(const char* lcd_msg) {
     #endif
   }
 
-  void lcd_completion_feedback(const bool good/*=true*/) {
+  void lcd_completion_feedback(const BOOL good/*=true*/) {
     if (good) {
       lcd_buzz(100, 659);
       lcd_buzz(100, 698);
@@ -684,7 +684,7 @@ void kill_screen(const char* lcd_msg) {
 
   #if ENABLED(MENU_ITEM_CASE_LIGHT)
 
-    extern bool case_light_on;
+    extern BOOL case_light_on;
     extern void update_case_light();
 
     void toggle_case_light() {
@@ -1337,7 +1337,7 @@ void kill_screen(const char* lcd_msg) {
     static uint8_t manual_probe_index;
 
     #if ENABLED(PROBE_MANUALLY)
-      extern bool g29_in_progress;
+      extern BOOL g29_in_progress;
     #endif
 
     // LCD probed points are from defaults
@@ -1666,7 +1666,7 @@ void kill_screen(const char* lcd_msg) {
       //
       // Cooldown
       //
-      bool has_heat = false;
+      BOOL has_heat = false;
       HOTEND_LOOP() if (thermalManager.target_temperature[HOTEND_INDEX]) { has_heat = true; break; }
       #if HAS_TEMP_BED
         if (thermalManager.target_temperature_bed) has_heat = true;
@@ -2210,7 +2210,7 @@ void kill_screen(const char* lcd_msg) {
     // Autotemp, Min, Max, Fact
     //
     #if ENABLED(AUTOTEMP) && (TEMP_SENSOR_0 != 0)
-      MENU_ITEM_EDIT(bool, MSG_AUTOTEMP, &planner.autotemp_enabled);
+      MENU_ITEM_EDIT(BOOL, MSG_AUTOTEMP, &planner.autotemp_enabled);
       MENU_ITEM_EDIT(float3, MSG_MIN, &planner.autotemp_min, 0, HEATER_0_MAXTEMP - 15);
       MENU_ITEM_EDIT(float3, MSG_MAX, &planner.autotemp_max, 0, HEATER_0_MAXTEMP - 15);
       MENU_ITEM_EDIT(float32, MSG_FACTOR, &planner.autotemp_factor, 0.0, 1.0);
@@ -2444,7 +2444,7 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
-      MENU_ITEM_EDIT(bool, MSG_ENDSTOP_ABORT, &stepper.abort_on_endstop_hit);
+      MENU_ITEM_EDIT(BOOL, MSG_ENDSTOP_ABORT, &stepper.abort_on_endstop_hit);
     #endif
     END_MENU();
   }
@@ -2458,7 +2458,7 @@ void kill_screen(const char* lcd_msg) {
     START_MENU();
     MENU_BACK(MSG_CONTROL);
 
-    MENU_ITEM_EDIT_CALLBACK(bool, MSG_VOLUMETRIC_ENABLED, &volumetric_enabled, calculate_volumetric_multipliers);
+    MENU_ITEM_EDIT_CALLBACK(BOOL, MSG_VOLUMETRIC_ENABLED, &volumetric_enabled, calculate_volumetric_multipliers);
 
     if (volumetric_enabled) {
       #if EXTRUDERS == 1
@@ -2514,7 +2514,7 @@ void kill_screen(const char* lcd_msg) {
     void lcd_control_retract_menu() {
       START_MENU();
       MENU_BACK(MSG_CONTROL);
-      MENU_ITEM_EDIT(bool, MSG_AUTORETRACT, &autoretract_enabled);
+      MENU_ITEM_EDIT(BOOL, MSG_AUTORETRACT, &autoretract_enabled);
       MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT, &retract_length, 0, 100);
       #if EXTRUDERS > 1
         MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_SWAP, &retract_length_swap, 0, 100);
@@ -3003,7 +3003,7 @@ void kill_screen(const char* lcd_msg) {
    *
    * For example, menu_edit_type(int, int3, itostr3, 1) expands into these functions:
    *
-   *   bool _menu_edit_int3();
+   *   BOOL _menu_edit_int3();
    *   void menu_edit_int3(); // edit int (interactively)
    *   void menu_edit_callback_int3(); // edit int (interactively) with callback on completion
    *   void _menu_action_setting_edit_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue);
@@ -3022,7 +3022,7 @@ void kill_screen(const char* lcd_msg) {
    *       menu_action_setting_edit_int3(PSTR(MSG_SPEED), &feedrate_percentage, 10, 999)
    */
   #define menu_edit_type(_type, _name, _strFunc, _scale) \
-    bool _menu_edit_ ## _name () { \
+    BOOL _menu_edit_ ## _name () { \
       ENCODER_DIRECTION_NORMAL(); \
       if ((int32_t)encoderPosition < 0) encoderPosition = 0; \
       if ((int32_t)encoderPosition > maxEditValue) encoderPosition = maxEditValue; \
@@ -3155,9 +3155,9 @@ void kill_screen(const char* lcd_msg) {
 
   #endif //SDSUPPORT
 
-  void menu_action_setting_edit_bool(const char* pstr, bool* ptr) {UNUSED(pstr); *ptr = !(*ptr); lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; }
-  void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callback) {
-    menu_action_setting_edit_bool(pstr, ptr);
+  void menu_action_setting_edit_BOOL(const char* pstr, BOOL* ptr) {UNUSED(pstr); *ptr = !(*ptr); lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; }
+  void menu_action_setting_edit_callback_BOOL(const char* pstr, BOOL* ptr, screenFunc_t callback) {
+    menu_action_setting_edit_BOOL(pstr, ptr);
     (*callback)();
   }
 
@@ -3259,7 +3259,7 @@ int lcd_strlen_P(const char* s) {
   return j;
 }
 
-bool lcd_blink() {
+BOOL lcd_blink() {
   static uint8_t blink = 0;
   static millis_t next_blink_ms = 0;
   millis_t ms = millis();
@@ -3311,9 +3311,9 @@ void lcd_update() {
     lcd_buttons_update();
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      const bool UBL_CONDITION = !ubl.has_control_of_lcd_panel;
+      const BOOL UBL_CONDITION = !ubl.has_control_of_lcd_panel;
     #else
-      constexpr bool UBL_CONDITION = true;
+      constexpr BOOL UBL_CONDITION = true;
     #endif
 
     // If the action button is pressed...
@@ -3330,7 +3330,7 @@ void lcd_update() {
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
 
-    bool sd_status = IS_SD_INSERTED;
+    BOOL sd_status = IS_SD_INSERTED;
     if (sd_status != lcd_sd_status && lcd_detected()) {
 
       if (sd_status) {
@@ -3376,7 +3376,7 @@ void lcd_update() {
         handle_reprapworld_keypad();
       #endif
 
-      bool encoderPastThreshold = (abs(encoderDiff) >= ENCODER_PULSES_PER_STEP);
+      BOOL encoderPastThreshold = (abs(encoderDiff) >= ENCODER_PULSES_PER_STEP);
       if (encoderPastThreshold || lcd_clicked) {
         if (encoderPastThreshold) {
           int32_t encoderMultiplier = 1;
@@ -3527,7 +3527,7 @@ void set_utf_strlen(char* s, uint8_t n) {
   s[i] = '\0';
 }
 
-void lcd_finishstatus(bool persist=false) {
+void lcd_finishstatus(BOOL persist=false) {
   set_utf_strlen(lcd_status_message, LCD_WIDTH);
   #if !(ENABLED(LCD_PROGRESS_BAR) && (PROGRESS_MSG_EXPIRE > 0))
     UNUSED(persist);
@@ -3550,9 +3550,9 @@ void lcd_finishstatus(bool persist=false) {
   void dontExpireStatus() { expire_status_ms = 0; }
 #endif
 
-bool lcd_hasstatus() { return (lcd_status_message[0] != '\0'); }
+BOOL lcd_hasstatus() { return (lcd_status_message[0] != '\0'); }
 
-void lcd_setstatus(const char* const message, bool persist) {
+void lcd_setstatus(const char* const message, BOOL persist) {
   if (lcd_status_message_level > 0) return;
   strncpy(lcd_status_message, message, 3 * (LCD_WIDTH));
   lcd_finishstatus(persist);
@@ -3738,9 +3738,9 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
   }
 
   #if (ENABLED(LCD_I2C_TYPE_MCP23017) || ENABLED(LCD_I2C_TYPE_MCP23008)) && ENABLED(DETECT_DEVICE)
-    bool lcd_detected() { return lcd.LcdDetected() == 1; }
+    BOOL lcd_detected() { return lcd.LcdDetected() == 1; }
   #else
-    bool lcd_detected() { return true; }
+    BOOL lcd_detected() { return true; }
   #endif
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -3753,7 +3753,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
       #endif
     }
 
-    bool ubl_lcd_clicked() { return LCD_CLICKED; }
+    BOOL ubl_lcd_clicked() { return LCD_CLICKED; }
 
   #endif
 

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -36,15 +36,15 @@
   int lcd_strlen_P(const char* s);
   void lcd_update();
   void lcd_init();
-  bool lcd_hasstatus();
-  void lcd_setstatus(const char* message, const bool persist=false);
+  BOOL lcd_hasstatus();
+  void lcd_setstatus(const char* message, const BOOL persist=false);
   void lcd_setstatuspgm(const char* message, const uint8_t level=0);
   void status_printf(uint8_t level, const char *Status, ...);
   void lcd_setalertstatuspgm(const char* message);
   void lcd_reset_alert_level();
   void lcd_kill_screen();
   void kill_screen(const char* lcd_msg);
-  bool lcd_detected(void);
+  BOOL lcd_detected(void);
 
   #if HAS_BUZZER
     void lcd_buzz(long duration, uint16_t freq);
@@ -81,7 +81,7 @@
     extern volatile uint8_t buttons;  // The last-checked buttons in a bit array.
     void lcd_buttons_update();
     void lcd_quick_feedback();        // Audible feedback for a button click - could also be visual
-    void lcd_completion_feedback(const bool good=true);
+    void lcd_completion_feedback(const BOOL good=true);
 
     #if ENABLED(FILAMENT_CHANGE_FEATURE)
       void lcd_filament_change_show_message(const FilamentChangeMessage message);
@@ -97,7 +97,7 @@
     extern millis_t previous_lcd_status_ms;
   #endif
 
-  bool lcd_blink();
+  BOOL lcd_blink();
 
   #if ENABLED(REPRAPWORLD_KEYPAD) // is also ULTIPANEL and NEWPANEL
 
@@ -151,13 +151,13 @@
 #else //no LCD
   inline void lcd_update() {}
   inline void lcd_init() {}
-  inline bool lcd_hasstatus() { return false; }
-  inline void lcd_setstatus(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
+  inline BOOL lcd_hasstatus() { return false; }
+  inline void lcd_setstatus(const char* const message, const BOOL persist=false) { UNUSED(message); UNUSED(persist); }
   inline void lcd_setstatuspgm(const char* const message, const uint8_t level=0) { UNUSED(message); UNUSED(level); }
   inline void status_printf(uint8_t level, const char *status, ...) { UNUSED(level); UNUSED(status); }
   inline void lcd_buttons_update() {}
   inline void lcd_reset_alert_level() {}
-  inline bool lcd_detected() { return true; }
+  inline BOOL lcd_detected() { return true; }
 
   #define LCD_MESSAGEPGM(x) NOOP
   #define LCD_ALERTMESSAGEPGM(x) NOOP

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -264,7 +264,7 @@ static void lcd_implementation_init() {
   #endif
 
   #if ENABLED(SHOW_BOOTSCREEN)
-    static bool show_bootscreen = true;
+    static BOOL show_bootscreen = true;
 
     #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
       if (show_bootscreen) {
@@ -335,9 +335,9 @@ FORCE_INLINE void _draw_centered_temp(const int temp, const uint8_t x, const uin
 
 FORCE_INLINE void _draw_heater_status(const uint8_t x, const int8_t heater) {
   #if HAS_TEMP_BED
-    bool isBed = heater < 0;
+    BOOL isBed = heater < 0;
   #else
-    const bool isBed = false;
+    const BOOL isBed = false;
   #endif
 
   if (PAGE_UNDER(7))
@@ -360,7 +360,7 @@ FORCE_INLINE void _draw_heater_status(const uint8_t x, const int8_t heater) {
   }
 }
 
-FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink) {
+FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const BOOL blink) {
   if (blink)
     lcd_printPGM(pstr);
   else {
@@ -381,7 +381,7 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
 
 static void lcd_implementation_status_screen() {
 
-  bool blink = lcd_blink();
+  BOOL blink = lcd_blink();
 
   // Status Menu Font
   lcd_setFont(FONT_STATUSMENU);
@@ -498,7 +498,7 @@ static void lcd_implementation_status_screen() {
 
       char buffer[10];
       duration_t elapsed = print_job_timer.duration();
-      bool has_days = (elapsed.value > 60*60*24L);
+      BOOL has_days = (elapsed.value > 60*60*24L);
       uint8_t len = elapsed.toDigital(buffer, has_days);
       u8g.setPrintPos(SD_DURATION_X, 48);
       lcd_print(buffer);
@@ -669,7 +669,7 @@ static void lcd_implementation_status_screen() {
   #endif // FILAMENT_CHANGE_FEATURE
 
   // Set the colors for a menu item based on whether it is selected
-  static void lcd_implementation_mark_as_selected(const uint8_t row, const bool isSelected) {
+  static void lcd_implementation_mark_as_selected(const uint8_t row, const BOOL isSelected) {
     row_y1 = row * row_height + 1;
     row_y2 = row_y1 + row_height - 1;
 
@@ -694,7 +694,7 @@ static void lcd_implementation_status_screen() {
   }
 
   // Draw a static line of text in the same idiom as a menu item
-  static void lcd_implementation_drawmenu_static(const uint8_t row, const char* pstr, const bool center=true, const bool invert=false, const char* valstr=NULL) {
+  static void lcd_implementation_drawmenu_static(const uint8_t row, const char* pstr, const BOOL center=true, const BOOL invert=false, const char* valstr=NULL) {
 
     lcd_implementation_mark_as_selected(row, invert);
 
@@ -719,7 +719,7 @@ static void lcd_implementation_status_screen() {
   }
 
   // Draw a generic menu item
-  static void lcd_implementation_drawmenu_generic(const bool isSelected, const uint8_t row, const char* pstr, const char pre_char, const char post_char) {
+  static void lcd_implementation_drawmenu_generic(const BOOL isSelected, const uint8_t row, const char* pstr, const char pre_char, const char post_char) {
     UNUSED(pre_char);
 
     lcd_implementation_mark_as_selected(row, isSelected);
@@ -744,7 +744,7 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_function(sel, row, pstr, data) lcd_implementation_drawmenu_generic(sel, row, pstr, '>', ' ')
 
   // Draw a menu item with an editable value
-  static void _drawmenu_setting_edit_generic(const bool isSelected, const uint8_t row, const char* pstr, const char* const data, const bool pgm) {
+  static void _drawmenu_setting_edit_generic(const BOOL isSelected, const uint8_t row, const char* pstr, const char* const data, const BOOL pgm) {
 
     lcd_implementation_mark_as_selected(row, isSelected);
 
@@ -776,7 +776,7 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_float51(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr51sign(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_float62(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr62rj(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_long5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_BOOL(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   #define lcd_implementation_drawmenu_setting_edit_callback_int3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, itostr3(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_callback_float3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr3(*(data)))
@@ -787,7 +787,7 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_callback_float51(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr51sign(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_callback_float62(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr62rj(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_callback_long5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_callback_BOOL(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* const pstr, const char* const value=NULL) {
     const uint8_t labellen = lcd_strlen_P(pstr),
@@ -834,7 +834,7 @@ static void lcd_implementation_status_screen() {
 
   #if ENABLED(SDSUPPORT)
 
-    static void _drawmenu_sd(const bool isSelected, const uint8_t row, const char* const pstr, const char* filename, char* const longFilename, const bool isDir) {
+    static void _drawmenu_sd(const BOOL isSelected, const uint8_t row, const char* const pstr, const char* filename, char* const longFilename, const BOOL isDir) {
       UNUSED(pstr);
 
       lcd_implementation_mark_as_selected(row, isSelected);

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -195,7 +195,7 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
 
 static void lcd_set_custom_characters(
   #if ENABLED(LCD_PROGRESS_BAR)
-    const bool info_screen_charset = true
+    const BOOL info_screen_charset = true
   #endif
 ) {
   static byte bedTemp[8] = {
@@ -316,7 +316,7 @@ static void lcd_set_custom_characters(
         B10101,
         B00000
       } };
-      static bool char_mode = false;
+      static BOOL char_mode = false;
       if (info_screen_charset != char_mode) {
         char_mode = info_screen_charset;
         if (info_screen_charset) { // Progress bar characters for info screen
@@ -341,7 +341,7 @@ static void lcd_set_custom_characters(
 
 static void lcd_implementation_init(
   #if ENABLED(LCD_PROGRESS_BAR)
-    const bool info_screen_charset = true
+    const BOOL info_screen_charset = true
   #endif
 ) {
 
@@ -556,7 +556,7 @@ void lcd_kill_screen() {
   lcd_printPGM(PSTR(MSG_PLEASE_RESET));
 }
 
-FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink) {
+FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const BOOL blink) {
   if (blink)
     lcd_printPGM(pstr);
   else {
@@ -685,7 +685,7 @@ static void lcd_implementation_status_screen() {
 
   #if LCD_HEIGHT > 2
 
-    bool blink = lcd_blink();
+    BOOL blink = lcd_blink();
 
     #if LCD_WIDTH < 20
 
@@ -777,7 +777,7 @@ static void lcd_implementation_status_screen() {
 
     // Draw the progress bar if the message has shown long enough
     // or if there is no message set.
-    if (card.isFileOpen() && ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0])
+    if (card.isFileOpen() && (ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0]))
       return lcd_draw_progress_bar(card.percentDone());
 
   #elif ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
@@ -814,7 +814,7 @@ static void lcd_implementation_status_screen() {
 
   #endif // FILAMENT_CHANGE_FEATURE
 
-  static void lcd_implementation_drawmenu_static(const uint8_t row, const char* pstr, const bool center=true, const bool invert=false, const char *valstr=NULL) {
+  static void lcd_implementation_drawmenu_static(const uint8_t row, const char* pstr, const BOOL center=true, const BOOL invert=false, const char *valstr=NULL) {
     UNUSED(invert);
     char c;
     int8_t n = LCD_WIDTH;
@@ -834,7 +834,7 @@ static void lcd_implementation_status_screen() {
     while (n-- > 0) lcd.print(' ');
   }
 
-  static void lcd_implementation_drawmenu_generic(const bool sel, const uint8_t row, const char* pstr, const char pre_char, const char post_char) {
+  static void lcd_implementation_drawmenu_generic(const BOOL sel, const uint8_t row, const char* pstr, const char pre_char, const char post_char) {
     char c;
     uint8_t n = LCD_WIDTH - 2;
     lcd.setCursor(0, row);
@@ -847,7 +847,7 @@ static void lcd_implementation_status_screen() {
     lcd.print(post_char);
   }
 
-  static void lcd_implementation_drawmenu_setting_edit_generic(const bool sel, const uint8_t row, const char* pstr, const char pre_char, const char* const data) {
+  static void lcd_implementation_drawmenu_setting_edit_generic(const BOOL sel, const uint8_t row, const char* pstr, const char pre_char, const char* const data) {
     char c;
     uint8_t n = LCD_WIDTH - 2 - lcd_strlen(data);
     lcd.setCursor(0, row);
@@ -860,7 +860,7 @@ static void lcd_implementation_status_screen() {
     while (n--) lcd.print(' ');
     lcd_print(data);
   }
-  static void lcd_implementation_drawmenu_setting_edit_generic_P(const bool sel, const uint8_t row, const char* pstr, const char pre_char, const char* const data) {
+  static void lcd_implementation_drawmenu_setting_edit_generic_P(const BOOL sel, const uint8_t row, const char* pstr, const char pre_char, const char* const data) {
     char c;
     uint8_t n = LCD_WIDTH - 2 - lcd_strlen_P(data);
     lcd.setCursor(0, row);
@@ -883,7 +883,7 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_float51(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr51sign(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_float62(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr62rj(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_long5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_BOOL(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   //Add version for callback functions
   #define lcd_implementation_drawmenu_setting_edit_callback_int3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', itostr3(*(data)))
@@ -895,7 +895,7 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_callback_float51(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr51sign(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_callback_float62(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr62rj(*(data)))
   #define lcd_implementation_drawmenu_setting_edit_callback_long5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_callback_BOOL(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* pstr, const char* const value=NULL) {
     lcd.setCursor(1, 1);
@@ -909,7 +909,7 @@ static void lcd_implementation_status_screen() {
 
   #if ENABLED(SDSUPPORT)
 
-    static void lcd_implementation_drawmenu_sd(const bool sel, const uint8_t row, const char* const pstr, const char* filename, char* const longFilename, const uint8_t concat, const char post_char) {
+    static void lcd_implementation_drawmenu_sd(const BOOL sel, const uint8_t row, const char* const pstr, const char* filename, char* const longFilename, const uint8_t concat, const char post_char) {
       UNUSED(pstr);
       char c;
       uint8_t n = LCD_WIDTH - concat;
@@ -927,11 +927,11 @@ static void lcd_implementation_status_screen() {
       lcd.print(post_char);
     }
 
-    static void lcd_implementation_drawmenu_sdfile(const bool sel, const uint8_t row, const char* pstr, const char* filename, char* const longFilename) {
+    static void lcd_implementation_drawmenu_sdfile(const BOOL sel, const uint8_t row, const char* pstr, const char* filename, char* const longFilename) {
       lcd_implementation_drawmenu_sd(sel, row, pstr, filename, longFilename, 2, ' ');
     }
 
-    static void lcd_implementation_drawmenu_sddirectory(const bool sel, const uint8_t row, const char* pstr, const char* filename, char* const longFilename) {
+    static void lcd_implementation_drawmenu_sddirectory(const BOOL sel, const uint8_t row, const char* pstr, const char* filename, char* const longFilename) {
       lcd_implementation_drawmenu_sd(sel, row, pstr, filename, longFilename, 2, LCD_STR_FOLDER[0]);
     }
 

--- a/Marlin/utf_mapper.h
+++ b/Marlin/utf_mapper.h
@@ -152,7 +152,7 @@
 
   char charset_mapper(const char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_c2 = false;
+    static BOOL seen_c2 = false;
     uint8_t d = c;
     if ( d >= 0x80u ) { // UTF-8 handling
       if ( (d >= 0xc0u) && (!seen_c2) ) {
@@ -185,9 +185,9 @@
 
   char charset_mapper(const char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_c2 = false;
-    static bool seen_c4 = false;
-    static bool seen_c5 = false;
+    static BOOL seen_c2 = false;
+    static BOOL seen_c4 = false;
+    static BOOL seen_c5 = false;
     uint8_t d = c;
     if ( d >= 0x80u ) { // UTF-8 handling
            if ( d == 0xc4u ) {seen_c4 = true; return 0;}
@@ -238,7 +238,7 @@
 
   char charset_mapper(const char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_ce = false;
+    static BOOL seen_ce = false;
     uint8_t d = c;
     if ( d >= 0x80 ) { // UTF-8 handling
       if ( (d >= 0xc0) && (!seen_ce) ) {
@@ -269,7 +269,7 @@
 
   char charset_mapper(const char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_ce = false;
+    static BOOL seen_ce = false;
     uint8_t d = c;
     if ( d >= 0x80 ) { // UTF-8 handling
       if ( (d >= 0xc0) && (!seen_ce) ) {
@@ -302,7 +302,7 @@
     // it is a Russian alphabet translation
     // except 0401 --> 0xa2 = Ё, 0451 --> 0xb5 = ё
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_d5 = false;
+    static BOOL seen_d5 = false;
     uint8_t d = c;
     if (d >= 0x80) { // UTF-8 handling
       if (d >= 0xd0 && !seen_d5) {
@@ -337,7 +337,7 @@
 
   char charset_mapper(const char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_d5 = false;
+    static BOOL seen_d5 = false;
     uint8_t d = c;
     if (d >= 0x80u) { // UTF-8 handling
       if (d >= 0xd0u && !seen_d5) {
@@ -368,8 +368,8 @@
 
   char charset_mapper(const char c) {
     static uint8_t utf_hi_char; // UTF-8 high part
-    static bool seen_e3 = false;
-    static bool seen_82_83 = false;
+    static BOOL seen_e3 = false;
+    static BOOL seen_82_83 = false;
     uint8_t d = c;
     if (d >= 0x80) { // UTF-8 handling
       if (d == 0xe3 && !seen_e3) {


### PR DESCRIPTION
This PR is for demonstration purposes, and still needs to be tested for its performance benefits. However, on my i3 with character display, sd card, mesh bed leveling, and a few other features enabled, this small change resulted in a PROGMEM savings of 19K, at an additional cost of 28 bytes of SRAM.

- Added `typdef unsigned int BOOL` to `types.h`
- All instances of `bool` have been replaced by `BOOL`