### PR TITLE
added shift register pins for reprapworld keypad v1.1

### DIFF
--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -131,6 +131,12 @@
 #define BTN_EN2            59
 #define BTN_ENC            43
 
+// Buttons that are attached using shift register of reprapworld keypad  v1.1
+#define SHIFT_CLK 63
+#define SHIFT_LD 42
+#define SHIFT_OUT 17
+#define SHIFT_EN 17
+
 //
 // M3/M4/M5 - Spindle/Laser Control
 //


### PR DESCRIPTION
I recently upgraded my Marlin to V1.1.x and decided to publish my fix to make marlin compile properly when #define board megatronics 2 in combination with #define reprapworld keypad v1.1. 

This was previously described in the comments of a closed pull request. MarlinFirmware#472. 

All the buttons on the keypad are now operational.