### PR TITLE
Fix LCD to draw after value changes

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -191,7 +191,7 @@
     // ask the user to resolve the issue
     lcd_setstatusPGM(PSTR("Release button"), 99); // will never appear...
     while (ubl_lcd_clicked()) idle();             // unless this loop happens
-    lcd_setstatusPGM(PSTR(""), -1);
+    lcd_reset_status();
 
     return true;
   }
@@ -771,7 +771,7 @@
     }
 
     #if ENABLED(ULTRA_LCD)
-      lcd_setstatusPGM(PSTR(""), -1);
+      lcd_reset_status();
       lcd_quick_feedback();
     #endif
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -40,8 +40,6 @@
   extern float destination[XYZE], current_position[XYZE];
 
   void lcd_return_to_status();
-  bool lcd_clicked();
-  void lcd_implementation_clear();
   void lcd_mesh_edit_setup(float initial);
   float lcd_mesh_edit();
   void lcd_z_offset_edit_setup(float);
@@ -53,12 +51,6 @@
 
   #define SIZE_OF_LITTLE_RAISE 1
   #define BIG_RAISE_NOT_NEEDED 0
-
-  extern void lcd_status_screen();
-  typedef void (*screenFunc_t)();
-  extern void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0);
-  extern void lcd_setstatus(const char* message, const bool persist);
-  extern void lcd_setstatusPGM(const char* message, const int8_t level);
 
   int    unified_bed_leveling::g29_verbose_level,
          unified_bed_leveling::g29_phase_value,
@@ -662,7 +654,7 @@
         do_blocking_move_to_z(measured_z);  // Get close to the bed, but leave some space so we don't damage anything
                                             // The user is not going to be locking in a new Z-Offset very often so
                                             // it won't be that painful to spin the Encoder Wheel for 1.5mm
-        lcd_implementation_clear();
+        lcd_refresh();
         lcd_z_offset_edit_setup(measured_z);
 
         KEEPALIVE_STATE(PAUSED_FOR_USER);
@@ -698,7 +690,7 @@
 
         state.z_offset = measured_z;
 
-        lcd_implementation_clear();
+        lcd_refresh();
         restore_ubl_active_state_and_leave();
       }
     }
@@ -940,7 +932,7 @@
 
     SERIAL_PROTOCOLPGM("Place shim under nozzle");
     LCD_MESSAGEPGM("Place shim & measure"); // TODO: Make translatable string
-    lcd_goto_screen(lcd_status_screen);
+    lcd_return_to_status();
     echo_and_take_a_measurement();
 
     const float z1 = measure_point_with_encoder();
@@ -979,7 +971,7 @@
     do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
     do_blocking_move_to_xy(lx, ly);
 
-    lcd_goto_screen(lcd_status_screen);
+    lcd_return_to_status();
     mesh_index_pair location;
     do {
       location = find_closest_mesh_point_of_type(INVALID, lx, ly, USE_NOZZLE_AS_REFERENCE, NULL, false);
@@ -1456,7 +1448,7 @@
 
       if (do_ubl_mesh_map) display_map(g29_map_type);  // show the user which point is being adjusted
 
-      lcd_implementation_clear();
+      lcd_refresh();
 
       lcd_mesh_edit_setup(new_z);
 
@@ -1497,7 +1489,7 @@
 
       z_values[location.x_index][location.y_index] = new_z;
 
-      lcd_implementation_clear();
+      lcd_refresh();
 
     } while (location.x_index >= 0 && --g29_repetition_cnt > 0);
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -718,7 +718,8 @@ void kill_screen(const char* lcd_msg) {
         for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
       #endif
       wait_for_heatup = false;
-      lcd_setstatusPGM(PSTR(MSG_PRINT_PAUSED), -1);
+      lcd_setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
+      lcd_return_to_status();
     }
 
   #endif // SDSUPPORT

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -236,23 +236,23 @@ uint16_t max_display_update_time = 0;
    *     menu_action_setting_edit_int3(PSTR(MSG_SPEED), &feedrate_percentage, 10, 999)
    *
    */
-  #define _MENU_ITEM_PART_1(TYPE, LABEL, ...) \
+  #define _MENU_ITEM_PART_1(TYPE, ...) \
     if (_menuLineNr == _thisItemNr) { \
-      if (lcdDrawUpdate) \
-        lcd_implementation_drawmenu_ ## TYPE(encoderLine == _thisItemNr, _lcdLineNr, PSTR(LABEL), ## __VA_ARGS__); \
       if (lcd_clicked && encoderLine == _thisItemNr) {
 
-  #define _MENU_ITEM_PART_2(TYPE, ...) \
+  #define _MENU_ITEM_PART_2(TYPE, LABEL, ...) \
         menu_action_ ## TYPE(__VA_ARGS__); \
         if (screen_changed) return; \
       } \
+      if (lcdDrawUpdate) \
+        lcd_implementation_drawmenu_ ## TYPE(encoderLine == _thisItemNr, _lcdLineNr, PSTR(LABEL), ## __VA_ARGS__); \
     } \
     ++_thisItemNr
 
   #define MENU_ITEM(TYPE, LABEL, ...) do { \
       _skipStatic = false; \
