### PR TITLE
Add template for github issues

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,7 @@
+### Expected behaviour
+
+### Actual behaviour
+
+### Steps to reproduce the behaviour
+
+#### please add your Configuration.h and Configuration_adv.h to a zip file and attach it to this issue


### PR DESCRIPTION
This is mostly just a heads up that this feature exists and might help get more clarity out of Issues without having to request configs and more info all the time. More confident users can of course just delete the template. The template is just an example and will need to be in the default branch.