### PR TITLE
Numerous UBL-related changes

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -666,6 +666,10 @@
   #define UBL_MESH_MAX_X (X_MAX_POS - (UBL_MESH_INSET))
   #define UBL_MESH_MIN_Y (Y_MIN_POS + UBL_MESH_INSET)
   #define UBL_MESH_MAX_Y (Y_MAX_POS - (UBL_MESH_INSET))
+
+  // If this is defined, the currently active mesh will be saved in the
+  // current slot on M500.
+  #define UBL_SAVE_ACTIVE_ON_M500
 #endif
 
 // @section extras

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8282,7 +8282,6 @@ void quickstop_stepper() {
         }
 
         ubl.load_mesh(storage_slot);
-        if (storage_slot != ubl.state.eeprom_storage_slot) ubl.store_state();
         ubl.state.eeprom_storage_slot = storage_slot;
       }
     #endif // AUTO_BED_LEVELING_UBL

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -57,7 +57,7 @@
     }
   }
 
-  ubl_state unified_bed_leveling::state, unified_bed_leveling::pre_initialized;
+  ubl_state unified_bed_leveling::state;
 
   float unified_bed_leveling::z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y],
         unified_bed_leveling::last_specified_z,
@@ -79,59 +79,46 @@
     reset();
   }
 