-      _MENU_ITEM_PART_1(TYPE, LABEL, ## __VA_ARGS__); \
-      _MENU_ITEM_PART_2(TYPE, ## __VA_ARGS__); \
+      _MENU_ITEM_PART_1(TYPE, ## __VA_ARGS__); \
+      _MENU_ITEM_PART_2(TYPE, LABEL, ## __VA_ARGS__); \
     } while(0)
 
   #define MENU_BACK(LABEL) MENU_ITEM(back, LABEL, 0)
@@ -281,10 +281,10 @@ uint16_t max_display_update_time = 0;
      * MENU_MULTIPLIER_ITEM generates drawing and handling code for a multiplier menu item
      */
     #define MENU_MULTIPLIER_ITEM(type, label, ...) do { \
-        _MENU_ITEM_PART_1(type, label, ## __VA_ARGS__); \
+        _MENU_ITEM_PART_1(type, ## __VA_ARGS__); \
         encoderRateMultiplierEnabled = true; \
         lastEncoderMovementMillis = 0; \
-        _MENU_ITEM_PART_2(type, ## __VA_ARGS__); \
+        _MENU_ITEM_PART_2(type, label, ## __VA_ARGS__); \
       } while(0)
 
   #else // !ENCODER_RATE_MULTIPLIER
@@ -581,8 +581,6 @@ void lcd_status_screen() {
     #endif
   #endif // LCD_PROGRESS_BAR
 
-  lcd_implementation_status_screen();
-
   #if ENABLED(ULTIPANEL)
 
     if (lcd_clicked) {
@@ -595,6 +593,7 @@ void lcd_status_screen() {
         #endif
       );
       lcd_goto_screen(lcd_main_menu);
+      return;
     }
 
     #if ENABLED(ULTIPANEL_FEEDMULTIPLY)
@@ -623,6 +622,8 @@ void lcd_status_screen() {
     feedrate_percentage = constrain(feedrate_percentage, 10, 999);
 
   #endif // ULTIPANEL
+
+  lcd_implementation_status_screen();
 }
 
 /**

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1766,7 +1766,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_BACK(MSG_UBL_EDIT_MESH_MENU);
       MENU_ITEM_EDIT(int3, MSG_UBL_MESH_HEIGHT_AMOUNT, &ubl_height_amount, -9, 9);
       MENU_ITEM(function, MSG_UBL_MESH_HEIGHT_ADJUST, _lcd_ubl_adjust_height_cmd);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+      MENU_ITEM(function, MSG_WATCH, lcd_return_to_status);
       END_MENU();
     }
 
@@ -1780,7 +1780,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM(gcode, MSG_UBL_FINE_TUNE_ALL, PSTR("G29 P4 R T"));
       MENU_ITEM(gcode, MSG_UBL_FINE_TUNE_CLOSEST, PSTR("G29 P4 T"));
       MENU_ITEM(submenu, MSG_UBL_MESH_HEIGHT_ADJUST, _lcd_ubl_height_adjust_menu);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+      MENU_ITEM(function, MSG_WATCH, lcd_return_to_status);
       END_MENU();
     }
 
@@ -1814,7 +1814,7 @@ void kill_screen(const char* lcd_msg) {
         MENU_ITEM(gcode, MSG_UBL_VALIDATE_ABS_MESH, PSTR("G28\nG26 C B0 H" STRINGIFY(PREHEAT_2_TEMP_HOTEND) " P"));
       #endif
       MENU_ITEM(function, MSG_UBL_VALIDATE_CUSTOM_MESH, _lcd_ubl_validate_custom_mesh);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+      MENU_ITEM(function, MSG_WATCH, lcd_return_to_status);
       END_MENU();
     }
 
@@ -1846,7 +1846,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_BACK(MSG_UBL_TOOLS);
       MENU_ITEM(gcode, MSG_UBL_3POINT_MESH_LEVELING, PSTR("G29 J0"));
       MENU_ITEM(submenu, MSG_UBL_GRID_MESH_LEVELING, _lcd_ubl_grid_level);
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+      MENU_ITEM(function, MSG_WATCH, lcd_return_to_status);
       END_MENU();
     }
 
@@ -1878,7 +1878,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM(function, MSG_UBL_FILLIN_MESH, _lcd_ubl_fillin_amount_cmd);
       MENU_ITEM(function, MSG_UBL_SMART_FILLIN, _lcd_ubl_smart_fillin_cmd);
       MENU_ITEM(gcode, MSG_UBL_MANUAL_FILLIN, PSTR("G29 P2 B T0"));
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+      MENU_ITEM(function, MSG_WATCH, lcd_return_to_status);
       END_MENU();
     }
 
@@ -1930,7 +1930,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM(gcode, MSG_UBL_CONTINUE_MESH, PSTR("G29 P1 C"));
       MENU_ITEM(function, MSG_UBL_INVALIDATE_ALL, _lcd_ubl_invalidate);
       MENU_ITEM(gcode, MSG_UBL_INVALIDATE_CLOSEST, PSTR("G29 I"));
-      MENU_ITEM(submenu, MSG_WATCH, lcd_status_screen);
+      MENU_ITEM(function, MSG_WATCH, lcd_return_to_status);
       END_MENU();
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -626,6 +626,8 @@ void lcd_status_screen() {
   lcd_implementation_status_screen();
 }
 
+void lcd_reset_status() { lcd_setstatusPGM(PSTR(""), -1); }
+
 /**
  *
  * draw the kill screen
@@ -633,7 +635,7 @@ void lcd_status_screen() {
  */
 void kill_screen(const char* lcd_msg) {
   lcd_init();
-  lcd_setalertstatuspgm(lcd_msg);
+  lcd_setalertstatusPGM(lcd_msg);
   #if ENABLED(DOGLCD)
     u8g.firstPage();
     do {
@@ -705,7 +707,7 @@ void kill_screen(const char* lcd_msg) {
         card.startFileprint();
         print_job_timer.start();
       #endif
-      lcd_setstatusPGM(PSTR(""), -1);
+      lcd_reset_status();
     }
 
     void lcd_sdcard_stop() {
@@ -4160,7 +4162,7 @@ void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...) {
   lcd_finishstatus(level > 0);
 }
 
-void lcd_setalertstatuspgm(const char * const message) {
+void lcd_setalertstatusPGM(const char * const message) {
   lcd_setstatusPGM(message, 1);
   #if ENABLED(ULTIPANEL)
     lcd_return_to_status();

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -39,8 +39,8 @@
   bool lcd_hasstatus();
   void lcd_setstatus(const char* message, const bool persist=false);
   void lcd_setstatusPGM(const char* message, const int8_t level=0);
+  void lcd_setalertstatusPGM(const char* message);
   void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...);
-  void lcd_setalertstatuspgm(const char* message);
   void lcd_reset_alert_level();
   void lcd_kill_screen();
   void kill_screen(const char* lcd_msg);
@@ -63,9 +63,6 @@
   #elif ENABLED(SHOW_BOOTSCREEN)
     void bootscreen();
   #endif
-
-  #define LCD_MESSAGEPGM(x) lcd_setstatusPGM(PSTR(x))
-  #define LCD_ALERTMESSAGEPGM(x) lcd_setalertstatuspgm(PSTR(x))
 
   #define LCD_UPDATE_INTERVAL 100
 
@@ -152,21 +149,25 @@
   #endif
 
 #else // no LCD
+
   inline void lcd_update() {}
   inline void lcd_init() {}
   inline bool lcd_hasstatus() { return false; }
   inline void lcd_setstatus(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
   inline void lcd_setstatusPGM(const char* const message, const int8_t level=0) { UNUSED(message); UNUSED(level); }
+  inline void lcd_setalertstatusPGM(const char* message) { UNUSED(message); }
   inline void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...) { UNUSED(level); UNUSED(fmt); }
   inline void lcd_buttons_update() {}
   inline void lcd_reset_alert_level() {}
   inline bool lcd_detected() { return true; }
   inline void lcd_refresh() {}
 
-  #define LCD_MESSAGEPGM(x) NOOP
-  #define LCD_ALERTMESSAGEPGM(x) NOOP
-
 #endif // ULTRA_LCD
+
+#define LCD_MESSAGEPGM(x)      lcd_setstatusPGM(PSTR(x))
+#define LCD_ALERTMESSAGEPGM(x) lcd_setalertstatusPGM(PSTR(x))
+
+void lcd_reset_status();
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   void lcd_mesh_edit_setup(float initial);


### PR DESCRIPTION
Screen handlers that include value editing should always draw after the value has been edited, (unless they set the `lcdDrawUpdate` flag to draw on the next lcd update). Controls will always feel more responsive if updated values are drawn in the same handler after they are altered.

- Fix: Feedrate final value not shown until next info screen update
- Fix: Final value is off by one tick from last value displayed on edit screen

Also:
- Fix: Incorrect message on SD Print abort
- Fix: UBL "Info Screen" items —
  (`function ... lcd_return_to_status` instead of `submenu ... lcd_status_screen`)
