### PR TITLE
HOMING_BUMP_DIVISOR was not being stored into PROGMEM

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1499,7 +1499,7 @@ static void set_axis_is_at_home(const AxisEnum axis) {
  * Some planner shorthand inline functions
  */
 inline float get_homing_bump_feedrate(const AxisEnum axis) {
-  const uint8_t homing_bump_divisor[] PROGMEM = HOMING_BUMP_DIVISOR;
+  static const uint8_t homing_bump_divisor[] PROGMEM = HOMING_BUMP_DIVISOR;
   uint8_t hbd = pgm_read_byte(&homing_bump_divisor[axis]);
   if (hbd < 1) {
     hbd = 10;


### PR DESCRIPTION
HOMING_BUMP_DIVISOR was not being stored into PROGMEM.  The solution is to add the "static" qualifier/attribute.

See issue #6993 for details.