### PR TITLE
Parser fix

### DIFF
--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -135,7 +135,7 @@ public:
     static bool seen(const char c) {
       char *p = strchr(command_args, c);
       const bool b = !!p;
-      if (b) value_ptr = DECIMAL_SIGNED(*p) ? p + 1 : NULL;
+      if (b) value_ptr = DECIMAL_SIGNED(*(p + 1)) ? p + 1 : NULL;
       return b;
     }
 


### PR DESCRIPTION
When FASTER_GCODE_PARSER was disabled, the value check was looking at the code so the parser always returned NULL.

This primarily affects those of us that don't do a full compare of the config files when moving to a new revision of the firmware.

This was discovered on issue #6854.