### PR TITLE
add SWITCHING_NOZZLE, exclude any XYZ-axis manipulations from SWITCHING_EXTRUDER

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -315,7 +315,7 @@
     #define E_STEPPERS   EXTRUDERS
     #define E_MANUAL     EXTRUDERS
     #define TOOL_E_INDEX current_block->active_extruder
-  #endif 
+  #endif
 
   /**
    * Distinct E Factors – Disable by commenting out DISTINCT_E_FACTORS

--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -291,20 +291,18 @@
    *  TOOL_E_INDEX - Index to use when getting/setting the tool state
    *
    */
-  #if ENABLED(SINGLENOZZLE) || ENABLED(MIXING_EXTRUDER)         // One hotend, one termistor, no XY offset
+  #if ENABLED(SINGLENOZZLE) || ENABLED(MIXING_EXTRUDER)         // One hotend, one thermistor, no XY offset
     #define HOTENDS      1
     #undef TEMP_SENSOR_1_AS_REDUNDANT
     #undef HOTEND_OFFSET_X
     #undef HOTEND_OFFSET_Y
   #else                                                         // Two hotends
-    #define HOTENDS      EXTRUDERS   
-    #if ENABLED(SWITCHING_NOZZLE)     
-      #ifndef HOTEND_OFFSET_Z
-        #define HOTEND_OFFSET_Z { 0 }
-      #endif  
-    #endif 
+    #define HOTENDS      EXTRUDERS
+    #if ENABLED(SWITCHING_NOZZLE) && !defined(HOTEND_OFFSET_Z)
+      #define HOTEND_OFFSET_Z { 0 }
+    #endif
   #endif
-   
+
   #if ENABLED(SWITCHING_EXTRUDER) || ENABLED(MIXING_EXTRUDER)   // unified E axis
     #if ENABLED(MIXING_EXTRUDER)
       #define E_STEPPERS   MIXING_STEPPERS
@@ -316,7 +314,7 @@
   #else
     #define E_STEPPERS   EXTRUDERS
     #define E_MANUAL     EXTRUDERS
-    #define TOOL_E_INDEX current_block->active_extruder    
+    #define TOOL_E_INDEX current_block->active_extruder
   #endif 
 
   /**

--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -291,33 +291,33 @@
    *  TOOL_E_INDEX - Index to use when getting/setting the tool state
    *
    */
-  #if ENABLED(SINGLENOZZLE)             // One hotend, multi-extruder
+  #if ENABLED(SINGLENOZZLE) || ENABLED(MIXING_EXTRUDER)         // One hotend, one termistor, no XY offset
     #define HOTENDS      1
-    #define E_STEPPERS   EXTRUDERS
-    #define E_MANUAL     EXTRUDERS
-    #define TOOL_E_INDEX current_block->active_extruder
     #undef TEMP_SENSOR_1_AS_REDUNDANT
     #undef HOTEND_OFFSET_X
     #undef HOTEND_OFFSET_Y
-  #elif ENABLED(SWITCHING_EXTRUDER)     // One E stepper, unified E axis, two hotends
-    #define HOTENDS      EXTRUDERS
-    #define E_STEPPERS   1
-    #define E_MANUAL     1
-    #define TOOL_E_INDEX 0
-    #ifndef HOTEND_OFFSET_Z
-      #define HOTEND_OFFSET_Z { 0 }
+  #else                                                         // Two hotends
+    #define HOTENDS      EXTRUDERS   
+    #if ENABLED(SWITCHING_NOZZLE)     
+      #ifndef HOTEND_OFFSET_Z
+        #define HOTEND_OFFSET_Z { 0 }
+      #endif  
+    #endif 
+  #endif
+   
+  #if ENABLED(SWITCHING_EXTRUDER) || ENABLED(MIXING_EXTRUDER)   // unified E axis
+    #if ENABLED(MIXING_EXTRUDER)
+      #define E_STEPPERS   MIXING_STEPPERS
+    #else
+      #define E_STEPPERS   1                                    // One E stepper
     #endif
-  #elif ENABLED(MIXING_EXTRUDER)        // Multi-stepper, unified E axis, one hotend
-    #define HOTENDS      1
-    #define E_STEPPERS   MIXING_STEPPERS
     #define E_MANUAL     1
     #define TOOL_E_INDEX 0
