### PR TITLE
Minor cleanup, optimize number-to-string

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -165,7 +165,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -167,7 +167,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -184,7 +184,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -167,7 +167,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -196,7 +196,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -186,7 +186,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -167,7 +167,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -168,7 +168,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -164,7 +164,7 @@
  * "Mixing Extruder"
  *   - Adds a new code, M165, to set the current mix factors.
  *   - Extends the stepping routines to move multiple steppers in proportion to the mix.
- *   - Optional support for Repetier Host M163, M164, and virtual extruder.
+ *   - Optional support for Repetier Firmware M163, M164, and virtual extruder.
  *   - This implementation supports only a single extruder.
  *   - Enable DIRECT_MIXING_IN_G1 for Pia Taubert's reference implementation
  */

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -250,9 +250,9 @@
    *                    for subsequent Load and Store operations. It will also store the current state of
    *                    the Unified Bed Leveling system in the EEPROM.
    *
-   *   S -1  Store      Store the current Mesh as a print out that is suitable to be feed back into
-   *                    the system at a later date. The text generated can be saved and later sent by PronterFace or
-   *                    Repetier Host to reconstruct the current mesh on another machine.
+   *   S -1  Store      Store the current Mesh as a print out that is suitable to be feed back into the system
+   *                    at a later date. The GCode output can be saved and later replayed by the host software
+   *                    to reconstruct the current mesh on another machine.
    *
    *   T     3-Point    Perform a 3 Point Bed Leveling on the current Mesh
    *

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -422,17 +422,17 @@ static void lcd_implementation_status_screen() {
       _draw_heater_status(81, -1);
     #endif
 
-    if (PAGE_CONTAINS(20, 27)) {
-      // Fan
-      u8g.setPrintPos(104, 27);
-      #if HAS_FAN0
-        int per = ((fanSpeeds[0] + 1) * 100) / 256;
+    #if HAS_FAN0
+      if (PAGE_CONTAINS(20, 27)) {
+        // Fan
+        const int per = ((fanSpeeds[0] + 1) * 100) / 256;
         if (per) {
+          u8g.setPrintPos(104, 27);
           lcd_print(itostr3(per));
           u8g.print('%');
         }
-      #endif
-    }
+      }
+    #endif
   }
 
   #if ENABLED(SDSUPPORT)

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -35,7 +35,7 @@ void safe_delay(millis_t ms) {
 
 #if ENABLED(ULTRA_LCD)
 
-  char conv[9];
+  char conv[8] = { 0 };
 
   #define DIGIT(n) ('0' + (n))
   #define DIGIMOD(n, f) DIGIT((n)/(f) % 10)
@@ -43,29 +43,25 @@ void safe_delay(millis_t ms) {
   #define MINUSOR(n, alt) (n >= 0 ? (alt) : (n = -n, '-'))
 
   // Convert unsigned int to string with 12 format
-  char* itostr2(const uint8_t& x) {
-    int xx = x;
-    conv[0] = DIGIMOD(xx, 10);
-    conv[1] = DIGIMOD(xx, 1);
-    conv[2] = '\0';
-    return conv;
+  char* itostr2(const uint8_t& xx) {
+    conv[5] = DIGIMOD(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[5];
   }
 
   // Convert signed int to rj string with 123 or -12 format
   char* itostr3(const int& x) {
     int xx = x;
-    conv[0] = MINUSOR(xx, RJDIGIT(xx, 100));
-    conv[1] = RJDIGIT(xx, 10);
-    conv[2] = DIGIMOD(xx, 1);
-    conv[3] = '\0';
-    return conv;
+    conv[4] = MINUSOR(xx, RJDIGIT(xx, 100));
+    conv[5] = RJDIGIT(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[4];
   }
 
   // Convert unsigned int to lj string with 123 format
   char* itostr3left(const int& xx) {
-    char *str = &conv[3];
-    *str = '\0';
-    *(--str) = DIGIMOD(xx, 1);
+    char *str = &conv[6];
+    *str = DIGIMOD(xx, 1);
     if (xx >= 10) {
       *(--str) = DIGIMOD(xx, 10);
       if (xx >= 100)
@@ -76,72 +72,70 @@ void safe_delay(millis_t ms) {
 
   // Convert signed int to rj string with 1234, _123, -123, _-12, or __-1 format
   char *itostr4sign(const int& x) {
-    int xx = abs(x);
+    const bool neg = x < 0;
+    const int xx = neg ? -x : x;
     if (x >= 1000) {
-      conv[0] = DIGIMOD(xx, 1000);
-      conv[1] = DIGIMOD(xx, 100);
-      conv[2] = DIGIMOD(xx, 10);
+      conv[3] = DIGIMOD(xx, 1000);
+      conv[4] = DIGIMOD(xx, 100);
+      conv[5] = DIGIMOD(xx, 10);
     }
     else {
       if (xx >= 100) {
-        conv[0] = x < 0 ? '-' : ' ';
-        conv[1] = DIGIMOD(xx, 100);
-        conv[2] = DIGIMOD(xx, 10);
+        conv[3] = neg ? '-' : ' ';
+        conv[4] = DIGIMOD(xx, 100);
+        conv[5] = DIGIMOD(xx, 10);
       }
       else {
-        conv[0] = ' ';
+        conv[4] = ' ';
         if (xx >= 10) {
-          conv[1] = x < 0 ? '-' : ' ';
-          conv[2] = DIGIMOD(xx, 10);
+          conv[4] = neg ? '-' : ' ';
+          conv[5] = DIGIMOD(xx, 10);
         }
         else {
-          conv[1] = ' ';
-          conv[2] = x < 0 ? '-' : ' ';
+          conv[4] = ' ';
+          conv[5] = neg ? '-' : ' ';
         }
       }
     }
-    conv[3] = DIGIMOD(xx, 1);
-    conv[4] = '\0';
-    return conv;
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[3];
   }
 
   // Convert unsigned float to string with 1.23 format
   char* ftostr12ns(const float& x) {
-    long xx = abs(x * 100);
-    conv[0] = DIGIMOD(xx, 100);
-    conv[1] = '.';
-    conv[2] = DIGIMOD(xx, 10);
-    conv[3] = DIGIMOD(xx, 1);
-    conv[4] = '\0';
-    return conv;
+    const long xx = (x < 0 ? -x : x) * 100;
+    conv[3] = DIGIMOD(xx, 100);
+    conv[4] = '.';
+    conv[5] = DIGIMOD(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[3];
   }
 
   // Convert signed float to fixed-length string with 023.45 / -23.45 format
   char *ftostr32(const float& x) {
     long xx = x * 100;
-    conv[0] = MINUSOR(xx, DIGIMOD(xx, 10000));
-    conv[1] = DIGIMOD(xx, 1000);
-    conv[2] = DIGIMOD(xx, 100);
-    conv[3] = '.';
-    conv[4] = DIGIMOD(xx, 10);
-    conv[5] = DIGIMOD(xx, 1);
-    conv[6] = '\0';
-    return conv;
+    conv[1] = MINUSOR(xx, DIGIMOD(xx, 10000));
+    conv[2] = DIGIMOD(xx, 1000);
+    conv[3] = DIGIMOD(xx, 100);
+    conv[4] = '.';
+    conv[5] = DIGIMOD(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[1];
   }
 
   #if ENABLED(LCD_DECIMAL_SMALL_XY)
 
     // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
     char *ftostr4sign(const float& fx) {
-      int x = fx * 10;
+      const int x = fx * 10;
       if (!WITHIN(x, -99, 999)) return itostr4sign((int)fx);
-      int xx = abs(x);
-      conv[0] = x < 0 ? '-' : (xx >= 100 ? DIGIMOD(xx, 100) : ' ');
-      conv[1] = DIGIMOD(xx, 10);
-      conv[2] = '.';
-      conv[3] = DIGIMOD(xx, 1);
-      conv[4] = '\0';
-      return conv;
+      const bool neg = x < 0;
+      const int xx = neg ? -x : x;
+      conv[3] = neg ? '-' : (xx >= 100 ? DIGIMOD(xx, 100) : ' ');
+      conv[4] = DIGIMOD(xx, 10);
+      conv[5] = '.';
+      conv[6] = DIGIMOD(xx, 1);
+      return &conv[3];
     }
 
   #endif // LCD_DECIMAL_SMALL_XY
@@ -149,39 +143,36 @@ void safe_delay(millis_t ms) {
   // Convert float to fixed-length string with +123.4 / -123.4 format
   char* ftostr41sign(const float& x) {
     int xx = x * 10;
-    conv[0] = MINUSOR(xx, '+');
-    conv[1] = DIGIMOD(xx, 1000);
-    conv[2] = DIGIMOD(xx, 100);
-    conv[3] = DIGIMOD(xx, 10);
-    conv[4] = '.';
-    conv[5] = DIGIMOD(xx, 1);
-    conv[6] = '\0';
-    return conv;
+    conv[1] = MINUSOR(xx, '+');
+    conv[2] = DIGIMOD(xx, 1000);
+    conv[3] = DIGIMOD(xx, 100);
+    conv[4] = DIGIMOD(xx, 10);
+    conv[5] = '.';
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[1];
   }
 
   // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
   char* ftostr43sign(const float& x, char plus/*=' '*/) {
     long xx = x * 1000;
-    conv[0] = xx ? MINUSOR(xx, plus) : ' ';
-    conv[1] = DIGIMOD(xx, 1000);
-    conv[2] = '.';
-    conv[3] = DIGIMOD(xx, 100);
-    conv[4] = DIGIMOD(xx, 10);
-    conv[5] = DIGIMOD(xx, 1);
-    conv[6] = '\0';
-    return conv;
+    conv[1] = xx ? MINUSOR(xx, plus) : ' ';
+    conv[2] = DIGIMOD(xx, 1000);
+    conv[3] = '.';
+    conv[4] = DIGIMOD(xx, 100);
+    conv[5] = DIGIMOD(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[1];
   }
 
   // Convert unsigned float to rj string with 12345 format
   char* ftostr5rj(const float& x) {
-    long xx = abs(x);
-    conv[0] = RJDIGIT(xx, 10000);
-    conv[1] = RJDIGIT(xx, 1000);
-    conv[2] = RJDIGIT(xx, 100);
-    conv[3] = RJDIGIT(xx, 10);
-    conv[4] = DIGIMOD(xx, 1);
-    conv[5] = '\0';
-    return conv;
+    const long xx = x < 0 ? -x : x;
+    conv[2] = RJDIGIT(xx, 10000);
+    conv[3] = RJDIGIT(xx, 1000);
+    conv[4] = RJDIGIT(xx, 100);
+    conv[5] = RJDIGIT(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[2];
   }
 
   // Convert signed float to string with +1234.5 format
@@ -194,7 +185,6 @@ void safe_delay(millis_t ms) {
     conv[4] = DIGIMOD(xx, 10);
     conv[5] = '.';
     conv[6] = DIGIMOD(xx, 1);
-    conv[7] = '\0';
     return conv;
   }
 
@@ -208,13 +198,12 @@ void safe_delay(millis_t ms) {
     conv[4] = '.';
     conv[5] = DIGIMOD(xx, 10);
     conv[6] = DIGIMOD(xx, 1);
-    conv[7] = '\0';
     return conv;
   }
 
   // Convert unsigned float to string with 1234.56 format omitting trailing zeros
   char* ftostr62rj(const float& x) {
-    long xx = abs(x * 100);
+    const long xx = (x < 0 ? -x : x) * 100;
     conv[0] = RJDIGIT(xx, 100000);
     conv[1] = RJDIGIT(xx, 10000);
     conv[2] = RJDIGIT(xx, 1000);
@@ -222,7 +211,6 @@ void safe_delay(millis_t ms) {
     conv[4] = '.';
     conv[5] = DIGIMOD(xx, 10);
     conv[6] = DIGIMOD(xx, 1);
-    conv[7] = '\0';
     return conv;
   }
 
@@ -230,26 +218,25 @@ void safe_delay(millis_t ms) {
   char* ftostr52sp(const float& x) {
     long xx = x * 100;
     uint8_t dig;
-    conv[0] = MINUSOR(xx, RJDIGIT(xx, 10000));
-    conv[1] = RJDIGIT(xx, 1000);
-    conv[2] = DIGIMOD(xx, 100);
+    conv[1] = MINUSOR(xx, RJDIGIT(xx, 10000));
+    conv[2] = RJDIGIT(xx, 1000);
+    conv[3] = DIGIMOD(xx, 100);
 
     if ((dig = xx % 10)) {          // second digit after decimal point?
-      conv[3] = '.';
-      conv[4] = DIGIMOD(xx, 10);
-      conv[5] = DIGIT(dig);
+      conv[4] = '.';
+      conv[5] = DIGIMOD(xx, 10);
+      conv[6] = DIGIT(dig);
     }
     else {
       if ((dig = (xx / 10) % 10)) { // first digit after decimal point?
-        conv[3] = '.';
-        conv[4] = DIGIT(dig);
+        conv[4] = '.';
+        conv[5] = DIGIT(dig);
       }
       else                          // nothing after decimal point
-        conv[3] = conv[4] = ' ';
-      conv[5] = ' ';
+        conv[4] = conv[5] = ' ';
+      conv[6] = ' ';
     }
-    conv[6] = '\0';
-    return conv;
+    return &conv[1];
   }
 
 #endif // ULTRA_LCD


### PR DESCRIPTION
- Optimize number-to-string conversion by using the same end-null for all
- Refer to `M163`/`M164` as Repetier Firmware (not Repetier Host) features
- When no fan is displayed skip screen segment test also