### PR TITLE
Gcode.cpp - spaces and parameters

### DIFF
--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -183,7 +183,8 @@ void GCodeParser::parse(char *p) {
     #endif
 
     if (PARAM_TEST) {
-
+    
+      while (*p == ' ') p++;                    // skip spaces vetween parameters & values
       const bool has_num = DECIMAL_SIGNED(*p);  // The parameter has a number [-+0-9.]
 
       #if ENABLED(DEBUG_GCODE_PARSER)
@@ -221,7 +222,7 @@ void GCodeParser::parse(char *p) {
     }
 
     if (!WITHIN(*p, 'A', 'Z')) {
-      while (*p && NUMERIC(*p)) p++;              // Skip over the parameter
+      while (*p && NUMERIC(*p)) p++;              // Skip over the value section of a parameter
       while (*p == ' ') p++;                      // Skip over all spaces
     }
   }

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -220,8 +220,10 @@ void GCodeParser::parse(char *p) {
       #endif
     }
 
-    while (*p && *p != ' ') p++;                // Skip over the parameter
-    while (*p == ' ') p++;                      // Skip over all spaces
+    if (!WITHIN(*p, 'A', 'Z')) {
+      while (*p && NUMERIC(*p)) p++;              // Skip over the parameter
+      while (*p == ' ') p++;                      // Skip over all spaces
+    }
   }
 }
 


### PR DESCRIPTION
This allows things like `G28 XY `and `G0X10Y45.6`.

This was asked for in a couple of threads but may violate some conventions.

----

Added the ability to skip spaces between a parameter and it's values  `M421 I 4 J 3 Z .12345` 

