### PR TITLE
Endstop not enabled if pin is zero

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -406,7 +406,9 @@
     #endif
   #endif
 
-  #define IS_Z2_OR_PROBE(P) (P == Z2_MIN_PIN || P == Z2_MAX_PIN || P == Z_MIN_PROBE_PIN)
+  #define IS_Z2_OR_PROBE(P) (PIN_EXISTS(Z2_MIN_PIN)      && (P == Z2_MIN_PIN) \
+                          || PIN_EXISTS(Z2_MAX_PIN)      && (P == Z2_MAX_PIN) \ 
+                          || PIN_EXISTS(Z_MIN_PROBE_PIN) && (P == Z_MIN_PROBE_PIN))
 
   /**
    * Set ENDSTOPPULLUPS for active endstop switches


### PR DESCRIPTION
Right now if an endstop pin is defined as D0 then Marlin ignores that endstop.

This was introduced between RC7 & RC8 - probably when the Z dual endstops were implemented.

This is a pre-processor issue. The HAS_xyz_MIN & HAS_xyz_MAX macros aren't fully evaluated when deciding if #if HAS_X_MIN is true or not. The problem is that the pre-processor hasn't yet evaluated the `Z2_MIN_PIN` and `Z2_MAX_PIN` macros at this point so they temporarily exist with a value of zero.  If the endstop pin number is also zero then the current `IS_Z2_OR_PROBE` macro evaluates to TRUE which means the code for that endstop will not be compiled.

This bug was discovered as a result of issue #6469.