### PR TITLE
[Expo] Direct stepper chunk support

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -417,6 +417,8 @@ extern uint8_t active_extruder;
 
 void calculate_volumetric_multipliers();
 
+void send_chunk_ok();
+
 /**
  * Blocking movement and shorthand functions
  */

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -34,6 +34,17 @@
 
 // Disable HardwareSerial.cpp to support chips without a UART (Attiny, etc.)
 
+unsigned char chunk_buffer[NUM_CHUNK_BUFFERS][CHUNK_BUFFER_SIZE] = { { 0 } };
+uint8_t chunk_buffer_idx = 0;
+uint8_t chunk_response[NUM_CHUNK_BUFFERS] = { CHUNK_RESPONSE_NONE };
+volatile uint8_t chunk_respond_busy = 0;
+volatile uint32_t check_sum_failures = 0;
+volatile uint32_t chunks_done = 0;
+
+uint8_t chunk_stage = CHUNK_STAGE_WAIT;
+uint8_t chunk_buffer_iter = 0;
+unsigned char chunk_checksum = 0;
+
 #if !defined(USBCON) && (defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(UBRR2H) || defined(UBRR3H))
 
   #if UART_PRESENT(SERIAL_PORT)
@@ -136,18 +147,79 @@
 
   #endif // EMERGENCY_PARSER
 
