### PR TITLE
UBL ultralcd.cpp patches

### DIFF
--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -170,17 +170,17 @@
   #ifndef MSG_UBL_DEACTIVATE_MESH
     #define MSG_UBL_DEACTIVATE_MESH           _UxGT("Deactivate UBL")
   #endif
-  #ifndef MSG_UBL_CUSTOM_BED_TEMP
-    #define MSG_UBL_CUSTOM_BED_TEMP           _UxGT("Bed Temp")
-  #endif
   #ifndef MSG_UBL_SET_BED_TEMP
     #define MSG_UBL_SET_BED_TEMP              _UxGT("Bed Temp")
   #endif
-  #ifndef MSG_UBL_CUSTOM_HOTEND_TEMP
-    #define MSG_UBL_CUSTOM_HOTEND_TEMP        _UxGT("Hotend Temp")
+  #ifndef MSG_UBL_CUSTOM_BED_TEMP
+    #define MSG_UBL_CUSTOM_BED_TEMP           MSG_UBL_SET_BED_TEMP
   #endif
   #ifndef MSG_UBL_SET_HOTEND_TEMP
     #define MSG_UBL_SET_HOTEND_TEMP           _UxGT("Hotend Temp")
+  #endif
+  #ifndef MSG_UBL_CUSTOM_HOTEND_TEMP
+    #define MSG_UBL_CUSTOM_HOTEND_TEMP        MSG_UBL_SET_HOTEND_TEMP
   #endif
   #ifndef MSG_UBL_EDIT_CUSTOM_MESH
     #define MSG_UBL_EDIT_CUSTOM_MESH          _UxGT("Edit Custom Mesh")

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1663,346 +1663,366 @@ void kill_screen(const char* lcd_msg) {
       END_MENU();
     }
 
-  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
 
-    void _lcd_ubl_level_bed();
+      void _lcd_ubl_level_bed();
 
-    int UBL_STORAGE_SLOT = 0,
-        CUSTOM_BED_TEMP = 50,
-        CUSTOM_HOTEND_TEMP = 190,
-        SIDE_POINTS = 3,
-        UBL_FILLIN_AMOUNT = 5,
-        UBL_HEIGHT_AMOUNT,
-        map_type;
+      static int ubl_storage_slot = 0,
+                 custom_bed_temp = 50,
+                 custom_hotend_temp = 190,
+                 side_points = 3,
+                 ubl_fillin_amount = 5,
+                 ubl_height_amount,
+                 map_type;
 
