### PR TITLE
Revert "Fix for Meshpositions if printer has negative endstop positions"

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -645,30 +645,14 @@
 // Below are the macros that are used to define the borders for the mesh area,
 // made available here for specialized needs, ie dual extruder setup.
 #if ENABLED(MESH_BED_LEVELING)
-  #if X_MIN_POS < 0
-    #define MESH_MIN_X (MESH_INSET)
-  #else
-    #define MESH_MIN_X (X_MIN_POS + (MESH_INSET))
-  #endif
+  #define MESH_MIN_X (X_MIN_POS + MESH_INSET)
   #define MESH_MAX_X (X_MAX_POS - (MESH_INSET))
-  #if Y_MIN_POS < 0
-    #define MESH_MIN_Y (MESH_INSET)
-  #else
-    #define MESH_MIN_Y (Y_MIN_POS + (MESH_INSET))
-  #endif
+  #define MESH_MIN_Y (Y_MIN_POS + MESH_INSET)
   #define MESH_MAX_Y (Y_MAX_POS - (MESH_INSET))
 #elif ENABLED(AUTO_BED_LEVELING_UBL)
-  #if X_MIN_POS < 0
-    #define UBL_MESH_MIN_X (UBL_MESH_INSET)
-  #else
-    #define UBL_MESH_MIN_X (X_MIN_POS + (UBL_MESH_INSET))
-  #endif
+  #define UBL_MESH_MIN_X (X_MIN_POS + UBL_MESH_INSET)
   #define UBL_MESH_MAX_X (X_MAX_POS - (UBL_MESH_INSET))
-  #if Y_MIN_POS < 0
-    #define UBL_MESH_MIN_Y (UBL_MESH_INSET)
-  #else
-    #define UBL_MESH_MIN_Y (Y_MIN_POS + (UBL_MESH_INSET))
-  #endif
+  #define UBL_MESH_MIN_Y (Y_MIN_POS + UBL_MESH_INSET)
   #define UBL_MESH_MAX_Y (Y_MAX_POS - (UBL_MESH_INSET))
 
   // If this is defined, the currently active mesh will be saved in the


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#6416

In the long run we should probably skip the sanity-checking on probing bounds and use `position_is_reachable` to prevent probing in a dangerous place. During probing we could, for example, give audio feedback if it tries to probe outside the reachable area. (On Delta we allow outside points to be specified because they can be extrapolated.)