### PR TITLE
Only queue babysteps if axis is in a known position

### DIFF
--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -431,31 +431,33 @@ class Temperature {
     #if ENABLED(BABYSTEPPING)
 
       static void babystep_axis(const AxisEnum axis, const int distance) {
-        #if IS_CORE
-          #if ENABLED(BABYSTEP_XY)
-            switch (axis) {
-              case CORE_AXIS_1: // X on CoreXY and CoreXZ, Y on CoreYZ
-                babystepsTodo[CORE_AXIS_1] += distance * 2;
-                babystepsTodo[CORE_AXIS_2] += distance * 2;
-                break;
-              case CORE_AXIS_2: // Y on CoreXY, Z on CoreXZ and CoreYZ
-                babystepsTodo[CORE_AXIS_1] += CORESIGN(distance * 2);
-                babystepsTodo[CORE_AXIS_2] -= CORESIGN(distance * 2);
-                break;
-              case NORMAL_AXIS: // Z on CoreXY, Y on CoreXZ, X on CoreYZ
-                babystepsTodo[NORMAL_AXIS] += distance;
-                break;
-            }
-          #elif CORE_IS_XZ || CORE_IS_YZ
-            // Only Z stepping needs to be handled here
-            babystepsTodo[CORE_AXIS_1] += CORESIGN(distance * 2);
-            babystepsTodo[CORE_AXIS_2] -= CORESIGN(distance * 2);
+        if (axis_known_position[axis]) {
+          #if IS_CORE
+            #if ENABLED(BABYSTEP_XY)
+              switch (axis) {
+                case CORE_AXIS_1: // X on CoreXY and CoreXZ, Y on CoreYZ
+                  babystepsTodo[CORE_AXIS_1] += distance * 2;
+                  babystepsTodo[CORE_AXIS_2] += distance * 2;
+                  break;
+                case CORE_AXIS_2: // Y on CoreXY, Z on CoreXZ and CoreYZ
+                  babystepsTodo[CORE_AXIS_1] += CORESIGN(distance * 2);
+                  babystepsTodo[CORE_AXIS_2] -= CORESIGN(distance * 2);
+                  break;
+                case NORMAL_AXIS: // Z on CoreXY, Y on CoreXZ, X on CoreYZ
+                  babystepsTodo[NORMAL_AXIS] += distance;
+                  break;
+              }
+            #elif CORE_IS_XZ || CORE_IS_YZ
+              // Only Z stepping needs to be handled here
+              babystepsTodo[CORE_AXIS_1] += CORESIGN(distance * 2);
+              babystepsTodo[CORE_AXIS_2] -= CORESIGN(distance * 2);
+            #else
+              babystepsTodo[Z_AXIS] += distance;
+            #endif
           #else
-            babystepsTodo[Z_AXIS] += distance;
+            babystepsTodo[axis] += distance;
           #endif
-        #else
-          babystepsTodo[axis] += distance;
-        #endif
+        }
       }
 
     #endif // BABYSTEPPING


### PR DESCRIPTION
Typically, babystepping can only be achieved via the Tune menu, which is only accessible when during a print. However, when BABYSTEP_ZPROBE_OFFSET is enabled, the babysteps will be applied when adjusting the Z Offset if ABL is enabled. If the the motors have been disabled (either via timeout or M18) after completing a G29 and adjustments to the Z Offset are then made, the babysteps will be applied, resulting in the Z axis jerking semi-violently as the motors are enabled, moved, and then disabled for each babystep.

This pull request modifies the behavior to only allow babysteps to be queued for an axis if that axis is in a known position (i.e. has been homed and is enabled).