### PR TITLE
Endstop logic fix (again) & sanity check fix

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -406,9 +406,13 @@
     #endif
   #endif
 
-  #define IS_Z2_OR_PROBE(P) (   (PIN_EXISTS(Z2_MIN)      && (P) == Z2_MIN_PIN)       \
-                             || (PIN_EXISTS(Z2_MAX)      && (P) == Z2_MAX_PIN)       \
-                             || (PIN_EXISTS(Z_MIN_PROBE) && (P) == Z_MIN_PROBE_PIN))
+  /**
+   *  Deciding which endstops are active at pre-processor time is "interesting"
+   *      all real pins are fully useable, when Z2_MIN_PIN or Z2_MAX_PIN exist they don't have a value (all compares fail)
+   */
+  #define IS_Z2_OR_PROBE(AXIS,MIN_MAX) (   (ENABLED(Z_DUAL_STEPPER_DRIVERS) && ENABLED(Z_DUAL_ENDSTOPS) \
+                                             && (Z2_USE_ENDSTOP == _##AXIS##MIN_MAX##_)) \
+                                        || (ENABLED(Z_MIN_PROBE_ENDSTOP) && Z_MIN_PROBE_PIN == AXIS##_##MIN_MAX##_PIN ) )
 
   /**
    * Set ENDSTOPPULLUPS for active endstop switches
@@ -498,12 +502,12 @@
   #define HAS_SOLENOID_4    (PIN_EXISTS(SOL4))
 
   // Endstops and bed probe
-  #define HAS_X_MIN (PIN_EXISTS(X_MIN) && !IS_Z2_OR_PROBE(X_MIN_PIN))
-  #define HAS_X_MAX (PIN_EXISTS(X_MAX) && !IS_Z2_OR_PROBE(X_MAX_PIN))
-  #define HAS_Y_MIN (PIN_EXISTS(Y_MIN) && !IS_Z2_OR_PROBE(Y_MIN_PIN))
-  #define HAS_Y_MAX (PIN_EXISTS(Y_MAX) && !IS_Z2_OR_PROBE(Y_MAX_PIN))
-  #define HAS_Z_MIN (PIN_EXISTS(Z_MIN) && !IS_Z2_OR_PROBE(Z_MIN_PIN))
-  #define HAS_Z_MAX (PIN_EXISTS(Z_MAX) && !IS_Z2_OR_PROBE(Z_MAX_PIN))
+  #define HAS_X_MIN (PIN_EXISTS(X_MIN) && !IS_Z2_OR_PROBE(X,MIN))
+  #define HAS_X_MAX (PIN_EXISTS(X_MAX) && !IS_Z2_OR_PROBE(X,MAX))
+  #define HAS_Y_MIN (PIN_EXISTS(Y_MIN) && !IS_Z2_OR_PROBE(Y,MIN))
+  #define HAS_Y_MAX (PIN_EXISTS(Y_MAX) && !IS_Z2_OR_PROBE(Y,MAX))
+  #define HAS_Z_MIN (PIN_EXISTS(Z_MIN) && !IS_Z2_OR_PROBE(Z,MIN))
+  #define HAS_Z_MAX (PIN_EXISTS(Z_MAX) && !IS_Z2_OR_PROBE(Z,MAX))
   #define HAS_Z2_MIN (PIN_EXISTS(Z2_MIN))
   #define HAS_Z2_MAX (PIN_EXISTS(Z2_MAX))
   #define HAS_Z_MIN_PROBE_PIN (PIN_EXISTS(Z_MIN_PROBE))
@@ -799,3 +803,4 @@
   #endif
 
 #endif // CONDITIONALS_POST_H
+

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -202,12 +202,12 @@
  */
 #if ENABLED(X_DUAL_STEPPER_DRIVERS) && ENABLED(DUAL_X_CARRIAGE)
   #error "DUAL_X_CARRIAGE is not compatible with X_DUAL_STEPPER_DRIVERS."
-#elif ENABLED(X_DUAL_STEPPER_DRIVERS) && (!HAS_X2_ENABLE || !HAS_X2_STEP || !HAS_X2_DIR)
-  #error "X_DUAL_STEPPER_DRIVERS requires X2 pins (and an extra E plug)."
-#elif ENABLED(Y_DUAL_STEPPER_DRIVERS) && (!HAS_Y2_ENABLE || !HAS_Y2_STEP || !HAS_Y2_DIR)
-  #error "Y_DUAL_STEPPER_DRIVERS requires Y2 pins (and an extra E plug)."
-#elif ENABLED(Z_DUAL_STEPPER_DRIVERS) && (!HAS_Z2_ENABLE || !HAS_Z2_STEP || !HAS_Z2_DIR)
-  #error "Z_DUAL_STEPPER_DRIVERS requires Z2 pins (and an extra E plug)."
+#elif ENABLED(X_DUAL_STEPPER_DRIVERS) && (X2_ENABLE_PIN == 00 || X2_STEP_PIN == 00 || X2_DIR_PIN == 00)
+  #error "pin(s) NOT assigned for second X stepper - probably because all E sockets already used"
+#elif ENABLED(Y_DUAL_STEPPER_DRIVERS) && (Y2_ENABLE_PIN == 00 || Y2_STEP_PIN == 00 || Y2_DIR_PIN == 00)
+  #error "pin(s) NOT assigned for second Y stepper - probably because all E sockets already used"
+#elif ENABLED(Z_DUAL_STEPPER_DRIVERS) && (Z2_ENABLE_PIN == 00 || Z2_STEP_PIN == 00 || Z2_DIR_PIN == 00)
+  #error "pin(s) NOT assigned for second Z stepper - probably because all E sockets already used"
 #endif
 
 /**


### PR DESCRIPTION
The endstop logic from PR #6520 has a bug in it.  It only works properly if you have a Z dual endstop system.

Th(i)s PR fixes that.

Sanity check wasn't catching when there weren't enough sockets for the
dual steppers.