### PR TITLE
Use planner.z_fade_height for ubl instead of private, ubl-specific fade-related variables

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -212,13 +212,7 @@ void MarlinSettings::postprocess() {
   #endif
 
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-    set_z_fade_height(
-      //#if ENABLED(AUTO_BED_LEVELING_UBL)
-      //  ubl.state.g29_correction_fade_height
-      //#else
-        planner.z_fade_height
-      //#endif
-    );
+    set_z_fade_height(planner.z_fade_height);
   #endif
 
   #if HAS_BED_PROBE
@@ -1412,9 +1406,9 @@ void MarlinSettings::reset() {
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M420 S", ubl.state.active ? 1 : 0);
-      //#if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      //  SERIAL_ECHOPAIR(" Z", ubl.state.g29_correction_fade_height);
-      //#endif
+      #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+        SERIAL_ECHOPAIR(" Z", planner.z_fade_height);
+      #endif
       SERIAL_EOL;
 
       if (!forReplay) {

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -90,14 +90,6 @@
 
     if (sanity_check())
       SERIAL_PROTOCOLLNPGM("?In load_state() sanity_check() failed.\n");
-
-    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      const float recip = ubl.state.g29_correction_fade_height ? 1.0 / ubl.state.g29_correction_fade_height : 1.0;
-      if (ubl.state.g29_fade_height_multiplier != recip) {
-        ubl.state.g29_fade_height_multiplier = recip;
-        store_state();
-      }
-    #endif
   }
 
   void unified_bed_leveling::load_mesh(const int16_t m) {

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -30,6 +30,7 @@
   #include "Marlin.h"
   #include "math.h"
   #include "vector_3.h"
+  #include "planner.h"
 
   #define UBL_VERSION "1.00"
   #define UBL_OK false
@@ -97,15 +98,9 @@
           mesh_x_dist = MESH_X_DIST,
           mesh_y_dist = MESH_Y_DIST;
 
-    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      float g29_correction_fade_height = 10.0,
-            g29_fade_height_multiplier = 1.0 / 10.0; // It's cheaper to do a floating point multiply than divide,
-                                                     // so keep this value and its reciprocal.
-    #endif
-
     // If you change this struct, adjust TOTAL_STRUCT_SIZE
 
-    #define TOTAL_STRUCT_SIZE 40 // Total size of the above fields
+    #define TOTAL_STRUCT_SIZE 32 // Total size of the above fields
 
     // padding provides space to add state variables without
     // changing the location of data structures in the EEPROM.
@@ -309,21 +304,21 @@
        * This function sets the Z leveling fade factor based on the given Z height,
        * only re-calculating when necessary.
        *
-       *  Returns 1.0 if g29_correction_fade_height is 0.0.
+       *  Returns 1.0 if planner.z_fade_height is 0.0.
        *  Returns 0.0 if Z is past the specified 'Fade Height'.
        */
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
         static FORCE_INLINE float fade_scaling_factor_for_z(const float &lz) {
-          if (state.g29_correction_fade_height == 0.0) return 1.0;
+          if (planner.z_fade_height == 0.0) return 1.0;
 
           static float fade_scaling_factor = 1.0;
           const float rz = RAW_Z_POSITION(lz);
           if (last_specified_z != rz) {
             last_specified_z = rz;
             fade_scaling_factor =
-              rz < state.g29_correction_fade_height
-                ? 1.0 - (rz * state.g29_fade_height_multiplier)
+              rz < planner.z_fade_height
+                ? 1.0 - (rz * planner.inverse_z_fade_height)
                 : 0.0;
           }
           return fade_scaling_factor;

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -30,7 +30,6 @@
   #include "Marlin.h"
   #include "hex_print_routines.h"
   #include "configuration_store.h"
-  #include "planner.h"
   #include "ultralcd.h"
 
   #include <math.h>
@@ -1068,8 +1067,7 @@
           SERIAL_PROTOCOLLNPGM("?Bed Level Correction Fade Height Not Plausible.\n");
           return UBL_ERR;
         }
-        ubl.state.g29_correction_fade_height = fh;
-        ubl.state.g29_fade_height_multiplier = 1.0 / fh;
+        set_z_fade_height(fh);
       }
     #endif
 
@@ -1166,7 +1164,7 @@
     safe_delay(50);
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      SERIAL_PROTOCOLLNPAIR("g29_correction_fade_height : ", ubl.state.g29_correction_fade_height);
+      SERIAL_PROTOCOLLNPAIR("planner.z_fade_height : ", planner.z_fade_height);
     #endif
 
     SERIAL_PROTOCOLPGM("z_offset: ");


### PR DESCRIPTION
This replaces the private UBL-specific g29_correction_fade_height and g29_fade_height_multiplier variables with planner.z_fade_height and planner.inverse_z_fade_height in various places, and makes use of set_z_fade_height().

This PR is a followon to PR https://github.com/MarlinFirmware/Marlin/pull/6361.