### PR TITLE
PIO Cleanup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ src_dir = Marlin
 envs_dir = .pioenvs
 lib_dir = .piolib
 libdeps_dir = .piolibdeps
-env_default = mega2560
+env_default = megaatmega2560
 
 [common]
 lib_deps = U8glib@1.19.1


### PR DESCRIPTION
platformio.ini `env_default=xxxxx` has to match one of the labels in the `[env:xxxxx]` blocks, otherwise nothing happens when you `pio run`, as there is no environment to compile for (unless you manually specify an environment using -e) ...