### PR TITLE
PlatformIO-related changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,7 @@ Marlin/.vs/
 #cmake
 CMakeLists.txt
 Marlin/CMakeLists.txt
+CMakeListsPrivate.txt
+
+#CLion
+cmake-build-*

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,10 +12,10 @@
 # targets = upload
 
 [platformio]
-src_dir = ./
-envs_dir = ../.pioenvs
-lib_dir = ../.piolib
-libdeps_dir = ../.piolibdeps
+src_dir = Marlin
+envs_dir = .pioenvs
+lib_dir = .piolib
+libdeps_dir = .piolibdeps
 env_default = mega2560
 
 [common]


### PR DESCRIPTION
- move platformio.ini out of source directory to be more consistent with 'normal' PlatformIO usage
  - facilitates IDE integration
  - simplifies use
- add related .gitignores