### PR TITLE
BABYSTEPPING updates Z probe offset

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -317,6 +317,7 @@ float code_value_temp_diff();
 
 #if HAS_BED_PROBE
   extern float zprobe_zoffset;
+  void refresh_zprobe_zoffset(const bool no_babystep=false);
   #define DEPLOY_PROBE() set_probe_deployed(true)
   #define STOW_PROBE() set_probe_deployed(false)
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7984,7 +7984,7 @@ inline void gcode_M503() {
           if (diff) {
             for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
               for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-                bed_level_grid[x][y] += diff;
+                bed_level_grid[x][y] -= diff;
           }
           #if ENABLED(ABL_BILINEAR_SUBDIVISION)
             bed_level_virt_interpolate();
@@ -7993,7 +7993,7 @@ inline void gcode_M503() {
 
         #if ENABLED(BABYSTEPPING)
           if (planner.abl_enabled)
-            thermalManager.babystep_axis(Z_AXIS, lround((value - zprobe_zoffset) * planner.axis_steps_per_mm[Z_AXIS]));
+            thermalManager.babystep_axis(Z_AXIS, lround(-(value - zprobe_zoffset) * planner.axis_steps_per_mm[Z_AXIS]));
         #endif
 
         zprobe_zoffset = value;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7991,6 +7991,11 @@ inline void gcode_M503() {
           #endif
         #endif
 
+        #if ENABLED(BABYSTEPPING)
+          if (planner.abl_enabled)
+            thermalManager.babystep_axis(Z_AXIS, lround((value - zprobe_zoffset) * planner.axis_steps_per_mm[Z_AXIS]));
+        #endif
+
         zprobe_zoffset = value;
         SERIAL_ECHO(zprobe_zoffset);
       }

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -216,6 +216,10 @@ void MarlinSettings::postprocess() {
       //#endif
     );
   #endif
+
+  #if HAS_BED_PROBE
+    refresh_zprobe_zoffset();
+  #endif
 }
 
 #if ENABLED(EEPROM_SETTINGS)
@@ -344,7 +348,7 @@ void MarlinSettings::postprocess() {
     #endif // MESH_BED_LEVELING
 
     #if !HAS_BED_PROBE
-      float zprobe_zoffset = 0;
+      const float zprobe_zoffset = 0;
     #endif
     EEPROM_WRITE(zprobe_zoffset);
 
@@ -685,7 +689,7 @@ void MarlinSettings::postprocess() {
       #endif // MESH_BED_LEVELING
 
       #if !HAS_BED_PROBE
-        float zprobe_zoffset = 0;
+        float zprobe_zoffset;
       #endif
       EEPROM_READ(zprobe_zoffset);
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -863,11 +863,12 @@ void kill_screen(const char* lcd_msg) {
 
           const float new_zoffset = zprobe_zoffset + steps_to_mm[Z_AXIS] * babystep_increment;
           if (WITHIN(new_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX)) {
-            
+
             if (planner.abl_enabled)
               thermalManager.babystep_axis(Z_AXIS, babystep_increment);
-      
+
             zprobe_zoffset = new_zoffset;
+            refresh_zprobe_zoffset(true);
             lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
           }
         }
@@ -2412,7 +2413,7 @@ void kill_screen(const char* lcd_msg) {
       #if ENABLED(BABYSTEPPING)
         MENU_ITEM(submenu, MSG_ZPROBE_ZOFFSET, lcd_babystep_zoffset);
       #else
-        MENU_ITEM_EDIT(float32, MSG_ZPROBE_ZOFFSET, &zprobe_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+        MENU_ITEM_EDIT_CALLBACK(float32, MSG_ZPROBE_ZOFFSET, &zprobe_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX, refresh_zprobe_zoffset);
       #endif
     #endif
     // Manual bed leveling, Bed Z:


### PR DESCRIPTION
Rebase and adjustment of #5821

- With a bed probe `BABYSTEPPING` behavior changes, so that:
  - Babystepping the Z axis now modifies `zprobe_zoffset` at the same time.
  - Setting the Z probe offset with the `M851` command causes the Z axis to immediately move (via babystepping) in accordance with the change. The usual limitation on allowed values applies.

The result of this babystepping can be saved to EEPROM.

I like this change. It makes sense in that moving the Z axis while keeping the Z coordinate unchanged (as babystepping does) should be balanced by one of the factors that affects the coordinate space, hence retaining the adjustment. The Z probe offset makes sense.

Without a Z probe, including with MBL, it makes sense to retain it as a change to `home_offset[Z_AXIS]`, which can also be saved to EEPROM.