### PR TITLE
M421:  Add 'adjust closest point' capability

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -740,12 +740,14 @@
     }
 
     if (code_seen('R')) {
-      g26_repeats = code_has_value() ? code_value_int() - 1 : 999;
+      g26_repeats = code_has_value() ? code_value_int() : 999;
 
       if (g26_repeats <= 0) {
         SERIAL_PROTOCOLLNPGM("?(R)epeat value not plausible; must be greater than 0.");
         return UBL_ERR;
       }
+
+      g26_repeats--;
     }
 
 

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -35,6 +35,9 @@
   #define UBL_OK false
   #define UBL_ERR true
 
+  #define USE_NOZZLE_AS_REFERENCE 0
+  #define USE_PROBE_AS_REFERENCE 1
+
   typedef struct {
     int8_t x_index, y_index;
     float distance; // When populated, the distance from the search location

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -311,9 +311,6 @@
    *   we now have the functionality and features of all three systems combined.
    */
 
-  #define USE_NOZZLE_AS_REFERENCE 0
-  #define USE_PROBE_AS_REFERENCE 1
-
   // The simple parameter flags and values are 'static' so parameter parsing can be in a support routine.
   static int g29_verbose_level, phase_value, repetition_cnt,
              storage_slot = 0, map_type, grid_size;


### PR DESCRIPTION
- Split M421 into separate versions for bilinear and ubl
- Fix minor issue in G26

This enables changing one point - whichever is closest to the nozzle.  Between the G26 improvements yesterday and this today, my mesh creation workflow has improved immensely.  We can now move the nozzle to any particular point, adjust the mesh up or down by issuing `M421 C Q <amount>`, and then reprint that point only by issuing `G26 R1 <other codes>` ...

Here's my Octoprint 'controls' screen:
![screenshot 2017-05-11 12 59 02](https://cloud.githubusercontent.com/assets/8062568/25961843/b0438cf8-3649-11e7-8ff1-b1ed4181ab99.png)
