### PR TITLE
Reactivate MBL after homing (G28)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3752,6 +3752,9 @@ inline void gcode_G28() {
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       const bool bed_leveling_state_at_entry = ubl.state.active;
     #endif
+	#if ENABLED(MESH_BED_LEVELING)
+	  mbl.set_reactivate(mbl.active());
+	#endif
     set_bed_leveling_enabled(false);
   #endif
 


### PR DESCRIPTION
The reactivate bit is used to reactivate MBL after homing, however is never set before homing, so I added this.