### PR TITLE
Allow DEBUG_GCODE_PARSER when UBL is enabled

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -35,6 +35,10 @@
 
 #include "MarlinConfig.h"
 
+#ifdef DEBUG_GCODE_PARSER
+  #include "gcode.h"
+#endif
+
 #include "enum.h"
 #include "types.h"
 #include "fastio.h"


### PR DESCRIPTION
Fixes "hex_address not defined" error when UBL and DEBUG_GCODE_PARSER are both enabled.