### PR TITLE
Make ADC sensor reading frequency adjustable

### DIFF
--- a/Marlin/enum.h
+++ b/Marlin/enum.h
@@ -91,28 +91,6 @@ enum EndstopEnum {
   Z2_MAX
 };
 
-/**
- * Temperature
- * Stages in the ISR loop
- */
-enum TempState {
-  PrepareTemp_0,
-  MeasureTemp_0,
-  PrepareTemp_BED,
-  MeasureTemp_BED,
-  PrepareTemp_1,
-  MeasureTemp_1,
-  PrepareTemp_2,
-  MeasureTemp_2,
-  PrepareTemp_3,
-  MeasureTemp_3,
-  PrepareTemp_4,
-  MeasureTemp_4,
-  Prepare_FILWIDTH,
-  Measure_FILWIDTH,
-  StartupDelay // Startup, delay initial temp reading a tiny bit so the hardware can settle
-};
-
 #if ENABLED(EMERGENCY_PARSER)
   enum e_parser_state {
     state_RESET,

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -50,6 +50,49 @@
   #define EXTRUDER_IDX  active_extruder
 #endif
 
+/**
+ * States for ADC reading in the ISR
+ */
+enum ADCSensorState {
+  #if HAS_TEMP_0
+    PrepareTemp_0,
+    MeasureTemp_0,
+  #endif
+  #if HAS_TEMP_1
+    PrepareTemp_1,
+    MeasureTemp_1,
+  #endif
+  #if HAS_TEMP_2
+    PrepareTemp_2,
+    MeasureTemp_2,
+  #endif
+  #if HAS_TEMP_3
+    PrepareTemp_3,
+    MeasureTemp_3,
+  #endif
+  #if HAS_TEMP_4
+    PrepareTemp_4,
+    MeasureTemp_4,
+  #endif
+  #if HAS_TEMP_BED
+    PrepareTemp_BED,
+    MeasureTemp_BED,
+  #endif
+  #if ENABLED(FILAMENT_WIDTH_SENSOR)
+    Prepare_FILWIDTH,
+    Measure_FILWIDTH,
+  #endif
+  SensorsReady, // Temperatures ready. Delay the next round of readings to let ADC pins settle.
+  StartupDelay  // Startup, delay initial temp reading a tiny bit so the hardware can settle
+};
+
+// Minimum number of Temperature::ISR loops between sensor readings.
+// Multiplied by 16 (OVERSAMPLENR) to obtain the total time to
+// get all oversampled sensor readings
+#define MIN_ADC_ISR_LOOPS 10
+
+#define ACTUAL_ADC_SAMPLES max(int(MIN_ADC_ISR_LOOPS), int(SensorsReady))
+
 class Temperature {
 
   public:
@@ -74,7 +117,7 @@ class Temperature {
     #endif
 
     #if ENABLED(PIDTEMP) || ENABLED(PIDTEMPBED)
-      #define PID_dT ((OVERSAMPLENR * 12.0)/(F_CPU / 64.0 / 256.0))
+      #define PID_dT ((OVERSAMPLENR * float(ACTUAL_ADC_SAMPLES)) / (F_CPU / 64.0 / 256.0))
     #endif
 
     #if ENABLED(PIDTEMP)


### PR DESCRIPTION
**Background:** Currently the total amount of time between temperature updates will fluctuate depending on the number of sensors we add to the code. At present, with 5 hot-ends supported, the delay is 14 calls of the ISR times 16 samples, or every 224th call of the ISR. This yields a sensor update frequency of 4.35Hz.

This PR adds a (hidden) option to impose a minimum delay between updates of the (converted) sensor readings, while also giving the option to increase or reduce the frequency of these updates. For a setup with 1 extruder and heated bed, the fastest possible sensor update frequency would be 15.26Hz, or 30.5Hz with no heated bed. By default (with `MIN_ADC_ISR_INTERVAL` set to 10) the sensor update rate will be 6.1Hz.

The rate of lcd button updates is made more easily adjustable also. The lcd button update frequency is kept as before, at 488Hz. The rate can probably be reduced to 325Hz or 244Hz, which would be a slight optimization to the temperature ISR.