### PR TITLE
Clip status message on LCD character displays

### DIFF
--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -795,7 +795,9 @@ static void lcd_implementation_status_screen() {
 
   #endif // FILAMENT_LCD_DISPLAY && SDSUPPORT
 
-  lcd_print(lcd_status_message);
+  char status_message[LCD_WIDTH + 1];
+  strlcpy(status_message, lcd_status_message, sizeof(status_message));
+  lcd_print(status_message);
 }
 
 #if ENABLED(ULTIPANEL)


### PR DESCRIPTION
The lcd_status_message can contain a string that is 3 * LCD_WIDTH, which is fine for full-screen messages, but can cause the text in the normal status messages displayed on the last line of a character display to wrap around to the first line, overlapping the temperature displays. This PR clips the status message that is displayed in the last line to prevent it from wrapping.