### PR TITLE
Mesh with BABYSTEP_ZPROBE_OFFSET: add sanity check

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -293,6 +293,8 @@
     #error "BABYSTEPPING is not implemented for SCARA yet."
   #elif ENABLED(DELTA) && ENABLED(BABYSTEP_XY)
     #error "BABYSTEPPING only implemented for Z axis on deltabots."
+  #elif ENABLED(BABYSTEP_ZPROBE_OFFSET) &&  ENABLED(MESH_BED_LEVELING)
+    #error "MESH_BED_LEVELING and BABYSTEP_ZPROBE_OFFSET is not a valid combination"
   #elif ENABLED(BABYSTEP_ZPROBE_OFFSET) && !HAS_BED_PROBE
     #error "BABYSTEP_ZPROBE_OFFSET requires a probe."
   #endif


### PR DESCRIPTION
EDIT: new text

I've been out in left field on this one.

MESH bed leveling and babystepping is a valid combination. It compiles without problems.

MESH bed leveling and babystepping and BABYSTEP_ZPROBE_OFFSET is NOT a valid combination. It does throw a compile error but not one that gives a hint as to the root cause.

I'm going to NOT change ultralcd.cpp but will add a test in sanity check.

----

EDIT: original text

When Mesh leveling and babystepping are both enabled then a compile error is generated at ultralcd.cpp line 995.

The problem is that `planner.abl_enabled` only exists if` HAS_ABL `is true. 

We can fix the compile error by making that line a conditional compile.  The problem is that I don't know if this is a valid combination or if it should be fixed some other way.

This was found in issue #6987 