### PR TITLE
Allow 10mm Movements for Z-Axis

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1940,8 +1940,7 @@ void kill_screen(const char* lcd_msg) {
       }
     }
     MENU_BACK(MSG_MOVE_AXIS);
-    if (axis == X_AXIS || axis == Y_AXIS)
-      MENU_ITEM(submenu, MSG_MOVE_10MM, lcd_move_menu_10mm);
+    MENU_ITEM(submenu, MSG_MOVE_10MM, lcd_move_menu_10mm);
     MENU_ITEM(submenu, MSG_MOVE_1MM, lcd_move_menu_1mm);
     MENU_ITEM(submenu, MSG_MOVE_01MM, lcd_move_menu_01mm);
     END_MENU();


### PR DESCRIPTION
I use the movement options via LCD quite often. Especially to get the nozzle out of the way. I see no reason, why the 10mm option is disabled for the Z-Axis, this is why i always delete this line when i compile a new version.
If this is unwanted, please just close this PR