### PR TITLE
Fix M100 compiler warnings, general patches

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -357,15 +357,15 @@
     #define BLTOUCH_RESET    160
     #define _TEST_BLTOUCH(P) (READ(P##_PIN) != P##_ENDSTOP_INVERTING)
 
+    // Always disable probe pin inverting for BLTouch
+    #undef Z_MIN_PROBE_ENDSTOP_INVERTING
+    #define Z_MIN_PROBE_ENDSTOP_INVERTING false
+
     #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
       #undef Z_MIN_ENDSTOP_INVERTING
       #define Z_MIN_ENDSTOP_INVERTING false
-      #undef Z_MIN_PROBE_ENDSTOP_INVERTING
-      #define Z_MIN_PROBE_ENDSTOP_INVERTING false
       #define TEST_BLTOUCH() _TEST_BLTOUCH(Z_MIN)
     #else
-      #undef Z_MIN_PROBE_ENDSTOP_INVERTING
-      #define Z_MIN_PROBE_ENDSTOP_INVERTING false
       #define TEST_BLTOUCH() _TEST_BLTOUCH(Z_MIN_PROBE)
     #endif
   #endif

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -78,7 +78,7 @@ char* top_of_stack() {
 }
 
 // Count the number of test bytes at the specified location.
-int16_t count_test_bytes(const uint8_t * const ptr) {
+int16_t count_test_bytes(const char * const ptr) {
   for (uint16_t i = 0; i < 32000; i++)
     if (((char) ptr[i]) != TEST_BYTE)
       return i - 1;
@@ -100,13 +100,13 @@ int16_t count_test_bytes(const uint8_t * const ptr) {
    *  the block. If so, it may indicate memory corruption due to a bad pointer.
    *  Unexpected bytes are flagged in the right column.
    */
-  void dump_free_memory(const uint8_t *ptr, const uint8_t *sp) {
+  void dump_free_memory(const char *ptr, const char *sp) {
     //
     // Start and end the dump on a nice 16 byte boundary
     // (even though the values are not 16-byte aligned).
     //
-    ptr = (uint8_t *)((uint16_t)ptr & 0xFFF0); // Align to 16-byte boundary
-    sp  = (uint8_t *)((uint16_t)sp  | 0x000F); // Align sp to the 15th byte (at or above sp)
+    ptr = (char *)((uint16_t)ptr & 0xFFF0); // Align to 16-byte boundary
+    sp  = (char *)((uint16_t)sp  | 0x000F); // Align sp to the 15th byte (at or above sp)
 
     // Dump command main loop
     while (ptr < sp) {
@@ -121,7 +121,7 @@ int16_t count_test_bytes(const uint8_t * const ptr) {
       SERIAL_CHAR('|');                   // Point out non test bytes
       for (uint8_t i = 0; i < 16; i++) {
         char ccc = (char)ptr[i]; // cast to char before automatically casting to char on assignment, in case the compiler is broken
-        if (&ptr[i] >= command_queue && &ptr[i] < &command_queue[BUFSIZE][MAX_CMD_SIZE]) { // Print out ASCII in the command buffer area
+        if (&ptr[i] >= (const char*)command_queue && &ptr[i] < (const char*)(command_queue + sizeof(command_queue))) { // Print out ASCII in the command buffer area
           if (!WITHIN(ccc, ' ', 0x7E)) ccc = ' ';
         }
         else { // If not in the command buffer area, flag bytes that don't match the test byte
@@ -153,13 +153,13 @@ void M100_dump_routine(const char * const title, const char *start, const char *
  *  Return the number of free bytes in the memory pool,
  *  with other vital statistics defining the pool.
  */
-void free_memory_pool_report(const char * const ptr, const uint16_t size) {
+void free_memory_pool_report(char * const ptr, const uint16_t size) {
   int16_t max_cnt = -1;
   uint16_t block_cnt = 0;
   char *max_addr = NULL;
   // Find the longest block of test bytes in the buffer
   for (uint16_t i = 0; i < size; i++) {
-    char * const addr = ptr + i;
+    char *addr = ptr + i;
     if (*addr == TEST_BYTE) {
       const uint16_t j = count_test_bytes(addr);
       if (j > 8) {
@@ -209,7 +209,7 @@ void free_memory_pool_report(const char * const ptr, const uint16_t size) {
  * M100 I
  *  Init memory for the M100 tests. (Automatically applied on the first M100.)
  */
-void init_free_memory(uint8_t *ptr, int16_t size) {
+void init_free_memory(char *ptr, int16_t size) {
   SERIAL_ECHOLNPGM("Initializing free memory block.\n\n");
 
   size -= 250;    // -250 to avoid interrupt activity that's altered the stack.
@@ -292,7 +292,7 @@ int check_for_free_memory_corruption(const char * const title) {
     //   idle();
     safe_delay(20);
     #ifdef M100_FREE_MEMORY_DUMPER
-      M100_dump_routine("   Memory corruption detected with sp<Heap\n", (char*)0x1B80, 0x21FF);
+      M100_dump_routine("   Memory corruption detected with sp<Heap\n", (char*)0x1B80, (char*)0x21FF);
     #endif
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9731,7 +9731,7 @@ void process_next_command() {
     SERIAL_ECHOLN(current_command);
     #if ENABLED(M100_FREE_MEMORY_WATCHER)
       SERIAL_ECHOPAIR("slot:", cmd_queue_index_r);
-      M100_dump_routine("   Command Queue:", &command_queue[0][0], &command_queue[BUFSIZE][MAX_CMD_SIZE]);
+      M100_dump_routine("   Command Queue:", (const char*)command_queue, (const char*)(command_queue + sizeof(command_queue)));
     #endif
   }
 


### PR DESCRIPTION
- Fix warnings from `M100` about pointer types
- Move redundant code up a level in BLTOUCH conditionals