### PR TITLE
Prevent home_all_axes picking up XYZ parameters from command

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -834,7 +834,7 @@
       #define DELTA_PROBEABLE_RADIUS DELTA_PRINTABLE_RADIUS
     #endif
   #endif
-    
+
   // Shorthand
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))
 

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -922,10 +922,10 @@
   // at which point movement will be level to the machine's XY plane.
   // The height can be set with M420 Z<height>
   //#define ENABLE_LEVELING_FADE_HEIGHT
-  
+
   // Set the boundaries for probing (where the probe can reach).
   #define DELTA_PROBEABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
-         
+
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_LINEAR) || ENABLED(AUTO_BED_LEVELING_BILINEAR)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -920,10 +920,10 @@
   // at which point movement will be level to the machine's XY plane.
   // The height can be set with M420 Z<height>
   //#define ENABLE_LEVELING_FADE_HEIGHT
-  
+
   // Set the boundaries for probing (where the probe can reach).
   #define DELTA_PROBEABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
-         
+
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_LINEAR) || ENABLED(AUTO_BED_LEVELING_BILINEAR)

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -926,10 +926,10 @@
   // at which point movement will be level to the machine's XY plane.
   // The height can be set with M420 Z<height>
   //#define ENABLE_LEVELING_FADE_HEIGHT
-  
+
   // Set the boundaries for probing (where the probe can reach).
   #define DELTA_PROBEABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
-         
+
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_LINEAR) || ENABLED(AUTO_BED_LEVELING_BILINEAR)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -989,10 +989,10 @@
   // at which point movement will be level to the machine's XY plane.
   // The height can be set with M420 Z<height>
   //#define ENABLE_LEVELING_FADE_HEIGHT
-  
+
   // Set the boundaries for probing (where the probe can reach).
   #define DELTA_PROBEABLE_RADIUS (DELTA_PRINTABLE_RADIUS - 10)
-         
+
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_LINEAR) || ENABLED(AUTO_BED_LEVELING_BILINEAR)

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -322,17 +322,15 @@
 
     // Check for commands that require the printer to be homed.
     if (axis_unhomed_error()) {
-      if (code_seen('J')) 
+      if (code_seen('J'))
         home_all_axes();
-      else
-        if (code_seen('P')) {
-          int p_val;
-	  if (code_has_value()) {
-            p_val = code_value_int();
-	    if ( p_val==1 || p_val==2 || p_val==4 )
-              home_all_axes();
-	  }
+      else if (code_seen('P')) {
+        if (code_has_value()) {
+          const int p_val = code_value_int();
+          if (p_val == 1 || p_val == 2 || p_val == 4)
+            home_all_axes();
         }
+      }
     }
 
     if (g29_parameter_parsing()) return; // abort if parsing the simple parameters causes a problem,
@@ -1341,15 +1339,7 @@
           // Also for round beds, there are grid points outside the bed that nozzle can't reach.
           // Prune them from the list and ignore them till the next Phase (manual nozzle probing).
 
-//        if ((probe_as_reference && position_is_reachable_by_probe_raw_xy(mx, my)) || position_is_reachable_raw_xy(mx, my))
-//          continue;
-//
-//        THE ABOVE CODE IS NOT A REPLACEMENT FOR THE CODE BELOW!!!!!!!
-//
-          bool reachable = probe_as_reference ?
-                             position_is_reachable_by_probe_raw_xy( mx, my ) :
-                             position_is_reachable_raw_xy( mx, my );
-          if ( ! reachable )
+          if ( ! (probe_as_reference ? position_is_reachable_by_probe_raw_xy(mx, my) : position_is_reachable_raw_xy(mx, my)) )
             continue;
 
           // Reachable. Check if it's the closest location to the nozzle.

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -632,7 +632,7 @@
                     z_cxyd = z_cxy1 - z_cxy0;                 // z height difference along cx from y0 to y1
 
               float z_cxym = z_cxyd * (1.0 / (MESH_Y_DIST));  // z slope per y along cx from y0 to y1
-        
+
         //    float z_cxcy = z_cxy0 + z_cxym * cy;            // interpolated mesh z height along cx at cy (do inside the segment loop)
 
         // As subsequent segments step through this cell, the z_cxy0 intercept will change
@@ -649,7 +649,7 @@
           #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
             z_cxcy *= fade_scaling_factor;          // apply fade factor to interpolated mesh height
           #endif
-        
+
           z_cxcy += ubl.state.z_offset;             // add fixed mesh offset from G29 Z
 
           if (--segments == 0) {                    // if this is last segment, use ltarget for exact


### PR DESCRIPTION
Fix `home_all_axes` so parameters `X`, `Y`, and `Z` of the current command won't be picked up by `gcode_G28`.

----

Please change your editor settings to use spaces, not tabs. It's always better to use the same spacing settings as the codebase. For Marlin, indentation is 2 spaces. If you must continue to use tabs, at least set them to expand to 2 spaces, not 4, so the spacing will be correct on conversion. (If the tab size isn't set to 2, end-of-line comments end up misaligned with each other when converted to spaces.) As always, closely examine your changes a few times before submitting and merging.