### PR TITLE
Fix EPROM -> EEPROM

### DIFF
--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -312,10 +312,10 @@
 #ifndef MSG_CONTRAST
   #define MSG_CONTRAST                        _UxGT("LCD contrast")
 #endif
-#ifndef MSG_STORE_EPROM
+#ifndef MSG_STORE_EEPROM
   #define MSG_STORE_EEPROM                    _UxGT("Store memory")
 #endif
-#ifndef MSG_LOAD_EPROM
+#ifndef MSG_LOAD_EEPROM
   #define MSG_LOAD_EEPROM                     _UxGT("Load memory")
 #endif
 #ifndef MSG_RESTORE_FAILSAFE


### PR DESCRIPTION
These fixes are needed because before it showed the english text even if language = de was selected