### PR TITLE
Tweak serial macros

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -288,7 +288,7 @@
           SERIAL_ECHOPAIR("   Doing circle at: (xi=", xi);
           SERIAL_ECHOPAIR(", yi=", yi);
           SERIAL_CHAR(')');
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
 
         start_angle = 0.0;    // assume it is going to be a full circle
@@ -467,7 +467,7 @@
                   SERIAL_ECHOPAIR(") -> (ex=", ex);
                   SERIAL_ECHOPAIR(", ey=", ey);
                   SERIAL_CHAR(')');
-                  SERIAL_EOL;
+                  SERIAL_EOL();
                   //debug_current_and_destination(PSTR("Connecting horizontal line."));
                 }
 
@@ -501,7 +501,7 @@
                     SERIAL_ECHOPAIR(") -> (ex=", ex);
                     SERIAL_ECHOPAIR(", ey=", ey);
                     SERIAL_CHAR(')');
-                    SERIAL_EOL;
+                    SERIAL_EOL();
                     debug_current_and_destination(PSTR("Connecting vertical line."));
                   }
                   print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), g26_layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), g26_layer_height);

--- a/Marlin/I2CPositionEncoder.cpp
+++ b/Marlin/I2CPositionEncoder.cpp
@@ -736,7 +736,7 @@
       char c;
       while (Wire.available() > 0 && (c = (char)Wire.read()) > 0)
         SERIAL_ECHO(c);
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
 
     // Set module back to normal (distance) mode

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -130,7 +130,7 @@ int16_t count_test_bytes(const char * const ptr) {
         }
         SERIAL_CHAR(ccc);
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
       ptr += 16;
       safe_delay(25);
       idle();
@@ -200,7 +200,7 @@ void free_memory_pool_report(char * const ptr, const int16_t size) {
         *addr = i;
         SERIAL_ECHOPAIR("\nCorrupting address: ", hex_address(addr));
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   }
 #endif // M100_FREE_MEMORY_CORRUPTOR
@@ -229,7 +229,7 @@ void init_free_memory(char *ptr, int16_t size) {
     if (ptr[i] != TEST_BYTE) {
       SERIAL_ECHOPAIR("? address : ", hex_address(ptr + i));
       SERIAL_ECHOLNPAIR("=", hex_byte(ptr[i]));
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   }
 }
