### PR TITLE
Fix sometimes crash/hang in G29 I

### DIFF
--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -342,6 +342,7 @@
           break;            // No more invalid Mesh Points to populate
         }
         ubl.z_values[location.x_index][location.y_index] = NAN;
+        cnt++;
       }
       SERIAL_PROTOCOLLNPGM("Locations invalidated.\n");
     }


### PR DESCRIPTION
Allows idle() to be called inside `G29 I`, which sometimes crashes the printer on large repetition_cnt if idle() isn't called.

Mentioned here: #6405 