### PR TITLE
SD card soft SPI - allow all CPU families to use it

### DIFF
--- a/Marlin/Sd2Card.h
+++ b/Marlin/Sd2Card.h
@@ -125,7 +125,7 @@ uint8_t const SD_CARD_TYPE_SDHC = 3;
  * define SOFTWARE_SPI to use bit-bang SPI
  */
 //------------------------------------------------------------------------------
-#if MEGA_SOFT_SPI && (defined(__AVR_ATmega1280__)||defined(__AVR_ATmega2560__))
+#if MEGA_SOFT_SPI
   #define SOFTWARE_SPI
 #elif USE_SOFTWARE_SPI
   #define SOFTWARE_SPI


### PR DESCRIPTION
Removed the check for 2560 family.

I found this restriction while interfacing a RepRap Discount Full Graphic LCD to my Teensylu.