### PR TITLE
fix redefinition errors for redundant_temperature

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -73,10 +73,6 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
   int16_t Temperature::target_temperature_bed = 0;
 #endif
 
-#if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-  float Temperature::redundant_temperature = 0.0;
-#endif
-
 #if ENABLED(PIDTEMP)
   #if ENABLED(PID_PARAMS_PER_HOTEND) && HOTENDS > 1
     float Temperature::Kp[HOTENDS] = ARRAY_BY_HOTENDS1(DEFAULT_Kp),

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -112,10 +112,6 @@ class Temperature {
 
     static volatile bool in_temp_isr;
 
-    #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-      static float redundant_temperature;
-    #endif
-
     static uint8_t soft_pwm_amount[HOTENDS],
                    soft_pwm_amount_bed;
 


### PR DESCRIPTION
Removing **redundant_temperature** from public section and leaving it in the private section.

The current setup was put in place between RC6 & RC8.

Issue #6885 found this problem.