-  #else                                 // One stepper, E axis, and hotend per tool
-    #define HOTENDS      EXTRUDERS
+  #else
     #define E_STEPPERS   EXTRUDERS
     #define E_MANUAL     EXTRUDERS
-    #define TOOL_E_INDEX current_block->active_extruder
-  #endif
+    #define TOOL_E_INDEX current_block->active_extruder    
+  #endif 
 
   /**
    * Distinct E Factors – Disable by commenting out DISTINCT_E_FACTORS

--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -326,7 +326,7 @@
     #ifndef HOTEND_OFFSET_Y
       #define HOTEND_OFFSET_Y { 0 } // Y offsets for each extruder
     #endif
-    #if !defined(HOTEND_OFFSET_Z) && (ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_EXTRUDER))
+    #if !defined(HOTEND_OFFSET_Z) && (ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_NOZZLE))
       #define HOTEND_OFFSET_Z { 0 }
     #endif
   #endif

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -143,6 +143,7 @@
   #define SWITCHING_EXTRUDER_SERVO_NR 0
   #define SWITCHING_EXTRUDER_SERVO_ANGLES { 0, 90 } // Angles for E0, E1
   //#define HOTEND_OFFSET_Z {0.0, 0.0}
+  //#define SWITCHING_EXTRUDER_MULTI_STEPPERS             //Use for disable single stepper reverse
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -137,13 +137,20 @@
 //#define SINGLENOZZLE
 
 // A dual extruder that uses a single stepper motor
-// Don't forget to set SSDE_SERVO_ANGLES and HOTEND_OFFSET_X/Y/Z
+// Don't forget to set SSDE_SERVO_ANGLES 
 //#define SWITCHING_EXTRUDER
 #if ENABLED(SWITCHING_EXTRUDER)
   #define SWITCHING_EXTRUDER_SERVO_NR 0
   #define SWITCHING_EXTRUDER_SERVO_ANGLES { 0, 90 } // Angles for E0, E1
-  //#define HOTEND_OFFSET_Z {0.0, 0.0}
-  //#define SWITCHING_EXTRUDER_MULTI_STEPPERS             //Use for disable single stepper reverse
+#endif
+
+// A dual nozzle x-carriege that uses a servo motor for switching nozzles
+// Don't forget to set SSDE_SERVO_ANGLES and HOTEND_OFFSET_X/Y/Z
+#define SWITCHING_NOZZLE             
+#if ENABLED(SWITCHING_NOZZLE)
+  #define SWITCHING_NOZZLE_SERVO_NR 0
+  #define SWITCHING_NOZZLE_SERVO_ANGLES { 0, 90 } // Angles for E0, E1 
+  #define HOTEND_OFFSET_Z {0.0, 0.0}               
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -146,7 +146,7 @@
 
 // A dual nozzle x-carriege that uses a servo motor for switching nozzles
 // Don't forget to set SSDE_SERVO_ANGLES and HOTEND_OFFSET_X/Y/Z
-#define SWITCHING_NOZZLE             
+//#define SWITCHING_NOZZLE             
 #if ENABLED(SWITCHING_NOZZLE)
   #define SWITCHING_NOZZLE_SERVO_NR 0
   #define SWITCHING_NOZZLE_SERVO_ANGLES { 0, 90 } // Angles for E0, E1 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -150,7 +150,7 @@
 #if ENABLED(SWITCHING_NOZZLE)
   #define SWITCHING_NOZZLE_SERVO_NR 0
   #define SWITCHING_NOZZLE_SERVO_ANGLES { 0, 90 } // Angles for E0, E1
-  #define HOTEND_OFFSET_Z {0.0, 0.0}
+  //#define HOTEND_OFFSET_Z {0.0, 0.0}
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -137,7 +137,7 @@
 //#define SINGLENOZZLE
 
 // A dual extruder that uses a single stepper motor
-// Don't forget to set SSDE_SERVO_ANGLES 
+// Don't forget to set SSDE_SERVO_ANGLES
 //#define SWITCHING_EXTRUDER
 #if ENABLED(SWITCHING_EXTRUDER)
   #define SWITCHING_EXTRUDER_SERVO_NR 0
@@ -146,11 +146,11 @@
 
 // A dual nozzle x-carriage that uses a servomotor for switching nozzles
 // Don't forget to set SSDE_SERVO_ANGLES and HOTEND_OFFSET_X/Y/Z
-//#define SWITCHING_NOZZLE             
+//#define SWITCHING_NOZZLE
 #if ENABLED(SWITCHING_NOZZLE)
   #define SWITCHING_NOZZLE_SERVO_NR 0
-  #define SWITCHING_NOZZLE_SERVO_ANGLES { 0, 90 } // Angles for E0, E1 
-  #define HOTEND_OFFSET_Z {0.0, 0.0}               
+  #define SWITCHING_NOZZLE_SERVO_ANGLES { 0, 90 } // Angles for E0, E1
+  #define HOTEND_OFFSET_Z {0.0, 0.0}
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -144,7 +144,7 @@
   #define SWITCHING_EXTRUDER_SERVO_ANGLES { 0, 90 } // Angles for E0, E1
 #endif
 
-// A dual nozzle x-carriege that uses a servo motor for switching nozzles
+// A dual nozzle x-carriage that uses a servomotor for switching nozzles
 // Don't forget to set SSDE_SERVO_ANGLES and HOTEND_OFFSET_X/Y/Z
 //#define SWITCHING_NOZZLE             
 #if ENABLED(SWITCHING_NOZZLE)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9550,7 +9550,6 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
           #if ENABLED(SWITCHING_EXTRUDER)
             stepper.synchronize();
-
             move_extruder_servo(active_extruder);
           #endif
 
@@ -9566,7 +9565,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
             move_nozzle_servo(active_extruder);
           #endif
-                  
+
           /**
            * Set current_position to the position of the new nozzle.
            * Offsets are based on linear distance, so we need to get

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9715,6 +9715,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
       UNUSED(fr_mm_s);
       UNUSED(no_move);
 
+      #if ENABLED(SWITCHING_EXTRUDER)
+        stepper.synchronize();
+        move_extruder_servo(active_extruder);
+      #endif
+            
     #endif // HOTENDS <= 1
 
     SERIAL_ECHO_START;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9548,11 +9548,6 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           // No extra case for HAS_ABL in DUAL_X_CARRIAGE. Does that mean they don't work together?
         #else // !DUAL_X_CARRIAGE
 
-          #if ENABLED(SWITCHING_EXTRUDER)
-            stepper.synchronize();
-            move_extruder_servo(active_extruder);
-          #endif
-
           #if ENABLED(SWITCHING_NOZZLE)
             // <0 if the new nozzle is higher, >0 if lower. A bigger raise when lower.
             const float z_diff = hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder],
@@ -9564,6 +9559,13 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             stepper.synchronize();
 
             move_nozzle_servo(active_extruder);
+          #endif
+
+          #if ENABLED(SWITCHING_EXTRUDER)
+            #if !(ENABLED(SWITCHING_NOZZLE) && (SWITCHING_EXTRUDER_SERVO_NR == SWITCHING_NOZZLE_SERVO_NR))
+              stepper.synchronize();
+              move_extruder_servo(active_extruder);
+            #endif
           #endif
 
           /**

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -329,6 +329,19 @@
 #endif
 
 /**
+ * A dual nozzle x-carriage with switching servo
+ */
+#if ENABLED(SWITCHING_NOZZLE)
+  #if ENABLED(SINGLENOZZLE)
+    #error "SWITCHING_NOZZLE and SINGLENOZZLE are incompatible."
+  #elif EXTRUDERS < 2
+    #error "SWITCHING_NOZZLE requires exactly 2 EXTRUDERS."
+  #elif NUM_SERVOS < 1
+    #error "SWITCHING_NOZZLE requires NUM_SERVOS >= 1."
+  #endif
+#endif
+
+/**
  * Single Stepper Dual Extruder with switching servo
  */
 #if ENABLED(SWITCHING_EXTRUDER)

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -329,14 +329,6 @@
 #endif
 
 /**
- * Only one type of extruder allowed
- */
-#if (ENABLED(SWITCHING_EXTRUDER) &&  ENABLED(MIXING_EXTRUDER)) \
-  || (ENABLED(SINGLENOZZLE) && ENABLED(MIXING_EXTRUDER))
-    #error "Please define only one type of extruder: SINGLENOZZLE/SWITCHING_EXTRUDER or MIXING_EXTRUDER."
-#endif
-
-/**
  * Single Stepper Dual Extruder with switching servo
  */
 #if ENABLED(SWITCHING_EXTRUDER)