-    char UBL_LCD_GCODE [30];
-
-    /**
-     * UBL Build Custom Mesh Command
-     */
-    void _lcd_ubl_build_custom_mesh() {
-      enqueue_and_echo_command("G28");
-      #if (WATCH_THE_BED)
-      sprintf_P(UBL_LCD_GCODE, PSTR("M190 S%i"), CUSTOM_BED_TEMP);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-      #endif
-      sprintf_P(UBL_LCD_GCODE, PSTR("M109 S%i"), CUSTOM_HOTEND_TEMP);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-      enqueue_and_echo_command("G29 P1");
-    }
-
-    /**
-     * UBL Custom Mesh submenu
-     */
-    void _lcd_ubl_custom_mesh() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_BUILD_MESH_MENU);
-      MENU_ITEM_EDIT(int3, MSG_UBL_CUSTOM_HOTEND_TEMP, &CUSTOM_HOTEND_TEMP, EXTRUDE_MINTEMP, (HEATER_0_MAXTEMP - 10));
-      #if (WATCH_THE_BED)
-      MENU_ITEM_EDIT(int3, MSG_UBL_CUSTOM_BED_TEMP, &CUSTOM_BED_TEMP, BED_MINTEMP, (BED_MAXTEMP - 5));
-      #endif
-      MENU_ITEM(function, MSG_UBL_BUILD_CUSTOM_MESH, _lcd_ubl_build_custom_mesh);
-      END_MENU();
-    }
-
-    /**
-     * UBL Adjust Mesh Height Command
-     */
-    void _lcd_ubl_adjust_height_cmd() {
-      if (UBL_HEIGHT_AMOUNT < 0) {
-        // Convert to positive for the `sprintf_P` string.
-        UBL_HEIGHT_AMOUNT = (UBL_HEIGHT_AMOUNT - (UBL_HEIGHT_AMOUNT * 2)); // Convert to positive
-        sprintf_P(UBL_LCD_GCODE, PSTR("G29 P6-.%i"), UBL_HEIGHT_AMOUNT);
-        // Convert back to negative to preserve the user setting.
-        UBL_HEIGHT_AMOUNT = (UBL_HEIGHT_AMOUNT - (UBL_HEIGHT_AMOUNT * 2)); // Convert back to negative
+      /**
+       * UBL Build Custom Mesh Command
+       */
+      void _lcd_ubl_build_custom_mesh() {
+        char UBL_LCD_GCODE[20];
+        enqueue_and_echo_commands_P(PSTR("G28"));
+        #if WATCH_THE_BED
+          sprintf_P(UBL_LCD_GCODE, PSTR("M190 S%i"), custom_bed_temp);
+          enqueue_and_echo_command(UBL_LCD_GCODE);
+        #endif
+        sprintf_P(UBL_LCD_GCODE, PSTR("M109 S%i"), custom_hotend_temp);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+        enqueue_and_echo_commands_P(PSTR("G29 P1"));
       }
-      else {
-        sprintf_P(UBL_LCD_GCODE, PSTR("G29 P6.%i"), UBL_HEIGHT_AMOUNT);
+
+      /**
+       * UBL Custom Mesh submenu
+       */
+      void _lcd_ubl_custom_mesh() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_BUILD_MESH_MENU);
+        MENU_ITEM_EDIT(int3, MSG_UBL_CUSTOM_HOTEND_TEMP, &custom_hotend_temp, EXTRUDE_MINTEMP, (HEATER_0_MAXTEMP - 10));
+        #if WATCH_THE_BED
+          MENU_ITEM_EDIT(int3, MSG_UBL_CUSTOM_BED_TEMP, &custom_bed_temp, BED_MINTEMP, (BED_MAXTEMP - 5));
+        #endif
+        MENU_ITEM(function, MSG_UBL_BUILD_CUSTOM_MESH, _lcd_ubl_build_custom_mesh);
+        END_MENU();
       }
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
 
-    /**
-     * UBL Adjust Mesh Height submenu
-     */
-    void _lcd_ubl_height_adjust_menu() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_EDIT_MESH_MENU);
-      MENU_ITEM_EDIT(int3, MSG_UBL_MESH_HEIGHT_AMOUNT, &UBL_HEIGHT_AMOUNT, -9, 9);
-      MENU_ITEM(function, MSG_UBL_MESH_HEIGHT_ADJUST, _lcd_ubl_adjust_height_cmd);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
-      END_MENU();
-    }
+      /**
+       * UBL Adjust Mesh Height Command
+       */
+      void _lcd_ubl_adjust_height_cmd() {
+        char UBL_LCD_GCODE[16];
+        const int ind = ubl_height_amount < 0 ? 6 : 7;
+        strcpy_P(UBL_LCD_GCODE, PSTR("G29 P6-"));
+        sprintf_P(&UBL_LCD_GCODE[ind], PSTR(".%i"), abs(ubl_height_amount));
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Edit Mesh submenu
-     */
-    void _lcd_ubl_edit_mesh() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_TOOLS);
-      MENU_BACK(MSG_UBL_LEVEL_BED);
-      MENU_ITEM(gcode, MSG_UBL_FINE_TUNE_ALL, PSTR("G29 P4 R T"));
-      MENU_ITEM(gcode, MSG_UBL_FINE_TUNE_CLOSEST, PSTR("G29 P4 T"));
-      MENU_ITEM(submenu, MSG_UBL_MESH_HEIGHT_ADJUST, _lcd_ubl_height_adjust_menu);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
-      END_MENU();
-    }
+      /**
+       * UBL Adjust Mesh Height submenu
+       */
+      void _lcd_ubl_height_adjust_menu() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_EDIT_MESH_MENU);
+        MENU_ITEM_EDIT(int3, MSG_UBL_MESH_HEIGHT_AMOUNT, &ubl_height_amount, -9, 9);
+        MENU_ITEM(function, MSG_UBL_MESH_HEIGHT_ADJUST, _lcd_ubl_adjust_height_cmd);
+        MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+        END_MENU();
+      }
 
