### PR TITLE
Change G26 default nozzle size to 0.4 from 0.3 to be consistent with instructions

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -37,7 +37,7 @@
 
   #define EXTRUSION_MULTIPLIER 1.0
   #define RETRACTION_MULTIPLIER 1.0
-  #define NOZZLE 0.3
+  #define NOZZLE 0.4
   #define FILAMENT 1.75
   #define LAYER_HEIGHT 0.2
   #define PRIME_LENGTH 10.0


### PR DESCRIPTION
Default nozzle size in G26_Mesh_Validation_Tool.cpp was 0.3; this PR changes it to 0.4 to be consistent with the G26 notes/instructions.  I believe 0.4mm is more common, so opted to change the default size over the instructions.

@Roxy-3D:  Mentioning you so you see this, as this should probably make it into the release.