### PR TITLE
Constrain LCD status message rendering

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2507,9 +2507,12 @@ void kill_screen(const char* lcd_msg) {
     #if ENABLED(EEPROM_SETTINGS)
       MENU_ITEM(function, MSG_STORE_EEPROM, lcd_store_settings);
       MENU_ITEM(function, MSG_LOAD_EEPROM, lcd_load_settings);
-      MENU_ITEM(function, MSG_RESTORE_FAILSAFE, lcd_factory_settings);
+    #endif
+    MENU_ITEM(function, MSG_RESTORE_FAILSAFE, lcd_factory_settings);
+    #if ENABLED(EEPROM_SETTINGS)
       MENU_ITEM(gcode, MSG_INIT_EEPROM, PSTR("M502\nM500")); // TODO: Add "Are You Sure?" step
     #endif
+
     END_MENU();
   }
 

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -634,7 +634,8 @@ static void lcd_implementation_status_screen() {
 
     #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
       if (PENDING(millis(), previous_lcd_status_ms + 5000UL)) {  //Display both Status message line and Filament display on the last line
-        lcd_print(lcd_status_message);
+        const char *str = lcd_status_message;
+        for (uint8_t i = 0; char c = str[i] && i < LCD_WIDTH; ++i) lcd_print(c);
       }
       else {
         lcd_printPGM(PSTR(LCD_STR_FILAM_DIA));
@@ -646,7 +647,8 @@ static void lcd_implementation_status_screen() {
         u8g.print('%');
       }
     #else
-      lcd_print(lcd_status_message);
+      const char *str = lcd_status_message;
+      for (uint8_t i = 0; char c = str[i] && i < LCD_WIDTH; ++i) lcd_print(c);
     #endif
   }
 }

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -635,7 +635,9 @@ static void lcd_implementation_status_screen() {
     #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
       if (PENDING(millis(), previous_lcd_status_ms + 5000UL)) {  //Display both Status message line and Filament display on the last line
         const char *str = lcd_status_message;
-        for (uint8_t i = 0; char c = str[i] && i < LCD_WIDTH; ++i) lcd_print(c);
+        uint8_t i = LCD_WIDTH;
+        char c;
+        while (i-- && (c = *str++)) lcd_print(c);
       }
       else {
         lcd_printPGM(PSTR(LCD_STR_FILAM_DIA));
@@ -648,7 +650,9 @@ static void lcd_implementation_status_screen() {
       }
     #else
       const char *str = lcd_status_message;
-      for (uint8_t i = 0; char c = str[i] && i < LCD_WIDTH; ++i) lcd_print(c);
+      uint8_t i = LCD_WIDTH;
+      char c;
+      while (i-- && (c = *str++)) lcd_print(c);
     #endif
   }
 }

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -386,10 +386,10 @@ void lcd_printPGM(const char *str) {
 }
 
 void lcd_print(const char* const str) {
-  for (uint8_t i = 0; char c = str[i]; ++i) charset_mapper(c);
+  for (uint8_t i = 0; const char c = str[i]; ++i) charset_mapper(c);
 }
 
-void lcd_print(char c) { charset_mapper(c); }
+void lcd_print(const char c) { charset_mapper(c); }
 
 #if ENABLED(SHOW_BOOTSCREEN)
 
@@ -796,7 +796,9 @@ static void lcd_implementation_status_screen() {
   #endif // FILAMENT_LCD_DISPLAY && SDSUPPORT
 
   const char *str = lcd_status_message;
-  for (uint8_t i = 0; char c = str[i] && i < LCD_WIDTH; ++i) lcd_print(c);
+  uint8_t i = LCD_WIDTH;
+  char c;
+  while (i-- && (c = *str++)) lcd_print(c);
 }
 
 #if ENABLED(ULTIPANEL)

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -795,7 +795,8 @@ static void lcd_implementation_status_screen() {
 
   #endif // FILAMENT_LCD_DISPLAY && SDSUPPORT
 
-  lcd_print(lcd_status_message);
+  const char *str = lcd_status_message;
+  for (uint8_t i = 0; char c = str[i] && i < LCD_WIDTH; ++i) lcd_print(c);
 }
 
 #if ENABLED(ULTIPANEL)


### PR DESCRIPTION
Prevent an over-long status message from making a mess of the screen, and open the door to scrolling status messages.

Reference: #6794