### PR TITLE
Initialize mixing virtual tools to behave like standard a multi-extruder setup

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12451,9 +12451,15 @@ void setup() {
     // Initialize mixing to 100% color 1
     for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
       mixing_factor[i] = (i == 0) ? 1.0 : 0.0;
-    for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS; t++)
+    // Initialize virtual tools to 100% color 1 for tool 1, 100% color 2 for tool 2,
+    // etc... for first MIXING_STEPPERS virtual tools
+    for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS && t < MIXING_STEPPERS; t++)
       for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
-        mixing_virtual_tool_mix[t][i] = mixing_factor[i];
+        mixing_virtual_tool_mix[t][i] = (t == i) ? 1.0 : 0.0;
+    // Initialize remaining virtual tools to 100% color 1
+    for (uint8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; t++)
+      for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
+        mixing_virtual_tool_mix[t][i] = (i == 0) ? 1.0 : 0.0;
   #endif
 
   #if ENABLED(BLTOUCH)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12448,18 +12448,19 @@ void setup() {
   #endif
 
   #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
-    // Initialize virtual tools to 100% color 1 for tool 1, 100% color 2 for tool 2,
-    // etc... for first MIXING_STEPPERS virtual tools
+    // Virtual Tools 0, 1, 2, 3 = Filament 1, 2, 3, 4, etc.
     for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS && t < MIXING_STEPPERS; t++)
       for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
         mixing_virtual_tool_mix[t][i] = (t == i) ? 1.0 : 0.0;
+
+    // Remaining virtual tools are 100% filament 1
     #if MIXING_STEPPERS < MIXING_VIRTUAL_TOOLS
-      // Initialize remaining virtual tools to 100% color 1
       for (uint8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; t++)
         for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
           mixing_virtual_tool_mix[t][i] = (i == 0) ? 1.0 : 0.0;
     #endif
-    // Initialize mixing to tool 1 color
+
+    // Initialize mixing to tool 0 color
     for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
       mixing_factor[i] = mixing_virtual_tool_mix[0][i];
   #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12448,18 +12448,20 @@ void setup() {
   #endif
 
   #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
-    // Initialize mixing to 100% color 1
-    for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
-      mixing_factor[i] = (i == 0) ? 1.0 : 0.0;
     // Initialize virtual tools to 100% color 1 for tool 1, 100% color 2 for tool 2,
     // etc... for first MIXING_STEPPERS virtual tools
     for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS && t < MIXING_STEPPERS; t++)
       for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
         mixing_virtual_tool_mix[t][i] = (t == i) ? 1.0 : 0.0;
-    // Initialize remaining virtual tools to 100% color 1
-    for (uint8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; t++)
-      for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
-        mixing_virtual_tool_mix[t][i] = (i == 0) ? 1.0 : 0.0;
+    #if MIXING_STEPPERS < MIXING_VIRTUAL_TOOLS
+      // Initialize remaining virtual tools to 100% color 1
+      for (uint8_t t = MIXING_STEPPERS; t < MIXING_VIRTUAL_TOOLS; t++)
+        for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
+          mixing_virtual_tool_mix[t][i] = (i == 0) ? 1.0 : 0.0;
+    #endif
+    // Initialize mixing to tool 1 color
+    for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
+      mixing_factor[i] = mixing_virtual_tool_mix[0][i];
   #endif
 
   #if ENABLED(BLTOUCH)


### PR DESCRIPTION
To me, it seems odd that selecting any tool with `MIXING_EXTRUDER` enabled would only utilize color Number 1. As such, this PR initializes the virtual tools such that:

1. Virtual tool # 1 (T0) will be 100% color 1, tool # 2 (T1) 100% color 2, etc... up to MIXING_EXTRUDER virtual tools
2. Virtual tools with after `MIXING_EXTRUDER` will be 100% color # 1