### PR TITLE
Tweak Azteeg X3 PRO _pins.h so Viki2 will work for those without a case light

### DIFF
--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -144,9 +144,11 @@
 //
 // Misc. Functions
 //
-#undef DOGLCD_A0            // steal pin 44 for the case light
-#define DOGLCD_A0      57
 #if ENABLED(OK_TO_CHANGE_CASE_LIGHT)
+  #undef DOGLCD_A0            // steal pin 44 for the case light; if you have a Viki2 and have connected it
+  #define DOGLCD_A0      57   // following the Panucatt wiring diagram, you may need to tweak these pin assignments
+                              // as the wiring diagram uses pin 44 for DOGLCD_A0
+
   #undef CASE_LIGHT_PIN
   #define CASE_LIGHT_PIN 44    // must have a hardware PWM
 #endif


### PR DESCRIPTION
- add comment explaining that the Panucatt Viki2 wiring diagram uses pin 44

Ref #6772.