### PR TITLE
Make UBL a complete singleton

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -135,54 +135,44 @@
   float code_value_axis_units(const AxisEnum axis);
   bool code_value_bool();
   bool code_has_value();
-  void lcd_init();
-  void lcd_setstatuspgm(const char* const message, const uint8_t level);
   void sync_plan_position_e();
   void chirp_at_user();
 
   // Private functions
 
-  void un_retract_filament(float where[XYZE]);
-  void retract_filament(float where[XYZE]);
-  bool look_for_lines_to_connect();
-  bool parse_G26_parameters();
-  void move_to(const float&, const float&, const float&, const float&) ;
-  void print_line_from_here_to_there(const float&, const float&, const float&, const float&, const float&, const float&);
-  bool turn_on_heaters();
-  bool prime_nozzle();
-
   static uint16_t circle_flags[16], horizontal_mesh_line_flags[16], vertical_mesh_line_flags[16];
   float g26_e_axis_feedrate = 0.020,
-        random_deviation = 0.0,
-        layer_height = LAYER_HEIGHT;
+        random_deviation = 0.0;
 
   static bool g26_retracted = false; // Track the retracted state of the nozzle so mismatched
                                      // retracts/recovers won't result in a bad state.
 
   float valid_trig_angle(float);
-  mesh_index_pair find_closest_circle_to_print(const float&, const float&);
 
-  static float extrusion_multiplier = EXTRUSION_MULTIPLIER,
-               retraction_multiplier = RETRACTION_MULTIPLIER,
-               nozzle = NOZZLE,
-               filament_diameter = FILAMENT,
-               prime_length = PRIME_LENGTH,
-               x_pos, y_pos,
-               ooze_amount = OOZE_AMOUNT;
+  float unified_bed_leveling::g26_extrusion_multiplier,
+        unified_bed_leveling::g26_retraction_multiplier,
+        unified_bed_leveling::g26_nozzle,
+        unified_bed_leveling::g26_filament_diameter,
+        unified_bed_leveling::g26_layer_height,
+        unified_bed_leveling::g26_prime_length,
+        unified_bed_leveling::g26_x_pos,
+        unified_bed_leveling::g26_y_pos,
+        unified_bed_leveling::g26_ooze_amount;
 
-  static int16_t bed_temp = BED_TEMP,
-                 hotend_temp = HOTEND_TEMP;
+  int16_t unified_bed_leveling::g26_bed_temp,
+          unified_bed_leveling::g26_hotend_temp;
 
-  static int8_t prime_flag = 0;
+  int8_t unified_bed_leveling::g26_prime_flag;
 
-  static bool continue_with_closest, keep_heaters_on;
+  bool unified_bed_leveling::g26_continue_with_closest,
+       unified_bed_leveling::g26_keep_heaters_on;
 
-  static int16_t g26_repeats;
+  int16_t unified_bed_leveling::g26_repeats;
 
