### PR TITLE
UBL - minor improvements

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1143,7 +1143,7 @@ void MarlinSettings::reset() {
 
   /**
    * M503 - Report current settings in RAM
-   *   
+   *
    * Unless specifically disabled, M503 is available even without EEPROM
    */
   void MarlinSettings::report(bool forReplay) {
@@ -1315,8 +1315,8 @@ void MarlinSettings::reset() {
         SERIAL_ECHOLNPGM("UBL_MESH_MAX_X     " STRINGIFY(UBL_MESH_MAX_X));
         SERIAL_ECHOLNPGM("UBL_MESH_MAX_Y     " STRINGIFY(UBL_MESH_MAX_Y));
 
-        SERIAL_ECHOLNPGM("MESH_X_DIST        " STRINGIFY(MESH_X_DIST));
-        SERIAL_ECHOLNPGM("MESH_Y_DIST        " STRINGIFY(MESH_Y_DIST));
+        SERIAL_ECHOLNPAIR("MESH_X_DIST        ", MESH_X_DIST);
+        SERIAL_ECHOLNPAIR("MESH_Y_DIST        ", MESH_Y_DIST);
         SERIAL_EOL;
       }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -915,12 +915,12 @@ void kill_screen(const char* lcd_msg) {
     }
 
     void _lcd_mesh_edit() {
-      _lcd_mesh_fine_tune(PSTR("Mesh Editor: "));
+      _lcd_mesh_fine_tune(PSTR("Mesh Editor"));
     }
 
     float lcd_mesh_edit() {
       lcd_goto_screen(_lcd_mesh_edit_NOP);
-      _lcd_mesh_fine_tune(PSTR("Mesh Editor: "));
+      _lcd_mesh_fine_tune(PSTR("Mesh Editor"));
       return mesh_edit_value;
     }
 


### PR DESCRIPTION
Here's a few items that @Roxy-3D can incorporate if she wishes.

----

Configuration_store.cpp - changed a couple of print statements so the
values were printed.  The old method resulted in the formula being
printed.

ubl_G29
1) added support for R option to P4.  Now probes all points unless R is
present and the number is greater than 0.

2) P2 - moved map print statement so it showed the point that was
currently being probed,  The old location did this only for the first
point.

3) P4 - Moved the map print for the same reason.

ultralcd.cpp - changed "Mesh Editor :" to "Mesh Editor" because the LCD
draw routine puts a ":" in automatically so you end up with an extra ":"
using the old message.