### PR TITLE
M355 case light improvements (replaces PR #5685)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 35
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -233,13 +233,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -225,13 +225,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -220,13 +220,19 @@
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED   255  // == full speed
 
-// Define a pin to turn case light on/off
-//#define CASE_LIGHT_PIN 4
-#if PIN_EXISTS(CASE_LIGHT)
-  #define INVERT_CASE_LIGHT false   // Set to true if HIGH is the OFF state (active low)
-  //#define CASE_LIGHT_DEFAULT_ON   // Uncomment to set default state to on
-  //#define MENU_ITEM_CASE_LIGHT    // Uncomment to have a Case Light On / Off entry in main menu
-#endif
+// M355 Case Light command 
+//   Set case light brightness/on/off
+
+//#define CASE_LIGHT_ENABLE 
+#if ENABLED(CASE_LIGHT_ENABLE) 
+  #define CASE_LIGHT_PIN 4          // can be defined here or in the pins_XXX.h file for your board 
+                                    //  pins_XXX.h file overrides this one 
+  #define INVERT_CASE_LIGHT false             // set to true if case light is ON when pin is at 0 
+  #define CASE_LIGHT_DEFAULT_ON true          // set default power up state to on or off
+  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // set power up brightness 0-255 ( only used if on PWM
+                                              // and if CASE_LIGHT_DEFAULT is set to on
+  //#define MENU_ITEM_CASE_LIGHT              // Uncomment to have a Case Light entry in main menu 
+#endif 
 
 //===========================================================================
 //============================ Mechanical Settings ==========================

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -26,10 +26,11 @@
  * Contributed by Triffid_Hunter. Modified by Kliment and the Marlin team.
  */
 
-#ifndef _FASTIO_ARDUINO_H 
+#ifndef _FASTIO_ARDUINO_H
 #define _FASTIO_ARDUINO_H
 
 #include <avr/io.h>
+#include "macros.h"
 
 /**
  * Enable this option to use Teensy++ 2.0 assignments for AT90USB processors.
@@ -237,5 +238,94 @@ typedef enum {
 #define SET_FOCA(T,V) SET_FOC(T,A,V)
 #define SET_FOCB(T,V) SET_FOC(T,B,V)
 #define SET_FOCC(T,V) SET_FOC(T,C,V)
+
+
+/**
+ * PWM availability macros
+ */
+#define AVR_AT90USB1286_FAMILY (defined(__AVR_AT90USB1287__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1286P__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB646P__)  || defined(__AVR_AT90USB647__))
+#define AVR_ATmega1284_FAMILY (defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__))
+#define AVR_ATmega2560_FAMILY (defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__))
+#define AVR_ATmega2561_FAMILY (defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__))
+#define AVR_ATmega328_FAMILY (defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328p__))
+
+//find out which harware PWMs are already in use
+#if PIN_EXISTS(CONTROLLER_FAN)
+  #define PWM_CHK_FAN_B(p) (p == CONTROLLER_FAN_PIN || p == E0_AUTO_FAN_PIN || p ==  E1_AUTO_FAN_PIN || p ==  E2_AUTO_FAN_PIN || p ==  E3_AUTO_FAN_PIN || p ==  E4_AUTO_FAN_PIN)
+#else
+  #define PWM_CHK_FAN_B(p) (p == E0_AUTO_FAN_PIN || p ==  E1_AUTO_FAN_PIN || p ==  E2_AUTO_FAN_PIN || p ==  E3_AUTO_FAN_PIN || p ==  E4_AUTO_FAN_PIN)
+#endif
+
+#if PIN_EXISTS(FAN) || PIN_EXISTS(FAN1) || PIN_EXISTS(FAN2)
+  #if PIN_EXISTS(FAN2)
+    #define PWM_CHK_FAN_A(p) (p == FAN_PIN || p == FAN1_PIN || p == FAN2_PIN)
+  #elif PIN_EXISTS(FAN1)
+    #define PWM_CHK_FAN_A(p) (p == FAN_PIN || p == FAN1_PIN)
+  #else
+    #define PWM_CHK_FAN_A(p) p == FAN_PIN
+  #endif
+#else
+  #define PWM_CHK_FAN_A(p) false
+#endif
+
+#if HAS_MOTOR_CURRENT_PWM
+  #if PIN_EXISTS(MOTOR_CURRENT_PWM_XY)
+    #define PWM_CHK_MOTOR_CURRENT(p) (p == MOTOR_CURRENT_PWM_E || p == MOTOR_CURRENT_PWM_Z || p == MOTOR_CURRENT_PWM_XY)
+  #elif PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
+    #define PWM_CHK_MOTOR_CURRENT(p) (p == MOTOR_CURRENT_PWM_E || p == MOTOR_CURRENT_PWM_Z)
+  #else
+    #define PWM_CHK_MOTOR_CURRENT(p) (p == MOTOR_CURRENT_PWM_E)
+  #endif
+#else
+  #define PWM_CHK_MOTOR_CURRENT(p) false
+#endif
+
+#if defined(NUM_SERVOS)
+  #if AVR_ATmega2560_FAMILY
+    #define PWM_CHK_SERVO(p) ( p == 5 || NUM_SERVOS > 12 && p == 6 || NUM_SERVOS > 24 && p == 46)  //PWMS 3A, 4A & 5A
+  #elif AVR_ATmega2561_FAMILY
+    #define PWM_CHK_SERVO(p)   p ==  5  //PWM3A
+  #elif AVR_ATmega1284_FAMILY
+    #define PWM_CHK_SERVO(p)   false
+  #elif AVR_AT90USB1286_FAMILY
+    #define PWM_CHK_SERVO(p)   p ==  16 //PWM3A
+  #elif AVR_ATmega328_FAMILY
+    #define PWM_CHK_SERVO(p)   false
+  #endif
+#else
+  #define PWM_CHK_SERVO(p) false
+#endif
+
+#if ENABLED(BARICUDA)
+  #if HAS_HEATER_1 && HAS_HEATER_2
+    #define PWM_CHK_HEATER(p) (p == HEATER_1_PIN || p == HEATER_2_PIN)
+  #elif HAS_HEATER_1
+    #define PWM_CHK_HEATER(p) (p == HEATER_1_PIN)
+  #endif
+#else
+    #define PWM_CHK_HEATER(p) false
+#endif
+
+#define PWM_CHK(p) (PWM_CHK_HEATER(p) || PWM_CHK_SERVO(p)  || PWM_CHK_MOTOR_CURRENT(p)\
+                     || PWM_CHK_FAN_A(p) || PWM_CHK_FAN_B(p))
+
+// define which hardware PWMs are available for the current CPU
+// all timer 1 PWMS deleted from this list because they are never available
+#if AVR_ATmega2560_FAMILY
+  #define PWM_PINS(p)  ((p >= 2 && p <= 10 ) || p ==  13 || p ==  44 || p ==  45 || p ==  46 )
+#elif AVR_ATmega2561_FAMILY
+  #define PWM_PINS(p)  ((p >= 2 && p <= 6 ) || p ==  9)
+#elif AVR_ATmega1284_FAMILY
+  #define PWM_PINS(p)  (p == 3 || p ==  4 || p ==  14 || p ==  15)
+#elif AVR_AT90USB1286_FAMILY
+  #define PWM_PINS(p)  (p == 0 || p ==  1 || p ==  14 || p ==  15 || p ==  16 || p ==  24)
+#elif AVR_ATmega328_FAMILY
+  #define PWM_PINS(p)  (p == 3 || p ==  5 || p ==  6 || p ==  11)
+#else
+  #error "unknown CPU"
+#endif
+
+// finally - the macro that tells us if a pin is an available hardware PWM
+#define USEABLE_HARDWARE_PWM(p) (PWM_PINS(p) && !PWM_CHK(p))
 
 #endif // _FASTIO_ARDUINO_H

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -706,7 +706,9 @@
 #ifndef MSG_CASE_LIGHT
   #define MSG_CASE_LIGHT                      _UxGT("Case light")
 #endif
