### PR TITLE
Some Monday patches

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -466,7 +466,7 @@
                   SERIAL_EOL;
                   //debug_current_and_destination(PSTR("Connecting horizontal line."));
                 }
-  
+
                 print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), layer_height);
               }
               bit_set(horizontal_mesh_line_flags, i, j);   // Mark it as done so we don't do it again, even if we skipped it
@@ -685,7 +685,7 @@
       }
     }
 
-    if (code_seen('S')) { 
+    if (code_seen('S')) {
       nozzle = code_value_float();
       if (!WITHIN(nozzle, 0.1, 1.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified nozzle size not plausible.");
@@ -727,7 +727,7 @@
       }
     }
 
-    if (code_seen('U')) { 
+    if (code_seen('U')) {
       randomSeed(millis());
       random_deviation = code_has_value() ? code_value_float() : 50.0;
     }

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1458,10 +1458,7 @@ void MarlinSettings::reset() {
       #endif
       SERIAL_EOL;
 
-      if (!forReplay) {
-        ubl.g29_what_command();        
-
-      }
+      if (!forReplay) ubl.g29_what_command();
 
     #elif HAS_ABL
 

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -110,7 +110,7 @@
       void save_ubl_active_state_and_disable();
       void restore_ubl_active_state_and_leave();
       void g29_what_command();
-      void g29_eeprom_dump() ;
+      void g29_eeprom_dump();
       void g29_compare_current_mesh_to_stored_mesh();
       void fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map);
       void smart_fill_mesh();

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1154,17 +1154,17 @@
 
     say_ubl_name();
     SERIAL_PROTOCOLPGM("System Version " UBL_VERSION " ");
-    if (ubl.state.active)
+    if (state.active)
       SERIAL_PROTOCOLCHAR('A');
     else
       SERIAL_PROTOCOLPGM("Ina");
     SERIAL_PROTOCOLLNPGM("ctive.\n");
     safe_delay(50);
 
-    if (ubl.state.eeprom_storage_slot == -1)
+    if (state.eeprom_storage_slot == -1)
       SERIAL_PROTOCOLPGM("No Mesh Loaded.");
     else {
-      SERIAL_PROTOCOLPAIR("Mesh ", ubl.state.eeprom_storage_slot);
+      SERIAL_PROTOCOLPAIR("Mesh ", state.eeprom_storage_slot);
       SERIAL_PROTOCOLPGM(" Loaded.");
     }
     SERIAL_EOL;
@@ -1181,7 +1181,7 @@
     SERIAL_PROTOCOL_F(zprobe_zoffset, 7);
     SERIAL_EOL;
 
-    SERIAL_PROTOCOLLNPAIR("ubl.eeprom_start=", hex_address((void*)ubl.eeprom_start));
+    SERIAL_PROTOCOLLNPAIR("ubl.eeprom_start=", hex_address((void*)eeprom_start));
 
     SERIAL_ECHOLNPAIR("GRID_MAX_POINTS_X  ", GRID_MAX_POINTS_X);
     SERIAL_ECHOLNPAIR("GRID_MAX_POINTS_Y  ", GRID_MAX_POINTS_Y);
@@ -1193,7 +1193,7 @@
 
     SERIAL_PROTOCOLPGM("X-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
-      SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(pgm_read_float(&ubl.mesh_index_to_xpos[i])), 3);
+      SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(pgm_read_float(&mesh_index_to_xpos[i])), 3);
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(25);
     }
@@ -1201,26 +1201,26 @@
 
     SERIAL_PROTOCOLPGM("Y-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; i++) {
-      SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(pgm_read_float(&ubl.mesh_index_to_ypos[i])), 3);
+      SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(pgm_read_float(&mesh_index_to_ypos[i])), 3);
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(25);
     }
     SERIAL_EOL;
 
