### PR TITLE
"M80 S" to report the state of the PSU pin

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -559,8 +559,8 @@ static uint8_t target_extruder;
 
 #endif // FWRETRACT
 
-#if ENABLED(ULTIPANEL) && HAS_POWER_SWITCH
-  bool powersupply =
+#if HAS_POWER_SWITCH
+  bool powersupply_on =
     #if ENABLED(PS_DEFAULT_OFF)
       false
     #else
@@ -7093,10 +7093,18 @@ inline void gcode_M140() {
 #if HAS_POWER_SWITCH
 
   /**
-   * M80: Turn on Power Supply
+   * M80   : Turn on the Power Supply
+   * M80 S : Report the current state and exit
    */
   inline void gcode_M80() {
-    OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE); //GND
+
+    // S: Report the current power supply state and exit
+    if (code_seen('S')) {
+      serialprintPGM(powersupply_on ? PSTR("PS:1\n") : PSTR("PS:0\n"));
+      return;
+    }
+
+    OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE); // GND
 
     /**
      * If you have a switch on suicide pin, this is useful
@@ -7112,8 +7120,9 @@ inline void gcode_M140() {
       tmc2130_init(); // Settings only stick when the driver has power
     #endif
 
+    powersupply_on = true;
+
     #if ENABLED(ULTIPANEL)
-      powersupply = true;
       LCD_MESSAGEPGM(WELCOME_MSG);
     #endif
   }
@@ -7128,25 +7137,26 @@ inline void gcode_M140() {
 inline void gcode_M81() {
   thermalManager.disable_all_heaters();
   stepper.finish_and_disable();
+
   #if FAN_COUNT > 0
     for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
-
     #if ENABLED(PROBING_FANS_OFF)
       fans_paused = false;
       ZERO(paused_fanSpeeds);
     #endif
   #endif
+
   safe_delay(1000); // Wait 1 second before switching off
+
   #if HAS_SUICIDE
     stepper.synchronize();
     suicide();
   #elif HAS_POWER_SWITCH
     OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+    powersupply_on = false;
   #endif
+
   #if ENABLED(ULTIPANEL)
-    #if HAS_POWER_SWITCH
-      powersupply = false;
-    #endif
     LCD_MESSAGEPGM(MACHINE_NAME " " MSG_OFF ".");
   #endif
 }
@@ -10119,7 +10129,7 @@ void process_next_command() {
         gcode_M81();
         break;
 
-      case 82: // M83: Set E axis normal mode (same as other axes)
+      case 82: // M82: Set E axis normal mode (same as other axes)
         gcode_M82();
         break;
       case 83: // M83: Set E axis relative mode

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -98,7 +98,7 @@ uint16_t max_display_update_time = 0;
   typedef void (*screenFunc_t)();
 
   #if HAS_POWER_SWITCH
-    extern bool powersupply;
+    extern bool powersupply_on;
   #endif
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -2129,7 +2129,7 @@ void kill_screen(const char* lcd_msg) {
     // Switch power on/off
     //
     #if HAS_POWER_SWITCH
-      if (powersupply)
+      if (powersupply_on)
         MENU_ITEM(gcode, MSG_SWITCH_PS_OFF, PSTR("M81"));
       else
         MENU_ITEM(gcode, MSG_SWITCH_PS_ON, PSTR("M80"));


### PR DESCRIPTION
Expand on #6671

Add an `S` parameter to `M80` which, when present, reports the current power-on state without affecting the current state.

- The `powersupply` flag was added to support state reporting, so we can remove the `ULTIPANEL` dependency, which only existed to prevent `powersupply` being defined when not in use.
----
- Rename `powersupply` => `powersupply_on`.
- Fix comment on `case 82:`