### PR TITLE
Add Linear Advance values to EEPROM and LCD

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,7 +36,7 @@
  *
  */
 
-#define EEPROM_VERSION "V34"
+#define EEPROM_VERSION "V35"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
@@ -149,8 +149,12 @@
  *  572  M906 E3   stepperE3 current                (uint16_t)
  *  576  M906 E4   stepperE4 current                (uint16_t)
  *
- *  580                                Minimum end-point
- * 1901 (580 + 36 + 9 + 288 + 988)     Maximum end-point
+ * Linear Advance:                                  8 bytes
+ *  580  M905 K    extruder_advance_k               (float)
+ *  584  M905 WHD  advance_ed_ratio                 (float)
+ *
+ *  588                                Minimum end-point
+ * 1909 (588 + 36 + 9 + 288 + 988)     Maximum end-point
  */
 #include "configuration_store.h"
 
@@ -570,6 +574,21 @@ void MarlinSettings::postprocess() {
       for (uint8_t q = 0; q < 11; ++q) EEPROM_WRITE(val);
     #endif
 
+    //
+    // Linear Advance
+    //
+
+    float extruder_advance_k = 0.0f;
+    float advance_ed_ratio = 0.0f;
+
+    #if ENABLED(LIN_ADVANCE)
+      extruder_advance_k = planner.get_extruder_advance_k();
+      advance_ed_ratio = planner.get_advance_ed_ratio();
+    #endif
+
+    EEPROM_WRITE(extruder_advance_k);
+    EEPROM_WRITE(advance_ed_ratio);
+
     if (!eeprom_write_error) {
 
       const uint16_t final_checksum = eeprom_checksum,
@@ -900,6 +919,20 @@ void MarlinSettings::postprocess() {
         for (uint8_t q = 0; q < 11; q++) EEPROM_READ(val);
       #endif
 
+      //
+      // Linear Advance
+      //
+
+      float extruder_advance_k;
+      float advance_ed_ratio;
+      EEPROM_READ(extruder_advance_k);
+      EEPROM_READ(advance_ed_ratio);
+
+      #if ENABLED(LIN_ADVANCE)
+        planner.set_extruder_advance_k(extruder_advance_k);
+        planner.set_advance_ed_ratio(advance_ed_ratio);
+      #endif
+
       if (eeprom_checksum == stored_checksum) {
         if (eeprom_read_error)
           reset();
@@ -1153,6 +1186,11 @@ void MarlinSettings::reset() {
     #if ENABLED(E3_IS_TMC2130)
       stepperE3.setCurrent(E3_CURRENT, R_SENSE, HOLD_MULTIPLIER);
     #endif
+  #endif
+
+  #if ENABLED(LIN_ADVANCE)
+    planner.set_extruder_advance_k(LIN_ADVANCE_K);
+    planner.set_advance_ed_ratio(LIN_ADVANCE_E_D_RATIO);
   #endif
 
   postprocess();
@@ -1600,6 +1638,20 @@ void MarlinSettings::reset() {
       #if ENABLED(E3_IS_TMC2130)
         SERIAL_ECHOPAIR(" E3", stepperE3.getCurrent());
       #endif
+      SERIAL_EOL;
+    #endif
+
+    /**
+     * Linear Advance
+     */
+    #if ENABLED(LIN_ADVANCE)
+      CONFIG_ECHO_START;
+      if (!forReplay) {
+        SERIAL_ECHOLNPGM("Linear Advance:");
+        CONFIG_ECHO_START;
+      }
+      SERIAL_ECHOPAIR("  M905 K", planner.get_extruder_advance_k());
+      SERIAL_ECHOPAIR("  E/D ratio: ", planner.get_advance_ed_ratio());
       SERIAL_EOL;
     #endif
   }

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 trangos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimiento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -116,7 +116,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 стъпки/mm")
 #define MSG_TEMPERATURE                     _UxGT("Температура")
 #define MSG_MOTION                          _UxGT("Движение")
-#define MSG_VOLUMETRIC                      _UxGT("Нишка")
+#define MSG_FILAMENT                        _UxGT("Нишка")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Диам. нишка")
 #define MSG_CONTRAST                        _UxGT("LCD контраст")

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -120,7 +120,7 @@
 #define MSG_E5STEPS                         _UxGT("E5passos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Moviment")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E en mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. Fil.")
 #define MSG_CONTRAST                        _UxGT("Contrast de LCD")

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -108,7 +108,7 @@
 #define MSG_E5STEPS                         "E5steps/mm"
 #define MSG_TEMPERATURE                     "\xc9\xd2"
 #define MSG_MOTION                          "\xdf\xb2"
-#define MSG_VOLUMETRIC                      "Filament"
+#define MSG_FILAMENT                        "Filament"
 #define MSG_VOLUMETRIC_ENABLED              "E in mm3"
 #define MSG_FILAMENT_DIAM                   "Fil. Dia."
 #define MSG_CONTRAST                        "LCD contrast"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -119,7 +119,7 @@
 #define MSG_E5STEPS                         _UxGT("E5kroku/mm")
 #define MSG_TEMPERATURE                     _UxGT("Teplota")
 #define MSG_MOTION                          _UxGT("Pohyb")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E na mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Prum.")
 #define MSG_CONTRAST                        _UxGT("Kontrast LCD")

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -117,7 +117,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatur")
 #define MSG_MOTION                          _UxGT("Bevægelse")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E i mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD kontrast")

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -121,7 +121,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 Steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatur")
 #define MSG_MOTION                          _UxGT("Bewegung")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
 #define MSG_FILAMENT_DIAM                   _UxGT("D Fil.")
 #define MSG_CONTRAST                        _UxGT("LCD Kontrast")

--- a/Marlin/language_el-gr.h
+++ b/Marlin/language_el-gr.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("Bήματα Ε5 ανά μμ")
 #define MSG_TEMPERATURE                     _UxGT("Θερμοκρασία")
 #define MSG_MOTION                          _UxGT("Κίνηση")
-#define MSG_VOLUMETRIC                      _UxGT("Νήμα")
+#define MSG_FILAMENT                        _UxGT("Νήμα")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("Ε σε μμ3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Διάμετρος νήματος")
 #define MSG_CONTRAST                        _UxGT("Κοντράστ LCD")

--- a/Marlin/language_el.h
+++ b/Marlin/language_el.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("Bήματα Ε5 ανά μμ")
 #define MSG_TEMPERATURE                     _UxGT("Θερμοκρασία")
 #define MSG_MOTION                          _UxGT("Κίνηση")
-#define MSG_VOLUMETRIC                      _UxGT("Νήμα")
+#define MSG_FILAMENT                        _UxGT("Νήμα")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("Ε σε μμ3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Διάμετρος νήματος")
 #define MSG_CONTRAST                        _UxGT("Κοντράστ LCD")

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -300,8 +300,8 @@
 #ifndef MSG_MOTION
   #define MSG_MOTION                          _UxGT("Motion")
 #endif
-#ifndef MSG_VOLUMETRIC
-  #define MSG_VOLUMETRIC                      _UxGT("Filament")
+#ifndef MSG_FILAMENT
+  #define MSG_FILAMENT                        _UxGT("Filament")
 #endif
 #ifndef MSG_VOLUMETRIC_ENABLED
   #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
@@ -669,5 +669,9 @@
     #define MSG_FILAMENT_CHANGE_RESUME_1        _UxGT("Resuming...")
   #endif
 #endif // LCD_HEIGHT < 4
+
+#ifndef MSG_ADVANCE_K
+  #define MSG_ADVANCE_K                         _UxGT("Advance K")
+#endif
 
 #endif // LANGUAGE_EN_H

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -119,7 +119,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 pasos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimiento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -106,7 +106,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 pausoak/mm")
 #define MSG_TEMPERATURE                     _UxGT("Tenperatura")
 #define MSG_MOTION                          _UxGT("Mugimendua")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD kontrastea")

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -107,7 +107,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Lämpötila")
 #define MSG_MOTION                          _UxGT("Liike")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD kontrasti")

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -120,7 +120,7 @@
 #define MSG_E5STEPS                         _UxGT("E5pas/mm")
 #define MSG_TEMPERATURE                     _UxGT("Tempzrature")
 #define MSG_MOTION                          _UxGT("Mouvement")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E en mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. Fil.")
 #define MSG_CONTRAST                        _UxGT("Contraste LCD")

--- a/Marlin/language_gl.h
+++ b/Marlin/language_gl.h
@@ -116,7 +116,7 @@
 #define MSG_E5STEPS                         _UxGT("E5pasos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movemento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E en mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. fil.")
 #define MSG_CONTRAST                        _UxGT("Constraste LCD")

--- a/Marlin/language_hr.h
+++ b/Marlin/language_hr.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperature")
 #define MSG_MOTION                          _UxGT("Gibanje")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("Kontrast LCD-a")

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -123,7 +123,7 @@
 #define MSG_E5STEPS                         _UxGT("E5passi/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. filo")
 #define MSG_CONTRAST                        _UxGT("Contrasto LCD")

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -151,7 +151,7 @@
 #endif
 #define MSG_TEMPERATURE                     "\xb5\xdd\xc4\xde"                                                 // "ｵﾝﾄﾞ" ("Temperature")
 #define MSG_MOTION                          "\xb3\xba\xde\xb7\xbe\xaf\xc3\xb2"                                 // "ｳｺﾞｷｾｯﾃｲ" ("Motion")
-#define MSG_VOLUMETRIC                      "\xcc\xa8\xd7\xd2\xdd\xc4"                                         // "ﾌｨﾗﾒﾝﾄ" ("Filament")
+#define MSG_FILAMENT                        "\xcc\xa8\xd7\xd2\xdd\xc4"                                         // "ﾌｨﾗﾒﾝﾄ" ("Filament")
 #define MSG_VOLUMETRIC_ENABLED              "E in mm3"
 #if LCD_WIDTH >= 20
   #define MSG_FILAMENT_DIAM                 "\xcc\xa8\xd7\xd2\xdd\xc4\xc1\xae\xaf\xb9\xb2"                     // "ﾌｨﾗﾒﾝﾄﾁｮｯｹｲ" ("Fil. Dia.")

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -125,7 +125,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("オンド")                      // "Temperature"
 #define MSG_MOTION                          _UxGT("ウゴキセッテイ")                // "Motion"
-#define MSG_VOLUMETRIC                      _UxGT("フィラメント")                   // "Filament"
+#define MSG_FILAMENT                        _UxGT("フィラメント")                   // "Filament"
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("フィラメントチョッケイ")            // "Fil. Dia."
 #define MSG_CONTRAST                        _UxGT("LCDコントラスト")               // "LCD contrast"

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatuur")
 #define MSG_MOTION                          _UxGT("Beweging")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD contrast")

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("krokiE5/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Ruch")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E w mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Sr. fil.")
 #define MSG_CONTRAST                        _UxGT("Kontrast LCD")

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -108,7 +108,7 @@
 #define MSG_E5STEPS                         "E5/mm"
 #define MSG_TEMPERATURE                     "Temperatura"
 #define MSG_MOTION                          "Movimento"
-#define MSG_VOLUMETRIC                      "Filamento"
+#define MSG_FILAMENT                        "Filamento"
 #define MSG_VOLUMETRIC_ENABLED              "Extr. em mm3"
 #define MSG_FILAMENT_DIAM                   "Diametro Fil."
 #define MSG_CONTRAST                        "Contraste"

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -108,7 +108,7 @@
 #define MSG_E5STEPS                         _UxGT("E5/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("Extr. em mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diametro Fil.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -112,7 +112,7 @@
 #define MSG_E5STEPS                         "E5 passo/mm"
 #define MSG_TEMPERATURE                     "Temperatura"
 #define MSG_MOTION                          "Movimento"
-#define MSG_VOLUMETRIC                      "Filamento"
+#define MSG_FILAMENT                        "Filamento"
 #define MSG_VOLUMETRIC_ENABLED              "E em mm3"
 #define MSG_FILAMENT_DIAM                   "Fil. Diam."
 #define MSG_CONTRAST                        "Contraste"

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -112,7 +112,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 passo/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E em mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Diam.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -111,7 +111,7 @@
 #define MSG_E4STEPS                         _UxGT("E4 шаг/мм")
 #define MSG_TEMPERATURE                     _UxGT("Температура")
 #define MSG_MOTION                          _UxGT("Механика")
-#define MSG_VOLUMETRIC                      _UxGT("Пруток")
+#define MSG_FILAMENT                        _UxGT("Пруток")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E в mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Диаметр прутка")
 #define MSG_CONTRAST                        _UxGT("Контраст LCD")

--- a/Marlin/language_test.h
+++ b/Marlin/language_test.h
@@ -148,7 +148,7 @@
   #define MSG_MAIN                            STRG_OKTAL_2
   #define MSG_TEMPERATURE                     STRG_OKTAL_3
   #define MSG_MOTION                          STRG_OKTAL_4
-  #define MSG_VOLUMETRIC                      STRG_OKTAL_5
+  #define MSG_FILAMENT                        STRG_OKTAL_5
   #define MSG_CONTRAST                        STRG_OKTAL_6
   #define MSG_RESTORE_FAILSAFE                STRG_OKTAL_7
 
@@ -183,7 +183,7 @@
   #define MSG_MAIN                            STRG_OKTAL_2
   #define MSG_TEMPERATURE                     STRG_OKTAL_3
   #define MSG_MOTION                          STRG_OKTAL_4
-  #define MSG_VOLUMETRIC                      STRG_OKTAL_5
+  #define MSG_FILAMENT                        STRG_OKTAL_5
   #define MSG_CONTRAST                        STRG_OKTAL_6
   #define MSG_RESTORE_FAILSAFE                STRG_OKTAL_7
 
@@ -218,7 +218,7 @@
   #define MSG_MAIN                            STRG_OKTAL_2
   #define MSG_TEMPERATURE                     STRG_OKTAL_3
   #define MSG_MOTION                          STRG_OKTAL_4
-  #define MSG_VOLUMETRIC                      STRG_OKTAL_5
+  #define MSG_FILAMENT                        STRG_OKTAL_5
   #define MSG_CONTRAST                        STRG_OKTAL_6
   #define MSG_RESTORE_FAILSAFE                STRG_OKTAL_7
 

--- a/Marlin/language_tr.h
+++ b/Marlin/language_tr.h
@@ -120,7 +120,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")                                         // E4steps/mm
 #define MSG_TEMPERATURE                     _UxGT("Sıcaklık")                                           // Sıcaklık
 #define MSG_MOTION                          _UxGT("Hareket")                                            // Hareket
-#define MSG_VOLUMETRIC                      _UxGT("Filaman")                                            // Filaman
+#define MSG_FILAMENT                        _UxGT("Filaman")                                            // Filaman
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")                                           // E in mm3
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Çap")                                           // Fil. Çap
 #define MSG_CONTRAST                        _UxGT("LCD Kontrast")                                       // LCD Kontrast

--- a/Marlin/language_uk.h
+++ b/Marlin/language_uk.h
@@ -116,7 +116,7 @@
 #define MSG_E5STEPS                         _UxGT("E5кроків/мм")
 #define MSG_TEMPERATURE                     _UxGT("Температура")
 #define MSG_MOTION                          _UxGT("Рух")
-#define MSG_VOLUMETRIC                      _UxGT("Волокно")
+#define MSG_FILAMENT                        _UxGT("Волокно")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E в мм3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Діам. волок.")
 #define MSG_CONTRAST                        _UxGT("контраст LCD")

--- a/Marlin/language_zh_CN.h
+++ b/Marlin/language_zh_CN.h
@@ -108,7 +108,7 @@
 #define MSG_ESTEPS                          _UxGT("挤出机步数/mm")  //"Esteps/mm"
 #define MSG_TEMPERATURE                     _UxGT("温度")  //"Temperature"
 #define MSG_MOTION                          _UxGT("运动")  //"Motion"
-#define MSG_VOLUMETRIC                      _UxGT("丝料测容")  //"Filament" lcd_control_volumetric_menu
+#define MSG_FILAMENT                        _UxGT("丝料测容")  //"Filament" lcd_control_volumetric_menu
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("测容积mm³")  //"E in mm3" volumetric_enabled
 #define MSG_FILAMENT_DIAM                   _UxGT("丝料直径")  //"Fil. Dia."
 #define MSG_CONTRAST                        _UxGT("LCD对比度")  //"LCD contrast"

--- a/Marlin/language_zh_TW.h
+++ b/Marlin/language_zh_TW.h
@@ -108,7 +108,7 @@
 #define MSG_ESTEPS                          _UxGT("擠出機步數/mm")  //"Esteps/mm"
 #define MSG_TEMPERATURE                     _UxGT("溫度")  //"Temperature"
 #define MSG_MOTION                          _UxGT("運動")  //"Motion"
-#define MSG_VOLUMETRIC                      _UxGT("絲料測容")  //"Filament" lcd_control_volumetric_menu
+#define MSG_FILAMENT                        _UxGT("絲料測容")  //"Filament" lcd_control_volumetric_menu
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("測容積mm³")  //"E in mm3" volumetric_enabled
 #define MSG_FILAMENT_DIAM                   _UxGT("絲料直徑")  //"Fil. Dia."
 #define MSG_CONTRAST                        _UxGT("LCD對比度")  //"LCD contrast"

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -267,9 +267,10 @@ class Planner {
     #endif
 
     #if ENABLED(LIN_ADVANCE)
-      static void set_extruder_advance_k(const float &k) { extruder_advance_k = k; };
+      static void set_extruder_advance_k(float k) { extruder_advance_k = k; };
       static float get_extruder_advance_k() { return extruder_advance_k; };
-      static void set_advance_ed_ratio(const float &ratio) { advance_ed_ratio = ratio; };
+      static void set_advance_ed_ratio(float ratio) { advance_ed_ratio = ratio; };
+      static float get_advance_ed_ratio() { return advance_ed_ratio; };
     #endif
 
     /**

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -143,7 +143,7 @@ uint16_t max_display_update_time = 0;
   void lcd_control_temperature_preheat_material1_settings_menu();
   void lcd_control_temperature_preheat_material2_settings_menu();
   void lcd_control_motion_menu();
-  void lcd_control_volumetric_menu();
+  void lcd_control_filament_menu();
 
   #if ENABLED(DAC_STEPPER_CURRENT)
     void dac_driver_commit();
@@ -198,26 +198,31 @@ uint16_t max_display_update_time = 0;
   void menu_action_submenu(screenFunc_t data);
   void menu_action_gcode(const char* pgcode);
   void menu_action_function(screenFunc_t data);
+
+  #define define_menu_edit_type(_type, _name) \
+    bool _menu_edit_ ## _name (); \
+    void menu_edit_ ## _name (); \
+    void menu_edit_callback_ ## _name (); \
+    void _menu_action_setting_edit_ ## _name (const char * const pstr, _type* const ptr, const _type minValue, const _type maxValue); \
+    void menu_action_setting_edit_ ## _name (const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue); \
+    void menu_action_setting_edit_callback_ ## _name (const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue, const screenFunc_t callback); \
+    void _menu_action_setting_edit_accessor_ ## _name (const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue); \
+    void menu_action_setting_edit_accessor_ ## _name (const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue); \
+    typedef void _name
+
+  define_menu_edit_type(int, int3);
+  define_menu_edit_type(float, float3);
+  define_menu_edit_type(float, float32);
+  define_menu_edit_type(float, float43);
+  define_menu_edit_type(float, float5);
+  define_menu_edit_type(float, float51);
+  define_menu_edit_type(float, float52);
+  define_menu_edit_type(float, float62);
+  define_menu_edit_type(unsigned long, long5);
+  
   void menu_action_setting_edit_bool(const char* pstr, bool* ptr);
-  void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
-  void menu_action_setting_edit_float3(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float32(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float43(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float5(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float51(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float52(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float62(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue);
   void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float3(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float32(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float43(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float5(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float51(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float52(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float62(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_accessor_bool(const char* pstr, bool (*pget)(), void (*pset)(bool));
 
   #if ENABLED(SDSUPPORT)
     void lcd_sdcard_menu();
@@ -375,12 +380,15 @@ uint16_t max_display_update_time = 0;
   #define MENU_ITEM_DUMMY() do { _thisItemNr++; } while(0)
   #define MENU_ITEM_EDIT(type, label, ...) MENU_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #define MENU_ITEM_EDIT_CALLBACK(type, label, ...) MENU_ITEM(setting_edit_callback_ ## type, label, PSTR(label), ## __VA_ARGS__)
+  #define MENU_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #if ENABLED(ENCODER_RATE_MULTIPLIER)
     #define MENU_MULTIPLIER_ITEM_EDIT(type, label, ...) MENU_MULTIPLIER_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
     #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(type, label, ...) MENU_MULTIPLIER_ITEM(setting_edit_callback_ ## type, label, PSTR(label), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_MULTIPLIER_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #else //!ENCODER_RATE_MULTIPLIER
     #define MENU_MULTIPLIER_ITEM_EDIT(type, label, ...) MENU_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
     #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(type, label, ...) MENU_ITEM(setting_edit_callback_ ## type, label, PSTR(label), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #endif //!ENCODER_RATE_MULTIPLIER
 
   /** Used variables to keep track of the menu */
@@ -417,6 +425,7 @@ uint16_t max_display_update_time = 0;
   // Variables used when editing values.
   const char* editLabel;
   void* editValue;
+  void* editSetter;
   int32_t minEditValue, maxEditValue;
   screenFunc_t callbackFunc;              // call this after editing
 
@@ -2105,7 +2114,7 @@ void kill_screen(const char* lcd_msg) {
     MENU_BACK(MSG_MAIN);
     MENU_ITEM(submenu, MSG_TEMPERATURE, lcd_control_temperature_menu);
     MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
-    MENU_ITEM(submenu, MSG_VOLUMETRIC, lcd_control_volumetric_menu);
+    MENU_ITEM(submenu, MSG_FILAMENT, lcd_control_filament_menu);
 
     #if HAS_LCD_CONTRAST
       //MENU_ITEM_EDIT(int3, MSG_CONTRAST, &lcd_contrast, 0, 63);
@@ -2543,9 +2552,13 @@ void kill_screen(const char* lcd_msg) {
    * "Control" > "Filament" submenu
    *
    */
-  void lcd_control_volumetric_menu() {
+  void lcd_control_filament_menu() {
     START_MENU();
     MENU_BACK(MSG_CONTROL);
+
+    #if ENABLED(LIN_ADVANCE)
+      MENU_ITEM_EDIT_ACCESSOR(float3, MSG_ADVANCE_K, planner.get_extruder_advance_k, planner.set_extruder_advance_k, 0, 999);
+    #endif
 
     MENU_ITEM_EDIT_CALLBACK(bool, MSG_VOLUMETRIC_ENABLED, &volumetric_enabled, calculate_volumetric_multipliers);
 
@@ -3101,6 +3114,8 @@ void kill_screen(const char* lcd_msg) {
    *   void _menu_action_setting_edit_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue);
    *   void menu_action_setting_edit_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue);
    *   void menu_action_setting_edit_callback_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue, const screenFunc_t callback); // edit int with callback
+   *   void _menu_action_setting_edit_accessor_int3(const char * const pstr, int (*pget)(), void (*pset)(int), const int minValue, const int maxValue);
+   *   void menu_action_setting_edit_accessor_int3(const char * const pstr, int (*pget)(), void (*pset)(int), const int minValue, const int maxValue); // edit int via pget and pset accessor functions
    *
    * You can then use one of the menu macros to present the edit interface:
    *   MENU_ITEM_EDIT(int3, MSG_SPEED, &feedrate_percentage, 10, 999)
@@ -3112,6 +3127,9 @@ void kill_screen(const char* lcd_msg) {
    * Also: MENU_MULTIPLIER_ITEM_EDIT, MENU_ITEM_EDIT_CALLBACK, and MENU_MULTIPLIER_ITEM_EDIT_CALLBACK
    *
    *       menu_action_setting_edit_int3(PSTR(MSG_SPEED), &feedrate_percentage, 10, 999)
+   *
+   * Values that are get/set via functions (As opposed to global variables) can use the accessor form:
+   *   MENU_ITEM_EDIT_ACCESSOR(int3, MSG_SPEED, get_feedrate_percentage, set_feedrate_percentage, 10, 999)
    */
   #define menu_edit_type(_type, _name, _strFunc, _scale) \
     bool _menu_edit_ ## _name () { \
@@ -3121,7 +3139,11 @@ void kill_screen(const char* lcd_msg) {
       if (lcdDrawUpdate) \
         lcd_implementation_drawedit(editLabel, _strFunc(((_type)((int32_t)encoderPosition + minEditValue)) * (1.0 / _scale))); \
       if (lcd_clicked) { \
-        *((_type*)editValue) = ((_type)((int32_t)encoderPosition + minEditValue)) * (1.0 / _scale); \
+        _type value = ((_type)((int32_t)encoderPosition + minEditValue)) * (1.0 / _scale); \
+        if (editValue != NULL) \
+          *((_type*)editValue) = value; \
+        else if (editSetter != NULL) \
+          ((void (*)(_type))editSetter)(value); \
         lcd_goto_previous_menu(); \
       } \
       return lcd_clicked; \
@@ -3135,6 +3157,7 @@ void kill_screen(const char* lcd_msg) {
       \
       editLabel = pstr; \
       editValue = ptr; \
+      editSetter = NULL; \
       minEditValue = minValue * _scale; \
       maxEditValue = maxValue * _scale - minEditValue; \
       encoderPosition = (*ptr) * _scale - minEditValue; \
@@ -3142,11 +3165,27 @@ void kill_screen(const char* lcd_msg) {
     void menu_action_setting_edit_ ## _name (const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue) { \
       _menu_action_setting_edit_ ## _name(pstr, ptr, minValue, maxValue); \
       currentScreen = menu_edit_ ## _name; \
-    }\
+    } \
     void menu_action_setting_edit_callback_ ## _name (const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue, const screenFunc_t callback) { \
       _menu_action_setting_edit_ ## _name(pstr, ptr, minValue, maxValue); \
       currentScreen = menu_edit_callback_ ## _name; \
       callbackFunc = callback; \
+    } \
+    void _menu_action_setting_edit_accessor_ ## _name (const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue) { \
+      lcd_save_previous_screen(); \
+      \
+      lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; \
+      \
+      editLabel = pstr; \
+      editValue = NULL; \
+      editSetter = pset; \
+      minEditValue = minValue * _scale; \
+      maxEditValue = maxValue * _scale - minEditValue; \
+      encoderPosition = pget() * _scale - minEditValue; \
+    } \
+    void menu_action_setting_edit_accessor_ ## _name (const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue) { \
+      _menu_action_setting_edit_accessor_ ## _name(pstr, pget, pset, minValue, maxValue); \
+      currentScreen = menu_edit_ ## _name; \
     } \
     typedef void _name
 
@@ -3251,6 +3290,11 @@ void kill_screen(const char* lcd_msg) {
   void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callback) {
     menu_action_setting_edit_bool(pstr, ptr);
     (*callback)();
+  }
+  void menu_action_setting_edit_accessor_bool(const char* pstr, bool (*pget)(), void (*pset)(bool)) {
+    UNUSED(pstr);
+    pset(!pget());
+    lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
   }
 
 #endif // ULTIPANEL

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -767,27 +767,30 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, data) _drawmenu_setting_edit_generic(sel, row, pstr, data, false)
   #define lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, data) _drawmenu_setting_edit_generic(sel, row, pstr, data, true)
 
-  #define lcd_implementation_drawmenu_setting_edit_int3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float32(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float43(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float52(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float51(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float62(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_long5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define define_lcd_implementation_drawmenu_setting_edit_type(_type, _name, _strFunc) \
+    inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _strFunc(pget())); \
+    }
 
-  #define lcd_implementation_drawmenu_setting_edit_callback_int3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float32(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float43(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float52(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float51(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float62(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_long5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
+  define_lcd_implementation_drawmenu_setting_edit_type(int, int3, itostr3);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float3, ftostr3);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float32, ftostr32);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float43, ftostr43sign);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float5, ftostr5rj);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float51, ftostr51sign);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float52, ftostr52sign);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float62, ftostr62rj);
+  define_lcd_implementation_drawmenu_setting_edit_type(long, long5, ftostr5rj);
+
+  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
   #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_accessor_bool(sel, row, pstr, pstr2, pget, pset) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* const pstr, const char* const value=NULL) {
     const uint8_t labellen = lcd_strlen_P(pstr),

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -874,28 +874,30 @@ static void lcd_implementation_status_screen() {
     lcd_printPGM(data);
   }
 
