### PR TITLE
Fix broken auto#.g, some other regressions

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -36,24 +36,27 @@
   #include "UBL.h"
   #include "ultralcd.h"
 
-  #define EXTRUSION_MULTIPLIER 1.0    // This is too much clutter for the main Configuration.h file  But
-  #define RETRACTION_MULTIPLIER 1.0   // some user have expressed an interest in being able to customize
-  #define NOZZLE 0.3                  // these numbers for their printer so they don't need to type all
-  #define FILAMENT 1.75               // the options every time they do a Mesh Validation Print.
+  #define EXTRUSION_MULTIPLIER 1.0
+  #define RETRACTION_MULTIPLIER 1.0
+  #define NOZZLE 0.3
+  #define FILAMENT 1.75
   #define LAYER_HEIGHT 0.2
-  #define PRIME_LENGTH 10.0           // So, we put these number in an easy to find and change place.
+  #define PRIME_LENGTH 10.0
   #define BED_TEMP 60.0
   #define HOTEND_TEMP 205.0
   #define OOZE_AMOUNT 0.3
 
   #define SIZE_OF_INTERSECTION_CIRCLES 5
-  #define SIZE_OF_CROSSHAIRS 3 // crosshairs inside the circle.  This number should be
-                               // less than SIZE_OR_INTERSECTION_CIRCLES
+  #define SIZE_OF_CROSSHAIRS 3
+
+  #if SIZE_OF_CROSSHAIRS >= SIZE_OF_INTERSECTION_CIRCLES
+    #error "SIZE_OF_CROSSHAIRS must be less than SIZE_OF_INTERSECTION_CIRCLES."
+  #endif
 
   /**
-   *   Roxy's G26 Mesh Validation Tool
+   *   G26 Mesh Validation Tool
    *
-   *   G26 Is a Mesh Validation Tool intended to provide support for the Marlin Unified Bed Leveling System.
+   *   G26 is a Mesh Validation Tool intended to provide support for the Marlin Unified Bed Leveling System.
    *   In order to fully utilize and benefit from the Marlin Unified Bed Leveling System an accurate Mesh must
    *   be defined.  G29 is designed to allow the user to quickly validate the correctness of her Mesh.  It will
    *   first heat the bed and nozzle. It will then print lines and circles along the Mesh Cell boundaries and
@@ -118,7 +121,7 @@
   //#if ENABLED(ULTRA_LCD)
     extern char lcd_status_message[];
   //#endif
-  extern float destination[];
+  extern float destination[XYZE];
   extern void set_destination_to_current();
   extern void set_current_to_destination();
   extern float code_value_float();

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -243,8 +243,8 @@ extern bool Running;
 inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }
 
-bool enqueue_and_echo_command(const char* cmd, bool say_ok=false); //put a single ASCII command at the end of the current buffer or return false when it is full
-void enqueue_and_echo_commands_P(const char* cmd); //put one or many ASCII commands at the end of the current buffer, read from flash
+bool enqueue_and_echo_command(const char* cmd, bool say_ok=false); // Add a single command to the end of the buffer. Return false on failure.
+void enqueue_and_echo_commands_P(const char * const cmd);          // Set one or more commands to be prioritized over the next Serial/SD command.
 void clear_command_queue();
 
 extern millis_t previous_cmd_ms;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -796,39 +796,6 @@ inline void echo_command(const char* cmd) {
 }
 
 /**
- * Shove a command in RAM to the front of the main command queue.
- * Return true if the command is successfully added.
- */
-inline bool _shovecommand(const char* cmd, bool say_ok=false) {
-  if (*cmd == ';' || commands_in_queue >= BUFSIZE) return false;
-  cmd_queue_index_r = (cmd_queue_index_r + BUFSIZE - 1) % BUFSIZE; // Index of the previous slot
-  commands_in_queue++;
-  strcpy(command_queue[cmd_queue_index_r], cmd);
-  send_ok[cmd_queue_index_r] = say_ok;
-  return true;
-}
-
-/**
- * Shove a command to the front of the queue with Serial Echo
- * Return true if the command is successfully added.
- */
-bool shove_and_echo_command(const char* cmd, bool say_ok=false) {
-  if (_shovecommand(cmd, say_ok)) {
-    echo_command(cmd);
-    return true;
-  }
-  return false;
-}
-
-/**
- * Shove a command onto the front of the queue,
- * and don't return until successful.
- */
-void shove_and_echo_command_now(const char* cmd) {
-  while (!shove_and_echo_command(cmd)) idle();
-}
-
-/**
  * Inject the next "immediate" command, when possible, onto the front of the queue.
  * Return true if any immediate commands remain to inject.
  */
@@ -840,7 +807,7 @@ static bool drain_injected_commands_P() {
     cmd[sizeof(cmd) - 1] = '\0';
     while ((c = cmd[i]) && c != '\n') i++; // find the end of this gcode command
     cmd[i] = '\0';
-    if (shove_and_echo_command(cmd))       // success?
+    if (enqueue_and_echo_command(cmd))     // success?
       injected_commands_P = c ? injected_commands_P + i + 1 : NULL; // next command or done
   }
   return (injected_commands_P != NULL);    // return whether any more remain

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -150,6 +150,8 @@
   #error "ABL_GRID_POINTS is now ABL_GRID_MAX_POINTS_X and ABL_GRID_MAX_POINTS_Y. Please update your configuration."
 #elif defined(ABL_GRID_POINTS_X) || defined(ABL_GRID_POINTS_Y)
   #error "ABL_GRID_POINTS_[XY] is now ABL_GRID_MAX_POINTS_[XY]. Please update your configuration."