-    SERIAL_PROTOCOLLNPAIR("Free EEPROM space starts at: ", hex_address((void*)ubl.eeprom_start));
+    SERIAL_PROTOCOLLNPAIR("Free EEPROM space starts at: ", hex_address((void*)eeprom_start));
     SERIAL_PROTOCOLLNPAIR("end of EEPROM: ", hex_address((void*)E2END));
     safe_delay(25);
 
-    SERIAL_PROTOCOLPAIR("sizeof(ubl.state) : ", (int)sizeof(ubl.state));
+    SERIAL_PROTOCOLPAIR("sizeof(ubl.state) : ", (int)sizeof(state));
     SERIAL_EOL;
-    SERIAL_PROTOCOLLNPAIR("z_value[][] size: ", (int)sizeof(ubl.z_values));
+    SERIAL_PROTOCOLLNPAIR("z_value[][] size: ", (int)sizeof(z_values));
     SERIAL_EOL;
     safe_delay(25);
 
     SERIAL_PROTOCOLLNPAIR("EEPROM free for UBL: ", hex_address((void*)k));
     safe_delay(25);
 
-    SERIAL_PROTOCOLPAIR("EEPROM can hold ", k / sizeof(ubl.z_values));
+    SERIAL_PROTOCOLPAIR("EEPROM can hold ", k / sizeof(z_values));
     SERIAL_PROTOCOLLNPGM(" meshes.\n");
     safe_delay(25);
 
@@ -1241,7 +1241,7 @@
     SERIAL_ECHOLNPAIR("=", UBL_MESH_MAX_Y);
     safe_delay(25);
 
-    if (!ubl.sanity_check()) {
+    if (!sanity_check()) {
       say_ubl_name();
       SERIAL_PROTOCOLLNPGM("sanity checks passed.");
     }
@@ -1565,11 +1565,11 @@
             SERIAL_ECHOPGM(")   measured: ");
             SERIAL_PROTOCOL_F(measured_z, 7);
             SERIAL_ECHOPGM("   correction: ");
-            SERIAL_PROTOCOL_F(ubl.get_z_correction(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y)), 7);
+            SERIAL_PROTOCOL_F(get_z_correction(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y)), 7);
           }
         #endif
 
-        measured_z -= ubl.get_z_correction(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y)) /* + zprobe_zoffset */ ;
+        measured_z -= get_z_correction(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y)) /* + zprobe_zoffset */ ;
 
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
@@ -1616,9 +1616,9 @@
 
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
       for (uint8_t j = 0; j < GRID_MAX_POINTS_Y; j++) {
-        float x_tmp = pgm_read_float(&ubl.mesh_index_to_xpos[i]),
-              y_tmp = pgm_read_float(&ubl.mesh_index_to_ypos[j]),
-              z_tmp = ubl.z_values[i][j];
+        float x_tmp = pgm_read_float(&mesh_index_to_xpos[i]),
+              y_tmp = pgm_read_float(&mesh_index_to_ypos[j]),
+              z_tmp = z_values[i][j];
 
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
@@ -1648,7 +1648,7 @@
           }
         #endif
 
-        ubl.z_values[i][j] += z_tmp - lsf_results.D;
+        z_values[i][j] += z_tmp - lsf_results.D;
       }
     }
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -106,10 +106,10 @@
    *
    *   I #   Invalidate Invalidate specified number of Mesh Points. The nozzle location is used unless
    *                    the X and Y parameter are used. If no number is specified, only the closest Mesh
-   *                    point to the location is invalidated. The M parameter is available as well to produce
+   *                    point to the location is invalidated. The 'T' parameter is also available to produce
    *                    a map after the operation. This command is useful to invalidate a portion of the
    *                    Mesh so it can be adjusted using other tools in the Unified Bed Leveling System. When
