### PR TITLE
Add Linear Advance values to EEPROM and LCD

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -633,12 +633,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1285,19 +1285,19 @@ inline bool code_value_bool() { return !code_has_value() || code_value_byte() > 
     volumetric_unit_factor = pow(linear_unit_factor, 3.0);
   }
 
-  inline float axis_unit_factor(int axis) {
+  inline float axis_unit_factor(const AxisEnum axis) {
     return (axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor : linear_unit_factor);
   }
 
   inline float code_value_linear_units() { return code_value_float() * linear_unit_factor; }
-  inline float code_value_axis_units(int axis) { return code_value_float() * axis_unit_factor(axis); }
-  inline float code_value_per_axis_unit(int axis) { return code_value_float() / axis_unit_factor(axis); }
+  inline float code_value_axis_units(const AxisEnum axis) { return code_value_float() * axis_unit_factor(axis); }
+  inline float code_value_per_axis_unit(const AxisEnum axis) { return code_value_float() / axis_unit_factor(axis); }
 
 #else
 
-  inline float code_value_linear_units() { return code_value_float(); }
-  inline float code_value_axis_units(int axis) { UNUSED(axis); return code_value_float(); }
-  inline float code_value_per_axis_unit(int axis) { UNUSED(axis); return code_value_float(); }
+  #define code_value_linear_units() code_value_float()
+  #define code_value_axis_units(A) code_value_float()
+  #define code_value_per_axis_unit(A) code_value_float()
 
 #endif
 
@@ -3063,7 +3063,7 @@ static void homeaxis(const AxisEnum axis) {
 void gcode_get_destination() {
   LOOP_XYZE(i) {
     if (code_seen(axis_codes[i]))
-      destination[i] = code_value_axis_units(i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0);
+      destination[i] = code_value_axis_units((AxisEnum)i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0);
     else
       destination[i] = current_position[i];
   }
@@ -3232,7 +3232,7 @@ inline void gcode_G0_G1(
 
       float arc_offset[2] = { 0.0, 0.0 };
       if (code_seen('R')) {
-        const float r = code_value_axis_units(X_AXIS),
+        const float r = code_value_linear_units(),
                     x1 = current_position[X_AXIS], y1 = current_position[Y_AXIS],
                     x2 = destination[X_AXIS], y2 = destination[Y_AXIS];
         if (r && (x2 != x1 || y2 != y1)) {
@@ -3248,8 +3248,8 @@ inline void gcode_G0_G1(
         }
       }
       else {
-        if (code_seen('I')) arc_offset[X_AXIS] = code_value_axis_units(X_AXIS);
-        if (code_seen('J')) arc_offset[Y_AXIS] = code_value_axis_units(Y_AXIS);
+        if (code_seen('I')) arc_offset[X_AXIS] = code_value_linear_units();
+        if (code_seen('J')) arc_offset[Y_AXIS] = code_value_linear_units();
       }
 
       if (arc_offset[0] || arc_offset[1]) {
@@ -3302,10 +3302,10 @@ inline void gcode_G4() {
       gcode_get_destination();
 
       const float offset[] = {
-        code_seen('I') ? code_value_axis_units(X_AXIS) : 0.0,
-        code_seen('J') ? code_value_axis_units(Y_AXIS) : 0.0,
-        code_seen('P') ? code_value_axis_units(X_AXIS) : 0.0,
-        code_seen('Q') ? code_value_axis_units(Y_AXIS) : 0.0
+        code_seen('I') ? code_value_linear_units() : 0.0,
+        code_seen('J') ? code_value_linear_units() : 0.0,
+        code_seen('P') ? code_value_linear_units() : 0.0,
+        code_seen('Q') ? code_value_linear_units() : 0.0
       };
 
       plan_cubic_move(offset);
@@ -4023,7 +4023,7 @@ inline void gcode_G28() {
         }
 
         if (code_seen('Z')) {
-          mbl.z_values[px][py] = code_value_axis_units(Z_AXIS);
+          mbl.z_values[px][py] = code_value_linear_units();
         }
         else {
           SERIAL_CHAR('Z'); say_not_entered();
@@ -4033,7 +4033,7 @@ inline void gcode_G28() {
 
       case MeshSetZOffset:
         if (code_seen('Z')) {
-          mbl.z_offset = code_value_axis_units(Z_AXIS);
+          mbl.z_offset = code_value_linear_units();
         }
         else {
           SERIAL_CHAR('Z'); say_not_entered();
@@ -4305,7 +4305,7 @@ inline void gcode_G28() {
 
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-        zoffset = code_seen('Z') ? code_value_axis_units(Z_AXIS) : 0;
+        zoffset = code_seen('Z') ? code_value_linear_units() : 0;
 
       #endif
 
@@ -4313,10 +4313,10 @@ inline void gcode_G28() {
 
         xy_probe_feedrate_mm_s = MMM_TO_MMS(code_seen('S') ? code_value_linear_units() : XY_PROBE_SPEED);
 
-        left_probe_bed_position = code_seen('L') ? (int)code_value_axis_units(X_AXIS) : LOGICAL_X_POSITION(LEFT_PROBE_BED_POSITION);
-        right_probe_bed_position = code_seen('R') ? (int)code_value_axis_units(X_AXIS) : LOGICAL_X_POSITION(RIGHT_PROBE_BED_POSITION);
-        front_probe_bed_position = code_seen('F') ? (int)code_value_axis_units(Y_AXIS) : LOGICAL_Y_POSITION(FRONT_PROBE_BED_POSITION);
-        back_probe_bed_position = code_seen('B') ? (int)code_value_axis_units(Y_AXIS) : LOGICAL_Y_POSITION(BACK_PROBE_BED_POSITION);
+        left_probe_bed_position = code_seen('L') ? (int)code_value_linear_units() : LOGICAL_X_POSITION(LEFT_PROBE_BED_POSITION);
+        right_probe_bed_position = code_seen('R') ? (int)code_value_linear_units() : LOGICAL_X_POSITION(RIGHT_PROBE_BED_POSITION);
+        front_probe_bed_position = code_seen('F') ? (int)code_value_linear_units() : LOGICAL_Y_POSITION(FRONT_PROBE_BED_POSITION);
+        back_probe_bed_position = code_seen('B') ? (int)code_value_linear_units() : LOGICAL_Y_POSITION(BACK_PROBE_BED_POSITION);
 
         const bool left_out_l = left_probe_bed_position < LOGICAL_X_POSITION(MIN_PROBE_X),
                    left_out = left_out_l || left_probe_bed_position > right_probe_bed_position - (MIN_PROBE_EDGE),
@@ -4927,8 +4927,8 @@ inline void gcode_G28() {
    *     S = Stows the probe if 1 (default=1)
    */
   inline void gcode_G30() {
-    float X_probe_location = code_seen('X') ? code_value_axis_units(X_AXIS) : current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER,
-          Y_probe_location = code_seen('Y') ? code_value_axis_units(Y_AXIS) : current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER;
+    float X_probe_location = code_seen('X') ? code_value_linear_units() : current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER,
+          Y_probe_location = code_seen('Y') ? code_value_linear_units() : current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER;
 
     float pos[XYZ] = { X_probe_location, Y_probe_location, LOGICAL_Z_POSITION(0) };
     if (!position_is_reachable(pos, true)) return;
@@ -5431,13 +5431,13 @@ inline void gcode_G92() {
   LOOP_XYZE(i) {
     if (code_seen(axis_codes[i])) {
       #if IS_SCARA
-        current_position[i] = code_value_axis_units(i);
+        current_position[i] = code_value_axis_units((AxisEnum)i);
         if (i != E_AXIS) didXYZ = true;
       #else
         #if HAS_POSITION_SHIFT
-          float p = current_position[i];
+          const float p = current_position[i];
         #endif
-        float v = code_value_axis_units(i);
+        float v = code_value_axis_units((AxisEnum)i);
 
         current_position[i] = v;
 
@@ -6078,7 +6078,7 @@ inline void gcode_M42() {
 
     bool stow_probe_after_each = code_seen('E');
 
-    float X_probe_location = code_seen('X') ? code_value_axis_units(X_AXIS) : X_current + X_PROBE_OFFSET_FROM_EXTRUDER;
+    float X_probe_location = code_seen('X') ? code_value_linear_units() : X_current + X_PROBE_OFFSET_FROM_EXTRUDER;
     #if DISABLED(DELTA)
       if (!WITHIN(X_probe_location, LOGICAL_X_POSITION(MIN_PROBE_X), LOGICAL_X_POSITION(MAX_PROBE_X))) {
         out_of_range_error(PSTR("X"));
@@ -6086,7 +6086,7 @@ inline void gcode_M42() {
       }
     #endif
 
-    float Y_probe_location = code_seen('Y') ? code_value_axis_units(Y_AXIS) : Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER;
+    float Y_probe_location = code_seen('Y') ? code_value_linear_units() : Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER;
     #if DISABLED(DELTA)
       if (!WITHIN(Y_probe_location, LOGICAL_Y_POSITION(MIN_PROBE_Y), LOGICAL_Y_POSITION(MAX_PROBE_Y))) {
         out_of_range_error(PSTR("Y"));
@@ -7063,7 +7063,7 @@ inline void gcode_M92() {
   LOOP_XYZE(i) {
     if (code_seen(axis_codes[i])) {
       if (i == E_AXIS) {
-        float value = code_value_per_axis_unit(E_AXIS + TARGET_EXTRUDER);
+        const float value = code_value_per_axis_unit(E_AXIS + TARGET_EXTRUDER);
         if (value < 20.0) {
           float factor = planner.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] / value; // increase e constants if M92 E14 is given for netfab.
           planner.max_jerk[E_AXIS] *= factor;
@@ -7250,7 +7250,7 @@ inline void gcode_M121() { endstops.enable_globally(false); }
     RUNPLAN(FILAMENT_CHANGE_RETRACT_FEEDRATE);
 
     // Lift Z axis
-    const float z_lift = code_seen('Z') ? code_value_axis_units(Z_AXIS) :
+    const float z_lift = code_seen('Z') ? code_value_linear_units() :
       #if defined(FILAMENT_CHANGE_Z_ADD) && FILAMENT_CHANGE_Z_ADD > 0
         FILAMENT_CHANGE_Z_ADD
       #else
@@ -7264,12 +7264,12 @@ inline void gcode_M121() { endstops.enable_globally(false); }
     }
 
     // Move XY axes to filament change position or given position
-    destination[X_AXIS] = code_seen('X') ? code_value_axis_units(X_AXIS) : 0
+    destination[X_AXIS] = code_seen('X') ? code_value_linear_units() : 0
       #ifdef FILAMENT_CHANGE_X_POS
         + FILAMENT_CHANGE_X_POS
       #endif
     ;
-    destination[Y_AXIS] = code_seen('Y') ? code_value_axis_units(Y_AXIS) : 0
+    destination[Y_AXIS] = code_seen('Y') ? code_value_linear_units() : 0
       #ifdef FILAMENT_CHANGE_Y_POS
         + FILAMENT_CHANGE_Y_POS
       #endif
@@ -7355,10 +7355,6 @@ inline void gcode_M200() {
         if (! filament_size[i]) filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
     }
   }
-  else {
-    //reserved for setting filament diameter via UFID or filament measuring device
-    return;
-  }
   calculate_volumetric_multipliers();
 }
 
@@ -7374,7 +7370,7 @@ inline void gcode_M201() {
   LOOP_XYZE(i) {
     if (code_seen(axis_codes[i])) {
       const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
-      planner.max_acceleration_mm_per_s2[a] = code_value_axis_units(a);
+      planner.max_acceleration_mm_per_s2[a] = code_value_axis_units((AxisEnum)a);
     }
   }
   // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
@@ -7384,7 +7380,7 @@ inline void gcode_M201() {
 #if 0 // Not used for Sprinter/grbl gen6
   inline void gcode_M202() {
     LOOP_XYZE(i) {
-      if (code_seen(axis_codes[i])) axis_travel_steps_per_sqr_second[i] = code_value_axis_units(i) * planner.axis_steps_per_mm[i];
+      if (code_seen(axis_codes[i])) axis_travel_steps_per_sqr_second[i] = code_value_axis_units((AxisEnum)i) * planner.axis_steps_per_mm[i];
     }
   }
 #endif
@@ -7402,7 +7398,7 @@ inline void gcode_M203() {
   LOOP_XYZE(i)
     if (code_seen(axis_codes[i])) {
       const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
-      planner.max_feedrate_mm_s[a] = code_value_axis_units(a);
+      planner.max_feedrate_mm_s[a] = code_value_axis_units((AxisEnum)a);
     }
 }
 
@@ -7449,10 +7445,10 @@ inline void gcode_M205() {
   if (code_seen('S')) planner.min_feedrate_mm_s = code_value_linear_units();
   if (code_seen('T')) planner.min_travel_feedrate_mm_s = code_value_linear_units();
   if (code_seen('B')) planner.min_segment_time = code_value_millis();
-  if (code_seen('X')) planner.max_jerk[X_AXIS] = code_value_axis_units(X_AXIS);
-  if (code_seen('Y')) planner.max_jerk[Y_AXIS] = code_value_axis_units(Y_AXIS);
-  if (code_seen('Z')) planner.max_jerk[Z_AXIS] = code_value_axis_units(Z_AXIS);
-  if (code_seen('E')) planner.max_jerk[E_AXIS] = code_value_axis_units(E_AXIS);
+  if (code_seen('X')) planner.max_jerk[X_AXIS] = code_value_linear_units();
+  if (code_seen('Y')) planner.max_jerk[Y_AXIS] = code_value_linear_units();
+  if (code_seen('Z')) planner.max_jerk[Z_AXIS] = code_value_linear_units();
+  if (code_seen('E')) planner.max_jerk[E_AXIS] = code_value_linear_units();
 }
 
 #if HAS_M206_COMMAND
@@ -7463,11 +7459,11 @@ inline void gcode_M205() {
   inline void gcode_M206() {
     LOOP_XYZ(i)
       if (code_seen(axis_codes[i]))
-        set_home_offset((AxisEnum)i, code_value_axis_units(i));
+        set_home_offset((AxisEnum)i, code_value_linear_units());
 
     #if ENABLED(MORGAN_SCARA)
-      if (code_seen('T')) set_home_offset(A_AXIS, code_value_axis_units(A_AXIS)); // Theta
-      if (code_seen('P')) set_home_offset(B_AXIS, code_value_axis_units(B_AXIS)); // Psi
+      if (code_seen('T')) set_home_offset(A_AXIS, code_value_linear_units()); // Theta
+      if (code_seen('P')) set_home_offset(B_AXIS, code_value_linear_units()); // Psi
     #endif
 
     SYNC_PLAN_POSITION_KINEMATIC();
@@ -7517,7 +7513,7 @@ inline void gcode_M205() {
     #endif
     LOOP_XYZ(i) {
       if (code_seen(axis_codes[i])) {
-        endstop_adj[i] = code_value_axis_units(i);
+        endstop_adj[i] = code_value_linear_units();
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOPAIR("endstop_adj[", axis_codes[i]);
@@ -7539,7 +7535,7 @@ inline void gcode_M205() {
    * M666: For Z Dual Endstop setup, set z axis offset to the z2 axis.
    */
   inline void gcode_M666() {
-    if (code_seen('Z')) z_endstop_adj = code_value_axis_units(Z_AXIS);
+    if (code_seen('Z')) z_endstop_adj = code_value_linear_units();
     SERIAL_ECHOLNPAIR("Z Endstop Adjustment set to (mm):", z_endstop_adj);
   }
 
@@ -7558,7 +7554,7 @@ inline void gcode_M205() {
   inline void gcode_M207() {
     if (code_seen('S')) retract_length = code_value_axis_units(E_AXIS);
     if (code_seen('F')) retract_feedrate_mm_s = MMM_TO_MMS(code_value_axis_units(E_AXIS));
-    if (code_seen('Z')) retract_zlift = code_value_axis_units(Z_AXIS);
+    if (code_seen('Z')) retract_zlift = code_value_linear_units();
     #if EXTRUDERS > 1
       if (code_seen('W')) retract_length_swap = code_value_axis_units(E_AXIS);
     #endif
@@ -7631,11 +7627,11 @@ inline void gcode_M211() {
   inline void gcode_M218() {
     if (get_target_extruder_from_command(218) || target_extruder == 0) return;
 
-    if (code_seen('X')) hotend_offset[X_AXIS][target_extruder] = code_value_axis_units(X_AXIS);
-    if (code_seen('Y')) hotend_offset[Y_AXIS][target_extruder] = code_value_axis_units(Y_AXIS);
+    if (code_seen('X')) hotend_offset[X_AXIS][target_extruder] = code_value_linear_units();
+    if (code_seen('Y')) hotend_offset[Y_AXIS][target_extruder] = code_value_linear_units();
 
     #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_EXTRUDER)
-      if (code_seen('Z')) hotend_offset[Z_AXIS][target_extruder] = code_value_axis_units(Z_AXIS);
+      if (code_seen('Z')) hotend_offset[Z_AXIS][target_extruder] = code_value_linear_units();
     #endif
 
     SERIAL_ECHO_START;
@@ -8285,11 +8281,11 @@ void quickstop_stepper() {
     int8_t px = 0, py = 0;
     float z = 0;
     bool hasX, hasY, hasZ, hasI, hasJ;
-    if ((hasX = code_seen('X'))) px = mbl.probe_index_x(code_value_axis_units(X_AXIS));
-    if ((hasY = code_seen('Y'))) py = mbl.probe_index_y(code_value_axis_units(Y_AXIS));
-    if ((hasI = code_seen('I'))) px = code_value_axis_units(X_AXIS);
-    if ((hasJ = code_seen('J'))) py = code_value_axis_units(Y_AXIS);
-    if ((hasZ = code_seen('Z'))) z = code_value_axis_units(Z_AXIS);
+    if ((hasX = code_seen('X'))) px = mbl.probe_index_x(code_value_linear_units());
+    if ((hasY = code_seen('Y'))) py = mbl.probe_index_y(code_value_linear_units());
+    if ((hasI = code_seen('I'))) px = code_value_linear_units();
+    if ((hasJ = code_seen('J'))) py = code_value_linear_units();
+    if ((hasZ = code_seen('Z'))) z = code_value_linear_units();
 
     if (hasX && hasY && hasZ) {
 
@@ -8325,9 +8321,9 @@ void quickstop_stepper() {
     int8_t px = 0, py = 0;
     float z = 0;
     bool hasI, hasJ, hasZ;
-    if ((hasI = code_seen('I'))) px = code_value_axis_units(X_AXIS);
-    if ((hasJ = code_seen('J'))) py = code_value_axis_units(Y_AXIS);
-    if ((hasZ = code_seen('Z'))) z = code_value_axis_units(Z_AXIS);
+    if ((hasI = code_seen('I'))) px = code_value_linear_units();
+    if ((hasJ = code_seen('J'))) py = code_value_linear_units();
+    if ((hasZ = code_seen('Z'))) z = code_value_linear_units();
 
     if (hasI && hasJ && hasZ) {
       if (WITHIN(px, 0, GRID_MAX_POINTS_X - 1) && WITHIN(py, 0, GRID_MAX_POINTS_X - 1)) {
@@ -8474,7 +8470,7 @@ inline void gcode_M503() {
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM(MSG_ZPROBE_ZOFFSET " ");
     if (code_seen('Z')) {
-      const float value = code_value_axis_units(Z_AXIS);
+      const float value = code_value_linear_units();
       if (WITHIN(value, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX)) {
         zprobe_zoffset = value;
         refresh_zprobe_zoffset();
@@ -8557,7 +8553,7 @@ inline void gcode_M503() {
     RUNPLAN(FILAMENT_CHANGE_RETRACT_FEEDRATE);
 
     // Lift Z axis
-    float z_lift = code_seen('Z') ? code_value_axis_units(Z_AXIS) :
+    float z_lift = code_seen('Z') ? code_value_linear_units() :
       #if defined(FILAMENT_CHANGE_Z_ADD) && FILAMENT_CHANGE_Z_ADD > 0
         FILAMENT_CHANGE_Z_ADD
       #else
@@ -8572,12 +8568,12 @@ inline void gcode_M503() {
     }
 
     // Move XY axes to filament exchange position
-    if (code_seen('X')) destination[X_AXIS] = code_value_axis_units(X_AXIS);
+    if (code_seen('X')) destination[X_AXIS] = code_value_linear_units();
     #ifdef FILAMENT_CHANGE_X_POS
       else destination[X_AXIS] = FILAMENT_CHANGE_X_POS;
     #endif
 
-    if (code_seen('Y')) destination[Y_AXIS] = code_value_axis_units(Y_AXIS);
+    if (code_seen('Y')) destination[Y_AXIS] = code_value_linear_units();
     #ifdef FILAMENT_CHANGE_Y_POS
       else destination[Y_AXIS] = FILAMENT_CHANGE_Y_POS;
     #endif
@@ -8766,7 +8762,7 @@ inline void gcode_M503() {
       case DXC_AUTO_PARK_MODE:
         break;
       case DXC_DUPLICATION_MODE:
-        if (code_seen('X')) duplicate_extruder_x_offset = max(code_value_axis_units(X_AXIS), X2_MIN_POS - x_home_pos(0));
+        if (code_seen('X')) duplicate_extruder_x_offset = max(code_value_linear_units(), X2_MIN_POS - x_home_pos(0));
         if (code_seen('R')) duplicate_extruder_temp_offset = code_value_temp_diff();
         SERIAL_ECHO_START;
         SERIAL_ECHOPGM(MSG_HOTEND_OFFSET);
@@ -9127,7 +9123,7 @@ inline void gcode_M355() {
    *
    */
   inline void gcode_M163() {
-    int mix_index = code_seen('S') ? code_value_int() : 0;
+    const int mix_index = code_seen('S') ? code_value_int() : 0;
     if (mix_index < MIXING_STEPPERS) {
       float mix_value = code_seen('P') ? code_value_float() : 0.0;
       NOLESS(mix_value, 0.0);
@@ -9144,7 +9140,7 @@ inline void gcode_M355() {
      *
      */
     inline void gcode_M164() {
-      int tool_index = code_seen('S') ? code_value_int() : 0;
+      const int tool_index = code_seen('S') ? code_value_int() : 0;
       if (tool_index < MIXING_VIRTUAL_TOOLS) {
         normalize_mix();
         for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
@@ -9542,7 +9538,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
 
     tool_change(
       tmp_extruder,
-      code_seen('F') ? MMM_TO_MMS(code_value_axis_units(X_AXIS)) : 0.0,
+      code_seen('F') ? MMM_TO_MMS(code_value_linear_units()) : 0.0,
       (tmp_extruder == active_extruder) || (code_seen('S') && code_value_bool())
     );
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8797,13 +8797,13 @@ inline void gcode_M503() {
 
 #if ENABLED(LIN_ADVANCE)
   /**
-   * M905: Set and/or Get advance K factor and WH/D ratio
+   * M900: Set and/or Get advance K factor and WH/D ratio
    *
    *  K<factor>                  Set advance K factor
    *  R<ratio>                   Set ratio directly (overrides WH/D)
    *  W<width> H<height> D<diam> Set ratio from WH/D
    */
-  inline void gcode_M905() {
+  inline void gcode_M900() {
     stepper.synchronize();
 
     const float newK = code_seen('K') ? code_value_float() : -1;
@@ -10264,8 +10264,8 @@ void process_next_command() {
       #endif // DUAL_X_CARRIAGE
 
       #if ENABLED(LIN_ADVANCE)
-        case 905: // M905: Set advance K factor.
-          gcode_M905();
+        case 900: // M900: Set advance K factor.
+          gcode_M900();
           break;
       #endif
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -67,27 +67,27 @@
  * Global Leveling:
  *  219            z_fade_height                    (float)
  *
- * Mesh bed leveling:                               43 bytes
+ * MESH_BED_LEVELING:                               43 bytes
  *  223  M420 S    from mbl.status                  (bool)
  *  224            mbl.z_offset                     (float)
  *  228            GRID_MAX_POINTS_X                (uint8_t)
  *  229            GRID_MAX_POINTS_Y                (uint8_t)
  *  230 G29 S3 XYZ z_values[][]                     (float x9, up to float x 81) +288
  *
- * AUTO BED LEVELING                                4 bytes
+ * HAS_BED_PROBE:                                   4 bytes
  *  266  M851      zprobe_zoffset                   (float)
  *
- * ABL_PLANAR (or placeholder):                     36 bytes
+ * ABL_PLANAR:                                      36 bytes
  *  270            planner.bed_level_matrix         (matrix_3x3 = float x9)
  *
- * AUTO_BED_LEVELING_BILINEAR (or placeholder):     47 bytes
+ * AUTO_BED_LEVELING_BILINEAR:                      47 bytes
  *  306            GRID_MAX_POINTS_X                (uint8_t)
  *  307            GRID_MAX_POINTS_Y                (uint8_t)
  *  308            bilinear_grid_spacing            (int x2)
  *  312  G29 L F   bilinear_start                   (int x2)
  *  316            bed_level_grid[][]               (float x9, up to float x256) +988
  *
- * DELTA (if deltabot):                             48 bytes
+ * DELTA:                                           48 bytes
  *  348  M666 XYZ  endstop_adj                      (float x3)
  *  360  M665 R    delta_radius                     (float)
  *  364  M665 L    delta_diagonal_rod               (float)
@@ -99,7 +99,7 @@
  *  388  M665 J    delta_tower_angle_trim[B]        (float)
  *  392  M665 K    delta_tower_angle_trim[C]        (float)
  *
- * Z_DUAL_ENDSTOPS (if not deltabot):               48 bytes
+ * Z_DUAL_ENDSTOPS:                                 48 bytes
  *  348  M666 Z    z_endstop_adj                    (float)
  *  ---            dummy data                       (float x11)
  *
@@ -136,7 +136,7 @@
  *  533  M200 D    volumetric_enabled               (bool)
  *  534  M200 T D  filament_size                    (float x5) (T0..3)
  *
- * TMC2130 Stepper Current:                         20 bytes
+ * HAVE_TMC2130:                                    20 bytes
  *  554  M906 X    stepperX current                 (uint16_t)
  *  556  M906 Y    stepperY current                 (uint16_t)
  *  558  M906 Z    stepperZ current                 (uint16_t)

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -150,8 +150,8 @@
  *  576  M906 E4   stepperE4 current                (uint16_t)
  *
  * LIN_ADVANCE:                                     8 bytes
- *  580  M905 K    extruder_advance_k               (float)
- *  584  M905 WHD  advance_ed_ratio                 (float)
+ *  580  M900 K    extruder_advance_k               (float)
+ *  584  M900 WHD  advance_ed_ratio                 (float)
  *
  *  588                                Minimum end-point
  * 1909 (588 + 36 + 9 + 288 + 988)     Maximum end-point
@@ -1665,7 +1665,7 @@ void MarlinSettings::reset() {
         SERIAL_ECHOLNPGM("Linear Advance:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPAIR("  M905 K", planner.get_extruder_advance_k());
+      SERIAL_ECHOPAIR("  M900 K", planner.get_extruder_advance_k());
       SERIAL_ECHOLNPAIR(" R", planner.get_advance_ed_ratio());
     #endif
   }

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -614,12 +614,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -643,12 +643,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -638,12 +638,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -633,12 +633,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -654,12 +654,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -654,12 +654,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -651,12 +651,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -651,12 +651,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -657,12 +657,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -651,12 +651,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -630,12 +630,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -633,12 +633,14 @@
    * to a fixed value. Note that using a fixed ratio will lead to wrong nozzle pressures
    * if the slicer is using variable widths or layer heights within one print!
    *
-   * This option sets the default E:D ratio at startup. Use `M905` to override this value.
+   * This option sets the default E:D ratio at startup. Use `M900` to override this value.
    *
-   * Example: `M905 W0.4 H0.2 D1.75`, where:
+   * Example: `M900 W0.4 H0.2 D1.75`, where:
    *   - W is the extrusion width in mm
    *   - H is the layer height in mm
    *   - D is the filament diameter in mm
+   *
+   * Example: `M900 R0.0458` to set the ratio directly.
    *
    * Set to 0 to auto-detect the ratio based on given Gcode G1 print moves.
    *

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 trangos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimiento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_bg.h
+++ b/Marlin/language_bg.h
@@ -116,7 +116,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 стъпки/mm")
 #define MSG_TEMPERATURE                     _UxGT("Температура")
 #define MSG_MOTION                          _UxGT("Движение")
-#define MSG_VOLUMETRIC                      _UxGT("Нишка")
+#define MSG_FILAMENT                        _UxGT("Нишка")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Диам. нишка")
 #define MSG_CONTRAST                        _UxGT("LCD контраст")

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -120,7 +120,7 @@
 #define MSG_E5STEPS                         _UxGT("E5passos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Moviment")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E en mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. Fil.")
 #define MSG_CONTRAST                        _UxGT("Contrast de LCD")

--- a/Marlin/language_cn.h
+++ b/Marlin/language_cn.h
@@ -108,7 +108,7 @@
 #define MSG_E5STEPS                         "E5steps/mm"
 #define MSG_TEMPERATURE                     "\xc9\xd2"
 #define MSG_MOTION                          "\xdf\xb2"
-#define MSG_VOLUMETRIC                      "Filament"
+#define MSG_FILAMENT                        "Filament"
 #define MSG_VOLUMETRIC_ENABLED              "E in mm3"
 #define MSG_FILAMENT_DIAM                   "Fil. Dia."
 #define MSG_CONTRAST                        "LCD contrast"

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -119,7 +119,7 @@
 #define MSG_E5STEPS                         _UxGT("E5kroku/mm")
 #define MSG_TEMPERATURE                     _UxGT("Teplota")
 #define MSG_MOTION                          _UxGT("Pohyb")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E na mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Prum.")
 #define MSG_CONTRAST                        _UxGT("Kontrast LCD")

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -117,7 +117,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatur")
 #define MSG_MOTION                          _UxGT("Bevægelse")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E i mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD kontrast")

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -121,7 +121,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 Steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatur")
 #define MSG_MOTION                          _UxGT("Bewegung")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
 #define MSG_FILAMENT_DIAM                   _UxGT("D Fil.")
 #define MSG_CONTRAST                        _UxGT("LCD Kontrast")

--- a/Marlin/language_el-gr.h
+++ b/Marlin/language_el-gr.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("Bήματα Ε5 ανά μμ")
 #define MSG_TEMPERATURE                     _UxGT("Θερμοκρασία")
 #define MSG_MOTION                          _UxGT("Κίνηση")
-#define MSG_VOLUMETRIC                      _UxGT("Νήμα")
+#define MSG_FILAMENT                        _UxGT("Νήμα")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("Ε σε μμ3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Διάμετρος νήματος")
 #define MSG_CONTRAST                        _UxGT("Κοντράστ LCD")

--- a/Marlin/language_el.h
+++ b/Marlin/language_el.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("Bήματα Ε5 ανά μμ")
 #define MSG_TEMPERATURE                     _UxGT("Θερμοκρασία")
 #define MSG_MOTION                          _UxGT("Κίνηση")
-#define MSG_VOLUMETRIC                      _UxGT("Νήμα")
+#define MSG_FILAMENT                        _UxGT("Νήμα")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("Ε σε μμ3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Διάμετρος νήματος")
 #define MSG_CONTRAST                        _UxGT("Κοντράστ LCD")

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -300,14 +300,17 @@
 #ifndef MSG_MOTION
   #define MSG_MOTION                          _UxGT("Motion")
 #endif
-#ifndef MSG_VOLUMETRIC
-  #define MSG_VOLUMETRIC                      _UxGT("Filament")
+#ifndef MSG_FILAMENT
+  #define MSG_FILAMENT                        _UxGT("Filament")
 #endif
 #ifndef MSG_VOLUMETRIC_ENABLED
   #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #endif
 #ifndef MSG_FILAMENT_DIAM
   #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
+#endif
+#ifndef MSG_ADVANCE_K
+  #define MSG_ADVANCE_K                       _UxGT("Advance K")
 #endif
 #ifndef MSG_CONTRAST
   #define MSG_CONTRAST                        _UxGT("LCD contrast")

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -119,7 +119,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 pasos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimiento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -106,7 +106,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 pausoak/mm")
 #define MSG_TEMPERATURE                     _UxGT("Tenperatura")
 #define MSG_MOTION                          _UxGT("Mugimendua")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD kontrastea")

--- a/Marlin/language_fi.h
+++ b/Marlin/language_fi.h
@@ -107,7 +107,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Lämpötila")
 #define MSG_MOTION                          _UxGT("Liike")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD kontrasti")

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -120,7 +120,7 @@
 #define MSG_E5STEPS                         _UxGT("E5pas/mm")
 #define MSG_TEMPERATURE                     _UxGT("Tempzrature")
 #define MSG_MOTION                          _UxGT("Mouvement")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E en mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. Fil.")
 #define MSG_CONTRAST                        _UxGT("Contraste LCD")

--- a/Marlin/language_gl.h
+++ b/Marlin/language_gl.h
@@ -116,7 +116,7 @@
 #define MSG_E5STEPS                         _UxGT("E5pasos/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movemento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E en mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. fil.")
 #define MSG_CONTRAST                        _UxGT("Constraste LCD")

--- a/Marlin/language_hr.h
+++ b/Marlin/language_hr.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperature")
 #define MSG_MOTION                          _UxGT("Gibanje")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("Kontrast LCD-a")

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -123,7 +123,7 @@
 #define MSG_E5STEPS                         _UxGT("E5passi/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diam. filo")
 #define MSG_CONTRAST                        _UxGT("Contrasto LCD")

--- a/Marlin/language_kana.h
+++ b/Marlin/language_kana.h
@@ -151,7 +151,7 @@
 #endif
 #define MSG_TEMPERATURE                     "\xb5\xdd\xc4\xde"                                                 // "ｵﾝﾄﾞ" ("Temperature")
 #define MSG_MOTION                          "\xb3\xba\xde\xb7\xbe\xaf\xc3\xb2"                                 // "ｳｺﾞｷｾｯﾃｲ" ("Motion")
-#define MSG_VOLUMETRIC                      "\xcc\xa8\xd7\xd2\xdd\xc4"                                         // "ﾌｨﾗﾒﾝﾄ" ("Filament")
+#define MSG_FILAMENT                        "\xcc\xa8\xd7\xd2\xdd\xc4"                                         // "ﾌｨﾗﾒﾝﾄ" ("Filament")
 #define MSG_VOLUMETRIC_ENABLED              "E in mm3"
 #if LCD_WIDTH >= 20
   #define MSG_FILAMENT_DIAM                 "\xcc\xa8\xd7\xd2\xdd\xc4\xc1\xae\xaf\xb9\xb2"                     // "ﾌｨﾗﾒﾝﾄﾁｮｯｹｲ" ("Fil. Dia.")

--- a/Marlin/language_kana_utf8.h
+++ b/Marlin/language_kana_utf8.h
@@ -125,7 +125,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("オンド")                      // "Temperature"
 #define MSG_MOTION                          _UxGT("ウゴキセッテイ")                // "Motion"
-#define MSG_VOLUMETRIC                      _UxGT("フィラメント")                   // "Filament"
+#define MSG_FILAMENT                        _UxGT("フィラメント")                   // "Filament"
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("フィラメントチョッケイ")            // "Fil. Dia."
 #define MSG_CONTRAST                        _UxGT("LCDコントラスト")               // "LCD contrast"

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatuur")
 #define MSG_MOTION                          _UxGT("Beweging")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")
 #define MSG_CONTRAST                        _UxGT("LCD contrast")

--- a/Marlin/language_pl.h
+++ b/Marlin/language_pl.h
@@ -115,7 +115,7 @@
 #define MSG_E5STEPS                         _UxGT("krokiE5/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Ruch")
-#define MSG_VOLUMETRIC                      _UxGT("Filament")
+#define MSG_FILAMENT                        _UxGT("Filament")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E w mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Sr. fil.")
 #define MSG_CONTRAST                        _UxGT("Kontrast LCD")

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -108,7 +108,7 @@
 #define MSG_E5STEPS                         "E5/mm"
 #define MSG_TEMPERATURE                     "Temperatura"
 #define MSG_MOTION                          "Movimento"
-#define MSG_VOLUMETRIC                      "Filamento"
+#define MSG_FILAMENT                        "Filamento"
 #define MSG_VOLUMETRIC_ENABLED              "Extr. em mm3"
 #define MSG_FILAMENT_DIAM                   "Diametro Fil."
 #define MSG_CONTRAST                        "Contraste"

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -108,7 +108,7 @@
 #define MSG_E5STEPS                         _UxGT("E5/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("Extr. em mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Diametro Fil.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_pt.h
+++ b/Marlin/language_pt.h
@@ -112,7 +112,7 @@
 #define MSG_E5STEPS                         "E5 passo/mm"
 #define MSG_TEMPERATURE                     "Temperatura"
 #define MSG_MOTION                          "Movimento"
-#define MSG_VOLUMETRIC                      "Filamento"
+#define MSG_FILAMENT                        "Filamento"
 #define MSG_VOLUMETRIC_ENABLED              "E em mm3"
 #define MSG_FILAMENT_DIAM                   "Fil. Diam."
 #define MSG_CONTRAST                        "Contraste"

--- a/Marlin/language_pt_utf8.h
+++ b/Marlin/language_pt_utf8.h
@@ -112,7 +112,7 @@
 #define MSG_E5STEPS                         _UxGT("E5 passo/mm")
 #define MSG_TEMPERATURE                     _UxGT("Temperatura")
 #define MSG_MOTION                          _UxGT("Movimento")
-#define MSG_VOLUMETRIC                      _UxGT("Filamento")
+#define MSG_FILAMENT                        _UxGT("Filamento")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E em mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Diam.")
 #define MSG_CONTRAST                        _UxGT("Contraste")

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -111,7 +111,7 @@
 #define MSG_E4STEPS                         _UxGT("E4 шаг/мм")
 #define MSG_TEMPERATURE                     _UxGT("Температура")
 #define MSG_MOTION                          _UxGT("Механика")
-#define MSG_VOLUMETRIC                      _UxGT("Пруток")
+#define MSG_FILAMENT                        _UxGT("Пруток")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E в mm3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Диаметр прутка")
 #define MSG_CONTRAST                        _UxGT("Контраст LCD")

--- a/Marlin/language_test.h
+++ b/Marlin/language_test.h
@@ -148,7 +148,7 @@
   #define MSG_MAIN                            STRG_OKTAL_2
   #define MSG_TEMPERATURE                     STRG_OKTAL_3
   #define MSG_MOTION                          STRG_OKTAL_4
-  #define MSG_VOLUMETRIC                      STRG_OKTAL_5
+  #define MSG_FILAMENT                        STRG_OKTAL_5
   #define MSG_CONTRAST                        STRG_OKTAL_6
   #define MSG_RESTORE_FAILSAFE                STRG_OKTAL_7
 
@@ -183,7 +183,7 @@
   #define MSG_MAIN                            STRG_OKTAL_2
   #define MSG_TEMPERATURE                     STRG_OKTAL_3
   #define MSG_MOTION                          STRG_OKTAL_4
-  #define MSG_VOLUMETRIC                      STRG_OKTAL_5
+  #define MSG_FILAMENT                        STRG_OKTAL_5
   #define MSG_CONTRAST                        STRG_OKTAL_6
   #define MSG_RESTORE_FAILSAFE                STRG_OKTAL_7
 
@@ -218,7 +218,7 @@
   #define MSG_MAIN                            STRG_OKTAL_2
   #define MSG_TEMPERATURE                     STRG_OKTAL_3
   #define MSG_MOTION                          STRG_OKTAL_4
-  #define MSG_VOLUMETRIC                      STRG_OKTAL_5
+  #define MSG_FILAMENT                        STRG_OKTAL_5
   #define MSG_CONTRAST                        STRG_OKTAL_6
   #define MSG_RESTORE_FAILSAFE                STRG_OKTAL_7
 

--- a/Marlin/language_tr.h
+++ b/Marlin/language_tr.h
@@ -120,7 +120,7 @@
 #define MSG_E5STEPS                         _UxGT("E5steps/mm")                                         // E4steps/mm
 #define MSG_TEMPERATURE                     _UxGT("Sıcaklık")                                           // Sıcaklık
 #define MSG_MOTION                          _UxGT("Hareket")                                            // Hareket
-#define MSG_VOLUMETRIC                      _UxGT("Filaman")                                            // Filaman
+#define MSG_FILAMENT                        _UxGT("Filaman")                                            // Filaman
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")                                           // E in mm3
 #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Çap")                                           // Fil. Çap
 #define MSG_CONTRAST                        _UxGT("LCD Kontrast")                                       // LCD Kontrast

--- a/Marlin/language_uk.h
+++ b/Marlin/language_uk.h
@@ -116,7 +116,7 @@
 #define MSG_E5STEPS                         _UxGT("E5кроків/мм")
 #define MSG_TEMPERATURE                     _UxGT("Температура")
 #define MSG_MOTION                          _UxGT("Рух")
-#define MSG_VOLUMETRIC                      _UxGT("Волокно")
+#define MSG_FILAMENT                        _UxGT("Волокно")
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("E в мм3")
 #define MSG_FILAMENT_DIAM                   _UxGT("Діам. волок.")
 #define MSG_CONTRAST                        _UxGT("контраст LCD")

--- a/Marlin/language_zh_CN.h
+++ b/Marlin/language_zh_CN.h
@@ -108,7 +108,7 @@
 #define MSG_ESTEPS                          _UxGT("挤出机步数/mm")  //"Esteps/mm"
 #define MSG_TEMPERATURE                     _UxGT("温度")  //"Temperature"
 #define MSG_MOTION                          _UxGT("运动")  //"Motion"
-#define MSG_VOLUMETRIC                      _UxGT("丝料测容")  //"Filament" lcd_control_volumetric_menu
+#define MSG_FILAMENT                        _UxGT("丝料测容")  //"Filament" lcd_control_volumetric_menu
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("测容积mm³")  //"E in mm3" volumetric_enabled
 #define MSG_FILAMENT_DIAM                   _UxGT("丝料直径")  //"Fil. Dia."
 #define MSG_CONTRAST                        _UxGT("LCD对比度")  //"LCD contrast"

--- a/Marlin/language_zh_TW.h
+++ b/Marlin/language_zh_TW.h
@@ -108,7 +108,7 @@
 #define MSG_ESTEPS                          _UxGT("擠出機步數/mm")  //"Esteps/mm"
 #define MSG_TEMPERATURE                     _UxGT("溫度")  //"Temperature"
 #define MSG_MOTION                          _UxGT("運動")  //"Motion"
-#define MSG_VOLUMETRIC                      _UxGT("絲料測容")  //"Filament" lcd_control_volumetric_menu
+#define MSG_FILAMENT                        _UxGT("絲料測容")  //"Filament" lcd_control_volumetric_menu
 #define MSG_VOLUMETRIC_ENABLED              _UxGT("測容積mm³")  //"E in mm3" volumetric_enabled
 #define MSG_FILAMENT_DIAM                   _UxGT("絲料直徑")  //"Fil. Dia."
 #define MSG_CONTRAST                        _UxGT("LCD對比度")  //"LCD contrast"

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -267,9 +267,10 @@ class Planner {
     #endif
 
     #if ENABLED(LIN_ADVANCE)
-      static void set_extruder_advance_k(const float &k) { extruder_advance_k = k; };
+      static void set_extruder_advance_k(float k) { extruder_advance_k = k; };
       static float get_extruder_advance_k() { return extruder_advance_k; };
-      static void set_advance_ed_ratio(const float &ratio) { advance_ed_ratio = ratio; };
+      static void set_advance_ed_ratio(float ratio) { advance_ed_ratio = ratio; };
+      static float get_advance_ed_ratio() { return advance_ed_ratio; };
     #endif
 
     /**

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2114,7 +2114,7 @@ void kill_screen(const char* lcd_msg) {
     MENU_BACK(MSG_MAIN);
     MENU_ITEM(submenu, MSG_TEMPERATURE, lcd_control_temperature_menu);
     MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
-    MENU_ITEM(submenu, MSG_VOLUMETRIC, lcd_control_filament_menu);
+    MENU_ITEM(submenu, MSG_FILAMENT, lcd_control_filament_menu);
 
     #if HAS_LCD_CONTRAST
       //MENU_ITEM_EDIT(int3, MSG_CONTRAST, &lcd_contrast, 0, 63);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -90,50 +90,25 @@ uint16_t max_display_update_time = 0;
 
 #if ENABLED(ULTIPANEL)
 
-  // place-holders for Ki and Kd edits
-  float raw_Ki, raw_Kd;
-
-  /**
-   * REVERSE_MENU_DIRECTION
-   *
-   * To reverse the menu direction we need a general way to reverse
-   * the direction of the encoder everywhere. So encoderDirection is
-   * added to allow the encoder to go the other way.
-   *
-   * This behavior is limited to scrolling Menus and SD card listings,
-   * and is disabled in other contexts.
-   */
-  #if ENABLED(REVERSE_MENU_DIRECTION)
-    int8_t encoderDirection = 1;
-    #define ENCODER_DIRECTION_NORMAL() (encoderDirection = 1)
-    #define ENCODER_DIRECTION_MENUS() (encoderDirection = -1)
-  #else
-    #define ENCODER_DIRECTION_NORMAL() ;
-    #define ENCODER_DIRECTION_MENUS() ;
+  #ifndef TALL_FONT_CORRECTION
+    #define TALL_FONT_CORRECTION 0
   #endif
 
-  int8_t encoderDiff; // updated from interrupt context and added to encoderPosition every LCD update
-
-  millis_t manual_move_start_time = 0;
-  int8_t manual_move_axis = (int8_t)NO_AXIS;
-  #if EXTRUDERS > 1
-    int8_t manual_move_e_index = 0;
-  #else
-    #define manual_move_e_index 0
-  #endif
-
-  bool encoderRateMultiplierEnabled;
-  int32_t lastEncoderMovementMillis;
-
-  #if ENABLED(AUTO_BED_LEVELING_UBL)
-    #include "ubl.h"
-  #endif
+  // Function pointer to menu functions.
+  typedef void (*screenFunc_t)();
 
   #if HAS_POWER_SWITCH
     extern bool powersupply;
   #endif
 
-  const float manual_feedrate_mm_m[] = MANUAL_FEEDRATE;
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    #include "ubl.h"
+  #endif
+
+  ////////////////////////////////////////////
+  ///////////////// Menu Tree ////////////////
+  ////////////////////////////////////////////
+
   void lcd_main_menu();
   void lcd_tune_menu();
   void lcd_prepare_menu();
@@ -144,13 +119,6 @@ uint16_t max_display_update_time = 0;
   void lcd_control_temperature_preheat_material2_settings_menu();
   void lcd_control_motion_menu();
   void lcd_control_filament_menu();
-
-  #if ENABLED(DAC_STEPPER_CURRENT)
-    void dac_driver_commit();
-    void dac_driver_getValues();
-    void lcd_dac_menu();
-    void lcd_dac_write_eeprom();
-  #endif
 
   #if ENABLED(LCD_INFO_MENU)
     #if ENABLED(PRINTCOUNTER)
@@ -173,6 +141,13 @@ uint16_t max_display_update_time = 0;
     void lcd_filament_change_resume_message();
   #endif
 
+  #if ENABLED(DAC_STEPPER_CURRENT)
+    void dac_driver_commit();
+    void dac_driver_getValues();
+    void lcd_dac_menu();
+    void lcd_dac_write_eeprom();
+  #endif
+
   #if HAS_LCD_CONTRAST
     void lcd_set_contrast();
   #endif
@@ -189,10 +164,10 @@ uint16_t max_display_update_time = 0;
     #include "mesh_bed_leveling.h"
   #endif
 
-  // Function pointer to menu functions.
-  typedef void (*screenFunc_t)();
+  ////////////////////////////////////////////
+  //////////// Menu System Actions ///////////
+  ////////////////////////////////////////////
 
-  // Different types of actions that can be used in menu items.
   #define menu_action_back(dummy) _menu_action_back()
   void _menu_action_back();
   void menu_action_submenu(screenFunc_t data);
@@ -230,7 +205,9 @@ uint16_t max_display_update_time = 0;
     void menu_action_sddirectory(const char* filename, char* longFilename);
   #endif
 
-  /* Helper macros for menus */
+  ////////////////////////////////////////////
+  //////////// Menu System Macros ////////////
+  ////////////////////////////////////////////
 
   #ifndef ENCODER_FEEDRATE_DEADZONE
     #define ENCODER_FEEDRATE_DEADZONE 10
@@ -241,59 +218,6 @@ uint16_t max_display_update_time = 0;
   #ifndef ENCODER_PULSES_PER_STEP
     #define ENCODER_PULSES_PER_STEP 1
   #endif
-
-  #ifndef TALL_FONT_CORRECTION
-    #define TALL_FONT_CORRECTION 0
-  #endif
-
-  /**
-   * START_SCREEN_OR_MENU generates init code for a screen or menu
-   *
-   *   encoderLine is the position based on the encoder
-   *   encoderTopLine is the top menu line to display
-   *   _lcdLineNr is the index of the LCD line (e.g., 0-3)
-   *   _menuLineNr is the menu item to draw and process
-   *   _thisItemNr is the index of each MENU_ITEM or STATIC_ITEM
-   *   _countedItems is the total number of items in the menu (after one call)
-   */
-  #define START_SCREEN_OR_MENU(LIMIT) \
-    ENCODER_DIRECTION_MENUS(); \
-    encoderRateMultiplierEnabled = false; \
-    if (encoderPosition > 0x8000) encoderPosition = 0; \
-    static int8_t _countedItems = 0; \
-    int8_t encoderLine = encoderPosition / (ENCODER_STEPS_PER_MENU_ITEM); \
-    if (_countedItems > 0 && encoderLine >= _countedItems - (LIMIT)) { \
-      encoderLine = max(0, _countedItems - (LIMIT)); \
-      encoderPosition = encoderLine * (ENCODER_STEPS_PER_MENU_ITEM); \
-    }
-
-  #define SCREEN_OR_MENU_LOOP() \
-    int8_t _menuLineNr = encoderTopLine, _thisItemNr; \
-    for (int8_t _lcdLineNr = 0; _lcdLineNr < LCD_HEIGHT - (TALL_FONT_CORRECTION); _lcdLineNr++, _menuLineNr++) { \
-      _thisItemNr = 0
-
-  /**
-   * START_SCREEN  Opening code for a screen having only static items.
-   *               Do simplified scrolling of the entire screen.
-   *
-   * START_MENU    Opening code for a screen with menu items.
-   *               Scroll as-needed to keep the selected line in view.
-   */
-  #define START_SCREEN() \
-    START_SCREEN_OR_MENU(LCD_HEIGHT - (TALL_FONT_CORRECTION)); \
-    encoderTopLine = encoderLine; \
-    bool _skipStatic = false; \
-    SCREEN_OR_MENU_LOOP()
-
-  #define START_MENU() \
-    START_SCREEN_OR_MENU(1); \
-    screen_changed = false; \
-    NOMORE(encoderTopLine, encoderLine); \
-    if (encoderLine >= encoderTopLine + LCD_HEIGHT - (TALL_FONT_CORRECTION)) { \
-      encoderTopLine = encoderLine - (LCD_HEIGHT - (TALL_FONT_CORRECTION) - 1); \
-    } \
-    bool _skipStatic = true; \
-    SCREEN_OR_MENU_LOOP()
 
   /**
    * MENU_ITEM generates draw & handler code for a menu item, potentially calling:
@@ -352,16 +276,10 @@ uint16_t max_display_update_time = 0;
     } \
     ++_thisItemNr
 
-  #define END_SCREEN() \
-    } \
-    _countedItems = _thisItemNr
-
-  #define END_MENU() \
-    } \
-    _countedItems = _thisItemNr; \
-    UNUSED(_skipStatic)
-
   #if ENABLED(ENCODER_RATE_MULTIPLIER)
+
+    bool encoderRateMultiplierEnabled;
+    #define ENCODER_RATE_MULTIPLY(F) (encoderRateMultiplierEnabled = F)
 
     //#define ENCODER_RATE_MULTIPLIER_DEBUG  // If defined, output the encoder steps per second value
 
@@ -375,7 +293,9 @@ uint16_t max_display_update_time = 0;
         _MENU_ITEM_PART_2(type, ## __VA_ARGS__); \
       } while(0)
 
-  #endif //ENCODER_RATE_MULTIPLIER
+  #else  // !ENCODER_RATE_MULTIPLIER
+    #define ENCODER_RATE_MULTIPLY(F) NOOP
+  #endif // !ENCODER_RATE_MULTIPLIER
 
   #define MENU_ITEM_DUMMY() do { _thisItemNr++; } while(0)
   #define MENU_ITEM_EDIT(type, label, ...) MENU_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
@@ -391,43 +311,137 @@ uint16_t max_display_update_time = 0;
     #define MENU_MULTIPLIER_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #endif //!ENCODER_RATE_MULTIPLIER
 
-  /** Used variables to keep track of the menu */
-  volatile uint8_t buttons;  //the last checked buttons in a bit array.
-  #if ENABLED(REPRAPWORLD_KEYPAD)
-    volatile uint8_t buttons_reprapworld_keypad; // to store the keypad shift register values
+  /**
+   * START_SCREEN_OR_MENU generates init code for a screen or menu
+   *
+   *   encoderLine is the position based on the encoder
+   *   encoderTopLine is the top menu line to display
+   *   _lcdLineNr is the index of the LCD line (e.g., 0-3)
+   *   _menuLineNr is the menu item to draw and process
+   *   _thisItemNr is the index of each MENU_ITEM or STATIC_ITEM
+   *   _countedItems is the total number of items in the menu (after one call)
+   */
+  #define START_SCREEN_OR_MENU(LIMIT) \
+    ENCODER_DIRECTION_MENUS(); \
+    ENCODER_RATE_MULTIPLY(false); \
+    if (encoderPosition > 0x8000) encoderPosition = 0; \
+    static int8_t _countedItems = 0; \
+    int8_t encoderLine = encoderPosition / (ENCODER_STEPS_PER_MENU_ITEM); \
+    if (_countedItems > 0 && encoderLine >= _countedItems - (LIMIT)) { \
+      encoderLine = max(0, _countedItems - (LIMIT)); \
+      encoderPosition = encoderLine * (ENCODER_STEPS_PER_MENU_ITEM); \
+    }
+
+  #define SCREEN_OR_MENU_LOOP() \
+    int8_t _menuLineNr = encoderTopLine, _thisItemNr; \
+    for (int8_t _lcdLineNr = 0; _lcdLineNr < LCD_HEIGHT - (TALL_FONT_CORRECTION); _lcdLineNr++, _menuLineNr++) { \
+      _thisItemNr = 0
+
+  /**
+   * START_SCREEN  Opening code for a screen having only static items.
+   *               Do simplified scrolling of the entire screen.
+   *
+   * START_MENU    Opening code for a screen with menu items.
+   *               Scroll as-needed to keep the selected line in view.
+   */
+  #define START_SCREEN() \
+    START_SCREEN_OR_MENU(LCD_HEIGHT - (TALL_FONT_CORRECTION)); \
+    encoderTopLine = encoderLine; \
+    bool _skipStatic = false; \
+    SCREEN_OR_MENU_LOOP()
+
+  #define START_MENU() \
+    START_SCREEN_OR_MENU(1); \
+    screen_changed = false; \
+    NOMORE(encoderTopLine, encoderLine); \
+    if (encoderLine >= encoderTopLine + LCD_HEIGHT - (TALL_FONT_CORRECTION)) { \
+      encoderTopLine = encoderLine - (LCD_HEIGHT - (TALL_FONT_CORRECTION) - 1); \
+    } \
+    bool _skipStatic = true; \
+    SCREEN_OR_MENU_LOOP()
+
+  #define END_SCREEN() \
+    } \
+    _countedItems = _thisItemNr
+
+  #define END_MENU() \
+    } \
+    _countedItems = _thisItemNr; \
+    UNUSED(_skipStatic)
+
+  ////////////////////////////////////////////
+  ///////////// Global Variables /////////////
+  ////////////////////////////////////////////
+
+  /**
+   * REVERSE_MENU_DIRECTION
+   *
+   * To reverse the menu direction we need a general way to reverse
+   * the direction of the encoder everywhere. So encoderDirection is
+   * added to allow the encoder to go the other way.
+   *
+   * This behavior is limited to scrolling Menus and SD card listings,
+   * and is disabled in other contexts.
+   */
+  #if ENABLED(REVERSE_MENU_DIRECTION)
+    int8_t encoderDirection = 1;
+    #define ENCODER_DIRECTION_NORMAL() (encoderDirection = 1)
+    #define ENCODER_DIRECTION_MENUS() (encoderDirection = -1)
+  #else
+    #define ENCODER_DIRECTION_NORMAL() ;
+    #define ENCODER_DIRECTION_MENUS() ;
   #endif
 
-  #if ENABLED(LCD_HAS_SLOW_BUTTONS)
-    volatile uint8_t slow_buttons; // Bits of the pressed buttons.
-  #endif
-  int8_t encoderTopLine;              /* scroll offset in the current menu */
-  millis_t next_button_update_ms;
-  uint8_t lastEncoderBits;
+  // Encoder Movement
+  volatile int8_t encoderDiff; // Updated in lcd_buttons_update, added to encoderPosition every LCD update
   uint32_t encoderPosition;
-  #if PIN_EXISTS(SD_DETECT)
-    uint8_t lcd_sd_status;
+  millis_t lastEncoderMovementMillis = 0;
+
+  // Button States
+  bool lcd_clicked, wait_for_unclick;
+  volatile uint8_t buttons;
+  millis_t next_button_update_ms;
+  #if ENABLED(REPRAPWORLD_KEYPAD)
+    volatile uint8_t buttons_reprapworld_keypad;
+  #endif
+  #if ENABLED(LCD_HAS_SLOW_BUTTONS)
+    volatile uint8_t slow_buttons;
   #endif
 
+  // Menu System Navigation
+  screenFunc_t currentScreen = lcd_status_screen;
+  int8_t encoderTopLine;
   typedef struct {
     screenFunc_t menu_function;
     uint32_t encoder_position;
   } menuPosition;
-
-  screenFunc_t currentScreen = lcd_status_screen; // pointer to the currently active menu handler
-
-  menuPosition screen_history[10];
+  menuPosition screen_history[6];
   uint8_t screen_history_depth = 0;
-  bool screen_changed;
+  bool screen_changed, defer_return_to_status;
 
-  // LCD and menu clicks
-  bool lcd_clicked, wait_for_unclick, defer_return_to_status;
-
-  // Variables used when editing values.
-  const char* editLabel;
-  void* editValue;
-  void* editSetter;
+  // Value Editing
+  const char *editLabel;
+  void *editValue, *editSetter;
   int32_t minEditValue, maxEditValue;
-  screenFunc_t callbackFunc;              // call this after editing
+  screenFunc_t callbackFunc;
+
+  // Manual Moves
+  const float manual_feedrate_mm_m[] = MANUAL_FEEDRATE;
+  millis_t manual_move_start_time = 0;
+  int8_t manual_move_axis = (int8_t)NO_AXIS;
+  #if EXTRUDERS > 1
+    int8_t manual_move_e_index = 0;
+  #else
+    #define manual_move_e_index 0
+  #endif
+
+  #if PIN_EXISTS(SD_DETECT)
+    uint8_t lcd_sd_status;
+  #endif
+
+  #if ENABLED(PIDTEMP)
+    float raw_Ki, raw_Kd; // place-holders for Ki and Kd edits
+  #endif
 
   /**
    * General function to go directly to a screen
@@ -528,7 +542,7 @@ void lcd_status_screen() {
 
   #if ENABLED(ULTIPANEL)
     ENCODER_DIRECTION_NORMAL();
-    encoderRateMultiplierEnabled = false;
+    ENCODER_RATE_MULTIPLY(false);
   #endif
 
   #if ENABLED(LCD_PROGRESS_BAR)
@@ -2186,28 +2200,28 @@ void kill_screen(const char* lcd_msg) {
       PID_PARAM(Kd, e) = scalePID_d(raw_Kd);
       thermalManager.updatePID();
     }
-    #define _PIDTEMP_BASE_FUNCTIONS(N) \
+    #define _DEFINE_PIDTEMP_BASE_FUNCS(N) \
       void copy_and_scalePID_i_E ## N() { copy_and_scalePID_i(N); } \
       void copy_and_scalePID_d_E ## N() { copy_and_scalePID_d(N); }
 
     #if ENABLED(PID_AUTOTUNE_MENU)
-      #define _PIDTEMP_FUNCTIONS(N) \
-        _PIDTEMP_BASE_FUNCTIONS(N); \
-        void lcd_autotune_callback_E ## N() { _lcd_autotune(N); }
+      #define DEFINE_PIDTEMP_FUNCS(N) \
+        _DEFINE_PIDTEMP_BASE_FUNCS(N); \
+        void lcd_autotune_callback_E ## N() { _lcd_autotune(N); } typedef void _pid_##N##_void
     #else
-      #define _PIDTEMP_FUNCTIONS(N) _PIDTEMP_BASE_FUNCTIONS(N)
+      #define DEFINE_PIDTEMP_FUNCS(N) _DEFINE_PIDTEMP_BASE_FUNCS(N) typedef void _pid_##N##_void
     #endif
 
-    _PIDTEMP_FUNCTIONS(0)
+    DEFINE_PIDTEMP_FUNCS(0);
     #if ENABLED(PID_PARAMS_PER_HOTEND)
       #if HOTENDS > 1
-        _PIDTEMP_FUNCTIONS(1)
+        DEFINE_PIDTEMP_FUNCS(1);
         #if HOTENDS > 2
-          _PIDTEMP_FUNCTIONS(2)
+          DEFINE_PIDTEMP_FUNCS(2);
           #if HOTENDS > 3
-            _PIDTEMP_FUNCTIONS(3)
+            DEFINE_PIDTEMP_FUNCS(3);
             #if HOTENDS > 4
-              _PIDTEMP_FUNCTIONS(4)
+              DEFINE_PIDTEMP_FUNCS(4);
             #endif // HOTENDS > 4
           #endif // HOTENDS > 3
         #endif // HOTENDS > 2
@@ -2660,7 +2674,7 @@ void kill_screen(const char* lcd_msg) {
     void lcd_sdcard_menu() {
       ENCODER_DIRECTION_MENUS();
       if (!lcdDrawUpdate && !lcd_clicked) return; // nothing to do (so don't thrash the SD card)
-      uint16_t fileCnt = card.getnrfilenames();
+      const uint16_t fileCnt = card.getnrfilenames();
       START_MENU();
       MENU_BACK(MSG_MAIN);
       card.getWorkDirName();
@@ -2675,11 +2689,11 @@ void kill_screen(const char* lcd_msg) {
 
       for (uint16_t i = 0; i < fileCnt; i++) {
         if (_menuLineNr == _thisItemNr) {
-          #if ENABLED(SDCARD_RATHERRECENTFIRST) && DISABLED(SDCARD_SORT_ALPHA)
-            int nr = fileCnt - 1 - i;
-          #else
-            int nr = i;
-          #endif
+          const uint16_t nr =
+            #if ENABLED(SDCARD_RATHERRECENTFIRST) && DISABLED(SDCARD_SORT_ALPHA)
+              fileCnt - 1 -
+            #endif
+          i;
 
           #if ENABLED(SDCARD_SORT_ALPHA)
             card.getfilename_sorted(nr);
@@ -3104,9 +3118,9 @@ void kill_screen(const char* lcd_msg) {
    *
    * Functions for editing single values
    *
-   * The "menu_edit_type" macro generates the functions needed to edit a numerical value.
+   * The "DEFINE_MENU_EDIT_TYPE" macro generates the functions needed to edit a numerical value.
    *
-   * For example, menu_edit_type(int, int3, itostr3, 1) expands into these functions:
+   * For example, DEFINE_MENU_EDIT_TYPE(int, int3, itostr3, 1) expands into these functions:
    *
    *   bool _menu_edit_int3();
    *   void menu_edit_int3(); // edit int (interactively)
@@ -3131,7 +3145,7 @@ void kill_screen(const char* lcd_msg) {
    * Values that are get/set via functions (As opposed to global variables) can use the accessor form:
    *   MENU_ITEM_EDIT_ACCESSOR(int3, MSG_SPEED, get_feedrate_percentage, set_feedrate_percentage, 10, 999)
    */
-  #define menu_edit_type(_type, _name, _strFunc, _scale) \
+  #define DEFINE_MENU_EDIT_TYPE(_type, _name, _strFunc, _scale) \
     bool _menu_edit_ ## _name () { \
       ENCODER_DIRECTION_NORMAL(); \
       if ((int32_t)encoderPosition < 0) encoderPosition = 0; \
@@ -3189,15 +3203,15 @@ void kill_screen(const char* lcd_msg) {
     } \
     typedef void _name
 
-  menu_edit_type(int, int3, itostr3, 1);
-  menu_edit_type(float, float3, ftostr3, 1.0);
-  menu_edit_type(float, float32, ftostr32, 100.0);
-  menu_edit_type(float, float43, ftostr43sign, 1000.0);
-  menu_edit_type(float, float5, ftostr5rj, 0.01);
-  menu_edit_type(float, float51, ftostr51sign, 10.0);
-  menu_edit_type(float, float52, ftostr52sign, 100.0);
-  menu_edit_type(float, float62, ftostr62rj, 100.0);
-  menu_edit_type(unsigned long, long5, ftostr5rj, 0.01);
+  DEFINE_MENU_EDIT_TYPE(int, int3, itostr3, 1);
+  DEFINE_MENU_EDIT_TYPE(float, float3, ftostr3, 1.0);
+  DEFINE_MENU_EDIT_TYPE(float, float32, ftostr32, 100.0);
+  DEFINE_MENU_EDIT_TYPE(float, float43, ftostr43sign, 1000.0);
+  DEFINE_MENU_EDIT_TYPE(float, float5, ftostr5rj, 0.01);
+  DEFINE_MENU_EDIT_TYPE(float, float51, ftostr51sign, 10.0);
+  DEFINE_MENU_EDIT_TYPE(float, float52, ftostr52sign, 100.0);
+  DEFINE_MENU_EDIT_TYPE(float, float62, ftostr62rj, 100.0);
+  DEFINE_MENU_EDIT_TYPE(unsigned long, long5, ftostr5rj, 0.01);
 
   /**
    *
@@ -3466,7 +3480,7 @@ void lcd_update() {
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
 
-    bool sd_status = IS_SD_INSERTED;
+    const bool sd_status = IS_SD_INSERTED;
     if (sd_status != lcd_sd_status && lcd_detected()) {
 
       if (sd_status) {
@@ -3489,7 +3503,7 @@ void lcd_update() {
 
   #endif //SDSUPPORT && SD_DETECT_PIN
 
-  millis_t ms = millis();
+  const millis_t ms = millis();
   if (ELAPSED(ms, next_lcd_update_ms)
     #if ENABLED(DOGLCD)
       || drawing_screen
@@ -3759,6 +3773,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
    * Warning: This function is called from interrupt context!
    */
   void lcd_buttons_update() {
+    static uint8_t lastEncoderBits;
     millis_t now = millis();
     if (ELAPSED(now, next_button_update_ms)) {
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -143,7 +143,7 @@ uint16_t max_display_update_time = 0;
   void lcd_control_temperature_preheat_material1_settings_menu();
   void lcd_control_temperature_preheat_material2_settings_menu();
   void lcd_control_motion_menu();
-  void lcd_control_volumetric_menu();
+  void lcd_control_filament_menu();
 
   #if ENABLED(DAC_STEPPER_CURRENT)
     void dac_driver_commit();
@@ -198,26 +198,31 @@ uint16_t max_display_update_time = 0;
   void menu_action_submenu(screenFunc_t data);
   void menu_action_gcode(const char* pgcode);
   void menu_action_function(screenFunc_t data);
+
+  #define DECLARE_MENU_EDIT_TYPE(_type, _name) \
+    bool _menu_edit_ ## _name(); \
+    void menu_edit_ ## _name(); \
+    void menu_edit_callback_ ## _name(); \
+    void _menu_action_setting_edit_ ## _name(const char * const pstr, _type* const ptr, const _type minValue, const _type maxValue); \
+    void menu_action_setting_edit_ ## _name(const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue); \
+    void menu_action_setting_edit_callback_ ## _name(const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue, const screenFunc_t callback); \
+    void _menu_action_setting_edit_accessor_ ## _name(const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue); \
+    void menu_action_setting_edit_accessor_ ## _name(const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue); \
+    typedef void _name##_void
+
+  DECLARE_MENU_EDIT_TYPE(int, int3);
+  DECLARE_MENU_EDIT_TYPE(float, float3);
+  DECLARE_MENU_EDIT_TYPE(float, float32);
+  DECLARE_MENU_EDIT_TYPE(float, float43);
+  DECLARE_MENU_EDIT_TYPE(float, float5);
+  DECLARE_MENU_EDIT_TYPE(float, float51);
+  DECLARE_MENU_EDIT_TYPE(float, float52);
+  DECLARE_MENU_EDIT_TYPE(float, float62);
+  DECLARE_MENU_EDIT_TYPE(unsigned long, long5);
+  
   void menu_action_setting_edit_bool(const char* pstr, bool* ptr);
-  void menu_action_setting_edit_int3(const char* pstr, int* ptr, int minValue, int maxValue);
-  void menu_action_setting_edit_float3(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float32(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float43(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float5(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float51(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float52(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_float62(const char* pstr, float* ptr, float minValue, float maxValue);
-  void menu_action_setting_edit_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue);
   void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_int3(const char* pstr, int* ptr, int minValue, int maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float3(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float32(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float43(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float5(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float51(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float52(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_float62(const char* pstr, float* ptr, float minValue, float maxValue, screenFunc_t callbackFunc);
-  void menu_action_setting_edit_callback_long5(const char* pstr, unsigned long* ptr, unsigned long minValue, unsigned long maxValue, screenFunc_t callbackFunc);
+  void menu_action_setting_edit_accessor_bool(const char* pstr, bool (*pget)(), void (*pset)(bool));
 
   #if ENABLED(SDSUPPORT)
     void lcd_sdcard_menu();
@@ -375,12 +380,15 @@ uint16_t max_display_update_time = 0;
   #define MENU_ITEM_DUMMY() do { _thisItemNr++; } while(0)
   #define MENU_ITEM_EDIT(type, label, ...) MENU_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #define MENU_ITEM_EDIT_CALLBACK(type, label, ...) MENU_ITEM(setting_edit_callback_ ## type, label, PSTR(label), ## __VA_ARGS__)
+  #define MENU_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #if ENABLED(ENCODER_RATE_MULTIPLIER)
     #define MENU_MULTIPLIER_ITEM_EDIT(type, label, ...) MENU_MULTIPLIER_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
     #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(type, label, ...) MENU_MULTIPLIER_ITEM(setting_edit_callback_ ## type, label, PSTR(label), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_MULTIPLIER_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #else //!ENCODER_RATE_MULTIPLIER
     #define MENU_MULTIPLIER_ITEM_EDIT(type, label, ...) MENU_ITEM(setting_edit_ ## type, label, PSTR(label), ## __VA_ARGS__)
     #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(type, label, ...) MENU_ITEM(setting_edit_callback_ ## type, label, PSTR(label), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT_ACCESSOR(type, label, ...) MENU_ITEM(setting_edit_accessor_ ## type, label, PSTR(label), ## __VA_ARGS__)
   #endif //!ENCODER_RATE_MULTIPLIER
 
   /** Used variables to keep track of the menu */
@@ -417,6 +425,7 @@ uint16_t max_display_update_time = 0;
   // Variables used when editing values.
   const char* editLabel;
   void* editValue;
+  void* editSetter;
   int32_t minEditValue, maxEditValue;
   screenFunc_t callbackFunc;              // call this after editing
 
@@ -2105,7 +2114,7 @@ void kill_screen(const char* lcd_msg) {
     MENU_BACK(MSG_MAIN);
     MENU_ITEM(submenu, MSG_TEMPERATURE, lcd_control_temperature_menu);
     MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
-    MENU_ITEM(submenu, MSG_VOLUMETRIC, lcd_control_volumetric_menu);
+    MENU_ITEM(submenu, MSG_VOLUMETRIC, lcd_control_filament_menu);
 
     #if HAS_LCD_CONTRAST
       //MENU_ITEM_EDIT(int3, MSG_CONTRAST, &lcd_contrast, 0, 63);
@@ -2543,9 +2552,13 @@ void kill_screen(const char* lcd_msg) {
    * "Control" > "Filament" submenu
    *
    */
-  void lcd_control_volumetric_menu() {
+  void lcd_control_filament_menu() {
     START_MENU();
     MENU_BACK(MSG_CONTROL);
+
+    #if ENABLED(LIN_ADVANCE)
+      MENU_ITEM_EDIT_ACCESSOR(float3, MSG_ADVANCE_K, planner.get_extruder_advance_k, planner.set_extruder_advance_k, 0, 999);
+    #endif
 
     MENU_ITEM_EDIT_CALLBACK(bool, MSG_VOLUMETRIC_ENABLED, &volumetric_enabled, calculate_volumetric_multipliers);
 
@@ -3101,6 +3114,8 @@ void kill_screen(const char* lcd_msg) {
    *   void _menu_action_setting_edit_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue);
    *   void menu_action_setting_edit_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue);
    *   void menu_action_setting_edit_callback_int3(const char * const pstr, int * const ptr, const int minValue, const int maxValue, const screenFunc_t callback); // edit int with callback
+   *   void _menu_action_setting_edit_accessor_int3(const char * const pstr, int (*pget)(), void (*pset)(int), const int minValue, const int maxValue);
+   *   void menu_action_setting_edit_accessor_int3(const char * const pstr, int (*pget)(), void (*pset)(int), const int minValue, const int maxValue); // edit int via pget and pset accessor functions
    *
    * You can then use one of the menu macros to present the edit interface:
    *   MENU_ITEM_EDIT(int3, MSG_SPEED, &feedrate_percentage, 10, 999)
@@ -3112,6 +3127,9 @@ void kill_screen(const char* lcd_msg) {
    * Also: MENU_MULTIPLIER_ITEM_EDIT, MENU_ITEM_EDIT_CALLBACK, and MENU_MULTIPLIER_ITEM_EDIT_CALLBACK
    *
    *       menu_action_setting_edit_int3(PSTR(MSG_SPEED), &feedrate_percentage, 10, 999)
+   *
+   * Values that are get/set via functions (As opposed to global variables) can use the accessor form:
+   *   MENU_ITEM_EDIT_ACCESSOR(int3, MSG_SPEED, get_feedrate_percentage, set_feedrate_percentage, 10, 999)
    */
   #define menu_edit_type(_type, _name, _strFunc, _scale) \
     bool _menu_edit_ ## _name () { \
@@ -3121,7 +3139,11 @@ void kill_screen(const char* lcd_msg) {
       if (lcdDrawUpdate) \
         lcd_implementation_drawedit(editLabel, _strFunc(((_type)((int32_t)encoderPosition + minEditValue)) * (1.0 / _scale))); \
       if (lcd_clicked) { \
-        *((_type*)editValue) = ((_type)((int32_t)encoderPosition + minEditValue)) * (1.0 / _scale); \
+        _type value = ((_type)((int32_t)encoderPosition + minEditValue)) * (1.0 / _scale); \
+        if (editValue != NULL) \
+          *((_type*)editValue) = value; \
+        else if (editSetter != NULL) \
+          ((void (*)(_type))editSetter)(value); \
         lcd_goto_previous_menu(); \
       } \
       return lcd_clicked; \
@@ -3135,6 +3157,7 @@ void kill_screen(const char* lcd_msg) {
       \
       editLabel = pstr; \
       editValue = ptr; \
+      editSetter = NULL; \
       minEditValue = minValue * _scale; \
       maxEditValue = maxValue * _scale - minEditValue; \
       encoderPosition = (*ptr) * _scale - minEditValue; \
@@ -3142,11 +3165,27 @@ void kill_screen(const char* lcd_msg) {
     void menu_action_setting_edit_ ## _name (const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue) { \
       _menu_action_setting_edit_ ## _name(pstr, ptr, minValue, maxValue); \
       currentScreen = menu_edit_ ## _name; \
-    }\
+    } \
     void menu_action_setting_edit_callback_ ## _name (const char * const pstr, _type * const ptr, const _type minValue, const _type maxValue, const screenFunc_t callback) { \
       _menu_action_setting_edit_ ## _name(pstr, ptr, minValue, maxValue); \
       currentScreen = menu_edit_callback_ ## _name; \
       callbackFunc = callback; \
+    } \
+    void _menu_action_setting_edit_accessor_ ## _name (const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue) { \
+      lcd_save_previous_screen(); \
+      \
+      lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; \
+      \
+      editLabel = pstr; \
+      editValue = NULL; \
+      editSetter = pset; \
+      minEditValue = minValue * _scale; \
+      maxEditValue = maxValue * _scale - minEditValue; \
+      encoderPosition = pget() * _scale - minEditValue; \
+    } \
+    void menu_action_setting_edit_accessor_ ## _name (const char * const pstr, _type (*pget)(), void (*pset)(_type), const _type minValue, const _type maxValue) { \
+      _menu_action_setting_edit_accessor_ ## _name(pstr, pget, pset, minValue, maxValue); \
+      currentScreen = menu_edit_ ## _name; \
     } \
     typedef void _name
 
@@ -3251,6 +3290,11 @@ void kill_screen(const char* lcd_msg) {
   void menu_action_setting_edit_callback_bool(const char* pstr, bool* ptr, screenFunc_t callback) {
     menu_action_setting_edit_bool(pstr, ptr);
     (*callback)();
+  }
+  void menu_action_setting_edit_accessor_bool(const char* pstr, bool (*pget)(), void (*pset)(bool)) {
+    UNUSED(pstr);
+    pset(!pget());
+    lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
   }
 
 #endif // ULTIPANEL

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -767,27 +767,31 @@ static void lcd_implementation_status_screen() {
   #define lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, data) _drawmenu_setting_edit_generic(sel, row, pstr, data, false)
   #define lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, data) _drawmenu_setting_edit_generic(sel, row, pstr, data, true)
 
-  #define lcd_implementation_drawmenu_setting_edit_int3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float32(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float43(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float52(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float51(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float62(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_long5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(_type, _name, _strFunc) \
+    inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _strFunc(pget())); \
+    } \
+    typedef void _name##_void
 
-  #define lcd_implementation_drawmenu_setting_edit_callback_int3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float32(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float43(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float52(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float51(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float62(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_long5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, ftostr5rj(*(data)))
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(int, int3, itostr3);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float3, ftostr3);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float32, ftostr32);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float43, ftostr43sign);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float5, ftostr5rj);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float51, ftostr51sign);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float52, ftostr52sign);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float62, ftostr62rj);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(long, long5, ftostr5rj);
+
+  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
   #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_accessor_bool(sel, row, pstr, pstr2, pget, pset) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* const pstr, const char* const value=NULL) {
     const uint8_t labellen = lcd_strlen_P(pstr),

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -874,28 +874,31 @@ static void lcd_implementation_status_screen() {
     lcd_printPGM(data);
   }
 
-  #define lcd_implementation_drawmenu_setting_edit_int3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float3(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float32(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float43(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float52(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float51(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_float62(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_long5(sel, row, pstr, pstr2, data, minValue, maxValue) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(_type, _name, _strFunc) \
+    inline void lcd_implementation_drawmenu_setting_edit_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_callback_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type * const data, ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', _strFunc(*(data))); \
+    } \
+    inline void lcd_implementation_drawmenu_setting_edit_accessor_ ## _name (const bool sel, const uint8_t row, const char* pstr, const char* pstr2, _type (*pget)(), void (*pset)(_type), ...) { \
+      lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', _strFunc(pget())); \
+    } \
+    typedef void _name##_void
 
-  //Add version for callback functions
-  #define lcd_implementation_drawmenu_setting_edit_callback_int3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', itostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float3(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr3(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float32(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr32(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float43(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr43sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float52(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr52sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float51(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr51sign(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_float62(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr62rj(*(data)))
-  #define lcd_implementation_drawmenu_setting_edit_callback_long5(sel, row, pstr, pstr2, data, minValue, maxValue, callback) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, '>', ftostr5rj(*(data)))
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(int, int3, itostr3);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float3, ftostr3);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float32, ftostr32);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float43, ftostr43sign);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float5, ftostr5rj);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float51, ftostr51sign);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float52, ftostr52sign);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(float, float62, ftostr62rj);
+  DEFINE_LCD_IMPLEMENTATION_DRAWMENU_SETTING_EDIT_TYPE(long, long5, ftostr5rj);
+
+  #define lcd_implementation_drawmenu_setting_edit_bool(sel, row, pstr, pstr2, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
   #define lcd_implementation_drawmenu_setting_edit_callback_bool(sel, row, pstr, pstr2, data, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+  #define lcd_implementation_drawmenu_setting_edit_accessor_bool(sel, row, pstr, pstr2, pget, pset, callback) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, '>', (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
 
   void lcd_implementation_drawedit(const char* pstr, const char* const value=NULL) {
     lcd.setCursor(1, 1);


### PR DESCRIPTION
Cleanup, adjustment of #6360
- Split language change and original work into separate commits.
- Replace `M905` with `M900` to sidestep conflict with RepRapFirmware.
- Extended `M900` with `R` to set the WH/D ratio directly. (Added for `M503`.)

Also:
- Cleaned up the heading of `ultralcd.cpp` to better group related vars.
- Replaced `code_value_axis_units` with `code_value_linear_units` for XYZ axes.
- Updated `M503` to support inches when `INCH_MODE_SUPPORT` is enabled.
- Cleaned up `M503` for consistent use of `SERIAL_ECHO_START`.

----
This pull request adds the Linear Advance values to the EEPROM and also allowsconfiguration of the K value via the LCD. My rational for this is that we can already configure and store the volumetric extrusion for the filament, so it only makes sense that we be able to do the same for the Linear Advance. It also allows gcode to be more generic since the K value wouldn't need to be explicitly specified.

A potentially beneficial bonus of this pull request is the addition of accessor versions of the menu macros and functions. Currently, all values edited via the LCD have to be done so through global variables. The accessor versions allow the programmer to specify pointers to get and set functions to be used in place of a pointer to a global variable.

As of now, I didn't provide any translations for the new "Advance K" item added to the LCD. Is this something I would need to do, or are there other contributors that can help with that?