### PR TITLE
Patch .gitattributes till UBL line endings are fixed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,7 +3,7 @@
 
 # Files with Unix line endings
 *.c   text eol=lf
-*.cpp text eol=lf
+# *.cpp text eol=lf
 *.h   text eol=lf
 *.ino text eol=lf
 *.py  text eol=lf


### PR DESCRIPTION
Apparently the line-endings of `UBL_G29.cpp` have long been Windows-style. This PR disables line-ending correction for `.cpp` files until after this file has been patched.