### PR TITLE
Patch DELTA_HEIGHT, BLTOUCH init

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -120,6 +120,13 @@
   #endif
 
   /**
+   * If DELTA_HEIGHT isn't defined use the old setting
+   */
+  #if ENABLED(DELTA) && !defined(DELTA_HEIGHT)
+    #define DELTA_HEIGHT Z_HOME_POS
+  #endif
+
+  /**
    * Auto Bed Leveling and Z Probe Repeatability Test
    */
   #define HOMING_Z_WITH_PROBE (HAS_BED_PROBE && Z_HOME_DIR < 0 && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN))

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2080,7 +2080,7 @@ static void clean_up_after_endstop_or_probe_move() {
     #if ENABLED(BLTOUCH_HEATERS_OFF)
 
       void set_heaters_for_bltouch(const bool deploy) {
-        static int8_t heaters_were_disabled = 0;
+        static bool heaters_were_disabled = false;
         static millis_t next_emi_protection;
         static float temps_at_entry[HOTENDS];
 
@@ -2111,6 +2111,7 @@ static void clean_up_after_endstop_or_probe_move() {
             thermalManager.setTargetBed(bed_temp_at_entry);
           #endif
         }
+        heaters_were_disabled = deploy;
       }
 
     #endif // BLTOUCH_HEATERS_OFF
@@ -12263,9 +12264,10 @@ void setup() {
   #endif
 
   #if ENABLED(BLTOUCH)
-    bltouch_command(BLTOUCH_RESET);    // Just in case the BLTouch is in the error state, try to
-    set_bltouch_deployed(true);        // reset it. Also needs to deploy and stow to clear the
-    set_bltouch_deployed(false);       // error condition.
+    // Make sure any BLTouch error condition is cleared
+    bltouch_command(BLTOUCH_RESET);
+    set_bltouch_deployed(true);
+    set_bltouch_deployed(false);
   #endif
 
   #if ENABLED(EXPERIMENTAL_I2CBUS) && I2C_SLAVE_ADDRESS > 0


### PR DESCRIPTION
- If the `DELTA_HEIGHT` setting is missing, just use the old option.
- Fix `set_heaters_for_bltouch` to remember the set state. (#6526)