@@ -361,6 +353,11 @@
   #endif
   #if ENABLED(FILAMENT_SENSOR)
     #error "MIXING_EXTRUDER is incompatible with FILAMENT_SENSOR. Comment out this line to use it anyway."
+  #endif
+  #if ENABLED(SWITCHING_EXTRUDER)
+    #error "Please select either MIXING_EXTRUDER or SWITCHING_EXTRUDER, not both."
+  #if ENABLED(SINGLENOZZLE)
+    #error "MIXING_EXTRUDER is incompatible with SINGLENOZZLE."
   #endif
 #endif
 

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -356,6 +356,7 @@
   #endif
   #if ENABLED(SWITCHING_EXTRUDER)
     #error "Please select either MIXING_EXTRUDER or SWITCHING_EXTRUDER, not both."
+  #endif
   #if ENABLED(SINGLENOZZLE)
     #error "MIXING_EXTRUDER is incompatible with SINGLENOZZLE."
   #endif

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -331,9 +331,9 @@
 /**
  * Only one type of extruder allowed
  */
-#if (ENABLED(SWITCHING_EXTRUDER) && (ENABLED(SINGLENOZZLE) || ENABLED(MIXING_EXTRUDER))) \
+#if (ENABLED(SWITCHING_EXTRUDER) &&  ENABLED(MIXING_EXTRUDER)) \
   || (ENABLED(SINGLENOZZLE) && ENABLED(MIXING_EXTRUDER))
