### PR TITLE
Initializing extruder/nozzle servo when turning on the printer

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12723,6 +12723,14 @@ void setup() {
   #if ENABLED(ENDSTOP_INTERRUPTS_FEATURE)
     setup_endstop_interrupts();
   #endif
+  
+  #if ENABLED(SWITCHING_EXTRUDER)
+    move_extruder_servo(0);  // Initialize extruder servo
+  #endif
+
+  #if ENABLED(SWITCHING_NOZZLE)
+    move_nozzle_servo(0);  // Initialize nozzle servo
+  #endif
 }
 
 /**


### PR DESCRIPTION
For SWITCHING_EXTRUDER and SWITCHING_NOZZLE features
Without this, the servo hangs in the air until it receives the command T0 / T1