### PR TITLE
PlatformIO-related improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 #
 # Marlin 3D Printer Firmware
-# Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+# Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
 #
 # Based on Sprinter and grbl.
 # Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -118,6 +118,7 @@ tags
 #PlatformIO files/dirs
 .pioenvs
 .piolib
+.piolibdeps
 
 #Visual Studio
 *.sln
@@ -127,3 +128,7 @@ Marlin/Release/
 Marlin/Debug/
 Marlin/__vm/
 Marlin/.vs/
+
+#cmake
+CMakeLists.txt
+Marlin/CMakeLists.txt

--- a/Marlin/platformio.ini
+++ b/Marlin/platformio.ini
@@ -15,7 +15,11 @@
 src_dir = ./
 envs_dir = ../.pioenvs
 lib_dir = ../.piolib
+libdeps_dir = ../.piolibdeps
 env_default = mega2560
+
+[common]
+lib_deps = U8glib@1.19.1
 
 [env:mega2560]
 platform = atmelavr
@@ -23,6 +27,7 @@ framework = arduino
 board = megaatmega2560
 build_flags = -I $BUILDSRC_DIR
 board_f_cpu = 16000000L
+lib_deps = ${common.lib_deps}
 
 [env:mega1280]
 platform = atmelavr
@@ -30,6 +35,7 @@ framework = arduino
 board = megaatmega1280
 build_flags = -I $BUILDSRC_DIR
 board_f_cpu = 16000000L
+lib_deps = ${common.lib_deps}
 
 [env:printrboard]
 platform = teensy
@@ -38,12 +44,14 @@ board = teensy20pp
 build_flags =  -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_PRINTRBOARD
 # Bug in arduino framework does not allow boards running at 20Mhz
 #board_f_cpu = 20000000L
+lib_deps = ${common.lib_deps}
 
 [env:brainwavepro]
 platform = teensy
 framework = arduino
 board = teensy20pp
 build_flags = -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_BRAINWAVE_PRO -D AT90USBxx_TEENSYPP_ASSIGNMENTS
+lib_deps = ${common.lib_deps}
 
 [env:rambo]
 platform = atmelavr
@@ -51,3 +59,4 @@ framework = arduino
 board = reprap_rambo
 build_flags = -I $BUILDSRC_DIR
 board_f_cpu = 16000000L
+lib_deps = ${common.lib_deps}


### PR DESCRIPTION
Add U8glib as a dependency to platformio.ini for those who use PlatformIO; this makes compiling even easier as u8glib will be downloaded and included automatically.

Also added the new .pio-related directory to .gitignore, and a few ignores for those who use cmake.