### PR TITLE
Automatically define Z_MIN_PROBE_ENDSTOP_INVERTING for BLTouch

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -360,8 +360,12 @@
     #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
       #undef Z_MIN_ENDSTOP_INVERTING
       #define Z_MIN_ENDSTOP_INVERTING false
+      #undef Z_MIN_PROBE_ENDSTOP_INVERTING
+      #define Z_MIN_PROBE_ENDSTOP_INVERTING false
       #define TEST_BLTOUCH() _TEST_BLTOUCH(Z_MIN)
     #else
+      #undef Z_MIN_PROBE_ENDSTOP_INVERTING
+      #define Z_MIN_PROBE_ENDSTOP_INVERTING false
       #define TEST_BLTOUCH() _TEST_BLTOUCH(Z_MIN_PROBE)
     #endif
   #endif


### PR DESCRIPTION
On machines that typically invert all of their endstops, it can be confusing when trying add a BLTouch as the user is likely to receive a `Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN requires Z_MIN_ENDSTOP_INVERTING to match Z_MIN_PROBE_ENDSTOP_INVERTING.` error message when compiling.

In this scenario, the user will likely have defined `Z_MIN_PROBE_ENDSTOP_INVERTING` as `true` with the other `ENDSTOP_INVERTING` definitions in a blanket change. Since `Z_MIN_ENDSTOP_INVERTING` is being forced to `false` in **Conditionals_LCD.h**, it will now be different than `Z_MIN_PROBE_ENDSTOP_INVERTING`, resulting in the compilation error.

This PR attempts to resolve the issue by forcing `Z_MIN_PROBE_ENDSTOP_INVERTING` to `false` if `BLTOUCH` is enabled.