### PR TITLE
Various msg and compiler warning fixes

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -407,7 +407,7 @@
   #endif
 
   #define IS_Z2_OR_PROBE(P) (PIN_EXISTS(Z2_MIN_PIN)      && (P == Z2_MIN_PIN) \
-                          || PIN_EXISTS(Z2_MAX_PIN)      && (P == Z2_MAX_PIN) \ 
+                          || PIN_EXISTS(Z2_MAX_PIN)      && (P == Z2_MAX_PIN) \
                           || PIN_EXISTS(Z_MIN_PROBE_PIN) && (P == Z_MIN_PROBE_PIN))
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2079,7 +2079,7 @@ static void clean_up_after_endstop_or_probe_move() {
      */
     #if ENABLED(BLTOUCH_HEATERS_OFF)
 
-      bool set_heaters_for_bltouch(const bool deploy) {
+      void set_heaters_for_bltouch(const bool deploy) {
         static bool heaters_were_disabled = false;
         static millis_t next_emi_protection;
         static float temps_at_entry[HOTENDS];

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -417,6 +417,12 @@
 #ifndef MSG_BLTOUCH_RESET
   #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
 #endif
+#ifndef MSG_BLTOUCH_DEPLOY
+  #define MSG_BLTOUCH_DEPLOY                  _UxGT("Deploy BLTouch")
+#endif
+#ifndef MSG_BLTOUCH_STOW
+  #define MSG_BLTOUCH_STOW                    _UxGT("Stow BLTouch")
+#endif
 #ifndef MSG_HOME
   #define MSG_HOME                            _UxGT("Home") // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #endif

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -161,6 +161,8 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Z sonde extè. lit")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("Autotest BLTouch")
 #define MSG_BLTOUCH_RESET                   _UxGT("RaZ BLTouch")
+#define MSG_BLTOUCH_DEPLOY                  _UxGT("Déployer BLTouch")
+#define MSG_BLTOUCH_STOW                    _UxGT("Ranger BLTouch")
 #define MSG_HOME                            _UxGT("Origine")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("Premier")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Décalage Z")

--- a/Marlin/least_squares_fit.cpp
+++ b/Marlin/least_squares_fit.cpp
@@ -41,7 +41,7 @@
 
 #include "least_squares_fit.h"
 
-void incremental_LSF_reset(struct linear_fit_data *lsf) { ZERO(lsf); }
+void incremental_LSF_reset(struct linear_fit_data *lsf) { memset(lsf,0,sizeof(linear_fit_data)); }
 
 void incremental_LSF(struct linear_fit_data *lsf, float x, float y, float z) {
   lsf->xbar += x;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -39,6 +39,10 @@
   #include "duration_t.h"
 #endif
 
+#if ENABLED(BLTOUCH)
+  #include "endstops.h"
+#endif
+
 int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
 
 #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)


### PR DESCRIPTION
- add BLTouch-related messages in english and (rusty) french;
- add missing endstops.h in ultralcd.cpp;
- fix misc. compiler warnings;
- fix lsf_reset - ZERO macro can't handle a pointer as it would only memset the size of the pointer, not the size of the entire struct

See #6512 & #6513