### PR TITLE
missing enable for M605 for duplication mode

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10676,7 +10676,7 @@ void process_next_command() {
           break;
       #endif // FILAMENT_CHANGE_FEATURE
 
-      #if ENABLED(DUAL_X_CARRIAGE)
+      #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
         case 605: // M605: Set Dual X Carriage movement mode
           gcode_M605();
           break;


### PR DESCRIPTION
I believe `gcode_M605` will not be called when using `DUAL_NOZZLE_DUPLICATION_MODE` without this change.

This is my first time contributing.  Please let me know if I did anything wrong.