### PR TITLE
Fix z_endstop_adj initializer

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7918,19 +7918,18 @@ inline void gcode_M121() { endstops.enable_globally(false); }
       #ifdef PAUSE_PARK_X_POS
         + PAUSE_PARK_X_POS
       #endif
+      #if HOTENDS > 1 && DISABLED(DUAL_X_CARRIAGE)
+        + (active_extruder ? hotend_offset[X_AXIS][active_extruder] : 0)
+      #endif
     ;
     const float y_pos = parser.seen('Y') ? parser.value_linear_units() : 0
       #ifdef PAUSE_PARK_Y_POS
         + PAUSE_PARK_Y_POS
       #endif
+      #if HOTENDS > 1 && DISABLED(DUAL_X_CARRIAGE)
+        + (active_extruder ? hotend_offset[Y_AXIS][active_extruder] : 0)
+      #endif
     ;
-
-    #if HOTENDS > 1 && DISABLED(DUAL_X_CARRIAGE)
-      if (active_extruder > 0) {
-        if (!parser.seen('X')) x_pos += hotend_offset[X_AXIS][active_extruder];
-        if (!parser.seen('Y')) y_pos += hotend_offset[Y_AXIS][active_extruder];
-      }
-    #endif
 
     const bool job_running = print_job_timer.isRunning();
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1192,7 +1192,7 @@ void MarlinSettings::reset() {
 
   #elif ENABLED(Z_DUAL_ENDSTOPS)
 
-    float z_endstop_adj =
+    z_endstop_adj =
       #ifdef Z_DUAL_ENDSTOPS_ADJUSTMENT
         Z_DUAL_ENDSTOPS_ADJUSTMENT
       #else

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1731,7 +1731,10 @@ void kill_screen(const char* lcd_msg) {
 
     static bool _level_state;
     void _lcd_toggle_bed_leveling() { set_bed_leveling_enabled(_level_state); }
-    void _lcd_set_z_fade_height() { set_z_fade_height(planner.z_fade_height); }
+
+    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+      void _lcd_set_z_fade_height() { set_z_fade_height(planner.z_fade_height); }
+    #endif
 
     /**
      * Step 1: Bed Level entry-point

--- a/buildroot/bin/build_marlin_fail
+++ b/buildroot/bin/build_marlin_fail
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if arduino --verify --board arduino:avr:mega:cpu=atmega2560 Marlin/Marlin.ino ; then
+  return 1
+else
+  return 0
+fi


### PR DESCRIPTION
The `float` keyword in front of the initializer prevented the global `z_endstop_adj` from being initialized when there is no EEPROM. Once the value was changed and stored to EEPROM then it would be retained.