### PR TITLE
Fix FWRetract with positive z-moves during retracted state

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3071,8 +3071,8 @@ static void homeaxis(const AxisEnum axis) {
     }
     else {
 
-      // If the height hasn't been altered, undo the Z hop
-      if (retract_zlift > 0.01 && hop_height == current_position[Z_AXIS]) {
+      // If the height hasn't been lowered, undo the Z hop
+      if (retract_zlift > 0.01 && hop_height <= current_position[Z_AXIS]) {
         // Pretend current position is higher. Z will lower on the next move
         current_position[Z_AXIS] += retract_zlift;
         SYNC_PLAN_POSITION_KINEMATIC();


### PR DESCRIPTION
See #6652

The original code was added to disallow the "un-hop" of the FW unretract when the z-axis was lowered whilst in the retracted state. This avoids driving the nozzle into the bed. However, the code also disallows the un-hop if the z-axis was raised whilst in the retracted state, (e.g. because of a layer change), which some slicers do all the time (cura) or when a setting akin to "retract between layer changes" is enabled.

This code-change allows performing the un-hop if the z-axis was raised or didn't change height whilst retracted and disallows it when the z-axis was lowered whilst retracted.