-    /**
-     * UBL Validate Custom Mesh Command
-     */
-    void _lcd_ubl_validate_custom_mesh() {
-      enqueue_and_echo_command("G28");
-      #if (WATCH_THE_BED)
-        sprintf_P(UBL_LCD_GCODE, PSTR("G26 C B%i H%i P"), CUSTOM_BED_TEMP, CUSTOM_HOTEND_TEMP);
-      #else
-        sprintf_P(UBL_LCD_GCODE, PSTR("G26 C B0 H%i P"), CUSTOM_HOTEND_TEMP);
-      #endif
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Edit Mesh submenu
+       */
+      void _lcd_ubl_edit_mesh() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_TOOLS);
+        MENU_BACK(MSG_UBL_LEVEL_BED);
+        MENU_ITEM(gcode, MSG_UBL_FINE_TUNE_ALL, PSTR("G29 P4 R T"));
+        MENU_ITEM(gcode, MSG_UBL_FINE_TUNE_CLOSEST, PSTR("G29 P4 T"));
+        MENU_ITEM(submenu, MSG_UBL_MESH_HEIGHT_ADJUST, _lcd_ubl_height_adjust_menu);
+        MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+        END_MENU();
+      }
 
-    /**
-     * UBL Validate Mesh submenu
-     */
-    void _lcd_ubl_validate_mesh() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_TOOLS);
-      #if (WATCH_THE_BED)
-        MENU_ITEM(gcode, MSG_UBL_VALIDATE_PLA_MESH, PSTR("G28\nG26 C B" STRINGIFY(PREHEAT_1_TEMP_BED)
-          " H" STRINGIFY(PREHEAT_1_TEMP_HOTEND) " P"));
-        MENU_ITEM(gcode, MSG_UBL_VALIDATE_ABS_MESH, PSTR("G28\nG26 C B" STRINGIFY(PREHEAT_2_TEMP_BED)
-          " H" STRINGIFY(PREHEAT_2_TEMP_HOTEND) " P"));
-      #else
-        MENU_ITEM(gcode, MSG_UBL_VALIDATE_PLA_MESH, PSTR("G28\nG26 C B0 H" STRINGIFY(PREHEAT_1_TEMP_HOTEND) " P"));
-        MENU_ITEM(gcode, MSG_UBL_VALIDATE_ABS_MESH, PSTR("G28\nG26 C B0 H" STRINGIFY(PREHEAT_2_TEMP_HOTEND) " P"));
-      #endif
-      MENU_ITEM(function, MSG_UBL_VALIDATE_CUSTOM_MESH, _lcd_ubl_validate_custom_mesh);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
-      END_MENU();
-    }
+      /**
+       * UBL Validate Custom Mesh Command
+       */
+      void _lcd_ubl_validate_custom_mesh() {
+        char UBL_LCD_GCODE[24];
+        const int temp = 
+          #if WATCH_THE_BED
+            custom_bed_temp
+          #else
+            0
+          #endif
+        ;
+        sprintf_P(UBL_LCD_GCODE, PSTR("G28\nG26 C B%i H%i P"), temp, custom_hotend_temp);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Grid Leveling Command
-     */
-    void _lcd_ubl_grid_level_cmd() {
-      sprintf_P(UBL_LCD_GCODE, PSTR("G29 J%i"), SIDE_POINTS);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Validate Mesh submenu
+       */
+      void _lcd_ubl_validate_mesh() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_TOOLS);
+        #if WATCH_THE_BED
+          MENU_ITEM(gcode, MSG_UBL_VALIDATE_PLA_MESH, PSTR("G28\nG26 C B" STRINGIFY(PREHEAT_1_TEMP_BED) " H" STRINGIFY(PREHEAT_1_TEMP_HOTEND) " P"));
+          MENU_ITEM(gcode, MSG_UBL_VALIDATE_ABS_MESH, PSTR("G28\nG26 C B" STRINGIFY(PREHEAT_2_TEMP_BED) " H" STRINGIFY(PREHEAT_2_TEMP_HOTEND) " P"));
+        #else
+          MENU_ITEM(gcode, MSG_UBL_VALIDATE_PLA_MESH, PSTR("G28\nG26 C B0 H" STRINGIFY(PREHEAT_1_TEMP_HOTEND) " P"));
+          MENU_ITEM(gcode, MSG_UBL_VALIDATE_ABS_MESH, PSTR("G28\nG26 C B0 H" STRINGIFY(PREHEAT_2_TEMP_HOTEND) " P"));
+        #endif
+        MENU_ITEM(function, MSG_UBL_VALIDATE_CUSTOM_MESH, _lcd_ubl_validate_custom_mesh);
+        MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+        END_MENU();
+      }
 
