### PR TITLE
Fix LCD scrolling character counting

### DIFF
--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -127,6 +127,7 @@
 #define DECIMAL(a) (NUMERIC(a) || a == '.')
 #define NUMERIC_SIGNED(a) (NUMERIC(a) || (a) == '-' || (a) == '+')
 #define DECIMAL_SIGNED(a) (DECIMAL(a) || (a) == '-' || (a) == '+')
+#define PRINTABLE(C) (((C) & 0xC0u) != 0x80u)
 #define COUNT(a) (sizeof(a)/sizeof(*a))
 #define ZERO(a) memset(a,0,sizeof(a))
 #define COPY(a,b) memcpy(a,b,min(sizeof(a),sizeof(b)))

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3814,7 +3814,7 @@ int lcd_strlen(const char* s) {
     #if ENABLED(MAPPER_NON)
       j++;
     #else
-      if ((s[i] & 0xC0u) != 0x80u) j++;
+      if (PRINTABLE(s[i])) j++;
     #endif
     i++;
   }
@@ -3827,7 +3827,7 @@ int lcd_strlen_P(const char* s) {
     #if ENABLED(MAPPER_NON)
       j++;
     #else
-      if ((pgm_read_byte(s) & 0xC0u) != 0x80u) j++;
+      if (PRINTABLE(pgm_read_byte(s))) j++;
     #endif
     s++;
   }
@@ -4096,7 +4096,7 @@ void lcd_update() {
       #if ENABLED(MAPPER_NON)
         j++;
       #else
-        if ((s[i] & 0xC0u) != 0x80u) j++;
+        if (PRINTABLE(s[i])) j++;
       #endif
       i++;
     }

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -412,7 +412,7 @@ inline void lcd_implementation_status_message() {
     const uint8_t slen = lcd_strlen(lcd_status_message);
     if (slen > LCD_WIDTH) {
       // Skip any non-printing bytes
-      while (!charset_mapper(lcd_status_message[status_scroll_pos])) ++status_scroll_pos;
+      while (!PRINTABLE(lcd_status_message[status_scroll_pos])) ++status_scroll_pos;
       if (++status_scroll_pos > slen - LCD_WIDTH) status_scroll_pos = 0;
     }
   #else

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -582,8 +582,8 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
 FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, const bool blink) {
   const bool isBed = heater < 0;
 
-  const float t1 = (isBed ? thermalManager.degBed() : thermalManager.degHotend(heater));
-  const float t2 = (isBed ? thermalManager.degTargetBed() : thermalManager.degTargetHotend(heater));
+  const float t1 = (isBed ? thermalManager.degBed()       : thermalManager.degHotend(heater)),
+              t2 = (isBed ? thermalManager.degTargetBed() : thermalManager.degTargetHotend(heater));
 
   if (prefix >= 0) lcd.print(prefix);
 
@@ -592,11 +592,11 @@ FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, co
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     const bool is_idle = (!isBed ? thermalManager.is_heater_idle(heater) :
-    #if HAS_TEMP_BED
-      thermalManager.is_bed_idle()
-    #else
-      false
-    #endif
+      #if HAS_TEMP_BED
+        thermalManager.is_bed_idle()
+      #else
+        false
+      #endif
     );
 
     if (!blink && is_idle) {
@@ -606,7 +606,7 @@ FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, co
     }
     else
   #endif
-  lcd.print(itostr3left(t2 + 0.5));
+      lcd.print(itostr3left(t2 + 0.5));
 
   if (prefix >= 0) {
     lcd_printPGM(PSTR(LCD_STR_DEGREE " "));

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -831,7 +831,7 @@ static void lcd_implementation_status_screen() {
     const uint8_t slen = lcd_strlen(lcd_status_message);
     if (slen > LCD_WIDTH) {
       // Skip any non-printing bytes
-      while (!charset_mapper(lcd_status_message[status_scroll_pos])) ++status_scroll_pos;
+      while (!PRINTABLE(lcd_status_message[status_scroll_pos])) ++status_scroll_pos;
       if (++status_scroll_pos > slen - LCD_WIDTH) status_scroll_pos = 0;
     }
   #else


### PR DESCRIPTION
Inline the non-printable character test instead of using the _printing_ `charset_mapper` function — oops! Fixes an issue where the first message character would appear at the top of the display.