### PR TITLE
G26's default behavior ought to be the entire mesh

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -734,7 +734,7 @@
       random_deviation = code_has_value() ? code_value_float() : 50.0;
     }
 
-    g26_repeats = code_seen('R') ? (code_has_value() ? code_value_int() : 999) : 1;
+    g26_repeats = code_seen('R') ? (code_has_value() ? code_value_int() : GRID_MAX_POINTS+1) : GRID_MAX_POINTS+1;
     if (g26_repeats < 1) {
       SERIAL_PROTOCOLLNPGM("?(R)epeat value not plausible; must be at least 1.");
       return UBL_ERR;


### PR DESCRIPTION
Adding the capability to specify ahead of time how much of the validation pattern to print made it so by default `G26` only did one circle and no connecting lines.

It is more natural for the unsophisticated user to just do the entire mesh (bed). We default the repetition count to `GRID_MAX_POINTS + 1` to ensure we get every last one of them!

But the '`R`' parameter still allows the user to specify how much of the pattern to do.