### PR TITLE
Configuration.h - Clarify role of XYZ_MIN_POS and XYZ_MAX_POS

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -770,7 +770,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -770,20 +770,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 200
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 200    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -769,20 +769,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 435
-#define Y_MAX_POS 270
-#define Z_MAX_POS 400
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 435    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 270    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 400    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -769,7 +769,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -753,7 +753,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -753,20 +753,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 255
-#define Y_MAX_POS 205
-#define Z_MAX_POS 235
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 255    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 205    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 235    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -753,7 +753,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -753,20 +753,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 255
-#define Y_MAX_POS 205
-#define Z_MAX_POS 235
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 255    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 205    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 235    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -761,7 +761,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -761,20 +761,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 215
-#define Y_MAX_POS 210
-#define Z_MAX_POS 180
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 215    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 210    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 180    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -764,7 +764,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -764,20 +764,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 210
-#define Y_MAX_POS 297
-#define Z_MAX_POS 210
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 210    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 297    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 210    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -798,7 +798,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -798,20 +798,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 200
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 200    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -770,7 +770,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 20
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -770,20 +770,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 20
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 190
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 20     // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 190    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -770,7 +770,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 20
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -770,20 +770,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 20
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 190
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 20     // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 190    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -770,7 +770,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -770,20 +770,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 200
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 200    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -769,7 +769,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -769,20 +769,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 254  // RigidBot regular is 254mm, RigitBot Big is 406mm
-#define Y_MAX_POS 248  // RigidBot regular is 248mm, RigitBot Big is 304mm
-#define Z_MAX_POS 254  // RigidBot regular and Big are 254mm
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0    // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0    // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0    // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 254  // RigidBot regular is 254mm, RigitBot Big is 406mm    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 248  // RigidBot regular is 248mm, RigitBot Big is 304mm    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 254  // RigidBot regular and Big are 254mm                  // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -785,20 +785,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS MANUAL_Z_HOME_POS
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 225
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0                    // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0                    // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS MANUAL_Z_HOME_POS    // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200                  // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200                  // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 225                  // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -785,7 +785,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS MANUAL_Z_HOME_POS

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -790,7 +790,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -790,20 +790,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 298
-#define Y_MAX_POS 275
-#define Z_MAX_POS 250
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 298    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 275    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 250    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -820,7 +820,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -820,24 +820,17 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
 // Tinyboy2: 100mm are marketed, actual length between endstop and end of rail is 98mm
-#define X_MAX_POS 98
-#define Y_MAX_POS 98
+#define X_MAX_POS 98     // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 98     // G28 sets Y to this when homing in +Y direction
 #if ENABLED(TB2_L10)
-  #define Z_MAX_POS 98
+  #define Z_MAX_POS 98   // G28 sets Z to this when homing in +Z direction
 #else
-  #define Z_MAX_POS 158
+  #define Z_MAX_POS 158  // G28 sets Z to this when homing in +Z direction
 #endif
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -761,20 +761,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 297
-#define Y_MAX_POS 210
-#define Z_MAX_POS 200
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 297    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 210    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 200    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -761,7 +761,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -770,7 +770,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -770,20 +770,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 200
-#define Y_MAX_POS 200
-#define Z_MAX_POS 200
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 200    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
@@ -877,19 +877,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
+// Travel limits after homing (units are in mm)
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0
-#define X_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Y_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Z_MAX_POS MANUAL_Z_HOME_POS
+#define X_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS MANUAL_Z_HOME_POS         // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/flsun_kossel_mini/Configuration.h
@@ -877,7 +877,13 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -861,7 +861,13 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -861,19 +861,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
+// Travel limits after homing (units are in mm)
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0
-#define X_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Y_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Z_MAX_POS MANUAL_Z_HOME_POS
+#define X_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS MANUAL_Z_HOME_POS         // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -856,19 +856,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
+// Travel limits after homing (units are in mm)
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0
-#define X_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Y_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Z_MAX_POS MANUAL_Z_HOME_POS
+#define X_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS MANUAL_Z_HOME_POS         // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -856,7 +856,13 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -863,19 +863,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
+// Travel limits after homing (units are in mm)
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0
-#define X_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Y_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Z_MAX_POS MANUAL_Z_HOME_POS
+#define X_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS MANUAL_Z_HOME_POS         // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -808,7 +808,7 @@
  */
 #define Z_CLEARANCE_DEPLOY_PROBE   100 // Z Clearance for Deploy/Stow
 #define Z_CLEARANCE_BETWEEN_PROBES   5 // Z Clearance between probe points
