### PR TITLE
gcode.h - fix compile error

### DIFF
--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -135,7 +135,7 @@ public:
     static bool seen(const char c) {
       const char *p = strchr(command_args, c);
       const bool b = !!p;
-      if (b) value_ptr = DECIMAL_SIGNED(p[1]) ? &p[1] : NULL;
+      if (b) value_ptr = (char*) (DECIMAL_SIGNED(p[1]) ? &p[1] : NULL);
       return b;
     }
 


### PR DESCRIPTION
"invalid conversion from 'const char*' to 'char*' [-fpermissive]" on line 138 in gcode.h sometimes shows up.

This was flagged on issue #6902 