### PR TITLE
Scrolling status message (option)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5881,7 +5881,7 @@ inline void gcode_M17() {
     KEEPALIVE_STATE(IN_HANDLER);
   }
 
-  static void resume_print(const float& load_length = 0, const float& initial_extrude_length = 0, int8_t max_beep_count = 0) {
+  static void resume_print(const float &load_length = 0, const float &initial_extrude_length = 0, int8_t max_beep_count = 0) {
     bool nozzle_timed_out = false;
 
     if (!move_away_flag) return;

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5746,9 +5746,9 @@ inline void gcode_M17() {
     static bool sd_print_paused = false;
   #endif
 
-  static void filament_change_beep(const int max_beep_count, const bool init=false) {
+  static void filament_change_beep(const int8_t max_beep_count, const bool init=false) {
     static millis_t next_buzz = 0;
-    static uint16_t runout_beep = 0;
+    static int8_t runout_beep = 0;
 
     if (init) next_buzz = runout_beep = 0;
 
@@ -5762,8 +5762,9 @@ inline void gcode_M17() {
     }
   }
 
-  static bool pause_print(const float& retract, const float& z_lift, const float& x_pos, const float& y_pos,
-                          const float& unload_length = 0 , int max_beep_count = 0, bool show_lcd = false) {
+  static bool pause_print(const float &retract, const float &z_lift, const float &x_pos, const float &y_pos,
+                          const float &unload_length = 0 , int8_t max_beep_count = 0, bool show_lcd = false
+  ) {
     if (move_away_flag) return false; // already paused
 
     if (!DEBUGGING(DRYRUN) && thermalManager.tooColdToExtrude(active_extruder) && unload_length > 0) {
@@ -5771,8 +5772,6 @@ inline void gcode_M17() {
       SERIAL_ERRORLNPGM(MSG_TOO_COLD_FOR_M600);
       return false;
     }
-
-    const bool job_running = print_job_timer.isRunning();
 
     // Indicate that the printer is paused
     move_away_flag = true;
@@ -5857,7 +5856,7 @@ inline void gcode_M17() {
     return true;
   }
 
-  static void wait_for_filament_reload(int max_beep_count = 0) {
+  static void wait_for_filament_reload(int8_t max_beep_count = 0) {
     bool nozzle_timed_out = false;
 
     // Wait for filament insert by user and press button
@@ -5882,7 +5881,7 @@ inline void gcode_M17() {
     KEEPALIVE_STATE(IN_HANDLER);
   }
 
-  static void resume_print(const float& load_length = 0, const float& initial_extrude_length = 0, int max_beep_count = 0) {
+  static void resume_print(const float& load_length = 0, const float& initial_extrude_length = 0, int8_t max_beep_count = 0) {
     bool nozzle_timed_out = false;
 
     if (!move_away_flag) return;

--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -1819,7 +1819,7 @@ fail:
 //------------------------------------------------------------------------------
 // suppress cpplint warnings with NOLINT comment
 #if ALLOW_DEPRECATED_FUNCTIONS && !defined(DOXYGEN)
-  void (*SdBaseFile::oldDateTime_)(uint16_t& date, uint16_t& time) = 0;  // NOLINT
+  void (*SdBaseFile::oldDateTime_)(uint16_t &date, uint16_t &time) = 0;  // NOLINT
 #endif  // ALLOW_DEPRECATED_FUNCTIONS
 
 

--- a/Marlin/SdBaseFile.h
+++ b/Marlin/SdBaseFile.h
@@ -402,7 +402,7 @@ class SdBaseFile {
    * \param[in] dateTime The user's call back function.
    */
   static void dateTimeCallback(
-    void (*dateTime)(uint16_t& date, uint16_t& time)) {  // NOLINT
+    void (*dateTime)(uint16_t &date, uint16_t &time)) {  // NOLINT
     oldDateTime_ = dateTime;
     dateTime_ = dateTime ? oldToNew : 0;
   }
@@ -477,7 +477,7 @@ class SdBaseFile {
   //------------------------------------------------------------------------------
   // rest are private
  private:
-  static void (*oldDateTime_)(uint16_t& date, uint16_t& time);  // NOLINT
+  static void (*oldDateTime_)(uint16_t &date, uint16_t &time);  // NOLINT
   static void oldToNew(uint16_t* date, uint16_t* time) {
     uint16_t d;
     uint16_t t;

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -443,6 +443,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 #define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -455,6 +455,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -444,6 +444,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -444,6 +444,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -444,6 +444,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -444,6 +444,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -449,6 +449,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -444,6 +444,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -442,6 +442,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Scroll a longer status message into view
+//#define STATUS_MESSAGE_SCROLLING
+
 // On the Info Screen, display XY with one decimal place when possible
 //#define LCD_DECIMAL_SMALL_XY
 

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -133,7 +133,7 @@ public:
     // Code is found in the string. If not found, value_ptr is unchanged.
     // This allows "if (seen('A')||seen('B'))" to use the last-found value.
     static bool seen(const char c) {
-      char *p = strchr(command_args, c);
+      const char *p = strchr(command_args, c);
       const bool b = !!p;
       if (b) value_ptr = DECIMAL_SIGNED(p[1]) ? &p[1] : NULL;
       return b;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1510,7 +1510,7 @@ void Planner::sync_from_steppers() {
 /**
  * Setters for planner position (also setting stepper position).
  */
-void Planner::set_position_mm(const AxisEnum axis, const float& v) {
+void Planner::set_position_mm(const AxisEnum axis, const float &v) {
   #if ENABLED(DISTINCT_E_FACTORS)
     const uint8_t axis_index = axis + (axis == E_AXIS ? active_extruder : 0);
     last_extruder = active_extruder;

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -67,8 +67,11 @@ float Temperature::current_temperature[HOTENDS] = { 0.0 },
       Temperature::current_temperature_bed = 0.0;
 int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
         Temperature::target_temperature[HOTENDS] = { 0 },
-        Temperature::current_temperature_bed_raw = 0,
-        Temperature::target_temperature_bed = 0;
+        Temperature::current_temperature_bed_raw = 0;
+
+#if HAS_HEATER_BED
+  int16_t Temperature::target_temperature_bed = 0;
+#endif
 
 #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
   float Temperature::redundant_temperature = 0.0;

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -585,8 +585,8 @@
       float seg_dest[XYZE];  // per-segment destination, initialize to first segment
       LOOP_XYZE(i) seg_dest[i] = current_position[i] + segment_distance[i];
 
-      const float& dx_seg = segment_distance[X_AXIS];  // alias for clarity
-      const float& dy_seg = segment_distance[Y_AXIS];
+      const float &dx_seg = segment_distance[X_AXIS];  // alias for clarity
+      const float &dy_seg = segment_distance[Y_AXIS];
 
       float rx = RAW_X_POSITION(seg_dest[X_AXIS]),  // assume raw vs logical coordinates shifted but not scaled.
             ry = RAW_Y_POSITION(seg_dest[Y_AXIS]);

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -57,14 +57,14 @@ void safe_delay(millis_t ms) {
   #define MINUSOR(n, alt) (n >= 0 ? (alt) : (n = -n, '-'))
 
   // Convert unsigned int to string with 12 format
-  char* itostr2(const uint8_t& xx) {
+  char* itostr2(const uint8_t &xx) {
     conv[5] = DIGIMOD(xx, 10);
     conv[6] = DIGIMOD(xx, 1);
     return &conv[5];
   }
 
   // Convert signed int to rj string with 123 or -12 format
-  char* itostr3(const int& x) {
+  char* itostr3(const int &x) {
     int xx = x;
     conv[4] = MINUSOR(xx, RJDIGIT(xx, 100));
     conv[5] = RJDIGIT(xx, 10);
@@ -73,7 +73,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert unsigned int to lj string with 123 format
-  char* itostr3left(const int& xx) {
+  char* itostr3left(const int &xx) {
     char *str = &conv[6];
     *str = DIGIMOD(xx, 1);
     if (xx >= 10) {
@@ -85,7 +85,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed int to rj string with 1234, _123, -123, _-12, or __-1 format
-  char *itostr4sign(const int& x) {
+  char *itostr4sign(const int &x) {
     const bool neg = x < 0;
     const int xx = neg ? -x : x;
     if (x >= 1000) {
@@ -116,7 +116,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert unsigned float to string with 1.23 format
-  char* ftostr12ns(const float& x) {
+  char* ftostr12ns(const float &x) {
     const long xx = (x < 0 ? -x : x) * 100;
     conv[3] = DIGIMOD(xx, 100);
     conv[4] = '.';
@@ -126,7 +126,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed float to fixed-length string with 023.45 / -23.45 format
-  char *ftostr32(const float& x) {
+  char *ftostr32(const float &x) {
     long xx = x * 100;
     conv[1] = MINUSOR(xx, DIGIMOD(xx, 10000));
     conv[2] = DIGIMOD(xx, 1000);
@@ -140,7 +140,7 @@ void safe_delay(millis_t ms) {
   #if ENABLED(LCD_DECIMAL_SMALL_XY)
 
     // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
-    char *ftostr4sign(const float& fx) {
+    char *ftostr4sign(const float &fx) {
       const int x = fx * 10;
       if (!WITHIN(x, -99, 999)) return itostr4sign((int)fx);
       const bool neg = x < 0;
@@ -155,7 +155,7 @@ void safe_delay(millis_t ms) {
   #endif // LCD_DECIMAL_SMALL_XY
 
   // Convert float to fixed-length string with +123.4 / -123.4 format
-  char* ftostr41sign(const float& x) {
+  char* ftostr41sign(const float &x) {
     int xx = x * 10;
     conv[1] = MINUSOR(xx, '+');
     conv[2] = DIGIMOD(xx, 1000);
@@ -167,7 +167,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
-  char* ftostr43sign(const float& x, char plus/*=' '*/) {
+  char* ftostr43sign(const float &x, char plus/*=' '*/) {
     long xx = x * 1000;
     conv[1] = xx ? MINUSOR(xx, plus) : ' ';
     conv[2] = DIGIMOD(xx, 1000);
@@ -179,7 +179,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert unsigned float to rj string with 12345 format
-  char* ftostr5rj(const float& x) {
+  char* ftostr5rj(const float &x) {
     const long xx = x < 0 ? -x : x;
     conv[2] = RJDIGIT(xx, 10000);
     conv[3] = RJDIGIT(xx, 1000);
@@ -190,7 +190,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed float to string with +1234.5 format
-  char* ftostr51sign(const float& x) {
+  char* ftostr51sign(const float &x) {
     long xx = x * 10;
     conv[0] = MINUSOR(xx, '+');
     conv[1] = DIGIMOD(xx, 10000);
@@ -203,7 +203,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed float to string with +123.45 format
-  char* ftostr52sign(const float& x) {
+  char* ftostr52sign(const float &x) {
     long xx = x * 100;
     conv[0] = MINUSOR(xx, '+');
     conv[1] = DIGIMOD(xx, 10000);
@@ -216,7 +216,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert unsigned float to string with 1234.56 format omitting trailing zeros
-  char* ftostr62rj(const float& x) {
+  char* ftostr62rj(const float &x) {
     const long xx = (x < 0 ? -x : x) * 100;
     conv[0] = RJDIGIT(xx, 100000);
     conv[1] = RJDIGIT(xx, 10000);
@@ -229,7 +229,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed float to space-padded string with -_23.4_ format
-  char* ftostr52sp(const float& x) {
+  char* ftostr52sp(const float &x) {
     long xx = x * 100;
     uint8_t dig;
     conv[1] = MINUSOR(xx, RJDIGIT(xx, 10000));

--- a/Marlin/utility.h
+++ b/Marlin/utility.h
@@ -32,53 +32,53 @@ void safe_delay(millis_t ms);
 #if ENABLED(ULTRA_LCD)
 
   // Convert unsigned int to string with 12 format
-  char* itostr2(const uint8_t& x);
+  char* itostr2(const uint8_t &x);
 
   // Convert signed int to rj string with 123 or -12 format
-  char* itostr3(const int& x);
+  char* itostr3(const int &x);
 
   // Convert unsigned int to lj string with 123 format
-  char* itostr3left(const int& xx);
+  char* itostr3left(const int &xx);
 
   // Convert signed int to rj string with _123, -123, _-12, or __-1 format
-  char *itostr4sign(const int& x);
+  char *itostr4sign(const int &x);
 
   // Convert unsigned float to string with 1.23 format
-  char* ftostr12ns(const float& x);
+  char* ftostr12ns(const float &x);
 
   // Convert signed float to fixed-length string with 023.45 / -23.45 format
-  char *ftostr32(const float& x);
+  char *ftostr32(const float &x);
 
   // Convert float to fixed-length string with +123.4 / -123.4 format
-  char* ftostr41sign(const float& x);
+  char* ftostr41sign(const float &x);
 
   // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
-  char* ftostr43sign(const float& x, char plus=' ');
+  char* ftostr43sign(const float &x, char plus=' ');
 
   // Convert unsigned float to rj string with 12345 format
-  char* ftostr5rj(const float& x);
+  char* ftostr5rj(const float &x);
 
   // Convert signed float to string with +1234.5 format
-  char* ftostr51sign(const float& x);
+  char* ftostr51sign(const float &x);
 
   // Convert signed float to space-padded string with -_23.4_ format
-  char* ftostr52sp(const float& x);
+  char* ftostr52sp(const float &x);
 
   // Convert signed float to string with +123.45 format
-  char* ftostr52sign(const float& x);
+  char* ftostr52sign(const float &x);
 
   // Convert unsigned float to string with 1234.56 format omitting trailing zeros
-  char* ftostr62rj(const float& x);
+  char* ftostr62rj(const float &x);
 
   // Convert float to rj string with 123 or -12 format
-  FORCE_INLINE char *ftostr3(const float& x) { return itostr3((int)x); }
+  FORCE_INLINE char *ftostr3(const float &x) { return itostr3((int)x); }
 
   #if ENABLED(LCD_DECIMAL_SMALL_XY)
     // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
-    char *ftostr4sign(const float& fx);
+    char *ftostr4sign(const float &fx);
   #else
     // Convert float to rj string with 1234, _123, -123, __12, _-12, ___1, or __-1 format
-    FORCE_INLINE char *ftostr4sign(const float& x) { return itostr4sign((int)x); }
+    FORCE_INLINE char *ftostr4sign(const float &x) { return itostr4sign((int)x); }
   #endif
 
 #endif // ULTRA_LCD

--- a/Marlin/vector_3.h
+++ b/Marlin/vector_3.h
@@ -77,7 +77,7 @@ struct matrix_3x3 {
 };
 
 
-void apply_rotation_xyz(matrix_3x3 rotationMatrix, float& x, float& y, float& z);
+void apply_rotation_xyz(matrix_3x3 rotationMatrix, float &x, float &y, float &z);
 
 #endif // HAS_ABL
 #endif // VECTOR_3_H


### PR DESCRIPTION
Handle status messages as UTF strings.

Add an option `STATUS_MESSAGE_SCROLLING` to allow an excess length status message to be set. The status message will be scrolled on each screen update if it's wider than the display.