### PR TITLE
Fix build when both PROBE_MANUALLY and MESH_LEVELING are defined

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1552,7 +1552,8 @@ void kill_screen(const char* lcd_msg) {
         lcd_synchronize();
       }
 
-    #elif ENABLED(PROBE_MANUALLY)
+    #endif
+    #if ENABLED(PROBE_MANUALLY)
 
       bool lcd_wait_for_move;
 


### PR DESCRIPTION
This at least fixes the build for when PROBE_MANUALLY is on.  With this fix
the probe will at least get through the X points at runtime and then hang.
(i.e. there is still a remainging issue with MESH_LEVELING).  However,
using AUTO_BED_LEVELING_BILINEAR works nicely with PROBE_MANUALLY.

As discussed here: https://github.com/MarlinFirmware/Marlin/issues/6595#issuecomment-306017166