-  void unified_bed_leveling::store_state() {
-    const uint16_t i = UBL_LAST_EEPROM_INDEX;
-    eeprom_write_block((void *)&ubl.state, (void *)i, sizeof(state));
-  }
-
-  void unified_bed_leveling::load_state() {
-    const uint16_t i = UBL_LAST_EEPROM_INDEX;
-    eeprom_read_block((void *)&ubl.state, (void *)i, sizeof(state));
-
-    if (sanity_check())
-      SERIAL_PROTOCOLLNPGM("?In load_state() sanity_check() failed.\n");
-  }
-
-  void unified_bed_leveling::load_mesh(const int16_t m) {
+  void unified_bed_leveling::load_mesh(const int16_t slot) {
     int16_t j = (UBL_LAST_EEPROM_INDEX - eeprom_start) / sizeof(z_values);
 
-    if (m == -1) {
+    if (slot == -1) {
       SERIAL_PROTOCOLLNPGM("?No mesh saved in EEPROM. Zeroing mesh in memory.\n");
       reset();
       return;
     }
 
-    if (!WITHIN(m, 0, j - 1) || eeprom_start <= 0) {
+    if (!WITHIN(slot, 0, j - 1) || eeprom_start <= 0) {
       SERIAL_PROTOCOLLNPGM("?EEPROM storage not available to load mesh.\n");
       return;
     }
 
-    j = UBL_LAST_EEPROM_INDEX - (m + 1) * sizeof(z_values);
+    j = UBL_LAST_EEPROM_INDEX - (slot + 1) * sizeof(z_values);
     eeprom_read_block((void *)&z_values, (void *)j, sizeof(z_values));
 
-    SERIAL_PROTOCOLPAIR("Mesh loaded from slot ", m);
+    SERIAL_PROTOCOLPAIR("Mesh loaded from slot ", slot);
     SERIAL_PROTOCOLLNPAIR(" at offset ", hex_address((void*)j));
   }
 
-  void unified_bed_leveling::store_mesh(const int16_t m) {
+  void unified_bed_leveling::store_mesh(const int16_t slot) {
     int16_t j = (UBL_LAST_EEPROM_INDEX - eeprom_start) / sizeof(z_values);
 
-    if (!WITHIN(m, 0, j - 1) || eeprom_start <= 0) {
+    if (!WITHIN(slot, 0, j - 1) || eeprom_start <= 0) {
       SERIAL_PROTOCOLLNPGM("?EEPROM storage not available to load mesh.\n");
-      SERIAL_PROTOCOL(m);
+      SERIAL_PROTOCOL(slot);
       SERIAL_PROTOCOLLNPGM(" mesh slots available.\n");
       SERIAL_PROTOCOLLNPAIR("E2END     : ", E2END);
       SERIAL_PROTOCOLLNPAIR("k         : ", (int)UBL_LAST_EEPROM_INDEX);
       SERIAL_PROTOCOLLNPAIR("j         : ", j);
-      SERIAL_PROTOCOLLNPAIR("m         : ", m);
+      SERIAL_PROTOCOLLNPAIR("m         : ", slot);
       SERIAL_EOL;
       return;
     }
 
-    j = UBL_LAST_EEPROM_INDEX - (m + 1) * sizeof(z_values);
+    j = UBL_LAST_EEPROM_INDEX - (slot + 1) * sizeof(z_values);
     eeprom_write_block((const void *)&z_values, (void *)j, sizeof(z_values));
 
-    SERIAL_PROTOCOLPAIR("Mesh saved in slot ", m);
+    SERIAL_PROTOCOLPAIR("Mesh saved in slot ", slot);
     SERIAL_PROTOCOLLNPAIR(" at offset ", hex_address((void*)j));
   }
 
@@ -228,48 +215,11 @@
   bool unified_bed_leveling::sanity_check() {
     uint8_t error_flag = 0;
 
-    if (state.n_x != GRID_MAX_POINTS_X) {
-      SERIAL_PROTOCOLLNPGM("?GRID_MAX_POINTS_X set wrong\n");
-      error_flag++;
-    }
-    if (state.n_y != GRID_MAX_POINTS_Y) {
-      SERIAL_PROTOCOLLNPGM("?GRID_MAX_POINTS_Y set wrong\n");
-      error_flag++;
-    }
-    if (state.mesh_x_min != UBL_MESH_MIN_X) {
-      SERIAL_PROTOCOLLNPGM("?UBL_MESH_MIN_X set wrong\n");
-      error_flag++;
-    }
-    if (state.mesh_y_min != UBL_MESH_MIN_Y) {
-      SERIAL_PROTOCOLLNPGM("?UBL_MESH_MIN_Y set wrong\n");
-      error_flag++;
-    }
-    if (state.mesh_x_max != UBL_MESH_MAX_X) {
-      SERIAL_PROTOCOLLNPGM("?UBL_MESH_MAX_X set wrong\n");
-      error_flag++;
-    }
-    if (state.mesh_y_max != UBL_MESH_MAX_Y) {
-      SERIAL_PROTOCOLLNPGM("?UBL_MESH_MAX_Y set wrong\n");
-      error_flag++;
-    }
-    if (state.mesh_x_dist != MESH_X_DIST) {
-      SERIAL_PROTOCOLLNPGM("?MESH_X_DIST set wrong\n");
-      error_flag++;
-    }
-    if (state.mesh_y_dist != MESH_Y_DIST) {
-      SERIAL_PROTOCOLLNPGM("?MESH_Y_DIST set wrong\n");
-      error_flag++;
-    }
-
     const int j = (UBL_LAST_EEPROM_INDEX - eeprom_start) / sizeof(z_values);
     if (j < 1) {
       SERIAL_PROTOCOLLNPGM("?No EEPROM storage available for a mesh of this size.\n");
       error_flag++;
     }
-
-    //  SERIAL_PROTOCOLPGM("?sanity_check() return value: ");
-    //  SERIAL_PROTOCOL(error_flag);
-    //  SERIAL_EOL;
 
     return !!error_flag;
   }

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -87,27 +87,7 @@
   typedef struct {
     bool active = false;
     float z_offset = 0.0;
-    int8_t eeprom_storage_slot = -1,
-           n_x = GRID_MAX_POINTS_X,
-           n_y = GRID_MAX_POINTS_Y;
-
-    float mesh_x_min = UBL_MESH_MIN_X,
-          mesh_y_min = UBL_MESH_MIN_Y,
-          mesh_x_max = UBL_MESH_MAX_X,
-          mesh_y_max = UBL_MESH_MAX_Y,
-          mesh_x_dist = MESH_X_DIST,
-          mesh_y_dist = MESH_Y_DIST;
-
-    // If you change this struct, adjust TOTAL_STRUCT_SIZE
-
-    #define TOTAL_STRUCT_SIZE 32 // Total size of the above fields
-
-    // padding provides space to add state variables without
-    // changing the location of data structures in the EEPROM.
-    // This is for compatibility with future versions to keep
-    // users from having to regenerate their mesh data.
-    unsigned char padding[64 - TOTAL_STRUCT_SIZE];
-
+    int8_t eeprom_storage_slot = -1;
   } ubl_state;
 
   class unified_bed_leveling {
@@ -117,7 +97,7 @@
 
     public:
 
-      static ubl_state state, pre_initialized;
+      static ubl_state state;
 
       static float z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y],
                    mesh_index_to_xpos[GRID_MAX_POINTS_X + 1], // +1 safety margin for now, until determinism prevails
@@ -137,8 +117,6 @@
       static void reset();
       static void invalidate();
 
-      static void store_state();
-      static void load_state();
       static void store_mesh(const int16_t);
       static void load_mesh(const int16_t);
 
@@ -330,7 +308,7 @@
 
   extern unified_bed_leveling ubl;
 
-  #define UBL_LAST_EEPROM_INDEX (E2END - sizeof(unified_bed_leveling::state))
+  #define UBL_LAST_EEPROM_INDEX E2END
 
 #endif // AUTO_BED_LEVELING_UBL
 #endif // UNIFIED_BED_LEVELING_H

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -247,8 +247,8 @@
    *                    current state of the Unified Bed Leveling system in the EEPROM.
    *
    *   S #   Store      Store the current Mesh at the specified location in EEPROM. Activate this location
-   *                    for subsequent Load and Store operations. It will also store the current state of
-   *                    the Unified Bed Leveling system in the EEPROM.
+   *                    for subsequent Load and Store operations. Valid storage slot numbers begin at 0 and
+   *                    extend to a limit related to the available EEPROM storage.
    *
    *   S -1  Store      Store the current Mesh as a print out that is suitable to be feed back into the system
    *                    at a later date. The GCode output can be saved and later replayed by the host software
@@ -574,8 +574,6 @@
       }
       ubl.load_mesh(storage_slot);
       ubl.state.eeprom_storage_slot = storage_slot;
-      if (storage_slot != ubl.state.eeprom_storage_slot)
-        ubl.store_state();
       SERIAL_PROTOCOLLNPGM("Done.\n");
     }
 
@@ -609,9 +607,6 @@
       }
       ubl.store_mesh(storage_slot);
       ubl.state.eeprom_storage_slot = storage_slot;
-      //
-      //  if (storage_slot != ubl.state.eeprom_storage_slot)
-      ubl.store_state();    // Always save an updated copy of the UBL State info
 
       SERIAL_PROTOCOLLNPGM("Done.\n");
     }
@@ -1048,7 +1043,6 @@
     if (code_seen('A')) {     // Activate the Unified Bed Leveling System
       ubl.state.active = 1;
       SERIAL_PROTOCOLLNPGM("Unified Bed Leveling System activated.\n");
-      ubl.store_state();
     }
 
     c_flag = code_seen('C') && code_has_value();
@@ -1057,7 +1051,6 @@
     if (code_seen('D')) {     // Disable the Unified Bed Leveling System
       ubl.state.active = 0;
       SERIAL_PROTOCOLLNPGM("Unified Bed Leveling System de-activated.\n");
-      ubl.store_state();
     }
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)


