### PR TITLE
Fixes for PROBE_MANUALLY and LCD_BED_LEVELING

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ tags
 *.lo
 *.o
 *.obj
+*.ino.cpp
 
 # Precompiled Headers
 *.gch

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1344,9 +1344,8 @@ void MarlinSettings::reset() {
     #else
       #define LINEAR_UNIT(N) N
       #define VOLUMETRIC_UNIT(N) N
-      SERIAL_ECHOLNPGM("  G21 ; Units in mm\n");
+      SERIAL_ECHOLNPGM("  G21    ; Units in mm");
     #endif
-    SERIAL_EOL;
 
     #if ENABLED(ULTIPANEL)
 
@@ -1361,11 +1360,12 @@ void MarlinSettings::reset() {
         serialprintPGM(parser.temp_units_name());
       #else
         #define TEMP_UNIT(N) N
-        SERIAL_ECHOLNPGM("  M149 C ; Units in Celsius\n");
+        SERIAL_ECHOLNPGM("  M149 C ; Units in Celsius");
       #endif
-      SERIAL_EOL;
 
     #endif
+
+    SERIAL_EOL;
 
     /**
      * Volumetric extrusion M200


### PR DESCRIPTION
- Fix probe index being off by 1 in `PROBE_MANUALLY` procedure
- Hide "Level Bed" menu item for `PROBE_MANUALLY` without `LCD_BED_LEVELING`
- Fix broken `PROBE_MANUALLY` + `LCD_BED_LEVELING`

Due to indentation changes, view [the concise diff](https://github.com/MarlinFirmware/Marlin/pull/6858/files?w=1).