### PR TITLE
Move BLTouch LCD menu from Main to Main/Control

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -815,10 +815,6 @@ void kill_screen(const char* lcd_msg) {
         MENU_ITEM(function, MSG_LIGHTS_ON, toggle_case_light);
     #endif
 
-    #if ENABLED(BLTOUCH)
-      MENU_ITEM(submenu, MSG_BLTOUCH, bltouch_menu);
-    #endif
-
     if (planner.movesplanned() || IS_SD_PRINTING) {
       MENU_ITEM(submenu, MSG_TUNE, lcd_tune_menu);
     }
@@ -2150,6 +2146,10 @@ void kill_screen(const char* lcd_msg) {
     #endif
     #if ENABLED(DAC_STEPPER_CURRENT)
       MENU_ITEM(submenu, MSG_DRIVE_STRENGTH, lcd_dac_menu);
+    #endif
+
+    #if ENABLED(BLTOUCH)
+      MENU_ITEM(submenu, MSG_BLTOUCH, bltouch_menu);
     #endif
 
     #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
Having the BLTouch menu at the top of the Main menu seems out of place for something that doesn't need to be accessed very often. This PR moves it down into the Control menu, which is where other menus of this type are located (stepper current, retract, etc).