### PR TITLE
Save / restore z_fade_height in EEPROM

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -307,6 +307,10 @@ float code_value_temp_diff();
   void reset_bed_level();
 #endif
 
+#if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+  void set_z_fade_height(const float zfh);
+#endif
+
 #if ENABLED(Z_DUAL_ENDSTOPS)
   extern float z_endstop_adj;
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -573,7 +573,7 @@ static uint8_t target_extruder;
         endstop_adj[ABC] = { 0 };
 
   // These values are loaded or reset at boot time when setup() calls
-  // Config_RetrieveSettings(), which calls recalc_delta_settings().
+  // settings.load(), which calls recalc_delta_settings().
   float delta_radius,
         delta_tower_angle_trim[ABC],
         delta_tower[ABC][2],
@@ -7898,28 +7898,28 @@ void quickstop_stepper() {
  * M500: Store settings in EEPROM
  */
 inline void gcode_M500() {
-  (void)Config_StoreSettings();
+  (void)settings.save();
 }
 
 /**
  * M501: Read settings from EEPROM
  */
 inline void gcode_M501() {
-  (void)Config_RetrieveSettings();
+  (void)settings.load();
 }
 
 /**
  * M502: Revert to default settings
  */
 inline void gcode_M502() {
-  (void)Config_ResetDefault();
+  (void)settings.reset();
 }
 
 /**
  * M503: print settings currently in memory
  */
 inline void gcode_M503() {
-  (void)Config_PrintSettings(code_seen('S') && !code_value_bool());
+  (void)settings.report(code_seen('S') && !code_value_bool());
 }
 
 #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
@@ -11343,7 +11343,7 @@ void setup() {
 
   // Load data from EEPROM if available (or use defaults)
   // This also updates variables in the planner, elsewhere
-  (void)Config_RetrieveSettings();
+  (void)settings.load();
 
   #if DISABLED(NO_WORKSPACE_OFFSETS)
     // Initialize current position based on home_offset

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -25,19 +25,38 @@
 
 #include "MarlinConfig.h"
 
-void Config_ResetDefault();
-bool Config_StoreSettings();
+class MarlinSettings {
+  public:
+    MarlinSettings() { }
 
-#if DISABLED(DISABLE_M503)
-  void Config_PrintSettings(bool forReplay=false);
-#else
-  FORCE_INLINE void Config_PrintSettings(bool forReplay=false) {}
-#endif
+    static void reset();
+    static bool save();
 
-#if ENABLED(EEPROM_SETTINGS)
-  bool Config_RetrieveSettings();
-#else
-  FORCE_INLINE bool Config_RetrieveSettings() { Config_ResetDefault(); Config_PrintSettings(); return true; }
-#endif
+    #if ENABLED(EEPROM_SETTINGS)
+      static bool load();
+    #else
+      FORCE_INLINE
+      static bool load() { reset(); report(); return true; }
+    #endif
 
-#endif //CONFIGURATION_STORE_H
+    #if DISABLED(DISABLE_M503)
+      static void report(bool forReplay=false);
+    #else
+      FORCE_INLINE
+      static void report(bool forReplay=false) { }
+    #endif
+
+  private:
+    static void postprocess();
+
+    #if ENABLED(EEPROM_SETTINGS)
+      static uint16_t eeprom_checksum;
+      static bool eeprom_read_error, eeprom_write_error;
+      static void write_data(int &pos, const uint8_t* value, uint16_t size);
+      static void read_data(int &pos, uint8_t* value, uint16_t size);
+    #endif
+};
+
+extern MarlinSettings settings;
+
+#endif // CONFIGURATION_STORE_H

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -819,7 +819,7 @@
  */
 #define Z_CLEARANCE_DEPLOY_PROBE   100 // Z Clearance for Deploy/Stow
 #define Z_CLEARANCE_BETWEEN_PROBES   5 // Z Clearance between probe points
- 
+
 // For M851 give a range for adjusting the Z probe offset
 
 #define Z_PROBE_OFFSET_RANGE_MIN -15

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -109,8 +109,8 @@ float Planner::min_feedrate_mm_s,
 #endif
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-  float Planner::z_fade_height = 0.0,
-        Planner::inverse_z_fade_height = 0.0;
+  float Planner::z_fade_height,
+        Planner::inverse_z_fade_height;
 #endif
 
 #if ENABLED(AUTOTEMP)

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2046,12 +2046,12 @@ void kill_screen(const char* lcd_msg) {
    */
 
   #if ENABLED(EEPROM_SETTINGS)
-    static void lcd_store_settings()   { lcd_completion_feedback(Config_StoreSettings()); }
-    static void lcd_load_settings()    { lcd_completion_feedback(Config_RetrieveSettings()); }
+    static void lcd_store_settings()   { lcd_completion_feedback(settings.save()); }
+    static void lcd_load_settings()    { lcd_completion_feedback(settings.load()); }
   #endif
 
   static void lcd_factory_settings() {
-    Config_ResetDefault();
+    settings.reset();
     lcd_completion_feedback();
   }
 


### PR DESCRIPTION
Rebase and rework of #5883 by @james94jeans2 

Firmware was forgetting the `z_fade_height` in Planner, set by `M420 Zn`, after each reset or loading settings from EEPROM. Added the float `z_fade_height` to EEPROM-Storage, now remembers the value.

- Includes placeholders for UBL to adopt `planner.z_fade_height` in future.
- Converted settings code to a singleton class.