### PR TITLE
Fix two UBL compile errors (one is AT90USB only and one affects all)

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -137,7 +137,11 @@
   void set_destination_to_current();
   void set_current_to_destination();
   void prepare_move_to_destination();
-  void sync_plan_position_e();
+  #if AVR_AT90USB1286_FAMILY  // Teensyduino & Printrboard IDE extensions have compile errors without this
+    inline void sync_plan_position_e() { planner.set_e_position_mm(current_position[E_AXIS]); }
+  #else
+    void sync_plan_position_e();
+  #endif
   #if ENABLED(NEWPANEL)
     void lcd_setstatusPGM(const char* const message, const int8_t level);
     void chirp_at_user();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5895,7 +5895,7 @@ inline void gcode_M17() {
 
     if (!DEBUGGING(DRYRUN) && unload_length != 0) {
       #if ENABLED(PREVENT_COLD_EXTRUSION)
-        if (!thermalManager.allow_cold_extrude && 
+        if (!thermalManager.allow_cold_extrude &&
             thermalManager.degTargetHotend(active_extruder) < thermalManager.extrude_min_temp) {
           SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM(MSG_TOO_COLD_FOR_M600);
@@ -7659,7 +7659,7 @@ inline void gcode_M18_M84() {
       #endif
     }
 
-    #if ENABLED(AUTO_BED_LEVELING_UBL)
+    #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  //only needed if have an LCD
       ubl_lcd_map_control = false;
       defer_return_to_status = false;
     #endif
@@ -12442,7 +12442,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     #if ENABLED(DISABLE_INACTIVE_E)
       disable_e_steppers();
     #endif
-    #if ENABLED(AUTO_BED_LEVELING_UBL)
+    #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  //only needed if have an LCD
       ubl_lcd_map_control = false;
       defer_return_to_status = false;
     #endif


### PR DESCRIPTION
On  AT90USB boards the G26 `void sync_plan_position_e();` doesn't work.  Rather than remove the "inline" qualifier in Marlin_main.cpp we decided to just make a local copy in G26.  **EDIT** - Made the local copy in G26 a conditional compile.

See issue #7015 for details.

NOTE - #7015 also talks about similar problems with `set_current_to_destination()` but that problem has disappeared in the last couple of days.

----

In Marlin_main.cpp the variables `ubl_lcd_map_control `and `defer_return_to_status `are enabled when UBL is enabled even if there is no LCD.  The solution is to add another condition to the conditional compiles.