### PR TITLE
Fix lcd_babystep_zoffset()

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -861,7 +861,7 @@ void kill_screen(const char* lcd_msg) {
           const int babystep_increment = (int32_t)encoderPosition * (BABYSTEP_MULTIPLICATOR);
           encoderPosition = 0;
 
-          const float new_zoffset = zprobe_zoffset + steps_to_mm[Z_AXIS] * babystep_increment;
+          const float new_zoffset = zprobe_zoffset + planner.steps_to_mm[Z_AXIS] * babystep_increment;
           if (WITHIN(new_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX)) {
 
             if (planner.abl_enabled)


### PR DESCRIPTION
Resolve 'steps_to_mm was not declared in this scope' compilation error after recent changes to merge babystepping with M851