### PR TITLE
Remove requirement for LCD when UBL is used.

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -468,8 +468,6 @@ static_assert(1 >= 0
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #if IS_SCARA
     #error "AUTO_BED_LEVELING_UBL does not yet support SCARA printers."
-  #elif DISABLED(NEWPANEL)
-    #error "AUTO_BED_LEVELING_UBL requires an LCD controller."
   #endif
 #endif
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -459,8 +459,8 @@
                             parser.seen('T'), parser.seen('E'), parser.seen('U'));
           break;
 
-        #if ENABLED(NEWPANEL)
-          case 2: {
+        case 2: {
+          #if ENABLED(NEWPANEL)
             //
             // Manually Probe Mesh in areas that can't be reached by the probe
             //
@@ -507,8 +507,11 @@
 
             manually_probe_remaining_mesh(g29_x_pos, g29_y_pos, height, g29_card_thickness, parser.seen('T'));
             SERIAL_PROTOCOLLNPGM("G29 P2 finished.");
-          } break;
-        #endif
+          #else
+            SERIAL_PROTOCOLLNPGM("?P2 is only available when an LCD is present.");
+            return;
+          #endif
+        } break;
 
         case 3: {
           /**
@@ -567,14 +570,14 @@
           break;
         }
 
-        #if ENABLED(NEWPANEL)
-          case 4:
-            //
-            // Fine Tune (i.e., Edit) the Mesh
-            //
+        case 4: // Fine Tune (i.e., Edit) the Mesh
+          #if ENABLED(NEWPANEL)
             fine_tune_mesh(g29_x_pos, g29_y_pos, parser.seen('T'));
-            break;
-        #endif
+          #else
+            SERIAL_PROTOCOLLNPGM("?P4 is only available when an LCD is present.");
+            return;
+          #endif
+          break;
 
         case 5: find_mean_mesh_height(); break;
 


### PR DESCRIPTION
UBL no longer actually needs an LCD, so it's silly to require one.

See this post for instructions on bringing up a mesh without an LCD:  https://github.com/MarlinFirmware/Marlin/pull/6772#issuecomment-303141441

(This PR is in response to https://github.com/MarlinFirmware/Marlin/issues/6910#issuecomment-306511956)