-    /**
-     * UBL Grid Leveling submenu
-     */
-    void _lcd_ubl_grid_level() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_TOOLS);
-      MENU_ITEM_EDIT(int3, MSG_UBL_SIDE_POINTS, &SIDE_POINTS, 2, 6);
-      MENU_ITEM(function, MSG_UBL_MESH_LEVEL, _lcd_ubl_grid_level_cmd);
-      END_MENU();
-    }
+      /**
+       * UBL Grid Leveling Command
+       */
+      void _lcd_ubl_grid_level_cmd() {
+        char UBL_LCD_GCODE[10];
+        sprintf_P(UBL_LCD_GCODE, PSTR("G29 J%i"), side_points);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Mesh Leveling submenu
-     */
-    void _lcd_ubl_mesh_leveling() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_TOOLS);
-      MENU_ITEM(gcode, MSG_UBL_3POINT_MESH_LEVELING, PSTR("G29 J0"));
-      MENU_ITEM(submenu, MSG_UBL_GRID_MESH_LEVELING, _lcd_ubl_grid_level);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
-      END_MENU();
-    }
+      /**
+       * UBL Grid Leveling submenu
+       */
+      void _lcd_ubl_grid_level() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_TOOLS);
+        MENU_ITEM_EDIT(int3, MSG_UBL_SIDE_POINTS, &side_points, 2, 6);
+        MENU_ITEM(function, MSG_UBL_MESH_LEVEL, _lcd_ubl_grid_level_cmd);
+        END_MENU();
+      }
 
-    /**
-     * UBL Fill-in Amount Mesh Command
-     */
-    void _lcd_ubl_fillin_amount_cmd() {
-      sprintf_P(UBL_LCD_GCODE, PSTR("G29 P3 R C.%i"), UBL_FILLIN_AMOUNT);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Mesh Leveling submenu
+       */
+      void _lcd_ubl_mesh_leveling() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_TOOLS);
+        MENU_ITEM(gcode, MSG_UBL_3POINT_MESH_LEVELING, PSTR("G29 J0"));
+        MENU_ITEM(submenu, MSG_UBL_GRID_MESH_LEVELING, _lcd_ubl_grid_level);
+        MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+        END_MENU();
+      }
 
-    /**
-     * UBL Smart Fill-in Command
-     */
-    void _lcd_ubl_smart_fillin_cmd() {
-      sprintf_P(UBL_LCD_GCODE, PSTR("G29 P3 T%i"), map_type);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Fill-in Amount Mesh Command
+       */
+      void _lcd_ubl_fillin_amount_cmd() {
+        char UBL_LCD_GCODE[16];
+        sprintf_P(UBL_LCD_GCODE, PSTR("G29 P3 R C.%i"), ubl_fillin_amount);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Fill-in Mesh submenu
-     */
-    void _lcd_ubl_fillin_menu() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_BUILD_MESH_MENU);
-      MENU_ITEM_EDIT(int3, MSG_UBL_FILLIN_AMOUNT, &UBL_FILLIN_AMOUNT, 0, 9);
-      MENU_ITEM(function, MSG_UBL_FILLIN_MESH, _lcd_ubl_fillin_amount_cmd);
-      MENU_ITEM(function, MSG_UBL_SMART_FILLIN, _lcd_ubl_smart_fillin_cmd);
-      MENU_ITEM(gcode, MSG_UBL_MANUAL_FILLIN, PSTR("G29 P2 B T0"));
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
-      END_MENU();
-    }
+      /**
+       * UBL Smart Fill-in Command
+       */
+      void _lcd_ubl_smart_fillin_cmd() {
+        char UBL_LCD_GCODE[12];
+        sprintf_P(UBL_LCD_GCODE, PSTR("G29 P3 T%i"), map_type);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    void _lcd_ubl_invalidate() {
-      ubl.invalidate();
-      SERIAL_PROTOCOLLNPGM("Mesh invalidated.");
-    }
+      /**
+       * UBL Fill-in Mesh submenu
+       */
+      void _lcd_ubl_fillin_menu() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_BUILD_MESH_MENU);
+        MENU_ITEM_EDIT(int3, MSG_UBL_FILLIN_AMOUNT, &ubl_fillin_amount, 0, 9);
+        MENU_ITEM(function, MSG_UBL_FILLIN_MESH, _lcd_ubl_fillin_amount_cmd);
+        MENU_ITEM(function, MSG_UBL_SMART_FILLIN, _lcd_ubl_smart_fillin_cmd);
+        MENU_ITEM(gcode, MSG_UBL_MANUAL_FILLIN, PSTR("G29 P2 B T0"));
+        MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+        END_MENU();
+      }
 
