### PR TITLE
Generate error if MIXING_EXTRUDER and LIN_ADVANCE are both enabled

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -372,6 +372,8 @@
     #error "Please select either MIXING_EXTRUDER or SWITCHING_EXTRUDER, not both."
   #elif ENABLED(SINGLENOZZLE)
     #error "MIXING_EXTRUDER is incompatible with SINGLENOZZLE."
+  #elif ENABLED(LIN_ADVANCE)
+    #error "MIXING_EXTRUDER is incompatible with LIN_ADVANCE."
   #endif
 #endif
 


### PR DESCRIPTION
Per #6787, this PR declares an error if MIXING_EXTRUDER and LIN_ADVANCE are both enabled.