### PR TITLE
Allow BL-Touch users to control heaters during probe event

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -577,6 +577,7 @@
  */
 //#define BLTOUCH
 //#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2067,10 +2067,11 @@ static void clean_up_after_endstop_or_probe_move() {
 
     // 
     // The BL-Touch probes have a HAL effect sensor.  The high currents switching
-    // on and off cause big magnetic fields that can affect the reliability of the
+    // on and off cause big magnetic fields that can affect the repeatability of the
     // sensor.  So, for BL-Touch probes, we turn off the heaters during the actual probe.
     // And then we quickly turn them back on after we have sampled the point
     //
+  #if ENABLED(BLTOUCH_HEATERS_OFF)
     void turn_heaters_on_or_off_for_bltouch(const bool deploy) {
       static int8_t bltouch_recursion_cnt=0;
       static millis_t last_emi_protection=0;
@@ -2105,9 +2106,12 @@ static void clean_up_after_endstop_or_probe_move() {
         }
       }
     }
+    #endif
 
     void set_bltouch_deployed(const bool deploy) {
+      #if ENABLED(BLTOUCH_HEATERS_OFF)
       turn_heaters_on_or_off_for_bltouch(deploy);
+      #endif
       if (deploy && TEST_BLTOUCH()) {      // If BL-Touch says it's triggered
         bltouch_command(BLTOUCH_RESET);    // try to reset it.
         bltouch_command(BLTOUCH_DEPLOY);   // Also needs to deploy and stow to
@@ -2143,7 +2147,9 @@ static void clean_up_after_endstop_or_probe_move() {
     #endif
 
     #if ENABLED(BLTOUCH)
+      #if ENABLED(BLTOUCH_HEATERS_OFF)
       turn_heaters_on_or_off_for_bltouch(deploy);
+      #endif
     #endif
 
     if (endstops.z_probe_enabled == deploy) return false;

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -575,7 +575,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -559,7 +559,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -559,7 +559,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
@@ -579,7 +579,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -567,7 +567,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -570,7 +570,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -605,7 +605,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -576,7 +576,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -576,7 +576,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -576,7 +576,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -575,7 +575,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -591,7 +591,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -596,7 +596,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -627,7 +627,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -567,7 +567,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -576,7 +576,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -650,7 +650,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -651,7 +651,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -640,7 +640,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -633,7 +633,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -634,7 +634,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -653,7 +653,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
@@ -590,7 +590,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 #define BLTOUCH
-#define BLTOUCH_DELAY 500 // (ms) Enable and increase if needed
+#define BLTOUCH_DELAY 500   // (ms) Enable and increase if needed
+#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -579,7 +579,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -572,7 +572,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -581,7 +581,8 @@
  *   with the possible exception of Z_ENDSTOP_SERVO_NR.
  */
 //#define BLTOUCH
-//#define BLTOUCH_DELAY 375 // (ms) Enable and increase if needed
+//#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
+//#define BLTOUCH_HEATERS_OFF // if defined the printer's heaters are turned off during probe event
 
 /**
  *   BLTouch WARNING  -  ONLY APPLIES TO VERSIONS OF MARLIN BEFORE 15 FEB 2017


### PR DESCRIPTION
The Configuration.h file entries for BL-Touch have been updated to:
```cpp
//#define BLTOUCH
//#define BLTOUCH_DELAY 375      // (ms) Enable and increase if needed
//#define BLTOUCH_HEATERS_OFF    // if defined the printer's heaters are turned off during probe event
```