### PR TITLE
Identifed a display initialization issue.

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -240,7 +240,7 @@ void lcd_printPGM(const char* str) {
   for (; char c = pgm_read_byte(str); ++str) lcd_print(c);
 }
 
-// Initialize or re-initializw the LCD
+// Initialize or re-initialize the LCD
 static void lcd_implementation_init() {
 
   #if PIN_EXISTS(LCD_BACKLIGHT) // Enable LCD backlight
@@ -248,7 +248,11 @@ static void lcd_implementation_init() {
   #endif
 
   #if PIN_EXISTS(LCD_RESET)
+    OUT_WRITE(LCD_RESET_PIN, LOW); // perform a clean hardware reset
+    _delay_ms(5);
     OUT_WRITE(LCD_RESET_PIN, HIGH);
+    _delay_ms(5); // delay to allow the display to initalize
+    u8g.begin(); // re-initialize the display
   #endif
 
   #if DISABLED(MINIPANEL) // setContrast not working for Mini Panel


### PR DESCRIPTION
I have identified an issue that can affect printers that define and use a LCD_RESET pin.  Displays that use the U8glib display library are initialized in the constructor of the display object.  This works fine unless the display uses a hardware reset pin.  If a hardware reset pin is used for the display the U8glib will attempt to initialize the display while controlling pin for the reset line is still an input and floating. 

I have drafted a proposed fix that performs the following:  Provide a clean reset to the display by asserting reset, delaying 5 milliseconds, deasserting reset, delaying 5ms, and then force the display to re-initalize by calling u8g.begin().

I have arbitrarily chosen 5ms for the reset delay.  This is more then enough time for the displays I am familiar with (SSD1306, SSD1309 family).

Oh and I fixed a typo while I was at it...

-Rob