-   *                    attempting to invalidate an isolated bad point in the mesh, the M option will indicate
+   *                    attempting to invalidate an isolated bad point in the mesh, the 'T' option will indicate
    *                    where the nozzle is positioned in the Mesh with (#). You can move the nozzle around on
    *                    the bed and use this feature to select the center of the area (or cell) you want to
    *                    invalidate.
@@ -124,14 +124,6 @@
    *
    *   L #   Load       Load Mesh from the specified location in the EEPROM. Set this location as activated
    *                    for subsequent Load and Store operations.
-   *
-   *   O     Map   *    Display the Mesh Map Topology.
-   *                    The parameter can be specified alone (ie. G29 O) or in combination with many of the
-   *                    other commands. The Mesh Map option works with all of the Phase
-   *                    commands (ie. G29 P4 R 5 X 50 Y100 C -.1 O)  The Map parameter can also of a Map Type
-   *                    specified.  A map type of 0 is the default is user readable.   A map type of 1 can
-   *                    be specified and is suitable to Cut & Paste into Excel to allow graphing of the user's
-   *                    mesh.
    *
    *   The P or Phase commands are used for the bulk of the work to setup a Mesh. In general, your Mesh will
    *   start off being initialized with a G29 P0 or a G29 P1. Further refinement of the Mesh happens with
@@ -171,7 +163,7 @@
    *                    area you are manually probing. Note that the command tries to start you in a corner
    *                    of the bed where movement will be predictable. You can force the location to be used in
    *                    the distance calculations by using the X and Y parameters. You may find it is helpful to
-   *                    print out a Mesh Map (G29 O) to understand where the mesh is invalidated and where
+   *                    print out a Mesh Map (G29 T) to understand where the mesh is invalidated and where
    *                    the nozzle will need to move in order to complete the command. The C parameter is
    *                    available on the Phase 2 command also and indicates the search for points to measure should
    *                    be done based on the current location of the nozzle.
@@ -187,7 +179,7 @@
    *                    to get it to grasp the shim with the same force as when you measured the thickness of the
    *                    shim at the start of the command.
    *
-   *                    Phase 2 allows the O (Map) parameter to be specified. This helps the user see the progression
+   *                    Phase 2 allows the T (Map) parameter to be specified. This helps the user see the progression
    *                    of the Mesh being built.
    *
    *   P3    Phase 3    Fill the unpopulated regions of the Mesh with a fixed value. There are two different paths the
@@ -260,6 +252,12 @@
    *   S -1  Store      Store the current Mesh as a print out that is suitable to be feed back into the system
    *                    at a later date. The GCode output can be saved and later replayed by the host software
    *                    to reconstruct the current mesh on another machine.
+   *
+   *   T     Topology   Display the Mesh Map Topology.
+   *                    'T' can be used alone (e.g., G29 T) or in combination with some of the other commands.
+   *                    This option works with all Phase commands (e.g., G29 P4 R 5 X 50 Y100 C -.1 O)
+   *                    This parameter can also specify a Map Type. T0 (the default) is user-readable. T1 can
+   *                    is suitable to paste into a spreadsheet for a 3D graph of the mesh.
    *
    *   U     Unlevel    Perform a probe of the outer perimeter to assist in physically leveling unlevel beds.
    *                    Only used for G29 P1 O U. This speeds up the probing of the edge of the bed. Useful
@@ -381,7 +379,7 @@
     if (code_seen('J')) {
       if (grid_size) {  // if not 0 it is a normal n x n grid being probed
         ubl.save_ubl_active_state_and_disable();
-        ubl.tilt_mesh_based_on_probed_grid(code_seen('O'));
+        ubl.tilt_mesh_based_on_probed_grid(code_seen('T'));
         ubl.restore_ubl_active_state_and_leave();
       } else { // grid_size==0 which means a 3-Point leveling has been requested
         float z1 = probe_pt(LOGICAL_X_POSITION(UBL_PROBE_PT_1_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_1_Y), false, g29_verbose_level),
@@ -438,7 +436,7 @@
             SERIAL_PROTOCOLLNPGM(").\n");
           }
           ubl.probe_entire_mesh(x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER,
-                            code_seen('O'), code_seen('E'), code_seen('U'));
+                            code_seen('T'), code_seen('E'), code_seen('U'));
           break;
 
         case 2: {
@@ -487,7 +485,7 @@
             return;
           }
 
-          manually_probe_remaining_mesh(x_pos, y_pos, height, card_thickness, code_seen('O'));
+          manually_probe_remaining_mesh(x_pos, y_pos, height, card_thickness, code_seen('T'));
           SERIAL_PROTOCOLLNPGM("G29 P2 finished.");
         } break;
 