-    /**
-     * UBL Build Mesh submenu
-     */
-    void _lcd_ubl_build_mesh() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_TOOLS);
-      #if (WATCH_THE_BED)
-        MENU_ITEM(gcode, MSG_UBL_BUILD_PLA_MESH, PSTR("G28\nM190 S" STRINGIFY(PREHEAT_1_TEMP_BED)
-          "\nM109 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND) "\nG29 P1\nM104 S0\nM140 S0"));
-        MENU_ITEM(gcode, MSG_UBL_BUILD_ABS_MESH, PSTR("G28\nM190 S" STRINGIFY(PREHEAT_1_TEMP_BED)
-          "\nM109 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND) "\nG29 P1\nM104 S0\nM140 S0"));
-      #else
-        MENU_ITEM(gcode, MSG_UBL_BUILD_PLA_MESH, PSTR("G28\nM109 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
-          "\nG29 P1\nM104 S0"));
-        MENU_ITEM(gcode, MSG_UBL_BUILD_ABS_MESH, PSTR("G28\nM109 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
-          "\nG29 P1\nM104 S0"));
-      #endif
-      MENU_ITEM(submenu, MSG_UBL_BUILD_CUSTOM_MESH, _lcd_ubl_custom_mesh);
-      MENU_ITEM(gcode, MSG_UBL_BUILD_COLD_MESH, PSTR("G28\nG29 P1"));
-      MENU_ITEM(submenu, MSG_UBL_FILLIN_MESH, _lcd_ubl_fillin_menu);
-      MENU_ITEM(gcode, MSG_UBL_CONTINUE_MESH, PSTR("G29 P1 C"));
-      MENU_ITEM(function, MSG_UBL_INVALIDATE_ALL, _lcd_ubl_invalidate);
-      MENU_ITEM(gcode, MSG_UBL_INVALIDATE_CLOSEST, PSTR("G29 I"));
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
-      END_MENU();
-    }
+      void _lcd_ubl_invalidate() {
+        ubl.invalidate();
+        SERIAL_PROTOCOLLNPGM("Mesh invalidated.");
+      }
 
-    /**
-     * UBL Load Mesh Command
-     */
-    void _lcd_ubl_load_mesh_cmd() {
-      sprintf_P(UBL_LCD_GCODE, PSTR("G29 L%i"), UBL_STORAGE_SLOT);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Build Mesh submenu
+       */
+      void _lcd_ubl_build_mesh() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_TOOLS);
+        #if WATCH_THE_BED
+          MENU_ITEM(gcode, MSG_UBL_BUILD_PLA_MESH, PSTR(
+            "G28\n"
+            "M190 S" STRINGIFY(PREHEAT_1_TEMP_BED) "\n"
+            "M109 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND) "\n"
+            "G29 P1\n"
+            "M104 S0\n"
+            "M140 S0"
+          ));
+          MENU_ITEM(gcode, MSG_UBL_BUILD_ABS_MESH, PSTR(
+            "G28\n"
+            "M190 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\n"
+            "M109 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND) "\n"
+            "G29 P1\n"
+            "M104 S0\n"
+            "M140 S0"
+          ));
+        #else
+          MENU_ITEM(gcode, MSG_UBL_BUILD_PLA_MESH, PSTR(
+            "G28\n"
+            "M109 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND) "\n"
+            "G29 P1\n"
+            "M104 S0"
+          ));
+          MENU_ITEM(gcode, MSG_UBL_BUILD_ABS_MESH, PSTR(
+            "G28\n"
+            "M109 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND) "\n"
+            "G29 P1\n"
+            "M104 S0"
+          ));
+        #endif
+        MENU_ITEM(submenu, MSG_UBL_BUILD_CUSTOM_MESH, _lcd_ubl_custom_mesh);
+        MENU_ITEM(gcode, MSG_UBL_BUILD_COLD_MESH, PSTR("G28\nG29 P1"));
+        MENU_ITEM(submenu, MSG_UBL_FILLIN_MESH, _lcd_ubl_fillin_menu);
+        MENU_ITEM(gcode, MSG_UBL_CONTINUE_MESH, PSTR("G29 P1 C"));
+        MENU_ITEM(function, MSG_UBL_INVALIDATE_ALL, _lcd_ubl_invalidate);
+        MENU_ITEM(gcode, MSG_UBL_INVALIDATE_CLOSEST, PSTR("G29 I"));
+        MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+        END_MENU();
+      }
 
-    /**
-     * UBL Save Mesh Command
-     */
-    void _lcd_ubl_save_mesh_cmd() {
-      sprintf_P(UBL_LCD_GCODE, PSTR("G29 S%i"), UBL_STORAGE_SLOT);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Load Mesh Command
+       */
+      void _lcd_ubl_load_mesh_cmd() {
+        char UBL_LCD_GCODE[8];
+        sprintf_P(UBL_LCD_GCODE, PSTR("G29 L%i"), ubl_storage_slot);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Mesh Storage submenu
-     */
-    void _lcd_ubl_storage_mesh() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_LEVEL_BED);
-      MENU_ITEM_EDIT(int3, MSG_UBL_STORAGE_SLOT, &UBL_STORAGE_SLOT, 0, 9);
-      MENU_ITEM(function, MSG_UBL_LOAD_MESH, _lcd_ubl_load_mesh_cmd);
-      MENU_ITEM(function, MSG_UBL_SAVE_MESH, _lcd_ubl_save_mesh_cmd);
-      END_MENU();
-    }
+      /**
+       * UBL Save Mesh Command
+       */
+      void _lcd_ubl_save_mesh_cmd() {
+        char UBL_LCD_GCODE[8];
+        sprintf_P(UBL_LCD_GCODE, PSTR("G29 S%i"), ubl_storage_slot);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Output map Command
-     */
-    void _lcd_ubl_output_map_cmd() {
-      sprintf_P(UBL_LCD_GCODE, PSTR("G29 T%i"), map_type);
-      enqueue_and_echo_command(UBL_LCD_GCODE);
-    }
+      /**
+       * UBL Mesh Storage submenu
+       */
+      void _lcd_ubl_storage_mesh() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_LEVEL_BED);
+        MENU_ITEM_EDIT(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, 9);
+        MENU_ITEM(function, MSG_UBL_LOAD_MESH, _lcd_ubl_load_mesh_cmd);
+        MENU_ITEM(function, MSG_UBL_SAVE_MESH, _lcd_ubl_save_mesh_cmd);
+        END_MENU();
+      }
 
-    /**
-     * UBL Output map submenu
-     */
-    void _lcd_ubl_output_map() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_LEVEL_BED);
-      MENU_ITEM_EDIT(int3, MSG_UBL_MAP_TYPE, &map_type, 0, 1);
-      if (map_type == 0) MENU_ITEM(function, MSG_UBL_OUTPUT_MAP_HOST, _lcd_ubl_output_map_cmd);
-      if (map_type == 1) MENU_ITEM(function, MSG_UBL_OUTPUT_MAP_CSV, _lcd_ubl_output_map_cmd);
-      END_MENU();
-    }
+      /**
+       * UBL Output map Command
+       */
+      void _lcd_ubl_output_map_cmd() {
+        char UBL_LCD_GCODE[10];
+        sprintf_P(UBL_LCD_GCODE, PSTR("G29 T%i"), map_type);
+        enqueue_and_echo_command(UBL_LCD_GCODE);
+      }
 