-
+#ifndef MSG_CASE_LIGHT_BRIGHTNESS
+  #define MSG_CASE_LIGHT_BRIGHTNESS           _UxGT("Light BRIGHTNESS")
+#endif
 #if LCD_WIDTH >= 20
   #ifndef MSG_INFO_PRINT_COUNT
     #define MSG_INFO_PRINT_COUNT              _UxGT("Print Count")

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -60,6 +60,7 @@ int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2
 
 uint8_t lcd_status_message_level;
 char lcd_status_message[3 * (LCD_WIDTH) + 1] = WELCOME_MSG; // worst case is kana with up to 3*LCD_WIDTH+1
+
 #if ENABLED(STATUS_MESSAGE_SCROLLING)
   uint8_t status_scroll_pos = 0;
 #endif
@@ -726,6 +727,24 @@ void kill_screen(const char* lcd_msg) {
 
   #endif // SDSUPPORT
 
+  #if ENABLED(MENU_ITEM_CASE_LIGHT)
+
+    extern int case_light_brightness;
+    extern bool case_light_on;
+    extern void update_case_light();
+
+    void case_light_menu() {
+      START_MENU();
+      //
+      // ^ Main
+      //
+      MENU_BACK(MSG_MAIN);
+      MENU_ITEM_EDIT_CALLBACK(int3, MSG_CASE_LIGHT_BRIGHTNESS, &case_light_brightness, 0, 255, update_case_light, true);
+      MENU_ITEM_EDIT_CALLBACK(bool, MSG_CASE_LIGHT, (bool*)&case_light_on, update_case_light);
+      END_MENU();
+    }
+  #endif // MENU_ITEM_CASE_LIGHT
+
   #if ENABLED(BLTOUCH)
 
     /**
@@ -847,11 +866,6 @@ void kill_screen(const char* lcd_msg) {
    *
    */
 
-  #if ENABLED(MENU_ITEM_CASE_LIGHT)
-    extern bool case_light_on;
-    extern void update_case_light();
-  #endif
-
   void lcd_main_menu() {
     START_MENU();
     MENU_BACK(MSG_WATCH);
@@ -868,10 +882,14 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     //
-    // Switch case light on/off
+    // Set Case light on/off/brightness
     //
     #if ENABLED(MENU_ITEM_CASE_LIGHT)
-      MENU_ITEM_EDIT_CALLBACK(bool, MSG_CASE_LIGHT, &case_light_on, update_case_light);
+      if (USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN)) {
+        MENU_ITEM(submenu, MSG_CASE_LIGHT, case_light_menu);
+      }
+      else
+        MENU_ITEM_EDIT_CALLBACK(bool, MSG_CASE_LIGHT, (bool*)&case_light_on, update_case_light);
     #endif
 
     if (planner.movesplanned() || IS_SD_PRINTING) {
@@ -1847,7 +1865,7 @@ void kill_screen(const char* lcd_msg) {
      */
     void _lcd_ubl_validate_custom_mesh() {
       char UBL_LCD_GCODE[24];
-      const int temp = 
+      const int temp =
         #if WATCH_THE_BED
           custom_bed_temp
         #else
@@ -2598,7 +2616,7 @@ void kill_screen(const char* lcd_msg) {
     MENU_ITEM(submenu, MSG_FILAMENT, lcd_control_filament_menu);
 
     #if HAS_LCD_CONTRAST
-      MENU_ITEM_EDIT_CALLBACK(int3, MSG_CONTRAST, &lcd_contrast, LCD_CONTRAST_MIN, LCD_CONTRAST_MAX, lcd_callback_set_contrast, true);
+      MENU_ITEM_EDIT_CALLBACK(int3, MSG_CONTRAST, (int) &lcd_contrast, LCD_CONTRAST_MIN, LCD_CONTRAST_MAX, lcd_callback_set_contrast, true);
     #endif
     #if ENABLED(FWRETRACT)
       MENU_ITEM(submenu, MSG_RETRACT, lcd_control_retract_menu);

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -59,7 +59,7 @@
 
   #if ENABLED(DOGLCD)
     extern uint16_t lcd_contrast;
-    void set_lcd_contrast(uint16_t value);
+    void set_lcd_contrast(const uint16_t value);
   #elif ENABLED(SHOW_BOOTSCREEN)
     void bootscreen();
   #endif


### PR DESCRIPTION
This PR is a 1.1x version of PR #5685.

Initial load is just of the functional files.  The Configuration_adv.h changes will be uploaded shortly.

This code has not been tested.  

----

This code currently is modelled after the M42 command:
M355 Sxxx - xxx varies from 0-255, on/off for digital pins is 127/128

There have been discussions about using the following methods:
1. M42 system - one parameter (S) & on/off for digital at 127/128
2. Two parameters - S is Boolean, P overrides & decision is at 127/128
3. Two parameters - S is Boolean, P overrides & decision is at 0/1