### PR TITLE
Save up to 94 bytes of RAM on 20x4 LCD Display machines

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -241,14 +241,14 @@
     #define LCD_STR_FILAM_MUL   "\xa4"
   #else
     /* Custom characters defined in the first 8 characters of the LCD */
-    #define LCD_STR_BEDTEMP     "\x00"  // Print only as a char. This will have 'unexpected' results when used in a string!
-    #define LCD_STR_DEGREE      "\x01"
-    #define LCD_STR_THERMOMETER "\x02"
-    #define LCD_STR_UPLEVEL     "\x03"
-    #define LCD_STR_REFRESH     "\x04"
+    #define LCD_BEDTEMP_CHAR     0x00  // Print only as a char. This will have 'unexpected' results when used in a string!
+    #define LCD_DEGREE_CHAR      0x01
+    #define LCD_STR_THERMOMETER "\x02" // Too many places use preprocessor string concatination to change this to a char right now.
+    #define LCD_UPLEVEL_CHAR     0x03
+    #define LCD_REFRESH_CHAR     0x04
     #define LCD_STR_FOLDER      "\x05"
-    #define LCD_STR_FEEDRATE    "\x06"
-    #define LCD_STR_CLOCK       "\x07"
+    #define LCD_FEEDRATE_CHAR    0x06
+    #define LCD_CLOCK_CHAR       0x07
     #define LCD_STR_ARROW_RIGHT ">"  /* from the default character set */
   #endif
 

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
@@ -649,7 +649,7 @@
  */
 #define X_PROBE_OFFSET_FROM_EXTRUDER 38     // X offset: -left  +right  [of the nozzle]
 #define Y_PROBE_OFFSET_FROM_EXTRUDER -7     // Y offset: -front +behind [the nozzle]
-#define Z_PROBE_OFFSET_FROM_EXTRUDER -10.1  // Z offset: -below +above  [the nozzle]
+#define Z_PROBE_OFFSET_FROM_EXTRUDER -10.4  // Z offset: -below +above  [the nozzle]
 
 // X and Y axis travel speed (mm/m) between probes
 #define XY_PROBE_SPEED 7500

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
@@ -509,7 +509,7 @@
   #endif
 
   // Show a progress bar on HD44780 LCDs for SD printing
-  //#define LCD_PROGRESS_BAR
+  #define LCD_PROGRESS_BAR
 
   #if ENABLED(LCD_PROGRESS_BAR)
     // Amount of time (ms) to show the bar
@@ -1228,7 +1228,7 @@
  *  - M206 and M428 are disabled.
  *  - G92 will revert to its behavior from Marlin 1.0.
  */
