### PR TITLE
M110 - set line number to current (RepetierHost)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1007,6 +1007,7 @@ inline void get_serial_commands() {
         if (M110) {
           char* n2pos = strchr(command + 4, 'N');
           if (n2pos) npos = n2pos;
+          else { gcode_LastN = strtol(npos + 1, NULL, 10); return;}
         }
 
         gcode_N = strtol(npos + 1, NULL, 10);


### PR DESCRIPTION
RepetierHost sends "N1 M110*34" immediately after sending M999.  

Currently Marlin ignores the "N1 M110*34".  The result is Marlin appears unresponsive for a variable amount of time.  This is because Marlin is waiting for its old line number to be sent but RepetierHost starts sending at line number 2.  Marlin doesn't respond until enough temperature requests have been sent for the RepetierHost line number to increment to the number Marlin is looking for.

The solution I found was to always respond to a M110 command.  If the "N" parameter is present then **gcode_N** is set to the number (no change).  If "N" isn't present then **gcode_LastN** is set to the sent line number.