### PR TITLE
ultralcd.cpp compile error - move definition of lcd_refresh_zprobe_zoffset

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1506,7 +1506,11 @@ void kill_screen(const char* lcd_msg) {
     static void lcd_load_settings()    { lcd_completion_feedback(settings.load()); }
   #endif
 
-  #if ENABLED(LCD_BED_LEVELING)
+  #if HAS_BED_PROBE && DISABLED(BABYSTEP_ZPROBE_OFFSET)
+    static void lcd_refresh_zprobe_zoffset() { refresh_zprobe_zoffset(); }
+  #endif
+
+#if ENABLED(LCD_BED_LEVELING)
 
     /**
      *
@@ -3155,10 +3159,6 @@ void kill_screen(const char* lcd_msg) {
         #endif // E_STEPPERS > 4
       #endif // E_STEPPERS > 3
     #endif // E_STEPPERS > 2
-  #endif
-
-  #if HAS_BED_PROBE && DISABLED(BABYSTEP_ZPROBE_OFFSET)
-    static void lcd_refresh_zprobe_zoffset() { refresh_zprobe_zoffset(); }
   #endif
 
   // M203 / M205 Velocity options

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -410,6 +410,7 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
 
 inline void lcd_implementation_status_message() {
   #if ENABLED(STATUS_MESSAGE_SCROLLING)
+    const bool blink = lcd_blink();
     static bool last_blink = false;
     const uint8_t slen = lcd_strlen(lcd_status_message);
     const char *stat = lcd_status_message + status_scroll_pos;


### PR DESCRIPTION
Move definition of `lcd_refresh_zprobe_zoffset` to before the first time it is used.

This was discovered in issue #7066.