-  #define lcd_implementation_drawmenu_setting_edit_int3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float32(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float43(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float52(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float51(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float62(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_long5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define define_lcd_implementation_drawmenu_setting_edit_type(_type, _name, _strFunc) \
+    inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', _strFunc(pget())); \
+    }
 
-  //Add version for callback functions
-  #define lcd_implementation_drawmenu_setting_edit_callback_int3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float32(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float43(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float52(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float51(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float62(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_long5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
+  define_lcd_implementation_drawmenu_setting_edit_type(int, int3, itostr3);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float3, ftostr3);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float32, ftostr32);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float43, ftostr43sign);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float5, ftostr5rj);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float51, ftostr51sign);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float52, ftostr52sign);
+  define_lcd_implementation_drawmenu_setting_edit_type(float, float62, ftostr62rj);
+  define_lcd_implementation_drawmenu_setting_edit_type(long, long5, ftostr5rj);
+
+  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
   #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_accessor_bool(sel, row, pstr, pstr2, pget, pset, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* pstr, const char* const value=NULL) {
     lcd.setCursor(1, 1);


### PR DESCRIPTION
This pull request adds the Linear Advance values to the EEPROM and also allowsconfiguration of the K value via the LCD. My rational for this is that we can already configure and store the volumetric extrusion for the filament, so it only makes sense that we be able to do the same for the Linear Advance. It also allows gcode to be more generic since the K value wouldn't need to be explicitly specified.

A potentially beneficial bonus of this pull request is the addition of accessor versions of the menu macros and functions. Currently, all values edited via the LCD have to be done so through global variables. The accessor versions allow the programmer to specify pointers to get and set functions to be used in place of a pointer to a global variable.

As of now, I didn't provide any translations for the new "Advance K" item added to the LCD. Is this something I would need to do, or are there other contributors that can help with that?