-    /**
-     * UBL Tools submenu
-     */
-    void _lcd_ubl_tools_menu() {
-      START_MENU();
-      MENU_BACK(MSG_UBL_LEVEL_BED);
-      MENU_ITEM(submenu, MSG_UBL_BUILD_MESH_MENU, _lcd_ubl_build_mesh);
-      MENU_ITEM(submenu, MSG_UBL_VALIDATE_MESH_MENU, _lcd_ubl_validate_mesh);
-      MENU_ITEM(submenu, MSG_UBL_EDIT_MESH_MENU, _lcd_ubl_edit_mesh);
-      MENU_ITEM(submenu, MSG_UBL_MESH_LEVELING, _lcd_ubl_mesh_leveling);
-      END_MENU();
-    }
+      /**
+       * UBL Output map submenu
+       */
+      void _lcd_ubl_output_map() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_LEVEL_BED);
+        MENU_ITEM_EDIT(int3, MSG_UBL_MAP_TYPE, &map_type, 0, 1);
+        if (map_type == 0) MENU_ITEM(function, MSG_UBL_OUTPUT_MAP_HOST, _lcd_ubl_output_map_cmd);
+        if (map_type == 1) MENU_ITEM(function, MSG_UBL_OUTPUT_MAP_CSV, _lcd_ubl_output_map_cmd);
+        END_MENU();
+      }
 
