### PR TITLE
Output (commented) coordinates on G29 S-1

### DIFF
--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -601,6 +601,8 @@
               SERIAL_ECHOPAIR(" J ", y);
               SERIAL_ECHOPGM(" Z ");
               SERIAL_ECHO_F(ubl.z_values[x][y], 6);
+              SERIAL_ECHOPAIR(" ; X ", LOGICAL_X_POSITION(pgm_read_float(&(ubl.mesh_index_to_xpos[x]))));
+              SERIAL_ECHOPAIR(", Y ", LOGICAL_Y_POSITION(pgm_read_float(&(ubl.mesh_index_to_ypos[y]))));
               SERIAL_EOL;
             }
         return;


### PR DESCRIPTION
This identifies the x/y coordinates that correspond with ubl i/j points, which eases manual tweaking of z values.  

Not sure if this will be useful to anyone but me, but sometimes it's easier to change a point directly without using G29 P and the rotary knob, and I can't specify the i/j point without first rotating the mesh in my head and then counting, which can be tedious.  Having the actual x/y points that correspond with i/j coordinates makes this a lot easier.

If not useful, no worries.