### PR TITLE
MCP4728 consistency ... Finish name change

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -417,7 +417,7 @@
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 #define DIGIPOT_MOTOR_CURRENT {150, 170, 180, 190, 180} // Values 0-255 (bq ZUM Mega 3D (default): X = 150 [~1.17A]; Y = 170 [~1.33A]; Z = 180 [~1.41A]; E0 = 190 [~1.49A])
 
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -429,7 +429,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -424,7 +424,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration_adv.h
@@ -418,7 +418,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -418,7 +418,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -418,7 +418,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -423,7 +423,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -418,7 +418,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -416,7 +416,7 @@
  */
 //#define PWM_MOTOR_CURRENT {1300, 1300, 1250} // Values in milliamps
 //#define DIGIPOT_MOTOR_CURRENT {135,135,135,135,135} // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
-//#define DAC_STEPPER_DFLT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
+//#define DAC_MOTOR_CURRENT_DEFAULT { 70, 80, 90, 80 } // Default drive percent - X, Y, Z, E axis
 
 /*  5DPRINT & AZTEEG_X3_PRO */
 //#define DIGIPOT_I2C  // uncomment to enable


### PR DESCRIPTION
DAC_STEPPER_DFLT wasn't changed to DAC_MOTOR_CURRENT_DEFAULT in all places on PR #6124