### PR TITLE
Fix recent regressions, &c.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -625,18 +625,18 @@ void MarlinSettings::postprocess() {
     if (!eeprom_error) {
       const int eeprom_size = eeprom_index;
 
-      const uint16_t tcrc = working_crc;
+      const uint16_t final_crc = working_crc;
 
       // Write the EEPROM header
       eeprom_index = EEPROM_OFFSET;
 
       EEPROM_WRITE(version);
-      EEPROM_WRITE(tcrc);
+      EEPROM_WRITE(final_crc);
 
       // Report storage size
       SERIAL_ECHO_START;
       SERIAL_ECHOPAIR("Settings Stored (", eeprom_size - (EEPROM_OFFSET));
-      SERIAL_ECHOPAIR(" bytes; crc ", tcrc);
+      SERIAL_ECHOPAIR(" bytes; crc ", final_crc);
       SERIAL_ECHOLNPGM(")");
     }
 
@@ -1066,7 +1066,7 @@ void MarlinSettings::postprocess() {
 
         // Write crc to MAT along with other data, or just tack on to the beginning or end
 
-        SERIAL_PROTOCOLPAIR("Mesh saved in slot ", slot);
+        SERIAL_PROTOCOLLNPAIR("Mesh saved in slot ", slot);
 
       #else
 
@@ -1093,7 +1093,7 @@ void MarlinSettings::postprocess() {
 
         // Compare crc with crc from MAT, or read from end
 
-        SERIAL_PROTOCOLPAIR("Mesh loaded from slot ", slot);
+        SERIAL_PROTOCOLLNPAIR("Mesh loaded from slot ", slot);
 
       #else
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -378,6 +378,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -370,6 +370,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -365,6 +365,8 @@
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // minimum feedrate
 #define DEFAULT_MINTRAVELFEEDRATE     0.0
 
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+
 // @section lcd
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -307,7 +307,7 @@
   static int g29_verbose_level, phase_value, repetition_cnt,
              storage_slot = 0, map_type, grid_size;
   static bool repeat_flag, c_flag, x_flag, y_flag;
-  static float x_pos, y_pos, measured_z, card_thickness = 0.0, ubl_constant = 0.0;
+  static float x_pos, y_pos, card_thickness = 0.0, ubl_constant = 0.0;
 
   extern void lcd_setstatus(const char* message, const bool persist);
   extern void lcd_setstatuspgm(const char* message, const uint8_t level);
@@ -1026,7 +1026,6 @@
 
     if (do_ubl_mesh_map) ubl.display_map(map_type);
 
-    LEAVE:
     ubl.restore_ubl_active_state_and_leave();
     KEEPALIVE_STATE(IN_HANDLER);
     do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1858,7 +1858,6 @@ void kill_screen(const char* lcd_msg) {
      * UBL Build Mesh submenu
      */
     void _lcd_ubl_build_mesh() {
-      int GRID_NUM_POINTS = GRID_MAX_POINTS;
       START_MENU();
       MENU_BACK(MSG_UBL_TOOLS);
       #if (WATCH_THE_BED)


### PR DESCRIPTION
- fix broken `M421` due to less-than-careful over-optimization
- add HOME_AFTER_DEACTIVATE define to advanced config so not everyone has to rehome after steppers are deactivated
- misc. cleanups (remove unused label, unused variables)

Ref #6772