### PR TITLE
Spend some SRAM to optimize bilinear leveling

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -313,8 +313,9 @@ float code_value_temp_diff();
 
 #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
   extern int bilinear_grid_spacing[2], bilinear_start[2];
-  extern float z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-  float bilinear_z_offset(float logical[XYZ]);
+  extern float bilinear_grid_factor[2],
+               z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
+  float bilinear_z_offset(const float logical[XYZ]);
   void set_bed_leveling_enabled(bool enable=true);
 #endif
 

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -313,7 +313,7 @@ float code_value_temp_diff();
 
 #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
   extern int bilinear_grid_spacing[2], bilinear_start[2];
-  extern float bed_level_grid[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
+  extern float z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
   float bilinear_z_offset(float logical[XYZ]);
   void set_bed_leveling_enabled(bool enable=true);
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4175,7 +4175,7 @@ inline void gcode_G28() {
       ABL_VAR int abl_probe_index;
     #endif
 
-    #if HAS_SOFTWARE_ENDSTOPS
+    #if HAS_SOFTWARE_ENDSTOPS && ENABLED(PROBE_MANUALLY)
       ABL_VAR bool enable_soft_endstops = true;
     #endif
 
@@ -4598,7 +4598,6 @@ inline void gcode_G28() {
         }
 
       #endif // AUTO_BED_LEVELING_3POINT
-
 
     #else // !PROBE_MANUALLY
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2714,6 +2714,14 @@ static void clean_up_after_endstop_or_probe_move() {
             }
     }
   #endif // ABL_BILINEAR_SUBDIVISION
+
+  // Refresh after other values have been updated
+  void refresh_bed_level() {
+    #if ENABLED(ABL_BILINEAR_SUBDIVISION)
+      bed_level_virt_interpolate();
+    #endif
+  }
+
 #endif // AUTO_BED_LEVELING_BILINEAR
 
 /**
@@ -4730,8 +4738,9 @@ inline void gcode_G28() {
       if (!dryrun) extrapolate_unprobed_bed_level();
       print_bilinear_leveling_grid();
 
+      refresh_bed_level();
+
       #if ENABLED(ABL_BILINEAR_SUBDIVISION)
-        bed_level_virt_interpolate();
         bed_level_virt_print();
       #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8858,7 +8858,7 @@ inline void gcode_M503() {
     stepper.synchronize();
 
     const float newK = code_seen('K') ? code_value_float() : -1;
-    if (newK >= 0) planner.set_extruder_advance_k(newK);
+    if (newK >= 0) planner.extruder_advance_k = newK;
 
     float newR = code_seen('R') ? code_value_float() : -1;
     if (newR < 0) {
@@ -8868,12 +8868,12 @@ inline void gcode_M503() {
       if (newD >= 0 && newW >= 0 && newH >= 0)
         newR = newD ? (newW * newH) / (sq(newD * 0.5) * M_PI) : 0;
     }
-    if (newR >= 0) planner.set_advance_ed_ratio(newR);
+    if (newR >= 0) planner.advance_ed_ratio = newR;
 
     SERIAL_ECHO_START;
-    SERIAL_ECHOPAIR("Advance K=", planner.get_extruder_advance_k());
+    SERIAL_ECHOPAIR("Advance K=", planner.extruder_advance_k);
     SERIAL_ECHOPGM(" E/D=");
-    const float ratio = planner.get_advance_ed_ratio();
+    const float ratio = planner.advance_ed_ratio;
     ratio ? SERIAL_ECHO(ratio) : SERIAL_ECHOPGM("Auto");
     SERIAL_EOL;
   }

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -578,15 +578,14 @@ void MarlinSettings::postprocess() {
     // Linear Advance
     //
 
-    float extruder_advance_k = 0.0f, advance_ed_ratio = 0.0f;
-
     #if ENABLED(LIN_ADVANCE)
-      extruder_advance_k = planner.get_extruder_advance_k();
-      advance_ed_ratio = planner.get_advance_ed_ratio();
+      EEPROM_WRITE(planner.extruder_advance_k);
+      EEPROM_WRITE(planner.advance_ed_ratio);
+    #else
+      dummy = 0.0f;
+      EEPROM_WRITE(dummy);
+      EEPROM_WRITE(dummy);
     #endif
-
-    EEPROM_WRITE(extruder_advance_k);
-    EEPROM_WRITE(advance_ed_ratio);
 
     if (!eeprom_write_error) {
 
@@ -922,13 +921,12 @@ void MarlinSettings::postprocess() {
       // Linear Advance
       //
 
-      float extruder_advance_k, advance_ed_ratio;
-      EEPROM_READ(extruder_advance_k);
-      EEPROM_READ(advance_ed_ratio);
-
       #if ENABLED(LIN_ADVANCE)
-        planner.set_extruder_advance_k(extruder_advance_k);
-        planner.set_advance_ed_ratio(advance_ed_ratio);
+        EEPROM_READ(planner.extruder_advance_k);
+        EEPROM_READ(planner.advance_ed_ratio);
+      #else
+        EEPROM_READ(dummy);
+        EEPROM_READ(dummy);
       #endif
 
       if (eeprom_checksum == stored_checksum) {
@@ -1187,8 +1185,8 @@ void MarlinSettings::reset() {
   #endif
 
   #if ENABLED(LIN_ADVANCE)
-    planner.set_extruder_advance_k(LIN_ADVANCE_K);
-    planner.set_advance_ed_ratio(LIN_ADVANCE_E_D_RATIO);
+    planner.extruder_advance_k = LIN_ADVANCE_K;
+    planner.advance_ed_ratio = LIN_ADVANCE_E_D_RATIO;
   #endif
 
   postprocess();
@@ -1658,8 +1656,8 @@ void MarlinSettings::reset() {
         SERIAL_ECHOLNPGM("Linear Advance:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPAIR("  M900 K", planner.get_extruder_advance_k());
-      SERIAL_ECHOLNPAIR(" R", planner.get_advance_ed_ratio());
+      SERIAL_ECHOPAIR("  M900 K", planner.extruder_advance_k);
+      SERIAL_ECHOLNPAIR(" R", planner.advance_ed_ratio);
     #endif
   }
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -85,7 +85,7 @@
  *  307            GRID_MAX_POINTS_Y                (uint8_t)
  *  308            bilinear_grid_spacing            (int x2)
  *  312  G29 L F   bilinear_start                   (int x2)
- *  316            bed_level_grid[][]               (float x9, up to float x256) +988
+ *  316            z_values[][]                     (float x9, up to float x256) +988
  *
  * DELTA:                                           48 bytes
  *  348  M666 XYZ  endstop_adj                      (float x3)
@@ -382,9 +382,9 @@ void MarlinSettings::postprocess() {
     //
 
     #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-      // Compile time test that sizeof(bed_level_grid) is as expected
+      // Compile time test that sizeof(z_values) is as expected
       static_assert(
-        sizeof(bed_level_grid) == (GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y) * sizeof(bed_level_grid[0][0]),
+        sizeof(z_values) == (GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y) * sizeof(z_values[0][0]),
         "Bilinear Z array is the wrong size."
       );
       const uint8_t grid_max_x = GRID_MAX_POINTS_X, grid_max_y = GRID_MAX_POINTS_Y;
@@ -392,7 +392,7 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(grid_max_y);            // 1 byte
       EEPROM_WRITE(bilinear_grid_spacing); // 2 ints
       EEPROM_WRITE(bilinear_start);        // 2 ints
-      EEPROM_WRITE(bed_level_grid);        // 9-256 floats
+      EEPROM_WRITE(z_values);              // 9-256 floats
     #else
       // For disabled Bilinear Grid write an empty 3x3 grid
       const uint8_t grid_max_x = 3, grid_max_y = 3;
@@ -757,7 +757,7 @@ void MarlinSettings::postprocess() {
           set_bed_leveling_enabled(false);
           EEPROM_READ(bilinear_grid_spacing);        // 2 ints
           EEPROM_READ(bilinear_start);               // 2 ints
-          EEPROM_READ(bed_level_grid);               // 9 to 256 floats
+          EEPROM_READ(z_values);                     // 9 to 256 floats
         }
         else // EEPROM data is stale
       #endif // AUTO_BED_LEVELING_BILINEAR

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -179,8 +179,8 @@ MarlinSettings settings;
   #include "ubl.h"
 #endif
 
-#if ENABLED(ABL_BILINEAR_SUBDIVISION)
-  extern void bed_level_virt_interpolate();
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+  extern void refresh_bed_level();
 #endif
 
 /**
@@ -217,6 +217,11 @@ void MarlinSettings::postprocess() {
 
   #if HAS_BED_PROBE
     refresh_zprobe_zoffset();
+  #endif
+
+  #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    refresh_bed_level();
+    //set_bed_leveling_enabled(leveling_is_on);
   #endif
 }
 
@@ -753,10 +758,6 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(bilinear_grid_spacing);        // 2 ints
           EEPROM_READ(bilinear_start);               // 2 ints
           EEPROM_READ(bed_level_grid);               // 9 to 256 floats
-          #if ENABLED(ABL_BILINEAR_SUBDIVISION)
-            bed_level_virt_interpolate();
-          #endif
-          //set_bed_leveling_enabled(leveling_is_on);
         }
         else // EEPROM data is stale
       #endif // AUTO_BED_LEVELING_BILINEAR

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -138,7 +138,7 @@ typedef enum {
   }while(0)
 
 #define SET_COM(T,Q,V) do{ \
-    TCCR##T##Q = (TCCR##T##Q & ~(0x3 << COM1##Q##0) | (int(V) & 0x3) << COM1##Q##0); \
+    TCCR##T##Q = (TCCR##T##Q & ~(0x3 << COM1##Q##0)) | ((int(V) & 0x3) << COM1##Q##0); \
   }while(0)
 #define SET_COMA(T,V) SET_COM(T,A,V)
 #define SET_COMB(T,V) SET_COM(T,B,V)

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -168,6 +168,10 @@ class Planner {
       static float z_fade_height, inverse_z_fade_height;
     #endif
 
+    #if ENABLED(LIN_ADVANCE)
+      static float extruder_advance_k, advance_ed_ratio;
+    #endif
+
   private:
 
     /**
@@ -209,8 +213,6 @@ class Planner {
 
     #if ENABLED(LIN_ADVANCE)
       static float position_float[NUM_AXIS];
-      static float extruder_advance_k;
-      static float advance_ed_ratio;
     #endif
 
     #if ENABLED(ULTRA_LCD)
@@ -264,13 +266,6 @@ class Planner {
       #define ARG_Y const float &ly
       #define ARG_Z const float &lz
 
-    #endif
-
-    #if ENABLED(LIN_ADVANCE)
-      static void set_extruder_advance_k(float k) { extruder_advance_k = k; };
-      static float get_extruder_advance_k() { return extruder_advance_k; };
-      static void set_advance_ed_ratio(float ratio) { advance_ed_ratio = ratio; };
-      static float get_advance_ed_ratio() { return advance_ed_ratio; };
     #endif
 
     /**


### PR DESCRIPTION
Naïvely optimize bilinear leveling compensation in some general ways:

- Pre-calculate grid box size reciprocals so multiplication is used during printing
- In `bilinear_z_offset`, retain calculated values  as `static` for re-use:
  - Recalculated only for the moving planes (so horizontal/vertical moves are optimal):
    - The normalized x/y location (ratio) within current grid box
    - The current (and next) x/y grid box indexes (for corner Zs)
  - Values fetched when the nozzle moves to a new grid region:
    - Two starting Z's and two Z deltas
  - These optimizations cost 46 bytes of SRAM

---
Do these heuristics save computation time or break even for the most common (non-optimal) case? There is a base recovery from pre-calculating the Z start/delta values that applies to all leveled moves. The overhead is a set of comparisons for equality (cheap) plus time to store the backups. Most of the time the XY tests will succeed, fall through, and incur full computational cost. However the grid tests will be only periodically invoked. Ultimately, straight horizontal/vertical lines will be the most optimal case. As a "dumb" system no extra heuristics is employed, but it accomplishes most of what more granular tests might do.

If underlying leveling changes, force re-calculation by calling `bilinear_z_offset` with unusual coordinates like `-9999.999, -9999.999`.

---
Also:
- Rename `bed_level_grid[][]` to `z_values[][]` to match other leveling
- Add a single function that gets the size reciprocals and refreshes the virtual grid
- Drop accessor-based lcd value editing, keep direct addressing (one fewer redundancy)

---
Note:
- It occurs to me that to get more accurate bilinear leveling, an extra subdivided grid is not necessarily needed. All you need is to subdivide moves even more than just on grid boundaries. Moves could just always be split into 1cm segments, for example. More subdivision causes moves to follow the bilinear curvature more accurately. Even though this is still not perfectly aligned to the measured bed, it is at least closer to the real bilinear interpolated value. Under usual conditions —with lines split only on grid boundaries— waves and troughs in the middle of longer moves will be skipped over.