### PR TITLE
Add why/when selecting Z_MIN_PROBE_ENDSTOP in probes section of Configuration.h

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -536,20 +536,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -533,20 +533,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -517,20 +517,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -517,20 +517,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
@@ -541,20 +541,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -525,20 +525,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 //#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -528,20 +528,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -564,20 +564,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -535,20 +535,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -535,20 +535,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/M150/Configuration.h
+++ b/Marlin/example_configurations/M150/Configuration.h
@@ -554,20 +554,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -535,20 +535,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -533,20 +533,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -550,20 +550,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -554,20 +554,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -586,20 +586,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -525,20 +525,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -535,20 +535,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -603,20 +603,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -610,20 +610,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -599,20 +599,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 //#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -599,20 +599,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -592,20 +592,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -611,20 +611,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 //#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
@@ -548,22 +548,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
-
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
-
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -538,20 +538,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -530,20 +530,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -540,20 +540,23 @@
 // @section probes
 
 //
-// See http://marlinfw.org/configuration/probes.html
+// IT IS HIGHLY RECOMMENDED TO VISIT THE PROBES SECTION OF THE MARLIN WIKI AT90USB
+// AT http://marlinfw.org/configuration/probes.html
 //
 
 /**
  * Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
  *
- * Enable this option for a probe connected to the Z Min endstop pin.
+ * Use this option if you want to use the probe for both homing and probing. The
+ * probe must be connected to the Z Min endstop pin.
  */
 #define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 /**
  * Z_MIN_PROBE_ENDSTOP
  *
- * Enable this option for a probe connected to any pin except Z-Min.
+ * Use this option if you want to use the probe for probing only and use the Z 
+ * Min endstop for homing. The probe can be connected to any pin except Z-Min.
  * (By default Marlin assumes the Z-Max endstop pin.)
  * To use a custom Z Probe pin, set Z_MIN_PROBE_PIN below.
  *


### PR DESCRIPTION
Users want to know why/when to pick Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN vs. Z_MIN_PROBE_ENDSTOP.