### PR TITLE
Add argument S to M80 to report the current state of the power supply

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7096,6 +7096,14 @@ inline void gcode_M140() {
    * M80: Turn on Power Supply
    */
   inline void gcode_M80() {
+    #if ENABLED(ULTIPANEL)
+      if (code_seen('S')){
+        // Report the current state of the power supply
+        if (powersupply) SERIAL_PROTOCOLLNPGM("PS:1");
+        else SERIAL_PROTOCOLLNPGM("PS:0");
+        return;
+      }
+    #endif
     OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE); //GND
 
     /**


### PR DESCRIPTION
I add a S argument to M80 to report the current state of the power supply.
"M80 S" only reports current state of the power supply without modify it (ie not power on if is off).