### PR TITLE
Fix prepare_move... for UBL

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -69,7 +69,7 @@
    *   B #  Bed         Set the Bed Temperature.  If not specified, a default of 60 C. will be assumed.
    *
    *   C    Current     When searching for Mesh Intersection points to draw, use the current nozzle location
-                        as the base for any distance comparison.
+   *                    as the base for any distance comparison.
    *
    *   D    Disable     Disable the Unified Bed Leveling System.  In the normal case the user is invoking this
    *                    command to see how well a Mesh as been adjusted to match a print surface.  In order to do
@@ -748,10 +748,7 @@
     }
 
     /**
-     * We save the question of what to do with the Unified Bed Leveling System's Activation until the very
-     * end.  The reason is, if one of the parameters specified up above is incorrect, we don't want to
-     * alter the system's status.  We wait until we know everything is correct before altering the state
-     * of the system.
+     * Wait until all parameters are verified before altering the state!
      */
     ubl.state.active = !code_seen('D');
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11235,32 +11235,36 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
    * Returns true if the caller didn't update current_position.
    */
   inline bool prepare_move_to_destination_cartesian() {
-    // Do not use feedrate_percentage for E or Z only moves
-    if (current_position[X_AXIS] == destination[X_AXIS] && current_position[Y_AXIS] == destination[Y_AXIS]) {
-      line_to_destination();
-    }
-    else {
-      #if ENABLED(MESH_BED_LEVELING)
-        if (mbl.active()) {
-          mesh_line_to_destination(MMS_SCALED(feedrate_mm_s));
-          return true;
-        }
-        else
-      #elif ENABLED(AUTO_BED_LEVELING_UBL)
-        if (ubl.state.active) {
-          ubl_line_to_destination_cartesian(MMS_SCALED(feedrate_mm_s), active_extruder);
-          return true;
-        }
-        else
-      #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
-        if (planner.abl_enabled) {
-          bilinear_line_to_destination(MMS_SCALED(feedrate_mm_s));
-          return true;
-        }
-        else
-      #endif
-          line_to_destination(MMS_SCALED(feedrate_mm_s));
-    }
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      const float fr_scaled = MMS_SCALED(feedrate_mm_s);
+      if (ubl.state.active) {
+        ubl_line_to_destination_cartesian(fr_scaled, active_extruder);
+        return true;
+      }
+      else
+        line_to_destination(fr_scaled);
+    #else
+      // Do not use feedrate_percentage for E or Z only moves
+      if (current_position[X_AXIS] == destination[X_AXIS] && current_position[Y_AXIS] == destination[Y_AXIS])
+        line_to_destination();
+      else {
+        const float fr_scaled = MMS_SCALED(feedrate_mm_s);
+        #if ENABLED(MESH_BED_LEVELING)
+          if (mbl.active()) {
+            mesh_line_to_destination(fr_scaled);
+            return true;
+          }
+          else
+        #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
+          if (planner.abl_enabled) {
+            bilinear_line_to_destination(fr_scaled);
+            return true;
+          }
+          else
+        #endif
+            line_to_destination(fr_scaled);
+      }
+    #endif
     return false;
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7610,13 +7610,14 @@ inline void gcode_M205() {
   /**
    * M665: Set delta configurations
    *
-   *    H = diagonal rod // AC-version
+   *    H = delta height
    *    L = diagonal rod
    *    R = delta radius
    *    S = segments per second
-   *    A = Alpha (Tower 1) diagonal rod trim
-   *    B = Beta (Tower 2) diagonal rod trim
-   *    C = Gamma (Tower 3) diagonal rod trim
+   *    B = delta calibration radius
+   *    X = Alpha (Tower 1) angle trim
+   *    Y = Beta (Tower 2) angle trim
+   *    Z = Rotate A and B by this angle
    */
   inline void gcode_M665() {
     if (code_seen('H')) {
@@ -7628,11 +7629,11 @@ inline void gcode_M205() {
     if (code_seen('R')) delta_radius = code_value_linear_units();
     if (code_seen('S')) delta_segments_per_second = code_value_float();
     if (code_seen('B')) delta_calibration_radius = code_value_float();
-    if (code_seen('X')) delta_tower_angle_trim[A_AXIS] = code_value_linear_units();
-    if (code_seen('Y')) delta_tower_angle_trim[B_AXIS] = code_value_linear_units();
+    if (code_seen('X')) delta_tower_angle_trim[A_AXIS] = code_value_float();
+    if (code_seen('Y')) delta_tower_angle_trim[B_AXIS] = code_value_float();
     if (code_seen('Z')) { // rotate all 3 axis for Z = 0
-      delta_tower_angle_trim[A_AXIS] -= code_value_linear_units();
-      delta_tower_angle_trim[B_AXIS] -= code_value_linear_units();
+      delta_tower_angle_trim[A_AXIS] -= code_value_float();
+      delta_tower_angle_trim[B_AXIS] -= code_value_float();
     }
     recalc_delta_settings(delta_radius, delta_diagonal_rod);
   }

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -539,7 +539,7 @@ void Planner::check_axes_activity() {
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         // if z_fade_height enabled (nonzero) and raw_z above it, no leveling required
         if ((planner.z_fade_height) && (planner.z_fade_height <= RAW_Z_POSITION(lz))) return;
-        lz += ubl.state.z_offset + ubl.get_z_correction(lx,ly) * ubl.fade_scaling_factor_for_z(lz);
+        lz += ubl.state.z_offset + ubl.get_z_correction(lx, ly) * ubl.fade_scaling_factor_for_z(lz);
       #else // no fade
         lz += ubl.state.z_offset + ubl.get_z_correction(lx,ly);
       #endif // FADE
@@ -617,7 +617,7 @@ void Planner::check_axes_activity() {
           //    so U==(L-O-M)/(1-M/H) for U<H
 
           if (planner.z_fade_height) {
-            float z_unfaded = z_unlevel / (1.0 - z_ublmesh * planner.inverse_z_fade_height);
+            const float z_unfaded = z_unlevel / (1.0 - z_ublmesh * planner.inverse_z_fade_height);
             if (z_unfaded < planner.z_fade_height)  // don't know until after compute
               z_unlevel = z_unfaded;
           }

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -61,8 +61,7 @@
 
   void dump(char * const str, const float &f);
   void probe_entire_mesh(const float&, const float&, const bool, const bool, const bool);
-  void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
-  float measure_business_card_thickness(const float&);
+  float measure_business_card_thickness(float&);
   mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, unsigned int[16], bool);
   void shift_mesh_height();
   void fine_tune_mesh(const float&, const float&, const bool);
@@ -108,7 +107,6 @@
       void probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
       void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
       void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
-      void manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map);
       void save_ubl_active_state_and_disable();
       void restore_ubl_active_state_and_leave();
       void g29_what_command();

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -56,7 +56,7 @@
   extern bool set_probe_deployed(bool);
   void smart_fill_mesh();
   float measure_business_card_thickness(float &in_height);
-  void manually_probe_remaining_mesh(const float &lx, const float &ly, float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map);
+  void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
 
   bool ProbeStay = true;
 
@@ -482,7 +482,7 @@
            */
           if (c_flag) {
 
-            if ( repetition_cnt >= ( GRID_MAX_POINTS_X * GRID_MAX_POINTS_Y )) {
+            if (repetition_cnt >= GRID_MAX_POINTS) {
               for ( uint8_t x = 0; x < GRID_MAX_POINTS_X; x++ ) {
                 for ( uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++ ) {
                   ubl.z_values[x][y] = ubl_constant;
@@ -735,7 +735,7 @@
     ubl.save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
     DEPLOY_PROBE();
 
-    uint16_t max_iterations = ( GRID_MAX_POINTS_X * GRID_MAX_POINTS_Y );
+    uint16_t max_iterations = GRID_MAX_POINTS;
 
     do {
       if (ubl_lcd_clicked()) {
@@ -941,7 +941,7 @@
     return thickness;
   }
 
-  void manually_probe_remaining_mesh(const float &lx, const float &ly, float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map) {
+  void manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map) {
 
     ubl.has_control_of_lcd_panel = true;
     ubl.save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
@@ -956,14 +956,11 @@
       if (location.x_index < 0 && location.y_index < 0) continue;
 
       const float rawx = pgm_read_float(&ubl.mesh_index_to_xpos[location.x_index]),
-                  rawy = pgm_read_float(&ubl.mesh_index_to_ypos[location.y_index]);
-
-      const float xProbe = LOGICAL_X_POSITION(rawx),
+                  rawy = pgm_read_float(&ubl.mesh_index_to_ypos[location.y_index]),
+                  xProbe = LOGICAL_X_POSITION(rawx),
                   yProbe = LOGICAL_Y_POSITION(rawy);
 
-      if ( ! position_is_reachable_raw_xy( rawx, rawy )) {    // SHOULD NOT OCCUR (find_closest_mesh_point only returns reachable points)
-        break;
-      }
+      if (!position_is_reachable_raw_xy(rawx, rawy)) break; // SHOULD NOT OCCUR (find_closest_mesh_point only returns reachable points)
 
       do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
 
@@ -1129,6 +1126,7 @@
       SERIAL_PROTOCOLLNPGM("Invalid map type.\n");
       return UBL_ERR;
     }
+
     // Check if a map type was specified
     if (code_seen('M')) { // Warning! Use of 'M' flouts established standards.
       map_type = code_has_value() ? code_value_int() : 0;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1674,13 +1674,13 @@ void kill_screen(const char* lcd_msg) {
 
     void _lcd_ubl_level_bed();
 
-    int UBL_STORAGE_SLOT = 0;
-    int CUSTOM_BED_TEMP = 50;
-    int CUSTOM_HOTEND_TEMP = 190;
-    int SIDE_POINTS = 3;
-    int UBL_FILLIN_AMOUNT = 5;
-    int UBL_HEIGHT_AMOUNT;
-    int map_type;
+    int UBL_STORAGE_SLOT = 0,
+        CUSTOM_BED_TEMP = 50,
+        CUSTOM_HOTEND_TEMP = 190,
+        SIDE_POINTS = 3,
+        UBL_FILLIN_AMOUNT = 5,
+        UBL_HEIGHT_AMOUNT,
+        map_type;
 
     char UBL_LCD_GCODE [30];
 
@@ -1858,7 +1858,7 @@ void kill_screen(const char* lcd_msg) {
      * UBL Build Mesh submenu
      */
     void _lcd_ubl_build_mesh() {
-      int GRID_NUM_POINTS = GRID_MAX_POINTS_X * GRID_MAX_POINTS_Y ;
+      int GRID_NUM_POINTS = GRID_MAX_POINTS;
       START_MENU();
       MENU_BACK(MSG_UBL_TOOLS);
       #if (WATCH_THE_BED)


### PR DESCRIPTION
The logic for `prepare_move_to_destination_cartesian` works for ABL and MBL, but UBL doesn't hook into the planner at the same level.

Reference: #6715