- 
+
 /* For M851 give a range for adjusting the Z probe offset */
 
 #define Z_PROBE_OFFSET_RANGE_MIN -15
@@ -863,7 +863,13 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -872,7 +872,13 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -872,19 +872,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
+// Travel limits after homing (units are in mm)
 #define X_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Y_MIN_POS -(DELTA_PRINTABLE_RADIUS)
 #define Z_MIN_POS 0
-#define X_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Y_MAX_POS DELTA_PRINTABLE_RADIUS
-#define Z_MAX_POS MANUAL_Z_HOME_POS
+#define X_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS DELTA_PRINTABLE_RADIUS    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS MANUAL_Z_HOME_POS         // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 //#define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -773,7 +773,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -773,20 +773,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 110
-#define Y_MAX_POS 150
-#define Z_MAX_POS 86
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 110    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 150    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 86     // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -766,20 +766,13 @@
 
 // @section machine
 
-/**
- * Travel limits after homing (units are in mm)
- *
- * Marlin assumes these are the limits to which the nozzle can travel
- *
- * When homing in the - direction, G28 sets the position to the xx_MIN_POS
- * When homing in the + direction, G28 sets the position to the xx_MAX_POS
- */
-#define X_MIN_POS 0
-#define Y_MIN_POS 0
-#define Z_MIN_POS 0
-#define X_MAX_POS 205
-#define Y_MAX_POS 205
-#define Z_MAX_POS 120
+// Travel limits after homing (units are in mm)
+#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
+#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
+#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
+#define X_MAX_POS 205    // G28 sets X to this when homing in +X direction
+#define Y_MAX_POS 205    // G28 sets Y to this when homing in +Y direction
+#define Z_MAX_POS 120    // G28 sets Z to this when homing in +Z direction
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -766,7 +766,14 @@
 
 // @section machine
 
-// Travel limits after homing (units are in mm)
+/**
+ * Travel limits after homing (units are in mm)
+ *
+ * Marlin assumes these are the limits to which the nozzle can travel
+ *
+ * When homing in the - direction, G28 sets the position to the xx_MIN_POS
+ * When homing in the + direction, G28 sets the position to the xx_MAX_POS
+ */
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0


### PR DESCRIPTION
I've seen several instances where confusion about the roles of the xx_MIN_POS and xx_MAX_POS defines contributed to problems.  This is an attempt to make it easier for the new Marlin users to understand.

These first two commits are mostly to get feedback.  The two commits have different methods.  The first one I changed the header. The second one I added inline comments.

Take a good look at the delta & SCARA sections and make sure they make sense.

In the header method I replaced `// Travel limits after homing (units are in mm)` with 
```
/**
 * Travel limits after homing (units are in mm)
 *
 * Marlin assumes these are the limits to which the nozzle can travel
 *
 * When homing in the - direction, G28 sets the position to the xx_MIN_POS
 * When homing in the + direction, G28 sets the position to the xx_MAX_POS
 */
```


The inline method looks like this:
```
// Travel limits after homing (units are in mm)
#define X_MIN_POS 0      // G28 sets X to this when homing in -X direction
#define Y_MIN_POS 0      // G28 sets Y to this when homing in -Y direction
#define Z_MIN_POS 0      // G28 sets Z to this when homing in -Z direction
#define X_MAX_POS 200    // G28 sets X to this when homing in +X direction
#define Y_MAX_POS 200    // G28 sets Y to this when homing in +Y direction
#define Z_MAX_POS 200    // G28 sets Z to this when homing in +Z direction
```