-    #error "Please define only one type of extruder: SINGLENOZZLE, SWITCHING_EXTRUDER, or MIXING_EXTRUDER."
+    #error "Please define only one type of extruder: SINGLENOZZLE/SWITCHING_EXTRUDER or MIXING_EXTRUDER."
 #endif
 
 /**

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1415,7 +1415,7 @@ void MarlinSettings::reset() {
         SERIAL_ECHOPAIR("  M218 T", (int)e);
         SERIAL_ECHOPAIR(" X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
         SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
-        #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_EXTRUDER)
+        #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_NOZZLE)
           SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]));
         #endif
         SERIAL_EOL;

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -415,7 +415,7 @@
 /**
  * Extruder indirection for the single E axis
  */
-#if (ENABLED(SWITCHING_EXTRUDER) && !ENABLED(SWITCHING_EXTRUDER_MULTI_STEPPERS)) 
+#if ENABLED(SWITCHING_EXTRUDER) 
   #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
   #define NORM_E_DIR() E0_DIR_WRITE(current_block->active_extruder ?  INVERT_E0_DIR : !INVERT_E0_DIR)
   #define  REV_E_DIR() E0_DIR_WRITE(current_block->active_extruder ? !INVERT_E0_DIR :  INVERT_E0_DIR)

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -415,7 +415,7 @@
 /**
  * Extruder indirection for the single E axis
  */
-#if ENABLED(SWITCHING_EXTRUDER) 
+#if ENABLED(SWITCHING_EXTRUDER)
   #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
   #define NORM_E_DIR() E0_DIR_WRITE(current_block->active_extruder ?  INVERT_E0_DIR : !INVERT_E0_DIR)
   #define  REV_E_DIR() E0_DIR_WRITE(current_block->active_extruder ? !INVERT_E0_DIR :  INVERT_E0_DIR)

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -415,7 +415,7 @@
 /**
  * Extruder indirection for the single E axis
  */
-#if ENABLED(SWITCHING_EXTRUDER)
+#if (ENABLED(SWITCHING_EXTRUDER) && !ENABLED(SWITCHING_EXTRUDER_MULTI_STEPPERS)) 
   #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
   #define NORM_E_DIR() E0_DIR_WRITE(current_block->active_extruder ?  INVERT_E0_DIR : !INVERT_E0_DIR)
   #define  REV_E_DIR() E0_DIR_WRITE(current_block->active_extruder ? !INVERT_E0_DIR :  INVERT_E0_DIR)


### PR DESCRIPTION
I have switching by servo hotends, but two steppers - one for each, because i use bowden extruders.

SWITCHING_EXTRUDER feature is almost suitable for me, but it is designed for DONDOLO like extruder with only one stepper that changes directions for each tool.

I made little changes in firmware to disable reverse and its works well for me.

P.S. sorry for wrong request that i made few days ago.