### PR TITLE
Add option to suicide via M81 after SD print finished

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -875,6 +875,7 @@ void setup_homepin(void) {
 void setup_powerhold() {
   #if HAS_SUICIDE
     OUT_WRITE(SUICIDE_PIN, HIGH);
+    bool kill_at_eof = false;
   #endif
   #if HAS_POWER_SWITCH
     #if ENABLED(PS_DEFAULT_OFF)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -872,10 +872,13 @@ void setup_homepin(void) {
   #endif
 }
 
+#if HAS_SUICIDE
+  bool kill_at_eof = false;
+#endif
+
 void setup_powerhold() {
   #if HAS_SUICIDE
     OUT_WRITE(SUICIDE_PIN, HIGH);
-    bool kill_at_eof = false;
   #endif
   #if HAS_POWER_SWITCH
     #if ENABLED(PS_DEFAULT_OFF)

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -877,8 +877,10 @@ void CardReader::printingHasFinished() {
     print_job_timer.stop();
     if (print_job_timer.duration() > 60)
       enqueue_and_echo_commands_P(PSTR("M31"));
-         if (kill_at_eof)
-         enqueue_and_echo_commands_P(PSTR("M81"));
+         #if HAS_SUICIDE
+            if (kill_at_eof)
+            enqueue_and_echo_commands_P(PSTR("M81"));
+         #endif 
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -861,6 +861,7 @@ void CardReader::updir() {
 #endif // SDCARD_SORT_ALPHA
 
 void CardReader::printingHasFinished() {
+  extern bool kill_at_eof;
   stepper.synchronize();
   file.close();
   if (file_subcall_ctr > 0) { // Heading up to a parent file that called current as a procedure.
@@ -876,6 +877,8 @@ void CardReader::printingHasFinished() {
     print_job_timer.stop();
     if (print_job_timer.duration() > 60)
       enqueue_and_echo_commands_P(PSTR("M31"));
+         if (kill_at_eof)
+         enqueue_and_echo_commands_P(PSTR("M81"));
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -528,6 +528,12 @@
 #ifndef MSG_LIGHTS_OFF
   #define MSG_LIGHTS_OFF                      _UxGT("Case light off")
 #endif
+#ifndef MSG_KILL_AT_EOF_ON
+  #define MSG_KILL_AT_EOF_ON                  _UxGT("Kill when done: ON")
+#endif
+#ifndef MSG_KILL_AT_EOF_OFF
+  #define MSG_KILL_AT_EOF_OFF                 _UxGT("Kill when done: OFF")
+#endif
 
 #if LCD_WIDTH >= 20
   #ifndef MSG_INFO_PRINT_COUNT

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -115,6 +115,8 @@
 #define E1_ENABLE_PIN      30
 #define E1_CS_PIN          44
 
+//#define SUICIDE_PIN        57  //Uncomment if you have a PIN that has to be turned on right after start, to keep power flowing.
+
 //
 // Temperature Sensors
 //

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -737,6 +737,17 @@ void kill_screen(const char* lcd_msg) {
 
   #endif // HAS_DEBUG_MENU
 
+  #if HAS_SUICIDE
+
+    extern bool kill_at_eof;
+
+    void toggle_kill_at_eof() {
+       kill_at_eof = !kill_at_eof;
+      lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;
+    }
+
+  #endif // HAS_SUICIDE
+
   /**
    *
    * "Main" menu
@@ -2070,6 +2081,12 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     MENU_ITEM(function, MSG_RESTORE_FAILSAFE, lcd_factory_settings);
+    #if HAS_SUICIDE
+      if (kill_at_eof)
+        MENU_ITEM(function, MSG_KILL_AT_EOF_ON, toggle_kill_at_eof);
+      else
+        MENU_ITEM(function, MSG_KILL_AT_EOF_OFF, toggle_kill_at_eof);
+    #endif
     END_MENU();
   }
 


### PR DESCRIPTION
Regarding #6323 i added the option to select sending a "kill" command after a printjob is already running from SD-Card. Quite useful in case you start a long printjob and forget to add a M81 command at the end script of your slicer. When M81 is called at the very end and the printer is equipped with a SSR in the mains line it will shut itself down completely. 
The option can be toggled in the LCDs control menu.
Works perfect here...