### PR TITLE
Fix typo in new SET_COM macro

### DIFF
--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -138,7 +138,7 @@ typedef enum {
   }while(0)
 
 #define SET_COM(T,Q,V) do{ \
-    TCCR##T##Q = (TCCR##T##Q & !(0x3 << COM1##Q##0) | (int(V) & 0x3) << COM1##Q##0); \
+    TCCR##T##Q = (TCCR##T##Q & ~(0x3 << COM1##Q##0) | (int(V) & 0x3) << COM1##Q##0); \
   }while(0)
 #define SET_COMA(T,V) SET_COM(T,A,V)
 #define SET_COMB(T,V) SET_COM(T,B,V)


### PR DESCRIPTION
Fixes issue with stepper motors after #6400, as described in #6417.