### PR TITLE
New GCode Parser

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -838,4 +838,7 @@
   // Shorthand
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))
 
+  // Add commands that need sub-codes to this list
+  #define USE_GCODE_SUBCODES ENABLED(G38_PROBE_TARGET)
+
 #endif // CONDITIONALS_POST_H

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1226,4 +1226,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -61,6 +61,7 @@ extern size_t  __heap_start, __heap_end, __flp;
 extern char __bss_end;
 
 #include "Marlin.h"
+#include "gcode.h"
 #include "hex_print_routines.h"
 
 //
@@ -188,7 +189,7 @@ void free_memory_pool_report(char * const ptr, const int16_t size) {
    *  This is useful to check the correctness of the M100 D and the M100 F commands.
    */
   void corrupt_free_memory(char *ptr, const uint16_t size) {
-    if (code_seen('C')) {
+    if (parser.seen('C')) {
       ptr += 8;
       const uint16_t near_top = top_of_stack() - ptr - 250, // -250 to avoid interrupt activity that's altered the stack.
                      j = near_top / (size + 1);
@@ -247,23 +248,23 @@ void gcode_M100() {
 
   // Always init on the first invocation of M100
   static bool m100_not_initialized = true;
-  if (m100_not_initialized || code_seen('I')) {
+  if (m100_not_initialized || parser.seen('I')) {
     m100_not_initialized = false;
     init_free_memory(ptr, sp - ptr);
   }
 
   #if ENABLED(M100_FREE_MEMORY_DUMPER)
-    if (code_seen('D'))
+    if (parser.seen('D'))
       return dump_free_memory(ptr, sp);
   #endif
 
-  if (code_seen('F'))
+  if (parser.seen('F'))
     return free_memory_pool_report(ptr, sp - ptr);
 
   #if ENABLED(M100_FREE_MEMORY_CORRUPTOR)
 
-    if (code_seen('C'))
-      return corrupt_free_memory(ptr, code_value_int());
+    if (parser.seen('C'))
+      return corrupt_free_memory(ptr, parser.value_int());
 
   #endif
 }

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -287,22 +287,6 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
   void update_software_endstops(const AxisEnum axis);
 #endif
 
-// GCode support for external objects
-bool code_seen(char);
-int code_value_int();
-int16_t code_value_temp_abs();
-int16_t code_value_temp_diff();
-
-#if ENABLED(INCH_MODE_SUPPORT)
-  float code_value_linear_units();
-  float code_value_axis_units(const AxisEnum axis);
-  float code_value_per_axis_unit(const AxisEnum axis);
-#else
-  #define code_value_linear_units() code_value_float()
-  #define code_value_axis_units(A) code_value_float()
-  #define code_value_per_axis_unit(A) code_value_float()
-#endif
-
 #if IS_KINEMATIC
   extern float delta[ABC];
   void inverse_kinematics(const float logical[XYZ]);
@@ -490,4 +474,4 @@ FORCE_INLINE bool position_is_reachable_xy(const float &lx, const float &ly) {
   return position_is_reachable_raw_xy(RAW_X_POSITION(lx), RAW_Y_POSITION(ly));
 }
 
-#endif //MARLIN_H
+#endif // MARLIN_H

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -242,6 +242,7 @@
 #include "nozzle.h"
 #include "duration_t.h"
 #include "types.h"
+#include "gcode.h"
 
 #if HAS_ABL
   #include "vector_3.h"
@@ -374,23 +375,11 @@ static char command_queue[BUFSIZE][MAX_CMD_SIZE];
 #endif
 
 /**
- * Current GCode Command
- * When a GCode handler is running, these will be set
- */
-static char *current_command,      // The command currently being executed
-            *current_command_args, // The address where arguments begin
-            *seen_pointer;         // Set by code_seen(), used by the code_value functions
-
-/**
  * Next Injected Command pointer. NULL if no commands are being injected.
  * Used by Marlin internally to ensure that commands initiated from within
  * are enqueued ahead of any pending serial or sd card commands.
  */
 static const char *injected_commands_P = NULL;
-
-#if ENABLED(INCH_MODE_SUPPORT)
-  float linear_unit_factor = 1.0, volumetric_unit_factor = 1.0;
-#endif
 
 #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
   TempUnit input_temp_units = TEMPUNIT_C;
@@ -408,7 +397,8 @@ float constexpr homing_feedrate_mm_s[] = {
   #endif
   MMM_TO_MMS(HOMING_FEEDRATE_Z), 0
 };
-float feedrate_mm_s = MMM_TO_MMS(1500.0), saved_feedrate_mm_s;
+float feedrate_mm_s = MMM_TO_MMS(1500.0);
+static float saved_feedrate_mm_s;
 int feedrate_percentage = 100, saved_feedrate_percentage,
     flow_percentage[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100);
 
@@ -1056,8 +1046,8 @@ inline void get_serial_commands() {
       char* command = serial_line_buffer;
 
       while (*command == ' ') command++; // skip any leading spaces
-      char* npos = (*command == 'N') ? command : NULL; // Require the N parameter to start the line
-      char* apos = strchr(command, '*');
+      char *npos = (*command == 'N') ? command : NULL, // Require the N parameter to start the line
+           *apos = strchr(command, '*');
 
       if (npos) {
 
@@ -1249,125 +1239,21 @@ void get_available_commands() {
   #endif
 }
 
-inline bool code_has_value() {
-  int i = 1;
-  char c = seen_pointer[i];
-  while (c == ' ') c = seen_pointer[++i];
-  if (c == '-' || c == '+') c = seen_pointer[++i];
-  if (c == '.') c = seen_pointer[++i];
-  return NUMERIC(c);
-}
-
-inline float code_value_float() {
-  char* e = strchr(seen_pointer, 'E');
-  if (!e) return strtod(seen_pointer + 1, NULL);
-  *e = 0;
-  float ret = strtod(seen_pointer + 1, NULL);
-  *e = 'E';
-  return ret;
-}
-
-inline unsigned long code_value_ulong() { return strtoul(seen_pointer + 1, NULL, 10); }
-
-inline long code_value_long() { return strtol(seen_pointer + 1, NULL, 10); }
-
-inline int code_value_int() { return (int)strtol(seen_pointer + 1, NULL, 10); }
-
-inline uint16_t code_value_ushort() { return (uint16_t)strtoul(seen_pointer + 1, NULL, 10); }
-
-inline uint8_t code_value_byte() { return (uint8_t)(constrain(strtol(seen_pointer + 1, NULL, 10), 0, 255)); }
-
-inline bool code_value_bool() { return !code_has_value() || code_value_byte() > 0; }
-
-#if ENABLED(INCH_MODE_SUPPORT)
-  inline void set_input_linear_units(LinearUnit units) {
-    switch (units) {
-      case LINEARUNIT_INCH:
-        linear_unit_factor = 25.4;
-        break;
-      case LINEARUNIT_MM:
-      default:
-        linear_unit_factor = 1.0;
-        break;
-    }
-    volumetric_unit_factor = pow(linear_unit_factor, 3.0);
-  }
-
-  inline float axis_unit_factor(const AxisEnum axis) {
-    return (axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor : linear_unit_factor);
-  }
-
-  inline float code_value_linear_units() { return code_value_float() * linear_unit_factor; }
-  inline float code_value_axis_units(const AxisEnum axis) { return code_value_float() * axis_unit_factor(axis); }
-  inline float code_value_per_axis_unit(const AxisEnum axis) { return code_value_float() / axis_unit_factor(axis); }
-#endif
-
-#if ENABLED(TEMPERATURE_UNITS_SUPPORT)
-  inline void set_input_temp_units(TempUnit units) { input_temp_units = units; }
-
-  float to_temp_units(const float &c) {
-    switch (input_temp_units) {
-      case TEMPUNIT_F:
-        return c * 0.5555555556 + 32.0;
-      case TEMPUNIT_K:
-        return c + 273.15;
-      case TEMPUNIT_C:
-      default:
-        return c;
-    }
-  }
-
-  int16_t code_value_temp_abs() {
-    const float c = code_value_float();
-    switch (input_temp_units) {
-      case TEMPUNIT_F:
-        return (int16_t)((c - 32.0) * 0.5555555556);
-      case TEMPUNIT_K:
-        return (int16_t)(c - 273.15);
-      case TEMPUNIT_C:
-      default:
-        return (int16_t)(c);
-    }
-  }
-
-  int16_t code_value_temp_diff() {
-    switch (input_temp_units) {
-      case TEMPUNIT_F:
-        return code_value_float() * 0.5555555556;
-      case TEMPUNIT_C:
-      case TEMPUNIT_K:
-      default:
-        return code_value_float();
-    }
-  }
-#else
-  int16_t code_value_temp_abs() { return code_value_int(); }
-  int16_t code_value_temp_diff() { return code_value_int(); }
-#endif
-
-FORCE_INLINE millis_t code_value_millis() { return code_value_ulong(); }
-inline millis_t code_value_millis_from_seconds() { return code_value_float() * 1000; }
-
-bool code_seen(char code) {
-  seen_pointer = strchr(current_command_args, code);
-  return (seen_pointer != NULL); // Return TRUE if the code-letter was found
-}
-
 /**
  * Set target_extruder from the T parameter or the active_extruder
  *
  * Returns TRUE if the target is invalid
  */
 bool get_target_extruder_from_command(int code) {
-  if (code_seen('T')) {
-    if (code_value_byte() >= EXTRUDERS) {
+  if (parser.seen('T')) {
+    if (parser.value_byte() >= EXTRUDERS) {
       SERIAL_ECHO_START;
       SERIAL_CHAR('M');
       SERIAL_ECHO(code);
-      SERIAL_ECHOLNPAIR(" " MSG_INVALID_EXTRUDER " ", code_value_byte());
+      SERIAL_ECHOLNPAIR(" " MSG_INVALID_EXTRUDER " ", parser.value_byte());
       return true;
     }
-    target_extruder = code_value_byte();
+    target_extruder = parser.value_byte();
   }
   else
     target_extruder = active_extruder;
@@ -3141,9 +3027,9 @@ static void homeaxis(const AxisEnum axis) {
       const char* mixing_codes = "ABCDHI";
       byte mix_bits = 0;
       for (uint8_t i = 0; i < MIXING_STEPPERS; i++) {
-        if (code_seen(mixing_codes[i])) {
+        if (parser.seen(mixing_codes[i])) {
           SBI(mix_bits, i);
-          float v = code_value_float();
+          float v = parser.value_float();
           NOLESS(v, 0.0);
           mixing_factor[i] = RECIPROCAL(v);
         }
@@ -3175,14 +3061,14 @@ static void homeaxis(const AxisEnum axis) {
  */
 void gcode_get_destination() {
   LOOP_XYZE(i) {
-    if (code_seen(axis_codes[i]))
-      destination[i] = code_value_axis_units((AxisEnum)i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0);
+    if (parser.seen(axis_codes[i]))
+      destination[i] = parser.value_axis_units((AxisEnum)i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0);
     else
       destination[i] = current_position[i];
   }
 
-  if (code_seen('F') && code_value_linear_units() > 0.0)
-    feedrate_mm_s = MMM_TO_MMS(code_value_linear_units());
+  if (parser.seen('F') && parser.value_linear_units() > 0.0)
+    feedrate_mm_s = MMM_TO_MMS(parser.value_feedrate());
 
   #if ENABLED(PRINTCOUNTER)
     if (!DEBUGGING(DRYRUN))
@@ -3193,13 +3079,6 @@ void gcode_get_destination() {
   #if ENABLED(MIXING_EXTRUDER) && ENABLED(DIRECT_MIXING_IN_G1)
     gcode_get_mix();
   #endif
-}
-
-void unknown_command_error() {
-  SERIAL_ECHO_START;
-  SERIAL_ECHOPAIR(MSG_UNKNOWN_COMMAND, current_command);
-  SERIAL_CHAR('"');
-  SERIAL_EOL;
 }
 
 #if ENABLED(HOST_KEEPALIVE_FEATURE)
@@ -3253,7 +3132,7 @@ inline void gcode_G0_G1(
 
     #if ENABLED(FWRETRACT)
 
-      if (autoretract_enabled && !(code_seen('X') || code_seen('Y') || code_seen('Z')) && code_seen('E')) {
+      if (autoretract_enabled && !(parser.seen('X') || parser.seen('Y') || parser.seen('Z')) && parser.seen('E')) {
         const float echange = destination[E_AXIS] - current_position[E_AXIS];
         // Is this move an attempt to retract or recover?
         if ((echange < -MIN_RETRACT && !retracted[active_extruder]) || (echange > MIN_RETRACT && retracted[active_extruder])) {
@@ -3264,7 +3143,7 @@ inline void gcode_G0_G1(
         }
       }
 
-    #endif //FWRETRACT
+    #endif // FWRETRACT
 
     #if IS_SCARA
       fast_move ? prepare_uninterpolated_move_to_destination() : prepare_move_to_destination();
@@ -3313,8 +3192,8 @@ inline void gcode_G0_G1(
       #endif
 
       float arc_offset[2] = { 0.0, 0.0 };
-      if (code_seen('R')) {
-        const float r = code_value_linear_units(),
+      if (parser.seen('R')) {
+        const float r = parser.value_linear_units(),
                     x1 = current_position[X_AXIS], y1 = current_position[Y_AXIS],
                     x2 = destination[X_AXIS], y2 = destination[Y_AXIS];
         if (r && (x2 != x1 || y2 != y1)) {
@@ -3330,8 +3209,8 @@ inline void gcode_G0_G1(
         }
       }
       else {
-        if (code_seen('I')) arc_offset[X_AXIS] = code_value_linear_units();
-        if (code_seen('J')) arc_offset[Y_AXIS] = code_value_linear_units();
+        if (parser.seen('I')) arc_offset[X_AXIS] = parser.value_linear_units();
+        if (parser.seen('J')) arc_offset[Y_AXIS] = parser.value_linear_units();
       }
 
       if (arc_offset[0] || arc_offset[1]) {
@@ -3354,8 +3233,8 @@ inline void gcode_G0_G1(
 inline void gcode_G4() {
   millis_t dwell_ms = 0;
 
-  if (code_seen('P')) dwell_ms = code_value_millis(); // milliseconds to wait
-  if (code_seen('S')) dwell_ms = code_value_millis_from_seconds(); // seconds to wait
+  if (parser.seen('P')) dwell_ms = parser.value_millis(); // milliseconds to wait
+  if (parser.seen('S')) dwell_ms = parser.value_millis_from_seconds(); // seconds to wait
 
   stepper.synchronize();
   refresh_cmd_timeout();
@@ -3384,10 +3263,10 @@ inline void gcode_G4() {
       gcode_get_destination();
 
       const float offset[] = {
-        code_seen('I') ? code_value_linear_units() : 0.0,
-        code_seen('J') ? code_value_linear_units() : 0.0,
-        code_seen('P') ? code_value_linear_units() : 0.0,
-        code_seen('Q') ? code_value_linear_units() : 0.0
+        parser.seen('I') ? parser.value_linear_units() : 0.0,
+        parser.seen('J') ? parser.value_linear_units() : 0.0,
+        parser.seen('P') ? parser.value_linear_units() : 0.0,
+        parser.seen('Q') ? parser.value_linear_units() : 0.0
       };
 
       plan_cubic_move(offset);
@@ -3405,7 +3284,7 @@ inline void gcode_G4() {
   inline void gcode_G10_G11(bool doRetract=false) {
     #if EXTRUDERS > 1
       if (doRetract) {
-        retracted_swap[active_extruder] = (code_seen('S') && code_value_bool()); // checks for swap retract argument
+        retracted_swap[active_extruder] = (parser.seen('S') && parser.value_bool()); // checks for swap retract argument
       }
     #endif
     retract(doRetract
@@ -3425,10 +3304,10 @@ inline void gcode_G4() {
     // Don't allow nozzle cleaning without homing first
     if (axis_unhomed_error()) return;
 
-    const uint8_t pattern = code_seen('P') ? code_value_ushort() : 0,
-                  strokes = code_seen('S') ? code_value_ushort() : NOZZLE_CLEAN_STROKES,
-                  objects = code_seen('T') ? code_value_ushort() : NOZZLE_CLEAN_TRIANGLES;
-    const float radius = code_seen('R') ? code_value_float() : NOZZLE_CLEAN_CIRCLE_RADIUS;
+    const uint8_t pattern = parser.seen('P') ? parser.value_ushort() : 0,
+                  strokes = parser.seen('S') ? parser.value_ushort() : NOZZLE_CLEAN_STROKES,
+                  objects = parser.seen('T') ? parser.value_ushort() : NOZZLE_CLEAN_TRIANGLES;
+    const float radius = parser.seen('R') ? parser.value_float() : NOZZLE_CLEAN_CIRCLE_RADIUS;
 
     Nozzle::clean(pattern, strokes, radius, objects);
   }
@@ -3438,12 +3317,12 @@ inline void gcode_G4() {
   /**
    * G20: Set input mode to inches
    */
-  inline void gcode_G20() { set_input_linear_units(LINEARUNIT_INCH); }
+  inline void gcode_G20() { parser.set_input_linear_units(LINEARUNIT_INCH); }
 
   /**
    * G21: Set input mode to millimeters
    */
-  inline void gcode_G21() { set_input_linear_units(LINEARUNIT_MM); }
+  inline void gcode_G21() { parser.set_input_linear_units(LINEARUNIT_MM); }
 #endif
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
@@ -3453,7 +3332,7 @@ inline void gcode_G4() {
   inline void gcode_G27() {
     // Don't allow nozzle parking without homing first
     if (axis_unhomed_error()) return;
-    Nozzle::park(code_seen('P') ? code_value_ushort() : 0);
+    Nozzle::park(parser.seen('P') ? parser.value_ushort() : 0);
   }
 #endif // NOZZLE_PARK_FEATURE
 
@@ -3770,9 +3649,9 @@ inline void gcode_G28(const bool always_home_all) {
 
   #else // NOT DELTA
 
-    const bool homeX = always_home_all || code_seen('X'),
-               homeY = always_home_all || code_seen('Y'),
-               homeZ = always_home_all || code_seen('Z'),
+    const bool homeX = always_home_all || parser.seen('X'),
+               homeY = always_home_all || parser.seen('Y'),
+               homeZ = always_home_all || parser.seen('Z'),
                home_all = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
 
     set_destination_to_current();
@@ -4001,7 +3880,7 @@ void home_all_axes() { gcode_G28(true); }
       static bool enable_soft_endstops;
     #endif
 
-    const MeshLevelingState state = code_seen('S') ? (MeshLevelingState)code_value_byte() : MeshReport;
+    const MeshLevelingState state = parser.seen('S') ? (MeshLevelingState)parser.value_byte() : MeshReport;
     if (!WITHIN(state, 0, 5)) {
       SERIAL_PROTOCOLLNPGM("S out of range (0-5).");
       return;
@@ -4073,8 +3952,8 @@ void home_all_axes() { gcode_G28(true); }
         break;
 
       case MeshSet:
-        if (code_seen('X')) {
-          px = code_value_int() - 1;
+        if (parser.seen('X')) {
+          px = parser.value_int() - 1;
           if (!WITHIN(px, 0, GRID_MAX_POINTS_X - 1)) {
             SERIAL_PROTOCOLLNPGM("X out of range (1-" STRINGIFY(GRID_MAX_POINTS_X) ").");
             return;
@@ -4085,8 +3964,8 @@ void home_all_axes() { gcode_G28(true); }
           return;
         }
 
-        if (code_seen('Y')) {
-          py = code_value_int() - 1;
+        if (parser.seen('Y')) {
+          py = parser.value_int() - 1;
           if (!WITHIN(py, 0, GRID_MAX_POINTS_Y - 1)) {
             SERIAL_PROTOCOLLNPGM("Y out of range (1-" STRINGIFY(GRID_MAX_POINTS_Y) ").");
             return;
@@ -4097,8 +3976,8 @@ void home_all_axes() { gcode_G28(true); }
           return;
         }
 
-        if (code_seen('Z')) {
-          mbl.z_values[px][py] = code_value_linear_units();
+        if (parser.seen('Z')) {
+          mbl.z_values[px][py] = parser.value_linear_units();
         }
         else {
           SERIAL_CHAR('Z'); echo_not_entered();
@@ -4107,8 +3986,8 @@ void home_all_axes() { gcode_G28(true); }
         break;
 
       case MeshSetZOffset:
-        if (code_seen('Z')) {
-          mbl.z_offset = code_value_linear_units();
+        if (parser.seen('Z')) {
+          mbl.z_offset = parser.value_linear_units();
         }
         else {
           SERIAL_CHAR('Z'); echo_not_entered();
@@ -4213,7 +4092,7 @@ void home_all_axes() { gcode_G28(true); }
 
     // G29 Q is also available if debugging
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      const bool query = code_seen('Q');
+      const bool query = parser.seen('Q');
       const uint8_t old_debug_flags = marlin_debug_flags;
       if (query) marlin_debug_flags |= DEBUG_LEVELING;
       if (DEBUGGING(LEVELING)) {
@@ -4227,7 +4106,7 @@ void home_all_axes() { gcode_G28(true); }
     #endif
 
     #if ENABLED(DEBUG_LEVELING_FEATURE) && DISABLED(PROBE_MANUALLY)
-      const bool faux = code_seen('C') && code_value_bool();
+      const bool faux = parser.seen('C') && parser.value_bool();
     #else
       bool constexpr faux = false;
     #endif
@@ -4318,24 +4197,24 @@ void home_all_axes() { gcode_G28(true); }
 
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-        if (code_seen('W')) {
+        if (parser.seen('W')) {
           if (!bilinear_grid_spacing[X_AXIS]) {
             SERIAL_ERROR_START;
             SERIAL_ERRORLNPGM("No bilinear grid");
             return;
           }
 
-          const float z = code_seen('Z') && code_has_value() ? code_value_float() : 99999;
+          const float z = parser.seen('Z') && parser.has_value() ? parser.value_float() : 99999;
           if (!WITHIN(z, -10, 10)) {
             SERIAL_ERROR_START;
             SERIAL_ERRORLNPGM("Bad Z value");
             return;
           }
 
-          const float x = code_seen('X') && code_has_value() ? code_value_float() : 99999,
-                      y = code_seen('Y') && code_has_value() ? code_value_float() : 99999;
-          int8_t i = code_seen('I') && code_has_value() ? code_value_byte() : -1,
-                 j = code_seen('J') && code_has_value() ? code_value_byte() : -1;
+          const float x = parser.seen('X') && parser.has_value() ? parser.value_float() : 99999,
+                      y = parser.seen('Y') && parser.has_value() ? parser.value_float() : 99999;
+          int8_t i = parser.seen('I') && parser.has_value() ? parser.value_byte() : -1,
+                 j = parser.seen('J') && parser.has_value() ? parser.value_byte() : -1;
 
           if (x < 99998 && y < 99998) {
             // Get nearest i / j from x / y
@@ -4353,37 +4232,37 @@ void home_all_axes() { gcode_G28(true); }
             set_bed_leveling_enabled(abl_should_enable);
           }
           return;
-        } // code_seen('W')
+        } // parser.seen('W')
 
       #endif
 
       #if HAS_LEVELING
 
         // Jettison bed leveling data
-        if (code_seen('J')) {
+        if (parser.seen('J')) {
           reset_bed_level();
           return;
         }
 
       #endif
 
-      verbose_level = code_seen('V') && code_has_value() ? code_value_int() : 0;
+      verbose_level = parser.seen('V') && parser.has_value() ? parser.value_int() : 0;
       if (!WITHIN(verbose_level, 0, 4)) {
         SERIAL_PROTOCOLLNPGM("?(V)erbose level is implausible (0-4).");
         return;
       }
 
-      dryrun = code_seen('D') && code_value_bool();
+      dryrun = parser.seen('D') && parser.value_bool();
 
       #if ENABLED(AUTO_BED_LEVELING_LINEAR)
 
-        do_topography_map = verbose_level > 2 || code_seen('T');
+        do_topography_map = verbose_level > 2 || parser.seen('T');
 
         // X and Y specify points in each direction, overriding the default
         // These values may be saved with the completed mesh
-        abl_grid_points_x = code_seen('X') ? code_value_int() : GRID_MAX_POINTS_X;
-        abl_grid_points_y = code_seen('Y') ? code_value_int() : GRID_MAX_POINTS_Y;
-        if (code_seen('P')) abl_grid_points_x = abl_grid_points_y = code_value_int();
+        abl_grid_points_x = parser.seen('X') ? parser.value_int() : GRID_MAX_POINTS_X;
+        abl_grid_points_y = parser.seen('Y') ? parser.value_int() : GRID_MAX_POINTS_Y;
+        if (parser.seen('P')) abl_grid_points_x = abl_grid_points_y = parser.value_int();
 
         if (abl_grid_points_x < 2 || abl_grid_points_y < 2) {
           SERIAL_PROTOCOLLNPGM("?Number of probe points is implausible (2 minimum).");
@@ -4394,18 +4273,18 @@ void home_all_axes() { gcode_G28(true); }
 
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-        zoffset = code_seen('Z') ? code_value_linear_units() : 0;
+        zoffset = parser.seen('Z') ? parser.value_linear_units() : 0;
 
       #endif
 
       #if ABL_GRID
 
-        xy_probe_feedrate_mm_s = MMM_TO_MMS(code_seen('S') ? code_value_linear_units() : XY_PROBE_SPEED);
+        xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.seen('S') ? parser.value_linear_units() : XY_PROBE_SPEED);
 
-        left_probe_bed_position = code_seen('L') ? (int)code_value_linear_units() : LOGICAL_X_POSITION(LEFT_PROBE_BED_POSITION);
-        right_probe_bed_position = code_seen('R') ? (int)code_value_linear_units() : LOGICAL_X_POSITION(RIGHT_PROBE_BED_POSITION);
-        front_probe_bed_position = code_seen('F') ? (int)code_value_linear_units() : LOGICAL_Y_POSITION(FRONT_PROBE_BED_POSITION);
-        back_probe_bed_position = code_seen('B') ? (int)code_value_linear_units() : LOGICAL_Y_POSITION(BACK_PROBE_BED_POSITION);
+        left_probe_bed_position = parser.seen('L') ? (int)parser.value_linear_units() : LOGICAL_X_POSITION(LEFT_PROBE_BED_POSITION);
+        right_probe_bed_position = parser.seen('R') ? (int)parser.value_linear_units() : LOGICAL_X_POSITION(RIGHT_PROBE_BED_POSITION);
+        front_probe_bed_position = parser.seen('F') ? (int)parser.value_linear_units() : LOGICAL_Y_POSITION(FRONT_PROBE_BED_POSITION);
+        back_probe_bed_position = parser.seen('B') ? (int)parser.value_linear_units() : LOGICAL_Y_POSITION(BACK_PROBE_BED_POSITION);
 
         const bool left_out_l = left_probe_bed_position < LOGICAL_X_POSITION(MIN_PROBE_X),
                    left_out = left_out_l || left_probe_bed_position > right_probe_bed_position - (MIN_PROBE_EDGE),
@@ -4519,7 +4398,7 @@ void home_all_axes() { gcode_G28(true); }
     #if ENABLED(PROBE_MANUALLY)
 
       // Abort current G29 procedure, go back to ABLStart
-      if (code_seen('A') && g29_in_progress) {
+      if (parser.seen('A') && g29_in_progress) {
         SERIAL_PROTOCOLLNPGM("Manual G29 aborted");
         #if HAS_SOFTWARE_ENDSTOPS
           soft_endstops_enabled = enable_soft_endstops;
@@ -4529,7 +4408,7 @@ void home_all_axes() { gcode_G28(true); }
       }
 
       // Query G29 status
-      if (code_seen('Q')) {
+      if (parser.seen('Q')) {
         if (!g29_in_progress)
           SERIAL_PROTOCOLLNPGM("Manual G29 idle");
         else {
@@ -4538,7 +4417,7 @@ void home_all_axes() { gcode_G28(true); }
         }
       }
 
-      if (code_seen('A') || code_seen('Q')) return;
+      if (parser.seen('A') || parser.seen('Q')) return;
 
       // Fall through to probe the first point
       g29_in_progress = true;
@@ -4674,7 +4553,7 @@ void home_all_axes() { gcode_G28(true); }
 
     #else // !PROBE_MANUALLY
 
-      bool stow_probe_after_each = code_seen('E');
+      const bool stow_probe_after_each = parser.seen('E');
 
       #if ABL_GRID
 
@@ -5015,8 +4894,8 @@ void home_all_axes() { gcode_G28(true); }
    *   S0  Leave the probe deployed
    */
   inline void gcode_G30() {
-    const float xpos = code_seen('X') ? code_value_linear_units() : current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER,
-                ypos = code_seen('Y') ? code_value_linear_units() : current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER;
+    const float xpos = parser.seen('X') ? parser.value_linear_units() : current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER,
+                ypos = parser.seen('Y') ? parser.value_linear_units() : current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER;
 
     if (!position_is_reachable_by_probe_xy(xpos, ypos)) return;
 
@@ -5027,7 +4906,7 @@ void home_all_axes() { gcode_G28(true); }
 
     setup_for_endstop_or_probe_move();
 
-    const float measured_z = probe_pt(xpos, ypos, !code_seen('S') || code_value_bool(), 1);
+    const float measured_z = probe_pt(xpos, ypos, !parser.seen('S') || parser.value_bool(), 1);
 
     if (!isnan(measured_z)) {
       SERIAL_PROTOCOLPAIR("Bed X: ", FIXFLOAT(xpos));
@@ -5080,25 +4959,25 @@ void home_all_axes() { gcode_G28(true); }
      */
     inline void gcode_G33() {
 
-      const int8_t probe_points = code_seen('P') ? code_value_int() : DELTA_CALIBRATION_DEFAULT_POINTS;
+      const int8_t probe_points = parser.seen('P') ? parser.value_int() : DELTA_CALIBRATION_DEFAULT_POINTS;
       if (!WITHIN(probe_points, 1, 7)) {
         SERIAL_PROTOCOLLNPGM("?(P)oints is implausible (1 to 7).");
         return;
       }
 
-      const int8_t verbose_level = code_seen('V') ? code_value_byte() : 1;
+      const int8_t verbose_level = parser.seen('V') ? parser.value_byte() : 1;
       if (!WITHIN(verbose_level, 0, 2)) {
         SERIAL_PROTOCOLLNPGM("?(V)erbose level is implausible (0-2).");
         return;
       }
 
-      const float calibration_precision = code_seen('C') ? code_value_float() : 0.0;
+      const float calibration_precision = parser.seen('C') ? parser.value_float() : 0.0;
       if (calibration_precision < 0) {
         SERIAL_PROTOCOLLNPGM("?(C)alibration precision is implausible (>0).");
         return;
       }
 
-      const bool towers_set = !code_seen('T'),
+      const bool towers_set = !parser.seen('T'),
                  _1p_calibration      = probe_points == 1,
                  _4p_calibration      = probe_points == 2,
                  _4p_towers_points    = _4p_calibration && towers_set,
@@ -5537,7 +5416,7 @@ void home_all_axes() { gcode_G28(true); }
     // If any axis has enough movement, do the move
     LOOP_XYZ(i)
       if (fabs(destination[i] - current_position[i]) >= G38_MINIMUM_MOVE) {
-        if (!code_seen('F')) feedrate_mm_s = homing_feedrate_mm_s[i];
+        if (!parser.seen('F')) feedrate_mm_s = homing_feedrate_mm_s[i];
         // If G38.2 fails throw an error
         if (!G38_run_probe() && is_38_2) {
           SERIAL_ERROR_START;
@@ -5558,10 +5437,10 @@ void home_all_axes() { gcode_G28(true); }
    */
   inline void gcode_G42() {
     if (IsRunning()) {
-      const bool hasI = code_seen('I');
-      const int8_t ix = code_has_value() ? code_value_int() : 0;
-      const bool hasJ = code_seen('J');
-      const int8_t iy = code_has_value() ? code_value_int() : 0;
+      const bool hasI = parser.seen('I');
+      const int8_t ix = parser.has_value() ? parser.value_int() : 0;
+      const bool hasJ = parser.seen('J');
+      const int8_t iy = parser.has_value() ? parser.value_int() : 0;
 
       if ((hasI && !WITHIN(ix, 0, GRID_MAX_POINTS_X - 1)) || (hasJ && !WITHIN(iy, 0, GRID_MAX_POINTS_Y - 1))) {
         SERIAL_ECHOLNPGM(MSG_ERR_MESH_XY);
@@ -5582,13 +5461,13 @@ void home_all_axes() { gcode_G28(true); }
       set_destination_to_current();
       if (hasI) destination[X_AXIS] = LOGICAL_X_POSITION(_GET_MESH_X(ix));
       if (hasJ) destination[Y_AXIS] = LOGICAL_Y_POSITION(_GET_MESH_Y(iy));
-      if (code_seen('P') && code_value_bool()) {
+      if (parser.seen('P') && parser.value_bool()) {
         if (hasI) destination[X_AXIS] -= X_PROBE_OFFSET_FROM_EXTRUDER;
         if (hasJ) destination[Y_AXIS] -= Y_PROBE_OFFSET_FROM_EXTRUDER;
       }
 
-      if (code_seen('F') && code_value_linear_units() > 0.0)
-        feedrate_mm_s = MMM_TO_MMS(code_value_linear_units());
+      if (parser.seen('F') && parser.value_linear_units() > 0.0)
+        feedrate_mm_s = MMM_TO_MMS(parser.value_linear_units());
 
       // SCARA kinematic has "safe" XY raw moves
       #if IS_SCARA
@@ -5606,20 +5485,20 @@ void home_all_axes() { gcode_G28(true); }
  */
 inline void gcode_G92() {
   bool didXYZ = false,
-       didE = code_seen('E');
+       didE = parser.seen('E');
 
   if (!didE) stepper.synchronize();
 
   LOOP_XYZE(i) {
-    if (code_seen(axis_codes[i])) {
+    if (parser.seen(axis_codes[i])) {
       #if IS_SCARA
-        current_position[i] = code_value_axis_units((AxisEnum)i);
+        current_position[i] = parser.value_axis_units((AxisEnum)i);
         if (i != E_AXIS) didXYZ = true;
       #else
         #if HAS_POSITION_SHIFT
           const float p = current_position[i];
         #endif
-        float v = code_value_axis_units((AxisEnum)i);
+        float v = parser.value_axis_units((AxisEnum)i);
 
         current_position[i] = v;
 
@@ -5648,22 +5527,22 @@ inline void gcode_G92() {
    * M1: Conditional stop   - Wait for user button press on LCD
    */
   inline void gcode_M0_M1() {
-    const char * const args = current_command_args;
+    const char * const args = parser.string_arg;
 
-    millis_t codenum = 0;
+    millis_t ms = 0;
     bool hasP = false, hasS = false;
-    if (code_seen('P')) {
-      codenum = code_value_millis(); // milliseconds to wait
-      hasP = codenum > 0;
+    if (parser.seen('P')) {
+      ms = parser.value_millis(); // milliseconds to wait
+      hasP = ms > 0;
     }
-    if (code_seen('S')) {
-      codenum = code_value_millis_from_seconds(); // seconds to wait
-      hasS = codenum > 0;
+    if (parser.seen('S')) {
+      ms = parser.value_millis_from_seconds(); // seconds to wait
+      hasS = ms > 0;
     }
 
     #if ENABLED(ULTIPANEL)
 
-      if (!hasP && !hasS && *args != '\0')
+      if (!hasP && !hasS && args && *args)
         lcd_setstatus(args, true);
       else {
         LCD_MESSAGEPGM(MSG_USERWAIT);
@@ -5674,7 +5553,7 @@ inline void gcode_G92() {
 
     #else
 
-      if (!hasP && !hasS && *args != '\0') {
+      if (!hasP && !hasS && args && *args) {
         SERIAL_ECHO_START;
         SERIAL_ECHOLN(args);
       }
@@ -5687,9 +5566,9 @@ inline void gcode_G92() {
     stepper.synchronize();
     refresh_cmd_timeout();
 
-    if (codenum > 0) {
-      codenum += previous_cmd_ms;  // wait until this time for a click
-      while (PENDING(millis(), codenum) && wait_for_user) idle();
+    if (ms > 0) {
+      ms += previous_cmd_ms;  // wait until this time for a click
+      while (PENDING(millis(), ms) && wait_for_user) idle();
     }
     else {
       #if ENABLED(ULTIPANEL)
@@ -5759,7 +5638,7 @@ inline void gcode_G92() {
    */
 
   inline void ocr_val_mode() {
-    uint8_t spindle_laser_power = code_value_byte();
+    uint8_t spindle_laser_power = parser.value_byte();
     WRITE(SPINDLE_LASER_ENABLE_PIN, SPINDLE_LASER_ENABLE_INVERT); // turn spindle on (active low)
     if (SPINDLE_LASER_PWM_INVERT) spindle_laser_power = 255 - spindle_laser_power;
     analogWrite(SPINDLE_LASER_PWM_PIN, spindle_laser_power);
@@ -5786,9 +5665,9 @@ inline void gcode_G92() {
      * Then needed to AND the uint16_t result with 0x00FF to make sure we only wrote the byte of interest.
      */
     #if ENABLED(SPINDLE_LASER_PWM)
-      if (code_seen('O')) ocr_val_mode();
+      if (parser.seen('O')) ocr_val_mode();
       else {
-        const float spindle_laser_power = code_seen('S') ? code_value_float() : 0;
+        const float spindle_laser_power = parser.seen('S') ? parser.value_float() : 0;
         if (spindle_laser_power == 0) {
           WRITE(SPINDLE_LASER_ENABLE_PIN, !SPINDLE_LASER_ENABLE_INVERT);                                    // turn spindle off (active low)
           delay_for_power_down();
@@ -5895,7 +5774,7 @@ inline void gcode_M17() {
   /**
    * M23: Open a file
    */
-  inline void gcode_M23() { card.openFile(current_command_args, true); }
+  inline void gcode_M23() { card.openFile(parser.string_arg, true); }
 
   /**
    * M24: Start or Resume SD Print
@@ -5925,8 +5804,8 @@ inline void gcode_M17() {
    * M26: Set SD Card file index
    */
   inline void gcode_M26() {
-    if (card.cardOK && code_seen('S'))
-      card.setIndex(code_value_long());
+    if (card.cardOK && parser.seen('S'))
+      card.setIndex(parser.value_long());
   }
 
   /**
@@ -5937,7 +5816,7 @@ inline void gcode_M17() {
   /**
    * M28: Start SD Write
    */
-  inline void gcode_M28() { card.openFile(current_command_args, false); }
+  inline void gcode_M28() { card.openFile(parser.string_arg, false); }
 
   /**
    * M29: Stop SD Write
@@ -5953,7 +5832,7 @@ inline void gcode_M17() {
   inline void gcode_M30() {
     if (card.cardOK) {
       card.closefile();
-      card.removeFile(current_command_args);
+      card.removeFile(parser.string_arg);
     }
   }
 
@@ -5977,23 +5856,18 @@ inline void gcode_M31() {
   /**
    * M32: Select file and start SD Print
    */
-  inline void gcode_M32() {  // Why is M32 allowed to flout the sacred GCode standard?
+  inline void gcode_M32() {
     if (card.sdprinting)
       stepper.synchronize();
 
-    char* namestartpos = strchr(current_command_args, '!');  // Find ! to indicate filename string start.
-    if (!namestartpos)
-      namestartpos = current_command_args; // Default name position, 4 letters after the M
-    else
-      namestartpos++; //to skip the '!'
-
-    bool call_procedure = code_seen('P') && (seen_pointer < namestartpos);
+    char* namestartpos = parser.string_arg;
+    bool call_procedure = parser.seen('P');
 
     if (card.cardOK) {
       card.openFile(namestartpos, true, call_procedure);
 
-      if (code_seen('S') && seen_pointer < namestartpos) // "S" (must occur _before_ the filename!)
-        card.setIndex(code_value_long());
+      if (parser.seen('S'))
+        card.setIndex(parser.value_long());
 
       card.startFileprint();
 
@@ -6017,7 +5891,7 @@ inline void gcode_M31() {
      *   /Miscellaneous/Armchair/Armchair.gcode
      */
     inline void gcode_M33() {
-      card.printLongPath(current_command_args);
+      card.printLongPath(parser.string_arg);
     }
 
   #endif
@@ -6027,12 +5901,12 @@ inline void gcode_M31() {
      * M34: Set SD Card Sorting Options
      */
     inline void gcode_M34() {
-      if (code_seen('S')) card.setSortOn(code_value_bool());
-      if (code_seen('F')) {
-        int v = code_value_long();
+      if (parser.seen('S')) card.setSortOn(parser.value_bool());
+      if (parser.seen('F')) {
+        int v = parser.value_long();
         card.setSortFolders(v < 0 ? -1 : v > 0 ? 1 : 0);
       }
-      //if (code_seen('R')) card.setSortReverse(code_value_bool());
+      //if (parser.seen('R')) card.setSortReverse(parser.value_bool());
     }
   #endif // SDCARD_SORT_ALPHA && SDSORT_GCODE
 
@@ -6040,7 +5914,7 @@ inline void gcode_M31() {
    * M928: Start SD Write
    */
   inline void gcode_M928() {
-    card.openLogFile(current_command_args);
+    card.openLogFile(parser.string_arg);
   }
 
 #endif // SDSUPPORT
@@ -6062,12 +5936,12 @@ static bool pin_is_protected(uint8_t pin) {
  *  S<byte> Pin status from 0 - 255
  */
 inline void gcode_M42() {
-  if (!code_seen('S')) return;
+  if (!parser.seen('S')) return;
 
-  int pin_status = code_value_int();
+  int pin_status = parser.value_int();
   if (!WITHIN(pin_status, 0, 255)) return;
 
-  int pin_number = code_seen('P') ? code_value_int() : LED_PIN;
+  int pin_number = parser.seen('P') ? parser.value_int() : LED_PIN;
   if (pin_number < 0) return;
 
   if (pin_is_protected(pin_number)) {
@@ -6100,11 +5974,11 @@ inline void gcode_M42() {
   #include "pinsDebug.h"
 
   inline void toggle_pins() {
-    const bool I_flag = code_seen('I') && code_value_bool();
-    const int repeat = code_seen('R') ? code_value_int() : 1,
-              start = code_seen('S') ? code_value_int() : 0,
-              end = code_seen('E') ? code_value_int() : NUM_DIGITAL_PINS - 1,
-              wait = code_seen('W') ? code_value_int() : 500;
+    const bool I_flag = parser.seen('I') && parser.value_bool();
+    const int repeat = parser.seen('R') ? parser.value_int() : 1,
+              start = parser.seen('S') ? parser.value_int() : 0,
+              end = parser.seen('E') ? parser.value_int() : NUM_DIGITAL_PINS - 1,
+              wait = parser.seen('W') ? parser.value_int() : 500;
 
     for (uint8_t pin = start; pin <= end; pin++) {
       if (!I_flag && pin_is_protected(pin)) {
@@ -6142,7 +6016,7 @@ inline void gcode_M42() {
 
     #else
 
-      const uint8_t probe_index = code_seen('P') ? code_value_byte() : Z_ENDSTOP_SERVO_NR;
+      const uint8_t probe_index = parser.seen('P') ? parser.value_byte() : Z_ENDSTOP_SERVO_NR;
 
       SERIAL_PROTOCOLLNPGM("Servo probe test");
       SERIAL_PROTOCOLLNPAIR(".  using index:  ", probe_index);
@@ -6284,35 +6158,35 @@ inline void gcode_M42() {
    */
   inline void gcode_M43() {
 
-    if (code_seen('T')) {   // must be first ot else it's "S" and "E" parameters will execute endstop or servo test
+    if (parser.seen('T')) {   // must be first ot else it's "S" and "E" parameters will execute endstop or servo test
       toggle_pins();
       return;
     }
 
     // Enable or disable endstop monitoring
-    if (code_seen('E')) {
-      endstop_monitor_flag = code_value_bool();
+    if (parser.seen('E')) {
+      endstop_monitor_flag = parser.value_bool();
       SERIAL_PROTOCOLPGM("endstop monitor ");
       SERIAL_PROTOCOL(endstop_monitor_flag ? "en" : "dis");
       SERIAL_PROTOCOLLNPGM("abled");
       return;
     }
 
-    if (code_seen('S')) {
+    if (parser.seen('S')) {
       servo_probe_test();
       return;
     }
 
     // Get the range of pins to test or watch
-    const uint8_t first_pin = code_seen('P') ? code_value_byte() : 0,
-                  last_pin = code_seen('P') ? first_pin : NUM_DIGITAL_PINS - 1;
+    const uint8_t first_pin = parser.seen('P') ? parser.value_byte() : 0,
+                  last_pin = parser.seen('P') ? first_pin : NUM_DIGITAL_PINS - 1;
 
     if (first_pin > last_pin) return;
 
-    const bool ignore_protection = code_seen('I') && code_value_bool();
+    const bool ignore_protection = parser.seen('I') && parser.value_bool();
 
     // Watch until click, M108, or reset
-    if (code_seen('W') && code_value_bool()) {
+    if (parser.seen('W') && parser.value_bool()) {
       SERIAL_PROTOCOLLNPGM("Watching pins");
       byte pin_state[last_pin - first_pin + 1];
       for (int8_t pin = first_pin; pin <= last_pin; pin++) {
@@ -6390,7 +6264,7 @@ inline void gcode_M42() {
 
     if (axis_unhomed_error()) return;
 
-    const int8_t verbose_level = code_seen('V') ? code_value_byte() : 1;
+    const int8_t verbose_level = parser.seen('V') ? parser.value_byte() : 1;
     if (!WITHIN(verbose_level, 0, 4)) {
       SERIAL_PROTOCOLLNPGM("?(V)erbose level is implausible (0-4).");
       return;
@@ -6399,19 +6273,19 @@ inline void gcode_M42() {
     if (verbose_level > 0)
       SERIAL_PROTOCOLLNPGM("M48 Z-Probe Repeatability Test");
 
-    int8_t n_samples = code_seen('P') ? code_value_byte() : 10;
+    int8_t n_samples = parser.seen('P') ? parser.value_byte() : 10;
     if (!WITHIN(n_samples, 4, 50)) {
       SERIAL_PROTOCOLLNPGM("?Sample size not plausible (4-50).");
       return;
     }
 
+    const bool stow_probe_after_each = parser.seen('E');
+
     float X_current = current_position[X_AXIS],
           Y_current = current_position[Y_AXIS];
 
-    bool stow_probe_after_each = code_seen('E');
-
-    const float X_probe_location = code_seen('X') ? code_value_linear_units() : X_current + X_PROBE_OFFSET_FROM_EXTRUDER,
-                Y_probe_location = code_seen('Y') ? code_value_linear_units() : Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER;
+    const float X_probe_location = parser.seen('X') ? parser.value_linear_units() : X_current + X_PROBE_OFFSET_FROM_EXTRUDER,
+                Y_probe_location = parser.seen('Y') ? parser.value_linear_units() : Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER;
 
     #if DISABLED(DELTA)
       if (!WITHIN(X_probe_location, LOGICAL_X_POSITION(MIN_PROBE_X), LOGICAL_X_POSITION(MAX_PROBE_X))) {
@@ -6429,15 +6303,15 @@ inline void gcode_M42() {
       }
     #endif
 
-    bool seen_L = code_seen('L');
-    uint8_t n_legs = seen_L ? code_value_byte() : 0;
+    bool seen_L = parser.seen('L');
+    uint8_t n_legs = seen_L ? parser.value_byte() : 0;
     if (n_legs > 15) {
       SERIAL_PROTOCOLLNPGM("?Number of legs in movement not plausible (0-15).");
       return;
     }
     if (n_legs == 1) n_legs = 2;
 
-    bool schizoid_flag = code_seen('S');
+    bool schizoid_flag = parser.seen('S');
     if (schizoid_flag && !seen_L) n_legs = 7;
 
     /**
@@ -6653,7 +6527,7 @@ inline void gcode_M77() { print_job_timer.stop(); }
    */
   inline void gcode_M78() {
     // "M78 S78" will reset the statistics
-    if (code_seen('S') && code_value_int() == 78)
+    if (parser.seen('S') && parser.value_int() == 78)
       print_job_timer.initStats();
     else
       print_job_timer.showStats();
@@ -6671,8 +6545,8 @@ inline void gcode_M104() {
     if (target_extruder != active_extruder) return;
   #endif
 
-  if (code_seen('S')) {
-    const int16_t temp = code_value_temp_abs();
+  if (parser.seen('S')) {
+    const int16_t temp = parser.value_celsius();
     thermalManager.setTargetHotend(temp, target_extruder);
 
     #if ENABLED(DUAL_X_CARRIAGE)
@@ -6687,13 +6561,13 @@ inline void gcode_M104() {
        * standby mode, for instance in a dual extruder setup, without affecting
        * the running print timer.
        */
-      if (code_value_temp_abs() <= (EXTRUDE_MINTEMP) / 2) {
+      if (parser.value_celsius() <= (EXTRUDE_MINTEMP) / 2) {
         print_job_timer.stop();
         LCD_MESSAGEPGM(WELCOME_MSG);
       }
     #endif
 
-    if (code_value_temp_abs() > thermalManager.degHotend(target_extruder))
+    if (parser.value_celsius() > thermalManager.degHotend(target_extruder))
       lcd_status_printf_P(0, PSTR("E%i %s"), target_extruder + 1, MSG_HEATING);
   }
 
@@ -6780,8 +6654,8 @@ inline void gcode_M105() {
    * M155: Set temperature auto-report interval. M155 S<seconds>
    */
   inline void gcode_M155() {
-    if (code_seen('S')) {
-      auto_report_temp_interval = code_value_byte();
+    if (parser.seen('S')) {
+      auto_report_temp_interval = parser.value_byte();
       NOMORE(auto_report_temp_interval, 60);
       next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
     }
@@ -6806,8 +6680,8 @@ inline void gcode_M105() {
    *  P<index> Fan index, if more than one fan
    */
   inline void gcode_M106() {
-    uint16_t s = code_seen('S') ? code_value_ushort() : 255,
-             p = code_seen('P') ? code_value_ushort() : 0;
+    uint16_t s = parser.seen('S') ? parser.value_ushort() : 255,
+             p = parser.seen('P') ? parser.value_ushort() : 0;
     NOMORE(s, 255);
     if (p < FAN_COUNT) fanSpeeds[p] = s;
   }
@@ -6816,7 +6690,7 @@ inline void gcode_M105() {
    * M107: Fan Off
    */
   inline void gcode_M107() {
-    uint16_t p = code_seen('P') ? code_value_ushort() : 0;
+    uint16_t p = parser.seen('P') ? parser.value_ushort() : 0;
     if (p < FAN_COUNT) fanSpeeds[p] = 0;
   }
 
@@ -6867,9 +6741,9 @@ inline void gcode_M109() {
     if (target_extruder != active_extruder) return;
   #endif
 
-  const bool no_wait_for_cooling = code_seen('S');
-  if (no_wait_for_cooling || code_seen('R')) {
-    const int16_t temp = code_value_temp_abs();
+  const bool no_wait_for_cooling = parser.seen('S');
+  if (no_wait_for_cooling || parser.seen('R')) {
+    const int16_t temp = parser.value_celsius();
     thermalManager.setTargetHotend(temp, target_extruder);
 
     #if ENABLED(DUAL_X_CARRIAGE)
@@ -6883,7 +6757,7 @@ inline void gcode_M109() {
        * standby mode, (e.g., in a dual extruder setup) without affecting
        * the running print timer.
        */
-      if (code_value_temp_abs() <= (EXTRUDE_MINTEMP) / 2) {
+      if (parser.value_celsius() <= (EXTRUDE_MINTEMP) / 2) {
         print_job_timer.stop();
         LCD_MESSAGEPGM(WELCOME_MSG);
       }
@@ -7020,12 +6894,11 @@ inline void gcode_M109() {
     if (DEBUGGING(DRYRUN)) return;
 
     LCD_MESSAGEPGM(MSG_BED_HEATING);
-    const bool no_wait_for_cooling = code_seen('S');
-    if (no_wait_for_cooling || code_seen('R')) {
-      thermalManager.setTargetBed(code_value_temp_abs());
-
+    const bool no_wait_for_cooling = parser.seen('S');
+    if (no_wait_for_cooling || parser.seen('R')) {
+      thermalManager.setTargetBed(parser.value_celsius());
       #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
-        if (code_value_temp_abs() > BED_MINTEMP)
+        if (parser.value_celsius() > BED_MINTEMP)
           print_job_timer.start();
       #endif
     }
@@ -7133,14 +7006,14 @@ inline void gcode_M109() {
  * M110: Set Current Line Number
  */
 inline void gcode_M110() {
-  if (code_seen('N')) gcode_LastN = code_value_long();
+  if (parser.seen('N')) gcode_LastN = parser.value_long();
 }
 
 /**
  * M111: Set the debug level
  */
 inline void gcode_M111() {
-  marlin_debug_flags = code_seen('S') ? code_value_byte() : (uint8_t)DEBUG_NONE;
+  marlin_debug_flags = parser.seen('S') ? parser.value_byte() : (uint8_t)DEBUG_NONE;
 
   const static char str_debug_1[] PROGMEM = MSG_DEBUG_ECHO;
   const static char str_debug_2[] PROGMEM = MSG_DEBUG_INFO;
@@ -7152,9 +7025,9 @@ inline void gcode_M111() {
   #endif
 
   const static char* const debug_strings[] PROGMEM = {
-    str_debug_1, str_debug_2, str_debug_4, str_debug_8, str_debug_16,
+    str_debug_1, str_debug_2, str_debug_4, str_debug_8, str_debug_16
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      str_debug_32
+      , str_debug_32
     #endif
   };
 
@@ -7183,8 +7056,8 @@ inline void gcode_M111() {
    *   S<seconds> Optional. Set the keepalive interval.
    */
   inline void gcode_M113() {
-    if (code_seen('S')) {
-      host_keepalive_interval = code_value_byte();
+    if (parser.seen('S')) {
+      host_keepalive_interval = parser.value_byte();
       NOMORE(host_keepalive_interval, 60);
     }
     else {
@@ -7201,7 +7074,7 @@ inline void gcode_M111() {
     /**
      * M126: Heater 1 valve open
      */
-    inline void gcode_M126() { baricuda_valve_pressure = code_seen('S') ? code_value_byte() : 255; }
+    inline void gcode_M126() { baricuda_valve_pressure = parser.seen('S') ? parser.value_byte() : 255; }
     /**
      * M127: Heater 1 valve close
      */
@@ -7212,7 +7085,7 @@ inline void gcode_M111() {
     /**
      * M128: Heater 2 valve open
      */
-    inline void gcode_M128() { baricuda_e_to_p_pressure = code_seen('S') ? code_value_byte() : 255; }
+    inline void gcode_M128() { baricuda_e_to_p_pressure = parser.seen('S') ? parser.value_byte() : 255; }
     /**
      * M129: Heater 2 valve close
      */
@@ -7226,7 +7099,7 @@ inline void gcode_M111() {
  */
 inline void gcode_M140() {
   if (DEBUGGING(DRYRUN)) return;
-  if (code_seen('S')) thermalManager.setTargetBed(code_value_temp_abs());
+  if (parser.seen('S')) thermalManager.setTargetBed(parser.value_celsius());
 }
 
 #if ENABLED(ULTIPANEL)
@@ -7240,24 +7113,24 @@ inline void gcode_M140() {
    *   F<fan speed>
    */
   inline void gcode_M145() {
-    uint8_t material = code_seen('S') ? (uint8_t)code_value_int() : 0;
+    uint8_t material = parser.seen('S') ? (uint8_t)parser.value_int() : 0;
     if (material >= COUNT(lcd_preheat_hotend_temp)) {
       SERIAL_ERROR_START;
       SERIAL_ERRORLNPGM(MSG_ERR_MATERIAL_INDEX);
     }
     else {
       int v;
-      if (code_seen('H')) {
-        v = code_value_int();
+      if (parser.seen('H')) {
+        v = parser.value_int();
         lcd_preheat_hotend_temp[material] = constrain(v, EXTRUDE_MINTEMP, HEATER_0_MAXTEMP - 15);
       }
-      if (code_seen('F')) {
-        v = code_value_int();
+      if (parser.seen('F')) {
+        v = parser.value_int();
         lcd_preheat_fan_speed[material] = constrain(v, 0, 255);
       }
       #if TEMP_SENSOR_BED != 0
-        if (code_seen('B')) {
-          v = code_value_int();
+        if (parser.seen('B')) {
+          v = parser.value_int();
           lcd_preheat_bed_temp[material] = constrain(v, BED_MINTEMP, BED_MAXTEMP - 15);
         }
       #endif
@@ -7271,9 +7144,9 @@ inline void gcode_M140() {
    * M149: Set temperature units
    */
   inline void gcode_M149() {
-         if (code_seen('C')) set_input_temp_units(TEMPUNIT_C);
-    else if (code_seen('K')) set_input_temp_units(TEMPUNIT_K);
-    else if (code_seen('F')) set_input_temp_units(TEMPUNIT_F);
+         if (parser.seen('C')) parser.set_input_temp_units(TEMPUNIT_C);
+    else if (parser.seen('K')) parser.set_input_temp_units(TEMPUNIT_K);
+    else if (parser.seen('F')) parser.set_input_temp_units(TEMPUNIT_F);
   }
 #endif
 
@@ -7286,7 +7159,7 @@ inline void gcode_M140() {
   inline void gcode_M80() {
 
     // S: Report the current power supply state and exit
-    if (code_seen('S')) {
+    if (parser.seen('S')) {
       serialprintPGM(powersupply_on ? PSTR("PS:1\n") : PSTR("PS:0\n"));
       return;
     }
@@ -7362,21 +7235,21 @@ inline void gcode_M83() { axis_relative_modes[E_AXIS] = true; }
  * M18, M84: Disable stepper motors
  */
 inline void gcode_M18_M84() {
-  if (code_seen('S')) {
-    stepper_inactive_time = code_value_millis_from_seconds();
+  if (parser.seen('S')) {
+    stepper_inactive_time = parser.value_millis_from_seconds();
   }
   else {
-    bool all_axis = !((code_seen('X')) || (code_seen('Y')) || (code_seen('Z')) || (code_seen('E')));
+    bool all_axis = !((parser.seen('X')) || (parser.seen('Y')) || (parser.seen('Z')) || (parser.seen('E')));
     if (all_axis) {
       stepper.finish_and_disable();
     }
     else {
       stepper.synchronize();
-      if (code_seen('X')) disable_X();
-      if (code_seen('Y')) disable_Y();
-      if (code_seen('Z')) disable_Z();
+      if (parser.seen('X')) disable_X();
+      if (parser.seen('Y')) disable_Y();
+      if (parser.seen('Z')) disable_Z();
       #if ((E0_ENABLE_PIN != X_ENABLE_PIN) && (E1_ENABLE_PIN != Y_ENABLE_PIN)) // Only enable on boards that have seperate ENABLE_PINS
-        if (code_seen('E')) disable_e_steppers();
+        if (parser.seen('E')) disable_e_steppers();
       #endif
     }
   }
@@ -7386,7 +7259,7 @@ inline void gcode_M18_M84() {
  * M85: Set inactivity shutdown timer with parameter S<seconds>. To disable set zero (default)
  */
 inline void gcode_M85() {
-  if (code_seen('S')) max_inactive_time = code_value_millis_from_seconds();
+  if (parser.seen('S')) max_inactive_time = parser.value_millis_from_seconds();
 }
 
 /**
@@ -7411,9 +7284,9 @@ inline void gcode_M92() {
   GET_TARGET_EXTRUDER(92);
 
   LOOP_XYZE(i) {
-    if (code_seen(axis_codes[i])) {
+    if (parser.seen(axis_codes[i])) {
       if (i == E_AXIS) {
-        const float value = code_value_per_axis_unit((AxisEnum)(E_AXIS + TARGET_EXTRUDER));
+        const float value = parser.value_per_axis_unit((AxisEnum)(E_AXIS + TARGET_EXTRUDER));
         if (value < 20.0) {
           float factor = planner.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] / value; // increase e constants if M92 E14 is given for netfab.
           planner.max_jerk[E_AXIS] *= factor;
@@ -7423,7 +7296,7 @@ inline void gcode_M92() {
         planner.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] = value;
       }
       else {
-        planner.axis_steps_per_mm[i] = code_value_per_axis_unit((AxisEnum)i);
+        planner.axis_steps_per_mm[i] = parser.value_per_axis_unit((AxisEnum)i);
       }
     }
   }
@@ -7531,7 +7404,7 @@ inline void gcode_M115() {
  * M117: Set LCD Status Message
  */
 inline void gcode_M117() {
-  lcd_setstatus(current_command_args);
+  lcd_setstatus(parser.string_arg);
 }
 
 /**
@@ -7592,7 +7465,7 @@ inline void gcode_M121() { endstops.enable_globally(false); }
     set_destination_to_current();
 
     // Initial retract before move to filament change position
-    destination[E_AXIS] += code_seen('L') ? code_value_axis_units(E_AXIS) : 0
+    destination[E_AXIS] += parser.seen('L') ? parser.value_axis_units(E_AXIS) : 0
       #if defined(FILAMENT_CHANGE_RETRACT_LENGTH) && FILAMENT_CHANGE_RETRACT_LENGTH > 0
         - (FILAMENT_CHANGE_RETRACT_LENGTH)
       #endif
@@ -7600,7 +7473,7 @@ inline void gcode_M121() { endstops.enable_globally(false); }
     RUNPLAN(FILAMENT_CHANGE_RETRACT_FEEDRATE);
 
     // Lift Z axis
-    const float z_lift = code_seen('Z') ? code_value_linear_units() :
+    const float z_lift = parser.seen('Z') ? parser.value_linear_units() :
       #if defined(FILAMENT_CHANGE_Z_ADD) && FILAMENT_CHANGE_Z_ADD > 0
         FILAMENT_CHANGE_Z_ADD
       #else
@@ -7614,12 +7487,12 @@ inline void gcode_M121() { endstops.enable_globally(false); }
     }
 
     // Move XY axes to filament change position or given position
-    destination[X_AXIS] = code_seen('X') ? code_value_linear_units() : 0
+    destination[X_AXIS] = parser.seen('X') ? parser.value_linear_units() : 0
       #ifdef FILAMENT_CHANGE_X_POS
         + FILAMENT_CHANGE_X_POS
       #endif
     ;
-    destination[Y_AXIS] = code_seen('Y') ? code_value_linear_units() : 0
+    destination[Y_AXIS] = parser.seen('Y') ? parser.value_linear_units() : 0
       #ifdef FILAMENT_CHANGE_Y_POS
         + FILAMENT_CHANGE_Y_POS
       #endif
@@ -7627,8 +7500,8 @@ inline void gcode_M121() { endstops.enable_globally(false); }
 
     #if HOTENDS > 1 && DISABLED(DUAL_X_CARRIAGE)
       if (active_extruder > 0) {
-        if (!code_seen('X')) destination[X_AXIS] += hotend_offset[X_AXIS][active_extruder];
-        if (!code_seen('Y')) destination[Y_AXIS] += hotend_offset[Y_AXIS][active_extruder];
+        if (!parser.seen('X')) destination[X_AXIS] += hotend_offset[X_AXIS][active_extruder];
+        if (!parser.seen('Y')) destination[Y_AXIS] += hotend_offset[Y_AXIS][active_extruder];
       }
     #endif
 
@@ -7672,11 +7545,11 @@ inline void gcode_M121() { endstops.enable_globally(false); }
    */
   inline void gcode_M150() {
     set_led_color(
-      code_seen('R') ? (code_has_value() ? code_value_byte() : 255) : 0,
-      code_seen('U') ? (code_has_value() ? code_value_byte() : 255) : 0,
-      code_seen('B') ? (code_has_value() ? code_value_byte() : 255) : 0
+      parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+      parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+      parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0
       #if ENABLED(RGBW_LED)
-        , code_seen('W') ? (code_has_value() ? code_value_byte() : 255) : 0
+        , parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0
       #endif
     );
   }
@@ -7693,13 +7566,13 @@ inline void gcode_M200() {
 
   if (get_target_extruder_from_command(200)) return;
 
-  if (code_seen('D')) {
+  if (parser.seen('D')) {
     // setting any extruder filament size disables volumetric on the assumption that
     // slicers either generate in extruder values as cubic mm or as as filament feeds
     // for all extruders
-    volumetric_enabled = (code_value_linear_units() != 0.0);
+    volumetric_enabled = (parser.value_linear_units() != 0.0);
     if (volumetric_enabled) {
-      filament_size[target_extruder] = code_value_linear_units();
+      filament_size[target_extruder] = parser.value_linear_units();
       // make sure all extruders have some sane value for the filament size
       for (uint8_t i = 0; i < COUNT(filament_size); i++)
         if (! filament_size[i]) filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
@@ -7718,9 +7591,9 @@ inline void gcode_M201() {
   GET_TARGET_EXTRUDER(201);
 
   LOOP_XYZE(i) {
-    if (code_seen(axis_codes[i])) {
+    if (parser.seen(axis_codes[i])) {
       const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
-      planner.max_acceleration_mm_per_s2[a] = code_value_axis_units((AxisEnum)a);
+      planner.max_acceleration_mm_per_s2[a] = parser.value_axis_units((AxisEnum)a);
     }
   }
   // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
@@ -7730,7 +7603,7 @@ inline void gcode_M201() {
 #if 0 // Not used for Sprinter/grbl gen6
   inline void gcode_M202() {
     LOOP_XYZE(i) {
-      if (code_seen(axis_codes[i])) axis_travel_steps_per_sqr_second[i] = code_value_axis_units((AxisEnum)i) * planner.axis_steps_per_mm[i];
+      if (parser.seen(axis_codes[i])) axis_travel_steps_per_sqr_second[i] = parser.value_axis_units((AxisEnum)i) * planner.axis_steps_per_mm[i];
     }
   }
 #endif
@@ -7746,9 +7619,9 @@ inline void gcode_M203() {
   GET_TARGET_EXTRUDER(203);
 
   LOOP_XYZE(i)
-    if (code_seen(axis_codes[i])) {
+    if (parser.seen(axis_codes[i])) {
       const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
-      planner.max_feedrate_mm_s[a] = code_value_axis_units((AxisEnum)a);
+      planner.max_feedrate_mm_s[a] = parser.value_axis_units((AxisEnum)a);
     }
 }
 
@@ -7762,20 +7635,20 @@ inline void gcode_M203() {
  *  Also sets minimum segment time in ms (B20000) to prevent buffer under-runs and M20 minimum feedrate
  */
 inline void gcode_M204() {
-  if (code_seen('S')) {  // Kept for legacy compatibility. Should NOT BE USED for new developments.
-    planner.travel_acceleration = planner.acceleration = code_value_linear_units();
+  if (parser.seen('S')) {  // Kept for legacy compatibility. Should NOT BE USED for new developments.
+    planner.travel_acceleration = planner.acceleration = parser.value_linear_units();
     SERIAL_ECHOLNPAIR("Setting Print and Travel Acceleration: ", planner.acceleration);
   }
-  if (code_seen('P')) {
-    planner.acceleration = code_value_linear_units();
+  if (parser.seen('P')) {
+    planner.acceleration = parser.value_linear_units();
     SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
   }
-  if (code_seen('R')) {
-    planner.retract_acceleration = code_value_linear_units();
+  if (parser.seen('R')) {
+    planner.retract_acceleration = parser.value_linear_units();
     SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
   }
-  if (code_seen('T')) {
-    planner.travel_acceleration = code_value_linear_units();
+  if (parser.seen('T')) {
+    planner.travel_acceleration = parser.value_linear_units();
     SERIAL_ECHOLNPAIR("Setting Travel Acceleration: ", planner.travel_acceleration);
   }
 }
@@ -7792,13 +7665,13 @@ inline void gcode_M204() {
  *    E = Max E Jerk (units/sec^2)
  */
 inline void gcode_M205() {
-  if (code_seen('S')) planner.min_feedrate_mm_s = code_value_linear_units();
-  if (code_seen('T')) planner.min_travel_feedrate_mm_s = code_value_linear_units();
-  if (code_seen('B')) planner.min_segment_time = code_value_millis();
-  if (code_seen('X')) planner.max_jerk[X_AXIS] = code_value_linear_units();
-  if (code_seen('Y')) planner.max_jerk[Y_AXIS] = code_value_linear_units();
-  if (code_seen('Z')) planner.max_jerk[Z_AXIS] = code_value_linear_units();
-  if (code_seen('E')) planner.max_jerk[E_AXIS] = code_value_linear_units();
+  if (parser.seen('S')) planner.min_feedrate_mm_s = parser.value_linear_units();
+  if (parser.seen('T')) planner.min_travel_feedrate_mm_s = parser.value_linear_units();
+  if (parser.seen('B')) planner.min_segment_time = parser.value_millis();
+  if (parser.seen('X')) planner.max_jerk[X_AXIS] = parser.value_linear_units();
+  if (parser.seen('Y')) planner.max_jerk[Y_AXIS] = parser.value_linear_units();
+  if (parser.seen('Z')) planner.max_jerk[Z_AXIS] = parser.value_linear_units();
+  if (parser.seen('E')) planner.max_jerk[E_AXIS] = parser.value_linear_units();
 }
 
 #if HAS_M206_COMMAND
@@ -7808,12 +7681,12 @@ inline void gcode_M205() {
    */
   inline void gcode_M206() {
     LOOP_XYZ(i)
-      if (code_seen(axis_codes[i]))
-        set_home_offset((AxisEnum)i, code_value_linear_units());
+      if (parser.seen(axis_codes[i]))
+        set_home_offset((AxisEnum)i, parser.value_linear_units());
 
     #if ENABLED(MORGAN_SCARA)
-      if (code_seen('T')) set_home_offset(A_AXIS, code_value_linear_units()); // Theta
-      if (code_seen('P')) set_home_offset(B_AXIS, code_value_linear_units()); // Psi
+      if (parser.seen('T')) set_home_offset(A_AXIS, parser.value_linear_units()); // Theta
+      if (parser.seen('P')) set_home_offset(B_AXIS, parser.value_linear_units()); // Psi
     #endif
 
     SYNC_PLAN_POSITION_KINEMATIC();
@@ -7836,20 +7709,20 @@ inline void gcode_M205() {
    *    Z = Rotate A and B by this angle
    */
   inline void gcode_M665() {
-    if (code_seen('H')) {
-      home_offset[Z_AXIS] = code_value_linear_units() - DELTA_HEIGHT;
-      current_position[Z_AXIS] += code_value_linear_units() - DELTA_HEIGHT - home_offset[Z_AXIS];
+    if (parser.seen('H')) {
+      home_offset[Z_AXIS] = parser.value_linear_units() - DELTA_HEIGHT;
+      current_position[Z_AXIS] += parser.value_linear_units() - DELTA_HEIGHT - home_offset[Z_AXIS];
       update_software_endstops(Z_AXIS);
     }
-    if (code_seen('L')) delta_diagonal_rod = code_value_linear_units();
-    if (code_seen('R')) delta_radius = code_value_linear_units();
-    if (code_seen('S')) delta_segments_per_second = code_value_float();
-    if (code_seen('B')) delta_calibration_radius = code_value_float();
-    if (code_seen('X')) delta_tower_angle_trim[A_AXIS] = code_value_float();
-    if (code_seen('Y')) delta_tower_angle_trim[B_AXIS] = code_value_float();
-    if (code_seen('Z')) { // rotate all 3 axis for Z = 0
-      delta_tower_angle_trim[A_AXIS] -= code_value_float();
-      delta_tower_angle_trim[B_AXIS] -= code_value_float();
+    if (parser.seen('L')) delta_diagonal_rod = parser.value_linear_units();
+    if (parser.seen('R')) delta_radius = parser.value_linear_units();
+    if (parser.seen('S')) delta_segments_per_second = parser.value_float();
+    if (parser.seen('B')) delta_calibration_radius = parser.value_float();
+    if (parser.seen('X')) delta_tower_angle_trim[A_AXIS] = parser.value_float();
+    if (parser.seen('Y')) delta_tower_angle_trim[B_AXIS] = parser.value_float();
+    if (parser.seen('Z')) { // rotate all 3 axis for Z = 0
+      delta_tower_angle_trim[A_AXIS] -= parser.value_float();
+      delta_tower_angle_trim[B_AXIS] -= parser.value_float();
     }
     recalc_delta_settings(delta_radius, delta_diagonal_rod);
   }
@@ -7863,8 +7736,8 @@ inline void gcode_M205() {
       }
     #endif
     LOOP_XYZ(i) {
-      if (code_seen(axis_codes[i])) {
-        endstop_adj[i] = code_value_linear_units();
+      if (parser.seen(axis_codes[i])) {
+        endstop_adj[i] = parser.value_linear_units();
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOPAIR("endstop_adj[", axis_codes[i]);
@@ -7890,7 +7763,7 @@ inline void gcode_M205() {
    * M666: For Z Dual Endstop setup, set z axis offset to the z2 axis.
    */
   inline void gcode_M666() {
-    if (code_seen('Z')) z_endstop_adj = code_value_linear_units();
+    if (parser.seen('Z')) z_endstop_adj = parser.value_linear_units();
     SERIAL_ECHOLNPAIR("Z Endstop Adjustment set to (mm):", z_endstop_adj);
   }
 
@@ -7907,11 +7780,11 @@ inline void gcode_M205() {
    *   Z[units]     retract_zlift
    */
   inline void gcode_M207() {
-    if (code_seen('S')) retract_length = code_value_axis_units(E_AXIS);
-    if (code_seen('F')) retract_feedrate_mm_s = MMM_TO_MMS(code_value_axis_units(E_AXIS));
-    if (code_seen('Z')) retract_zlift = code_value_linear_units();
+    if (parser.seen('S')) retract_length = parser.value_axis_units(E_AXIS);
+    if (parser.seen('F')) retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
+    if (parser.seen('Z')) retract_zlift = parser.value_linear_units();
     #if EXTRUDERS > 1
-      if (code_seen('W')) retract_length_swap = code_value_axis_units(E_AXIS);
+      if (parser.seen('W')) retract_length_swap = parser.value_axis_units(E_AXIS);
     #endif
   }
 
@@ -7923,10 +7796,10 @@ inline void gcode_M205() {
    *   F[units/min] retract_recover_feedrate_mm_s
    */
   inline void gcode_M208() {
-    if (code_seen('S')) retract_recover_length = code_value_axis_units(E_AXIS);
-    if (code_seen('F')) retract_recover_feedrate_mm_s = MMM_TO_MMS(code_value_axis_units(E_AXIS));
+    if (parser.seen('S')) retract_recover_length = parser.value_axis_units(E_AXIS);
+    if (parser.seen('F')) retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
     #if EXTRUDERS > 1
-      if (code_seen('W')) retract_recover_length_swap = code_value_axis_units(E_AXIS);
+      if (parser.seen('W')) retract_recover_length_swap = parser.value_axis_units(E_AXIS);
     #endif
   }
 
@@ -7936,8 +7809,8 @@ inline void gcode_M205() {
    *   moves will be classified as retraction.
    */
   inline void gcode_M209() {
-    if (code_seen('S')) {
-      autoretract_enabled = code_value_bool();
+    if (parser.seen('S')) {
+      autoretract_enabled = parser.value_bool();
       for (int i = 0; i < EXTRUDERS; i++) retracted[i] = false;
     }
   }
@@ -7952,7 +7825,7 @@ inline void gcode_M205() {
 inline void gcode_M211() {
   SERIAL_ECHO_START;
   #if HAS_SOFTWARE_ENDSTOPS
-    if (code_seen('S')) soft_endstops_enabled = code_value_bool();
+    if (parser.seen('S')) soft_endstops_enabled = parser.value_bool();
     SERIAL_ECHOPGM(MSG_SOFT_ENDSTOPS);
     serialprintPGM(soft_endstops_enabled ? PSTR(MSG_ON) : PSTR(MSG_OFF));
   #else
@@ -7982,11 +7855,11 @@ inline void gcode_M211() {
   inline void gcode_M218() {
     if (get_target_extruder_from_command(218) || target_extruder == 0) return;
 
-    if (code_seen('X')) hotend_offset[X_AXIS][target_extruder] = code_value_linear_units();
-    if (code_seen('Y')) hotend_offset[Y_AXIS][target_extruder] = code_value_linear_units();
+    if (parser.seen('X')) hotend_offset[X_AXIS][target_extruder] = parser.value_linear_units();
+    if (parser.seen('Y')) hotend_offset[Y_AXIS][target_extruder] = parser.value_linear_units();
 
     #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_NOZZLE)
-      if (code_seen('Z')) hotend_offset[Z_AXIS][target_extruder] = code_value_linear_units();
+      if (parser.seen('Z')) hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
     #endif
 
     SERIAL_ECHO_START;
@@ -8010,7 +7883,7 @@ inline void gcode_M211() {
  * M220: Set speed percentage factor, aka "Feed Rate" (M220 S95)
  */
 inline void gcode_M220() {
-  if (code_seen('S')) feedrate_percentage = code_value_int();
+  if (parser.seen('S')) feedrate_percentage = parser.value_int();
 }
 
 /**
@@ -8018,17 +7891,17 @@ inline void gcode_M220() {
  */
 inline void gcode_M221() {
   if (get_target_extruder_from_command(221)) return;
-  if (code_seen('S'))
-    flow_percentage[target_extruder] = code_value_int();
+  if (parser.seen('S'))
+    flow_percentage[target_extruder] = parser.value_int();
 }
 
 /**
  * M226: Wait until the specified pin reaches the state required (M226 P<pin> S<state>)
  */
 inline void gcode_M226() {
-  if (code_seen('P')) {
-    int pin_number = code_value_int(),
-        pin_state = code_seen('S') ? code_value_int() : -1; // required pin state - default is inverted
+  if (parser.seen('P')) {
+    int pin_number = parser.value_int(),
+        pin_state = parser.seen('S') ? parser.value_int() : -1; // required pin state - default is inverted
 
     if (pin_state >= -1 && pin_state <= 1 && pin_number > -1 && !pin_is_protected(pin_number)) {
 
@@ -8052,7 +7925,7 @@ inline void gcode_M226() {
       while (digitalRead(pin_number) != target) idle();
 
     } // pin_state -1 0 1 && pin_number > -1
-  } // code_seen('P')
+  } // parser.seen('P')
 }
 
 #if ENABLED(EXPERIMENTAL_I2CBUS)
@@ -8075,16 +7948,16 @@ inline void gcode_M226() {
    */
   inline void gcode_M260() {
     // Set the target address
-    if (code_seen('A')) i2c.address(code_value_byte());
+    if (parser.seen('A')) i2c.address(parser.value_byte());
 
     // Add a new byte to the buffer
-    if (code_seen('B')) i2c.addbyte(code_value_byte());
+    if (parser.seen('B')) i2c.addbyte(parser.value_byte());
 
     // Flush the buffer to the bus
-    if (code_seen('S')) i2c.send();
+    if (parser.seen('S')) i2c.send();
 
     // Reset and rewind the buffer
-    else if (code_seen('R')) i2c.reset();
+    else if (parser.seen('R')) i2c.reset();
   }
 
   /**
@@ -8093,9 +7966,9 @@ inline void gcode_M226() {
    * Usage: M261 A<slave device address base 10> B<number of bytes>
    */
   inline void gcode_M261() {
-    if (code_seen('A')) i2c.address(code_value_byte());
+    if (parser.seen('A')) i2c.address(parser.value_byte());
 
-    uint8_t bytes = code_seen('B') ? code_value_byte() : 1;
+    uint8_t bytes = parser.seen('B') ? parser.value_byte() : 1;
 
     if (i2c.addr && bytes && bytes <= TWIBUS_BUFFER_SIZE) {
       i2c.relay(bytes);
@@ -8114,11 +7987,11 @@ inline void gcode_M226() {
    * M280: Get or set servo position. P<index> [S<angle>]
    */
   inline void gcode_M280() {
-    if (!code_seen('P')) return;
-    int servo_index = code_value_int();
+    if (!parser.seen('P')) return;
+    int servo_index = parser.value_int();
     if (WITHIN(servo_index, 0, NUM_SERVOS - 1)) {
-      if (code_seen('S'))
-        MOVE_SERVO(servo_index, code_value_int());
+      if (parser.seen('S'))
+        MOVE_SERVO(servo_index, parser.value_int());
       else {
         SERIAL_ECHO_START;
         SERIAL_ECHOPAIR(" Servo ", servo_index);
@@ -8140,8 +8013,8 @@ inline void gcode_M226() {
    * M300: Play beep sound S<frequency Hz> P<duration ms>
    */
   inline void gcode_M300() {
-    uint16_t const frequency = code_seen('S') ? code_value_ushort() : 260;
-    uint16_t duration = code_seen('P') ? code_value_ushort() : 1000;
+    uint16_t const frequency = parser.seen('S') ? parser.value_ushort() : 260;
+    uint16_t duration = parser.seen('P') ? parser.value_ushort() : 1000;
 
     // Limits the tone duration to 0-5 seconds.
     NOMORE(duration, 5000);
@@ -8169,15 +8042,15 @@ inline void gcode_M226() {
 
     // multi-extruder PID patch: M301 updates or prints a single extruder's PID values
     // default behaviour (omitting E parameter) is to update for extruder 0 only
-    int e = code_seen('E') ? code_value_int() : 0; // extruder being updated
+    int e = parser.seen('E') ? parser.value_int() : 0; // extruder being updated
 
     if (e < HOTENDS) { // catch bad input value
-      if (code_seen('P')) PID_PARAM(Kp, e) = code_value_float();
-      if (code_seen('I')) PID_PARAM(Ki, e) = scalePID_i(code_value_float());
-      if (code_seen('D')) PID_PARAM(Kd, e) = scalePID_d(code_value_float());
+      if (parser.seen('P')) PID_PARAM(Kp, e) = parser.value_float();
+      if (parser.seen('I')) PID_PARAM(Ki, e) = scalePID_i(parser.value_float());
+      if (parser.seen('D')) PID_PARAM(Kd, e) = scalePID_d(parser.value_float());
       #if ENABLED(PID_EXTRUSION_SCALING)
-        if (code_seen('C')) PID_PARAM(Kc, e) = code_value_float();
-        if (code_seen('L')) lpq_len = code_value_float();
+        if (parser.seen('C')) PID_PARAM(Kc, e) = parser.value_float();
+        if (parser.seen('L')) lpq_len = parser.value_float();
         NOMORE(lpq_len, LPQ_MAX_LEN);
       #endif
 
@@ -8206,9 +8079,9 @@ inline void gcode_M226() {
 #if ENABLED(PIDTEMPBED)
 
   inline void gcode_M304() {
-    if (code_seen('P')) thermalManager.bedKp = code_value_float();
-    if (code_seen('I')) thermalManager.bedKi = scalePID_i(code_value_float());
-    if (code_seen('D')) thermalManager.bedKd = scalePID_d(code_value_float());
+    if (parser.seen('P')) thermalManager.bedKp = parser.value_float();
+    if (parser.seen('I')) thermalManager.bedKi = scalePID_i(parser.value_float());
+    if (parser.seen('D')) thermalManager.bedKd = scalePID_d(parser.value_float());
 
     thermalManager.updatePID();
 
@@ -8262,7 +8135,7 @@ inline void gcode_M226() {
    * M250: Read and optionally set the LCD contrast
    */
   inline void gcode_M250() {
-    if (code_seen('C')) set_lcd_contrast(code_value_int());
+    if (parser.seen('C')) set_lcd_contrast(parser.value_int());
     SERIAL_PROTOCOLPGM("lcd contrast value: ");
     SERIAL_PROTOCOL(lcd_contrast);
     SERIAL_EOL;
@@ -8288,14 +8161,14 @@ inline void gcode_M226() {
    *       M302 S170 P1 ; set min extrude temp to 170 but leave disabled
    */
   inline void gcode_M302() {
-    bool seen_S = code_seen('S');
+    bool seen_S = parser.seen('S');
     if (seen_S) {
-      thermalManager.extrude_min_temp = code_value_temp_abs();
+      thermalManager.extrude_min_temp = parser.value_celsius();
       thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0);
     }
 
-    if (code_seen('P'))
-      thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0) || code_value_bool();
+    if (parser.seen('P'))
+      thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0) || parser.value_bool();
     else if (!seen_S) {
       // Report current state
       SERIAL_ECHO_START;
@@ -8317,11 +8190,11 @@ inline void gcode_M226() {
  */
 inline void gcode_M303() {
   #if HAS_PID_HEATING
-    const int e = code_seen('E') ? code_value_int() : 0,
-              c = code_seen('C') ? code_value_int() : 5;
-    const bool u = code_seen('U') && code_value_bool();
+    const int e = parser.seen('E') ? parser.value_int() : 0,
+              c = parser.seen('C') ? parser.value_int() : 5;
+    const bool u = parser.seen('U') && parser.value_bool();
 
-    int16_t temp = code_seen('S') ? code_value_temp_abs() : (e < 0 ? 70 : 150);
+    int16_t temp = parser.seen('S') ? parser.value_celsius() : (e < 0 ? 70 : 150);
 
     if (WITHIN(e, 0, HOTENDS - 1))
       target_extruder = e;
@@ -8482,8 +8355,8 @@ inline void gcode_M400() { stepper.synchronize(); }
    * M404: Display or set (in current units) the nominal filament width (3mm, 1.75mm ) W<3.0>
    */
   inline void gcode_M404() {
-    if (code_seen('W')) {
-      filament_width_nominal = code_value_linear_units();
+    if (parser.seen('W')) {
+      filament_width_nominal = parser.value_linear_units();
     }
     else {
       SERIAL_PROTOCOLPGM("Filament dia (nominal mm):");
@@ -8496,8 +8369,8 @@ inline void gcode_M400() { stepper.synchronize(); }
    */
   inline void gcode_M405() {
     // This is technically a linear measurement, but since it's quantized to centimeters and is a different unit than
-    // everything else, it uses code_value_int() instead of code_value_linear_units().
-    if (code_seen('D')) meas_delay_cm = code_value_int();
+    // everything else, it uses parser.value_int() instead of parser.value_linear_units().
+    if (parser.seen('D')) meas_delay_cm = parser.value_int();
     NOMORE(meas_delay_cm, MAX_MEASUREMENT_DELAY);
 
     if (filwidth_delay_index[1] == -1) { // Initialize the ring buffer if not done since startup
@@ -8555,8 +8428,8 @@ void quickstop_stepper() {
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       // L to load a mesh from the EEPROM
-      if (code_seen('L')) {
-        const int8_t storage_slot = code_has_value() ? code_value_int() : ubl.state.storage_slot;
+      if (parser.seen('L')) {
+        const int8_t storage_slot = parser.has_value() ? parser.value_int() : ubl.state.storage_slot;
         const int16_t a = settings.calc_num_meshes();
 
         if (!a) {
@@ -8576,7 +8449,7 @@ void quickstop_stepper() {
     #endif // AUTO_BED_LEVELING_UBL
 
     // V to print the matrix or mesh
-    if (code_seen('V')) {
+    if (parser.seen('V')) {
       #if ABL_PLANAR
         planner.bed_level_matrix.debug(PSTR("Bed Level Correction Matrix:"));
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
@@ -8596,7 +8469,7 @@ void quickstop_stepper() {
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       // L to load a mesh from the EEPROM
-      if (code_seen('L') || code_seen('V')) {
+      if (parser.seen('L') || parser.seen('V')) {
         ubl.display_map(0);  // Currently only supports one map type
         SERIAL_ECHOLNPAIR("UBL_MESH_VALID = ", UBL_MESH_VALID);
         SERIAL_ECHOLNPAIR("ubl.state.storage_slot = ", ubl.state.storage_slot);
@@ -8604,13 +8477,13 @@ void quickstop_stepper() {
     #endif
 
     bool to_enable = false;
-    if (code_seen('S')) {
-      to_enable = code_value_bool();
+    if (parser.seen('S')) {
+      to_enable = parser.value_bool();
       set_bed_leveling_enabled(to_enable);
     }
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      if (code_seen('Z')) set_z_fade_height(code_value_linear_units());
+      if (parser.seen('Z')) set_z_fade_height(parser.value_linear_units());
     #endif
 
     const bool new_status =
@@ -8645,11 +8518,11 @@ void quickstop_stepper() {
    *   M421 I<xindex> J<yindex> Q<offset>
    */
   inline void gcode_M421() {
-    const bool hasX = code_seen('X'), hasI = code_seen('I');
-    const int8_t ix = hasI ? code_value_int() : hasX ? mbl.probe_index_x(RAW_X_POSITION(code_value_linear_units())) : -1;
-    const bool hasY = code_seen('Y'), hasJ = code_seen('J');
-    const int8_t iy = hasJ ? code_value_int() : hasY ? mbl.probe_index_y(RAW_Y_POSITION(code_value_linear_units())) : -1;
-    const bool hasZ = code_seen('Z'), hasQ = !hasZ && code_seen('Q');
+    const bool hasX = parser.seen('X'), hasI = parser.seen('I');
+    const int8_t ix = hasI ? parser.value_int() : hasX ? mbl.probe_index_x(RAW_X_POSITION(parser.value_linear_units())) : -1;
+    const bool hasY = parser.seen('Y'), hasJ = parser.seen('J');
+    const int8_t iy = hasJ ? parser.value_int() : hasY ? mbl.probe_index_y(RAW_Y_POSITION(parser.value_linear_units())) : -1;
+    const bool hasZ = parser.seen('Z'), hasQ = !hasZ && parser.seen('Q');
 
     if (int(hasI && hasJ) + int(hasX && hasY) != 1 || !(hasZ || hasQ)) {
       SERIAL_ERROR_START;
@@ -8660,7 +8533,7 @@ void quickstop_stepper() {
       SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
     }
     else
-      mbl.set_z(ix, iy, code_value_linear_units() + (hasQ ? mbl.z_values[ix][iy] : 0));
+      mbl.set_z(ix, iy, parser.value_linear_units() + (hasQ ? mbl.z_values[ix][iy] : 0));
   }
 
 #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
@@ -8673,11 +8546,11 @@ void quickstop_stepper() {
    *   M421 I<xindex> J<yindex> Q<offset>
    */
   inline void gcode_M421() {
-    const bool hasI = code_seen('I');
-    const int8_t ix = hasI ? code_value_int() : -1;
-    const bool hasJ = code_seen('J');
-    const int8_t iy = hasJ ? code_value_int() : -1;
-    const bool hasZ = code_seen('Z'), hasQ = !hasZ && code_seen('Q');
+    const bool hasI = parser.seen('I');
+    const int8_t ix = hasI ? parser.value_int() : -1;
+    const bool hasJ = parser.seen('J');
+    const int8_t iy = hasJ ? parser.value_int() : -1;
+    const bool hasZ = parser.seen('Z'), hasQ = !hasZ && parser.seen('Q');
 
     if (!hasI || !hasJ || !(hasZ || hasQ)) {
       SERIAL_ERROR_START;
@@ -8688,7 +8561,7 @@ void quickstop_stepper() {
       SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
     }
     else {
-      z_values[ix][iy] = code_value_linear_units() + (hasQ ? z_values[ix][iy] : 0);
+      z_values[ix][iy] = parser.value_linear_units() + (hasQ ? z_values[ix][iy] : 0);
       #if ENABLED(ABL_BILINEAR_SUBDIVISION)
         bed_level_virt_interpolate();
       #endif
@@ -8707,12 +8580,11 @@ void quickstop_stepper() {
    *   M421 C Q<offset>
    */
   inline void gcode_M421() {
-    const bool hasC = code_seen('C');
-    const bool hasI = code_seen('I');
-    int8_t ix = hasI ? code_value_int() : -1;
-    const bool hasJ = code_seen('J');
-    int8_t iy = hasJ ? code_value_int() : -1;
-    const bool hasZ = code_seen('Z'), hasQ = !hasZ && code_seen('Q');
+    const bool hasC = parser.seen('C'), hasI = parser.seen('I');
+    int8_t ix = hasI ? parser.value_int() : -1;
+    const bool hasJ = parser.seen('J');
+    int8_t iy = hasJ ? parser.value_int() : -1;
+    const bool hasZ = parser.seen('Z'), hasQ = !hasZ && parser.seen('Q');
 
     if (hasC) {
       const mesh_index_pair location = ubl.find_closest_mesh_point_of_type(REAL, current_position[X_AXIS], current_position[Y_AXIS], USE_NOZZLE_AS_REFERENCE, NULL, false);
@@ -8729,7 +8601,7 @@ void quickstop_stepper() {
       SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
     }
     else
-      ubl.z_values[ix][iy] = code_value_linear_units() + (hasQ ? ubl.z_values[ix][iy] : 0);
+      ubl.z_values[ix][iy] = parser.value_linear_units() + (hasQ ? ubl.z_values[ix][iy] : 0);
   }
 
 #endif // AUTO_BED_LEVELING_UBL
@@ -8803,7 +8675,7 @@ inline void gcode_M502() {
  * M503: print settings currently in memory
  */
 inline void gcode_M503() {
-  (void)settings.report(code_seen('S') && !code_value_bool());
+  (void)settings.report(parser.seen('S') && !parser.value_bool());
 }
 
 #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
@@ -8812,7 +8684,7 @@ inline void gcode_M503() {
    * M540: Set whether SD card print should abort on endstop hit (M540 S<0|1>)
    */
   inline void gcode_M540() {
-    if (code_seen('S')) stepper.abort_on_endstop_hit = code_value_bool();
+    if (parser.seen('S')) stepper.abort_on_endstop_hit = parser.value_bool();
   }
 
 #endif // ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED
@@ -8858,8 +8730,8 @@ inline void gcode_M503() {
   inline void gcode_M851() {
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM(MSG_ZPROBE_ZOFFSET " ");
-    if (code_seen('Z')) {
-      const float value = code_value_linear_units();
+    if (parser.seen('Z')) {
+      const float value = parser.value_linear_units();
       if (WITHIN(value, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX)) {
         zprobe_zoffset = value;
         refresh_zprobe_zoffset();
@@ -8933,7 +8805,7 @@ inline void gcode_M503() {
     set_destination_to_current();
 
     // Initial retract before move to filament change position
-    destination[E_AXIS] += code_seen('E') ? code_value_axis_units(E_AXIS) : 0
+    destination[E_AXIS] += parser.seen('E') ? parser.value_axis_units(E_AXIS) : 0
       #if defined(FILAMENT_CHANGE_RETRACT_LENGTH) && FILAMENT_CHANGE_RETRACT_LENGTH > 0
         - (FILAMENT_CHANGE_RETRACT_LENGTH)
       #endif
@@ -8942,7 +8814,7 @@ inline void gcode_M503() {
     RUNPLAN(FILAMENT_CHANGE_RETRACT_FEEDRATE);
 
     // Lift Z axis
-    float z_lift = code_seen('Z') ? code_value_linear_units() :
+    float z_lift = parser.seen('Z') ? parser.value_linear_units() :
       #if defined(FILAMENT_CHANGE_Z_ADD) && FILAMENT_CHANGE_Z_ADD > 0
         FILAMENT_CHANGE_Z_ADD
       #else
@@ -8957,12 +8829,12 @@ inline void gcode_M503() {
     }
 
     // Move XY axes to filament exchange position
-    if (code_seen('X')) destination[X_AXIS] = code_value_linear_units();
+    if (parser.seen('X')) destination[X_AXIS] = parser.value_linear_units();
     #ifdef FILAMENT_CHANGE_X_POS
       else destination[X_AXIS] = FILAMENT_CHANGE_X_POS;
     #endif
 
-    if (code_seen('Y')) destination[Y_AXIS] = code_value_linear_units();
+    if (parser.seen('Y')) destination[Y_AXIS] = parser.value_linear_units();
     #ifdef FILAMENT_CHANGE_Y_POS
       else destination[Y_AXIS] = FILAMENT_CHANGE_Y_POS;
     #endif
@@ -8974,7 +8846,7 @@ inline void gcode_M503() {
     idle();
 
     // Unload filament
-    destination[E_AXIS] += code_seen('L') ? code_value_axis_units(E_AXIS) : 0
+    destination[E_AXIS] += parser.seen('L') ? parser.value_axis_units(E_AXIS) : 0
       #if FILAMENT_CHANGE_UNLOAD_LENGTH > 0
         - (FILAMENT_CHANGE_UNLOAD_LENGTH)
       #endif
@@ -9062,7 +8934,7 @@ inline void gcode_M503() {
     lcd_filament_change_show_message(FILAMENT_CHANGE_MESSAGE_LOAD);
 
     // Load filament
-    destination[E_AXIS] += code_seen('L') ? -code_value_axis_units(E_AXIS) : 0
+    destination[E_AXIS] += parser.seen('L') ? -parser.value_axis_units(E_AXIS) : 0
       #if FILAMENT_CHANGE_LOAD_LENGTH > 0
         + FILAMENT_CHANGE_LOAD_LENGTH
       #endif
@@ -9145,14 +9017,14 @@ inline void gcode_M503() {
    */
   inline void gcode_M605() {
     stepper.synchronize();
-    if (code_seen('S')) dual_x_carriage_mode = (DualXMode)code_value_byte();
+    if (parser.seen('S')) dual_x_carriage_mode = (DualXMode)parser.value_byte();
     switch (dual_x_carriage_mode) {
       case DXC_FULL_CONTROL_MODE:
       case DXC_AUTO_PARK_MODE:
         break;
       case DXC_DUPLICATION_MODE:
-        if (code_seen('X')) duplicate_extruder_x_offset = max(code_value_linear_units(), X2_MIN_POS - x_home_pos(0));
-        if (code_seen('R')) duplicate_extruder_temp_offset = code_value_temp_diff();
+        if (parser.seen('X')) duplicate_extruder_x_offset = max(parser.value_linear_units(), X2_MIN_POS - x_home_pos(0));
+        if (parser.seen('R')) duplicate_extruder_temp_offset = parser.value_celsius_diff();
         SERIAL_ECHO_START;
         SERIAL_ECHOPGM(MSG_HOTEND_OFFSET);
         SERIAL_CHAR(' ');
@@ -9177,7 +9049,7 @@ inline void gcode_M503() {
 
   inline void gcode_M605() {
     stepper.synchronize();
-    extruder_duplication_enabled = code_seen('S') && code_value_int() == (int)DXC_DUPLICATION_MODE;
+    extruder_duplication_enabled = parser.seen('S') && parser.value_int() == (int)DXC_DUPLICATION_MODE;
     SERIAL_ECHO_START;
     SERIAL_ECHOLNPAIR(MSG_DUPLICATION_MODE, extruder_duplication_enabled ? MSG_ON : MSG_OFF);
   }
@@ -9195,14 +9067,14 @@ inline void gcode_M503() {
   inline void gcode_M900() {
     stepper.synchronize();
 
-    const float newK = code_seen('K') ? code_value_float() : -1;
+    const float newK = parser.seen('K') ? parser.value_float() : -1;
     if (newK >= 0) planner.extruder_advance_k = newK;
 
-    float newR = code_seen('R') ? code_value_float() : -1;
+    float newR = parser.seen('R') ? parser.value_float() : -1;
     if (newR < 0) {
-      const float newD = code_seen('D') ? code_value_float() : -1,
-                  newW = code_seen('W') ? code_value_float() : -1,
-                  newH = code_seen('H') ? code_value_float() : -1;
+      const float newD = parser.seen('D') ? parser.value_float() : -1,
+                  newW = parser.seen('W') ? parser.value_float() : -1,
+                  newH = parser.seen('H') ? parser.value_float() : -1;
       if (newD >= 0 && newW >= 0 && newH >= 0)
         newR = newD ? (newW * newH) / (sq(newD * 0.5) * M_PI) : 0;
     }
@@ -9271,7 +9143,7 @@ inline void gcode_M503() {
   inline void gcode_M906() {
     uint16_t values[XYZE];
     LOOP_XYZE(i)
-      values[i] = code_seen(axis_codes[i]) ? code_value_int() : 0;
+      values[i] = parser.seen(axis_codes[i]) ? parser.value_int() : 0;
 
     #if ENABLED(X_IS_TMC2130)
       if (values[X_AXIS]) tmc2130_set_current(stepperX, 'X', values[X_AXIS]);
@@ -9291,7 +9163,7 @@ inline void gcode_M503() {
     #endif
 
     #if ENABLED(AUTOMATIC_CURRENT_CONTROL)
-      if (code_seen('S')) auto_current_control = code_value_bool();
+      if (parser.seen('S')) auto_current_control = parser.value_bool();
     #endif
   }
 
@@ -9300,7 +9172,7 @@ inline void gcode_M503() {
    * The flag is held by the library and persist until manually cleared by M912
    */
   inline void gcode_M911() {
-    const bool reportX = code_seen('X'), reportY = code_seen('Y'), reportZ = code_seen('Z'), reportE = code_seen('E'),
+    const bool reportX = parser.seen('X'), reportY = parser.seen('Y'), reportZ = parser.seen('Z'), reportE = parser.seen('E'),
              reportAll = (!reportX && !reportY && !reportZ && !reportE) || (reportX && reportY && reportZ && reportE);
     #if ENABLED(X_IS_TMC2130)
       if (reportX || reportAll) tmc2130_report_otpw(stepperX, 'X');
@@ -9320,7 +9192,7 @@ inline void gcode_M503() {
    * M912: Clear TMC2130 stepper driver overtemperature pre-warn flag held by the library
    */
   inline void gcode_M912() {
-    const bool clearX = code_seen('X'), clearY = code_seen('Y'), clearZ = code_seen('Z'), clearE = code_seen('E'),
+    const bool clearX = parser.seen('X'), clearY = parser.seen('Y'), clearZ = parser.seen('Z'), clearE = parser.seen('E'),
              clearAll = (!clearX && !clearY && !clearZ && !clearE) || (clearX && clearY && clearZ && clearE);
     #if ENABLED(X_IS_TMC2130)
       if (clearX || clearAll) tmc2130_clear_otpw(stepperX, 'X');
@@ -9343,7 +9215,7 @@ inline void gcode_M503() {
     inline void gcode_M913() {
       uint16_t values[XYZE];
       LOOP_XYZE(i)
-        values[i] = code_seen(axis_codes[i]) ? code_value_int() : 0;
+        values[i] = parser.seen(axis_codes[i]) ? parser.value_int() : 0;
 
       #if ENABLED(X_IS_TMC2130)
         if (values[X_AXIS]) tmc2130_set_pwmthrs(stepperX, 'X', values[X_AXIS], planner.axis_steps_per_mm[X_AXIS]);
@@ -9370,11 +9242,11 @@ inline void gcode_M503() {
   #if ENABLED(SENSORLESS_HOMING)
     inline void gcode_M914() {
       #if ENABLED(X_IS_TMC2130)
-        if (code_seen(axis_codes[X_AXIS])) tmc2130_set_sgt(stepperX, 'X', code_value_int());
+        if (parser.seen(axis_codes[X_AXIS])) tmc2130_set_sgt(stepperX, 'X', parser.value_int());
         else tmc2130_get_sgt(stepperX, 'X');
       #endif
       #if ENABLED(Y_IS_TMC2130)
-        if (code_seen(axis_codes[Y_AXIS])) tmc2130_set_sgt(stepperY, 'Y', code_value_int());
+        if (parser.seen(axis_codes[Y_AXIS])) tmc2130_set_sgt(stepperY, 'Y', parser.value_int());
         else tmc2130_get_sgt(stepperY, 'Y');
       #endif
     }
@@ -9387,32 +9259,32 @@ inline void gcode_M503() {
  */
 inline void gcode_M907() {
   #if HAS_DIGIPOTSS
-    LOOP_XYZE(i) if (code_seen(axis_codes[i])) stepper.digipot_current(i, code_value_int());
-    if (code_seen('B')) stepper.digipot_current(4, code_value_int());
-    if (code_seen('S')) for (uint8_t i = 0; i <= 4; i++) stepper.digipot_current(i, code_value_int());
+    LOOP_XYZE(i) if (parser.seen(axis_codes[i])) stepper.digipot_current(i, parser.value_int());
+    if (parser.seen('B')) stepper.digipot_current(4, parser.value_int());
+    if (parser.seen('S')) for (uint8_t i = 0; i <= 4; i++) stepper.digipot_current(i, parser.value_int());
   #elif HAS_MOTOR_CURRENT_PWM
     #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
-      if (code_seen('X')) stepper.digipot_current(0, code_value_int());
+      if (parser.seen('X')) stepper.digipot_current(0, parser.value_int());
     #endif
     #if PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
-      if (code_seen('Z')) stepper.digipot_current(1, code_value_int());
+      if (parser.seen('Z')) stepper.digipot_current(1, parser.value_int());
     #endif
     #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
-      if (code_seen('E')) stepper.digipot_current(2, code_value_int());
+      if (parser.seen('E')) stepper.digipot_current(2, parser.value_int());
     #endif
   #endif
   #if ENABLED(DIGIPOT_I2C)
     // this one uses actual amps in floating point
-    LOOP_XYZE(i) if (code_seen(axis_codes[i])) digipot_i2c_set_current(i, code_value_float());
+    LOOP_XYZE(i) if (parser.seen(axis_codes[i])) digipot_i2c_set_current(i, parser.value_float());
     // for each additional extruder (named B,C,D,E..., channels 4,5,6,7...)
-    for (uint8_t i = NUM_AXIS; i < DIGIPOT_I2C_NUM_CHANNELS; i++) if (code_seen('B' + i - (NUM_AXIS))) digipot_i2c_set_current(i, code_value_float());
+    for (uint8_t i = NUM_AXIS; i < DIGIPOT_I2C_NUM_CHANNELS; i++) if (parser.seen('B' + i - (NUM_AXIS))) digipot_i2c_set_current(i, parser.value_float());
   #endif
   #if ENABLED(DAC_STEPPER_CURRENT)
-    if (code_seen('S')) {
-      const float dac_percent = code_value_float();
+    if (parser.seen('S')) {
+      const float dac_percent = parser.value_float();
       for (uint8_t i = 0; i <= 4; i++) dac_current_percent(i, dac_percent);
     }
-    LOOP_XYZE(i) if (code_seen(axis_codes[i])) dac_current_percent(i, code_value_float());
+    LOOP_XYZE(i) if (parser.seen(axis_codes[i])) dac_current_percent(i, parser.value_float());
   #endif
 }
 
@@ -9424,14 +9296,14 @@ inline void gcode_M907() {
   inline void gcode_M908() {
     #if HAS_DIGIPOTSS
       stepper.digitalPotWrite(
-        code_seen('P') ? code_value_int() : 0,
-        code_seen('S') ? code_value_int() : 0
+        parser.seen('P') ? parser.value_int() : 0,
+        parser.seen('S') ? parser.value_int() : 0
       );
     #endif
     #ifdef DAC_STEPPER_CURRENT
       dac_current_raw(
-        code_seen('P') ? code_value_byte() : -1,
-        code_seen('S') ? code_value_ushort() : 0
+        parser.seen('P') ? parser.value_byte() : -1,
+        parser.seen('S') ? parser.value_ushort() : 0
       );
     #endif
   }
@@ -9450,9 +9322,9 @@ inline void gcode_M907() {
 
   // M350 Set microstepping mode. Warning: Steps per unit remains unchanged. S code sets stepping mode for all drivers.
   inline void gcode_M350() {
-    if (code_seen('S')) for (int i = 0; i <= 4; i++) stepper.microstep_mode(i, code_value_byte());
-    LOOP_XYZE(i) if (code_seen(axis_codes[i])) stepper.microstep_mode(i, code_value_byte());
-    if (code_seen('B')) stepper.microstep_mode(4, code_value_byte());
+    if (parser.seen('S')) for (int i = 0; i <= 4; i++) stepper.microstep_mode(i, parser.value_byte());
+    LOOP_XYZE(i) if (parser.seen(axis_codes[i])) stepper.microstep_mode(i, parser.value_byte());
+    if (parser.seen('B')) stepper.microstep_mode(4, parser.value_byte());
     stepper.microstep_readings();
   }
 
@@ -9461,14 +9333,14 @@ inline void gcode_M907() {
    *       S# determines MS1 or MS2, X# sets the pin high/low.
    */
   inline void gcode_M351() {
-    if (code_seen('S')) switch (code_value_byte()) {
+    if (parser.seen('S')) switch (parser.value_byte()) {
       case 1:
-        LOOP_XYZE(i) if (code_seen(axis_codes[i])) stepper.microstep_ms(i, code_value_byte(), -1);
-        if (code_seen('B')) stepper.microstep_ms(4, code_value_byte(), -1);
+        LOOP_XYZE(i) if (parser.seen(axis_codes[i])) stepper.microstep_ms(i, parser.value_byte(), -1);
+        if (parser.seen('B')) stepper.microstep_ms(4, parser.value_byte(), -1);
         break;
       case 2:
-        LOOP_XYZE(i) if (code_seen(axis_codes[i])) stepper.microstep_ms(i, -1, code_value_byte());
-        if (code_seen('B')) stepper.microstep_ms(4, -1, code_value_byte());
+        LOOP_XYZE(i) if (parser.seen(axis_codes[i])) stepper.microstep_ms(i, -1, parser.value_byte());
+        if (parser.seen('B')) stepper.microstep_ms(4, -1, parser.value_byte());
         break;
     }
     stepper.microstep_readings();
@@ -9495,8 +9367,8 @@ inline void gcode_M907() {
  */
 inline void gcode_M355() {
   #if HAS_CASE_LIGHT
-    if (code_seen('P')) case_light_brightness = code_value_byte();
-    if (code_seen('S')) case_light_on = code_value_bool();
+    if (parser.seen('P')) case_light_brightness = parser.value_byte();
+    if (parser.seen('S')) case_light_on = parser.value_bool();
     update_case_light();
     SERIAL_ECHO_START;
     SERIAL_ECHOPGM("Case lights ");
@@ -9518,9 +9390,9 @@ inline void gcode_M355() {
    *
    */
   inline void gcode_M163() {
-    const int mix_index = code_seen('S') ? code_value_int() : 0;
+    const int mix_index = parser.seen('S') ? parser.value_int() : 0;
     if (mix_index < MIXING_STEPPERS) {
-      float mix_value = code_seen('P') ? code_value_float() : 0.0;
+      float mix_value = parser.seen('P') ? parser.value_float() : 0.0;
       NOLESS(mix_value, 0.0);
       mixing_factor[mix_index] = RECIPROCAL(mix_value);
     }
@@ -9535,7 +9407,7 @@ inline void gcode_M355() {
      *
      */
     inline void gcode_M164() {
-      const int tool_index = code_seen('S') ? code_value_int() : 0;
+      const int tool_index = parser.seen('S') ? parser.value_int() : 0;
       if (tool_index < MIXING_VIRTUAL_TOOLS) {
         normalize_mix();
         for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
@@ -9578,7 +9450,7 @@ inline void gcode_M999() {
   Running = true;
   lcd_reset_alert_level();
 
-  if (code_seen('S') && code_value_bool()) return;
+  if (parser.seen('S') && parser.value_bool()) return;
 
   // gcode_LastN = Stopped_gcode_LastN;
   FlushSerialRequestResend();
@@ -9953,8 +9825,8 @@ inline void gcode_T(uint8_t tmp_extruder) {
 
     tool_change(
       tmp_extruder,
-      code_seen('F') ? MMM_TO_MMS(code_value_linear_units()) : 0.0,
-      (tmp_extruder == active_extruder) || (code_seen('S') && code_value_bool())
+      parser.seen('F') ? MMM_TO_MMS(parser.value_linear_units()) : 0.0,
+      (tmp_extruder == active_extruder) || (parser.seen('S') && parser.value_bool())
     );
 
   #endif
@@ -9972,7 +9844,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
  * This is called from the main loop()
  */
 void process_next_command() {
-  current_command = command_queue[cmd_queue_index_r];
+  char * const current_command = command_queue[cmd_queue_index_r];
 
   if (DEBUGGING(ECHO)) {
     SERIAL_ECHO_START;
@@ -9983,70 +9855,20 @@ void process_next_command() {
     #endif
   }
 
-  // Sanitize the current command:
-  //  - Skip leading spaces
-  //  - Bypass N[-0-9][0-9]*[ ]*
-  //  - Overwrite * with nul to mark the end
-  while (*current_command == ' ') ++current_command;
-  if (*current_command == 'N' && NUMERIC_SIGNED(current_command[1])) {
-    current_command += 2; // skip N[-0-9]
-    while (NUMERIC(*current_command)) ++current_command; // skip [0-9]*
-    while (*current_command == ' ') ++current_command; // skip [ ]*
-  }
-  char* starpos = strchr(current_command, '*');  // * should always be the last parameter
-  if (starpos) while (*starpos == ' ' || *starpos == '*') *starpos-- = '\0'; // nullify '*' and ' '
-
-  char *cmd_ptr = current_command;
-
-  // Get the command code, which must be G, M, or T
-  char command_code = *cmd_ptr++;
-
-  // Skip spaces to get the numeric part
-  while (*cmd_ptr == ' ') cmd_ptr++;
-
-  // Allow for decimal point in command
-  #if ENABLED(G38_PROBE_TARGET)
-    uint8_t subcode = 0;
-  #endif
-
-  uint16_t codenum = 0; // define ahead of goto
-
-  // Bail early if there's no code
-  bool code_is_good = NUMERIC(*cmd_ptr);
-  if (!code_is_good) goto ExitUnknownCommand;
-
-  // Get and skip the code number
-  do {
-    codenum = (codenum * 10) + (*cmd_ptr - '0');
-    cmd_ptr++;
-  } while (NUMERIC(*cmd_ptr));
-
-  // Allow for decimal point in command
-  #if ENABLED(G38_PROBE_TARGET)
-    if (*cmd_ptr == '.') {
-      cmd_ptr++;
-      while (NUMERIC(*cmd_ptr))
-        subcode = (subcode * 10) + (*cmd_ptr++ - '0');
-    }
-  #endif
-
-  // Skip all spaces to get to the first argument, or nul
-  while (*cmd_ptr == ' ') cmd_ptr++;
-
-  // The command's arguments (if any) start here, for sure!
-  current_command_args = cmd_ptr;
-
   KEEPALIVE_STATE(IN_HANDLER);
 
+  // Parse the next command in the queue
+  parser.parse(current_command);
+
   // Handle a known G, M, or T
-  switch (command_code) {
-    case 'G': switch (codenum) {
+  switch (parser.command_letter) {
+    case 'G': switch (parser.codenum) {
 
       // G0, G1
       case 0:
       case 1:
         #if IS_SCARA
-          gcode_G0_G1(codenum == 0);
+          gcode_G0_G1(parser.codenum == 0);
         #else
           gcode_G0_G1();
         #endif
@@ -10056,7 +9878,7 @@ void process_next_command() {
       #if ENABLED(ARC_SUPPORT) && DISABLED(SCARA)
         case 2: // G2  - CW ARC
         case 3: // G3  - CCW ARC
-          gcode_G2_G3(codenum == 2);
+          gcode_G2_G3(parser.codenum == 2);
           break;
       #endif
 
@@ -10075,7 +9897,7 @@ void process_next_command() {
       #if ENABLED(FWRETRACT)
         case 10: // G10: retract
         case 11: // G11: retract_recover
-          gcode_G10_G11(codenum == 10);
+          gcode_G10_G11(parser.codenum == 10);
           break;
       #endif // FWRETRACT
 
@@ -10170,10 +9992,15 @@ void process_next_command() {
           break;
       #endif
 
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        case 800:
+          parser.debug(); // GCode Parser Test for G
+          break;
+      #endif
     }
     break;
 
-    case 'M': switch (codenum) {
+    case 'M': switch (parser.codenum) {
       #if HAS_RESUME_CONTINUE
         case 0: // M0: Unconditional stop - Wait for user button press on LCD
         case 1: // M1: Conditional stop - Wait for user button press on LCD
@@ -10764,6 +10591,12 @@ void process_next_command() {
         gcode_M355();
         break;
 
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        case 800:
+          parser.debug(); // GCode Parser Test for M
+          break;
+      #endif
+
       case 999: // M999: Restart after being Stopped
         gcode_M999();
         break;
@@ -10771,18 +10604,13 @@ void process_next_command() {
     break;
 
     case 'T':
-      gcode_T(codenum);
+      gcode_T(parser.codenum);
       break;
 
-    default: code_is_good = false;
+    default: parser.unknown_command_error();
   }
 
   KEEPALIVE_STATE(NOT_BUSY);
-
-ExitUnknownCommand:
-
-  // Still unknown command? Throw an error
-  if (!code_is_good) unknown_command_error();
 
   ok_to_send();
 }
@@ -12163,7 +11991,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   if (max_inactive_time && ELAPSED(ms, previous_cmd_ms + max_inactive_time)) {
     SERIAL_ERROR_START;
-    SERIAL_ECHOLNPAIR(MSG_KILL_INACTIVE_TIME, current_command);
+    SERIAL_ECHOLNPAIR(MSG_KILL_INACTIVE_TIME, parser.command_ptr);
     kill(PSTR(MSG_KILLED));
   }
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
@@ -1230,4 +1230,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.5
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -1203,4 +1203,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -1232,4 +1232,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -1222,4 +1222,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1224,4 +1224,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1223,4 +1223,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -1221,4 +1221,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -1221,4 +1221,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -1226,4 +1226,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -1221,4 +1221,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
@@ -1226,4 +1226,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.5
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -1219,4 +1219,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -1222,4 +1222,9 @@
  */
 #define PROPORTIONAL_FONT_RATIO 1.0
 
+/**
+ * Spend 28 bytes of SRAM to optimize the GCode parser
+ */
+#define FASTER_GCODE_PARSER
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -1,0 +1,279 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * gcode.cpp - Parser for a GCode line, providing a parameter interface.
+ */
+
+#include "gcode.h"
+
+#include "Marlin.h"
+#include "language.h"
+
+// Must be declared for allocation and to satisfy the linker
+// Zero values need no initialization.
+
+#if ENABLED(INCH_MODE_SUPPORT)
+  float GCodeParser::linear_unit_factor, GCodeParser::volumetric_unit_factor;
+#endif
+
+#if ENABLED(TEMPERATURE_UNITS_SUPPORT)
+  TempUnit GCodeParser::input_temp_units;
+#endif
+
+char *GCodeParser::command_ptr,
+     *GCodeParser::string_arg,
+     *GCodeParser::value_ptr;
+char GCodeParser::command_letter;
+int GCodeParser::codenum;
+#if USE_GCODE_SUBCODES
+  int GCodeParser::subcode;
+#endif
+
+#if ENABLED(FASTER_GCODE_PARSER)
+  // Optimized Parameters
+  byte GCodeParser::codebits[4];   // found bits
+  uint8_t GCodeParser::param[26];  // parameter offsets from command_ptr
+#else
+  char *GCodeParser::command_args; // start of parameters
+#endif
+
+// Create a global instance of the GCode parser singleton
+GCodeParser parser;
+
+/**
+ * Clear all code-seen (and value pointers)
+ *
+ * Since each param is set/cleared on seen codes,
+ * this may be optimized by commenting out ZERO(param)
+ */
+void GCodeParser::reset() {
+  string_arg = NULL;                    // No whole line argument
+  command_letter = '?';                 // No command letter
+  codenum = 0;                          // No command code
+  #if USE_GCODE_SUBCODES
+    subcode = 0;                        // No command sub-code
+  #endif
+  #if ENABLED(FASTER_GCODE_PARSER)
+    ZERO(codebits);                     // No codes yet
+    //ZERO(param);                      // No parameters (should be safe to comment out this line)
+  #endif
+}
+
+// Populate all fields by parsing a single line of GCode
+// 58 bytes of SRAM are used to speed up seen/value
+void GCodeParser::parse(char *p) {
+
+  reset(); // No codes to report
+
+  // Skip spaces
+  while (*p == ' ') ++p;
+
+  // Skip N[-0-9] if included in the command line
+  if (*p == 'N' && NUMERIC_SIGNED(p[1])) {
+    #if ENABLED(FASTER_GCODE_PARSER)
+      //set('N', p + 1);     // (optional) Set the 'N' parameter value
+    #endif
+    p += 2;                  // skip N[-0-9]
+    while (NUMERIC(*p)) ++p; // skip [0-9]*
+    while (*p == ' ')   ++p; // skip [ ]*
+  }
+
+  // *p now points to the current command, which should be G, M, or T
+  command_ptr = p;
+
+  // Get the command letter, which must be G, M, or T
+  const char letter = *p++;
+
+  // Nullify asterisk and trailing whitespace
+  char *starpos = strchr(p, '*');
+  if (starpos) {
+    --starpos;                          // *
+    while (*starpos == ' ') --starpos;  // spaces...
+    starpos[1] = '\0';
+  }
+
+  // Bail if the letter is not G, M, or T
+  switch (letter) { case 'G': case 'M': case 'T': break; default: return; }
+
+  // Skip spaces to get the numeric part
+  while (*p == ' ') p++;
+
+  // Bail if there's no command code number
+  if (!NUMERIC(*p)) return;
+
+  // Save the command letter at this point
+  // A '?' signifies an unknown command
+  command_letter = letter;
+
+  // Get the code number - integer digits only
+  codenum = 0;
+  do {
+    codenum *= 10, codenum += *p++ - '0';
+  } while (NUMERIC(*p));
+
+  // Allow for decimal point in command
+  #if USE_GCODE_SUBCODES
+    if (*p == '.') {
+      p++;
+      while (NUMERIC(*p))
+        subcode *= 10, subcode += *p++ - '0';
+    }
+  #endif
+
+  // Skip all spaces to get to the first argument, or nul
+  while (*p == ' ') p++;
+
+  // The command parameters (if any) start here, for sure!
+
+  #if DISABLED(FASTER_GCODE_PARSER)
+    command_args = p; // Scan for parameters in seen()
+  #endif
+
+  // Only use string_arg for these M codes
+  if (letter == 'M') switch (codenum) { case 23: case 28: case 30: case 117: case 928: string_arg = p; return; default: break; }
+
+  #if ENABLED(DEBUG_GCODE_PARSER)
+    const bool debug = codenum == 800;
+  #endif
+
+  /**
+   * Find all parameters, set flags and pointers for fast parsing
+   *
+   * Most codes ignore 'string_arg', but those that want a string will get the right pointer.
+   * The following loop assigns the first "parameter" having no numeric value to 'string_arg'.
+   * This allows M0/M1 with expire time to work: "M0 S5 You Win!"
+   */
+  string_arg = NULL;
+  while (char code = *p++) {                    // Get the next parameter. A NUL ends the loop
+
+    // Special handling for M32 [P] !/path/to/file.g#
+    // The path must be the last parameter
+    if (code == '!' && letter == 'M' && codenum == 32) {
+      string_arg = p;                           // Name starts after '!'
+      char * const lb = strchr(p, '#');         // Already seen '#' as SD char (to pause buffering)
+      if (lb) *lb = '\0';                       // Safe to mark the end of the filename
+      return;
+    }
+
+    // Arguments MUST be uppercase for fast GCode parsing
+    #if ENABLED(FASTER_GCODE_PARSER)
+      #define PARAM_TEST WITHIN(code, 'A', 'Z')
+    #else
+      #define PARAM_TEST true
+    #endif
+
+    if (PARAM_TEST) {
+
+      const bool has_num = DECIMAL_SIGNED(*p);  // The parameter has a number [-+0-9.]
+
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        if (debug) {
+          SERIAL_ECHOPAIR("Got letter ", code); // DEBUG
+          SERIAL_ECHOPAIR(" at index ", (int)(p - command_ptr - 1)); // DEBUG
+          if (has_num) SERIAL_ECHOPGM(" (has_num)");
+        }
+      #endif
+
+      if (!has_num && !string_arg) {            // No value? First time, keep as string_arg
+        string_arg = p - 1;
+        #if ENABLED(DEBUG_GCODE_PARSER)
+          if (debug) SERIAL_ECHOPAIR(" string_arg: ", hex_address((void*)string_arg)); // DEBUG
+        #endif
+      }
+
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        if (debug) SERIAL_EOL;
+      #endif
+
+      #if ENABLED(FASTER_GCODE_PARSER)
+        set(code, has_num ? p : NULL            // Set parameter exists and pointer (NULL for no number)
+          #if ENABLED(DEBUG_GCODE_PARSER)
+            , debug
+          #endif
+        );
+      #endif
+    }
+    else if (!string_arg) {                     // Not A-Z? First time, keep as the string_arg
+      string_arg = p - 1;
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        if (debug) SERIAL_ECHOPAIR(" string_arg: ", hex_address((void*)string_arg)); // DEBUG
+      #endif
+    }
+
+    while (*p && *p != ' ') p++;                // Skip over the parameter
+    while (*p == ' ') p++;                      // Skip over all spaces
+  }
+}
+
+void GCodeParser::unknown_command_error() {
+  SERIAL_ECHO_START;
+  SERIAL_ECHOPAIR(MSG_UNKNOWN_COMMAND, command_ptr);
+  SERIAL_CHAR('"');
+  SERIAL_EOL;
+}
+
+#if ENABLED(DEBUG_GCODE_PARSER)
+
+  void GCodeParser::debug() {
+    SERIAL_ECHOPAIR("Command: ", command_ptr);
+    SERIAL_ECHOPAIR(" (", command_letter);
+    SERIAL_ECHO(codenum);
+    SERIAL_ECHOLNPGM(")");
+    #if ENABLED(FASTER_GCODE_PARSER)
+      SERIAL_ECHO(" args: \"");
+      for (char c = 'A'; c <= 'Z'; ++c)
+        if (seen(c)) { SERIAL_CHAR(c); SERIAL_CHAR(' '); }
+    #else
+      SERIAL_ECHOPAIR(" args: \"", command_args);
+    #endif
+    SERIAL_ECHOPGM("\"");
+    if (string_arg) {
+      SERIAL_ECHOPGM(" string: \"");
+      SERIAL_ECHO(string_arg);
+      SERIAL_CHAR('"');
+    }
+    SERIAL_ECHOPGM("\n\n");
+    for (char c = 'A'; c <= 'Z'; ++c) {
+      if (seen(c)) {
+        SERIAL_ECHOPAIR("Code '", c); SERIAL_ECHOPGM("':");
+        if (has_value()) {
+          SERIAL_ECHOPAIR("\n    float: ", value_float());
+          SERIAL_ECHOPAIR("\n     long: ", value_long());
+          SERIAL_ECHOPAIR("\n    ulong: ", value_ulong());
+          SERIAL_ECHOPAIR("\n   millis: ", value_millis());
+          SERIAL_ECHOPAIR("\n   sec-ms: ", value_millis_from_seconds());
+          SERIAL_ECHOPAIR("\n      int: ", value_int());
+          SERIAL_ECHOPAIR("\n   ushort: ", value_ushort());
+          SERIAL_ECHOPAIR("\n     byte: ", (int)value_byte());
+          SERIAL_ECHOPAIR("\n     bool: ", (int)value_bool());
+          SERIAL_ECHOPAIR("\n   linear: ", value_linear_units());
+          SERIAL_ECHOPAIR("\n  celsius: ", value_celsius());
+        }
+        else
+          SERIAL_ECHOPGM(" (no value)");
+        SERIAL_ECHOPGM("\n\n");
+      }
+    }
+  }
+
+#endif // DEBUG_GCODE_PARSER

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -1,0 +1,285 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * gcode.h - Parser for a GCode line, providing a parameter interface.
+ *           Codes like M149 control the way the GCode parser behaves,
+ *           so settings for these codes are located in this class.
+ */
+
+#ifndef GCODE_H
+#define GCODE_H
+
+#include "enum.h"
+#include "types.h"
+#include "MarlinConfig.h"
+
+//#define DEBUG_GCODE_PARSER
+
+#if ENABLED(DEBUG_GCODE_PARSER)
+  #include "hex_print_routines.h"
+  #include "serial.h"
+#endif
+
+#if ENABLED(INCH_MODE_SUPPORT)
+  extern bool volumetric_enabled;
+#endif
+
+/**
+ * GCode parser
+ *
+ *  - Parse a single gcode line for its letter, code, subcode, and parameters
+ *  - FASTER_GCODE_PARSER:
+ *    - Flags existing params (1 bit each)
+ *    - Stores value offsets (1 byte each)
+ *  - Provide accessors for parameters:
+ *    - Parameter exists
+ *    - Parameter has value
+ *    - Parameter value in different units and types
+ */
+class GCodeParser {
+
+private:
+  static char *value_ptr;           // Set by seen, used to fetch the value
+
+  #if ENABLED(FASTER_GCODE_PARSER)
+    static byte codebits[4];        // Parameters pre-scanned
+    static uint8_t param[26];       // For A-Z, offsets into command args
+  #else
+    static char *command_args;      // Args start here, for slow scan
+  #endif
+
+public:
+
+  // Global states for GCode-level units features
+
+  #if ENABLED(INCH_MODE_SUPPORT)
+    static float linear_unit_factor, volumetric_unit_factor;
+  #endif
+
+  #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
+    static TempUnit input_temp_units;
+  #endif
+
+  // Command line state
+  static char *command_ptr,               // The command, so it can be echoed
+              *string_arg;                // string of command line
+
+  static char command_letter;             // G, M, or T
+  static int codenum;                     // 123
+  #if USE_GCODE_SUBCODES
+    static int subcode;                   // .1
+  #endif
+
+  #if ENABLED(DEBUG_GCODE_PARSER)
+    void debug();
+  #endif
+
+  // Reset is done before parsing
+  static void reset();
+
+  #if ENABLED(FASTER_GCODE_PARSER)
+
+    // Set the flag and pointer for a parameter
+    static void set(const char c, char * const ptr
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        , const bool debug=false
+      #endif
+    ) {
+      const uint8_t ind = c - 'A';
+      if (ind >= COUNT(param)) return;           // Only A-Z
+      SBI(codebits[ind >> 3], ind & 0x7);        // parameter exists
+      param[ind] = ptr ? ptr - command_ptr : 0;  // parameter offset or 0
+      #if ENABLED(DEBUG_GCODE_PARSER)
+        if (debug) {
+          SERIAL_ECHOPAIR("Set bit ", (int)(ind & 0x7));
+          SERIAL_ECHOPAIR(" of index ", (int)(ind >> 3));
+          SERIAL_ECHOLNPAIR(" | param = ", hex_address((void*)param[ind]));
+        }
+      #endif
+    }
+
+    // Code seen bit was set. If not found, value_ptr is unchanged.
+    // This allows "if (seen('A')||seen('B'))" to use the last-found value.
+    static bool seen(const char c) {
+      const uint8_t ind = c - 'A';
+      if (ind >= COUNT(param)) return false; // Only A-Z
+      const bool b = TEST(codebits[ind >> 3], ind & 0x7);
+      if (b) value_ptr = command_ptr + param[ind];
+      return b;
+    }
+
+  #else
+
+    // Code is found in the string. If not found, value_ptr is unchanged.
+    // This allows "if (seen('A')||seen('B'))" to use the last-found value.
+    static bool seen(const char c) {
+      char *p = strchr(command_args, c);
+      const bool b = !!p;
+      if (b) value_ptr = DECIMAL_SIGNED(*p) ? p + 1 : NULL;
+      return b;
+    }
+
+  #endif // FASTER_GCODE_PARSER
+
+  // Populate all fields by parsing a single line of GCode
+  // This uses 54 bytes of SRAM to speed up seen/value
+  static void parse(char * p);
+
+  // Code value pointer was set
+  FORCE_INLINE static bool has_value() { return value_ptr != NULL; }
+
+  // Float removes 'E' to prevent scientific notation interpretation
+  inline static float value_float() {
+    if (value_ptr) {
+      char *e = value_ptr;
+      for (;;) {
+        const char c = *e;
+        if (c == '\0' || c == ' ') break;
+        if (c == 'E' || c == 'e') {
+          *e = '\0';
+          const float ret = strtod(value_ptr, NULL);
+          *e = c;
+          return ret;
+        }
+        ++e;
+      }
+      return strtod(value_ptr, NULL);
+    }
+    return 0.0;
+  }
+
+  // Code value as a long or ulong
+  inline          static long value_long()  { return value_ptr ? strtol(value_ptr, NULL, 10) : 0L; }
+  inline unsigned static long value_ulong() { return value_ptr ? strtoul(value_ptr, NULL, 10) : 0UL; }
+
+  // Code value for use as time
+  FORCE_INLINE static millis_t value_millis() { return value_ulong(); }
+  FORCE_INLINE static millis_t value_millis_from_seconds() { return value_float() * 1000UL; }
+
+  // Reduce to fewer bits
+  FORCE_INLINE static int value_int()    { return (int)value_long(); }
+  FORCE_INLINE uint16_t value_ushort()   { return (uint16_t)value_long(); }
+  inline static uint8_t value_byte()     { return (uint8_t)(constrain(value_long(), 0, 255)); }
+
+  // Bool is true with no value or non-zero
+  inline static bool value_bool()        { return !has_value() || value_byte(); }
+
+  // Units modes: Inches, Fahrenheit, Kelvin
+
+  #if ENABLED(INCH_MODE_SUPPORT)
+
+    inline static void set_input_linear_units(LinearUnit units) {
+      switch (units) {
+        case LINEARUNIT_INCH:
+          linear_unit_factor = 25.4;
+          break;
+        case LINEARUNIT_MM:
+        default:
+          linear_unit_factor = 1.0;
+          break;
+      }
+      volumetric_unit_factor = pow(linear_unit_factor, 3.0);
+    }
+
+    inline static float axis_unit_factor(const AxisEnum axis) {
+      return (axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor : linear_unit_factor);
+    }
+
+    inline static float value_linear_units()                     { return value_float() * linear_unit_factor; }
+    inline static float value_axis_units(const AxisEnum axis)    { return value_float() * axis_unit_factor(axis); }
+    inline static float value_per_axis_unit(const AxisEnum axis) { return value_float() / axis_unit_factor(axis); }
+
+  #else
+
+    FORCE_INLINE static float value_linear_units()                  {            return value_float(); }
+    FORCE_INLINE static float value_axis_units(const AxisEnum a)    { UNUSED(a); return value_float(); }
+    FORCE_INLINE static float value_per_axis_unit(const AxisEnum a) { UNUSED(a); return value_float(); }
+
+  #endif
+
+  #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
+
+    inline static void set_input_temp_units(TempUnit units) { input_temp_units = units; }
+
+    #if ENABLED(ULTIPANEL) && DISABLED(DISABLE_M503)
+
+      FORCE_INLINE static char temp_units_code() {
+        return input_temp_units == TEMPUNIT_K ? 'K' : input_temp_units == TEMPUNIT_F ? 'F' : 'C';
+      }
+      FORCE_INLINE static char* temp_units_name() {
+        return input_temp_units == TEMPUNIT_K ? PSTR("Kelvin") : input_temp_units == TEMPUNIT_F ? PSTR("Fahrenheit") : PSTR("Celsius")
+      }
+      inline static float to_temp_units(const float &f) {
+        switch (input_temp_units) {
+          case TEMPUNIT_F:
+            return f * 0.5555555556 + 32.0;
+          case TEMPUNIT_K:
+            return f + 273.15;
+          case TEMPUNIT_C:
+          default:
+            return f;
+        }
+      }
+
+    #endif // ULTIPANEL && !DISABLE_M503
+
+    inline static float value_celsius() {
+      const float f = value_float();
+      switch (input_temp_units) {
+        case TEMPUNIT_F:
+          return (f - 32.0) * 0.5555555556;
+        case TEMPUNIT_K:
+          return f - 273.15;
+        case TEMPUNIT_C:
+        default:
+          return f;
+      }
+    }
+
+    inline static float value_celsius_diff() {
+      switch (input_temp_units) {
+        case TEMPUNIT_F:
+          return value_float() * 0.5555555556;
+        case TEMPUNIT_C:
+        case TEMPUNIT_K:
+        default:
+          return value_float();
+      }
+    }
+
+  #else
+
+    FORCE_INLINE static float value_celsius()      { return value_float(); }
+    FORCE_INLINE static float value_celsius_diff() { return value_float(); }
+
+  #endif
+
+  FORCE_INLINE static float value_feedrate() { return value_linear_units(); }
+
+  void unknown_command_error();
+
+};
+
+extern GCodeParser parser;
+
+#endif // GCODE_H

--- a/Marlin/hex_print_routines.cpp
+++ b/Marlin/hex_print_routines.cpp
@@ -20,7 +20,9 @@
  *
  */
 #include "Marlin.h"
-#if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(M100_FREE_MEMORY_WATCHER)
+#include "gcode.h"
+
+#if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(M100_FREE_MEMORY_WATCHER) || ENABLED(DEBUG_GCODE_PARSER)
 
 #include "hex_print_routines.h"
 
@@ -50,4 +52,4 @@ void print_hex_byte(const uint8_t b)         { SERIAL_ECHO(hex_byte(b));    }
 void print_hex_word(const uint16_t w)        { SERIAL_ECHO(hex_word(w));    }
 void print_hex_address(const void * const w) { SERIAL_ECHO(hex_address(w)); }
 
-#endif // AUTO_BED_LEVELING_UBL || M100_FREE_MEMORY_WATCHER
+#endif // AUTO_BED_LEVELING_UBL || M100_FREE_MEMORY_WATCHER || DEBUG_GCODE_PARSER

--- a/Marlin/hex_print_routines.h
+++ b/Marlin/hex_print_routines.h
@@ -24,8 +24,9 @@
 #define HEX_PRINT_ROUTINES_H
 
 #include "MarlinConfig.h"
+#include "gcode.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(M100_FREE_MEMORY_WATCHER)
+#if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(M100_FREE_MEMORY_WATCHER) || ENABLED(DEBUG_GCODE_PARSER)
 
 //
 // Utility functions to create and print hex strings as nybble, byte, and word.
@@ -43,5 +44,5 @@ void print_hex_byte(const uint8_t b);
 void print_hex_word(const uint16_t w);
 void print_hex_address(const void * const w);
 
-#endif // AUTO_BED_LEVELING_UBL || M100_FREE_MEMORY_WATCHER
+#endif // AUTO_BED_LEVELING_UBL || M100_FREE_MEMORY_WATCHER || DEBUG_GCODE_PARSER
 #endif // HEX_PRINT_ROUTINES_H

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -124,7 +124,9 @@
 
 #define WITHIN(V,L,H) ((V) >= (L) && (V) <= (H))
 #define NUMERIC(a) WITHIN(a, '0', '9')
-#define NUMERIC_SIGNED(a) (NUMERIC(a) || (a) == '-')
+#define DECIMAL(a) (NUMERIC(a) || a == '.')
+#define NUMERIC_SIGNED(a) (NUMERIC(a) || (a) == '-' || (a) == '+')
+#define DECIMAL_SIGNED(a) (DECIMAL(a) || (a) == '-' || (a) == '+')
 #define COUNT(a) (sizeof(a)/sizeof(*a))
 #define ZERO(a) memset(a,0,sizeof(a))
 #define COPY(a,b) memcpy(a,b,min(sizeof(a),sizeof(b)))

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -64,6 +64,7 @@
 #include "ultralcd.h"
 #include "language.h"
 #include "ubl.h"
+#include "gcode.h"
 
 #include "Marlin.h"
 
@@ -1549,10 +1550,10 @@ void Planner::refresh_positioning() {
 #if ENABLED(AUTOTEMP)
 
   void Planner::autotemp_M104_M109() {
-    autotemp_enabled = code_seen('F');
-    if (autotemp_enabled) autotemp_factor = code_value_temp_diff();
-    if (code_seen('S')) autotemp_min = code_value_temp_abs();
-    if (code_seen('B')) autotemp_max = code_value_temp_abs();
+    autotemp_enabled = parser.seen('F');
+    if (autotemp_enabled) autotemp_factor = parser.value_celsius_diff();
+    if (parser.seen('S')) autotemp_min = parser.value_celsius();
+    if (parser.seen('B')) autotemp_max = parser.value_celsius();
   }
 
 #endif


### PR DESCRIPTION
Move the GCode line parser into a separate singleton class and optimize for speed.

- The speed-up option is called `FASTER_GCODE_PARSER`:
  - Pre-scan the GCode line up front and save parameter offsets (cost: 26 bytes SRAM).
  - Current methods still apply, but `parser.seen()` is faster with no use of `strchr`.
  - Fetching values still parses the numerical string in-place, so no faster.

Also:

- Speed up `value_float` by dropping `strchr` and scanning fewer characters.
- Replace '`N`' argument to `G26` with '`S`'.
- ~~Drop Activate/Deactivate arguments to `G29` (use `M420 S1`)~~
  - ~~Replace '`N`' argument to `G29` with '`A`'.~~
  - ~~Replace '`j`' argument to `G29` with '`D`'.~~