@@ -523,7 +521,7 @@
           //
           // Fine Tune (i.e., Edit) the Mesh
           //
-          fine_tune_mesh(x_pos, y_pos, code_seen('O'));
+          fine_tune_mesh(x_pos, y_pos, code_seen('T'));
           break;
 
         case 5: ubl.find_mean_mesh_height(); break;
@@ -601,7 +599,7 @@
       SERIAL_PROTOCOLLNPGM("Done.\n");
     }
 
-    if (code_seen('O'))
+    if (code_seen('T'))
       ubl.display_map(code_has_value() ? code_value_int() : 0);
 
     /*
@@ -1112,7 +1110,7 @@
       }
     #endif
 
-    map_type = code_seen('O') && code_has_value() ? code_value_int() : 0;
+    map_type = code_seen('T') && code_has_value() ? code_value_int() : 0;
     if (!WITHIN(map_type, 0, 1)) {
       SERIAL_PROTOCOLLNPGM("Invalid map type.\n");
       return UBL_ERR;

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -74,18 +74,17 @@
    *   A     Activate   Activate the Unified Bed Leveling system.
    *
    *   B #   Business   Use the 'Business Card' mode of the Manual Probe subsystem. This is invoked as
-   *                    G29 P2 B   The mode of G29 P2 allows you to use a bussiness card or recipe card
+   *                    G29 P2 B. The mode of G29 P2 allows you to use a business card or recipe card
    *                    as a shim that the nozzle will pinch as it is lowered. The idea is that you
    *                    can easily feel the nozzle getting to the same height by the amount of resistance
    *                    the business card exhibits to movement. You should try to achieve the same amount
    *                    of resistance on each probed point to facilitate accurate and repeatable measurements.
-   *                    You should be very careful not to drive the nozzle into the bussiness card with a
+   *                    You should be very careful not to drive the nozzle into the business card with a
    *                    lot of force as it is very possible to cause damage to your printer if your are
-   *                    careless. If you use the B option with G29 P2 B you can leave the number parameter off
-   *                    on its first use to enable measurement of the business card thickness. Subsequent usage
-   *                    of the B parameter can have the number previously measured supplied to the command.
-   *                    Incidently, you are much better off using something like a Spark Gap feeler gauge than
-   *                    something that compresses like a Business Card.
+   *                    careless. If you use the B option with G29 P2 B you can omit the numeric value
+   *                    on first use to measure the business card's thickness. Subsequent usage of 'B'
+   *                    will apply the previously-measured thickness as the default.
+   *                    Note: A non-compressible Spark Gap feeler gauge is recommended over a Business Card.
    *
    *   C     Continue   Continue, Constant, Current Location. This is not a primary command. C is used to
    *                    further refine the behaviour of several other commands. Issuing a G29 P1 C will
@@ -98,7 +97,7 @@
    *
    *   E     Stow_probe Stow the probe after each sampled point.
    *
-   *   F #   Fade   *   Fade the amount of Mesh Based Compensation over a specified height. At the
+   *   F #   Fade       Fade the amount of Mesh Based Compensation over a specified height. At the
    *                    specified height, no correction is applied and natural printer kenimatics take over. If no
    *                    number is specified for the command, 10mm is assumed to be reasonable.
    *
@@ -115,15 +114,15 @@
    *                    the bed and use this feature to select the center of the area (or cell) you want to
    *                    invalidate.
    *
-   *   J #   Grid   *   Perform a Grid Based Leveling of the current Mesh using a grid with n points on a side.
+   *   J #   Grid       Perform a Grid Based Leveling of the current Mesh using a grid with n points on a side.
    *                    Not specifying a grid size will invoke the 3-Point leveling function.
    *
    *   K #   Kompare    Kompare current Mesh with stored Mesh # replacing current Mesh with the result. This
    *                    command literally performs a diff between two Meshes.
    *
-   *   L     Load   *   Load Mesh from the previously activated location in the EEPROM.
+   *   L     Load       Load Mesh from the previously activated location in the EEPROM.
    *
-   *   L #   Load   *   Load Mesh from the specified location in the EEPROM. Set this location as activated
+   *   L #   Load       Load Mesh from the specified location in the EEPROM. Set this location as activated
    *                    for subsequent Load and Store operations.
    *
    *   O     Map   *    Display the Mesh Map Topology.
@@ -151,12 +150,11 @@
    *                    probing needed locations. This allows you to invalidate portions of the Mesh but still
    *                    use the automatic probing capabilities of the Unified Bed Leveling System. An X and Y
    *                    parameter can be given to prioritize where the command should be trying to measure points.
-   *                    If the X and Y parameters are not specified the current probe position is used. Phase 1
-   *                    allows you to specify the M (Map) parameter so you can watch the generation of the Mesh.
-   *                    Phase 1 also watches for the LCD Panel's Encoder Switch being held in a depressed state.
-   *                    It will suspend generation of the Mesh if it sees the user request that. (This check is
-   *                    only done between probe points. You will need to press and hold the switch until the
-   *                    Phase 1 command can detect it.)
+   *                    If the X and Y parameters are not specified the current probe position is used.
+   *                    P1 accepts a 'T' (Topology) parameter so you can observe mesh generation.
+   *                    P1 also watches for the LCD Panel Encoder Switch to be held down, and will suspend
+   *                    generation of the Mesh in that case. (Note: This check is only done between probe points,
+   *                    so you must press and hold the switch until the Phase 1 command detects it.)
    *
    *   P2    Phase 2    Probe areas of the Mesh that can't be automatically handled. Phase 2 respects an H
    *                    parameter to control the height between Mesh points. The default height for movement
@@ -179,7 +177,7 @@
    *                    be done based on the current location of the nozzle.
    *
    *                    A B parameter is also available for this command and described up above. It places the
-   *                    manual probe subsystem into Business Card mode where the thickness of a business care is
+   *                    manual probe subsystem into Business Card mode where the thickness of a business card is
    *                    measured and then used to accurately set the nozzle height in all manual probing for the
    *                    duration of the command. (S for Shim mode would be a better parameter name, but S is needed
    *                    for Save or Store of the Mesh to EEPROM)  A Business card can be used, but you will have
@@ -245,7 +243,7 @@
    *                    you should have the Mesh adjusted for a Mean Height of 0.00 and the Z-Probe measuring
    *                    0.000 at the Z Home location.
    *
-   *   Q     Test   *   Load specified Test Pattern to assist in checking correct operation of system. This
+   *   Q     Test       Load specified Test Pattern to assist in checking correct operation of system. This
    *                    command is not anticipated to be of much value to the typical user. It is intended
    *                    for developers to help them verify correct operation of the Unified Bed Leveling System.
    *
@@ -264,14 +262,16 @@
    *                    to reconstruct the current mesh on another machine.
    *
    *   U     Unlevel    Perform a probe of the outer perimeter to assist in physically leveling unlevel beds.
-   *                    Only used for G29 P1 O U   It will speed up the probing of the edge of the bed.  This
-   *                    is useful when the entire bed does not need to be probed because it will be adjusted.
+   *                    Only used for G29 P1 O U. This speeds up the probing of the edge of the bed. Useful
+   *                    when the entire bed doesn't need to be probed because it will be adjusted.
    *
-   *   W     What?      Display valuable data the Unified Bed Leveling System knows.
+   *   V #   Verbosity  Set the verbosity level (0-4) for extra details. (Default 0)
    *
-   *   X #   *      *   X Location for this line of commands
+   *   W     What?      Display valuable Unified Bed Leveling System data.
    *
-   *   Y #   *      *   Y Location for this line of commands
+   *   X #              X Location for this command
+   *
+   *   Y #              Y Location for this command
    *
    *
    *   Release Notes:
@@ -320,7 +320,7 @@
     }
 
     // Don't allow auto-leveling without homing first
-    if (axis_unhomed_error()) 
+    if (axis_unhomed_error())
       home_all_axes();
 
     if (g29_parameter_parsing()) return; // abort if parsing the simple parameters causes a problem,
@@ -379,9 +379,9 @@
     }
 
     if (code_seen('J')) {
-      if (grid_size!=0) {  // if not 0 it is a normal n x n grid being probed
+      if (grid_size) {  // if not 0 it is a normal n x n grid being probed
         ubl.save_ubl_active_state_and_disable();
-        ubl.tilt_mesh_based_on_probed_grid(code_seen('O')); 
+        ubl.tilt_mesh_based_on_probed_grid(code_seen('O'));
         ubl.restore_ubl_active_state_and_leave();
       } else { // grid_size==0 which means a 3-Point leveling has been requested
         float z1 = probe_pt(LOGICAL_X_POSITION(UBL_PROBE_PT_1_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_1_Y), false, g29_verbose_level),
@@ -438,7 +438,7 @@
             SERIAL_PROTOCOLLNPGM(").\n");
           }
           ubl.probe_entire_mesh(x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER,
-                            code_seen('O'), code_seen('E'), code_seen('U')); 
+                            code_seen('O'), code_seen('E'), code_seen('U'));
           break;
 
         case 2: {
@@ -481,7 +481,7 @@
           }
 
           if (code_seen('H') && code_has_value()) height = code_value_float();
-          
+
           if ( !position_is_reachable_xy( x_pos, y_pos )) {
             SERIAL_PROTOCOLLNPGM("(X,Y) outside printable radius.");
             return;
@@ -499,15 +499,15 @@
            *   - Allow 'G29 P3' to choose a 'reasonable' constant.
            */
           if (c_flag) {
-
             if (repetition_cnt >= GRID_MAX_POINTS) {
-              for ( uint8_t x = 0; x < GRID_MAX_POINTS_X; x++ ) {
-                for ( uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++ ) {
+              for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
+                for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
                   ubl.z_values[x][y] = ubl_constant;
                 }
               }
-            } else {
-              while (repetition_cnt--) {  // this only populates reachable mesh points near 
+            }
+            else {
+              while (repetition_cnt--) {  // this only populates reachable mesh points near
                 const mesh_index_pair location = find_closest_mesh_point_of_type(INVALID, x_pos, y_pos, USE_NOZZLE_AS_REFERENCE, NULL, false);
                 if (location.x_index < 0) break; // No more reachable invalid Mesh Points to populate
                 ubl.z_values[location.x_index][location.y_index] = ubl_constant;
@@ -523,7 +523,7 @@
           //
           // Fine Tune (i.e., Edit) the Mesh
           //
-          fine_tune_mesh(x_pos, y_pos, code_seen('O')); 
+          fine_tune_mesh(x_pos, y_pos, code_seen('O'));
           break;
 
         case 5: ubl.find_mean_mesh_height(); break;
@@ -538,7 +538,7 @@
     // good to have the extra information. Soon... we prune this to just a few items
     //
     if (code_seen('W')) ubl.g29_what_command();
- 
+
     //
     // When we are fully debugged, this may go away. But there are some valid
     // use cases for the users. So we can wait and see what to do with it.
@@ -1580,7 +1580,7 @@
       SERIAL_ECHOPGM("Could not complete LSF!");
       return;
     }
-    
+
     if (g29_verbose_level > 3) {
       SERIAL_ECHOPGM("LSF Results A=");
       SERIAL_PROTOCOL_F(lsf_results.A, 7);

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -55,8 +55,8 @@
                 dy = current_position[Y_AXIS] - destination[Y_AXIS],
                 xy_dist = HYPOT(dx, dy);
 
-    if (xy_dist == 0.0) 
-	    return;
+    if (xy_dist == 0.0)
+      return;
     else {
       SERIAL_ECHOPGM("   fpmm=");
       const float fpmm = de / xy_dist;
@@ -461,7 +461,7 @@
       static float scara_feed_factor, scara_oldA, scara_oldB;
     #endif
 
-    // We don't want additional apply_leveling() performed by regular buffer_line or buffer_line_kinematic, 
+    // We don't want additional apply_leveling() performed by regular buffer_line or buffer_line_kinematic,
     // so we call _buffer_line directly here.  Per-segmented leveling performed first.
 
     static inline void ubl_buffer_line_segment(const float ltarget[XYZE], const float &fr_mm_s, const uint8_t extruder) {
@@ -530,7 +530,7 @@
                     difference[X_AXIS] * inv_segments,
                     difference[Y_AXIS] * inv_segments,
                     difference[Z_AXIS] * inv_segments,
-                    difference[E_AXIS] * inv_segments 
+                    difference[E_AXIS] * inv_segments
                   };
 
       // Note that E segment distance could vary slightly as z mesh height
@@ -610,7 +610,7 @@
               z_x0y1 = ubl.z_values[cell_xi  ][cell_yi+1],  // z at lower right corner
               z_x1y1 = ubl.z_values[cell_xi+1][cell_yi+1];  // z at upper right corner
 
-        if (isnan(z_x0y0)) z_x0y0 = 0;              // ideally activating ubl.state.active (G29 A) 
+        if (isnan(z_x0y0)) z_x0y0 = 0;              // ideally activating ubl.state.active (G29 A)
         if (isnan(z_x1y0)) z_x1y0 = 0;              //   should refuse if any invalid mesh points
         if (isnan(z_x0y1)) z_x0y1 = 0;              //   in order to avoid isnan tests per cell,
         if (isnan(z_x1y1)) z_x1y1 = 0;              //   thus guessing zero for undefined points
@@ -664,7 +664,7 @@
           if (!WITHIN(cx, 0, MESH_X_DIST) || !WITHIN(cy, 0, MESH_Y_DIST)) {  // done within this cell, break to next
             rx = RAW_X_POSITION(seg_dest[X_AXIS]);
             ry = RAW_Y_POSITION(seg_dest[Y_AXIS]);
-            break;  
+            break;
           }
 
           // Next segment still within same mesh cell, adjust the per-segment

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1945,7 +1945,7 @@ void kill_screen(const char* lcd_msg) {
 
     /**
      * UBL System submenu
-     * 
+     *
      *  Prepare
      * - Unified Bed Leveling
      *   - Activate UBL

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -777,7 +777,7 @@ static void lcd_implementation_status_screen() {
 
     // Draw the progress bar if the message has shown long enough
     // or if there is no message set.
-    if (card.isFileOpen() && ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0])
+    if (card.isFileOpen() && (ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0]))
       return lcd_draw_progress_bar(card.percentDone());
 
   #elif ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)


### PR DESCRIPTION
- Fix `ubl::g29_what_command` - removing `ubl.` prefix from member references
- Clean up trailing whitespace and tabs left in source (please change editor settings!)
- Finished adding `Q` parameter to `M421` (bilinear and MBL)