### PR TITLE
Fix case light logic on Azteeg_X3 boards.

### DIFF
--- a/Marlin/pins_AZTEEG_X3.h
+++ b/Marlin/pins_AZTEEG_X3.h
@@ -32,11 +32,10 @@
   #error "Azteeg X3 supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_NAME "Azteeg X3"
-
-#if !PIN_EXISTS(CASE_LIGHT)         // doesn't already exist so OK to change the definition coming
-  #define OK_TO_CHANGE_CASE_LIGHT   // in from from the include file
+#if ENABLED(CASE_LIGHT_ENABLE)  && !PIN_EXISTS(CASE_LIGHT)
+  #define CASE_LIGHT_PIN 6     // must define it here or else RAMPS will define it
 #endif
+#define BOARD_NAME "Azteeg X3"
 
 #include "pins_RAMPS_13.h"
 
@@ -75,10 +74,8 @@
 //
 // Misc
 //
-#if ENABLED(OK_TO_CHANGE_CASE_LIGHT) && STAT_LED_RED_PIN == 6
+#if ENABLED(CASE_LIGHT_ENABLE)  && PIN_EXISTS(CASE_LIGHT) && PIN_EXISTS(STAT_LED_RED) && STAT_LED_RED_PIN == CASE_LIGHT_PIN 
   #undef STAT_LED_RED_PIN
-  #undef CASE_LIGHT_PIN
-  #define CASE_LIGHT_PIN 6  // open collector FET driver
 #endif
 
 //
@@ -94,6 +91,7 @@
   #if SERVO0_PIN == 7
     #undef SERVO0_PIN
     #def SERVO0_PIN 11
+  #endif
   #define SPINDLE_LASER_PWM_PIN     7  // MUST BE HARDWARE PWM
   #define SPINDLE_LASER_ENABLE_PIN 20  // Pin should have a pullup!
   #define SPINDLE_DIR_PIN          21

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -28,11 +28,12 @@
   #error "Azteeg X3 Pro supports up to 5 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_NAME "Azteeg X3 Pro"
-
-#if !PIN_EXISTS(CASE_LIGHT)         // doesn't already exist so OK to change the definition coming
-  #define OK_TO_CHANGE_CASE_LIGHT   // in from from the include file
+#if ENABLED(CASE_LIGHT_ENABLE)  && !PIN_EXISTS(CASE_LIGHT)
+  #define CASE_LIGHT_PIN 44     // must define it here or else RAMPS will define it
 #endif
+
+
+#define BOARD_NAME "Azteeg X3 Pro"
 
 #include "pins_RAMPS.h"
 
@@ -144,19 +145,16 @@
 //
 // Misc. Functions
 //
-#if ENABLED(OK_TO_CHANGE_CASE_LIGHT)
+#if ENABLED(CASE_LIGHT_ENABLE)  && PIN_EXISTS(CASE_LIGHT) && defined(DOGLCD_A0) && DOGLCD_A0 == CASE_LIGHT_PIN 
   #undef DOGLCD_A0            // steal pin 44 for the case light; if you have a Viki2 and have connected it
   #define DOGLCD_A0      57   // following the Panucatt wiring diagram, you may need to tweak these pin assignments
-                              // as the wiring diagram uses pin 44 for DOGLCD_A0
-
-  #undef CASE_LIGHT_PIN
-  #define CASE_LIGHT_PIN 44    // must have a hardware PWM
+                                // as the wiring diagram uses pin 44 for DOGLCD_A0
 #endif
 
 //
 // M3/M4/M5 - Spindle/Laser Control
 //
-#undef SPINDLE_LASER_PWM_PIN    // Definitions in pins_RAMPS.h are no good with the AzteegX3 board
+#undef SPINDLE_LASER_PWM_PIN    // Definitions in pins_RAMPS.h are no good with the AzteegX3pro board
 #undef SPINDLE_LASER_ENABLE_PIN
 #undef SPINDLE_DIR_PIN
 

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -204,8 +204,7 @@
 
 #define PS_ON_PIN          12
 
-#if !PIN_EXISTS(CASE_LIGHT) && !defined(SPINDLE_LASER_ENABLE_PIN)
-  #undef CASE_LIGHT_PIN
+#if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT) && !defined(SPINDLE_LASER_ENABLE_PIN)
   #if !defined(NUM_SERVOS) || NUM_SERVOS == 0 // try to use servo connector first
     #define CASE_LIGHT_PIN   6      // MUST BE HARDWARE PWM
   #elif !(ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL) \


### PR DESCRIPTION
The current logic would define the `CASE_LIGHT_PIN` even when disabled.  On the AzteegX3pro this would step on the defines needed for the Viki2 LCD display.