-  void G26_line_to_destination(const float &feed_rate) {
+  void unified_bed_leveling::G26_line_to_destination(const float &feed_rate) {
     const float save_feedrate = feedrate_mm_s;
     feedrate_mm_s = feed_rate;      // use specified feed rate
-    prepare_move_to_destination();  // will ultimately call ubl_line_to_destination_cartesian or ubl_prepare_linear_move_to for UBL_DELTA
+    prepare_move_to_destination();  // will ultimately call ubl.line_to_destination_cartesian or ubl.prepare_linear_move_to for UBL_DELTA
     feedrate_mm_s = save_feedrate;  // restore global feed rate
   }
 
@@ -216,7 +206,7 @@
    * Used to interactively edit UBL's Mesh by placing the
    * nozzle in a problem area and doing a G29 P4 R command.
    */
-  void gcode_G26() {
+  void unified_bed_leveling::G26() {
     SERIAL_ECHOLNPGM("G26 command started.  Waiting for heater(s).");
     float tmp, start_angle, end_angle;
     int   i, xi, yi;
@@ -237,7 +227,7 @@
     current_position[E_AXIS] = 0.0;
     sync_plan_position_e();
 
-    if (prime_flag && prime_nozzle()) goto LEAVE;
+    if (g26_prime_flag && prime_nozzle()) goto LEAVE;
 
     /**
      *  Bed is preheated
@@ -255,11 +245,11 @@
 
     // Move nozzle to the specified height for the first layer
     set_destination_to_current();
-    destination[Z_AXIS] = layer_height;
+    destination[Z_AXIS] = g26_layer_height;
     move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 0.0);
-    move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], ooze_amount);
+    move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], g26_ooze_amount);
 
-    ubl.has_control_of_lcd_panel = true;
+    has_control_of_lcd_panel = true;
     //debug_current_and_destination(PSTR("Starting G26 Mesh Validation Pattern."));
 
     /**
@@ -273,13 +263,13 @@
     }
 
     do {
-      location = continue_with_closest
+      location = g26_continue_with_closest
         ? find_closest_circle_to_print(current_position[X_AXIS], current_position[Y_AXIS])
-        : find_closest_circle_to_print(x_pos, y_pos); // Find the closest Mesh Intersection to where we are now.
+        : find_closest_circle_to_print(g26_x_pos, g26_y_pos); // Find the closest Mesh Intersection to where we are now.
 
       if (location.x_index >= 0 && location.y_index >= 0) {
-        const float circle_x = pgm_read_float(&ubl.mesh_index_to_xpos[location.x_index]),
-                    circle_y = pgm_read_float(&ubl.mesh_index_to_ypos[location.y_index]);
+        const float circle_x = mesh_index_to_xpos(location.x_index),
+                    circle_y = mesh_index_to_ypos(location.y_index);
 
         // If this mesh location is outside the printable_radius, skip it.
 
@@ -288,7 +278,7 @@
         xi = location.x_index;  // Just to shrink the next few lines and make them easier to understand
         yi = location.y_index;
 
-        if (ubl.g26_debug_flag) {
+        if (g26_debug_flag) {
           SERIAL_ECHOPAIR("   Doing circle at: (xi=", xi);
           SERIAL_ECHOPAIR(", yi=", yi);
           SERIAL_CHAR(')');
@@ -344,7 +334,7 @@
             ye = constrain(ye, Y_MIN_POS + 1, Y_MAX_POS - 1);
           #endif
 
-          //if (ubl.g26_debug_flag) {
+          //if (g26_debug_flag) {
           //  char ccc, *cptr, seg_msg[50], seg_num[10];
           //  strcpy(seg_msg, "   segment: ");
           //  strcpy(seg_num, "    \n");
@@ -355,7 +345,7 @@
           //  debug_current_and_destination(seg_msg);
           //}
 
-          print_line_from_here_to_there(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y), layer_height, LOGICAL_X_POSITION(xe), LOGICAL_Y_POSITION(ye), layer_height);
+          print_line_from_here_to_there(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y), g26_layer_height, LOGICAL_X_POSITION(xe), LOGICAL_Y_POSITION(ye), g26_layer_height);
 
         }
         if (look_for_lines_to_connect())
@@ -374,16 +364,16 @@
     move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 0); // Raise the nozzle
     //debug_current_and_destination(PSTR("done doing Z-Raise."));
 
-    destination[X_AXIS] = x_pos;                                               // Move back to the starting position
-    destination[Y_AXIS] = y_pos;
+    destination[X_AXIS] = g26_x_pos;                                               // Move back to the starting position
+    destination[Y_AXIS] = g26_y_pos;
     //destination[Z_AXIS] = Z_CLEARANCE_BETWEEN_PROBES;                        // Keep the nozzle where it is
 
     move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], 0); // Move back to the starting position
     //debug_current_and_destination(PSTR("done doing X/Y move."));
 
-    ubl.has_control_of_lcd_panel = false;     // Give back control of the LCD Panel!
+    has_control_of_lcd_panel = false;     // Give back control of the LCD Panel!
 
-    if (!keep_heaters_on) {
+    if (!g26_keep_heaters_on) {
       #if HAS_TEMP_BED
         thermalManager.setTargetBed(0);
       #endif
@@ -391,14 +381,13 @@
     }
   }
 
-
   float valid_trig_angle(float d) {
     while (d > 360.0) d -= 360.0;
     while (d < 0.0) d += 360.0;
     return d;
   }
 
-  mesh_index_pair find_closest_circle_to_print(const float &X, const float &Y) {
+  mesh_index_pair unified_bed_leveling::find_closest_circle_to_print(const float &X, const float &Y) {
     float closest = 99999.99;
     mesh_index_pair return_val;
 
@@ -407,8 +396,8 @@
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
       for (uint8_t j = 0; j < GRID_MAX_POINTS_Y; j++) {
         if (!is_bit_set(circle_flags, i, j)) {
-          const float mx = pgm_read_float(&ubl.mesh_index_to_xpos[i]),  // We found a circle that needs to be printed
-                      my = pgm_read_float(&ubl.mesh_index_to_ypos[j]);
+          const float mx = mesh_index_to_xpos(i),  // We found a circle that needs to be printed
+                      my = mesh_index_to_ypos(j);
 
           // Get the distance to this intersection
           float f = HYPOT(X - mx, Y - my);
@@ -417,7 +406,7 @@
           // to let us find the closest circle to the start position.
           // But if this is not the case, add a small weighting to the
           // distance calculation to help it choose a better place to continue.
-          f += HYPOT(x_pos - mx, y_pos - my) / 15.0;
+          f += HYPOT(g26_x_pos - mx, g26_y_pos - my) / 15.0;
 
           // Add in the specified amount of Random Noise to our search
           if (random_deviation > 1.0)
@@ -436,7 +425,7 @@
     return return_val;
   }
 
-  bool look_for_lines_to_connect() {
+  bool unified_bed_leveling::look_for_lines_to_connect() {
     float sx, sy, ex, ey;
 
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
@@ -454,16 +443,16 @@
               // We found two circles that need a horizontal line to connect them
               // Print it!
               //
-              sx = pgm_read_float(&ubl.mesh_index_to_xpos[  i  ]) + (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // right edge
-              ex = pgm_read_float(&ubl.mesh_index_to_xpos[i + 1]) - (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // left edge
+              sx = mesh_index_to_xpos(  i  ) + (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // right edge
+              ex = mesh_index_to_xpos(i + 1) - (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // left edge
 
               sx = constrain(sx, X_MIN_POS + 1, X_MAX_POS - 1);
-              sy = ey = constrain(pgm_read_float(&ubl.mesh_index_to_ypos[j]), Y_MIN_POS + 1, Y_MAX_POS - 1);
+              sy = ey = constrain(mesh_index_to_ypos(j), Y_MIN_POS + 1, Y_MAX_POS - 1);
               ex = constrain(ex, X_MIN_POS + 1, X_MAX_POS - 1);
 
               if (position_is_reachable_raw_xy(sx, sy) && position_is_reachable_raw_xy(ex, ey)) {
 
-                if (ubl.g26_debug_flag) {
+                if (g26_debug_flag) {
                   SERIAL_ECHOPAIR(" Connecting with horizontal line (sx=", sx);
                   SERIAL_ECHOPAIR(", sy=", sy);
                   SERIAL_ECHOPAIR(") -> (ex=", ex);
@@ -473,7 +462,7 @@
                   //debug_current_and_destination(PSTR("Connecting horizontal line."));
                 }
 
-                print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), layer_height);
+                print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), g26_layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), g26_layer_height);
               }
               bit_set(horizontal_mesh_line_flags, i, j);   // Mark it as done so we don't do it again, even if we skipped it
             }
@@ -488,16 +477,16 @@
                 // We found two circles that need a vertical line to connect them
                 // Print it!
                 //
-                sy = pgm_read_float(&ubl.mesh_index_to_ypos[  j  ]) + (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // top edge
-                ey = pgm_read_float(&ubl.mesh_index_to_ypos[j + 1]) - (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // bottom edge
+                sy = mesh_index_to_ypos(  j  ) + (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // top edge
+                ey = mesh_index_to_ypos(j + 1) - (SIZE_OF_INTERSECTION_CIRCLES - (SIZE_OF_CROSSHAIRS)); // bottom edge
 
-                sx = ex = constrain(pgm_read_float(&ubl.mesh_index_to_xpos[i]), X_MIN_POS + 1, X_MAX_POS - 1);
+                sx = ex = constrain(mesh_index_to_xpos(i), X_MIN_POS + 1, X_MAX_POS - 1);
                 sy = constrain(sy, Y_MIN_POS + 1, Y_MAX_POS - 1);
                 ey = constrain(ey, Y_MIN_POS + 1, Y_MAX_POS - 1);
 
                 if (position_is_reachable_raw_xy(sx, sy) && position_is_reachable_raw_xy(ex, ey)) {
 
-                  if (ubl.g26_debug_flag) {
+                  if (g26_debug_flag) {
                     SERIAL_ECHOPAIR(" Connecting with vertical line (sx=", sx);
                     SERIAL_ECHOPAIR(", sy=", sy);
                     SERIAL_ECHOPAIR(") -> (ex=", ex);
@@ -506,7 +495,7 @@
                     SERIAL_EOL;
                     debug_current_and_destination(PSTR("Connecting vertical line."));
                   }
-                  print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), layer_height);
+                  print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), g26_layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), g26_layer_height);
                 }
                 bit_set(vertical_mesh_line_flags, i, j);   // Mark it as done so we don't do it again, even if skipped
               }
@@ -518,7 +507,7 @@
     return false;
   }
 
-  void move_to(const float &x, const float &y, const float &z, const float &e_delta) {
+  void unified_bed_leveling::move_to(const float &x, const float &y, const float &z, const float &e_delta) {
     float feed_value;
     static float last_z = -999.99;
 
@@ -540,10 +529,10 @@
     }
 
     // Check if X or Y is involved in the movement.
-    // Yes: a 'normal' movement. No: a retract() or un_retract()
+    // Yes: a 'normal' movement. No: a retract() or recover()
     feed_value = has_xy_component ? PLANNER_XY_FEEDRATE() / 10.0 : planner.max_feedrate_mm_s[E_AXIS] / 1.5;
 
-    if (ubl.g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to() feed_value for XY:", feed_value);
+    if (g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to() feed_value for XY:", feed_value);
 
     destination[X_AXIS] = x;
     destination[Y_AXIS] = y;
@@ -556,16 +545,16 @@
 
   }
 
-  void retract_filament(float where[XYZE]) {
+  void unified_bed_leveling::retract_filament(float where[XYZE]) {
     if (!g26_retracted) { // Only retract if we are not already retracted!
       g26_retracted = true;
-      move_to(where[X_AXIS], where[Y_AXIS], where[Z_AXIS], -1.0 * retraction_multiplier);
+      move_to(where[X_AXIS], where[Y_AXIS], where[Z_AXIS], -1.0 * g26_retraction_multiplier);
     }
   }
 
-  void un_retract_filament(float where[XYZE]) {
+  void unified_bed_leveling::recover_filament(float where[XYZE]) {
     if (g26_retracted) { // Only un-retract if we are retracted.
-      move_to(where[X_AXIS], where[Y_AXIS], where[Z_AXIS], 1.2 * retraction_multiplier);
+      move_to(where[X_AXIS], where[Y_AXIS], where[Z_AXIS], 1.2 * g26_retraction_multiplier);
       g26_retracted = false;
     }
   }
@@ -585,7 +574,7 @@
    * segment of a 'circle'.   The time this requires is very short and is easily saved by the other
    * cases where the optimization comes into play.
    */
-  void print_line_from_here_to_there(const float &sx, const float &sy, const float &sz, const float &ex, const float &ey, const float &ez) {
+  void unified_bed_leveling::print_line_from_here_to_there(const float &sx, const float &sy, const float &sz, const float &ex, const float &ey, const float &ez) {
     const float dx_s = current_position[X_AXIS] - sx,   // find our distance from the start of the actual line segment
                 dy_s = current_position[Y_AXIS] - sy,
                 dist_start = HYPOT2(dx_s, dy_s),        // We don't need to do a sqrt(), we can compare the distance^2
@@ -613,9 +602,9 @@
 
     move_to(sx, sy, sz, 0.0); // Get to the starting point with no extrusion / un-Z bump
 
-    const float e_pos_delta = line_length * g26_e_axis_feedrate * extrusion_multiplier;
+    const float e_pos_delta = line_length * g26_e_axis_feedrate * g26_extrusion_multiplier;
 
-    un_retract_filament(destination);
+    recover_filament(destination);
     move_to(ex, ey, ez, e_pos_delta);  // Get to the ending point with an appropriate amount of extrusion
   }
 
@@ -624,33 +613,33 @@
    * parameters it made sense to turn them into static globals and get
    * this code out of sight of the main routine.
    */
-  bool parse_G26_parameters() {
+  bool unified_bed_leveling::parse_G26_parameters() {
 
-    extrusion_multiplier  = EXTRUSION_MULTIPLIER;
-    retraction_multiplier = RETRACTION_MULTIPLIER;
-    nozzle                = NOZZLE;
-    filament_diameter     = FILAMENT;
-    layer_height          = LAYER_HEIGHT;
-    prime_length          = PRIME_LENGTH;
-    bed_temp              = BED_TEMP;
-    hotend_temp           = HOTEND_TEMP;
-    prime_flag            = 0;
+    g26_extrusion_multiplier  = EXTRUSION_MULTIPLIER;
+    g26_retraction_multiplier = RETRACTION_MULTIPLIER;
+    g26_nozzle                = NOZZLE;
+    g26_filament_diameter     = FILAMENT;
+    g26_layer_height          = LAYER_HEIGHT;
+    g26_prime_length          = PRIME_LENGTH;
+    g26_bed_temp              = BED_TEMP;
+    g26_hotend_temp           = HOTEND_TEMP;
+    g26_prime_flag            = 0;
 
-    ooze_amount           = code_seen('O') && code_has_value() ? code_value_linear_units() : OOZE_AMOUNT;
-    keep_heaters_on       = code_seen('K') && code_value_bool();
-    continue_with_closest = code_seen('C') && code_value_bool();
+    g26_ooze_amount           = code_seen('O') && code_has_value() ? code_value_linear_units() : OOZE_AMOUNT;
+    g26_keep_heaters_on       = code_seen('K') && code_value_bool();
+    g26_continue_with_closest = code_seen('C') && code_value_bool();
 
     if (code_seen('B')) {
-      bed_temp = code_value_temp_abs();
-      if (!WITHIN(bed_temp, 15, 140)) {
+      g26_bed_temp = code_value_temp_abs();
+      if (!WITHIN(g26_bed_temp, 15, 140)) {
         SERIAL_PROTOCOLLNPGM("?Specified bed temperature not plausible.");
         return UBL_ERR;
       }
     }
 
     if (code_seen('L')) {
-      layer_height = code_value_linear_units();
-      if (!WITHIN(layer_height, 0.0, 2.0)) {
+      g26_layer_height = code_value_linear_units();
+      if (!WITHIN(g26_layer_height, 0.0, 2.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified layer height not plausible.");
         return UBL_ERR;
       }
@@ -658,8 +647,8 @@
 
     if (code_seen('Q')) {
       if (code_has_value()) {
-        retraction_multiplier = code_value_float();
-        if (!WITHIN(retraction_multiplier, 0.05, 15.0)) {
+        g26_retraction_multiplier = code_value_float();
+        if (!WITHIN(g26_retraction_multiplier, 0.05, 15.0)) {
           SERIAL_PROTOCOLLNPGM("?Specified Retraction Multiplier not plausible.");
           return UBL_ERR;
         }
@@ -671,8 +660,8 @@
     }
 
     if (code_seen('S')) {
-      nozzle = code_value_float();
-      if (!WITHIN(nozzle, 0.1, 1.0)) {
+      g26_nozzle = code_value_float();
+      if (!WITHIN(g26_nozzle, 0.1, 1.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified nozzle size not plausible.");
         return UBL_ERR;
       }
@@ -680,11 +669,11 @@
 
     if (code_seen('P')) {
       if (!code_has_value())
-        prime_flag = -1;
+        g26_prime_flag = -1;
       else {
-        prime_flag++;
-        prime_length = code_value_linear_units();
-        if (!WITHIN(prime_length, 0.0, 25.0)) {
+        g26_prime_flag++;
+        g26_prime_length = code_value_linear_units();
+        if (!WITHIN(g26_prime_length, 0.0, 25.0)) {
           SERIAL_PROTOCOLLNPGM("?Specified prime length not plausible.");
           return UBL_ERR;
         }
@@ -692,21 +681,21 @@
     }
 
     if (code_seen('F')) {
-      filament_diameter = code_value_linear_units();
-      if (!WITHIN(filament_diameter, 1.0, 4.0)) {
+      g26_filament_diameter = code_value_linear_units();
+      if (!WITHIN(g26_filament_diameter, 1.0, 4.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified filament size not plausible.");
         return UBL_ERR;
       }
     }
-    extrusion_multiplier *= sq(1.75) / sq(filament_diameter);         // If we aren't using 1.75mm filament, we need to
+    g26_extrusion_multiplier *= sq(1.75) / sq(g26_filament_diameter);         // If we aren't using 1.75mm filament, we need to
                                                                       // scale up or down the length needed to get the
                                                                       // same volume of filament
 
-    extrusion_multiplier *= filament_diameter * sq(nozzle) / sq(0.3); // Scale up by nozzle size
+    g26_extrusion_multiplier *= g26_filament_diameter * sq(g26_nozzle) / sq(0.3); // Scale up by nozzle size
 
     if (code_seen('H')) {
-      hotend_temp = code_value_temp_abs();
-      if (!WITHIN(hotend_temp, 165, 280)) {
+      g26_hotend_temp = code_value_temp_abs();
+      if (!WITHIN(g26_hotend_temp, 165, 280)) {
         SERIAL_PROTOCOLLNPGM("?Specified nozzle temperature not plausible.");
         return UBL_ERR;
       }
@@ -723,9 +712,9 @@
       return UBL_ERR;
     }
 
-    x_pos = code_seen('X') ? code_value_linear_units() : current_position[X_AXIS];
-    y_pos = code_seen('Y') ? code_value_linear_units() : current_position[Y_AXIS];
-    if (!position_is_reachable_xy(x_pos, y_pos)) {
+    g26_x_pos = code_seen('X') ? code_value_linear_units() : current_position[X_AXIS];
+    g26_y_pos = code_seen('Y') ? code_value_linear_units() : current_position[Y_AXIS];
+    if (!position_is_reachable_xy(g26_x_pos, g26_y_pos)) {
       SERIAL_PROTOCOLLNPGM("?Specified X,Y coordinate out of bounds.");
       return UBL_ERR;
     }
@@ -733,12 +722,12 @@
     /**
      * Wait until all parameters are verified before altering the state!
      */
-    ubl.state.active = !code_seen('D');
+    state.active = !code_seen('D');
 
     return UBL_OK;
   }
 
-  bool exit_from_g26() {
+  bool unified_bed_leveling::exit_from_g26() {
     lcd_reset_alert_level();
     lcd_setstatuspgm(PSTR("Leaving G26"));
     while (ubl_lcd_clicked()) idle();
@@ -749,18 +738,18 @@
    * Turn on the bed and nozzle heat and
    * wait for them to get up to temperature.
    */
-  bool turn_on_heaters() {
+  bool unified_bed_leveling::turn_on_heaters() {
     millis_t next;
     #if HAS_TEMP_BED
       #if ENABLED(ULTRA_LCD)
-        if (bed_temp > 25) {
+        if (g26_bed_temp > 25) {
           lcd_setstatuspgm(PSTR("G26 Heating Bed."), 99);
           lcd_quick_feedback();
       #endif
-          ubl.has_control_of_lcd_panel = true;
-          thermalManager.setTargetBed(bed_temp);
+          has_control_of_lcd_panel = true;
+          thermalManager.setTargetBed(g26_bed_temp);
           next = millis() + 5000UL;
-          while (abs(thermalManager.degBed() - bed_temp) > 3) {
+          while (abs(thermalManager.degBed() - g26_bed_temp) > 3) {
             if (ubl_lcd_clicked()) return exit_from_g26();
             if (PENDING(millis(), next)) {
               next = millis() + 5000UL;
@@ -776,8 +765,8 @@
     #endif
 
     // Start heating the nozzle and wait for it to reach temperature.
-    thermalManager.setTargetHotend(hotend_temp, 0);
-    while (abs(thermalManager.degHotend(0) - hotend_temp) > 3) {
+    thermalManager.setTargetHotend(g26_hotend_temp, 0);
+    while (abs(thermalManager.degHotend(0) - g26_hotend_temp) > 3) {
       if (ubl_lcd_clicked()) return exit_from_g26();
       if (PENDING(millis(), next)) {
         next = millis() + 5000UL;
@@ -798,19 +787,19 @@
   /**
    * Prime the nozzle if needed. Return true on error.
    */
-  bool prime_nozzle() {
+  bool unified_bed_leveling::prime_nozzle() {
     float Total_Prime = 0.0;
 
-    if (prime_flag == -1) {  // The user wants to control how much filament gets purged
+    if (g26_prime_flag == -1) {  // The user wants to control how much filament gets purged
 
-      ubl.has_control_of_lcd_panel = true;
+      has_control_of_lcd_panel = true;
 
       lcd_setstatuspgm(PSTR("User-Controlled Prime"), 99);
       chirp_at_user();
 
       set_destination_to_current();
 
-      un_retract_filament(destination); // Make sure G26 doesn't think the filament is retracted().
+      recover_filament(destination); // Make sure G26 doesn't think the filament is retracted().
 
       while (!ubl_lcd_clicked()) {
         chirp_at_user();
@@ -838,7 +827,7 @@
         lcd_quick_feedback();
       #endif
 
-      ubl.has_control_of_lcd_panel = false;
+      has_control_of_lcd_panel = false;
 
     }
     else {
@@ -847,7 +836,7 @@
         lcd_quick_feedback();
       #endif
       set_destination_to_current();
-      destination[E_AXIS] += prime_length;
+      destination[E_AXIS] += g26_prime_length;
       G26_line_to_destination(planner.max_feedrate_mm_s[E_AXIS] / 15.0);
       stepper.synchronize();
       set_destination_to_current();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3416,8 +3416,8 @@ inline void gcode_G7(
       return;
     }
 
-    destination[X_AXIS] = hasI ? pgm_read_float(&ubl.mesh_index_to_xpos[ix]) : current_position[X_AXIS];
-    destination[Y_AXIS] = hasJ ? pgm_read_float(&ubl.mesh_index_to_ypos[iy]) : current_position[Y_AXIS];
+    destination[X_AXIS] = hasI ? ubl.mesh_index_to_xpos(ix) : current_position[X_AXIS];
+    destination[Y_AXIS] = hasJ ? ubl.mesh_index_to_ypos(iy) : current_position[Y_AXIS];
     destination[Z_AXIS] = current_position[Z_AXIS]; //todo: perhaps add Z-move support?
     destination[E_AXIS] = current_position[E_AXIS];
 
@@ -8704,7 +8704,7 @@ void quickstop_stepper() {
     const bool hasZ = code_seen('Z'), hasQ = !hasZ && code_seen('Q');
 
     if (hasC) {
-      const mesh_index_pair location = find_closest_mesh_point_of_type(REAL, current_position[X_AXIS], current_position[Y_AXIS], USE_NOZZLE_AS_REFERENCE, NULL, false);
+      const mesh_index_pair location = ubl.find_closest_mesh_point_of_type(REAL, current_position[X_AXIS], current_position[Y_AXIS], USE_NOZZLE_AS_REFERENCE, NULL, false);
       ix = location.x_index;
       iy = location.y_index;
     }
@@ -11467,7 +11467,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       const float fr_scaled = MMS_SCALED(feedrate_mm_s);
       if (ubl.state.active) {
-        ubl_line_to_destination_cartesian(fr_scaled, active_extruder);
+        ubl.line_to_destination_cartesian(fr_scaled, active_extruder);
         return true;
       }
       else
@@ -11612,14 +11612,14 @@ void prepare_move_to_destination() {
   if (
     #if IS_KINEMATIC
       #if UBL_DELTA
-        ubl_prepare_linear_move_to(destination, feedrate_mm_s)
+        ubl.prepare_linear_move_to(destination, feedrate_mm_s)
       #else
         prepare_kinematic_move_to(destination)
       #endif
     #elif ENABLED(DUAL_X_CARRIAGE)
       prepare_move_to_destination_dualx()
     #elif UBL_DELTA // will work for CARTESIAN too (smaller segments follow mesh more closely)
-      ubl_prepare_linear_move_to(destination, feedrate_mm_s)
+      ubl.prepare_linear_move_to(destination, feedrate_mm_s)
     #else
       prepare_move_to_destination_cartesian()
     #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5107,9 +5107,9 @@ void home_all_axes() { gcode_G28(true); }
      *      P4-P7  Probe all positions at different locations and average them.
      *
      *   T   Don't calibrate tower angle corrections
-     *   
+     *
      *   Cn.nn Calibration precision; when omitted calibrates to maximum precision
-     *   
+     *
      *   Vn  Verbose level:
      *
      *      V0  Dry-run mode. Report settings and probe results. No calibration.
@@ -5229,7 +5229,7 @@ void home_all_axes() { gcode_G28(true); }
       #endif
 
       int8_t iterations = 0;
-      
+
       home_offset[Z_AXIS] -= probe_pt(0.0, 0.0 , true, 1); // 1st probe to set height
       do_probe_raise(Z_CLEARANCE_BETWEEN_PROBES);
 
@@ -5239,7 +5239,7 @@ void home_all_axes() { gcode_G28(true); }
         int16_t N = 0;
 
         test_precision = zero_std_dev_old != 999.0 ? (zero_std_dev + zero_std_dev_old) / 2 : zero_std_dev;
-        
+
         iterations++;
 
         // Probe the points
@@ -5286,7 +5286,7 @@ void home_all_axes() { gcode_G28(true); }
           }
         zero_std_dev_old = zero_std_dev;
         zero_std_dev = round(sqrt(S2 / N) * 1000.0) / 1000.0 + 0.00001;
-        
+
         if (iterations == 1) home_offset[Z_AXIS] = zh_old; // reset height after 1st probe change
 
         // Solve matrices
@@ -5416,7 +5416,7 @@ void home_all_axes() { gcode_G28(true); }
             else {
               SERIAL_PROTOCOLPGM("std dev:");
               SERIAL_PROTOCOL_F(zero_std_dev, 3);
-            }            
+            }
             SERIAL_EOL;
             LCD_MESSAGEPGM("Calibration OK"); // TODO: Make translatable string
           }
@@ -5481,7 +5481,7 @@ void home_all_axes() { gcode_G28(true); }
         home_delta();
         endstops.not_homing();
 
-      } 
+      }
       while (zero_std_dev < test_precision && zero_std_dev > calibration_precision && iterations < 31);
 
       #if ENABLED(DELTA_HOME_TO_SAFE_ZONE)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2355,7 +2355,7 @@ static void clean_up_after_endstop_or_probe_move() {
    *   - Raise to the BETWEEN height
    * - Return the probed Z position
    */
-  float probe_pt(const float x, const float y, const bool stow/*=true*/, const int verbose_level/*=1*/) {
+  float probe_pt(const float &x, const float &y, const bool stow/*=true*/, const int verbose_level/*=1*/) {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR(">>> probe_pt(", x);

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -903,7 +903,7 @@
   #define UBL_PROBE_PT_3_Y 20
   #define UBL_G26_MESH_VALIDATION   // Enable G26 mesh validation
   #define UBL_MESH_EDIT_MOVES_Z     // Sophisticated users prefer no movement of nozzle
- 
+
 #elif ENABLED(MESH_BED_LEVELING)
 
   //===========================================================================

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -907,7 +907,7 @@
   #define UBL_PROBE_PT_3_Y 20
   #define UBL_G26_MESH_VALIDATION   // Enable G26 mesh validation
   #define UBL_MESH_EDIT_MOVES_Z     // Sophisticated users prefer no movement of nozzle
- 
+
 #elif ENABLED(MESH_BED_LEVELING)
 
   //===========================================================================

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -943,7 +943,7 @@
   #define UBL_PROBE_PT_3_Y 20
   #define UBL_G26_MESH_VALIDATION   // Enable G26 mesh validation
   #define UBL_MESH_EDIT_MOVES_Z     // Sophisticated users prefer no movement of nozzle
- 
+
 #elif ENABLED(MESH_BED_LEVELING)
 
   //===========================================================================

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -878,7 +878,7 @@
   #define UBL_PROBE_PT_3_Y 20
   #define UBL_G26_MESH_VALIDATION   // Enable G26 mesh validation
   #define UBL_MESH_EDIT_MOVES_Z     // Sophisticated users prefer no movement of nozzle
- 
+
 #elif ENABLED(MESH_BED_LEVELING)
 
   //===========================================================================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -883,7 +883,7 @@
   #define UBL_PROBE_PT_3_Y 20
   #define UBL_G26_MESH_VALIDATION   // Enable G26 mesh validation
   #define UBL_MESH_EDIT_MOVES_Z     // Sophisticated users prefer no movement of nozzle
- 
+
 #elif ENABLED(MESH_BED_LEVELING)
 
   //===========================================================================

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -58,7 +58,7 @@
 #endif
 
 #ifndef _BV
-  #define _BV(PIN) (1 << PIN)
+  #define _BV(PIN) (1UL << PIN)
 #endif
 
 /**

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -21,24 +21,24 @@
  */
 
 /**
- * Contributed by Triffid_Hunter, modified by Kliment, extended by the Marlin team
- * Why double up on these macros? see http://gcc.gnu.org/onlinedocs/cpp/Stringification.html
+ * Fast I/O Routines
+ * Use direct port manipulation to save scads of processor time.
+ * Contributed by Triffid_Hunter. Modified by Kliment and the Marlin team.
  */
 
-#ifndef _FASTIO_ARDUINO_H
+#ifndef _FASTIO_ARDUINO_H 
 #define _FASTIO_ARDUINO_H
 
 #include <avr/io.h>
-
-/**
- * Include Ports and Functions
- */
 
 /**
  * Enable this option to use Teensy++ 2.0 assignments for AT90USB processors.
  */
 //#define AT90USBxx_TEENSYPP_ASSIGNMENTS
 
+/**
+ * Include Ports and Functions
+ */
 #if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__)
   #include "fastio_168.h"
 #elif defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__)
@@ -65,6 +65,8 @@
  * Magic I/O routines
  *
  * Now you can simply SET_OUTPUT(PIN); WRITE(PIN, HIGH); WRITE(PIN, LOW);
+ *
+ * Why double up on these macros? see http://gcc.gnu.org/onlinedocs/cpp/Stringification.html
  */
 
 #define _READ(IO) ((bool)(DIO ## IO ## _RPORT & _BV(DIO ## IO ## _PIN)))

--- a/Marlin/fastio_AT90USB-Teensy.h
+++ b/Marlin/fastio_AT90USB-Teensy.h
@@ -679,5 +679,4 @@
 #define PF7_PWM     NULL
 #define PF7_DDR     DDRF
 
-#endif // AT90USBxx_TEENSYPP_ASSIGNMENTS Teensyduino assignments
 #endif // _FASTIO_AT90USB

--- a/Marlin/least_squares_fit.h
+++ b/Marlin/least_squares_fit.h
@@ -52,7 +52,7 @@ void inline incremental_LSF_reset(struct linear_fit_data *lsf) {
   memset(lsf, 0, sizeof(linear_fit_data));
 }
 
-void inline incremental_WLSF(struct linear_fit_data *lsf, float x, float y, float z, float w) {
+void inline incremental_WLSF(struct linear_fit_data *lsf, const float &x, const float &y, const float &z, const float &w) {
   // weight each accumulator by factor w, including the "number" of samples
   // (analagous to calling inc_LSF twice with same values to weight it by 2X)
   lsf->xbar  += w * x;
@@ -65,11 +65,11 @@ void inline incremental_WLSF(struct linear_fit_data *lsf, float x, float y, floa
   lsf->xzbar += w * x * z;
   lsf->yzbar += w * y * z;
   lsf->N     += w;
-  lsf->max_absx = max(fabs( w * x ), lsf->max_absx);
-  lsf->max_absy = max(fabs( w * y ), lsf->max_absy);
+  lsf->max_absx = max(fabs(w * x), lsf->max_absx);
+  lsf->max_absy = max(fabs(w * y), lsf->max_absy);
 }
 
-void inline incremental_LSF(struct linear_fit_data *lsf, float x, float y, float z) {
+void inline incremental_LSF(struct linear_fit_data *lsf, const float &x, const float &y, const float &z) {
   lsf->xbar += x;
   lsf->ybar += y;
   lsf->zbar += z;

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -29,12 +29,12 @@
 #define XYZ  3
 
 #define FORCE_INLINE __attribute__((always_inline)) inline
-
-#define _O0 __attribute__((optimize("O0")))
-#define _Os __attribute__((optimize("Os")))
-#define _O1 __attribute__((optimize("O1")))
-#define _O2 __attribute__((optimize("O2")))
-#define _O3 __attribute__((optimize("O3")))
+#define _UNUSED      __attribute__((unused))
+#define _O0          __attribute__((optimize("O0")))
+#define _Os          __attribute__((optimize("Os")))
+#define _O1          __attribute__((optimize("O1")))
+#define _O2          __attribute__((optimize("O2")))
+#define _O3          __attribute__((optimize("O3")))
 
 // Bracket code that shouldn't be interrupted
 #ifndef CRITICAL_SECTION_START

--- a/Marlin/nozzle.cpp
+++ b/Marlin/nozzle.cpp
@@ -12,9 +12,9 @@
   * @param strokes number of strokes to execute
   */
 void Nozzle::stroke(
-  __attribute__((unused)) point_t const &start,
-  __attribute__((unused)) point_t const &end,
-  __attribute__((unused)) uint8_t const &strokes
+  _UNUSED point_t const &start,
+  _UNUSED point_t const &end,
+  _UNUSED uint8_t const &strokes
 ) {
   #if ENABLED(NOZZLE_CLEAN_FEATURE)
 
@@ -56,10 +56,10 @@ void Nozzle::stroke(
   * @param objects number of objects to create
   */
 void Nozzle::zigzag(
-  __attribute__((unused)) point_t const &start,
-  __attribute__((unused)) point_t const &end,
-  __attribute__((unused)) uint8_t const &strokes,
-  __attribute__((unused)) uint8_t const &objects
+  _UNUSED point_t const &start,
+  _UNUSED point_t const &end,
+  _UNUSED uint8_t const &strokes,
+  _UNUSED uint8_t const &objects
 ) {
   #if ENABLED(NOZZLE_CLEAN_FEATURE)
     const float A = nozzle_clean_horizontal ? nozzle_clean_height : nozzle_clean_length, // [twice the] Amplitude
@@ -114,10 +114,10 @@ void Nozzle::zigzag(
   * @param radius radius of circle
   */
 void Nozzle::circle(
-  __attribute__((unused)) point_t const &start,
-  __attribute__((unused)) point_t const &middle,
-  __attribute__((unused)) uint8_t const &strokes,
-  __attribute__((unused)) float const &radius
+  _UNUSED point_t const &start,
+  _UNUSED point_t const &middle,
+  _UNUSED uint8_t const &strokes,
+  _UNUSED float const &radius
 ) {
   #if ENABLED(NOZZLE_CLEAN_FEATURE)
     if (strokes == 0) return;
@@ -177,10 +177,10 @@ void Nozzle::circle(
   * @param argument depends on the cleaning pattern
   */
 void Nozzle::clean(
-  __attribute__((unused)) uint8_t const &pattern,
-  __attribute__((unused)) uint8_t const &strokes,
-  __attribute__((unused)) float const &radius,
-  __attribute__((unused)) uint8_t const &objects
+  _UNUSED uint8_t const &pattern,
+  _UNUSED uint8_t const &strokes,
+  _UNUSED float const &radius,
+  _UNUSED uint8_t const &objects
 ) {
   #if ENABLED(NOZZLE_CLEAN_FEATURE)
     #if ENABLED(DELTA)
@@ -209,7 +209,7 @@ void Nozzle::clean(
 }
 
 void Nozzle::park(
-  __attribute__((unused)) uint8_t const &z_action
+  _UNUSED uint8_t const &z_action
 ) {
   #if ENABLED(NOZZLE_PARK_FEATURE)
     float const z = current_position[Z_AXIS];

--- a/Marlin/nozzle.h
+++ b/Marlin/nozzle.h
@@ -50,10 +50,10 @@ class Nozzle {
      * @param strokes number of strokes to execute
      */
     static void stroke(
-      __attribute__((unused)) point_t const &start,
-      __attribute__((unused)) point_t const &end,
-      __attribute__((unused)) uint8_t const &strokes
-    ) __attribute__((optimize ("Os")));
+      _UNUSED point_t const &start,
+      _UNUSED point_t const &end,
+      _UNUSED uint8_t const &strokes
+    ) _Os;
 
     /**
      * @brief Zig-zag clean pattern
@@ -65,11 +65,11 @@ class Nozzle {
      * @param objects number of objects to create
      */
     static void zigzag(
-      __attribute__((unused)) point_t const &start,
-      __attribute__((unused)) point_t const &end,
-      __attribute__((unused)) uint8_t const &strokes,
-      __attribute__((unused)) uint8_t const &objects
-    ) __attribute__((optimize ("Os")));
+      _UNUSED point_t const &start,
+      _UNUSED point_t const &end,
+      _UNUSED uint8_t const &strokes,
+      _UNUSED uint8_t const &objects
+    ) _Os;
 
     /**
      * @brief Circular clean pattern
@@ -80,11 +80,11 @@ class Nozzle {
      * @param radius radius of circle
      */
     static void circle(
-      __attribute__((unused)) point_t const &start,
-      __attribute__((unused)) point_t const &middle,
-      __attribute__((unused)) uint8_t const &strokes,
-      __attribute__((unused)) float const &radius
-    ) __attribute__((optimize ("Os")));
+      _UNUSED point_t const &start,
+      _UNUSED point_t const &middle,
+      _UNUSED uint8_t const &strokes,
+      _UNUSED float const &radius
+    ) _Os;
 
   public:
     /**
@@ -95,15 +95,15 @@ class Nozzle {
      * @param argument depends on the cleaning pattern
      */
     static void clean(
-      __attribute__((unused)) uint8_t const &pattern,
-      __attribute__((unused)) uint8_t const &strokes,
-      __attribute__((unused)) float const &radius,
-      __attribute__((unused)) uint8_t const &objects = 0
-    ) __attribute__((optimize ("Os")));
+      _UNUSED uint8_t const &pattern,
+      _UNUSED uint8_t const &strokes,
+      _UNUSED float const &radius,
+      _UNUSED uint8_t const &objects = 0
+    ) _Os;
 
     static void park(
-      __attribute__((unused)) uint8_t const &z_action
-    ) __attribute__((optimize ("Os")));
+      _UNUSED uint8_t const &z_action
+    ) _Os;
 };
 
 #endif

--- a/Marlin/spi.h
+++ b/Marlin/spi.h
@@ -27,37 +27,26 @@
 #include "softspi.h"
 
 template<uint8_t MisoPin, uint8_t MosiPin, uint8_t SckPin>
-class Spi {
-  static SoftSPI<MisoPin, MosiPin, SckPin> softSpi;
+class SPI {
+  static SoftSPI<MisoPin, MosiPin, SckPin> softSPI;
   public:
-    inline __attribute__((always_inline))
-    static void init() {
-        softSpi.begin();
-    }
-    inline __attribute__((always_inline))
-    static void send(uint8_t data) {
-        softSpi.send(data);
-    }
-    inline __attribute__((always_inline))
-    static uint8_t receive() {
-        return softSpi.receive();
-    }
+    FORCE_INLINE static void init() { softSPI.begin(); }
+    FORCE_INLINE static void send(uint8_t data) { softSPI.send(data); }
+    FORCE_INLINE static uint8_t receive() { return softSPI.receive(); }
 };
 
 
-//hardware spi
+// Hardware SPI
 template<>
-class Spi<MISO_PIN, MOSI_PIN, SCK_PIN> {
+class SPI<MISO_PIN, MOSI_PIN, SCK_PIN> {
   public:
-    inline __attribute__((always_inline))
-    static void init() {
+    FORCE_INLINE static void init() {
         OUT_WRITE(SCK_PIN, LOW);
         OUT_WRITE(MOSI_PIN, HIGH);
         SET_INPUT(MISO_PIN);
         WRITE(MISO_PIN, HIGH);
     }
-    inline __attribute__((always_inline))
-    static uint8_t receive() {
+    FORCE_INLINE static uint8_t receive() {
       SPDR = 0;
       for (;!TEST(SPSR, SPIF););
       return SPDR;
@@ -65,4 +54,4 @@ class Spi<MISO_PIN, MOSI_PIN, SCK_PIN> {
 
 };
 
-#endif
+#endif // __SPI_H__

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -935,7 +935,7 @@ void Temperature::updateTemperaturesFromRawValues() {
   #ifndef MAX6675_DO_PIN
     #define MAX6675_DO_PIN MISO_PIN
   #endif
-  Spi<MAX6675_DO_PIN, MOSI_PIN, MAX6675_SCK_PIN> max6675_spi;
+  SPI<MAX6675_DO_PIN, MOSI_PIN, MAX6675_SCK_PIN> max6675_spi;
 #endif
 
 /**

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -288,8 +288,7 @@ class Temperature {
     /**
      * Call periodically to manage heaters
      */
-    //static void manage_heater(); // changed to address compiler error
-    static void manage_heater()  __attribute__((__optimize__("O2")));
+    static void manage_heater() _O2; // Added _O2 to work around a compiler error
 
     /**
      * Preheating hotends

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -69,8 +69,8 @@
 
   // 15 is the maximum nubmer of grid points supported + 1 safety margin for now,
   // until determinism prevails
-  constexpr float unified_bed_leveling::mesh_index_to_xpos[16],
-                  unified_bed_leveling::mesh_index_to_ypos[16];
+  constexpr float unified_bed_leveling::_mesh_index_to_xpos[16],
+                  unified_bed_leveling::_mesh_index_to_ypos[16];
 
   bool unified_bed_leveling::g26_debug_flag = false,
        unified_bed_leveling::has_control_of_lcd_panel = false;
@@ -117,8 +117,8 @@
       SERIAL_EOL;
     }
 
-    const float current_xi = ubl.get_cell_index_x(current_position[X_AXIS] + (MESH_X_DIST) / 2.0),
-                current_yi = ubl.get_cell_index_y(current_position[Y_AXIS] + (MESH_Y_DIST) / 2.0);
+    const float current_xi = get_cell_index_x(current_position[X_AXIS] + (MESH_X_DIST) / 2.0),
+                current_yi = get_cell_index_y(current_position[Y_AXIS] + (MESH_Y_DIST) / 2.0);
 
     for (int8_t j = GRID_MAX_POINTS_Y - 1; j >= 0; j--) {
       for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -53,30 +53,16 @@
   // ubl_motion.cpp
 
   void debug_current_and_destination(const char * const title);
-  void ubl_line_to_destination_cartesian(const float&, uint8_t);
-  bool ubl_prepare_linear_move_to(const float ltarget[XYZE], const float &feedrate );
 
   // ubl_G29.cpp
 
   enum MeshPointType { INVALID, REAL, SET_IN_BITMAP };
-
-  void dump(char * const str, const float &f);
-  void probe_entire_mesh(const float&, const float&, const bool, const bool, const bool);
-  float measure_business_card_thickness(float&);
-  mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, unsigned int[16], bool);
-  void shift_mesh_height();
-  void fine_tune_mesh(const float&, const float&, const bool);
-  bool g29_parameter_parsing();
-  void g29_eeprom_dump();
-  void g29_compare_current_mesh_to_stored_mesh();
 
   // External references
 
   char *ftostr43sign(const float&, char);
   bool ubl_lcd_clicked();
   void home_all_axes();
-  void gcode_G26();
-  void gcode_G29();
 
   extern uint8_t ubl_cnt;
 
@@ -101,26 +87,81 @@
 
       static float last_specified_z;
 
+      static int    g29_verbose_level,
+                    g29_phase_value,
+                    g29_repetition_cnt,
+                    g29_storage_slot,
+                    g29_map_type,
+                    g29_grid_size;
+      static bool   g29_c_flag, g29_x_flag, g29_y_flag;
+      static float  g29_x_pos, g29_y_pos,
+                    g29_card_thickness,
+                    g29_constant;
+
+      #if ENABLED(UBL_G26_MESH_VALIDATION)
+        static float   g26_extrusion_multiplier,
+                       g26_retraction_multiplier,
+                       g26_nozzle,
+                       g26_filament_diameter,
+                       g26_prime_length,
+                       g26_x_pos, g26_y_pos,
+                       g26_ooze_amount,
+                       g26_layer_height;
+        static int16_t g26_bed_temp,
+                       g26_hotend_temp,
+                       g26_repeats;
+        static int8_t  g26_prime_flag;
+        static bool    g26_continue_with_closest, g26_keep_heaters_on;
+      #endif
+
+      static float measure_point_with_encoder();
+      static float measure_business_card_thickness(float&);
+      static bool g29_parameter_parsing();
+      static void find_mean_mesh_height();
+      static void shift_mesh_height();
+      static void probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
+      static void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
+      static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
+      static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
+      static void g29_what_command();
+      static void g29_eeprom_dump();
+      static void g29_compare_current_mesh_to_stored_mesh();
+      static void fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map);
+      static bool smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir);
+      static void smart_fill_mesh();
+
+      #if ENABLED(UBL_G26_MESH_VALIDATION)
+        static bool exit_from_g26();
+        static bool parse_G26_parameters();
+        static void G26_line_to_destination(const float &feed_rate);
+        static mesh_index_pair find_closest_circle_to_print(const float&, const float&);
+        static bool look_for_lines_to_connect();
+        static bool turn_on_heaters();
+        static bool prime_nozzle();
+        static void retract_filament(float where[XYZE]);
+        static void recover_filament(float where[XYZE]);
+        static void print_line_from_here_to_there(const float&, const float&, const float&, const float&, const float&, const float&);
+        static void move_to(const float&, const float&, const float&, const float&);
+      #endif
+
     public:
 
-      void echo_name();
-      void report_state();
-      void find_mean_mesh_height();
-      void shift_mesh_height();
-      void probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
-      void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
-      void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
-      void save_ubl_active_state_and_disable();
-      void restore_ubl_active_state_and_leave();
-      void g29_what_command();
-      void g29_eeprom_dump();
-      void g29_compare_current_mesh_to_stored_mesh();
-      void fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map);
-      void smart_fill_mesh();
-      void display_map(const int);
-      void reset();
-      void invalidate();
-      bool sanity_check();
+      static void echo_name();
+      static void report_state();
+      static void save_ubl_active_state_and_disable();
+      static void restore_ubl_active_state_and_leave();
+      static void display_map(const int);
+      static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, unsigned int[16], bool);
+      static void reset();
+      static void invalidate();
+      static bool sanity_check();
+
+      static void G29() _O0;                          // O0 for no optimization
+      static void smart_fill_wlsf(const float &) _O2; // O2 gives smaller code than Os on A2560
+
+      #if ENABLED(UBL_G26_MESH_VALIDATION)
+        static void G26();
+      #endif
 
       static ubl_state state;
 
@@ -128,7 +169,7 @@
 
       // 15 is the maximum nubmer of grid points supported + 1 safety margin for now,
       // until determinism prevails
-      constexpr static float mesh_index_to_xpos[16] PROGMEM = {
+      constexpr static float _mesh_index_to_xpos[16] PROGMEM = {
                                 UBL_MESH_MIN_X +  0 * (MESH_X_DIST), UBL_MESH_MIN_X +  1 * (MESH_X_DIST),
                                 UBL_MESH_MIN_X +  2 * (MESH_X_DIST), UBL_MESH_MIN_X +  3 * (MESH_X_DIST),
                                 UBL_MESH_MIN_X +  4 * (MESH_X_DIST), UBL_MESH_MIN_X +  5 * (MESH_X_DIST),
@@ -139,7 +180,7 @@
                                 UBL_MESH_MIN_X + 14 * (MESH_X_DIST), UBL_MESH_MIN_X + 15 * (MESH_X_DIST)
                               };
 
-      constexpr static float mesh_index_to_ypos[16] PROGMEM = {
+      constexpr static float _mesh_index_to_ypos[16] PROGMEM = {
                                 UBL_MESH_MIN_Y +  0 * (MESH_Y_DIST), UBL_MESH_MIN_Y +  1 * (MESH_Y_DIST),
                                 UBL_MESH_MIN_Y +  2 * (MESH_Y_DIST), UBL_MESH_MIN_Y +  3 * (MESH_Y_DIST),
                                 UBL_MESH_MIN_Y +  4 * (MESH_Y_DIST), UBL_MESH_MIN_Y +  5 * (MESH_Y_DIST),
@@ -156,16 +197,16 @@
 
       unified_bed_leveling();
 
-      FORCE_INLINE void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
+      FORCE_INLINE static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
 
-      int8_t get_cell_index_x(const float &x) {
+      static int8_t get_cell_index_x(const float &x) {
         const int8_t cx = (x - (UBL_MESH_MIN_X)) * (1.0 / (MESH_X_DIST));
         return constrain(cx, 0, (GRID_MAX_POINTS_X) - 1);   // -1 is appropriate if we want all movement to the X_MAX
       }                                                     // position. But with this defined this way, it is possible
                                                             // to extrapolate off of this point even further out. Probably
                                                             // that is OK because something else should be keeping that from
                                                             // happening and should not be worried about at this level.
-      int8_t get_cell_index_y(const float &y) {
+      static int8_t get_cell_index_y(const float &y) {
         const int8_t cy = (y - (UBL_MESH_MIN_Y)) * (1.0 / (MESH_Y_DIST));
         return constrain(cy, 0, (GRID_MAX_POINTS_Y) - 1);   // -1 is appropriate if we want all movement to the Y_MAX
       }                                                     // position. But with this defined this way, it is possible
@@ -173,12 +214,12 @@
                                                             // that is OK because something else should be keeping that from
                                                             // happening and should not be worried about at this level.
 
-      int8_t find_closest_x_index(const float &x) {
+      static int8_t find_closest_x_index(const float &x) {
         const int8_t px = (x - (UBL_MESH_MIN_X) + (MESH_X_DIST) * 0.5) * (1.0 / (MESH_X_DIST));
         return WITHIN(px, 0, GRID_MAX_POINTS_X - 1) ? px : -1;
       }
 
-      int8_t find_closest_y_index(const float &y) {
+      static int8_t find_closest_y_index(const float &y) {
         const int8_t py = (y - (UBL_MESH_MIN_Y) + (MESH_Y_DIST) * 0.5) * (1.0 / (MESH_Y_DIST));
         return WITHIN(py, 0, GRID_MAX_POINTS_Y - 1) ? py : -1;
       }
@@ -198,7 +239,7 @@
        *  It is fairly expensive with its 4 floating point additions and 2 floating point
        *  multiplications.
        */
-      FORCE_INLINE float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
+      FORCE_INLINE static float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
         return z1 + (z2 - z1) * (a0 - a1) / (a2 - a1);
       }
 
@@ -206,7 +247,7 @@
        * z_correction_for_x_on_horizontal_mesh_line is an optimization for
        * the rare occasion when a point lies exactly on a Mesh line (denoted by index yi).
        */
-      inline float z_correction_for_x_on_horizontal_mesh_line(const float &lx0, const int x1_i, const int yi) {
+      inline static float z_correction_for_x_on_horizontal_mesh_line(const float &lx0, const int x1_i, const int yi) {
         if (!WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(yi, 0, GRID_MAX_POINTS_Y - 1)) {
           serialprintPGM( !WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) ? PSTR("x1l_i") : PSTR("yi") );
           SERIAL_ECHOPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(lx0=", lx0);
@@ -217,7 +258,7 @@
           return NAN;
         }
 
-        const float xratio = (RAW_X_POSITION(lx0) - pgm_read_float(&mesh_index_to_xpos[x1_i])) * (1.0 / (MESH_X_DIST)),
+        const float xratio = (RAW_X_POSITION(lx0) - mesh_index_to_xpos(x1_i)) * (1.0 / (MESH_X_DIST)),
                     z1 = z_values[x1_i][yi];
 
         return z1 + xratio * (z_values[x1_i + 1][yi] - z1);
@@ -226,7 +267,7 @@
       //
       // See comments above for z_correction_for_x_on_horizontal_mesh_line
       //
-      inline float z_correction_for_y_on_vertical_mesh_line(const float &ly0, const int xi, const int y1_i) {
+      inline static float z_correction_for_y_on_vertical_mesh_line(const float &ly0, const int xi, const int y1_i) {
         if (!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(y1_i, 0, GRID_MAX_POINTS_Y - 1)) {
           serialprintPGM( !WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) ? PSTR("xi") : PSTR("yl_i") );
           SERIAL_ECHOPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ly0=", ly0);
@@ -237,7 +278,7 @@
           return NAN;
         }
 
-        const float yratio = (RAW_Y_POSITION(ly0) - pgm_read_float(&mesh_index_to_ypos[y1_i])) * (1.0 / (MESH_Y_DIST)),
+        const float yratio = (RAW_Y_POSITION(ly0) - mesh_index_to_ypos(y1_i)) * (1.0 / (MESH_Y_DIST)),
                     z1 = z_values[xi][y1_i];
 
         return z1 + yratio * (z_values[xi][y1_i + 1] - z1);
@@ -249,7 +290,7 @@
        * Z-Height at both ends. Then it does a linear interpolation of these heights based
        * on the Y position within the cell.
        */
-      float get_z_correction(const float &lx0, const float &ly0) {
+      static float get_z_correction(const float &lx0, const float &ly0) {
         const int8_t cx = get_cell_index_x(RAW_X_POSITION(lx0)),
                      cy = get_cell_index_y(RAW_Y_POSITION(ly0));
 
@@ -268,16 +309,16 @@
         }
 
         const float z1 = calc_z0(RAW_X_POSITION(lx0),
-                                 pgm_read_float(&mesh_index_to_xpos[cx]), z_values[cx][cy],
-                                 pgm_read_float(&mesh_index_to_xpos[cx + 1]), z_values[cx + 1][cy]);
+                                 mesh_index_to_xpos(cx), z_values[cx][cy],
+                                 mesh_index_to_xpos(cx + 1), z_values[cx + 1][cy]);
 
         const float z2 = calc_z0(RAW_X_POSITION(lx0),
-                                 pgm_read_float(&mesh_index_to_xpos[cx]), z_values[cx][cy + 1],
-                                 pgm_read_float(&mesh_index_to_xpos[cx + 1]), z_values[cx + 1][cy + 1]);
+                                 mesh_index_to_xpos(cx), z_values[cx][cy + 1],
+                                 mesh_index_to_xpos(cx + 1), z_values[cx + 1][cy + 1]);
 
         float z0 = calc_z0(RAW_Y_POSITION(ly0),
-                           pgm_read_float(&mesh_index_to_ypos[cy]), z1,
-                           pgm_read_float(&mesh_index_to_ypos[cy + 1]), z2);
+                           mesh_index_to_ypos(cy), z1,
+                           mesh_index_to_ypos(cy + 1), z2);
 
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(MESH_ADJUST)) {
@@ -324,7 +365,7 @@
        *  Returns 0.0 if Z is past the specified 'Fade Height'.
        */
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-        inline float fade_scaling_factor_for_z(const float &lz) {
+        static inline float fade_scaling_factor_for_z(const float &lz) {
           if (planner.z_fade_height == 0.0) return 1.0;
           static float fade_scaling_factor = 1.0;
           const float rz = RAW_Z_POSITION(lz);
@@ -338,14 +379,24 @@
           return fade_scaling_factor;
         }
       #else
-        inline float fade_scaling_factor_for_z(const float &lz) {
-          return 1.0;
-        }
+        FORCE_INLINE static float fade_scaling_factor_for_z(const float &lz) { return 1.0; }
       #endif
+
+      FORCE_INLINE static float mesh_index_to_xpos(const uint8_t i) { return pgm_read_float(&_mesh_index_to_xpos[i]); }
+      FORCE_INLINE static float mesh_index_to_ypos(const uint8_t i) { return pgm_read_float(&_mesh_index_to_ypos[i]); }
+
+      static bool prepare_linear_move_to(const float ltarget[XYZE], const float &feedrate);
+      static void line_to_destination_cartesian(const float &fr, uint8_t e);
 
   }; // class unified_bed_leveling
 
   extern unified_bed_leveling ubl;
+
+  #if ENABLED(UBL_G26_MESH_VALIDATION)
+    FORCE_INLINE void gcode_G26() { ubl.G26(); }
+  #endif
+
+  FORCE_INLINE void gcode_G29() { ubl.G29(); }
 
 #endif // AUTO_BED_LEVELING_UBL
 #endif // UNIFIED_BED_LEVELING_H

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -53,12 +53,6 @@
   extern bool code_has_value();
   extern float probe_pt(const float &x, const float &y, bool, int);
   extern bool set_probe_deployed(bool);
-  void smart_fill_mesh();
-  void smart_fill_wlsf(const float &);
-  float measure_business_card_thickness(float &in_height);
-  void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
-
-  bool ProbeStay = true;
 
   #define SIZE_OF_LITTLE_RAISE 1
   #define BIG_RAISE_NOT_NEEDED 0
@@ -66,6 +60,22 @@
   extern void lcd_status_screen();
   typedef void (*screenFunc_t)();
   extern void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0);
+  extern void lcd_setstatus(const char* message, const bool persist);
+  extern void lcd_setstatuspgm(const char* message, const uint8_t level);
+
+  int    unified_bed_leveling::g29_verbose_level,
+         unified_bed_leveling::g29_phase_value,
+         unified_bed_leveling::g29_repetition_cnt,
+         unified_bed_leveling::g29_storage_slot = 0,
+         unified_bed_leveling::g29_map_type,
+         unified_bed_leveling::g29_grid_size;
+  bool   unified_bed_leveling::g29_c_flag,
+         unified_bed_leveling::g29_x_flag,
+         unified_bed_leveling::g29_y_flag;
+  float  unified_bed_leveling::g29_x_pos,
+         unified_bed_leveling::g29_y_pos,
+         unified_bed_leveling::g29_card_thickness = 0.0,
+         unified_bed_leveling::g29_constant = 0.0;
 
   /**
    *   G29: Unified Bed Leveling by Roxy
@@ -304,16 +314,7 @@
    *   we now have the functionality and features of all three systems combined.
    */
 
-  // The simple parameter flags and values are 'static' so parameter parsing can be in a support routine.
-  static int g29_verbose_level, phase_value, repetition_cnt,
-             storage_slot = 0, map_type, grid_size;
-  static bool repeat_flag, c_flag, x_flag, y_flag;
-  static float x_pos, y_pos, card_thickness = 0.0, ubl_constant = 0.0;
-
-  extern void lcd_setstatus(const char* message, const bool persist);
-  extern void lcd_setstatuspgm(const char* message, const uint8_t level);
-
-  void _O0 gcode_G29() {
+  void unified_bed_leveling::G29() {
 
     if (!settings.calc_num_meshes()) {
       SERIAL_PROTOCOLLNPGM("?You need to enable your EEPROM and initialize it");
@@ -340,15 +341,15 @@
     // it directly specifies the repetition count and does not use the 'R' parameter.
     if (code_seen('I')) {
       uint8_t cnt = 0;
-      repetition_cnt = code_has_value() ? code_value_int() : 1;
-      while (repetition_cnt--) {
+      g29_repetition_cnt = code_has_value() ? code_value_int() : 1;
+      while (g29_repetition_cnt--) {
         if (cnt > 20) { cnt = 0; idle(); }
-        const mesh_index_pair location = find_closest_mesh_point_of_type(REAL, x_pos, y_pos, USE_NOZZLE_AS_REFERENCE, NULL, false);
+        const mesh_index_pair location = find_closest_mesh_point_of_type(REAL, g29_x_pos, g29_y_pos, USE_NOZZLE_AS_REFERENCE, NULL, false);
         if (location.x_index < 0) {
           SERIAL_PROTOCOLLNPGM("Entire Mesh invalidated.\n");
           break;            // No more invalid Mesh Points to populate
         }
-        ubl.z_values[location.x_index][location.y_index] = NAN;
+        z_values[location.x_index][location.y_index] = NAN;
         cnt++;
       }
       SERIAL_PROTOCOLLNPGM("Locations invalidated.\n");
@@ -370,30 +371,30 @@
             for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) { // a poorly calibrated Delta.
               const float p1 = 0.5 * (GRID_MAX_POINTS_X) - x,
                           p2 = 0.5 * (GRID_MAX_POINTS_Y) - y;
-              ubl.z_values[x][y] += 2.0 * HYPOT(p1, p2);
+              z_values[x][y] += 2.0 * HYPOT(p1, p2);
             }
           }
           break;
         case 1:
           for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {  // Create a diagonal line several Mesh cells thick that is raised
-            ubl.z_values[x][x] += 9.999;
-            ubl.z_values[x][x + (x < GRID_MAX_POINTS_Y - 1) ? 1 : -1] += 9.999; // We want the altered line several mesh points thick
+            z_values[x][x] += 9.999;
+            z_values[x][x + (x < GRID_MAX_POINTS_Y - 1) ? 1 : -1] += 9.999; // We want the altered line several mesh points thick
           }
           break;
         case 2:
           // Allow the user to specify the height because 10mm is a little extreme in some cases.
           for (uint8_t x = (GRID_MAX_POINTS_X) / 3; x < 2 * (GRID_MAX_POINTS_X) / 3; x++)   // Create a rectangular raised area in
             for (uint8_t y = (GRID_MAX_POINTS_Y) / 3; y < 2 * (GRID_MAX_POINTS_Y) / 3; y++) // the center of the bed
-              ubl.z_values[x][y] += code_seen('C') ? ubl_constant : 9.99;
+              z_values[x][y] += code_seen('C') ? g29_constant : 9.99;
           break;
       }
     }
 
     if (code_seen('J')) {
-      if (grid_size) {  // if not 0 it is a normal n x n grid being probed
-        ubl.save_ubl_active_state_and_disable();
-        ubl.tilt_mesh_based_on_probed_grid(code_seen('T'));
-        ubl.restore_ubl_active_state_and_leave();
+      if (g29_grid_size) {  // if not 0 it is a normal n x n grid being probed
+        save_ubl_active_state_and_disable();
+        tilt_mesh_based_on_probed_grid(code_seen('T'));
+        restore_ubl_active_state_and_leave();
       }
       else { // grid_size == 0 : A 3-Point leveling has been requested
         float z3, z2, z1 = probe_pt(LOGICAL_X_POSITION(UBL_PROBE_PT_1_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_1_Y), false, g29_verbose_level);
@@ -413,29 +414,29 @@
         // doesn't mean the Mesh is tilted! (Compensate each probe point by what the Mesh says
         // its height is.)
 
-        ubl.save_ubl_active_state_and_disable();
-        z1 -= ubl.get_z_correction(LOGICAL_X_POSITION(UBL_PROBE_PT_1_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_1_Y)) /* + zprobe_zoffset */ ;
-        z2 -= ubl.get_z_correction(LOGICAL_X_POSITION(UBL_PROBE_PT_2_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_2_Y)) /* + zprobe_zoffset */ ;
-        z3 -= ubl.get_z_correction(LOGICAL_X_POSITION(UBL_PROBE_PT_3_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_3_Y)) /* + zprobe_zoffset */ ;
+        save_ubl_active_state_and_disable();
+        z1 -= get_z_correction(LOGICAL_X_POSITION(UBL_PROBE_PT_1_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_1_Y)) /* + zprobe_zoffset */ ;
+        z2 -= get_z_correction(LOGICAL_X_POSITION(UBL_PROBE_PT_2_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_2_Y)) /* + zprobe_zoffset */ ;
+        z3 -= get_z_correction(LOGICAL_X_POSITION(UBL_PROBE_PT_3_X), LOGICAL_Y_POSITION(UBL_PROBE_PT_3_Y)) /* + zprobe_zoffset */ ;
 
         do_blocking_move_to_xy(0.5 * (UBL_MESH_MAX_X - (UBL_MESH_MIN_X)), 0.5 * (UBL_MESH_MAX_Y - (UBL_MESH_MIN_Y)));
-        ubl.tilt_mesh_based_on_3pts(z1, z2, z3);
-        ubl.restore_ubl_active_state_and_leave();
+        tilt_mesh_based_on_3pts(z1, z2, z3);
+        restore_ubl_active_state_and_leave();
       }
     }
 
     if (code_seen('P')) {
-      if (WITHIN(phase_value, 0, 1) && ubl.state.storage_slot == -1) {
-        ubl.state.storage_slot = 0;
+      if (WITHIN(g29_phase_value, 0, 1) && state.storage_slot == -1) {
+        state.storage_slot = 0;
         SERIAL_PROTOCOLLNPGM("Default storage slot 0 selected.");
       }
 
-      switch (phase_value) {
+      switch (g29_phase_value) {
         case 0:
           //
           // Zero Mesh Data
           //
-          ubl.reset();
+          reset();
           SERIAL_PROTOCOLLNPGM("Mesh zeroed.");
           break;
 
@@ -444,16 +445,16 @@
           // Invalidate Entire Mesh and Automatically Probe Mesh in areas that can be reached by the probe
           //
           if (!code_seen('C')) {
-            ubl.invalidate();
+            invalidate();
             SERIAL_PROTOCOLLNPGM("Mesh invalidated. Probing mesh.");
           }
           if (g29_verbose_level > 1) {
-            SERIAL_PROTOCOLPAIR("Probing Mesh Points Closest to (", x_pos);
+            SERIAL_PROTOCOLPAIR("Probing Mesh Points Closest to (", g29_x_pos);
             SERIAL_PROTOCOLCHAR(',');
-            SERIAL_PROTOCOL(y_pos);
+            SERIAL_PROTOCOL(g29_y_pos);
             SERIAL_PROTOCOLLNPGM(").\n");
           }
-          ubl.probe_entire_mesh(x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER,
+          probe_entire_mesh(g29_x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, g29_y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER,
                             code_seen('T'), code_seen('E'), code_seen('U'));
           break;
 
@@ -463,7 +464,7 @@
           //
           SERIAL_PROTOCOLLNPGM("Manually probing unreachable mesh locations.");
           do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
-          if (!x_flag && !y_flag) {
+          if (!g29_x_flag && !g29_y_flag) {
             /**
              * Use a good default location for the path.
              * The flipped > and < operators in these comparisons is intentional.
@@ -472,25 +473,25 @@
              * Until that is decided, this can be forced with the X and Y parameters.
              */
             #if IS_KINEMATIC
-              x_pos = X_HOME_POS;
-              y_pos = Y_HOME_POS;
+              g29_x_pos = X_HOME_POS;
+              g29_y_pos = Y_HOME_POS;
             #else // cartesian
-              x_pos = X_PROBE_OFFSET_FROM_EXTRUDER > 0 ? X_MAX_POS : X_MIN_POS;
-              y_pos = Y_PROBE_OFFSET_FROM_EXTRUDER < 0 ? Y_MAX_POS : Y_MIN_POS;
+              g29_x_pos = X_PROBE_OFFSET_FROM_EXTRUDER > 0 ? X_MAX_POS : X_MIN_POS;
+              g29_y_pos = Y_PROBE_OFFSET_FROM_EXTRUDER < 0 ? Y_MAX_POS : Y_MIN_POS;
             #endif
           }
 
           if (code_seen('C')) {
-            x_pos = current_position[X_AXIS];
-            y_pos = current_position[Y_AXIS];
+            g29_x_pos = current_position[X_AXIS];
+            g29_y_pos = current_position[Y_AXIS];
           }
 
           float height = Z_CLEARANCE_BETWEEN_PROBES;
 
           if (code_seen('B')) {
-            card_thickness = code_has_value() ? code_value_float() : measure_business_card_thickness(height);
+            g29_card_thickness = code_has_value() ? code_value_float() : measure_business_card_thickness(height);
 
-            if (fabs(card_thickness) > 1.5) {
+            if (fabs(g29_card_thickness) > 1.5) {
               SERIAL_PROTOCOLLNPGM("?Error in Business Card measurement.");
               return;
             }
@@ -498,12 +499,12 @@
 
           if (code_seen('H') && code_has_value()) height = code_value_float();
 
-          if (!position_is_reachable_xy(x_pos, y_pos)) {
+          if (!position_is_reachable_xy(g29_x_pos, g29_y_pos)) {
             SERIAL_PROTOCOLLNPGM("(X,Y) outside printable radius.");
             return;
           }
 
-          manually_probe_remaining_mesh(x_pos, y_pos, height, card_thickness, code_seen('T'));
+          manually_probe_remaining_mesh(g29_x_pos, g29_y_pos, height, g29_card_thickness, code_seen('T'));
           SERIAL_PROTOCOLLNPGM("G29 P2 finished.");
         } break;
 
@@ -514,19 +515,19 @@
            *   - Specify a constant with the 'C' parameter.
            *   - Allow 'G29 P3' to choose a 'reasonable' constant.
            */
-          if (c_flag) {
-            if (repetition_cnt >= GRID_MAX_POINTS) {
+          if (g29_c_flag) {
+            if (g29_repetition_cnt >= GRID_MAX_POINTS) {
               for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
                 for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
-                  ubl.z_values[x][y] = ubl_constant;
+                  z_values[x][y] = g29_constant;
                 }
               }
             }
             else {
-              while (repetition_cnt--) {  // this only populates reachable mesh points near
-                const mesh_index_pair location = find_closest_mesh_point_of_type(INVALID, x_pos, y_pos, USE_NOZZLE_AS_REFERENCE, NULL, false);
+              while (g29_repetition_cnt--) {  // this only populates reachable mesh points near
+                const mesh_index_pair location = find_closest_mesh_point_of_type(INVALID, g29_x_pos, g29_y_pos, USE_NOZZLE_AS_REFERENCE, NULL, false);
                 if (location.x_index < 0) break; // No more reachable invalid Mesh Points to populate
-                ubl.z_values[location.x_index][location.y_index] = ubl_constant;
+                z_values[location.x_index][location.y_index] = g29_constant;
               }
             }
           } else {
@@ -561,13 +562,13 @@
           // Fine Tune (i.e., Edit) the Mesh
           //
 
-          fine_tune_mesh(x_pos, y_pos, code_seen('T'));
+          fine_tune_mesh(g29_x_pos, g29_y_pos, code_seen('T'));
 
           break;
 
-        case 5: ubl.find_mean_mesh_height(); break;
+        case 5: find_mean_mesh_height(); break;
 
-        case 6: ubl.shift_mesh_height(); break;
+        case 6: shift_mesh_height(); break;
       }
     }
 
@@ -575,7 +576,7 @@
     // Much of the 'What?' command can be eliminated. But until we are fully debugged, it is
     // good to have the extra information. Soon... we prune this to just a few items
     //
-    if (code_seen('W')) ubl.g29_what_command();
+    if (code_seen('W')) g29_what_command();
 
     //
     // When we are fully debugged, this may go away. But there are some valid
@@ -590,7 +591,7 @@
     //
 
     if (code_seen('L')) {     // Load Current Mesh Data
-      storage_slot = code_has_value() ? code_value_int() : ubl.state.storage_slot;
+      g29_storage_slot = code_has_value() ? code_value_int() : state.storage_slot;
 
       int16_t a = settings.calc_num_meshes();
 
@@ -599,14 +600,14 @@
         return;
       }
 
-      if (!WITHIN(storage_slot, 0, a - 1)) {
+      if (!WITHIN(g29_storage_slot, 0, a - 1)) {
         SERIAL_PROTOCOLLNPGM("?Invalid storage slot.");
         SERIAL_PROTOCOLLNPAIR("?Use 0 to ", a - 1);
         return;
       }
 
-      settings.load_mesh(storage_slot);
-      ubl.state.storage_slot = storage_slot;
+      settings.load_mesh(g29_storage_slot);
+      state.storage_slot = g29_storage_slot;
 
       SERIAL_PROTOCOLLNPGM("Done.");
     }
@@ -616,19 +617,19 @@
     //
 
     if (code_seen('S')) {     // Store (or Save) Current Mesh Data
-      storage_slot = code_has_value() ? code_value_int() : ubl.state.storage_slot;
+      g29_storage_slot = code_has_value() ? code_value_int() : state.storage_slot;
 
-      if (storage_slot == -1) {                     // Special case, we are going to 'Export' the mesh to the
+      if (g29_storage_slot == -1) {                     // Special case, we are going to 'Export' the mesh to the
         SERIAL_ECHOLNPGM("G29 I 999");              // host in a form it can be reconstructed on a different machine
         for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
           for (uint8_t y = 0;  y < GRID_MAX_POINTS_Y; y++)
-            if (!isnan(ubl.z_values[x][y])) {
+            if (!isnan(z_values[x][y])) {
               SERIAL_ECHOPAIR("M421 I ", x);
               SERIAL_ECHOPAIR(" J ", y);
               SERIAL_ECHOPGM(" Z ");
-              SERIAL_ECHO_F(ubl.z_values[x][y], 6);
-              SERIAL_ECHOPAIR(" ; X ", LOGICAL_X_POSITION(pgm_read_float(&ubl.mesh_index_to_xpos[x])));
-              SERIAL_ECHOPAIR(", Y ", LOGICAL_Y_POSITION(pgm_read_float(&ubl.mesh_index_to_ypos[y])));
+              SERIAL_ECHO_F(z_values[x][y], 6);
+              SERIAL_ECHOPAIR(" ; X ", LOGICAL_X_POSITION(mesh_index_to_xpos(x)));
+              SERIAL_ECHOPAIR(", Y ", LOGICAL_Y_POSITION(mesh_index_to_ypos(y)));
               SERIAL_EOL;
             }
         return;
@@ -641,32 +642,32 @@
         goto LEAVE;
       }
 
-      if (!WITHIN(storage_slot, 0, a - 1)) {
+      if (!WITHIN(g29_storage_slot, 0, a - 1)) {
         SERIAL_PROTOCOLLNPGM("?Invalid storage slot.");
         SERIAL_PROTOCOLLNPAIR("?Use 0 to ", a - 1);
         goto LEAVE;
       }
 
-      settings.store_mesh(storage_slot);
-      ubl.state.storage_slot = storage_slot;
+      settings.store_mesh(g29_storage_slot);
+      state.storage_slot = g29_storage_slot;
 
       SERIAL_PROTOCOLLNPGM("Done.");
     }
 
     if (code_seen('T'))
-      ubl.display_map(code_has_value() ? code_value_int() : 0);
+      display_map(code_has_value() ? code_value_int() : 0);
 
     /*
      * This code may not be needed...  Prepare for its removal...
      *
     if (code_seen('Z')) {
       if (code_has_value())
-        ubl.state.z_offset = code_value_float();   // do the simple case. Just lock in the specified value
+        state.z_offset = code_value_float();   // do the simple case. Just lock in the specified value
       else {
-        ubl.save_ubl_active_state_and_disable();
-        //float measured_z = probe_pt(x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER, ProbeDeployAndStow, g29_verbose_level);
+        save_ubl_active_state_and_disable();
+        //float measured_z = probe_pt(g29_x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, g29_y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER, ProbeDeployAndStow, g29_verbose_level);
 
-        ubl.has_control_of_lcd_panel = true;     // Grab the LCD Hardware
+        has_control_of_lcd_panel = true;     // Grab the LCD Hardware
         float measured_z = 1.5;
         do_blocking_move_to_z(measured_z);  // Get close to the bed, but leave some space so we don't damage anything
                                             // The user is not going to be locking in a new Z-Offset very often so
@@ -682,7 +683,7 @@
           do_blocking_move_to_z(measured_z);
         } while (!ubl_lcd_clicked());
 
-        ubl.has_control_of_lcd_panel = true;   // There is a race condition for the encoder click.
+        has_control_of_lcd_panel = true;   // There is a race condition for the encoder click.
                                                // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune)
                                                // or here. So, until we are done looking for a long encoder press,
                                                // we need to take control of the panel
@@ -698,17 +699,17 @@
             SERIAL_PROTOCOLLNPGM("\nZ-Offset Adjustment Stopped.");
             do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
             LCD_MESSAGEPGM("Z-Offset Stopped"); // TODO: Make translatable string
-            ubl.restore_ubl_active_state_and_leave();
+            restore_ubl_active_state_and_leave();
             goto LEAVE;
           }
         }
-        ubl.has_control_of_lcd_panel = false;
+        has_control_of_lcd_panel = false;
         safe_delay(20); // We don't want any switch noise.
 
-        ubl.state.z_offset = measured_z;
+        state.z_offset = measured_z;
 
         lcd_implementation_clear();
-        ubl.restore_ubl_active_state_and_leave();
+        restore_ubl_active_state_and_leave();
       }
     }
     */
@@ -719,7 +720,7 @@
     LCD_MESSAGEPGM("");
     lcd_quick_feedback();
 
-    ubl.has_control_of_lcd_panel = false;
+    has_control_of_lcd_panel = false;
   }
 
   void unified_bed_leveling::find_mean_mesh_height() {
@@ -727,8 +728,8 @@
     int n = 0;
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-        if (!isnan(ubl.z_values[x][y])) {
-          sum += ubl.z_values[x][y];
+        if (!isnan(z_values[x][y])) {
+          sum += z_values[x][y];
           n++;
         }
 
@@ -740,8 +741,8 @@
     float sum_of_diff_squared = 0.0;
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-        if (!isnan(ubl.z_values[x][y]))
-          sum_of_diff_squared += sq(ubl.z_values[x][y] - mean);
+        if (!isnan(z_values[x][y]))
+          sum_of_diff_squared += sq(z_values[x][y] - mean);
 
     SERIAL_ECHOLNPAIR("# of samples: ", n);
     SERIAL_ECHOPGM("Mean Mesh Height: ");
@@ -753,18 +754,18 @@
     SERIAL_ECHO_F(sigma, 6);
     SERIAL_EOL;
 
-    if (c_flag)
+    if (g29_c_flag)
       for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
         for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-          if (!isnan(ubl.z_values[x][y]))
-            ubl.z_values[x][y] -= mean + ubl_constant;
+          if (!isnan(z_values[x][y]))
+            z_values[x][y] -= mean + g29_constant;
   }
 
   void unified_bed_leveling::shift_mesh_height() {
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-        if (!isnan(ubl.z_values[x][y]))
-          ubl.z_values[x][y] += ubl_constant;
+        if (!isnan(z_values[x][y]))
+          z_values[x][y] += g29_constant;
   }
 
   /**
@@ -774,8 +775,8 @@
   void unified_bed_leveling::probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool close_or_far) {
     mesh_index_pair location;
 
-    ubl.has_control_of_lcd_panel = true;
-    ubl.save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
+    has_control_of_lcd_panel = true;
+    save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
     DEPLOY_PROBE();
 
     uint16_t max_iterations = GRID_MAX_POINTS;
@@ -786,8 +787,8 @@
         lcd_quick_feedback();
         STOW_PROBE();
         while (ubl_lcd_clicked()) idle();
-        ubl.has_control_of_lcd_panel = false;
-        ubl.restore_ubl_active_state_and_leave();
+        has_control_of_lcd_panel = false;
+        restore_ubl_active_state_and_leave();
         safe_delay(50);  // Debounce the Encoder wheel
         return;
       }
@@ -795,19 +796,19 @@
       location = find_closest_mesh_point_of_type(INVALID, lx, ly, USE_PROBE_AS_REFERENCE, NULL, close_or_far);
 
       if (location.x_index >= 0) {    // mesh point found and is reachable by probe
-        const float rawx = pgm_read_float(&ubl.mesh_index_to_xpos[location.x_index]),
-                    rawy = pgm_read_float(&ubl.mesh_index_to_ypos[location.y_index]);
+        const float rawx = mesh_index_to_xpos(location.x_index),
+                    rawy = mesh_index_to_ypos(location.y_index);
 
         const float measured_z = probe_pt(LOGICAL_X_POSITION(rawx), LOGICAL_Y_POSITION(rawy), stow_probe, g29_verbose_level); // TODO: Needs error handling
-        ubl.z_values[location.x_index][location.y_index] = measured_z;
+        z_values[location.x_index][location.y_index] = measured_z;
       }
 
-      if (do_ubl_mesh_map) ubl.display_map(map_type);
+      if (do_ubl_mesh_map) display_map(g29_map_type);
 
     } while (location.x_index >= 0 && --max_iterations);
 
     STOW_PROBE();
-    ubl.restore_ubl_active_state_and_leave();
+    restore_ubl_active_state_and_leave();
 
     do_blocking_move_to_xy(
       constrain(lx - (X_PROBE_OFFSET_FROM_EXTRUDER), UBL_MESH_MIN_X, UBL_MESH_MAX_X),
@@ -886,9 +887,9 @@
 
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
       for (uint8_t j = 0; j < GRID_MAX_POINTS_Y; j++) {
-        float x_tmp = pgm_read_float(&ubl.mesh_index_to_xpos[i]),
-              y_tmp = pgm_read_float(&ubl.mesh_index_to_ypos[j]),
-              z_tmp = ubl.z_values[i][j];
+        float x_tmp = mesh_index_to_xpos(i),
+              y_tmp = mesh_index_to_ypos(j),
+              z_tmp = z_values[i][j];
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOPGM("before rotation = [");
@@ -914,12 +915,12 @@
             safe_delay(55);
           }
         #endif
-        ubl.z_values[i][j] += z_tmp - d;
+        z_values[i][j] += z_tmp - d;
       }
     }
   }
 
-  float use_encoder_wheel_to_measure_point() {
+  float unified_bed_leveling::measure_point_with_encoder() {
 
     while (ubl_lcd_clicked()) delay(50);  // wait for user to release encoder wheel
     delay(50);  // debounce
@@ -927,9 +928,9 @@
     KEEPALIVE_STATE(PAUSED_FOR_USER);
     while (!ubl_lcd_clicked()) {     // we need the loop to move the nozzle based on the encoder wheel here!
       idle();
-      if (ubl.encoder_diff) {
-        do_blocking_move_to_z(current_position[Z_AXIS] + 0.01 * float(ubl.encoder_diff));
-        ubl.encoder_diff = 0;
+      if (encoder_diff) {
+        do_blocking_move_to_z(current_position[Z_AXIS] + 0.01 * float(encoder_diff));
+        encoder_diff = 0;
       }
     }
     KEEPALIVE_STATE(IN_HANDLER);
@@ -938,9 +939,9 @@
 
   static void echo_and_take_a_measurement() { SERIAL_PROTOCOLLNPGM(" and take a measurement."); }
 
-  float measure_business_card_thickness(float &in_height) {
-    ubl.has_control_of_lcd_panel = true;
-    ubl.save_ubl_active_state_and_disable();   // Disable bed level correction for probing
+  float unified_bed_leveling::measure_business_card_thickness(float &in_height) {
+    has_control_of_lcd_panel = true;
+    save_ubl_active_state_and_disable();   // Disable bed level correction for probing
 
     do_blocking_move_to_z(in_height);
     do_blocking_move_to_xy(0.5 * (UBL_MESH_MAX_X - (UBL_MESH_MIN_X)), 0.5 * (UBL_MESH_MAX_Y - (UBL_MESH_MIN_Y)));
@@ -952,7 +953,7 @@
     lcd_goto_screen(lcd_status_screen);
     echo_and_take_a_measurement();
 
-    const float z1 = use_encoder_wheel_to_measure_point();
+    const float z1 = measure_point_with_encoder();
     do_blocking_move_to_z(current_position[Z_AXIS] + SIZE_OF_LITTLE_RAISE);
     stepper.synchronize();
 
@@ -960,7 +961,7 @@
     LCD_MESSAGEPGM("Remove & measure bed"); // TODO: Make translatable string
     echo_and_take_a_measurement();
 
-    const float z2 = use_encoder_wheel_to_measure_point();
+    const float z2 = measure_point_with_encoder();
 
     do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_BETWEEN_PROBES);
 
@@ -974,17 +975,17 @@
 
     in_height = current_position[Z_AXIS]; // do manual probing at lower height
 
-    ubl.has_control_of_lcd_panel = false;
+    has_control_of_lcd_panel = false;
 
-    ubl.restore_ubl_active_state_and_leave();
+    restore_ubl_active_state_and_leave();
 
     return thickness;
   }
 
-  void manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &card_thickness, const bool do_ubl_mesh_map) {
+  void unified_bed_leveling::manually_probe_remaining_mesh(const float &lx, const float &ly, const float &z_clearance, const float &thick, const bool do_ubl_mesh_map) {
 
-    ubl.has_control_of_lcd_panel = true;
-    ubl.save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
+    has_control_of_lcd_panel = true;
+    save_ubl_active_state_and_disable();   // we don't do bed level correction because we want the raw data when we probe
     do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
     do_blocking_move_to_xy(lx, ly);
 
@@ -995,8 +996,8 @@
       // It doesn't matter if the probe can't reach the NAN location. This is a manual probe.
       if (location.x_index < 0 && location.y_index < 0) continue;
 
-      const float rawx = pgm_read_float(&ubl.mesh_index_to_xpos[location.x_index]),
-                  rawy = pgm_read_float(&ubl.mesh_index_to_ypos[location.y_index]),
+      const float rawx = mesh_index_to_xpos(location.x_index),
+                  rawy = mesh_index_to_ypos(location.y_index),
                   xProbe = LOGICAL_X_POSITION(rawx),
                   yProbe = LOGICAL_Y_POSITION(rawy);
 
@@ -1010,9 +1011,9 @@
       do_blocking_move_to_z(z_clearance);
 
       KEEPALIVE_STATE(PAUSED_FOR_USER);
-      ubl.has_control_of_lcd_panel = true;
+      has_control_of_lcd_panel = true;
 
-      if (do_ubl_mesh_map) ubl.display_map(map_type);  // show user where we're probing
+      if (do_ubl_mesh_map) display_map(g29_map_type);  // show user where we're probing
 
       if (code_seen('B'))
         LCD_MESSAGEPGM("Place shim & measure"); // TODO: Make translatable string
@@ -1023,9 +1024,9 @@
       delay(50);                                       // debounce
       while (!ubl_lcd_clicked()) {                     // we need the loop to move the nozzle based on the encoder wheel here!
         idle();
-        if (ubl.encoder_diff) {
-          do_blocking_move_to_z(current_position[Z_AXIS] + float(ubl.encoder_diff) / 100.0);
-          ubl.encoder_diff = 0;
+        if (encoder_diff) {
+          do_blocking_move_to_z(current_position[Z_AXIS] + float(encoder_diff) / 100.0);
+          encoder_diff = 0;
         }
       }
 
@@ -1040,48 +1041,47 @@
           do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
           lcd_quick_feedback();
           while (ubl_lcd_clicked()) idle();
-          ubl.has_control_of_lcd_panel = false;
+          has_control_of_lcd_panel = false;
           KEEPALIVE_STATE(IN_HANDLER);
-          ubl.restore_ubl_active_state_and_leave();
+          restore_ubl_active_state_and_leave();
           return;
         }
       }
 
-      ubl.z_values[location.x_index][location.y_index] = current_position[Z_AXIS] - card_thickness;
+      z_values[location.x_index][location.y_index] = current_position[Z_AXIS] - thick;
       if (g29_verbose_level > 2) {
         SERIAL_PROTOCOLPGM("Mesh Point Measured at: ");
-        SERIAL_PROTOCOL_F(ubl.z_values[location.x_index][location.y_index], 6);
+        SERIAL_PROTOCOL_F(z_values[location.x_index][location.y_index], 6);
         SERIAL_EOL;
       }
     } while (location.x_index >= 0 && location.y_index >= 0);
 
-    if (do_ubl_mesh_map) ubl.display_map(map_type);
+    if (do_ubl_mesh_map) display_map(g29_map_type);
 
-    ubl.restore_ubl_active_state_and_leave();
+    restore_ubl_active_state_and_leave();
     KEEPALIVE_STATE(IN_HANDLER);
     do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
     do_blocking_move_to_xy(lx, ly);
   }
 
-  bool g29_parameter_parsing() {
+  bool unified_bed_leveling::g29_parameter_parsing() {
     bool err_flag = false;
 
     LCD_MESSAGEPGM("Doing G29 UBL!"); // TODO: Make translatable string
     lcd_quick_feedback();
 
-    ubl_constant = 0.0;
-    repetition_cnt = 0;
+    g29_constant = 0.0;
+    g29_repetition_cnt = 0;
 
-    x_flag = code_seen('X') && code_has_value();
-    x_pos = x_flag ? code_value_float() : current_position[X_AXIS];
-    y_flag = code_seen('Y') && code_has_value();
-    y_pos = y_flag ? code_value_float() : current_position[Y_AXIS];
+    g29_x_flag = code_seen('X') && code_has_value();
+    g29_x_pos = g29_x_flag ? code_value_float() : current_position[X_AXIS];
+    g29_y_flag = code_seen('Y') && code_has_value();
+    g29_y_pos = g29_y_flag ? code_value_float() : current_position[Y_AXIS];
 
-    repeat_flag = code_seen('R');
-    if (repeat_flag) {
-      repetition_cnt = code_has_value() ? code_value_int() : GRID_MAX_POINTS;
-      NOMORE(repetition_cnt, GRID_MAX_POINTS);
-      if (repetition_cnt < 1) {
+    if (code_seen('R')) {
+      g29_repetition_cnt = code_has_value() ? code_value_int() : GRID_MAX_POINTS;
+      NOMORE(g29_repetition_cnt, GRID_MAX_POINTS);
+      if (g29_repetition_cnt < 1) {
         SERIAL_PROTOCOLLNPGM("?(R)epetition count invalid (1+).\n");
         return UBL_ERR;
       }
@@ -1094,31 +1094,31 @@
     }
 
     if (code_seen('P')) {
-      phase_value = code_value_int();
-      if (!WITHIN(phase_value, 0, 6)) {
+      g29_phase_value = code_value_int();
+      if (!WITHIN(g29_phase_value, 0, 6)) {
         SERIAL_PROTOCOLLNPGM("?(P)hase value invalid (0-6).\n");
         err_flag = true;
       }
     }
 
     if (code_seen('J')) {
-      grid_size = code_has_value() ? code_value_int() : 0;
-      if (grid_size!=0 && !WITHIN(grid_size, 2, 9)) {
+      g29_grid_size = code_has_value() ? code_value_int() : 0;
+      if (g29_grid_size && !WITHIN(g29_grid_size, 2, 9)) {
         SERIAL_PROTOCOLLNPGM("?Invalid grid size (J) specified (2-9).\n");
         err_flag = true;
       }
     }
 
-    if (x_flag != y_flag) {
+    if (g29_x_flag != g29_y_flag) {
       SERIAL_PROTOCOLLNPGM("Both X & Y locations must be specified.\n");
       err_flag = true;
     }
-    if (!WITHIN(RAW_X_POSITION(x_pos), X_MIN_POS, X_MAX_POS)) {
+    if (!WITHIN(RAW_X_POSITION(g29_x_pos), X_MIN_POS, X_MAX_POS)) {
       SERIAL_PROTOCOLLNPGM("Invalid X location specified.\n");
       err_flag = true;
     }
 
-    if (!WITHIN(RAW_Y_POSITION(y_pos), Y_MIN_POS, Y_MAX_POS)) {
+    if (!WITHIN(RAW_Y_POSITION(g29_y_pos), Y_MIN_POS, Y_MAX_POS)) {
       SERIAL_PROTOCOLLNPGM("Invalid Y location specified.\n");
       err_flag = true;
     }
@@ -1131,17 +1131,17 @@
         SERIAL_PROTOCOLLNPGM("?Can't activate and deactivate at the same time.\n");
         return UBL_ERR;
       }
-      ubl.state.active = true;
-      ubl.report_state();
+      state.active = true;
+      report_state();
     }
     else if (code_seen('D')) {
-      ubl.state.active = false;
-      ubl.report_state();
+      state.active = false;
+      report_state();
     }
 
     // Set global 'C' flag and its value
-    if ((c_flag = code_seen('C')))
-      ubl_constant = code_value_float();
+    if ((g29_c_flag = code_seen('C')))
+      g29_constant = code_value_float();
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       if (code_seen('F') && code_has_value()) {
@@ -1154,8 +1154,8 @@
       }
     #endif
 
-    map_type = code_seen('T') && code_has_value() ? code_value_int() : 0;
-    if (!WITHIN(map_type, 0, 1)) {
+    g29_map_type = code_seen('T') && code_has_value() ? code_value_int() : 0;
+    if (!WITHIN(g29_map_type, 0, 1)) {
       SERIAL_PROTOCOLLNPGM("Invalid map type.\n");
       return UBL_ERR;
     }
@@ -1173,8 +1173,8 @@
       lcd_quick_feedback();
       return;
     }
-    ubl_state_at_invocation = ubl.state.active;
-    ubl.state.active = 0;
+    ubl_state_at_invocation = state.active;
+    state.active = 0;
   }
 
   void unified_bed_leveling::restore_ubl_active_state_and_leave() {
@@ -1184,7 +1184,7 @@
       lcd_quick_feedback();
       return;
     }
-    ubl.state.active = ubl_state_at_invocation;
+    state.active = ubl_state_at_invocation;
   }
 
   /**
@@ -1232,7 +1232,7 @@
 
     SERIAL_PROTOCOLPGM("X-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
-      SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(pgm_read_float(&mesh_index_to_xpos[i])), 3);
+      SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(mesh_index_to_xpos(i)), 3);
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(25);
     }
@@ -1240,7 +1240,7 @@
 
     SERIAL_PROTOCOLPGM("Y-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; i++) {
-      SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(pgm_read_float(&mesh_index_to_ypos[i])), 3);
+      SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(mesh_index_to_ypos(i)), 3);
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(25);
     }
@@ -1286,7 +1286,7 @@
    * When we are fully debugged, the EEPROM dump command will get deleted also. But
    * right now, it is good to have the extra information. Soon... we prune this.
    */
-  void g29_eeprom_dump() {
+  void unified_bed_leveling::g29_eeprom_dump() {
     unsigned char cccc;
     uint16_t kkkk;
 
@@ -1311,7 +1311,7 @@
    * When we are fully debugged, this may go away. But there are some valid
    * use cases for the users. So we can wait and see what to do with it.
    */
-  void g29_compare_current_mesh_to_stored_mesh() {
+  void unified_bed_leveling::g29_compare_current_mesh_to_stored_mesh() {
     int16_t a = settings.calc_num_meshes();
 
     if (!a) {
@@ -1325,26 +1325,26 @@
       return;
     }
 
-    storage_slot = code_value_int();
+    g29_storage_slot = code_value_int();
 
-    if (!WITHIN(storage_slot, 0, a - 1)) {
+    if (!WITHIN(g29_storage_slot, 0, a - 1)) {
       SERIAL_PROTOCOLLNPGM("?Invalid storage slot.");
       SERIAL_PROTOCOLLNPAIR("?Use 0 to ", a - 1);
       return;
     }
 
     float tmp_z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-    settings.load_mesh(storage_slot, &tmp_z_values);
+    settings.load_mesh(g29_storage_slot, &tmp_z_values);
 
-    SERIAL_PROTOCOLPAIR("Subtracting mesh in slot ", storage_slot);
+    SERIAL_PROTOCOLPAIR("Subtracting mesh in slot ", g29_storage_slot);
     SERIAL_PROTOCOLLNPGM(" from current mesh.");
 
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-        ubl.z_values[x][y] -= tmp_z_values[x][y];
+        z_values[x][y] -= tmp_z_values[x][y];
   }
 
-  mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType type, const float &lx, const float &ly, const bool probe_as_reference, unsigned int bits[16], const bool far_flag) {
+  mesh_index_pair unified_bed_leveling::find_closest_mesh_point_of_type(const MeshPointType type, const float &lx, const float &ly, const bool probe_as_reference, unsigned int bits[16], const bool far_flag) {
     mesh_index_pair out_mesh;
     out_mesh.x_index = out_mesh.y_index = -1;
 
@@ -1357,15 +1357,15 @@
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
       for (uint8_t j = 0; j < GRID_MAX_POINTS_Y; j++) {
 
-        if ( (type == INVALID && isnan(ubl.z_values[i][j]))  // Check to see if this location holds the right thing
-          || (type == REAL && !isnan(ubl.z_values[i][j]))
+        if ( (type == INVALID && isnan(z_values[i][j]))  // Check to see if this location holds the right thing
+          || (type == REAL && !isnan(z_values[i][j]))
           || (type == SET_IN_BITMAP && is_bit_set(bits, i, j))
         ) {
           // We only get here if we found a Mesh Point of the specified type
 
           float raw_x = RAW_CURRENT_POSITION(X), raw_y = RAW_CURRENT_POSITION(Y);
-          const float mx = pgm_read_float(&ubl.mesh_index_to_xpos[i]),
-                      my = pgm_read_float(&ubl.mesh_index_to_ypos[j]);
+          const float mx = mesh_index_to_xpos(i),
+                      my = mesh_index_to_ypos(j);
 
           // If using the probe as the reference there are some unreachable locations.
           // Also for round beds, there are grid points outside the bed the nozzle can't reach.
@@ -1389,7 +1389,7 @@
           if (far_flag) {
             for (uint8_t k = 0; k < GRID_MAX_POINTS_X; k++) {
               for (uint8_t l = 0; l < GRID_MAX_POINTS_Y; l++) {
-                if (i != k && j != l && !isnan(ubl.z_values[k][l])) {
+                if (i != k && j != l && !isnan(z_values[k][l])) {
                   //distance += pow((float) abs(i - k) * (MESH_X_DIST), 2) + pow((float) abs(j - l) * (MESH_Y_DIST), 2);  // working here
                   distance += HYPOT(MESH_X_DIST, MESH_Y_DIST) / log(HYPOT((i - k) * (MESH_X_DIST) + .001, (j - l) * (MESH_Y_DIST)) + .001);
                 }
@@ -1415,20 +1415,19 @@
     return out_mesh;
   }
 
-  void fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map) {
+  void unified_bed_leveling::fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map) {
     if (!code_seen('R'))    // fine_tune_mesh() is special. If no repetition count flag is specified
-      repetition_cnt = 1;   // do exactly one mesh location. Otherwise use what the parser decided.
+      g29_repetition_cnt = 1;   // do exactly one mesh location. Otherwise use what the parser decided.
 
     mesh_index_pair location;
     uint16_t not_done[16];
-    int32_t round_off;
 
     if (!position_is_reachable_xy(lx, ly)) {
       SERIAL_PROTOCOLLNPGM("(X,Y) outside printable radius.");
       return;
     }
 
-    ubl.save_ubl_active_state_and_disable();
+    save_ubl_active_state_and_disable();
 
     memset(not_done, 0xFF, sizeof(not_done));
 
@@ -1444,13 +1443,13 @@
       bit_clear(not_done, location.x_index, location.y_index);  // Mark this location as 'adjusted' so we will find a
                                                                 // different location the next time through the loop
 
-      const float rawx = pgm_read_float(&ubl.mesh_index_to_xpos[location.x_index]),
-                  rawy = pgm_read_float(&ubl.mesh_index_to_ypos[location.y_index]);
+      const float rawx = mesh_index_to_xpos(location.x_index),
+                  rawy = mesh_index_to_ypos(location.y_index);
 
       if (!position_is_reachable_raw_xy(rawx, rawy)) // SHOULD NOT OCCUR because find_closest_mesh_point_of_type will only return reachable
         break;
 
-      float new_z = ubl.z_values[location.x_index][location.y_index];
+      float new_z = z_values[location.x_index][location.y_index];
 
       if (isnan(new_z)) // if the mesh point is invalid, set it to 0.0 so it can be edited
         new_z = 0.0;
@@ -1461,9 +1460,9 @@
       new_z = floor(new_z * 1000.0) * 0.001; // Chop off digits after the 1000ths place
 
       KEEPALIVE_STATE(PAUSED_FOR_USER);
-      ubl.has_control_of_lcd_panel = true;
+      has_control_of_lcd_panel = true;
 
-      if (do_ubl_mesh_map) ubl.display_map(map_type);  // show the user which point is being adjusted
+      if (do_ubl_mesh_map) display_map(g29_map_type);  // show the user which point is being adjusted
 
       lcd_implementation_clear();
 
@@ -1482,7 +1481,7 @@
       // The technique used here generates a race condition for the encoder click.
       // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune) or here.
       // Let's work on specifying a proper API for the LCD ASAP, OK?
-      ubl.has_control_of_lcd_panel = true;
+      has_control_of_lcd_panel = true;
 
       // this sequence to detect an ubl_lcd_clicked() debounce it and leave if it is
       // a Press and Hold is repeated in a lot of places (including G26_Mesh_Validation.cpp).   This
@@ -1504,19 +1503,19 @@
 
       safe_delay(20);                       // We don't want any switch noise.
 
-      ubl.z_values[location.x_index][location.y_index] = new_z;
+      z_values[location.x_index][location.y_index] = new_z;
 
       lcd_implementation_clear();
 
-    } while (location.x_index >= 0 && --repetition_cnt > 0);
+    } while (location.x_index >= 0 && --g29_repetition_cnt > 0);
 
     FINE_TUNE_EXIT:
 
-    ubl.has_control_of_lcd_panel = false;
+    has_control_of_lcd_panel = false;
     KEEPALIVE_STATE(IN_HANDLER);
 
-    if (do_ubl_mesh_map) ubl.display_map(map_type);
-    ubl.restore_ubl_active_state_and_leave();
+    if (do_ubl_mesh_map) display_map(g29_map_type);
+    restore_ubl_active_state_and_leave();
     do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
 
     do_blocking_move_to_xy(lx, ly);
@@ -1531,15 +1530,15 @@
    * calculate a 'reasonable' value for the unprobed mesh point.
    */
 
-  bool smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir) {
+  bool unified_bed_leveling::smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir) {
     const int8_t x1 = x + xdir, x2 = x1 + xdir,
                  y1 = y + ydir, y2 = y1 + ydir;
     // A NAN next to a pair of real values?
-    if (isnan(ubl.z_values[x][y]) && !isnan(ubl.z_values[x1][y1]) && !isnan(ubl.z_values[x2][y2])) {
-      if (ubl.z_values[x1][y1] < ubl.z_values[x2][y2])                  // Angled downward?
-        ubl.z_values[x][y] = ubl.z_values[x1][y1];                      // Use nearest (maybe a little too high.)
+    if (isnan(z_values[x][y]) && !isnan(z_values[x1][y1]) && !isnan(z_values[x2][y2])) {
+      if (z_values[x1][y1] < z_values[x2][y2])                  // Angled downward?
+        z_values[x][y] = z_values[x1][y1];                      // Use nearest (maybe a little too high.)
       else
-        ubl.z_values[x][y] = 2.0 * ubl.z_values[x1][y1] - ubl.z_values[x2][y2];   // Angled upward...
+        z_values[x][y] = 2.0 * z_values[x1][y1] - z_values[x2][y2];   // Angled upward...
       return true;
     }
     return false;
@@ -1547,7 +1546,7 @@
 
   typedef struct { uint8_t sx, ex, sy, ey; bool yfirst; } smart_fill_info;
 
-  void smart_fill_mesh() {
+  void unified_bed_leveling::smart_fill_mesh() {
     const smart_fill_info info[] = {
       { 0, GRID_MAX_POINTS_X,      0, GRID_MAX_POINTS_Y - 2,  false },  // Bottom of the mesh looking up
       { 0, GRID_MAX_POINTS_X,      GRID_MAX_POINTS_Y - 1, 0,  false },  // Top of the mesh looking down
@@ -1577,17 +1576,17 @@
                       y_min = max(MIN_PROBE_Y, UBL_MESH_MIN_Y),
                       y_max = min(MAX_PROBE_Y, UBL_MESH_MAX_Y);
 
-    const float dx = float(x_max - x_min) / (grid_size - 1.0),
-                dy = float(y_max - y_min) / (grid_size - 1.0);
+    const float dx = float(x_max - x_min) / (g29_grid_size - 1.0),
+                dy = float(y_max - y_min) / (g29_grid_size - 1.0);
 
     struct linear_fit_data lsf_results;
     incremental_LSF_reset(&lsf_results);
 
     bool zig_zag = false;
-    for (uint8_t ix = 0; ix < grid_size; ix++) {
+    for (uint8_t ix = 0; ix < g29_grid_size; ix++) {
       const float x = float(x_min) + ix * dx;
-      for (int8_t iy = 0; iy < grid_size; iy++) {
-        const float y = float(y_min) + dy * (zig_zag ? grid_size - 1 - iy : iy);
+      for (int8_t iy = 0; iy < g29_grid_size; iy++) {
+        const float y = float(y_min) + dy * (zig_zag ? g29_grid_size - 1 - iy : iy);
         float measured_z = probe_pt(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y), code_seen('E'), g29_verbose_level); // TODO: Needs error handling
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
@@ -1654,8 +1653,8 @@
 
     for (uint8_t i = 0; i < GRID_MAX_POINTS_X; i++) {
       for (uint8_t j = 0; j < GRID_MAX_POINTS_Y; j++) {
-        float x_tmp = pgm_read_float(&mesh_index_to_xpos[i]),
-              y_tmp = pgm_read_float(&mesh_index_to_ypos[j]),
+        float x_tmp = mesh_index_to_xpos(i),
+              y_tmp = mesh_index_to_ypos(j),
               z_tmp = z_values[i][j];
 
         #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -1715,47 +1714,40 @@
   }
 
   #if ENABLED(UBL_G29_P31)
-
-    // Note: using optimize("O2") for this routine results in smaller
-    // codegen than default optimize("Os") on A2560.
-
-    void _O2 smart_fill_wlsf( float weight_factor ) {
+    void unified_bed_leveling::smart_fill_wlsf(const float &weight_factor) {
 
       // For each undefined mesh point, compute a distance-weighted least squares fit
       // from all the originally populated mesh points, weighted toward the point
       // being extrapolated so that nearby points will have greater influence on
       // the point being extrapolated.  Then extrapolate the mesh point from WLSF.
 
-      static_assert( GRID_MAX_POINTS_Y <= 16, "GRID_MAX_POINTS_Y too big" );
-      uint16_t bitmap[GRID_MAX_POINTS_X] = {0};
+      static_assert(GRID_MAX_POINTS_Y <= 16, "GRID_MAX_POINTS_Y too big");
+      uint16_t bitmap[GRID_MAX_POINTS_X] = { 0 };
       struct linear_fit_data lsf_results;
 
       SERIAL_ECHOPGM("Extrapolating mesh...");
 
       const float weight_scaled = weight_factor * max(MESH_X_DIST, MESH_Y_DIST);
 
-      for (uint8_t jx = 0; jx < GRID_MAX_POINTS_X; jx++) {
-        for (uint8_t jy = 0; jy < GRID_MAX_POINTS_Y; jy++) {
-          if ( !isnan( ubl.z_values[jx][jy] )) {
-            bitmap[jx] |= (uint16_t)1 << jy;
-          }
-        }
-      }
+      for (uint8_t jx = 0; jx < GRID_MAX_POINTS_X; jx++)
+        for (uint8_t jy = 0; jy < GRID_MAX_POINTS_Y; jy++)
+          if (!isnan(z_values[jx][jy]))
+            SBI(bitmap[jx], jy);
 
       for (uint8_t ix = 0; ix < GRID_MAX_POINTS_X; ix++) {
-        const float px = pgm_read_float(&(ubl.mesh_index_to_xpos[ix]));
+        const float px = mesh_index_to_xpos(ix);
         for (uint8_t iy = 0; iy < GRID_MAX_POINTS_Y; iy++) {
-          const float py = pgm_read_float(&(ubl.mesh_index_to_ypos[iy]));
-          if ( isnan( ubl.z_values[ix][iy] )) {
+          const float py = mesh_index_to_ypos(iy);
+          if (isnan(z_values[ix][iy])) {
             // undefined mesh point at (px,py), compute weighted LSF from original valid mesh points.
             incremental_LSF_reset(&lsf_results);
             for (uint8_t jx = 0; jx < GRID_MAX_POINTS_X; jx++) {
-              const float rx = pgm_read_float(&(ubl.mesh_index_to_xpos[jx]));
+              const float rx = mesh_index_to_xpos(jx);
               for (uint8_t jy = 0; jy < GRID_MAX_POINTS_Y; jy++) {
-                if ( bitmap[jx] & (uint16_t)1 << jy ) {
-                  const float ry = pgm_read_float(&(ubl.mesh_index_to_ypos[jy]));
-                  const float rz = ubl.z_values[jx][jy];
-                  const float w  = 1.0 + weight_scaled / HYPOT((rx - px),(ry - py));
+                if (TEST(bitmap[jx], jy)) {
+                  const float ry = mesh_index_to_ypos(jy),
+                              rz = z_values[jx][jy],
+                              w  = 1.0 + weight_scaled / HYPOT((rx - px), (ry - py));
                   incremental_WLSF(&lsf_results, rx, ry, rz, w);
                 }
               }
@@ -1765,7 +1757,7 @@
               return;
             }
             const float ez = -lsf_results.D - lsf_results.A * px - lsf_results.B * py;
-            ubl.z_values[ix][iy] = ez;
+            z_values[ix][iy] = ez;
             idle();   // housekeeping
           }
         }
@@ -1774,6 +1766,5 @@
       SERIAL_ECHOLNPGM("done");
     }
   #endif // UBL_G29_P31
-
 
 #endif // AUTO_BED_LEVELING_UBL

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -36,8 +36,7 @@
 
   #define UBL_G29_P31
 
-  extern float destination[XYZE];
-  extern float current_position[XYZE];
+  extern float destination[XYZE], current_position[XYZE];
 
   void lcd_return_to_status();
   bool lcd_clicked();
@@ -63,6 +62,7 @@
 
   #define SIZE_OF_LITTLE_RAISE 1
   #define BIG_RAISE_NOT_NEEDED 0
+
   extern void lcd_status_screen();
   typedef void (*screenFunc_t)();
   extern void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0);
@@ -936,9 +936,7 @@
     return current_position[Z_AXIS];
   }
 
-  static void echo_and_take_a_measurement() {
-    SERIAL_PROTOCOLLNPGM(" and take a measurement.");
-  }
+  static void echo_and_take_a_measurement() { SERIAL_PROTOCOLLNPGM(" and take a measurement."); }
 
   float measure_business_card_thickness(float &in_height) {
     ubl.has_control_of_lcd_panel = true;
@@ -1392,8 +1390,8 @@
             for (uint8_t k = 0; k < GRID_MAX_POINTS_X; k++) {
               for (uint8_t l = 0; l < GRID_MAX_POINTS_Y; l++) {
                 if (i != k && j != l && !isnan(ubl.z_values[k][l])) {
-//                distance += pow((float) abs(i - k) * (MESH_X_DIST), 2) + pow((float) abs(j - l) * (MESH_Y_DIST), 2);  // working here
-                  distance += HYPOT((MESH_X_DIST),(MESH_Y_DIST)) / log(HYPOT((i - k) * (MESH_X_DIST)+.001, (j - l) * (MESH_Y_DIST))+.001);
+                  //distance += pow((float) abs(i - k) * (MESH_X_DIST), 2) + pow((float) abs(j - l) * (MESH_Y_DIST), 2);  // working here
+                  distance += HYPOT(MESH_X_DIST, MESH_Y_DIST) / log(HYPOT((i - k) * (MESH_X_DIST) + .001, (j - l) * (MESH_Y_DIST)) + .001);
                 }
               }
             }
@@ -1474,7 +1472,7 @@
       do {
         new_z = lcd_mesh_edit();
         #ifdef UBL_MESH_EDIT_MOVES_Z
-          do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES+new_z);  // Move the nozzle as the point is edited
+          do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES + new_z);  // Move the nozzle as the point is edited
         #endif
         idle();
       } while (!ubl_lcd_clicked());

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -51,10 +51,10 @@
   extern uint8_t code_value_byte();
   extern bool code_value_bool();
   extern bool code_has_value();
-  extern float probe_pt(float x, float y, bool, int);
+  extern float probe_pt(const float &x, const float &y, bool, int);
   extern bool set_probe_deployed(bool);
   void smart_fill_mesh();
-  void smart_fill_wlsf(float);
+  void smart_fill_wlsf(const float &);
   float measure_business_card_thickness(float &in_height);
   void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
 
@@ -531,7 +531,7 @@
             }
           } else {
             const float cvf = code_value_float();
-            switch( (int)truncf( cvf * 10.0 ) - 30 ) {   // 3.1 -> 1
+            switch((int)truncf(cvf * 10.0) - 30) {   // 3.1 -> 1
               #if ENABLED(UBL_G29_P31)
                 case 1: {
 
@@ -541,9 +541,9 @@
                   // P3.12 100X distance weighting
                   // P3.13 1000X distance weighting, approaches simple average of nearest points
 
-                  const float weight_power  = (cvf - 3.10) * 100.0;  // 3.12345 -> 2.345
-                  const float weight_factor = weight_power ? pow( 10.0, weight_power ) : 0;
-                  smart_fill_wlsf( weight_factor );
+                  const float weight_power  = (cvf - 3.10) * 100.0,  // 3.12345 -> 2.345
+                              weight_factor = weight_power ? pow(10.0, weight_power) : 0;
+                  smart_fill_wlsf(weight_factor);
                 }
                 break;
               #endif

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -85,7 +85,7 @@
 
   }
 
-  void ubl_line_to_destination_cartesian(const float &feed_rate, uint8_t extruder) {
+  void unified_bed_leveling::line_to_destination_cartesian(const float &feed_rate, uint8_t extruder) {
     /**
      * Much of the nozzle movement will be within the same cell. So we will do as little computation
      * as possible to determine if this is the case. If this move is within the same cell, we will
@@ -104,19 +104,19 @@
                   destination[E_AXIS]
                 };
 
-    const int cell_start_xi = ubl.get_cell_index_x(RAW_X_POSITION(start[X_AXIS])),
-              cell_start_yi = ubl.get_cell_index_y(RAW_Y_POSITION(start[Y_AXIS])),
-              cell_dest_xi  = ubl.get_cell_index_x(RAW_X_POSITION(end[X_AXIS])),
-              cell_dest_yi  = ubl.get_cell_index_y(RAW_Y_POSITION(end[Y_AXIS]));
+    const int cell_start_xi = get_cell_index_x(RAW_X_POSITION(start[X_AXIS])),
+              cell_start_yi = get_cell_index_y(RAW_Y_POSITION(start[Y_AXIS])),
+              cell_dest_xi  = get_cell_index_x(RAW_X_POSITION(end[X_AXIS])),
+              cell_dest_yi  = get_cell_index_y(RAW_Y_POSITION(end[Y_AXIS]));
 
-    if (ubl.g26_debug_flag) {
-      SERIAL_ECHOPAIR(" ubl_line_to_destination(xe=", end[X_AXIS]);
+    if (g26_debug_flag) {
+      SERIAL_ECHOPAIR(" ubl.line_to_destination(xe=", end[X_AXIS]);
       SERIAL_ECHOPAIR(", ye=", end[Y_AXIS]);
       SERIAL_ECHOPAIR(", ze=", end[Z_AXIS]);
       SERIAL_ECHOPAIR(", ee=", end[E_AXIS]);
       SERIAL_CHAR(')');
       SERIAL_EOL;
-      debug_current_and_destination(PSTR("Start of ubl_line_to_destination()"));
+      debug_current_and_destination(PSTR("Start of ubl.line_to_destination()"));
     }
 
     if (cell_start_xi == cell_dest_xi && cell_start_yi == cell_dest_yi) { // if the whole move is within the same cell,
@@ -132,11 +132,11 @@
         // Note: There is no Z Correction in this case. We are off the grid and don't know what
         // a reasonable correction would be.
 
-        planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + ubl.state.z_offset, end[E_AXIS], feed_rate, extruder);
+        planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + state.z_offset, end[E_AXIS], feed_rate, extruder);
         set_current_to_destination();
 
-        if (ubl.g26_debug_flag)
-          debug_current_and_destination(PSTR("out of bounds in ubl_line_to_destination()"));
+        if (g26_debug_flag)
+          debug_current_and_destination(PSTR("out of bounds in ubl.line_to_destination()"));
 
         return;
       }
@@ -152,20 +152,20 @@
        * to create a 1-over number for us. That will allow us to do a floating point multiply instead of a floating point divide.
        */
 
-      const float xratio = (RAW_X_POSITION(end[X_AXIS]) - pgm_read_float(&ubl.mesh_index_to_xpos[cell_dest_xi])) * (1.0 / (MESH_X_DIST)),
-                  z1 = ubl.z_values[cell_dest_xi    ][cell_dest_yi    ] + xratio *
-                      (ubl.z_values[cell_dest_xi + 1][cell_dest_yi    ] - ubl.z_values[cell_dest_xi][cell_dest_yi    ]),
-                  z2 = ubl.z_values[cell_dest_xi    ][cell_dest_yi + 1] + xratio *
-                      (ubl.z_values[cell_dest_xi + 1][cell_dest_yi + 1] - ubl.z_values[cell_dest_xi][cell_dest_yi + 1]);
+      const float xratio = (RAW_X_POSITION(end[X_AXIS]) - mesh_index_to_xpos(cell_dest_xi)) * (1.0 / (MESH_X_DIST)),
+                  z1 = z_values[cell_dest_xi    ][cell_dest_yi    ] + xratio *
+                      (z_values[cell_dest_xi + 1][cell_dest_yi    ] - z_values[cell_dest_xi][cell_dest_yi    ]),
+                  z2 = z_values[cell_dest_xi    ][cell_dest_yi + 1] + xratio *
+                      (z_values[cell_dest_xi + 1][cell_dest_yi + 1] - z_values[cell_dest_xi][cell_dest_yi + 1]);
 
       // we are done with the fractional X distance into the cell. Now with the two Z-Heights we have calculated, we
       // are going to apply the Y-Distance into the cell to interpolate the final Z correction.
 
-      const float yratio = (RAW_Y_POSITION(end[Y_AXIS]) - pgm_read_float(&ubl.mesh_index_to_ypos[cell_dest_yi])) * (1.0 / (MESH_Y_DIST));
+      const float yratio = (RAW_Y_POSITION(end[Y_AXIS]) - mesh_index_to_ypos(cell_dest_yi)) * (1.0 / (MESH_Y_DIST));
 
       float z0 = z1 + (z2 - z1) * yratio;
 
-      z0 *= ubl.fade_scaling_factor_for_z(end[Z_AXIS]);
+      z0 *= fade_scaling_factor_for_z(end[Z_AXIS]);
 
       /**
        * If part of the Mesh is undefined, it will show up as NAN
@@ -176,10 +176,10 @@
        */
       if (isnan(z0)) z0 = 0.0;
 
-      planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + z0 + ubl.state.z_offset, end[E_AXIS], feed_rate, extruder);
+      planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + z0 + state.z_offset, end[E_AXIS], feed_rate, extruder);
 
-      if (ubl.g26_debug_flag)
-        debug_current_and_destination(PSTR("FINAL_MOVE in ubl_line_to_destination()"));
+      if (g26_debug_flag)
+        debug_current_and_destination(PSTR("FINAL_MOVE in ubl.line_to_destination()"));
 
       set_current_to_destination();
       return;
@@ -240,7 +240,7 @@
       current_yi += down_flag;  // Line is heading down, we just want to go to the bottom
       while (current_yi != cell_dest_yi + down_flag) {
         current_yi += dyi;
-        const float next_mesh_line_y = LOGICAL_Y_POSITION(pgm_read_float(&ubl.mesh_index_to_ypos[current_yi]));
+        const float next_mesh_line_y = LOGICAL_Y_POSITION(mesh_index_to_ypos(current_yi));
 
         /**
          * if the slope of the line is infinite, we won't do the calculations
@@ -249,9 +249,9 @@
          */
         const float x = inf_m_flag ? start[X_AXIS] : (next_mesh_line_y - c) / m;
 
-        float z0 = ubl.z_correction_for_x_on_horizontal_mesh_line(x, current_xi, current_yi);
+        float z0 = z_correction_for_x_on_horizontal_mesh_line(x, current_xi, current_yi);
 
-        z0 *= ubl.fade_scaling_factor_for_z(end[Z_AXIS]);
+        z0 *= fade_scaling_factor_for_z(end[Z_AXIS]);
 
         /**
          * If part of the Mesh is undefined, it will show up as NAN
@@ -262,7 +262,7 @@
          */
         if (isnan(z0)) z0 = 0.0;
 
-        const float y = LOGICAL_Y_POSITION(pgm_read_float(&ubl.mesh_index_to_ypos[current_yi]));
+        const float y = LOGICAL_Y_POSITION(mesh_index_to_ypos(current_yi));
 
         /**
          * Without this check, it is possible for the algorithm to generate a zero length move in the case
@@ -281,12 +281,12 @@
             z_position = end[Z_AXIS];
           }
 
-          planner._buffer_line(x, y, z_position + z0 + ubl.state.z_offset, e_position, feed_rate, extruder);
+          planner._buffer_line(x, y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
-      if (ubl.g26_debug_flag)
-        debug_current_and_destination(PSTR("vertical move done in ubl_line_to_destination()"));
+      if (g26_debug_flag)
+        debug_current_and_destination(PSTR("vertical move done in ubl.line_to_destination()"));
 
       //
       // Check if we are at the final destination. Usually, we won't be, but if it is on a Y Mesh Line, we are done.
@@ -311,12 +311,12 @@
                                 // edge of this cell for the first move.
       while (current_xi != cell_dest_xi + left_flag) {
         current_xi += dxi;
-        const float next_mesh_line_x = LOGICAL_X_POSITION(pgm_read_float(&ubl.mesh_index_to_xpos[current_xi])),
+        const float next_mesh_line_x = LOGICAL_X_POSITION(mesh_index_to_xpos(current_xi)),
                     y = m * next_mesh_line_x + c;   // Calculate Y at the next X mesh line
 
-        float z0 = ubl.z_correction_for_y_on_vertical_mesh_line(y, current_xi, current_yi);
+        float z0 = z_correction_for_y_on_vertical_mesh_line(y, current_xi, current_yi);
 
-        z0 *= ubl.fade_scaling_factor_for_z(end[Z_AXIS]);
+        z0 *= fade_scaling_factor_for_z(end[Z_AXIS]);
 
         /**
          * If part of the Mesh is undefined, it will show up as NAN
@@ -327,7 +327,7 @@
          */
         if (isnan(z0)) z0 = 0.0;
 
-        const float x = LOGICAL_X_POSITION(pgm_read_float(&ubl.mesh_index_to_xpos[current_xi]));
+        const float x = LOGICAL_X_POSITION(mesh_index_to_xpos(current_xi));
 
         /**
          * Without this check, it is possible for the algorithm to generate a zero length move in the case
@@ -346,12 +346,12 @@
             z_position = end[Z_AXIS];
           }
 
-          planner._buffer_line(x, y, z_position + z0 + ubl.state.z_offset, e_position, feed_rate, extruder);
+          planner._buffer_line(x, y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
-      if (ubl.g26_debug_flag)
-        debug_current_and_destination(PSTR("horizontal move done in ubl_line_to_destination()"));
+      if (g26_debug_flag)
+        debug_current_and_destination(PSTR("horizontal move done in ubl.line_to_destination()"));
 
       if (current_position[X_AXIS] != end[X_AXIS] || current_position[Y_AXIS] != end[Y_AXIS])
         goto FINAL_MOVE;
@@ -377,8 +377,8 @@
 
     while (xi_cnt > 0 || yi_cnt > 0) {
 
-      const float next_mesh_line_x = LOGICAL_X_POSITION(pgm_read_float(&ubl.mesh_index_to_xpos[current_xi + dxi])),
-                  next_mesh_line_y = LOGICAL_Y_POSITION(pgm_read_float(&ubl.mesh_index_to_ypos[current_yi + dyi])),
+      const float next_mesh_line_x = LOGICAL_X_POSITION(mesh_index_to_xpos(current_xi + dxi)),
+                  next_mesh_line_y = LOGICAL_Y_POSITION(mesh_index_to_ypos(current_yi + dyi)),
                   y = m * next_mesh_line_x + c,   // Calculate Y at the next X mesh line
                   x = (next_mesh_line_y - c) / m; // Calculate X at the next Y mesh line
                                                   // (No need to worry about m being zero.
@@ -387,9 +387,9 @@
 
       if (left_flag == (x > next_mesh_line_x)) { // Check if we hit the Y line first
         // Yes!  Crossing a Y Mesh Line next
-        float z0 = ubl.z_correction_for_x_on_horizontal_mesh_line(x, current_xi - left_flag, current_yi + dyi);
+        float z0 = z_correction_for_x_on_horizontal_mesh_line(x, current_xi - left_flag, current_yi + dyi);
 
-        z0 *= ubl.fade_scaling_factor_for_z(end[Z_AXIS]);
+        z0 *= fade_scaling_factor_for_z(end[Z_AXIS]);
 
         /**
          * If part of the Mesh is undefined, it will show up as NAN
@@ -409,15 +409,15 @@
           e_position = end[E_AXIS];
           z_position = end[Z_AXIS];
         }
-        planner._buffer_line(x, next_mesh_line_y, z_position + z0 + ubl.state.z_offset, e_position, feed_rate, extruder);
+        planner._buffer_line(x, next_mesh_line_y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
         current_yi += dyi;
         yi_cnt--;
       }
       else {
         // Yes!  Crossing a X Mesh Line next
-        float z0 = ubl.z_correction_for_y_on_vertical_mesh_line(y, current_xi + dxi, current_yi - down_flag);
+        float z0 = z_correction_for_y_on_vertical_mesh_line(y, current_xi + dxi, current_yi - down_flag);
 
-        z0 *= ubl.fade_scaling_factor_for_z(end[Z_AXIS]);
+        z0 *= fade_scaling_factor_for_z(end[Z_AXIS]);
 
         /**
          * If part of the Mesh is undefined, it will show up as NAN
@@ -438,7 +438,7 @@
           z_position = end[Z_AXIS];
         }
 
-        planner._buffer_line(next_mesh_line_x, y, z_position + z0 + ubl.state.z_offset, e_position, feed_rate, extruder);
+        planner._buffer_line(next_mesh_line_x, y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
         current_xi += dxi;
         xi_cnt--;
       }
@@ -446,8 +446,8 @@
       if (xi_cnt < 0 || yi_cnt < 0) break; // we've gone too far, so exit the loop and move on to FINAL_MOVE
     }
 
-    if (ubl.g26_debug_flag)
-      debug_current_and_destination(PSTR("generic move done in ubl_line_to_destination()"));
+    if (g26_debug_flag)
+      debug_current_and_destination(PSTR("generic move done in ubl.line_to_destination()"));
 
     if (current_position[X_AXIS] != end[X_AXIS] || current_position[Y_AXIS] != end[Y_AXIS])
       goto FINAL_MOVE;
@@ -502,7 +502,7 @@
      * Returns true if the caller did NOT update current_position, otherwise false.
      */
 
-    static bool ubl_prepare_linear_move_to(const float ltarget[XYZE], const float &feedrate) {
+    static bool unified_bed_leveling::prepare_linear_move_to(const float ltarget[XYZE], const float &feedrate) {
 
       if (!position_is_reachable_xy(ltarget[X_AXIS], ltarget[Y_AXIS]))  // fail if moving outside reachable boundary
         return true; // did not move, so current_position still accurate
@@ -554,9 +554,9 @@
 
       // Only compute leveling per segment if ubl active and target below z_fade_height.
 
-      if (!ubl.state.active || above_fade_height) {   // no mesh leveling
+      if (!state.active || above_fade_height) {   // no mesh leveling
 
-        const float z_offset = ubl.state.active ? ubl.state.z_offset : 0.0;
+        const float z_offset = state.active ? state.z_offset : 0.0;
 
         float seg_dest[XYZE];                   // per-segment destination,
         COPY_XYZE(seg_dest, current_position);  // starting from current position
@@ -579,7 +579,7 @@
       // Otherwise perform per-segment leveling
 
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-        const float fade_scaling_factor = ubl.fade_scaling_factor_for_z(ltarget[Z_AXIS]);
+        const float fade_scaling_factor = fade_scaling_factor_for_z(ltarget[Z_AXIS]);
       #endif
 
       float seg_dest[XYZE];  // per-segment destination, initialize to first segment
@@ -591,7 +591,7 @@
       float rx = RAW_X_POSITION(seg_dest[X_AXIS]),  // assume raw vs logical coordinates shifted but not scaled.
             ry = RAW_Y_POSITION(seg_dest[Y_AXIS]);
 
-      do {  // for each mesh cell encountered during the move
+      for(;;) {  // for each mesh cell encountered during the move
 
         // Compute mesh cell invariants that remain constant for all segments within cell.
         // Note for cell index, if point is outside the mesh grid (in MESH_INSET perimeter)
@@ -606,19 +606,19 @@
         cell_xi = constrain(cell_xi, 0, (GRID_MAX_POINTS_X) - 1);
         cell_yi = constrain(cell_yi, 0, (GRID_MAX_POINTS_Y) - 1);
 
-        const float x0 = pgm_read_float(&(ubl.mesh_index_to_xpos[cell_xi  ])),  // 64 byte table lookup avoids mul+add
-                    y0 = pgm_read_float(&(ubl.mesh_index_to_ypos[cell_yi  ])),  // 64 byte table lookup avoids mul+add
-                    x1 = pgm_read_float(&(ubl.mesh_index_to_xpos[cell_xi+1])),  // 64 byte table lookup avoids mul+add
-                    y1 = pgm_read_float(&(ubl.mesh_index_to_ypos[cell_yi+1]));  // 64 byte table lookup avoids mul+add
+        const float x0 = pgm_read_float(&(mesh_index_to_xpos[cell_xi  ])),  // 64 byte table lookup avoids mul+add
+                    y0 = pgm_read_float(&(mesh_index_to_ypos[cell_yi  ])),  // 64 byte table lookup avoids mul+add
+                    x1 = pgm_read_float(&(mesh_index_to_xpos[cell_xi+1])),  // 64 byte table lookup avoids mul+add
+                    y1 = pgm_read_float(&(mesh_index_to_ypos[cell_yi+1]));  // 64 byte table lookup avoids mul+add
 
         float cx = rx - x0,   // cell-relative x
               cy = ry - y0,   // cell-relative y
-              z_x0y0 = ubl.z_values[cell_xi  ][cell_yi  ],  // z at lower left corner
-              z_x1y0 = ubl.z_values[cell_xi+1][cell_yi  ],  // z at upper left corner
-              z_x0y1 = ubl.z_values[cell_xi  ][cell_yi+1],  // z at lower right corner
-              z_x1y1 = ubl.z_values[cell_xi+1][cell_yi+1];  // z at upper right corner
+              z_x0y0 = z_values[cell_xi  ][cell_yi  ],  // z at lower left corner
+              z_x1y0 = z_values[cell_xi+1][cell_yi  ],  // z at upper left corner
+              z_x0y1 = z_values[cell_xi  ][cell_yi+1],  // z at lower right corner
+              z_x1y1 = z_values[cell_xi+1][cell_yi+1];  // z at upper right corner
 
-        if (isnan(z_x0y0)) z_x0y0 = 0;              // ideally activating ubl.state.active (G29 A)
+        if (isnan(z_x0y0)) z_x0y0 = 0;              // ideally activating state.active (G29 A)
         if (isnan(z_x1y0)) z_x1y0 = 0;              //   should refuse if any invalid mesh points
         if (isnan(z_x0y1)) z_x0y1 = 0;              //   in order to avoid isnan tests per cell,
         if (isnan(z_x1y1)) z_x1y1 = 0;              //   thus guessing zero for undefined points
@@ -642,7 +642,7 @@
         const float z_sxy0 = z_xmy0 * dx_seg,                                     // per-segment adjustment to z_cxy0
                     z_sxym = (z_xmy1 - z_xmy0) * (1.0 / (MESH_Y_DIST)) * dx_seg;  // per-segment adjustment to z_cxym
 
-        do {  // for all segments within this mesh cell
+        for(;;) {  // for all segments within this mesh cell
 
           float z_cxcy = z_cxy0 + z_cxym * cy;      // interpolated mesh z height along cx at cy
 
@@ -650,7 +650,7 @@
             z_cxcy *= fade_scaling_factor;          // apply fade factor to interpolated mesh height
           #endif
 
-          z_cxcy += ubl.state.z_offset;             // add fixed mesh offset from G29 Z
+          z_cxcy += state.z_offset;             // add fixed mesh offset from G29 Z
 
           if (--segments == 0) {                    // if this is last segment, use ltarget for exact
             COPY_XYZE(seg_dest, ltarget);
@@ -681,9 +681,9 @@
           z_cxy0 += z_sxy0;   // adjust z_cxy0 by per-segment z_sxy0
           z_cxym += z_sxym;   // adjust z_cxym by per-segment z_sxym
 
-        } while (true);   // per-segment loop exits by break after last segment within cell, or by return on final segment
-      } while (true);   // per-cell loop
-    }                 // end of function
+        } // segment loop
+      } // cell loop
+    }
 
   #endif // UBL_DELTA
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1480,7 +1480,7 @@ void kill_screen(const char* lcd_msg) {
     void _lcd_level_bed_get_z() {
       ENCODER_DIRECTION_NORMAL();
 
-      // Encoder wheel adjusts the Z position
+      // Encoder knob or keypad buttons adjust the Z position
       if (encoderPosition) {
         refresh_cmd_timeout();
         current_position[Z_AXIS] += float((int32_t)encoderPosition) * (MBL_Z_STEP);
@@ -4202,9 +4202,9 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
       }
       #if ENABLED(AUTO_BED_LEVELING_UBL)
         if (ubl.has_control_of_lcd_panel) {
-          ubl.encoder_diff = encoderDiff;    // Make the encoder's rotation available to G29's Mesh Editor
+          ubl.encoder_diff = encoderDiff;   // Make the encoder's rotation available to G29's Mesh Editor
           encoderDiff = 0;                  // We are going to lie to the LCD Panel and claim the encoder
-                                            // wheel has not turned.
+                                            // knob has not turned.
         }
       #endif
       lastEncoderBits = enc;


### PR DESCRIPTION
- Move most UBL-related static functions into the `unified_bed_leveling` class.
- Add 'user_canceled' for repeated use by `G26`.
- Move G26 and G29 arguments into the class.
- Simplify `mesh_index_to_xpos` and `mesh_index_to_ypos` interface.

Also:
- Cleanups for `fastio.h`