### PR TITLE
Fix mbl_mesh_report

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3769,7 +3769,7 @@ inline void gcode_G28() {
     SERIAL_PROTOCOLPGM("Z offset: "); SERIAL_PROTOCOL_F(mbl.z_offset, 5);
     SERIAL_PROTOCOLLNPGM("\nMeasured points:");
     print_2d_array(GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y, 5,
-      [](const uint8_t ix, const uint8_t iy) { return mbl.z_values[ix][iy]; }
+      [](const uint8_t ix, const uint8_t iy) { return mbl.z_values[iy][ix]; }
     );
   }
 


### PR DESCRIPTION
z_values array is constructed with first Y and second X.