+  //CHUNK RESPONSE
+
   FORCE_INLINE void store_char(unsigned char c) {
     CRITICAL_SECTION_START;
-      const uint8_t h = rx_buffer.head,
-                    i = (uint8_t)(h + 1) & (RX_BUFFER_SIZE - 1);
+      switch(chunk_stage) {
+      case CHUNK_STAGE_COLLECT:
+        chunk_buffer[chunk_buffer_idx][chunk_buffer_iter++] = c;
+        chunk_checksum ^= c;
 
-      // if we should be storing the received character into the location
-      // just before the tail (meaning that the head would advance to the
-      // current location of the tail), we're about to overflow the buffer
-      // and so we don't write the character or advance the head.
-      if (i != rx_buffer.tail) {
-        rx_buffer.buffer[h] = c;
-        rx_buffer.head = i;
+        //has not rolled back to 0, buffer still filling
+        if(chunk_buffer_iter)
+          break;
+
+        chunk_stage = CHUNK_STAGE_CHECKSUM;
+
+        break;
+      case CHUNK_STAGE_CHECKSUM:
+        chunk_stage = CHUNK_STAGE_WAIT;
+        chunks_done++;
+
+        chunk_response[chunk_buffer_idx] = CHUNK_RESPONSE_OK;
+
+        if(chunk_checksum == c)
+          break;
+
+        chunk_response[chunk_buffer_idx] = CHUNK_RESPONSE_FAIL;
+
+        check_sum_failures++;
+
+        break;
+      case CHUNK_STAGE_DRAIN:
+        chunk_buffer_iter++;
+
+        //has not rolled back to 0, buffer still filling
+        if(chunk_buffer_iter)
+          break;
+
+        chunk_stage = CHUNK_STAGE_DRAIN_POST;
+
+        break;
+      case CHUNK_STAGE_DRAIN_POST:
+        chunk_stage = CHUNK_STAGE_WAIT;
+        chunk_respond_busy++;
+
+        break;
+      case CHUNK_STAGE_WAIT:
+      default:
+        if(c == CHUNK_START_CHAR) {
+          uint8_t oldIndex = chunk_buffer_idx;
+
+          chunk_stage = CHUNK_STAGE_COLLECT;
+          chunk_buffer_iter = 0;
+          chunk_checksum = 0;
+          chunk_buffer_idx = (uint8_t)(chunk_buffer_idx + 1) % (NUM_CHUNK_BUFFERS - 1);
+
+          //if chunk is still busy, drain data and respond with a busy response
+          if(chunk_response[chunk_buffer_idx] != CHUNK_RESPONSE_NONE) {
+            chunk_buffer_idx = oldIndex;
+            chunk_stage = CHUNK_STAGE_DRAIN;
+          }
+        } else {
+          const uint8_t h = rx_buffer.head,
+                        i = (uint8_t)(h + 1) & (RX_BUFFER_SIZE - 1);
+
+          // if we should be storing the received character into the location
+          // just before the tail (meaning that the head would advance to the
+          // current location of the tail), we're about to overflow the buffer
+          // and so we don't write the character or advance the head.
+          if (i != rx_buffer.tail) {
+              rx_buffer.buffer[h] = c;
+              rx_buffer.head = i;
+          }
+        }
       }
     CRITICAL_SECTION_END;
 
@@ -355,9 +427,10 @@
   }
 
   #else
+
     void MarlinSerial::write(uint8_t c) {
-      while (!TEST(M_UCSRxA, M_UDREx))
-        ;
+      while (!TEST(M_UCSRxA, M_UDREx));
+
       M_UDRx = c;
     }
   #endif

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -91,8 +91,9 @@
 #define BYTE 0
 
 extern unsigned char chunk_buffer[NUM_CHUNK_BUFFERS][CHUNK_BUFFER_SIZE];
-extern uint8_t chunk_buffer_idx;
 extern uint8_t chunk_response[NUM_CHUNK_BUFFERS];
+
+extern volatile uint8_t chunk_buffer_idx;
 extern volatile uint8_t chunk_respond_busy;
 extern volatile uint32_t check_sum_failures;
 extern volatile uint32_t chunks_done;

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -38,6 +38,21 @@
   #define SERIAL_PORT 0
 #endif
 
+#define CHUNK_BUFFER_SIZE 256
+#define NUM_CHUNK_BUFFERS 16
+#define CHUNK_START_CHAR '!'
+
+#define CHUNK_STAGE_COLLECT 0
+#define CHUNK_STAGE_CHECKSUM 1
+#define CHUNK_STAGE_DRAIN 2
+#define CHUNK_STAGE_DRAIN_POST 3
+#define CHUNK_STAGE_WAIT 4
+
+#define CHUNK_RESPONSE_NONE 0
+#define CHUNK_RESPONSE_PENDING 1
+#define CHUNK_RESPONSE_OK 2
+#define CHUNK_RESPONSE_FAIL 3
+
 // The presence of the UBRRH register is used to detect a UART.
 #define UART_PRESENT(port) ((port == 0 && (defined(UBRRH) || defined(UBRR0H))) || \
                             (port == 1 && defined(UBRR1H)) || (port == 2 && defined(UBRR2H)) || \
@@ -74,6 +89,13 @@
 #define OCT 8
 #define BIN 2
 #define BYTE 0
+
+extern unsigned char chunk_buffer[NUM_CHUNK_BUFFERS][CHUNK_BUFFER_SIZE];
+extern uint8_t chunk_buffer_idx;
+extern uint8_t chunk_response[NUM_CHUNK_BUFFERS];
+extern volatile uint8_t chunk_respond_busy;
+extern volatile uint32_t check_sum_failures;
+extern volatile uint32_t chunks_done;
 
 #ifndef USBCON
   // Define constants and variables for buffering incoming serial data.  We're

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3266,7 +3266,7 @@ bool position_is_reachable(const float target[XYZ]
 inline void gcode_C0() {
   static uint32_t step_speed = 0;
 
-  uint8_t chunk_idx = 0;
+  uint8_t chunk_idx;
   uint8_t chunk_num = 1;
 
   if (code_seen('S'))

--- a/Marlin/chunk_support.cpp
+++ b/Marlin/chunk_support.cpp
@@ -2,12 +2,11 @@
 #include "Macros.h"
 #include "Configuration.h"
 #include "serial.h"
-#include "temperature.h"
 
 #define BLINK_LED LED_BUILTIN
 
-//wave tables, 4 bit move, +/- 7
-uint8_t block_moves[16][8] = {
+//wave tables, 3 bit move, +/- 7
+uint8_t segment_moves[16][8] = {
     { 1, 1, 1, 1, 1, 1, 1, 0 },//14 = 7
     { 1, 1, 1, 0, 1, 1, 1, 0 },//13 = 6
     { 0, 1, 1, 0, 1, 0, 1, 1 },//12 = 5
@@ -31,6 +30,8 @@ uint8_t block_moves[16][8] = {
 void send_chunk_ok() {
   static uint8_t chunk_respond_busy_done = 0;
 
+  const uint8_t startIdx = chunk_buffer_idx;
+
   //concurrently keep up with response counter, should auto roll over
   while(chunk_respond_busy_done != chunk_respond_busy) {
     SERIAL_PROTOCOLPGM("!busy");
@@ -38,9 +39,9 @@ void send_chunk_ok() {
     chunk_respond_busy_done++;
   }
 
-  //TODO: this needs to somehow respect ordering. Should we start from the current index?
-  for(int n = 0 ; n < NUM_CHUNK_BUFFERS ; n++) {
-    const int i = (uint8_t)(chunk_buffer_idx + n) % (NUM_CHUNK_BUFFERS - 1);
+  //this needs to respect ordering
+  for(uint8_t n = 0 ; n < NUM_CHUNK_BUFFERS ; n++) {
+    const int i = (uint8_t)(startIdx + n) % (NUM_CHUNK_BUFFERS - 1);
 
     switch(chunk_response[i]) {
     case CHUNK_RESPONSE_NONE:

--- a/Marlin/chunk_support.cpp
+++ b/Marlin/chunk_support.cpp
@@ -1,0 +1,68 @@
+#include "Arduino.h"
+#include "Macros.h"
+#include "Configuration.h"
+#include "serial.h"
+#include "temperature.h"
+
+#define BLINK_LED LED_BUILTIN
+
+//wave tables, 4 bit move, +/- 7
+uint8_t block_moves[16][8] = {
+    { 1, 1, 1, 1, 1, 1, 1, 0 },//14 = 7
+    { 1, 1, 1, 0, 1, 1, 1, 0 },//13 = 6
+    { 0, 1, 1, 0, 1, 0, 1, 1 },//12 = 5
+    { 0, 1, 0, 1, 0, 1, 0, 1 },//11 = 4
+    { 0, 1, 0, 0, 1, 0, 0, 1 },//10 = 3
+    { 0, 0, 1, 0, 0, 0, 1, 0 },//9 = 2
+    { 0, 0, 0, 0, 1, 0, 0, 0 },//8 = 1
+
+    { 0, 0, 0, 0, 0, 0, 0, 0 },//7 = 0
+
+    { 0, 0, 0, 0, 1, 0, 0, 0 },//8 = 1
+    { 0, 0, 1, 0, 0, 0, 1, 0 },//9 = 2
+    { 0, 1, 0, 0, 1, 0, 0, 1 },//10 = 3
+    { 0, 1, 0, 1, 0, 1, 0, 1 },//11 = 4
+    { 0, 1, 1, 0, 1, 0, 1, 1 },//12 = 5
+    { 1, 1, 1, 0, 1, 1, 1, 0 },//13 = 6
+    { 1, 1, 1, 1, 1, 1, 1, 0 },//14 = 7
+    { 0 }
+};
+
+void send_chunk_ok() {
+  static uint8_t chunk_respond_busy_done = 0;
+
+  //concurrently keep up with response counter, should auto roll over
+  while(chunk_respond_busy_done != chunk_respond_busy) {
+    SERIAL_PROTOCOLPGM("!busy");
+    SERIAL_EOL;
+    chunk_respond_busy_done++;
+  }
+
+  //TODO: this needs to somehow respect ordering. Should we start from the current index?
+  for(int n = 0 ; n < NUM_CHUNK_BUFFERS ; n++) {
+    const int i = (uint8_t)(chunk_buffer_idx + n) % (NUM_CHUNK_BUFFERS - 1);
+
+    switch(chunk_response[i]) {
+    case CHUNK_RESPONSE_NONE:
+    case CHUNK_RESPONSE_PENDING:
+      break;
+    case CHUNK_RESPONSE_OK:
+      SERIAL_PROTOCOLPGM("!ok ");
+      SERIAL_ECHO(i);
+      SERIAL_EOL;
+
+      chunk_response[i] = CHUNK_RESPONSE_PENDING;
+
+      break;
+    case CHUNK_RESPONSE_FAIL:
+      SERIAL_PROTOCOLPGM("!fail");
+      SERIAL_EOL;
+
+      chunk_response[i] = CHUNK_RESPONSE_NONE;
+
+      break;
+    }
+  }
+}
+
+

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -254,6 +254,8 @@
 #define MSG_FILAMENT_CHANGE_RESUME_1        _UxGT("Esperando imp.")
 #define MSG_FILAMENT_CHANGE_RESUME_2        _UxGT("para resumir")
 #define MSG_FILAMENT_CHANGE_HEAT_1          _UxGT("Oprima boton para")
+#define MSG_FILAMENT_CHANGE_HEAT_2          _UxGT("Calentar la boquilla")
 #define MSG_FILAMENT_CHANGE_HEATING_1       _UxGT("Calentando boquilla")
+#define MSG_FILAMENT_CHANGE_HEATING_2       _UxGT("Espere por favor")
 
 #endif // LANGUAGE_ES_H

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -84,6 +84,7 @@ typedef struct {
 
   // Fields used by the Bresenham algorithm for tracing the line
   int32_t steps[NUM_AXIS];                  // Step count along each axis
+
   uint32_t step_event_count;                // The number of step events required to complete this block
 
   #if ENABLED(MIXING_EXTRUDER)
@@ -94,9 +95,10 @@ typedef struct {
           decelerate_after,                 // The index of the step event on which to start decelerating
           acceleration_rate;                // The acceleration rate used for acceleration calculation
 
-  uint8_t direction_bits;                   // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
-
-  uint8_t chunk_idx;                        // Chunk index, used for chunk moves only
+  union {
+    uint8_t direction_bits;                 // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
+    uint8_t chunk_idx;                      // Chunk index, used for chunk moves only
+  };
 
   // Advance extrusion
   #if ENABLED(LIN_ADVANCE)

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -53,14 +53,18 @@ enum BlockFlagBit {
   BLOCK_BIT_START_FROM_FULL_HALT,
 
   // The block is busy
-  BLOCK_BIT_BUSY
+  BLOCK_BIT_BUSY,
+
+  //if the block is a predefined chunk instead of the normal trapezoid
+  BLOCK_BIT_IS_CHUNK
 };
 
 enum BlockFlag {
   BLOCK_FLAG_RECALCULATE          = _BV(BLOCK_BIT_RECALCULATE),
   BLOCK_FLAG_NOMINAL_LENGTH       = _BV(BLOCK_BIT_NOMINAL_LENGTH),
   BLOCK_FLAG_START_FROM_FULL_HALT = _BV(BLOCK_BIT_START_FROM_FULL_HALT),
-  BLOCK_FLAG_BUSY                 = _BV(BLOCK_BIT_BUSY)
+  BLOCK_FLAG_BUSY                 = _BV(BLOCK_BIT_BUSY),
+  BLOCK_FLAG_IS_CHUNK             = _BV(BLOCK_BIT_IS_CHUNK)
 };
 
 /**
@@ -91,6 +95,8 @@ typedef struct {
           acceleration_rate;                // The acceleration rate used for acceleration calculation
 
   uint8_t direction_bits;                   // The direction bit set for this block (refers to *_DIRECTION_BIT in config.h)
+
+  uint8_t chunk_idx;                        // Chunk index, used for chunk moves only
 
   // Advance extrusion
   #if ENABLED(LIN_ADVANCE)
@@ -283,6 +289,8 @@ class Planner {
 
     static void _set_position_mm(const float &a, const float &b, const float &c, const float &e);
 
+    static void buffer_chunk(const uint8_t chunk_idx, const uint8_t chunk_num, const uint8_t extruder, const uint32_t step_speed);
+
     /**
      * Add a new linear movement to the buffer.
      * The target is NOT translated to delta/scara
@@ -470,6 +478,8 @@ class Planner {
 };
 
 #define PLANNER_XY_FEEDRATE() (min(planner.max_feedrate_mm_s[X_AXIS], planner.max_feedrate_mm_s[Y_AXIS]))
+
+#define IS_CHUNK(block) (block->flag & BLOCK_FLAG_IS_CHUNK)
 
 extern Planner planner;
 

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -52,6 +52,8 @@
 class Stepper;
 extern Stepper stepper;
 
+extern const uint8_t block_moves[16][8];
+
 // intRes = intIn1 * intIn2 >> 16
 // uses:
 // r26 to store 0
@@ -327,7 +329,8 @@ class Stepper {
 
       static int8_t last_extruder = -1;
 
-      if (current_block->direction_bits != last_direction_bits || current_block->active_extruder != last_extruder) {
+      if ((current_block->direction_bits != last_direction_bits && !IS_CHUNK(current_block))
+          || current_block->active_extruder != last_extruder) {
         last_direction_bits = current_block->direction_bits;
         last_extruder = current_block->active_extruder;
         set_directions();
@@ -381,6 +384,7 @@ class Stepper {
     }
 
     static void digipot_init();
+    static void chunk_steps();
 
     #if HAS_MICROSTEPS
       static void microstep_init();

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -52,7 +52,7 @@
 class Stepper;
 extern Stepper stepper;
 
-extern const uint8_t block_moves[16][8];
+extern const uint8_t segment_moves[16][8];
 
 // intRes = intIn1 * intIn2 >> 16
 // uses:
@@ -104,6 +104,7 @@ class Stepper {
 
     // Counter variables for the Bresenham line tracer
     static long counter_X, counter_Y, counter_Z, counter_E;
+
     static volatile uint32_t step_events_completed; // The number of step events executed in the current block
 
     #if ENABLED(ADVANCE) || ENABLED(LIN_ADVANCE)
@@ -384,7 +385,7 @@ class Stepper {
     }
 
     static void digipot_init();
-    static void chunk_steps();
+    FORCE_INLINE static void chunk_steps();
 
     #if HAS_MICROSTEPS
       static void microstep_init();


### PR DESCRIPTION
**moving over to #7047**

This is an exposition PR intended to get feedback on a possible future addition to Marlin. I expect lots of input and there will be future changes, proper branch basing, etc. It should eventually just get closed out and not merged. (proof of concept?)

This feature adds a new G-code and serial extension that allows an external service to send direct step buffers to Marlin via USB serial. The intention here is to allow users that have the standard 8-bit control board and a more powerful external device to use the more powerful device to handle planning and step sequencing (the Raspberry Pi is the target hardware here). 

This feature addition allows an external device to concurrently upload chunks of 1024 steps to the device, and trigger their sequencing by using a new G-code command (currently, 'C0'). The protocol for updating chunk buffers themselves is a binary protocol that starts a packet using the control character '!'. This character is not used elsewhere in g-code (input anyways), and allows low-level processing of the serial sequence- enabling buffering independent of the command parser (all handled in the ISR). 

C0 command format:
_C0 **I**[chunk start index] **R**[number of chunks, defaults to 1] **S**[steps per second]_

The execution of the chunks is done by extending the Marlin block format with a field and flag that lets it execute the buffered chunk instead of looking for the normal trapezoid related parameters. The step speed is configurable, I've had success with 10k-30k steps/s, although 30k seems to starve the temperature ISR causing runaway errors.

The bandwidth/load limitations and whatnot were tested in advance, and the device seems capable of running healthy at 500kbps. 250kbps is probably also fine. My testing seemed to benchmark stable transfer bitrate at about half of the line bitrate (due to waiting for responses etc). This was with my test planner that doesn't implement the buffering pipeline as optimally as it could, otherwise effective bitrates could be closer to the max.

My external test planner: https://github.com/colinrgodsey/step-daemon

I finally got to a point where I could print a blazing fast 120mm/s benchy that seemed to provide the same dimensional accuracy to what I would normally get from Marlin (board is an MKS Base v1.4, Atmega 2560). So, figured it's time I start cramming things down "ye ol' open source pipeline".