+#elif defined(UBL_MESH_EDIT_ENABLED)
+  #error "UBL_MESH_EDIT_ENABLED is now UBL_G26_MESH_EDITING. Please update your configuration."
 #elif defined(BEEPER)
   #error "BEEPER is now BEEPER_PIN. Please update your pins definitions."
 #elif defined(SDCARDDETECT)

--- a/Marlin/UBL_G29.cpp
+++ b/Marlin/UBL_G29.cpp
@@ -22,7 +22,7 @@
 
 #include "MarlinConfig.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(UBL_G26_MESH_EDITING)
+#if ENABLED(AUTO_BED_LEVELING_UBL)
   //#include "vector_3.h"
   //#include "qr_solve.h"
 
@@ -1048,7 +1048,7 @@
 
     /*
     if (code_seen('M')) {     // Check if a map type was specified
-      map_type = code_has_value() ? code_value_int() : 0; 
+      map_type = code_has_value() ? code_value_int() : 0;
       if (!WITHIN(map_type, 0, 1)) {
         SERIAL_PROTOCOLLNPGM("Invalid map type.\n");
         return UBL_ERR;
@@ -1371,7 +1371,7 @@
       do_blocking_move_to_xy(LOGICAL_X_POSITION(rawx), LOGICAL_Y_POSITION(rawy));
 
       float new_z = ubl.z_values[location.x_index][location.y_index];
-      
+
       round_off = (int32_t)(new_z * 1000.0);    // we chop off the last digits just to be clean. We are rounding to the
       new_z = float(round_off) / 1000.0;
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -1017,7 +1017,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -1047,7 +1047,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -1042,7 +1042,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -918,7 +918,7 @@
   #define UBL_PROBE_PT_2_Y 20
   #define UBL_PROBE_PT_3_X 180
   #define UBL_PROBE_PT_3_Y 20
-  #define UBL_MESH_EDIT_ENABLED     // Enable G26 mesh editing
+  #define UBL_G26_MESH_EDITING     // Enable G26 mesh editing
 
 #elif ENABLED(MESH_BED_LEVELING)
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration_adv.h
@@ -1039,7 +1039,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -1036,7 +1036,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -1036,7 +1036,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -1041,7 +1041,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -1036,7 +1036,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -1034,7 +1034,7 @@
 #define I2C_SLAVE_ADDRESS  0 // Set a value from 8 to 127 to act as a slave
 
 /**
- * Add M43 command for pins info and testing
+ * Add M43, M44 and M45 commands for pins info and testing
  */
 //#define PINS_DEBUGGING
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1141,16 +1141,16 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
     // Limit acceleration per axis
     if (block->step_event_count <= cutoff_long) {
-      LIMIT_ACCEL_LONG(X_AXIS,0);
-      LIMIT_ACCEL_LONG(Y_AXIS,0);
-      LIMIT_ACCEL_LONG(Z_AXIS,0);
-      LIMIT_ACCEL_LONG(E_AXIS,ACCEL_IDX);
+      LIMIT_ACCEL_LONG(X_AXIS, 0);
+      LIMIT_ACCEL_LONG(Y_AXIS, 0);
+      LIMIT_ACCEL_LONG(Z_AXIS, 0);
+      LIMIT_ACCEL_LONG(E_AXIS, ACCEL_IDX);
     }
     else {
-      LIMIT_ACCEL_FLOAT(X_AXIS,0);
-      LIMIT_ACCEL_FLOAT(Y_AXIS,0);
-      LIMIT_ACCEL_FLOAT(Z_AXIS,0);
-      LIMIT_ACCEL_FLOAT(E_AXIS,ACCEL_IDX);
+      LIMIT_ACCEL_FLOAT(X_AXIS, 0);
+      LIMIT_ACCEL_FLOAT(Y_AXIS, 0);
+      LIMIT_ACCEL_FLOAT(Z_AXIS, 0);
+      LIMIT_ACCEL_FLOAT(E_AXIS, ACCEL_IDX);
     }
   }
   block->acceleration_steps_per_s2 = accel;
@@ -1256,6 +1256,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
         v_exit *= v_factor;
         v_entry *= v_factor;
       }
+
       // Calculate jerk depending on whether the axis is coasting in the same direction or reversing.
       const float jerk = (v_exit > v_entry)
           ? //                                  coasting             axis reversal


### PR DESCRIPTION
Address some regressions:

- Command injection to the front of the queue is great as long as all injection is done consistently. But there are a few cases where commands are injected to the buffer directly, bypassing the injector, and this will cause them to be out of order. Thus for `auto#.g` handling, `M24` ends up ahead of `M23`. So this concept is reverted until the immediate command injector can be revisited.

- Add a sanity check for UBL's `G26` config option, which was renamed so it doesn't imply the original meaning, which was to disable both `G26` and `G29`. (There may be cases where users want `G29` but not `G26`.)

This branch will gain some additional fixes soon, as I give all recent commits a thorough vetting, but these initial fixes will be merged right away.