### PR TITLE
Add Z Fade Height to M420 output if it is enabled

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9005,6 +9005,11 @@ void quickstop_stepper() {
 
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR("Bed Leveling ", new_status ? MSG_ON : MSG_OFF);
+    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPAIR("Fade Height ", planner.z_fade_height);
+    #endif
+   
   }
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9005,11 +9005,11 @@ void quickstop_stepper() {
 
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR("Bed Leveling ", new_status ? MSG_ON : MSG_OFF);
+
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       SERIAL_ECHO_START();
       SERIAL_ECHOLNPAIR("Fade Height ", planner.z_fade_height);
     #endif
-   
   }
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9008,7 +9008,11 @@ void quickstop_stepper() {
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       SERIAL_ECHO_START();
-      SERIAL_ECHOLNPAIR("Fade Height ", planner.z_fade_height);
+      SERIAL_ECHOPGM("Fade Height ");
+      if (planner.z_fade_height > 0.0)
+        SERIAL_ECHOLN(planner.z_fade_height);
+      else
+        SERIAL_ECHOLNPGM(MSG_OFF)
     #endif
   }
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9012,7 +9012,7 @@ void quickstop_stepper() {
       if (planner.z_fade_height > 0.0)
         SERIAL_ECHOLN(planner.z_fade_height);
       else
-        SERIAL_ECHOLNPGM(MSG_OFF)
+        SERIAL_ECHOLNPGM(MSG_OFF);
     #endif
   }
 #endif


### PR DESCRIPTION
When M420 is used, it echos the current state of the leveling.
With this change M420 will also echo the current value of the z fade height (if it is enabled).

This makes it easier to deduce what value the z fade height currently has.