### PR TITLE
allow for variable 'hot' temperature as related to TEMP_STAT_LEDS

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1499,9 +1499,10 @@
 //#define SOFT_PWM_DITHER
 
 // Temperature status LEDs that display the hotend and bed temperature.
-// If all hotends, bed temperature, and target temperature are under 54C
-// then the BLUE led is on. Otherwise the RED led is on. (1C hysteresis)
-//#define TEMP_STAT_LEDS
+// If all hotends, bed temperature, and target temperature are under the
+// defined value (default 54.0C, 1C hysteresis), the BLUE led is on;
+// otherwise, the RED led is on.  To disable entirely, comment out.
+#define TEMP_STAT_LEDS 54.0
 
 // M240  Triggers a camera by emulating a Canon RC-1 Remote
 // Data from: http://www.doc-diy.net/photo/rc-1_hacked/

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11417,7 +11417,7 @@ void prepare_move_to_destination() {
 
 #endif // MORGAN_SCARA
 
-#if ENABLED(TEMP_STAT_LEDS)
+#ifdef TEMP_STAT_LEDS
 
   static bool red_led = false;
   static millis_t next_status_led_update_ms = 0;
@@ -11432,7 +11432,7 @@ void prepare_move_to_destination() {
       HOTEND_LOOP() {
         max_temp = MAX3(max_temp, thermalManager.degHotend(e), thermalManager.degTargetHotend(e));
       }
-      bool new_led = (max_temp > 55.0) ? true : (max_temp < 54.0) ? false : red_led;
+      bool new_led = (max_temp > TEMP_STAT_LEDS+1.0) ? true : (max_temp < TEMP_STAT_LEDS) ? false : red_led;
       if (new_led != red_led) {
         red_led = new_led;
         #if PIN_EXISTS(STAT_LED_RED)
@@ -11851,7 +11851,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     }
   #endif
 
-  #if ENABLED(TEMP_STAT_LEDS)
+  #ifdef TEMP_STAT_LEDS
     handle_status_leds();
   #endif
 

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -862,7 +862,7 @@ static_assert(1 >= 0
 /**
  * Temperature status LEDs
  */
-#if ENABLED(TEMP_STAT_LEDS) && !PIN_EXISTS(STAT_LED_RED) && !PIN_EXISTS(STAT_LED_BLUE)
+#if defined(TEMP_STAT_LEDS) && !PIN_EXISTS(STAT_LED_RED) && !PIN_EXISTS(STAT_LED_BLUE)
   #error "TEMP_STAT_LEDS requires STAT_LED_RED_PIN or STAT_LED_BLUE_PIN, preferably both."
 #endif
 


### PR DESCRIPTION
This modification allows for setting the 'hot' temperature used when determining whether the TEMP_STAT_LEDS are red or blue.  Used the same configuration #define.  Was previously hardcoded to an arbitrary 54C; can think of a number of scenarios where it'd be nice to be able to set the temp for the color switch.