-//#define NO_WORKSPACE_OFFSETS
+#define NO_WORKSPACE_OFFSETS
 
 /**
  * Set the number of proportional font spaces required to fill up a typical character space.

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -193,12 +193,18 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
   static void lcd_implementation_update_indicators();
 #endif
 
-static void lcd_set_custom_characters(
-  #if ENABLED(LCD_PROGRESS_BAR)
-    const bool info_screen_charset = true
-  #endif
-) {
-  static byte bedTemp[8] = {
+
+static void createChar_P(char c, PROGMEM byte *ptr) {
+  byte temp[8];  
+  int8_t i;
+
+  for(i=0; i<8; i++)  {
+    temp[i] = pgm_read_byte(&ptr[i]);  
+  }
+  lcd.createChar(c, temp);
+}
+
+const static PROGMEM byte bedTemp[8] = {
     B00000,
     B11111,
     B10101,
@@ -207,8 +213,9 @@ static void lcd_set_custom_characters(
     B11111,
     B00000,
     B00000
-  }; //thanks Sonny Mounicou
-  static byte degree[8] = {
+}; 
+
+const static PROGMEM byte degree[8] = {
     B01100,
     B10010,
     B10010,
@@ -218,7 +225,8 @@ static void lcd_set_custom_characters(
     B00000,
     B00000
   };
-  static byte thermometer[8] = {
+
+const static PROGMEM byte thermometer[8] = {
     B00100,
     B01010,
     B01010,
@@ -228,7 +236,8 @@ static void lcd_set_custom_characters(
     B10001,
     B01110
   };
-  static byte uplevel[8] = {
+
+const static PROGMEM byte uplevel[8] = {
     B00100,
     B01110,
     B11111,
@@ -237,8 +246,9 @@ static void lcd_set_custom_characters(
     B00000,
     B00000,
     B00000
-  }; //thanks joris
-  static byte feedrate[8] = {
+}; 
+
+const static PROGMEM byte feedrate[8] = {
     B11100,
     B10000,
     B11000,
@@ -247,8 +257,9 @@ static void lcd_set_custom_characters(
     B00110,
     B00101,
     B00000
-  }; //thanks Sonny Mounicou
-  static byte clock[8] = {
+};
+
+const static PROGMEM byte clock[8] = {
     B00000,
     B01110,
     B10011,
@@ -257,16 +268,10 @@ static void lcd_set_custom_characters(
     B01110,
     B00000,
     B00000
-  }; //thanks Sonny Mounicou
-
-  lcd.createChar(LCD_STR_BEDTEMP[0], bedTemp);
-  lcd.createChar(LCD_STR_DEGREE[0], degree);
-  lcd.createChar(LCD_STR_THERMOMETER[0], thermometer);
-  lcd.createChar(LCD_STR_FEEDRATE[0], feedrate);
-  lcd.createChar(LCD_STR_CLOCK[0], clock);
+}; 
 
   #if ENABLED(SDSUPPORT)
-    static byte refresh[8] = {
+  const static PROGMEM byte refresh[8] = {
       B00000,
       B00110,
       B11001,
@@ -275,8 +280,8 @@ static void lcd_set_custom_characters(
       B10011,
       B01100,
       B00000,
-    }; //thanks joris
-    static byte folder[8] = {
+  }; 
+  const static PROGMEM byte folder[8] = {
       B00000,
       B11100,
       B11111,
@@ -285,10 +290,10 @@ static void lcd_set_custom_characters(
       B11111,
       B00000,
       B00000
-    }; //thanks joris
+  };
 
     #if ENABLED(LCD_PROGRESS_BAR)
-      static byte progress[3][8] = { {
+    const static PROGMEM byte progress[3][8] = { {
         B00000,
         B10000,
         B10000,
@@ -316,26 +321,43 @@ static void lcd_set_custom_characters(
         B10101,
         B00000
       } };
+  #endif
+#endif
+
+static void lcd_set_custom_characters(
+  #if ENABLED(LCD_PROGRESS_BAR)
+    const bool info_screen_charset = true
+  #endif
+) {
+
+  createChar_P(LCD_BEDTEMP_CHAR, bedTemp);
+  createChar_P(LCD_DEGREE_CHAR, degree);
+  createChar_P(LCD_STR_THERMOMETER[0], thermometer);
+  createChar_P(LCD_FEEDRATE_CHAR, feedrate);
+  createChar_P(LCD_CLOCK_CHAR, clock);
+
+  #if ENABLED(SDSUPPORT)
+    #if ENABLED(LCD_PROGRESS_BAR)
       static bool char_mode = false;
       if (info_screen_charset != char_mode) {
         char_mode = info_screen_charset;
         if (info_screen_charset) { // Progress bar characters for info screen
-          for (int i = 3; i--;) lcd.createChar(LCD_STR_PROGRESS[i], progress[i]);
+          for (int i = 3; i--;) createChar_P(LCD_STR_PROGRESS[i], progress[i]);
         }
         else { // Custom characters for submenus
-          lcd.createChar(LCD_STR_UPLEVEL[0], uplevel);
-          lcd.createChar(LCD_STR_REFRESH[0], refresh);
-          lcd.createChar(LCD_STR_FOLDER[0], folder);
+          createChar_P(LCD_UPLEVEL_CHAR, uplevel );
+          createChar_P(LCD_REFRESH_CHAR, refresh);
+          createChar_P(LCD_STR_FOLDER[0], folder);
         }
       }
     #else
-      lcd.createChar(LCD_STR_UPLEVEL[0], uplevel);
-      lcd.createChar(LCD_STR_REFRESH[0], refresh);
-      lcd.createChar(LCD_STR_FOLDER[0], folder);
+      createChar_P(LCD_UPLEVEL_CHAR, uplevel );
+      createChar_P(LCD_REFRESH_CHAR, refresh);
+      createChar_P(LCD_STR_FOLDER[0], folder);
     #endif
 
   #else
-    lcd.createChar(LCD_STR_UPLEVEL[0], uplevel);
+    createChar_P(LCD_UPLEVEL_CHAR, uplevel );
   #endif
 }
 
@@ -607,7 +629,8 @@ FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, co
       lcd.print(itostr3left(t2 + 0.5));
 
   if (prefix >= 0) {
-    lcd_printPGM(PSTR(LCD_STR_DEGREE " "));
+    lcd.print((char)LCD_DEGREE_CHAR);
+    lcd.print(' ');
     if (t2 < 10) lcd.print(' ');
   }
 }
@@ -677,10 +700,10 @@ static void lcd_implementation_status_screen() {
 
       lcd.setCursor(8, 0);
       #if HOTENDS > 1
-        lcd.print(LCD_STR_THERMOMETER[0]);
+        lcd.print((CHAR)LCD_STR_THERMOMETER[0]);
         _draw_heater_status(1, -1, blink);
       #else
-        lcd.print(LCD_STR_BEDTEMP[0]);
+        lcd.print((CHAR)LCD_BEDTEMP_CHAR);
         _draw_heater_status(-1, -1, blink);
       #endif
 
@@ -701,7 +724,7 @@ static void lcd_implementation_status_screen() {
       #if HOTENDS > 1
         _draw_heater_status(1, LCD_STR_THERMOMETER[0], blink);
       #else
-        _draw_heater_status(-1, LCD_STR_BEDTEMP[0], blink);
+        _draw_heater_status(-1, LCD_BEDTEMP_CHAR, blink);
       #endif
 
     #endif // HOTENDS > 1 || TEMP_SENSOR_BED != 0
@@ -735,7 +758,7 @@ static void lcd_implementation_status_screen() {
         // If we both have a 2nd extruder and a heated bed,
         // show the heated bed temp on the left,
         // since the first line is filled with extruder temps
-      _draw_heater_status(-1, LCD_STR_BEDTEMP[0], blink);
+      _draw_heater_status(-1, LCD_BEDTEMP_CHAR, blink);
 
       #else
         // Before homing the axis letters are blinking 'X' <-> '?'.
@@ -767,7 +790,7 @@ static void lcd_implementation_status_screen() {
   #if LCD_HEIGHT > 3
 
     lcd.setCursor(0, 2);
-    lcd.print(LCD_STR_FEEDRATE[0]);
+    lcd.print((char)LCD_FEEDRATE_CHAR);
     lcd.print(itostr3(feedrate_percentage));
     lcd.print('%');
 
@@ -788,7 +811,7 @@ static void lcd_implementation_status_screen() {
     uint8_t len = elapsed.toDigital(buffer);
 
     lcd.setCursor(LCD_WIDTH - len - 1, 2);
-    lcd.print(LCD_STR_CLOCK[0]);
+    lcd.print((char)LCD_CLOCK_CHAR);
     lcd_print(buffer);
 
   #endif // LCD_HEIGHT > 3
@@ -980,7 +1003,7 @@ static void lcd_implementation_status_screen() {
 
   #endif // SDSUPPORT
 
-  #define lcd_implementation_drawmenu_back(sel, row, pstr, dummy) lcd_implementation_drawmenu_generic(sel, row, pstr, LCD_STR_UPLEVEL[0], LCD_STR_UPLEVEL[0])
+  #define lcd_implementation_drawmenu_back(sel, row, pstr, dummy) lcd_implementation_drawmenu_generic(sel, row, pstr, LCD_UPLEVEL_CHAR,LCD_UPLEVEL_CHAR)
   #define lcd_implementation_drawmenu_submenu(sel, row, pstr, data) lcd_implementation_drawmenu_generic(sel, row, pstr, '>', LCD_STR_ARROW_RIGHT[0])
   #define lcd_implementation_drawmenu_gcode(sel, row, pstr, gcode) lcd_implementation_drawmenu_generic(sel, row, pstr, '>', ' ')
   #define lcd_implementation_drawmenu_function(sel, row, pstr, data) lcd_implementation_drawmenu_generic(sel, row, pstr, '>', ' ')

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -195,11 +195,11 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
 
 
 static void createChar_P(char c, PROGMEM byte *ptr) {
-  byte temp[8];  
+  byte temp[8];
   int8_t i;
 
   for(i=0; i<8; i++)  {
-    temp[i] = pgm_read_byte(&ptr[i]);  
+    temp[i] = pgm_read_byte(&ptr[i]);
   }
   lcd.createChar(c, temp);
 }
@@ -213,7 +213,7 @@ const static PROGMEM byte bedTemp[8] = {
     B11111,
     B00000,
     B00000
-}; 
+};
 
 const static PROGMEM byte degree[8] = {
     B01100,
@@ -246,7 +246,7 @@ const static PROGMEM byte uplevel[8] = {
     B00000,
     B00000,
     B00000
-}; 
+};
 
 const static PROGMEM byte feedrate[8] = {
     B11100,
@@ -268,9 +268,9 @@ const static PROGMEM byte clock[8] = {
     B01110,
     B00000,
     B00000
-}; 
+};
 
-  #if ENABLED(SDSUPPORT)
+#if ENABLED(SDSUPPORT)
   const static PROGMEM byte refresh[8] = {
       B00000,
       B00110,
@@ -280,7 +280,7 @@ const static PROGMEM byte clock[8] = {
       B10011,
       B01100,
       B00000,
-  }; 
+  };
   const static PROGMEM byte folder[8] = {
       B00000,
       B11100,
@@ -292,7 +292,7 @@ const static PROGMEM byte clock[8] = {
       B00000
   };
 
-    #if ENABLED(LCD_PROGRESS_BAR)
+  #if ENABLED(LCD_PROGRESS_BAR)
     const static PROGMEM byte progress[3][8] = { {
         B00000,
         B10000,
@@ -345,19 +345,19 @@ static void lcd_set_custom_characters(
           for (int i = 3; i--;) createChar_P(LCD_STR_PROGRESS[i], progress[i]);
         }
         else { // Custom characters for submenus
-          createChar_P(LCD_UPLEVEL_CHAR, uplevel );
+          createChar_P(LCD_UPLEVEL_CHAR, uplevel);
           createChar_P(LCD_REFRESH_CHAR, refresh);
           createChar_P(LCD_STR_FOLDER[0], folder);
         }
       }
     #else
-      createChar_P(LCD_UPLEVEL_CHAR, uplevel );
+      createChar_P(LCD_UPLEVEL_CHAR, uplevel);
       createChar_P(LCD_REFRESH_CHAR, refresh);
       createChar_P(LCD_STR_FOLDER[0], folder);
     #endif
 
   #else
-    createChar_P(LCD_UPLEVEL_CHAR, uplevel );
+    createChar_P(LCD_UPLEVEL_CHAR, uplevel);
   #endif
 }
 


### PR DESCRIPTION
Moved the custom screen characters out of RAM into Program Memory.  With
SD-Card support and the Progress Bar enabled, this saves 94 bytes of RAM
memory.

Probably...  We can find similar savings in the Graphics LCD code if we
comb through it.   And if so...  That is the place we really need to
save RAM memory!

This was tested using the example_configurations/FolgerTech-i3-2020
files.  So a couple small changes to those files snuck into this Pull
Request.
