### PR TITLE
Limit status message display taking multi-byte characters into account

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -234,13 +234,19 @@ char lcd_print_and_count(const char c) {
   else return charset_mapper(c);
 }
 
-void lcd_print(const char* const str) {
-  for (uint8_t i = 0; char c = str[i]; ++i) lcd_print(c);
+void lcd_print(const char* const str, const int maxLength = LCD_WIDTH) {
+  char c;
+  for (uint8_t i = 0, len = 0; len < maxLength && (c = str[i]); ++i) {
+    if (charset_mapper(c)) ++len;
+  }
 }
 
 /* Arduino < 1.0.0 is missing a function to print PROGMEM strings, so we need to implement our own */
-void lcd_printPGM(const char* str) {
-  for (; char c = pgm_read_byte(str); ++str) lcd_print(c);
+void lcd_printPGM(const char* str, const int maxLength = LCD_WIDTH) {
+  char c;
+  for (uint8_t len = 0; len < maxLength && (c = pgm_read_byte(str)); ++str) {
+    if (charset_mapper(c)) ++len;
+  }
 }
 
 // Initialize or re-initialize the LCD
@@ -634,10 +640,7 @@ static void lcd_implementation_status_screen() {
 
     #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
       if (PENDING(millis(), previous_lcd_status_ms + 5000UL)) {  //Display both Status message line and Filament display on the last line
-        const char *str = lcd_status_message;
-        uint8_t i = LCD_WIDTH;
-        char c;
-        while (i-- && (c = *str++)) lcd_print(c);
+        lcd_print(lcd_status_message);
       }
       else {
         lcd_printPGM(PSTR(LCD_STR_FILAM_DIA));
@@ -649,10 +652,7 @@ static void lcd_implementation_status_screen() {
         u8g.print('%');
       }
     #else
-      const char *str = lcd_status_message;
-      uint8_t i = LCD_WIDTH;
-      char c;
-      while (i-- && (c = *str++)) lcd_print(c);
+      lcd_print(lcd_status_message);
     #endif
   }
 }

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -381,12 +381,18 @@ static void lcd_implementation_init(
 void lcd_implementation_clear() { lcd.clear(); }
 
 /* Arduino < 1.0.0 is missing a function to print PROGMEM strings, so we need to implement our own */
-void lcd_printPGM(const char *str) {
-  for (; char c = pgm_read_byte(str); ++str) charset_mapper(c);
+void lcd_printPGM(const char* str, const int maxLength = LCD_WIDTH) {
+  char c;
+  for (uint8_t len = 0; len < maxLength && (c = pgm_read_byte(str)); ++str) {
+    if (charset_mapper(c)) ++len;
+  }
 }
 
-void lcd_print(const char* const str) {
-  for (uint8_t i = 0; const char c = str[i]; ++i) charset_mapper(c);
+void lcd_print(const char* const str, const int maxLength = LCD_WIDTH) {
+  char c;
+  for (uint8_t i = 0, len = 0; len < maxLength && (c = str[i]); ++i) {
+    if (charset_mapper(c)) ++len;
+  }
 }
 
 void lcd_print(const char c) { charset_mapper(c); }
@@ -795,10 +801,7 @@ static void lcd_implementation_status_screen() {
 
   #endif // FILAMENT_LCD_DISPLAY && SDSUPPORT
 
-  const char *str = lcd_status_message;
-  uint8_t i = LCD_WIDTH;
-  char c;
-  while (i-- && (c = *str++)) lcd_print(c);
+  lcd_print(lcd_status_message);
 }
 
 #if ENABLED(ULTIPANEL)


### PR DESCRIPTION
This PR reverts the changes made in #6816 and implements my proposed solution in the comments for that PR. 

To test this on my machine with a 20x4 LCD, I set the machine name to "MACHINE NAME ó" and set the language to "ca" (the 'ó' character is a two-byte Unicode charter). It would be a good idea of someone with a DOGM display could perform similar testing. 

This first image shows the result with #6816 applied, and it can be seen that the status message is missing one character. 

![img_20170525_085438](https://cloud.githubusercontent.com/assets/1868773/26456626/474ee9c8-4133-11e7-85ab-07c3ae0fba1f.jpg)

This image shows the change in #6816 reverted. 

![img_20170525_085723](https://cloud.githubusercontent.com/assets/1868773/26456748/a12258ae-4133-11e7-8768-053b2a1ab980.jpg)

This image is with this PR applied. 

![img_20170525_090843](https://cloud.githubusercontent.com/assets/1868773/26456790/c74e358e-4133-11e7-9b15-dcfc63e8f158.jpg)

For this image, I removed the special character from the machine name to verify the message is clipped properly with​ only single-byte charters in the string.

![img_20170525_091214](https://cloud.githubusercontent.com/assets/1868773/26456926/2ae9d9d6-4134-11e7-9ded-f0f43e4f8469.jpg)

And finally, I set the machine name to a short value to show that messages less than LCD_WIDTH are displayed properly. 

![img_20170525_091405](https://cloud.githubusercontent.com/assets/1868773/26457072/8728809e-4134-11e7-801c-9085cd9eea53.jpg)
