### PR TITLE
G29 P1 stops reporting Invalid location with this patch

### DIFF
--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1057,12 +1057,12 @@
       err_flag = true;
     }
 
-    if (!WITHIN(RAW_X_POSITION(x_pos), UBL_MESH_MIN_X, UBL_MESH_MAX_X)) {
+    if (!WITHIN(RAW_X_POSITION(x_pos), X_MIN_POS, X_MAX_POS)) {
       SERIAL_PROTOCOLLNPGM("Invalid X location specified.\n");
       err_flag = true;
     }
 
-    if (!WITHIN(RAW_Y_POSITION(y_pos), UBL_MESH_MIN_Y, UBL_MESH_MAX_Y)) {
+    if (!WITHIN(RAW_Y_POSITION(y_pos), Y_MIN_POS, Y_MAX_POS)) {
       SERIAL_PROTOCOLLNPGM("Invalid Y location specified.\n");
       err_flag = true;
     }


### PR DESCRIPTION
I used bugfix-1.1.x to test the UBL...
The result was 
``` 18:37:19.710 : N152 G29 P1*85
18:37:19.710 : Invalid X location specified.
18:37:19.726 : Invalid Y location specified.
18:37:19.726 : ok```

I was lucky enough to find in #6566 the correction... 

This PR was tested as perfectly working in bugfix-1.1.x...

@Bob-the-Kuhn. feel free to merge, re-edit, whatever. I just wanted to make sure this does find its way in the code poeple will use.