### PR TITLE
Fix issue in itostr4sign with numbers <100

### DIFF
--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -87,13 +87,13 @@ void safe_delay(millis_t ms) {
         conv[5] = DIGIMOD(xx, 10);
       }
       else {
+        conv[3] = ' ';
         conv[4] = ' ';
         if (xx >= 10) {
           conv[4] = neg ? '-' : ' ';
           conv[5] = DIGIMOD(xx, 10);
         }
         else {
-          conv[4] = ' ';
           conv[5] = neg ? '-' : ' ';
         }
       }


### PR DESCRIPTION
The first character in the string wasn't blanked if the number went from >= 100 to <100, resulting in artefacts in the displayed string.