@@ -323,7 +323,7 @@ int check_for_free_memory_corruption(const char * const title) {
   SERIAL_ECHOPGM(" return=");
   if (block_cnt == 1) {
     SERIAL_CHAR('0');       // if the block_cnt is 1, nothing has broken up the free memory
-    SERIAL_EOL;             // area and it is appropriate to say 'no corruption'.
+    SERIAL_EOL();             // area and it is appropriate to say 'no corruption'.
     return 0;
   }
   SERIAL_ECHOLNPGM("true");

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -734,7 +734,7 @@ void report_current_position_detail();
     SERIAL_CHAR(')');
 
     if (suffix) {serialprintPGM(suffix);}  //won't compile for Teensy with the previous construction
-    else SERIAL_EOL;
+    else SERIAL_EOL();
   }
 
   void print_xyz(const char* prefix, const char* suffix, const float xyz[]) {
@@ -868,10 +868,10 @@ inline bool _enqueuecommand(const char* cmd, bool say_ok=false) {
  */
 bool enqueue_and_echo_command(const char* cmd, bool say_ok/*=false*/) {
   if (_enqueuecommand(cmd, say_ok)) {
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPAIR(MSG_ENQUEUEING, cmd);
     SERIAL_CHAR('"');
-    SERIAL_EOL;
+    SERIAL_EOL();
     return true;
   }
   return false;
@@ -1010,7 +1010,7 @@ void servo_init() {
 #endif // HAS_COLOR_LEDS
 
 void gcode_line_error(const char* err, bool doFlush = true) {
-  SERIAL_ERROR_START;
+  SERIAL_ERROR_START();
   serialprintPGM(err);
   SERIAL_ERRORLN(gcode_LastN);
   //Serial.println(gcode_N);
@@ -1206,7 +1206,7 @@ inline void get_serial_commands() {
           card.checkautostart(true);
         }
         else if (n == -1) {
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ECHOLNPGM(MSG_SD_ERR_READ);
         }
         if (sd_char == '#') stop_buffering = true;
@@ -1261,7 +1261,7 @@ void get_available_commands() {
 bool get_target_extruder_from_command(int code) {
   if (parser.seen('T')) {
     if (parser.value_byte() >= EXTRUDERS) {
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_CHAR('M');
       SERIAL_ECHO(code);
       SERIAL_ECHOLNPAIR(" " MSG_INVALID_EXTRUDER " ", parser.value_byte());
@@ -1421,7 +1421,7 @@ static void set_axis_is_at_home(const AxisEnum axis) {
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOPAIR(">>> set_axis_is_at_home(", axis_codes[axis]);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   #endif
 
@@ -1510,7 +1510,7 @@ static void set_axis_is_at_home(const AxisEnum axis) {
       DEBUG_POS("", current_position);
       SERIAL_ECHOPAIR("<<< set_axis_is_at_home(", axis_codes[axis]);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   #endif
 
@@ -1527,7 +1527,7 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
   uint8_t hbd = pgm_read_byte(&homing_bump_divisor[axis]);
   if (hbd < 1) {
     hbd = 10;
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM("Warning: Homing Bump Divisor < 1");
   }
   return homing_feedrate(axis) / hbd;
@@ -1748,7 +1748,7 @@ static void clean_up_after_endstop_or_probe_move() {
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR("do_probe_raise(", z_raise);
         SERIAL_CHAR(')');
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
     #endif
 
@@ -1777,7 +1777,7 @@ static void clean_up_after_endstop_or_probe_move() {
                  zz = z && !axis_homed[Z_AXIS];
     #endif
     if (xx || yy || zz) {
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPGM(MSG_HOME " ");
       if (xx) SERIAL_ECHOPGM(MSG_X);
       if (yy) SERIAL_ECHOPGM(MSG_Y);
@@ -1811,7 +1811,7 @@ static void clean_up_after_endstop_or_probe_move() {
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR("dock_sled(", stow);
         SERIAL_CHAR(')');
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
     #endif
 
@@ -2054,7 +2054,7 @@ static void clean_up_after_endstop_or_probe_move() {
                                            //  (Measured completion time was 0.65 seconds
                                            //   after reset, deploy, and stow sequence)
         if (TEST_BLTOUCH()) {              // If it still claims to be triggered...
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM(MSG_STOP_BLTOUCH);
           stop();                          // punt!
         }
@@ -2066,7 +2066,7 @@ static void clean_up_after_endstop_or_probe_move() {
         if (DEBUGGING(LEVELING)) {
           SERIAL_ECHOPAIR("set_bltouch_deployed(", deploy);
           SERIAL_CHAR(')');
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       #endif
     }
@@ -2098,7 +2098,7 @@ static void clean_up_after_endstop_or_probe_move() {
                                            //   measured completion time was 0.65 seconds
                                            //   after reset, deploy & stow sequence
         if (TEST_BLTOUCH()) {              // If it still claims to be triggered...
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM(MSG_STOP_BLTOUCH);
           stop();                          // punt!
           return true;
@@ -2111,7 +2111,7 @@ static void clean_up_after_endstop_or_probe_move() {
         #define _AUE_ARGS
       #endif
       if (axis_unhomed_error(_AUE_ARGS)) {
-        SERIAL_ERROR_START;
+        SERIAL_ERROR_START();
         SERIAL_ERRORLNPGM(MSG_STOP_UNHOMED);
         stop();
         return true;
@@ -2159,7 +2159,7 @@ static void clean_up_after_endstop_or_probe_move() {
       if (_TRIGGERED_WHEN_STOWED_TEST == deploy) { // State hasn't changed?
 
         if (IsRunning()) {
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("Z-Probe failed");
           LCD_ALERTMESSAGEPGM("Err: ZPROBE");
         }
@@ -2323,7 +2323,7 @@ static void clean_up_after_endstop_or_probe_move() {
       SERIAL_PROTOCOL_F(y, 3);
       SERIAL_PROTOCOLPGM(" Z: ");
       SERIAL_PROTOCOL_F(measured_z, 3);
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -2523,7 +2523,7 @@ static void clean_up_after_endstop_or_probe_move() {
           SERIAL_PROTOCOLCHAR(' ');
         SERIAL_PROTOCOL((int)x);
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
     #endif
     #ifdef SCAD_MESH_OUTPUT
       SERIAL_PROTOCOLLNPGM("measured_z = ["); // open 2D array
@@ -2561,12 +2561,12 @@ static void clean_up_after_endstop_or_probe_move() {
         SERIAL_PROTOCOLCHAR(']');                     // close sub-array
         if (y < sy - 1) SERIAL_PROTOCOLCHAR(',');
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
     #ifdef SCAD_MESH_OUTPUT
       SERIAL_PROTOCOLPGM("];");                       // close 2D array
     #endif
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
 #endif
@@ -2596,7 +2596,7 @@ static void clean_up_after_endstop_or_probe_move() {
       #endif
       return;  // Don't overwrite good values.
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     // Get X neighbors, Y neighbors, and XY neighbors
     const uint8_t x1 = x + xdir, y1 = y + ydir, x2 = x1 + xdir, y2 = y1 + ydir;
@@ -2798,7 +2798,7 @@ static void do_homing_move(const AxisEnum axis, const float distance, const floa
       SERIAL_ECHOPAIR(", ", distance);
       SERIAL_ECHOPAIR(", ", fr_mm_s);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   #endif
 
@@ -2841,7 +2841,7 @@ static void do_homing_move(const AxisEnum axis, const float distance, const floa
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOPAIR("<<< do_homing_move(", axis_codes[axis]);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   #endif
 }
@@ -2896,7 +2896,7 @@ static void homeaxis(const AxisEnum axis) {
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOPAIR(">>> homeaxis(", axis_codes[axis]);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   #endif
 
@@ -3029,7 +3029,7 @@ static void homeaxis(const AxisEnum axis) {
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOPAIR("<<< homeaxis(", axis_codes[axis]);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   #endif
 } // homeaxis()
@@ -3176,15 +3176,15 @@ void gcode_get_destination() {
       switch (busy_state) {
         case IN_HANDLER:
         case IN_PROCESS:
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOLNPGM(MSG_BUSY_PROCESSING);
           break;
         case PAUSED_FOR_USER:
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOLNPGM(MSG_BUSY_PAUSED_FOR_USER);
           break;
         case PAUSED_FOR_INPUT:
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOLNPGM(MSG_BUSY_PAUSED_FOR_INPUT);
           break;
         default:
@@ -3302,7 +3302,7 @@ inline void gcode_G0_G1(
       }
       else {
         // Bad arguments
-        SERIAL_ERROR_START;
+        SERIAL_ERROR_START();
         SERIAL_ERRORLNPGM(MSG_ERR_ARC_ARGS);
       }
     }
@@ -3543,7 +3543,7 @@ inline void gcode_G4() {
       else
         SERIAL_ECHOLNPGM(" (disabled)");
 
-      SERIAL_EOL;
+      SERIAL_EOL();
 
     #elif ENABLED(MESH_BED_LEVELING)
 
@@ -3557,7 +3557,7 @@ inline void gcode_G4() {
       else
         SERIAL_ECHOPGM(" (disabled)");
 
-      SERIAL_EOL;
+      SERIAL_EOL();
 
     #endif // MESH_BED_LEVELING
   }
@@ -3613,7 +3613,7 @@ inline void gcode_G4() {
     // Disallow Z homing if X or Y are unknown
     if (!axis_known_position[X_AXIS] || !axis_known_position[Y_AXIS]) {
       LCD_MESSAGEPGM(MSG_ERR_Z_HOMING);
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOLNPGM(MSG_ERR_Z_HOMING);
       return;
     }
@@ -3652,7 +3652,7 @@ inline void gcode_G4() {
     }
     else {
       LCD_MESSAGEPGM(MSG_ZPROBE_OUT);
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOLNPGM(MSG_ZPROBE_OUT);
     }
 
@@ -4300,14 +4300,14 @@ void home_all_axes() { gcode_G28(true); }
 
         if (parser.seen('W')) {
           if (!leveling_is_valid()) {
-            SERIAL_ERROR_START;
+            SERIAL_ERROR_START();
             SERIAL_ERRORLNPGM("No bilinear grid");
             return;
           }
 
           const float z = parser.seen('Z') && parser.has_value() ? parser.value_float() : NAN;
           if (!isnan(z) || !WITHIN(z, -10, 10)) {
-            SERIAL_ERROR_START;
+            SERIAL_ERROR_START();
             SERIAL_ERRORLNPGM("Bad Z value");
             return;
           }
@@ -4837,11 +4837,11 @@ void home_all_axes() { gcode_G28(true); }
         SERIAL_PROTOCOL_F(plane_equation_coefficients[1], 8);
         SERIAL_PROTOCOLPGM(" d: ");
         SERIAL_PROTOCOL_F(plane_equation_coefficients[2], 8);
-        SERIAL_EOL;
+        SERIAL_EOL();
         if (verbose_level > 2) {
           SERIAL_PROTOCOLPGM("Mean of sampled points: ");
           SERIAL_PROTOCOL_F(mean, 8);
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       }
 
@@ -4887,9 +4887,9 @@ void home_all_axes() { gcode_G28(true); }
               SERIAL_PROTOCOLCHAR(' ');
             SERIAL_PROTOCOL_F(diff, 5);
           } // xx
-          SERIAL_EOL;
+          SERIAL_EOL();
         } // yy
-        SERIAL_EOL;
+        SERIAL_EOL();
 
         if (verbose_level > 3) {
           SERIAL_PROTOCOLLNPGM("\nCorrected Bed Height vs. Bed Topology:");
@@ -4911,9 +4911,9 @@ void home_all_axes() { gcode_G28(true); }
                 SERIAL_PROTOCOLCHAR(' ');
               SERIAL_PROTOCOL_F(diff, 5);
             } // xx
-            SERIAL_EOL;
+            SERIAL_EOL();
           } // yy
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       } //do_topography_map
 
@@ -5163,7 +5163,7 @@ void home_all_axes() { gcode_G28(true); }
 
       SERIAL_PROTOCOLPGM("Checking... AC");
       if (verbose_level == 0) SERIAL_PROTOCOLPGM(" (DRY-RUN)");
-      SERIAL_EOL;
+      SERIAL_EOL();
       LCD_MESSAGEPGM("Checking... AC"); // TODO: Make translatable string
 
       SERIAL_PROTOCOLPAIR(".Height:", DELTA_HEIGHT + home_offset[Z_AXIS]);
@@ -5179,7 +5179,7 @@ void home_all_axes() { gcode_G28(true); }
         SERIAL_PROTOCOL_F(endstop_adj[C_AXIS], 2);
         SERIAL_PROTOCOLPAIR("    Radius:", delta_radius);
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
       if (_7p_calibration && towers_set) {
         SERIAL_PROTOCOLPGM(".Tower angle :    Tx:");
         if (delta_tower_angle_trim[A_AXIS] >= 0) SERIAL_CHAR('+');
@@ -5188,7 +5188,7 @@ void home_all_axes() { gcode_G28(true); }
         if (delta_tower_angle_trim[B_AXIS] >= 0) SERIAL_CHAR('+');
         SERIAL_PROTOCOL_F(delta_tower_angle_trim[B_AXIS], 2);
         SERIAL_PROTOCOLPGM("  Tz:+0.00");
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
 
       #if ENABLED(Z_PROBE_SLED)
@@ -5356,7 +5356,7 @@ void home_all_axes() { gcode_G28(true); }
             if (z_at_pt[9] >= 0) SERIAL_CHAR('+');
             SERIAL_PROTOCOL_F(z_at_pt[9], 2);
           }
-          if (!_4p_opposite_points) SERIAL_EOL;
+          if (!_4p_opposite_points) SERIAL_EOL();
           if ((_4p_opposite_points) || _7p_calibration) {
             if (_7p_calibration) {
               SERIAL_CHAR('.');
@@ -5371,7 +5371,7 @@ void home_all_axes() { gcode_G28(true); }
             SERIAL_PROTOCOLPGM("  xy:");
             if (z_at_pt[3] >= 0) SERIAL_CHAR('+');
             SERIAL_PROTOCOL_F(z_at_pt[3], 2);
-            SERIAL_EOL;
+            SERIAL_EOL();
           }
         }
         if (test_precision != 0.0) {                                 // !forced end
@@ -5384,7 +5384,7 @@ void home_all_axes() { gcode_G28(true); }
               SERIAL_PROTOCOLPGM("std dev:");
               SERIAL_PROTOCOL_F(zero_std_dev, 3);
             }
-            SERIAL_EOL;
+            SERIAL_EOL();
             LCD_MESSAGEPGM("Calibration OK"); // TODO: Make translatable string
           }
           else {                                                     // !end iterations
@@ -5395,7 +5395,7 @@ void home_all_axes() { gcode_G28(true); }
             SERIAL_PROTOCOL_SP(36);
             SERIAL_PROTOCOLPGM("std dev:");
             SERIAL_PROTOCOL_F(zero_std_dev, 3);
-            SERIAL_EOL;
+            SERIAL_EOL();
             lcd_setstatus(mess);
           }
           SERIAL_PROTOCOLPAIR(".Height:", DELTA_HEIGHT + home_offset[Z_AXIS]);
@@ -5411,7 +5411,7 @@ void home_all_axes() { gcode_G28(true); }
             SERIAL_PROTOCOL_F(endstop_adj[C_AXIS], 2);
             SERIAL_PROTOCOLPAIR("    Radius:", delta_radius);
           }
-          SERIAL_EOL;
+          SERIAL_EOL();
           if (_7p_calibration && towers_set) {
             SERIAL_PROTOCOLPGM(".Tower angle :    Tx:");
             if (delta_tower_angle_trim[A_AXIS] >= 0) SERIAL_CHAR('+');
@@ -5420,11 +5420,11 @@ void home_all_axes() { gcode_G28(true); }
             if (delta_tower_angle_trim[B_AXIS] >= 0) SERIAL_CHAR('+');
             SERIAL_PROTOCOL_F(delta_tower_angle_trim[B_AXIS], 2);
             SERIAL_PROTOCOLPGM("  Tz:+0.00");
-            SERIAL_EOL;
+            SERIAL_EOL();
           }
           if (zero_std_dev >= test_precision || zero_std_dev <= calibration_precision)
             serialprintPGM(save_message);
-            SERIAL_EOL;
+            SERIAL_EOL();
         }
         else {                                                       // forced end
           if (verbose_level == 0) {
@@ -5432,15 +5432,15 @@ void home_all_axes() { gcode_G28(true); }
             SERIAL_PROTOCOL_SP(39);
             SERIAL_PROTOCOLPGM("std dev:");
             SERIAL_PROTOCOL_F(zero_std_dev, 3);
-            SERIAL_EOL;
+            SERIAL_EOL();
           }
           else {
             SERIAL_PROTOCOLLNPGM("Calibration OK");
             LCD_MESSAGEPGM("Calibration OK"); // TODO: Make translatable string
             SERIAL_PROTOCOLPAIR(".Height:", DELTA_HEIGHT + home_offset[Z_AXIS]);
-            SERIAL_EOL;
+            SERIAL_EOL();
             serialprintPGM(save_message);
-            SERIAL_EOL;
+            SERIAL_EOL();
           }
         }
 
@@ -5545,7 +5545,7 @@ void home_all_axes() { gcode_G28(true); }
         if (!parser.seen('F')) feedrate_mm_s = homing_feedrate(i);
         // If G38.2 fails throw an error
         if (!G38_run_probe() && is_38_2) {
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("Failed to reach target");
         }
         break;
@@ -5685,7 +5685,7 @@ inline void gcode_G92() {
     #else
 
       if (!hasP && !hasS && args && *args) {
-        SERIAL_ECHO_START;
+        SERIAL_ECHO_START();
         SERIAL_ECHOLN(args);
       }
 
@@ -5899,7 +5899,7 @@ inline void gcode_M17() {
       #if ENABLED(PREVENT_COLD_EXTRUSION)
         if (!thermalManager.allow_cold_extrude && 
             thermalManager.degTargetHotend(active_extruder) < thermalManager.extrude_min_temp) {
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM(MSG_TOO_COLD_FOR_M600);
           return false;
         }
@@ -6232,7 +6232,7 @@ inline void gcode_M31() {
   elapsed.toString(buffer);
   lcd_setstatus(buffer);
 
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   SERIAL_ECHOLNPAIR("Print time: ", buffer);
 }
 
@@ -6330,7 +6330,7 @@ inline void gcode_M42() {
   if (pin_number < 0) return;
 
   if (pin_is_protected(pin_number)) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_ERR_PROTECTED_PIN);
     return;
   }
@@ -6391,12 +6391,12 @@ inline void gcode_M42() {
   inline void servo_probe_test() {
     #if !(NUM_SERVOS > 0 && HAS_SERVO_0)
 
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM("SERVO not setup");
 
     #elif !HAS_Z_SERVO_ENDSTOP
 
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM("Z_ENDSTOP_SERVO_NR not setup");
 
     #else
@@ -6832,7 +6832,7 @@ inline void gcode_M42() {
             SERIAL_PROTOCOLPGM(" range: ");
             SERIAL_PROTOCOL_F(max-min, 3);
           }
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       }
 
@@ -6841,7 +6841,7 @@ inline void gcode_M42() {
     if (STOW_PROBE()) return;
 
     SERIAL_PROTOCOLPGM("Finished!");
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     if (verbose_level > 0) {
       SERIAL_PROTOCOLPGM("Mean: ");
@@ -6852,13 +6852,13 @@ inline void gcode_M42() {
       SERIAL_PROTOCOL_F(max, 3);
       SERIAL_PROTOCOLPGM(" Range: ");
       SERIAL_PROTOCOL_F(max-min, 3);
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
 
     SERIAL_PROTOCOLPGM("Standard Deviation: ");
     SERIAL_PROTOCOL_F(sigma, 6);
-    SERIAL_EOL;
-    SERIAL_EOL;
+    SERIAL_EOL();
+    SERIAL_EOL();
 
     clean_up_after_endstop_or_probe_move();
 
@@ -7014,11 +7014,11 @@ inline void gcode_M105() {
     SERIAL_PROTOCOLPGM(MSG_OK);
     print_heaterstates();
   #else // !HAS_TEMP_HOTEND && !HAS_TEMP_BED
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_ERR_NO_THERMISTORS);
   #endif
 
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 #if ENABLED(AUTO_REPORT_TEMPERATURES) && (HAS_TEMP_HOTEND || HAS_TEMP_BED)
@@ -7041,7 +7041,7 @@ inline void gcode_M105() {
     if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
       next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
       print_heaterstates();
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   }
 
@@ -7194,7 +7194,7 @@ inline void gcode_M109() {
           SERIAL_PROTOCOLLNPGM("?");
         }
       #else
-        SERIAL_EOL;
+        SERIAL_EOL();
       #endif
     }
 
@@ -7327,7 +7327,7 @@ inline void gcode_M109() {
             SERIAL_PROTOCOLLNPGM("?");
           }
         #else
-          SERIAL_EOL;
+          SERIAL_EOL();
         #endif
       }
 
@@ -7407,7 +7407,7 @@ inline void gcode_M111() {
     #endif
   };
 
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   SERIAL_ECHOPGM(MSG_DEBUG_PREFIX);
   if (marlin_debug_flags) {
     uint8_t comma = 0;
@@ -7421,7 +7421,7 @@ inline void gcode_M111() {
   else {
     SERIAL_ECHOPGM(MSG_DEBUG_OFF);
   }
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 #if ENABLED(HOST_KEEPALIVE_FEATURE)
@@ -7437,7 +7437,7 @@ inline void gcode_M111() {
       NOMORE(host_keepalive_interval, 60);
     }
     else {
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOLNPAIR("M113 S", (unsigned long)host_keepalive_interval);
     }
   }
@@ -7491,7 +7491,7 @@ inline void gcode_M140() {
   inline void gcode_M145() {
     uint8_t material = parser.seen('S') ? (uint8_t)parser.value_int() : 0;
     if (material >= COUNT(lcd_preheat_hotend_temp)) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_MATERIAL_INDEX);
     }
     else {
@@ -7697,7 +7697,7 @@ void report_current_position() {
   #if IS_SCARA
     SERIAL_PROTOCOLPAIR("SCARA Theta:", stepper.get_axis_position_degrees(A_AXIS));
     SERIAL_PROTOCOLLNPAIR("   Psi+Theta:", stepper.get_axis_position_degrees(B_AXIS));
-    SERIAL_EOL;
+    SERIAL_EOL();
   #endif
 }
 
@@ -7711,7 +7711,7 @@ void report_current_position() {
       SERIAL_CHAR(':');
       SERIAL_PROTOCOL(dtostrf(pos[i], 8, precision, str));
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
   inline void report_xyz(const float pos[XYZ]) { report_xyze(pos, 3); }
@@ -8214,7 +8214,7 @@ inline void gcode_M205() {
     if (sumAPX == 1)
       home_offset[A_AXIS] = parser.value_float();
     else if (sumAPX > 1) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM("Only one of A, P, or X is allowed.");
       return;
     }
@@ -8224,7 +8224,7 @@ inline void gcode_M205() {
     if (sumBTY == 1)
       home_offset[B_AXIS] = parser.value_float();
     else if (sumBTY > 1) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM("Only one of B, T, or Y is allowed.");
       return;
     }
@@ -8296,7 +8296,7 @@ inline void gcode_M205() {
  * Usage: M211 S1 to enable, M211 S0 to disable, M211 alone for report
  */
 inline void gcode_M211() {
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   #if HAS_SOFTWARE_ENDSTOPS
     if (parser.seen('S')) soft_endstops_enabled = parser.value_bool();
     SERIAL_ECHOPGM(MSG_SOFT_ENDSTOPS);
@@ -8335,7 +8335,7 @@ inline void gcode_M211() {
       if (parser.seen('Z')) hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
     #endif
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_HOTEND_OFFSET);
     HOTEND_LOOP() {
       SERIAL_CHAR(' ');
@@ -8347,7 +8347,7 @@ inline void gcode_M211() {
         SERIAL_ECHO(hotend_offset[Z_AXIS][e]);
       #endif
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
 #endif // HOTENDS > 1
@@ -8447,7 +8447,7 @@ inline void gcode_M226() {
       i2c.relay(bytes);
     }
     else {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLN("Bad i2c request");
     }
   }
@@ -8466,13 +8466,13 @@ inline void gcode_M226() {
       if (parser.seen('S'))
         MOVE_SERVO(servo_index, parser.value_int());
       else {
-        SERIAL_ECHO_START;
+        SERIAL_ECHO_START();
         SERIAL_ECHOPAIR(" Servo ", servo_index);
         SERIAL_ECHOLNPAIR(": ", servo[servo_index].read());
       }
     }
     else {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ECHOPAIR("Servo ", servo_index);
       SERIAL_ECHOLNPGM(" out of range");
     }
@@ -8528,7 +8528,7 @@ inline void gcode_M226() {
       #endif
 
       thermalManager.updatePID();
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       #if ENABLED(PID_PARAMS_PER_HOTEND)
         SERIAL_ECHOPAIR(" e:", e); // specify extruder in serial output
       #endif // PID_PARAMS_PER_HOTEND
@@ -8539,10 +8539,10 @@ inline void gcode_M226() {
         //Kc does not have scaling applied above, or in resetting defaults
         SERIAL_ECHOPAIR(" c:", PID_PARAM(Kc, e));
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
     else {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLN(MSG_INVALID_EXTRUDER);
     }
   }
@@ -8558,7 +8558,7 @@ inline void gcode_M226() {
 
     thermalManager.updatePID();
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPAIR(" p:", thermalManager.bedKp);
     SERIAL_ECHOPAIR(" i:", unscalePID_i(thermalManager.bedKi));
     SERIAL_ECHOLNPAIR(" d:", unscalePID_d(thermalManager.bedKd));
@@ -8611,7 +8611,7 @@ inline void gcode_M226() {
     if (parser.seen('C')) set_lcd_contrast(parser.value_int());
     SERIAL_PROTOCOLPGM("lcd contrast value: ");
     SERIAL_PROTOCOL(lcd_contrast);
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
 #endif // HAS_LCD_CONTRAST
@@ -8644,7 +8644,7 @@ inline void gcode_M226() {
       thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0) || parser.value_bool();
     else if (!seen_S) {
       // Report current state
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPAIR("Cold extrudes are ", (thermalManager.allow_cold_extrude ? "en" : "dis"));
       SERIAL_ECHOPAIR("abled (min temp ", thermalManager.extrude_min_temp);
       SERIAL_ECHOLNPGM("C)");
@@ -8678,7 +8678,7 @@ inline void gcode_M303() {
 
     KEEPALIVE_STATE(IN_HANDLER);
   #else
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_ERR_M303_DISABLED);
   #endif
 }
@@ -8767,7 +8767,7 @@ inline void gcode_M303() {
             break;
         #endif
       default:
-        SERIAL_ECHO_START;
+        SERIAL_ECHO_START();
         SERIAL_ECHOLNPGM(MSG_INVALID_SOLENOID);
         break;
     }
@@ -8971,11 +8971,11 @@ void quickstop_stepper() {
     const bool new_status = leveling_is_active();
 
     if (to_enable && !new_status) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_M420_FAILED);
     }
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR("Bed Leveling ", new_status ? MSG_ON : MSG_OFF);
   }
 #endif
@@ -8999,11 +8999,11 @@ void quickstop_stepper() {
     const bool hasZ = parser.seen('Z'), hasQ = !hasZ && parser.seen('Q');
 
     if (int(hasI && hasJ) + int(hasX && hasY) != 1 || !(hasZ || hasQ)) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_M421_PARAMETERS);
     }
     else if (ix < 0 || iy < 0) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
     }
     else
@@ -9027,11 +9027,11 @@ void quickstop_stepper() {
     const bool hasZ = parser.seen('Z'), hasQ = !hasZ && parser.seen('Q');
 
     if (!hasI || !hasJ || !(hasZ || hasQ)) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_M421_PARAMETERS);
     }
     else if (!WITHIN(ix, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(iy, 0, GRID_MAX_POINTS_Y - 1)) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
     }
     else {
@@ -9067,11 +9067,11 @@ void quickstop_stepper() {
     }
 
     if (int(hasC) + int(hasI && hasJ) != 1 || !(hasZ || hasQ)) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_M421_PARAMETERS);
     }
     else if (!WITHIN(ix, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(iy, 0, GRID_MAX_POINTS_Y - 1)) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_MESH_XY);
     }
     else
@@ -9103,7 +9103,7 @@ void quickstop_stepper() {
           set_home_offset((AxisEnum)i, diff);
         }
         else {
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM(MSG_ERR_M428_TOO_FAR);
           LCD_ALERTMESSAGEPGM("Err: Too far!");
           BUZZ(200, 40);
@@ -9202,7 +9202,7 @@ inline void gcode_M503() {
   }
 
   inline void gcode_M851() {
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_ZPROBE_ZOFFSET " ");
     if (parser.seen('Z')) {
       const float value = parser.value_linear_units();
@@ -9217,7 +9217,7 @@ inline void gcode_M503() {
     else
       SERIAL_ECHOPAIR(": ", zprobe_zoffset);
 
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
 #endif // HAS_BED_PROBE
@@ -9327,7 +9327,7 @@ inline void gcode_M503() {
       case DXC_DUPLICATION_MODE:
         if (parser.seen('X')) duplicate_extruder_x_offset = max(parser.value_linear_units(), X2_MIN_POS - x_home_pos(0));
         if (parser.seen('R')) duplicate_extruder_temp_offset = parser.value_celsius_diff();
-        SERIAL_ECHO_START;
+        SERIAL_ECHO_START();
         SERIAL_ECHOPGM(MSG_HOTEND_OFFSET);
         SERIAL_CHAR(' ');
         SERIAL_ECHO(hotend_offset[X_AXIS][0]);
@@ -9352,7 +9352,7 @@ inline void gcode_M503() {
   inline void gcode_M605() {
     stepper.synchronize();
     extruder_duplication_enabled = parser.seen('S') && parser.value_int() == (int)DXC_DUPLICATION_MODE;
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_DUPLICATION_MODE, extruder_duplication_enabled ? MSG_ON : MSG_OFF);
   }
 
@@ -9382,12 +9382,12 @@ inline void gcode_M503() {
     }
     if (newR >= 0) planner.advance_ed_ratio = newR;
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPAIR("Advance K=", planner.extruder_advance_k);
     SERIAL_ECHOPGM(" E/D=");
     const float ratio = planner.advance_ed_ratio;
     if (ratio) SERIAL_ECHO(ratio); else SERIAL_ECHOPGM("Auto");
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 #endif // LIN_ADVANCE
 
@@ -9407,7 +9407,7 @@ inline void gcode_M503() {
     SERIAL_CHAR(name);
     SERIAL_ECHOPGM(" axis temperature prewarn triggered: ");
     serialprintPGM(st.getOTPW() ? PSTR("true") : PSTR("false"));
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
   static void tmc2130_clear_otpw(TMC2130Stepper &st, const char name) {
     st.clear_otpw();
@@ -9690,7 +9690,7 @@ inline void gcode_M355() {
     if (args) update_case_light();
 
     // always report case light status
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     if (!case_light_on) {
       SERIAL_ECHOLN("Case light: off");
     }
@@ -9700,7 +9700,7 @@ inline void gcode_M355() {
     }
 
   #else
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_ERR_M355_NONE);
   #endif // HAS_CASE_LIGHT
 }
@@ -9799,7 +9799,7 @@ inline void gcode_M999() {
 #endif
 
 inline void invalid_extruder_error(const uint8_t &e) {
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   SERIAL_CHAR('T');
   SERIAL_ECHO_F(e, DEC);
   SERIAL_ECHOLN(MSG_INVALID_EXTRUDER);
@@ -10120,7 +10120,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
     #endif // HOTENDS <= 1
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, (int)active_extruder);
 
   #endif // !MIXING_EXTRUDER || MIXING_VIRTUAL_TOOLS <= 1
@@ -10138,7 +10138,7 @@ inline void gcode_T(uint8_t tmp_extruder) {
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOPAIR(">>> gcode_T(", tmp_extruder);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
       DEBUG_POS("BEFORE", current_position);
     }
   #endif
@@ -10173,7 +10173,7 @@ void process_next_command() {
   char * const current_command = command_queue[cmd_queue_index_r];
 
   if (DEBUGGING(ECHO)) {
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLN(current_command);
     #if ENABLED(M100_FREE_MEMORY_WATCHER)
       SERIAL_ECHOPAIR("slot:", cmd_queue_index_r);
@@ -11021,7 +11021,7 @@ void ok_to_send() {
     SERIAL_PROTOCOLPGM(" P"); SERIAL_PROTOCOL(int(BLOCK_BUFFER_SIZE - planner.movesplanned() - 1));
     SERIAL_PROTOCOLPGM(" B"); SERIAL_PROTOCOL(BUFSIZE - commands_in_queue);
   #endif
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 #if HAS_SOFTWARE_ENDSTOPS
@@ -11813,13 +11813,13 @@ void prepare_move_to_destination() {
       if (destination[E_AXIS] != current_position[E_AXIS]) {
         if (thermalManager.tooColdToExtrude(active_extruder)) {
           current_position[E_AXIS] = destination[E_AXIS]; // Behave as if the move really took place, but ignore E part
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
         }
         #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
           if (labs(destination[E_AXIS] - current_position[E_AXIS]) > EXTRUDE_MAXLENGTH) {
             current_position[E_AXIS] = destination[E_AXIS]; // Behave as if the move really took place, but ignore E part
-            SERIAL_ECHO_START;
+            SERIAL_ECHO_START();
             SERIAL_ECHOLNPGM(MSG_ERR_LONG_EXTRUDE_STOP);
           }
         #endif
@@ -12300,7 +12300,7 @@ void disable_all_steppers() {
           #endif
         }
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
     #endif
   }
 
@@ -12373,7 +12373,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
   const millis_t ms = millis();
 
   if (max_inactive_time && ELAPSED(ms, previous_cmd_ms + max_inactive_time)) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ECHOLNPAIR(MSG_KILL_INACTIVE_TIME, parser.command_ptr);
     kill(PSTR(MSG_KILLED));
   }
@@ -12424,7 +12424,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     // KILL the machine
     // ----------------------------------------------------------------
     if (killCount >= KILL_DELAY) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_KILL_BUTTON);
       kill(PSTR(MSG_KILLED));
     }
@@ -12575,7 +12575,7 @@ void idle(
  * After this the machine will need to be reset.
  */
 void kill(const char* lcd_msg) {
-  SERIAL_ERROR_START;
+  SERIAL_ERROR_START();
   SERIAL_ERRORLNPGM(MSG_ERR_KILLED);
 
   thermalManager.disable_all_heaters();
@@ -12618,7 +12618,7 @@ void stop() {
 
   if (IsRunning()) {
     Stopped_gcode_LastN = gcode_LastN; // Save last g_code for restart
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_ERR_STOPPED);
     LCD_MESSAGEPGM(MSG_STOPPED);
     safe_delay(350);       // allow enough time for messages to get out before stopping
@@ -12666,7 +12666,7 @@ void setup() {
 
   MYSERIAL.begin(BAUDRATE);
   SERIAL_PROTOCOLLNPGM("start");
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
 
   // Check startup - does nothing if bootloader sets MCUSR to 0
   byte mcu = MCUSR;
@@ -12680,17 +12680,17 @@ void setup() {
   SERIAL_ECHOPGM(MSG_MARLIN);
   SERIAL_CHAR(' ');
   SERIAL_ECHOLNPGM(SHORT_BUILD_VERSION);
-  SERIAL_EOL;
+  SERIAL_EOL();
 
   #if defined(STRING_DISTRIBUTION_DATE) && defined(STRING_CONFIG_H_AUTHOR)
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_CONFIGURATION_VER);
     SERIAL_ECHOPGM(STRING_DISTRIBUTION_DATE);
     SERIAL_ECHOLNPGM(MSG_AUTHOR STRING_CONFIG_H_AUTHOR);
     SERIAL_ECHOLNPGM("Compiled: " __DATE__);
   #endif
 
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   SERIAL_ECHOPAIR(MSG_FREE_MEMORY, freeMemory());
   SERIAL_ECHOLNPAIR(MSG_PLANNER_BUFFER_BYTES, (int)sizeof(block_t)*BLOCK_BUFFER_SIZE);
 

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -109,7 +109,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
       SdFile dir;
       if (!dir.open(parent, lfilename, O_READ)) {
         if (lsAction == LS_SerialPrint) {
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
           SERIAL_ECHOLN(lfilename);
         }
@@ -208,8 +208,8 @@ void CardReader::ls() {
       // Open the sub-item as the new dive parent
       SdFile dir;
       if (!dir.open(diveDir, segment, O_READ)) {
-        SERIAL_EOL;
-        SERIAL_ECHO_START;
+        SERIAL_EOL();
+        SERIAL_ECHO_START();
         SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
         SERIAL_ECHO(segment);
         break;
@@ -220,7 +220,7 @@ void CardReader::ls() {
 
     } // while i<pathLen
 
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
 #endif // LONG_FILENAME_HOST_SUPPORT
@@ -239,20 +239,20 @@ void CardReader::initsd() {
     #endif
   ) {
     //if (!card.init(SPI_HALF_SPEED,SDSS))
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM(MSG_SD_INIT_FAIL);
   }
   else if (!volume.init(&card)) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_SD_VOL_INIT_FAIL);
   }
   else if (!root.openRoot(&volume)) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_SD_OPENROOT_FAIL);
   }
   else {
     cardOK = true;
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM(MSG_SD_CARD_OK);
   }
   workDir = root;
@@ -331,7 +331,7 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
   if (isFileOpen()) { //replacing current file by new file, or subfile call
     if (push_current) {
       if (file_subcall_ctr > SD_PROCEDURE_DEPTH - 1) {
-        SERIAL_ERROR_START;
+        SERIAL_ERROR_START();
         SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
         SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
         kill(PSTR(MSG_KILLED));
@@ -341,7 +341,7 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
       // Store current filename and position
       getAbsFilename(proc_filenames[file_subcall_ctr]);
 
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPAIR("SUBROUTINE CALL target:\"", name);
       SERIAL_ECHOPAIR("\" parent:\"", proc_filenames[file_subcall_ctr]);
       SERIAL_ECHOLNPAIR("\" pos", sdpos);
@@ -358,7 +358,7 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
   }
 
   if (doing) {
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Now ");
     SERIAL_ECHO(doing == 1 ? "doing" : "fresh");
     SERIAL_ECHOLNPAIR(" file: ", name);
@@ -421,14 +421,14 @@ void CardReader::openFile(char* name, bool read, bool push_current/*=false*/) {
     else {
       SERIAL_PROTOCOLPAIR(MSG_SD_OPEN_FILE_FAIL, fname);
       SERIAL_PROTOCOLCHAR('.');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   }
   else { //write
     if (!file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)) {
       SERIAL_PROTOCOLPAIR(MSG_SD_OPEN_FILE_FAIL, fname);
       SERIAL_PROTOCOLCHAR('.');
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
     else {
       saving = true;
@@ -462,7 +462,7 @@ void CardReader::removeFile(char* name) {
         if (!myDir.open(curDir, subdirname, O_READ)) {
           SERIAL_PROTOCOLPAIR("open failed, File: ", subdirname);
           SERIAL_PROTOCOLCHAR('.');
-          SERIAL_EOL;
+          SERIAL_EOL();
           return;
         }
         else {
@@ -526,7 +526,7 @@ void CardReader::write_command(char *buf) {
   end[3] = '\0';
   file.write(begin);
   if (file.writeError) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_SD_ERR_WRITE_TO_FILE);
   }
 }
@@ -617,7 +617,7 @@ void CardReader::chdir(const char * relpath) {
   if (workDir.isOpen()) parent = &workDir;
 
   if (!newfile.open(*parent, relpath, O_READ)) {
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_SD_CANT_ENTER_SUBDIR);
     SERIAL_ECHOLN(relpath);
   }

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -247,7 +247,7 @@ void MarlinSettings::postprocess() {
   #define EEPROM_SKIP(VAR) eeprom_index += sizeof(VAR)
   #define EEPROM_WRITE(VAR) write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
   #define EEPROM_READ(VAR) read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
-  #define EEPROM_ASSERT(TST,ERR) if (!(TST)) do{ SERIAL_ERROR_START; SERIAL_ERRORLNPGM(ERR); eeprom_read_error = true; }while(0)
+  #define EEPROM_ASSERT(TST,ERR) if (!(TST)) do{ SERIAL_ERROR_START(); SERIAL_ERRORLNPGM(ERR); eeprom_read_error = true; }while(0)
 
   const char version[4] = EEPROM_VERSION;
 
@@ -267,7 +267,7 @@ void MarlinSettings::postprocess() {
       if (v != eeprom_read_byte(p)) {
         eeprom_write_byte(p, v);
         if (eeprom_read_byte(p) != v) {
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOLNPGM(MSG_ERR_EEPROM_WRITE);
           eeprom_error = true;
           return;
@@ -638,7 +638,7 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(final_crc);
 
       // Report storage size
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPAIR("Settings Stored (", eeprom_size - (EEPROM_OFFSET));
       SERIAL_ECHOPAIR(" bytes; crc ", final_crc);
       SERIAL_ECHOLNPGM(")");
@@ -672,7 +672,7 @@ void MarlinSettings::postprocess() {
         stored_ver[0] = '?';
         stored_ver[1] = '\0';
       }
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPGM("EEPROM version mismatch ");
       SERIAL_ECHOPAIR("(EEPROM=", stored_ver);
       SERIAL_ECHOLNPGM(" Marlin=" EEPROM_VERSION ")");
@@ -981,14 +981,14 @@ void MarlinSettings::postprocess() {
 
       if (working_crc == stored_crc) {
           postprocess();
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHO(version);
           SERIAL_ECHOPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
           SERIAL_ECHOPAIR(" bytes; crc ", working_crc);
           SERIAL_ECHOLNPGM(")");
       }
       else {
-        SERIAL_ERROR_START;
+        SERIAL_ERROR_START();
         SERIAL_ERRORPGM("EEPROM CRC mismatch - (stored) ");
         SERIAL_ERROR(stored_crc);
         SERIAL_ERRORPGM(" != ");
@@ -1004,7 +1004,7 @@ void MarlinSettings::postprocess() {
         ubl.report_state();
 
         if (!ubl.sanity_check()) {
-          SERIAL_EOL;
+          SERIAL_EOL();
           ubl.echo_name();
           SERIAL_ECHOLNPGM(" initialized.\n");
         }
@@ -1059,7 +1059,7 @@ void MarlinSettings::postprocess() {
           SERIAL_PROTOCOLPAIR("E2END=", E2END);
           SERIAL_PROTOCOLPAIR(" meshes_end=", meshes_end);
           SERIAL_PROTOCOLLNPAIR(" slot=", slot);
-          SERIAL_EOL;
+          SERIAL_EOL();
           return;
         }
 
@@ -1114,7 +1114,7 @@ void MarlinSettings::postprocess() {
 #else // !EEPROM_SETTINGS
 
   bool MarlinSettings::save() {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM("EEPROM disabled");
     return false;
   }
@@ -1315,13 +1315,13 @@ void MarlinSettings::reset() {
 
   postprocess();
 
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   SERIAL_ECHOLNPGM("Hardcoded Default Settings Loaded");
 }
 
 #if DISABLED(DISABLE_M503)
 
-  #define CONFIG_ECHO_START do{ if (!forReplay) SERIAL_ECHO_START; }while(0)
+  #define CONFIG_ECHO_START do{ if (!forReplay) SERIAL_ECHO_START(); }while(0)
 
   /**
    * M503 - Report current settings in RAM
@@ -1365,7 +1365,7 @@ void MarlinSettings::reset() {
 
     #endif
 
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     /**
      * Volumetric extrusion M200
@@ -1374,30 +1374,30 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_START;
       SERIAL_ECHOPGM("Filament settings:");
       if (volumetric_enabled)
-        SERIAL_EOL;
+        SERIAL_EOL();
       else
         SERIAL_ECHOLNPGM(" Disabled");
     }
 
     CONFIG_ECHO_START;
     SERIAL_ECHOPAIR("  M200 D", filament_size[0]);
-    SERIAL_EOL;
+    SERIAL_EOL();
     #if EXTRUDERS > 1
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M200 T1 D", filament_size[1]);
-      SERIAL_EOL;
+      SERIAL_EOL();
       #if EXTRUDERS > 2
         CONFIG_ECHO_START;
         SERIAL_ECHOPAIR("  M200 T2 D", filament_size[2]);
-        SERIAL_EOL;
+        SERIAL_EOL();
         #if EXTRUDERS > 3
           CONFIG_ECHO_START;
           SERIAL_ECHOPAIR("  M200 T3 D", filament_size[3]);
-          SERIAL_EOL;
+          SERIAL_EOL();
           #if EXTRUDERS > 4
             CONFIG_ECHO_START;
             SERIAL_ECHOPAIR("  M200 T4 D", filament_size[4]);
-            SERIAL_EOL;
+            SERIAL_EOL();
           #endif // EXTRUDERS > 4
         #endif // EXTRUDERS > 3
       #endif // EXTRUDERS > 2
@@ -1419,7 +1419,7 @@ void MarlinSettings::reset() {
     #if DISABLED(DISTINCT_E_FACTORS)
       SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.axis_steps_per_mm[E_AXIS]));
     #endif
-    SERIAL_EOL;
+    SERIAL_EOL();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START;
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
@@ -1439,7 +1439,7 @@ void MarlinSettings::reset() {
     #if DISABLED(DISTINCT_E_FACTORS)
       SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.max_feedrate_mm_s[E_AXIS]));
     #endif
-    SERIAL_EOL;
+    SERIAL_EOL();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START;
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
@@ -1459,7 +1459,7 @@ void MarlinSettings::reset() {
     #if DISABLED(DISTINCT_E_FACTORS)
       SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.max_acceleration_mm_per_s2[E_AXIS]));
     #endif
-    SERIAL_EOL;
+    SERIAL_EOL();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START;
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
@@ -1514,7 +1514,7 @@ void MarlinSettings::reset() {
         #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_NOZZLE)
           SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]));
         #endif
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
     #endif
 
@@ -1529,7 +1529,7 @@ void MarlinSettings::reset() {
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.z_fade_height));
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
       for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
         for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
           CONFIG_ECHO_START;
@@ -1537,7 +1537,7 @@ void MarlinSettings::reset() {
           SERIAL_ECHOPAIR(" Y", (int)py + 1);
           SERIAL_ECHOPGM(" Z");
           SERIAL_PROTOCOL_F(LINEAR_UNIT(mbl.z_values[px][py]), 5);
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       }
 
@@ -1553,17 +1553,17 @@ void MarlinSettings::reset() {
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         SERIAL_ECHOPAIR(" Z", planner.z_fade_height);
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
 
       if (!forReplay) {
-        SERIAL_EOL;
+        SERIAL_EOL();
         ubl.report_state();
 
         SERIAL_ECHOLNPAIR("\nActive Mesh Slot: ", ubl.state.storage_slot);
 
         SERIAL_ECHOPGM("z_offset: ");
         SERIAL_ECHO_F(ubl.state.z_offset, 6);
-        SERIAL_EOL;
+        SERIAL_EOL();
 
         SERIAL_ECHOPAIR("EEPROM can hold ", calc_num_meshes());
         SERIAL_ECHOLNPGM(" meshes.\n");
@@ -1580,7 +1580,7 @@ void MarlinSettings::reset() {
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.z_fade_height));
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
 
     #endif
 
@@ -1606,7 +1606,7 @@ void MarlinSettings::reset() {
       SERIAL_ECHOPAIR(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
       SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
       SERIAL_ECHOPAIR(" Z", 0.00);
-      SERIAL_EOL;
+      SERIAL_EOL();
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       if (!forReplay) {
         CONFIG_ECHO_START;
@@ -1649,7 +1649,7 @@ void MarlinSettings::reset() {
                 SERIAL_ECHOPAIR(" C", PID_PARAM(Kc, e));
                 if (e == 0) SERIAL_ECHOPAIR(" L", lpq_len);
               #endif
-              SERIAL_EOL;
+              SERIAL_EOL();
             }
           }
           else
@@ -1664,7 +1664,7 @@ void MarlinSettings::reset() {
             SERIAL_ECHOPAIR(" C", PID_PARAM(Kc, 0));
             SERIAL_ECHOPAIR(" L", lpq_len);
           #endif
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       #endif // PIDTEMP
 
@@ -1673,7 +1673,7 @@ void MarlinSettings::reset() {
         SERIAL_ECHOPAIR("  M304 P", thermalManager.bedKp);
         SERIAL_ECHOPAIR(" I", unscalePID_i(thermalManager.bedKi));
         SERIAL_ECHOPAIR(" D", unscalePID_d(thermalManager.bedKd));
-        SERIAL_EOL;
+        SERIAL_EOL();
       #endif
 
     #endif // PIDTEMP || PIDTEMPBED
@@ -1773,7 +1773,7 @@ void MarlinSettings::reset() {
       #if ENABLED(E3_IS_TMC2130)
         SERIAL_ECHOPAIR(" E3", stepperE3.getCurrent());
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
     #endif
 
     /**

--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -161,7 +161,7 @@ void Endstops::report_state() {
     #define ENDSTOP_HIT_TEST_Y() _ENDSTOP_HIT_TEST(Y,'Y')
     #define ENDSTOP_HIT_TEST_Z() _ENDSTOP_HIT_TEST(Z,'Z')
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_ENDSTOPS_HIT);
     ENDSTOP_HIT_TEST_X();
     ENDSTOP_HIT_TEST_Y();
@@ -171,7 +171,7 @@ void Endstops::report_state() {
       #define P_AXIS Z_AXIS
       if (TEST(endstop_hit_bits, Z_MIN_PROBE)) _ENDSTOP_HIT_ECHO(P, 'P');
     #endif
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     #if ENABLED(ULTRA_LCD)
       lcd_status_printf_P(0, PSTR(MSG_LCD_ENDSTOPS " %c %c %c %c"), chrX, chrY, chrZ, chrP);

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -203,7 +203,7 @@ void GCodeParser::parse(char *p) {
       }
 
       #if ENABLED(DEBUG_GCODE_PARSER)
-        if (debug) SERIAL_EOL;
+        if (debug) SERIAL_EOL();
       #endif
 
       #if ENABLED(FASTER_GCODE_PARSER)
@@ -229,10 +229,10 @@ void GCodeParser::parse(char *p) {
 }
 
 void GCodeParser::unknown_command_error() {
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   SERIAL_ECHOPAIR(MSG_UNKNOWN_COMMAND, command_ptr);
   SERIAL_CHAR('"');
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 #if ENABLED(DEBUG_GCODE_PARSER)

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -128,9 +128,7 @@ public:
       return b;
     }
 
-    static volatile bool seen_any() {
-      return codebits[3] || codebits[2] || codebits[1] || codebits[0];
-    }
+    static volatile bool seen_any() { return codebits[3] || codebits[2] || codebits[1] || codebits[0]; }
 
     #define SEEN_TEST(L) TEST(codebits[(L - 'A') >> 3], (L - 'A') & 0x7)
 
@@ -145,9 +143,7 @@ public:
       return b;
     }
 
-    static volatile bool seen_any() {
-      return *command_args == '\0';
-    }
+    static volatile bool seen_any() { return *command_args == '\0'; }
 
     #define SEEN_TEST(L) !!strchr(command_args, L)
 
@@ -207,7 +203,7 @@ public:
 
   #if ENABLED(INCH_MODE_SUPPORT)
 
-    inline static void set_input_linear_units(LinearUnit units) {
+    inline static void set_input_linear_units(const LinearUnit units) {
       switch (units) {
         case LINEARUNIT_INCH:
           linear_unit_factor = 25.4;

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -163,176 +163,174 @@
   #define MSG_USER_MENU                       _UxGT("Custom Commands")
 #endif
 
-#if ENABLED(AUTO_BED_LEVELING_UBL)
-  #ifndef MSG_UBL_DOING_G29
-    #define MSG_UBL_DOING_G29                 _UxGT("Doing G29 UBL!")
-  #endif
-  #ifndef MSG_UBL_UNHOMED
-    #define MSG_UBL_UNHOMED                   _UxGT("Home XYZ first")
-  #endif
-  #ifndef MSG_UBL_TOOLS
-    #define MSG_UBL_TOOLS                     _UxGT("UBL Tools")
-  #endif
-  #ifndef MSG_UBL_LEVEL_BED
-    #define MSG_UBL_LEVEL_BED                 _UxGT("Unified Bed Leveling")
-  #endif
-  #ifndef MSG_UBL_MANUAL_MESH
-    #define MSG_UBL_MANUAL_MESH               _UxGT("Manually Build Mesh")
-  #endif
-  #ifndef MSG_UBL_BC_INSERT
-    #define MSG_UBL_BC_INSERT                 _UxGT("Place shim & measure")
-  #endif
-  #ifndef MSG_UBL_BC_INSERT2
-    #define MSG_UBL_BC_INSERT2                _UxGT("Measure")
-  #endif 
-  #ifndef MSG_UBL_BC_REMOVE
-    #define MSG_UBL_BC_REMOVE                 _UxGT("Remove & measure bed")
-  #endif
-  #ifndef MSG_UBL_MOVING_TO_NEXT
-    #define MSG_UBL_MOVING_TO_NEXT            _UxGT("Moving to next")
-  #endif
-  #ifndef MSG_UBL_ACTIVATE_MESH
-    #define MSG_UBL_ACTIVATE_MESH             _UxGT("Activate UBL")
-  #endif
-  #ifndef MSG_UBL_DEACTIVATE_MESH
-    #define MSG_UBL_DEACTIVATE_MESH           _UxGT("Deactivate UBL")
-  #endif
-  #ifndef MSG_UBL_SET_BED_TEMP
-    #define MSG_UBL_SET_BED_TEMP              _UxGT("Bed Temp")
-  #endif
-  #ifndef MSG_UBL_CUSTOM_BED_TEMP
-    #define MSG_UBL_CUSTOM_BED_TEMP           MSG_UBL_SET_BED_TEMP
-  #endif
-  #ifndef MSG_UBL_SET_HOTEND_TEMP
-    #define MSG_UBL_SET_HOTEND_TEMP           _UxGT("Hotend Temp")
-  #endif
-  #ifndef MSG_UBL_CUSTOM_HOTEND_TEMP
-    #define MSG_UBL_CUSTOM_HOTEND_TEMP        MSG_UBL_SET_HOTEND_TEMP
-  #endif
-  #ifndef MSG_UBL_EDIT_CUSTOM_MESH
-    #define MSG_UBL_EDIT_CUSTOM_MESH          _UxGT("Edit Custom Mesh")
-  #endif
-  #ifndef MSG_UBL_FINE_TUNE_MESH
-    #define MSG_UBL_FINE_TUNE_MESH            _UxGT("Fine Tuning Mesh")
-  #endif
-  #ifndef MSG_UBL_DONE_EDITING_MESH
-    #define MSG_UBL_DONE_EDITING_MESH         _UxGT("Done Editing Mesh")
-  #endif
-  #ifndef MSG_UBL_BUILD_CUSTOM_MESH
-    #define MSG_UBL_BUILD_CUSTOM_MESH         _UxGT("Build Custom Mesh")
-  #endif
-  #ifndef MSG_UBL_BUILD_MESH_MENU
-    #define MSG_UBL_BUILD_MESH_MENU           _UxGT("Build Mesh")
-  #endif
-  #ifndef MSG_UBL_BUILD_PLA_MESH
-    #define MSG_UBL_BUILD_PLA_MESH            _UxGT("Build PLA Mesh")
-  #endif
-  #ifndef MSG_UBL_BUILD_ABS_MESH
-    #define MSG_UBL_BUILD_ABS_MESH            _UxGT("Build ABS Mesh")
-  #endif
-  #ifndef MSG_UBL_BUILD_COLD_MESH
-    #define MSG_UBL_BUILD_COLD_MESH           _UxGT("Build Cold Mesh")
-  #endif
-  #ifndef MSG_UBL_MESH_HEIGHT_ADJUST
-    #define MSG_UBL_MESH_HEIGHT_ADJUST        _UxGT("Adjust Mesh Height")
-  #endif
-  #ifndef MSG_UBL_MESH_HEIGHT_AMOUNT
-    #define MSG_UBL_MESH_HEIGHT_AMOUNT        _UxGT("Height Amount")
-  #endif
-  #ifndef MSG_UBL_VALIDATE_MESH_MENU
-    #define MSG_UBL_VALIDATE_MESH_MENU        _UxGT("Validate Mesh")
-  #endif
-  #ifndef MSG_UBL_VALIDATE_PLA_MESH
-    #define MSG_UBL_VALIDATE_PLA_MESH         _UxGT("Validate PLA Mesh")
-  #endif
-  #ifndef MSG_UBL_VALIDATE_ABS_MESH
-    #define MSG_UBL_VALIDATE_ABS_MESH         _UxGT("Validate ABS Mesh")
-  #endif
-  #ifndef MSG_UBL_VALIDATE_CUSTOM_MESH
-    #define MSG_UBL_VALIDATE_CUSTOM_MESH      _UxGT("Validate Custom Mesh")
-  #endif
-  #ifndef MSG_UBL_CONTINUE_MESH
-    #define MSG_UBL_CONTINUE_MESH             _UxGT("Continue Bed Mesh")
-  #endif
-  #ifndef MSG_UBL_MESH_LEVELING
-    #define MSG_UBL_MESH_LEVELING             _UxGT("Mesh Leveling")
-  #endif
-  #ifndef MSG_UBL_3POINT_MESH_LEVELING
-    #define MSG_UBL_3POINT_MESH_LEVELING      _UxGT("3-Point Leveling")
-  #endif
-  #ifndef MSG_UBL_GRID_MESH_LEVELING
-    #define MSG_UBL_GRID_MESH_LEVELING        _UxGT("Grid Mesh Leveling")
-  #endif
-  #ifndef MSG_UBL_MESH_LEVEL
-    #define MSG_UBL_MESH_LEVEL                _UxGT("Level Mesh")
-  #endif
-  #ifndef MSG_UBL_SIDE_POINTS
-    #define MSG_UBL_SIDE_POINTS               _UxGT("Side Points")
-  #endif
-  #ifndef MSG_UBL_MAP_TYPE
-    #define MSG_UBL_MAP_TYPE                  _UxGT("Map Type")
-  #endif
-  #ifndef MSG_UBL_OUTPUT_MAP
-    #define MSG_UBL_OUTPUT_MAP                _UxGT("Output Mesh Map")
-  #endif
-  #ifndef MSG_UBL_OUTPUT_MAP_HOST
-    #define MSG_UBL_OUTPUT_MAP_HOST           _UxGT("Output for Host")
-  #endif
-  #ifndef MSG_UBL_OUTPUT_MAP_CSV
-    #define MSG_UBL_OUTPUT_MAP_CSV            _UxGT("Output for CSV")
-  #endif
-  #ifndef MSG_UBL_INFO_UBL
-    #define MSG_UBL_INFO_UBL                  _UxGT("Output UBL Info")
-  #endif
-  #ifndef MSG_UBL_EDIT_MESH_MENU
-    #define MSG_UBL_EDIT_MESH_MENU            _UxGT("Edit Mesh")
-  #endif
-  #ifndef MSG_UBL_FILLIN_AMOUNT
-    #define MSG_UBL_FILLIN_AMOUNT             _UxGT("Fill-in Amount")
-  #endif
-  #ifndef MSG_UBL_MANUAL_FILLIN
-    #define MSG_UBL_MANUAL_FILLIN             _UxGT("Manual Fill-in")
-  #endif
-  #ifndef MSG_UBL_SMART_FILLIN
-    #define MSG_UBL_SMART_FILLIN              _UxGT("Smart Fill-in")
-  #endif
-  #ifndef MSG_UBL_FILLIN_MESH
-    #define MSG_UBL_FILLIN_MESH               _UxGT("Fill-in Mesh")
-  #endif
-  #ifndef MSG_UBL_INVALIDATE_ALL
-    #define MSG_UBL_INVALIDATE_ALL            _UxGT("Invalidate All")
-  #endif
-  #ifndef MSG_UBL_INVALIDATE_CLOSEST
-    #define MSG_UBL_INVALIDATE_CLOSEST        _UxGT("Invalidate Closest")
-  #endif
-  #ifndef MSG_UBL_FINE_TUNE_ALL
-    #define MSG_UBL_FINE_TUNE_ALL             _UxGT("Fine Tune All")
-  #endif
-  #ifndef MSG_UBL_FINE_TUNE_CLOSEST
-    #define MSG_UBL_FINE_TUNE_CLOSEST         _UxGT("Fine Tune Closest")
-  #endif
-  #ifndef MSG_UBL_STORAGE_MESH_MENU
-    #define MSG_UBL_STORAGE_MESH_MENU         _UxGT("Mesh Storage")
-  #endif
-  #ifndef MSG_UBL_STORAGE_SLOT
-    #define MSG_UBL_STORAGE_SLOT              _UxGT("Memory Slot")
-  #endif
-  #ifndef MSG_UBL_LOAD_MESH
-    #define MSG_UBL_LOAD_MESH                 _UxGT("Load Bed Mesh")
-  #endif
-  #ifndef MSG_UBL_SAVE_MESH
-    #define MSG_UBL_SAVE_MESH                 _UxGT("Save Bed Mesh")
-  #endif
-  #ifndef MSG_UBL_SAVE_ERROR
-    #define MSG_UBL_SAVE_ERROR                _UxGT("save_UBL_active() error")
-  #endif
-  #ifndef MSG_UBL_RESTORE_ERROR
-    #define MSG_UBL_RESTORE_ERROR             _UxGT("restore_UBL_active() error")
-  #endif
-  #ifndef MSG_UBL_Z_OFFSET_STOPPED
-    #define MSG_UBL_Z_OFFSET_STOPPED          _UxGT("Z-Offset Stopped")
-  #endif
-#endif  // AUTO_BED_LEVELING_UBL
+#ifndef MSG_UBL_DOING_G29
+  #define MSG_UBL_DOING_G29                   _UxGT("Doing G29")
+#endif
+#ifndef MSG_UBL_UNHOMED
+  #define MSG_UBL_UNHOMED                     _UxGT("Home XYZ first")
+#endif
+#ifndef MSG_UBL_TOOLS
+  #define MSG_UBL_TOOLS                       _UxGT("UBL Tools")
+#endif
+#ifndef MSG_UBL_LEVEL_BED
+  #define MSG_UBL_LEVEL_BED                   _UxGT("Unified Bed Leveling")
+#endif
+#ifndef MSG_UBL_MANUAL_MESH
+  #define MSG_UBL_MANUAL_MESH                 _UxGT("Manually Build Mesh")
+#endif
+#ifndef MSG_UBL_BC_INSERT
+  #define MSG_UBL_BC_INSERT                   _UxGT("Place shim & measure")
+#endif
+#ifndef MSG_UBL_BC_INSERT2
+  #define MSG_UBL_BC_INSERT2                  _UxGT("Measure")
+#endif
+#ifndef MSG_UBL_BC_REMOVE
+  #define MSG_UBL_BC_REMOVE                   _UxGT("Remove & measure bed")
+#endif
+#ifndef MSG_UBL_MOVING_TO_NEXT
+  #define MSG_UBL_MOVING_TO_NEXT              _UxGT("Moving to next")
+#endif
+#ifndef MSG_UBL_ACTIVATE_MESH
+  #define MSG_UBL_ACTIVATE_MESH               _UxGT("Activate UBL")
+#endif
+#ifndef MSG_UBL_DEACTIVATE_MESH
+  #define MSG_UBL_DEACTIVATE_MESH             _UxGT("Deactivate UBL")
+#endif
+#ifndef MSG_UBL_SET_BED_TEMP
+  #define MSG_UBL_SET_BED_TEMP                _UxGT("Bed Temp")
+#endif
+#ifndef MSG_UBL_CUSTOM_BED_TEMP
+  #define MSG_UBL_CUSTOM_BED_TEMP             MSG_UBL_SET_BED_TEMP
+#endif
+#ifndef MSG_UBL_SET_HOTEND_TEMP
+  #define MSG_UBL_SET_HOTEND_TEMP             _UxGT("Hotend Temp")
+#endif
+#ifndef MSG_UBL_CUSTOM_HOTEND_TEMP
+  #define MSG_UBL_CUSTOM_HOTEND_TEMP          MSG_UBL_SET_HOTEND_TEMP
+#endif
+#ifndef MSG_UBL_EDIT_CUSTOM_MESH
+  #define MSG_UBL_EDIT_CUSTOM_MESH            _UxGT("Edit Custom Mesh")
+#endif
+#ifndef MSG_UBL_FINE_TUNE_MESH
+  #define MSG_UBL_FINE_TUNE_MESH              _UxGT("Fine Tuning Mesh")
+#endif
+#ifndef MSG_UBL_DONE_EDITING_MESH
+  #define MSG_UBL_DONE_EDITING_MESH           _UxGT("Done Editing Mesh")
+#endif
+#ifndef MSG_UBL_BUILD_CUSTOM_MESH
+  #define MSG_UBL_BUILD_CUSTOM_MESH           _UxGT("Build Custom Mesh")
+#endif
+#ifndef MSG_UBL_BUILD_MESH_MENU
+  #define MSG_UBL_BUILD_MESH_MENU             _UxGT("Build Mesh")
+#endif
+#ifndef MSG_UBL_BUILD_PLA_MESH
+  #define MSG_UBL_BUILD_PLA_MESH              _UxGT("Build PLA Mesh")
+#endif
+#ifndef MSG_UBL_BUILD_ABS_MESH
+  #define MSG_UBL_BUILD_ABS_MESH              _UxGT("Build ABS Mesh")
+#endif
+#ifndef MSG_UBL_BUILD_COLD_MESH
+  #define MSG_UBL_BUILD_COLD_MESH             _UxGT("Build Cold Mesh")
+#endif
+#ifndef MSG_UBL_MESH_HEIGHT_ADJUST
+  #define MSG_UBL_MESH_HEIGHT_ADJUST          _UxGT("Adjust Mesh Height")
+#endif
+#ifndef MSG_UBL_MESH_HEIGHT_AMOUNT
+  #define MSG_UBL_MESH_HEIGHT_AMOUNT          _UxGT("Height Amount")
+#endif
+#ifndef MSG_UBL_VALIDATE_MESH_MENU
+  #define MSG_UBL_VALIDATE_MESH_MENU          _UxGT("Validate Mesh")
+#endif
+#ifndef MSG_UBL_VALIDATE_PLA_MESH
+  #define MSG_UBL_VALIDATE_PLA_MESH           _UxGT("Validate PLA Mesh")
+#endif
+#ifndef MSG_UBL_VALIDATE_ABS_MESH
+  #define MSG_UBL_VALIDATE_ABS_MESH           _UxGT("Validate ABS Mesh")
+#endif
+#ifndef MSG_UBL_VALIDATE_CUSTOM_MESH
+  #define MSG_UBL_VALIDATE_CUSTOM_MESH        _UxGT("Validate Custom Mesh")
+#endif
+#ifndef MSG_UBL_CONTINUE_MESH
+  #define MSG_UBL_CONTINUE_MESH               _UxGT("Continue Bed Mesh")
+#endif
+#ifndef MSG_UBL_MESH_LEVELING
+  #define MSG_UBL_MESH_LEVELING               _UxGT("Mesh Leveling")
+#endif
+#ifndef MSG_UBL_3POINT_MESH_LEVELING
+  #define MSG_UBL_3POINT_MESH_LEVELING        _UxGT("3-Point Leveling")
+#endif
+#ifndef MSG_UBL_GRID_MESH_LEVELING
+  #define MSG_UBL_GRID_MESH_LEVELING          _UxGT("Grid Mesh Leveling")
+#endif
+#ifndef MSG_UBL_MESH_LEVEL
+  #define MSG_UBL_MESH_LEVEL                  _UxGT("Level Mesh")
+#endif
+#ifndef MSG_UBL_SIDE_POINTS
+  #define MSG_UBL_SIDE_POINTS                 _UxGT("Side Points")
+#endif
+#ifndef MSG_UBL_MAP_TYPE
+  #define MSG_UBL_MAP_TYPE                    _UxGT("Map Type")
+#endif
+#ifndef MSG_UBL_OUTPUT_MAP
+  #define MSG_UBL_OUTPUT_MAP                  _UxGT("Output Mesh Map")
+#endif
+#ifndef MSG_UBL_OUTPUT_MAP_HOST
+  #define MSG_UBL_OUTPUT_MAP_HOST             _UxGT("Output for Host")
+#endif
+#ifndef MSG_UBL_OUTPUT_MAP_CSV
+  #define MSG_UBL_OUTPUT_MAP_CSV              _UxGT("Output for CSV")
+#endif
+#ifndef MSG_UBL_INFO_UBL
+  #define MSG_UBL_INFO_UBL                    _UxGT("Output UBL Info")
+#endif
+#ifndef MSG_UBL_EDIT_MESH_MENU
+  #define MSG_UBL_EDIT_MESH_MENU              _UxGT("Edit Mesh")
+#endif
+#ifndef MSG_UBL_FILLIN_AMOUNT
+  #define MSG_UBL_FILLIN_AMOUNT               _UxGT("Fill-in Amount")
+#endif
+#ifndef MSG_UBL_MANUAL_FILLIN
+  #define MSG_UBL_MANUAL_FILLIN               _UxGT("Manual Fill-in")
+#endif
+#ifndef MSG_UBL_SMART_FILLIN
+  #define MSG_UBL_SMART_FILLIN                _UxGT("Smart Fill-in")
+#endif
+#ifndef MSG_UBL_FILLIN_MESH
+  #define MSG_UBL_FILLIN_MESH                 _UxGT("Fill-in Mesh")
+#endif
+#ifndef MSG_UBL_INVALIDATE_ALL
+  #define MSG_UBL_INVALIDATE_ALL              _UxGT("Invalidate All")
+#endif
+#ifndef MSG_UBL_INVALIDATE_CLOSEST
+  #define MSG_UBL_INVALIDATE_CLOSEST          _UxGT("Invalidate Closest")
+#endif
+#ifndef MSG_UBL_FINE_TUNE_ALL
+  #define MSG_UBL_FINE_TUNE_ALL               _UxGT("Fine Tune All")
+#endif
+#ifndef MSG_UBL_FINE_TUNE_CLOSEST
+  #define MSG_UBL_FINE_TUNE_CLOSEST           _UxGT("Fine Tune Closest")
+#endif
+#ifndef MSG_UBL_STORAGE_MESH_MENU
+  #define MSG_UBL_STORAGE_MESH_MENU           _UxGT("Mesh Storage")
+#endif
+#ifndef MSG_UBL_STORAGE_SLOT
+  #define MSG_UBL_STORAGE_SLOT                _UxGT("Memory Slot")
+#endif
+#ifndef MSG_UBL_LOAD_MESH
+  #define MSG_UBL_LOAD_MESH                   _UxGT("Load Bed Mesh")
+#endif
+#ifndef MSG_UBL_SAVE_MESH
+  #define MSG_UBL_SAVE_MESH                   _UxGT("Save Bed Mesh")
+#endif
+#ifndef MSG_UBL_SAVE_ERROR
+  #define MSG_UBL_SAVE_ERROR                  _UxGT("Err: UBL Save")
+#endif
+#ifndef MSG_UBL_RESTORE_ERROR
+  #define MSG_UBL_RESTORE_ERROR               _UxGT("Err: UBL Restore")
+#endif
+#ifndef MSG_UBL_Z_OFFSET_STOPPED
+  #define MSG_UBL_Z_OFFSET_STOPPED            _UxGT("Z-Offset Stopped")
+#endif
 
 #ifndef MSG_MOVING
   #define MSG_MOVING                          _UxGT("Moving...")

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -452,7 +452,7 @@ inline void report_pin_state_extended(int8_t pin, bool ignore, bool extended = t
         }
         if (!multi_name_pin && extended) pwm_details(pin);  // report PWM capabilities only on the first pass & only if doing an extended report
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
     }  // end of IF
   } // end of for loop
 
@@ -483,7 +483,7 @@ inline void report_pin_state_extended(int8_t pin, bool ignore, bool extended = t
     }
     //if (!pwm_status(pin)) SERIAL_CHAR(' ');    // add padding if it's not a PWM pin
     if (extended) pwm_details(pin);  // report PWM capabilities only if doing an extended report
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 }
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -740,7 +740,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   #endif
   SERIAL_ECHOPAIR(" (", dc);
   SERIAL_CHAR(')');
-  SERIAL_EOL;
+  SERIAL_EOL();
   //*/
 
   // DRYRUN ignores all temperature constraints and assures that the extruder is instantly satisfied
@@ -766,7 +766,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
           position_float[E_AXIS] = e;
           de_float = 0;
         #endif
-        SERIAL_ECHO_START;
+        SERIAL_ECHO_START();
         SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
       }
       #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
@@ -777,7 +777,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
             position_float[E_AXIS] = e;
             de_float = 0;
           #endif
-          SERIAL_ECHO_START;
+          SERIAL_ECHO_START();
           SERIAL_ECHOLNPGM(MSG_ERR_LONG_EXTRUDE_STOP);
         }
       #endif
@@ -1420,7 +1420,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
       block->advance_rate = block->advance = 0;
 
     /**
-     SERIAL_ECHO_START;
+     SERIAL_ECHO_START();
      SERIAL_ECHOPGM("advance :");
      SERIAL_ECHO(block->advance/256.0);
      SERIAL_ECHOPGM("advance rate :");

--- a/Marlin/printcounter.cpp
+++ b/Marlin/printcounter.cpp
@@ -108,7 +108,7 @@ void PrintCounter::showStats() {
   SERIAL_ECHO(this->data.totalPrints - this->data.finishedPrints
     - ((this->isRunning() || this->isPaused()) ? 1 : 0));
 
-  SERIAL_EOL;
+  SERIAL_EOL();
   SERIAL_PROTOCOLPGM(MSG_STATS);
 
   elapsed = this->data.printTime;
@@ -135,14 +135,14 @@ void PrintCounter::showStats() {
     SERIAL_CHAR(')');
   #endif
 
-  SERIAL_EOL;
+  SERIAL_EOL();
   SERIAL_PROTOCOLPGM(MSG_STATS);
 
   SERIAL_ECHOPGM("Filament used: ");
   SERIAL_ECHO(this->data.filamentUsed / 1000);
   SERIAL_ECHOPGM("m");
 
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 void PrintCounter::tick() {

--- a/Marlin/serial.h
+++ b/Marlin/serial.h
@@ -41,18 +41,18 @@ extern const char echomagic[] PROGMEM;
 extern const char errormagic[] PROGMEM;
 
 #define SERIAL_CHAR(x) (MYSERIAL.write(x))
-#define SERIAL_EOL SERIAL_CHAR('\n')
+#define SERIAL_EOL() SERIAL_CHAR('\n')
 
 #define SERIAL_PROTOCOLCHAR(x)              SERIAL_CHAR(x)
 #define SERIAL_PROTOCOL(x)                  (MYSERIAL.print(x))
 #define SERIAL_PROTOCOL_F(x,y)              (MYSERIAL.print(x,y))
 #define SERIAL_PROTOCOLPGM(x)               (serialprintPGM(PSTR(x)))
-#define SERIAL_PROTOCOLLN(x)                do{ MYSERIAL.print(x); SERIAL_EOL; }while(0)
+#define SERIAL_PROTOCOLLN(x)                do{ MYSERIAL.print(x); SERIAL_EOL(); }while(0)
 #define SERIAL_PROTOCOLLNPGM(x)             (serialprintPGM(PSTR(x "\n")))
 #define SERIAL_PROTOCOLPAIR(name, value)    (serial_echopair_P(PSTR(name),(value)))
-#define SERIAL_PROTOCOLLNPAIR(name, value)  do{ SERIAL_PROTOCOLPAIR(name, value); SERIAL_EOL; }while(0)
+#define SERIAL_PROTOCOLLNPAIR(name, value)  do{ SERIAL_PROTOCOLPAIR(name, value); SERIAL_EOL(); }while(0)
 
-#define SERIAL_ECHO_START             (serialprintPGM(echomagic))
+#define SERIAL_ECHO_START()            (serialprintPGM(echomagic))
 #define SERIAL_ECHO(x)                 SERIAL_PROTOCOL(x)
 #define SERIAL_ECHOPGM(x)              SERIAL_PROTOCOLPGM(x)
 #define SERIAL_ECHOLN(x)               SERIAL_PROTOCOLLN(x)
@@ -61,7 +61,7 @@ extern const char errormagic[] PROGMEM;
 #define SERIAL_ECHOLNPAIR(name, value) SERIAL_PROTOCOLLNPAIR(name, value)
 #define SERIAL_ECHO_F(x,y)             SERIAL_PROTOCOL_F(x,y)
 
-#define SERIAL_ERROR_START            (serialprintPGM(errormagic))
+#define SERIAL_ERROR_START()           (serialprintPGM(errormagic))
 #define SERIAL_ERROR(x)                SERIAL_PROTOCOL(x)
 #define SERIAL_ERRORPGM(x)             SERIAL_PROTOCOLPGM(x)
 #define SERIAL_ERRORLN(x)              SERIAL_PROTOCOLLN(x)

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1305,7 +1305,7 @@ void Stepper::report_positions() {
   #endif
   SERIAL_PROTOCOL(zpos);
 
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 #if ENABLED(BABYSTEPPING)

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -369,7 +369,7 @@ class Stepper {
         }
       #endif
 
-      // SERIAL_ECHO_START;
+      // SERIAL_ECHO_START();
       // SERIAL_ECHOPGM("advance :");
       // SERIAL_ECHO(current_block->advance/256.0);
       // SERIAL_ECHOPGM("advance rate :");

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -103,9 +103,9 @@
   void dac_print_values() {
     if (!dac_present) return;
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM("Stepper current values in % (Amps):");
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOPAIR(" X:",  dac_perc(X_AXIS));
     SERIAL_ECHOPAIR(" (",   dac_amps(X_AXIS));
     SERIAL_ECHOPAIR(") Y:", dac_perc(Y_AXIS));

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -389,7 +389,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
       if (ELAPSED(ms, temp_ms + 2000UL)) {
         #if HAS_TEMP_HOTEND || HAS_TEMP_BED
           print_heaterstates();
-          SERIAL_EOL;
+          SERIAL_EOL();
         #endif
 
         temp_ms = ms;
@@ -404,17 +404,17 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
 
         #if HAS_PID_FOR_BOTH
           const char* estring = hotend < 0 ? "bed" : "";
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_", estring); SERIAL_PROTOCOLPAIR("Kp ", workKp); SERIAL_EOL;
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_", estring); SERIAL_PROTOCOLPAIR("Ki ", workKi); SERIAL_EOL;
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_", estring); SERIAL_PROTOCOLPAIR("Kd ", workKd); SERIAL_EOL;
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_", estring); SERIAL_PROTOCOLPAIR("Kp ", workKp); SERIAL_EOL();
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_", estring); SERIAL_PROTOCOLPAIR("Ki ", workKi); SERIAL_EOL();
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_", estring); SERIAL_PROTOCOLPAIR("Kd ", workKd); SERIAL_EOL();
         #elif ENABLED(PIDTEMP)
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_Kp ", workKp); SERIAL_EOL;
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_Ki ", workKi); SERIAL_EOL;
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_Kd ", workKd); SERIAL_EOL;
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_Kp ", workKp); SERIAL_EOL();
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_Ki ", workKi); SERIAL_EOL();
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_Kd ", workKd); SERIAL_EOL();
         #else
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_bedKp ", workKp); SERIAL_EOL;
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_bedKi ", workKi); SERIAL_EOL;
-          SERIAL_PROTOCOLPAIR("#define  DEFAULT_bedKd ", workKd); SERIAL_EOL;
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_bedKp ", workKp); SERIAL_EOL();
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_bedKi ", workKi); SERIAL_EOL();
+          SERIAL_PROTOCOLPAIR("#define  DEFAULT_bedKd ", workKd); SERIAL_EOL();
         #endif
 
         #define _SET_BED_PID() do { \
@@ -508,7 +508,7 @@ int Temperature::getHeaterPower(int heater) {
 void Temperature::_temp_error(int e, const char* serial_msg, const char* lcd_msg) {
   static bool killed = false;
   if (IsRunning()) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     serialprintPGM(serial_msg);
     SERIAL_ERRORPGM(MSG_STOPPED_HEATER);
     if (e >= 0) SERIAL_ERRORLN((int)e); else SERIAL_ERRORLNPGM(MSG_HEATER_BED);
@@ -619,7 +619,7 @@ float Temperature::get_pid_output(int e) {
     #endif // PID_OPENLOOP
 
     #if ENABLED(PID_DEBUG)
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPAIR(MSG_PID_DEBUG, HOTEND_INDEX);
       SERIAL_ECHOPAIR(MSG_PID_DEBUG_INPUT, current_temperature[HOTEND_INDEX]);
       SERIAL_ECHOPAIR(MSG_PID_DEBUG_OUTPUT, pid_output);
@@ -629,7 +629,7 @@ float Temperature::get_pid_output(int e) {
       #if ENABLED(PID_EXTRUSION_SCALING)
         SERIAL_ECHOPAIR(MSG_PID_DEBUG_CTERM, cTerm[HOTEND_INDEX]);
       #endif
-      SERIAL_EOL;
+      SERIAL_EOL();
     #endif // PID_DEBUG
 
   #else /* PID off */
@@ -670,7 +670,7 @@ float Temperature::get_pid_output(int e) {
     #endif // PID_OPENLOOP
 
     #if ENABLED(PID_BED_DEBUG)
-      SERIAL_ECHO_START;
+      SERIAL_ECHO_START();
       SERIAL_ECHOPGM(" PID_BED_DEBUG ");
       SERIAL_ECHOPGM(": Input ");
       SERIAL_ECHO(current_temperature_bed);
@@ -854,7 +854,7 @@ float Temperature::analog2temp(int raw, uint8_t e) {
     if (e >= HOTENDS)
   #endif
     {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERROR((int)e);
       SERIAL_ERRORLNPGM(MSG_INVALID_EXTRUDER_NUM);
       kill(PSTR(MSG_KILLED));
@@ -1278,7 +1278,7 @@ void Temperature::init() {
     static float tr_target_temperature[HOTENDS + 1] = { 0.0 };
 
     /**
-        SERIAL_ECHO_START;
+        SERIAL_ECHO_START();
         SERIAL_ECHOPGM("Thermal Thermal Runaway Running. Heater ID: ");
         if (heater_id < 0) SERIAL_ECHOPGM("bed"); else SERIAL_ECHO(heater_id);
         SERIAL_ECHOPAIR(" ;  State:", *state);
@@ -1289,7 +1289,7 @@ void Temperature::init() {
           SERIAL_ECHOPAIR(" ;  Idle Timeout:", heater_idle_timeout_exceeded[heater_id]);
         else
           SERIAL_ECHOPAIR(" ;  Idle Timeout:", bed_idle_timeout_exceeded);
-        SERIAL_EOL;
+        SERIAL_EOL();
     */
 
     int heater_index = heater_id >= 0 ? heater_id : HOTENDS;
@@ -1457,7 +1457,7 @@ void Temperature::disable_all_heaters() {
     WRITE(MAX6675_SS, 1); // disable TT_MAX6675
 
     if (max6675_temp & MAX6675_ERROR_MASK) {
-      SERIAL_ERROR_START;
+      SERIAL_ERROR_START();
       SERIAL_ERRORPGM("Temp measurement error! ");
       #if MAX6675_ERROR_MASK == 7
         SERIAL_ERRORPGM("MAX31855 ");

--- a/Marlin/twibus.cpp
+++ b/Marlin/twibus.cpp
@@ -43,7 +43,7 @@ void TWIBus::reset() {
 
 void TWIBus::address(const uint8_t adr) {
   if (!WITHIN(adr, 8, 127)) {
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM("Bad I2C address (8-127)");
   }
 
@@ -90,7 +90,7 @@ void TWIBus::send() {
 
 // static
 void TWIBus::echoprefix(uint8_t bytes, const char prefix[], uint8_t adr) {
-  SERIAL_ECHO_START;
+  SERIAL_ECHO_START();
   serialprintPGM(prefix);
   SERIAL_ECHOPAIR(": from:", adr);
   SERIAL_ECHOPAIR(" bytes:", bytes);
@@ -101,13 +101,13 @@ void TWIBus::echoprefix(uint8_t bytes, const char prefix[], uint8_t adr) {
 void TWIBus::echodata(uint8_t bytes, const char prefix[], uint8_t adr) {
   echoprefix(bytes, prefix, adr);
   while (bytes-- && Wire.available()) SERIAL_CHAR(Wire.read());
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 void TWIBus::echobuffer(const char prefix[], uint8_t adr) {
   echoprefix(this->buffer_s, prefix, adr);
   for (uint8_t i = 0; i < this->buffer_s; i++) SERIAL_CHAR(this->buffer[i]);
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 bool TWIBus::request(const uint8_t bytes) {

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -116,11 +116,11 @@
       serial_echo_xy(0, GRID_MAX_POINTS_Y - 1);
       SERIAL_ECHO_SP(spaces + 3);
       serial_echo_xy(GRID_MAX_POINTS_X - 1, GRID_MAX_POINTS_Y - 1);
-      SERIAL_EOL;
+      SERIAL_EOL();
       serial_echo_xy(UBL_MESH_MIN_X, UBL_MESH_MAX_Y);
       SERIAL_ECHO_SP(spaces);
       serial_echo_xy(UBL_MESH_MAX_X, UBL_MESH_MAX_Y);
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
 
     const float current_xi = get_cell_index_x(current_position[X_AXIS] + (MESH_X_DIST) / 2.0),
@@ -154,10 +154,10 @@
           SERIAL_CHAR(' ');
         }
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
       if (j && map0) { // we want the (0,0) up tight against the block of numbers
         SERIAL_CHAR(' ');
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
     }
 
@@ -165,11 +165,11 @@
       serial_echo_xy(UBL_MESH_MIN_X, UBL_MESH_MIN_Y);
       SERIAL_ECHO_SP(spaces + 4);
       serial_echo_xy(UBL_MESH_MAX_X, UBL_MESH_MIN_Y);
-      SERIAL_EOL;
+      SERIAL_EOL();
       serial_echo_xy(0, 0);
       SERIAL_ECHO_SP(spaces + 5);
       serial_echo_xy(GRID_MAX_POINTS_X - 1, 0);
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
   }
 

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -256,7 +256,7 @@
           SERIAL_ECHOPAIR(",x1_i=", x1_i);
           SERIAL_ECHOPAIR(",yi=", yi);
           SERIAL_CHAR(')');
-          SERIAL_EOL;
+          SERIAL_EOL();
           return NAN;
         }
 
@@ -276,7 +276,7 @@
           SERIAL_ECHOPAIR(", xi=", xi);
           SERIAL_ECHOPAIR(", y1_i=", y1_i);
           SERIAL_CHAR(')');
-          SERIAL_EOL;
+          SERIAL_EOL();
           return NAN;
         }
 
@@ -301,7 +301,7 @@
           SERIAL_ECHOPAIR("? in get_z_correction(lx0=", lx0);
           SERIAL_ECHOPAIR(", ly0=", ly0);
           SERIAL_CHAR(')');
-          SERIAL_EOL;
+          SERIAL_EOL();
 
           #if ENABLED(ULTRA_LCD)
             strcpy(lcd_status_message, "get_z_correction() indexes out of range.");
@@ -336,7 +336,7 @@
           if (DEBUGGING(MESH_ADJUST)) {
             SERIAL_ECHOPGM(" >>>---> ");
             SERIAL_ECHO_F(z0, 6);
-            SERIAL_EOL;
+            SERIAL_EOL();
           }
         #endif
 
@@ -352,7 +352,7 @@
               SERIAL_CHAR(',');
               SERIAL_ECHO(ly0);
               SERIAL_CHAR(')');
-              SERIAL_EOL;
+              SERIAL_EOL();
             }
           #endif
         }

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -406,7 +406,7 @@
         }
 
         if (isnan(z1) || isnan(z2) || isnan(z3)) { // probe_pt will return NAN if unreachable
-          SERIAL_ERROR_START;
+          SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("Attempt to probe off the bed.");
           goto LEAVE;
         }
@@ -643,7 +643,7 @@
               SERIAL_ECHO_F(z_values[x][y], 6);
               SERIAL_ECHOPAIR(" ; X ", LOGICAL_X_POSITION(mesh_index_to_xpos(x)));
               SERIAL_ECHOPAIR(", Y ", LOGICAL_Y_POSITION(mesh_index_to_ypos(y)));
-              SERIAL_EOL;
+              SERIAL_EOL();
             }
         return;
       }
@@ -766,12 +766,12 @@
     SERIAL_ECHOLNPAIR("# of samples: ", n);
     SERIAL_ECHOPGM("Mean Mesh Height: ");
     SERIAL_ECHO_F(mean, 6);
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     const float sigma = sqrt(sum_of_diff_squared / (n + 1));
     SERIAL_ECHOPGM("Standard Deviation: ");
     SERIAL_ECHO_F(sigma, 6);
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     if (g29_c_flag)
       for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
@@ -892,17 +892,17 @@
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPGM("d from 1st point: ");
         SERIAL_ECHO_F(d, 6);
-        SERIAL_EOL;
+        SERIAL_EOL();
         t = normal.x * (UBL_PROBE_PT_2_X) + normal.y * (UBL_PROBE_PT_2_Y);
         d = t + normal.z * z2;
         SERIAL_ECHOPGM("d from 2nd point: ");
         SERIAL_ECHO_F(d, 6);
-        SERIAL_EOL;
+        SERIAL_EOL();
         t = normal.x * (UBL_PROBE_PT_3_X) + normal.y * (UBL_PROBE_PT_3_Y);
         d = t + normal.z * z3;
         SERIAL_ECHOPGM("d from 3rd point: ");
         SERIAL_ECHO_F(d, 6);
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
     #endif
 
@@ -1080,7 +1080,7 @@
         if (g29_verbose_level > 2) {
           SERIAL_PROTOCOLPGM("Mesh Point Measured at: ");
           SERIAL_PROTOCOL_F(z_values[location.x_index][location.y_index], 6);
-          SERIAL_EOL;
+          SERIAL_EOL();
         }
       } while (location.x_index >= 0 && location.y_index >= 0);
 
@@ -1244,7 +1244,7 @@
       SERIAL_PROTOCOLPAIR("Mesh ", state.storage_slot);
       SERIAL_PROTOCOLPGM(" Loaded.");
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
     safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("UBL object count: ", (int)ubl_cnt);
@@ -1252,13 +1252,13 @@
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       SERIAL_PROTOCOL("planner.z_fade_height : ");
       SERIAL_PROTOCOL_F(planner.z_fade_height, 4);
-      SERIAL_EOL;
+      SERIAL_EOL();
     #endif
 
     #if HAS_BED_PROBE
       SERIAL_PROTOCOLPGM("zprobe_zoffset: ");
       SERIAL_PROTOCOL_F(zprobe_zoffset, 7);
-      SERIAL_EOL;
+      SERIAL_EOL();
     #endif
 
     SERIAL_ECHOLNPAIR("UBL_MESH_MIN_X  " STRINGIFY(UBL_MESH_MIN_X) "=", UBL_MESH_MIN_X);
@@ -1280,7 +1280,7 @@
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(25);
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     SERIAL_PROTOCOLPGM("Y-Axis Mesh Points at: ");
     for (uint8_t i = 0; i < GRID_MAX_POINTS_Y; i++) {
@@ -1288,19 +1288,19 @@
       SERIAL_PROTOCOLPGM("  ");
       safe_delay(25);
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
 
     #if HAS_KILL
       SERIAL_PROTOCOLPAIR("Kill pin on :", KILL_PIN);
       SERIAL_PROTOCOLLNPAIR("  state:", READ(KILL_PIN));
     #endif
-    SERIAL_EOL;
+    SERIAL_EOL();
     safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("ubl_state_at_invocation :", ubl_state_at_invocation);
-    SERIAL_EOL;
+    SERIAL_EOL();
     SERIAL_PROTOCOLLNPAIR("ubl_state_recursion_chk :", ubl_state_recursion_chk);
-    SERIAL_EOL;
+    SERIAL_EOL();
     safe_delay(50);
 
     SERIAL_PROTOCOLPAIR("Meshes go from ", hex_address((void*)settings.get_start_of_meshes()));
@@ -1308,9 +1308,9 @@
     safe_delay(50);
 
     SERIAL_PROTOCOLLNPAIR("sizeof(ubl) :  ", (int)sizeof(ubl));
-    SERIAL_EOL;
+    SERIAL_EOL();
     SERIAL_PROTOCOLLNPAIR("z_value[][] size: ", (int)sizeof(z_values));
-    SERIAL_EOL;
+    SERIAL_EOL();
     safe_delay(25);
 
     SERIAL_PROTOCOLLNPAIR("EEPROM free for UBL: ", hex_address((void*)(settings.get_end_of_meshes() - settings.get_start_of_meshes())));
@@ -1334,7 +1334,7 @@
     unsigned char cccc;
     uint16_t kkkk;
 
-    SERIAL_ECHO_START;
+    SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM("EEPROM Dump:");
     for (uint16_t i = 0; i < E2END + 1; i += 16) {
       if (!(i & 0x3)) idle();
@@ -1346,9 +1346,9 @@
         print_hex_byte(cccc);
         SERIAL_ECHO(' ');
       }
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 
   /**
@@ -1667,7 +1667,7 @@
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOPGM("   final >>>---> ");
             SERIAL_PROTOCOL_F(measured_z, 7);
-            SERIAL_EOL;
+            SERIAL_EOL();
           }
         #endif
 
@@ -1689,7 +1689,7 @@
       SERIAL_PROTOCOL_F(lsf_results.B, 7);
       SERIAL_ECHOPGM("  D=");
       SERIAL_PROTOCOL_F(lsf_results.D, 7);
-      SERIAL_EOL;
+      SERIAL_EOL();
     }
 
     vector_3 normal = vector_3(lsf_results.A, lsf_results.B, 1.0000).get_normal();
@@ -1753,7 +1753,7 @@
         SERIAL_PROTOCOL_F(lsf_results.B, 7);
         SERIAL_ECHOPGM("  D=");
         SERIAL_PROTOCOL_F(lsf_results.D, 7);
-        SERIAL_EOL;
+        SERIAL_EOL();
         safe_delay(55);
 
         SERIAL_ECHOPGM("bed plane normal = [");
@@ -1763,7 +1763,7 @@
         SERIAL_PROTOCOLCHAR(',');
         SERIAL_PROTOCOL_F(normal.z, 7);
         SERIAL_ECHOPGM("]\n");
-        SERIAL_EOL;
+        SERIAL_EOL();
       }
     #endif
 

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -97,7 +97,7 @@
     debug_echo_axis(E_AXIS);
     SERIAL_ECHOPGM(" )   ");
     SERIAL_ECHO(title);
-    SERIAL_EOL;
+    SERIAL_EOL();
 
   }
 
@@ -131,7 +131,7 @@
       SERIAL_ECHOPAIR(", ze=", end[Z_AXIS]);
       SERIAL_ECHOPAIR(", ee=", end[E_AXIS]);
       SERIAL_CHAR(')');
-      SERIAL_EOL;
+      SERIAL_EOL();
       debug_current_and_destination(PSTR("Start of ubl.line_to_destination()"));
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -4043,12 +4043,12 @@ void lcd_update() {
                 else if (encoderStepRate >= ENCODER_10X_STEPS_PER_SEC) encoderMultiplier = 10;
 
                 #if ENABLED(ENCODER_RATE_MULTIPLIER_DEBUG)
-                  SERIAL_ECHO_START;
+                  SERIAL_ECHO_START();
                   SERIAL_ECHOPAIR("Enc Step Rate: ", encoderStepRate);
                   SERIAL_ECHOPAIR("  Multiplier: ", encoderMultiplier);
                   SERIAL_ECHOPAIR("  ENCODER_10X_STEPS_PER_SEC: ", ENCODER_10X_STEPS_PER_SEC);
                   SERIAL_ECHOPAIR("  ENCODER_100X_STEPS_PER_SEC: ", ENCODER_100X_STEPS_PER_SEC);
-                  SERIAL_EOL;
+                  SERIAL_EOL();
                 #endif // ENCODER_RATE_MULTIPLIER_DEBUG
               }
 

--- a/Marlin/vector_3.cpp
+++ b/Marlin/vector_3.cpp
@@ -89,7 +89,7 @@ void vector_3::debug(const char * const title) {
   SERIAL_PROTOCOL_F(y, 6);
   SERIAL_PROTOCOLPGM(" z: ");
   SERIAL_PROTOCOL_F(z, 6);
-  SERIAL_EOL;
+  SERIAL_EOL();
 }
 
 void apply_rotation_xyz(matrix_3x3 matrix, float &x, float &y, float &z) {
@@ -152,7 +152,7 @@ void matrix_3x3::debug(const char * const title) {
       SERIAL_PROTOCOLCHAR(' ');
       count++;
     }
-    SERIAL_EOL;
+    SERIAL_EOL();
   }
 }
 

--- a/Marlin/watchdog.cpp
+++ b/Marlin/watchdog.cpp
@@ -46,7 +46,7 @@ void watchdog_init() {
 // Watchdog timer interrupt, called if main program blocks >4sec and manual reset is enabled.
 #if ENABLED(WATCHDOG_RESET_MANUAL)
   ISR(WDT_vect) {
-    SERIAL_ERROR_START;
+    SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM("Something is wrong, please turn off the printer.");
     kill(PSTR("ERR:Please Reset")); //kill blocks //16 characters so it fits on a 16x2 display
     while (1); //wait for user or serial reset


### PR DESCRIPTION
Add parentheses to `SERIAL_ECHO_START`, `SERIAL_ERROR_START`, and `SERIAL_EOL` so that editors and IDEs see as being like functions. This mainly affects syntax coloring, which is less intelligent than CLANG and Lint.

- Minor cleanup in gcode.h
- Remove conditional from string definitions for consistency