### PR DESCRIPTION
Numerous UBL-related changes:
- relocated ubl state to config. store from its own area at the end of the EEPROM:
  - removed a number of ubl state variables and padding which were largely unused - saved 58 bytes of both SRAM and EEPROM;
   - modified ubl sanity_check - no longer checks removed state variables that were otherwise unused; 
      - _it didn't seem that the sanity check achieved anything other than a comparison between current state variables and saved state variables -- there was no prevention of loading old meshes that wouldn't work, etc.  I think ideally when we have more eeprom (or maybe we could use the sd card now?), we can come up with some kind of mesh storage system that tracks the meshes stored, their x/y sizes, mins and maxes, etc.  I think that would better do what you were shooting for?;_
   - removed (and replaced effective functionality of) 'pre_initialized' state - saved 64 bytes of SRAM;
   - removed automatic saving of UBL state after UBL activation/deactivation, favoring simple `M500` for state saving;
- minor update to G29 Sx notes/instructions;
- renamed mesh load and save function parameters to 'slot' from 'm' for clarity;

---
**NOTES**
- These changes significantly alter the EEPROM structure by adding UBL variables and optimizing, and so `M502` -> `M500` -> `M501` is definitely required;
- We also remove the ubl state stored at the end of the EEPROM and adjust the last address for ubl mesh storage to the end of the EEPROM; this will 'break' stored meshes, so users of UBL should be sure to issue `G29 L<mesh index>` and `G29 S-1` for each saved mesh **PRIOR to flashing the new version**, so meshes can copied down and later restored;
 - See https://github.com/MarlinFirmware/Marlin/issues/6331 for some relevant discussion;