-    /**
-     * UBL System submenu
-     *
-     *  Prepare
-     * - Unified Bed Leveling
-     *   - Activate UBL
-     *   - Deactivate UBL
-     *   - Mesh Storage
-     *       Memory Slot:
-     *       Load Bed Mesh
-     *       Save Bed Mesh
-     *   - Output Map
-     *       Map Type:
-     *       Output Bed Mesh Host / Output Bed Mesh CSV
-     *   - UBL Tools
-     *     - Build Mesh
-     *         Build PLA Mesh
-     *         Build ABS Mesh
-     *       - Build Custom Mesh
-     *           Hotend Temp:
-     *           Bed Temp:
-     *           Build Custom Mesh
-     *         Info Screen
-     *       - Build Cold Mesh
-     *       - Fill-in Mesh
-     *           Fill-in Mesh
-     *           Smart Fill-in
-     *           Manual Fill-in
-     *           Info Screen
-     *         Continue Bed Mesh
-     *         Invalidate All
-     *         Invalidate Closest
-     *     - Validate Mesh
-     *         PLA Mesh Validation
-     *         ABS Mesh Validation
-     *       - Custom Mesh Validation
-     *           Hotend Temp:
-     *           Bed Temp:
-     *           Validate Mesh
-     *         Info Screen
-     *     - Edit Mesh
-     *         Fine Tune All
-     *         Fine Tune Closest
-     *       - Adjust Mesh Height
-     *           Height Amount:
-     *           Adjust Mesh Height
-     *         Info Screen
-     *     - Mesh Leveling
-     *         3-Point Mesh Leveling
-     *       - Grid Mesh Leveling
-     *           Side points:
-     *           Level Mesh
-     *         Info Screen
-     *   - Output UBL Info
-     */
+      /**
+       * UBL Tools submenu
+       */
+      void _lcd_ubl_tools_menu() {
+        START_MENU();
+        MENU_BACK(MSG_UBL_LEVEL_BED);
+        MENU_ITEM(submenu, MSG_UBL_BUILD_MESH_MENU, _lcd_ubl_build_mesh);
+        MENU_ITEM(submenu, MSG_UBL_VALIDATE_MESH_MENU, _lcd_ubl_validate_mesh);
+        MENU_ITEM(submenu, MSG_UBL_EDIT_MESH_MENU, _lcd_ubl_edit_mesh);
+        MENU_ITEM(submenu, MSG_UBL_MESH_LEVELING, _lcd_ubl_mesh_leveling);
+        END_MENU();
+      }
 
