### PR TITLE
Fix issues with advanced pause

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5931,7 +5931,8 @@ inline void gcode_M17() {
       idle();
       wait_for_heatup = false;
       HOTEND_LOOP() {
-        if (abs(thermalManager.degHotend(e) - thermalManager.degTargetHotend(e)) > 3) {
+        const int16_t target_temp = thermalManager.degTargetHotend(e);
+        if (target_temp && abs(thermalManager.degHotend(e) - target_temp) > 3) {
           wait_for_heatup = true;
           break;
         }

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -704,7 +704,9 @@ static void lcd_implementation_status_screen() {
       lcd_print(' ');
       lcd_print(itostr3(thermalManager.degHotend(active_extruder)));
       lcd_print('/');
-      lcd_print(itostr3(thermalManager.degTargetHotend(active_extruder)));
+
+      if (lcd_blink() || !thermalManager.is_heater_idle(active_extruder))
+        lcd_print(itostr3(thermalManager.degTargetHotend(active_extruder)));
     }
 
   #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -844,10 +844,7 @@ static void lcd_implementation_status_screen() {
     static void lcd_implementation_hotend_status(const uint8_t row) {
       if (row < LCD_HEIGHT) {
         lcd.setCursor(LCD_WIDTH - 9, row);
-        lcd.print(LCD_STR_THERMOMETER[0]);
-        lcd.print(itostr3(thermalManager.degHotend(active_extruder)));
-        lcd.print('/');
-        lcd.print(itostr3(thermalManager.degTargetHotend(active_extruder)));
+        _draw_heater_status(active_extruder, LCD_STR_THERMOMETER[0], lcd_blink());
       }
     }
 


### PR DESCRIPTION
This PR fixes the following issues with the advanced pause feature:

1. The target extruder temperature in the pause displays now flashes when the heater is idle.
2. Resuming no longer waits for inactive extruders to heat up.

@Roxy-3D tested the first issue with a DOGLCD and I tested on my 20x4 LCD. I also tested the second issue on my dual-extruder setup.