### PR TITLE
gcode.h - another compile error

### DIFF
--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -227,7 +227,7 @@ public:
         return input_temp_units == TEMPUNIT_K ? 'K' : input_temp_units == TEMPUNIT_F ? 'F' : 'C';
       }
       FORCE_INLINE static char* temp_units_name() {
-        return input_temp_units == TEMPUNIT_K ? PSTR("Kelvin") : input_temp_units == TEMPUNIT_F ? PSTR("Fahrenheit") : PSTR("Celsius")
+        return input_temp_units == TEMPUNIT_K ? PSTR("Kelvin") : input_temp_units == TEMPUNIT_F ? PSTR("Fahrenheit") : PSTR("Celsius");
       }
       inline static float to_temp_units(const float &f) {
         switch (input_temp_units) {


### PR DESCRIPTION
Per issue #6849 

Only seen if
```
#if ENABLED(TEMPERATURE_UNITS_SUPPORT)
      ...
    #if ENABLED(ULTIPANEL) && DISABLED(DISABLE_M503)
```

