### PR TITLE
Reduce Marlin by ~218 bytes

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -113,7 +113,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   bool Temperature::allow_cold_extrude = false;
-  uint16_t Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
+  int16_t Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
 #endif
 
 // private:

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -172,7 +172,7 @@ class Temperature {
 
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       static bool allow_cold_extrude;
-      static uint16_t extrude_min_temp;
+      static int16_t extrude_min_temp;
       static bool tooColdToExtrude(uint8_t e) {
         #if HOTENDS == 1
           UNUSED(e);


### PR DESCRIPTION
The code to print heater states is redundant and can be consolidated. With 1 extruder and a bed, this PR saves 218 bytes. With 2 or more extruders, it saves ~300 bytes.