### PR TITLE
Fix bilinear levelling z offset

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1346,7 +1346,7 @@ bool get_target_extruder_from_command(int code) {
    * at the same positions relative to the machine.
    */
   void update_software_endstops(const AxisEnum axis) {
-    const float offs = workspace_offset[axis] = LOGICAL_POSITION(0, axis);
+    const float offs = workspace_offset[axis] = home_offset[axis] + position_shift[axis];
 
     #if ENABLED(DUAL_X_CARRIAGE)
       if (axis == X_AXIS) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4300,7 +4300,7 @@ inline void gcode_G28() {
 
         #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-          bed_level_grid[xCount][yCount] = measured_z + zoffset;
+          bed_level_grid[xCount][yCount] = measured_z;
 
         #elif ENABLED(AUTO_BED_LEVELING_3POINT)
 
@@ -4472,7 +4472,7 @@ inline void gcode_G28() {
 
             #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-              bed_level_grid[xCount][yCount] = measured_z + zoffset;
+              bed_level_grid[xCount][yCount] = measured_z;
 
             #endif
 


### PR DESCRIPTION
Since run_probe was altered to return the probe Z position rather than the nozzle Z position bilinear levelling has been broken because the Z-offset has been applied twice - once in the run_probe function, and then again in the G29 code for bilinear levelling. This results in Z0 being below the bed when the Z-offset is negative.

On the assumption that the change to run_probe is needed elsewhere, this PR removes the extra addition of the Z offset in the G29 code for bilinear levelling.