-    void _lcd_ubl_level_bed() {
-      START_MENU();
-      MENU_BACK(MSG_PREPARE);
-      MENU_ITEM(gcode, MSG_UBL_ACTIVATE_MESH, PSTR("G29 A"));
-      MENU_ITEM(gcode, MSG_UBL_DEACTIVATE_MESH, PSTR("G29 D"));
-      MENU_ITEM(submenu, MSG_UBL_STORAGE_MESH_MENU, _lcd_ubl_storage_mesh);
-      MENU_ITEM(submenu, MSG_UBL_OUTPUT_MAP, _lcd_ubl_output_map);
-      MENU_ITEM(submenu, MSG_UBL_TOOLS, _lcd_ubl_tools_menu);
-      MENU_ITEM(gcode, MSG_UBL_INFO_UBL, PSTR("G29 W"));
-      END_MENU();
-    }
-  #endif
+      /**
+       * UBL System submenu
+       *
+       *  Prepare
+       * - Unified Bed Leveling
+       *   - Activate UBL
+       *   - Deactivate UBL
+       *   - Mesh Storage
+       *       Memory Slot:
+       *       Load Bed Mesh
+       *       Save Bed Mesh
+       *   - Output Map
+       *       Map Type:
+       *       Output Bed Mesh Host / Output Bed Mesh CSV
+       *   - UBL Tools
+       *     - Build Mesh
+       *         Build PLA Mesh
+       *         Build ABS Mesh
+       *       - Build Custom Mesh
+       *           Hotend Temp:
+       *           Bed Temp:
+       *           Build Custom Mesh
+       *         Info Screen
+       *       - Build Cold Mesh
+       *       - Fill-in Mesh
+       *           Fill-in Mesh
+       *           Smart Fill-in
+       *           Manual Fill-in
+       *           Info Screen
+       *         Continue Bed Mesh
+       *         Invalidate All
+       *         Invalidate Closest
+       *     - Validate Mesh
+       *         PLA Mesh Validation
+       *         ABS Mesh Validation
+       *       - Custom Mesh Validation
+       *           Hotend Temp:
+       *           Bed Temp:
+       *           Validate Mesh
+       *         Info Screen
+       *     - Edit Mesh
+       *         Fine Tune All
+       *         Fine Tune Closest
+       *       - Adjust Mesh Height
+       *           Height Amount:
+       *           Adjust Mesh Height
+       *         Info Screen
+       *     - Mesh Leveling
+       *         3-Point Mesh Leveling
+       *       - Grid Mesh Leveling
+       *           Side points:
+       *           Level Mesh
+       *         Info Screen
+       *   - Output UBL Info
+       */
+
+      void _lcd_ubl_level_bed() {
+        START_MENU();
+        MENU_BACK(MSG_PREPARE);
+        MENU_ITEM(gcode, MSG_UBL_ACTIVATE_MESH, PSTR("G29 A"));
+        MENU_ITEM(gcode, MSG_UBL_DEACTIVATE_MESH, PSTR("G29 D"));
+        MENU_ITEM(submenu, MSG_UBL_STORAGE_MESH_MENU, _lcd_ubl_storage_mesh);
+        MENU_ITEM(submenu, MSG_UBL_OUTPUT_MAP, _lcd_ubl_output_map);
+        MENU_ITEM(submenu, MSG_UBL_TOOLS, _lcd_ubl_tools_menu);
+        MENU_ITEM(gcode, MSG_UBL_INFO_UBL, PSTR("G29 W"));
+        END_MENU();
+      }
+    #endif
 
   #endif // LCD_BED_LEVELING || HAS_ABL
 
@@ -2052,7 +2072,7 @@ void kill_screen(const char* lcd_msg) {
         MENU_ITEM(submenu, MSG_LEVEL_BED, lcd_level_bed);
       #endif
 
-    #endif
+    #endif // LCD_BED_LEVELING || HAS_ABL
 
     #if HAS_M206_COMMAND
       //


### PR DESCRIPTION
- Fix incorrect temperature in BUILD_ABS_MESH menu items.
- Free up 30 bytes of SRAM used by a mostly idle string buffer.
- Free up more SRAM by using `PSTR` command injectors.
- Fix the indentation level of the UBL menu code block.
- Negate `VAL` using `-VAL` instead of `VAL = VAL - (VAL * 2)`.

Due to indentation changes please [view the concise diff](https://github.com/MarlinFirmware/Marlin/pull/6839/files?w=1).