### PR TITLE
LCD Panel Clean Up Work

### DIFF
--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -26,7 +26,6 @@
 #include "Marlin.h"
 
 #if ENABLED(ULTRA_LCD)
-
   #define BUTTON_EXISTS(BN) (defined(BTN_## BN) && BTN_## BN >= 0)
   #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
 
@@ -47,6 +46,7 @@
   bool lcd_detected(void);
 
   extern uint8_t lcdDrawUpdate;
+  extern char lcd_status_message[];
   inline void lcd_refresh() { lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; }
 
   #if HAS_BUZZER

--- a/Marlin/ultralcd_impl_DOGM.cpp
+++ b/Marlin/ultralcd_impl_DOGM.cpp
@@ -70,7 +70,7 @@ uint16_t lcd_contrast;
 char currentfont = 0;
 
 // The current graphical page being rendered
-u8g_page_t &page = ((u8g_pb_t *)((u8g.getU8g())->dev->dev_mem))->p;
+u8g_page_t page = ((u8g_pb_t *)((u8g.getU8g())->dev->dev_mem))->p;
 
 void lcd_setFont(const char font_nr) {
   switch (font_nr) {

--- a/Marlin/ultralcd_impl_DOGM.cpp
+++ b/Marlin/ultralcd_impl_DOGM.cpp
@@ -1,0 +1,6 @@
+#if ENABLED(DOGLCD)
+  #include "ultralcd_impl_DOGM.h"
+  #include <U8glib.h>
+#else
+  #include "ultralcd_impl_HD44780.h"
+#endif

--- a/Marlin/ultralcd_impl_DOGM.cpp
+++ b/Marlin/ultralcd_impl_DOGM.cpp
@@ -1,6 +1,39 @@
+#include "ultralcd.h"
+#if ENABLED(ULTRA_LCD)
+#include "Marlin.h"
+#include "language.h"
+#include "cardreader.h"
+#include "temperature.h"
+#include "planner.h"
+#include "stepper.h"
+#include "configuration_store.h"
+#include "utility.h"
+
+#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
+  #include "buzzer.h"
+#endif
+
+#if ENABLED(PRINTCOUNTER)
+  #include "printcounter.h"
+  #include "duration_t.h"
+#endif
+
+#if ENABLED(BLTOUCH)
+  #include "endstops.h"
+#endif
+
+#if ENABLED(AUTO_BED_LEVELING_UBL)
+  #include "ubl.h"
+  bool ubl_lcd_map_control = false;
+#endif
+
 #if ENABLED(DOGLCD)
   #include "ultralcd_impl_DOGM.h"
   #include <U8glib.h>
 #else
   #include "ultralcd_impl_HD44780.h"
+  #include "utf_mapper.h"
 #endif
+
+#endif //ULTRA_LCD
+

--- a/Marlin/ultralcd_impl_DOGM.cpp
+++ b/Marlin/ultralcd_impl_DOGM.cpp
@@ -1,6 +1,6 @@
-#include "ultralcd.h"
-#if ENABLED(ULTRA_LCD)
 #include "Marlin.h"
+#include "ultralcd.h"
+#if ENABLED(DOGLCD)
 #include "language.h"
 #include "cardreader.h"
 #include "temperature.h"
@@ -27,11 +27,280 @@
   bool ubl_lcd_map_control = false;
 #endif
 
-#if ENABLED(DOGLCD)
   #include "ultralcd_impl_DOGM.h"
   #include <U8glib.h>
-#else
-  #include "ultralcd_impl_HD44780.h"
+
+#if ENABLED(USE_SMALL_INFOFONT)
+  #include "dogm_font_data_6x9_marlin.h"
 #endif
+
+#include "dogm_font_data_Marlin_symbols.h"   // The Marlin special symbols
+
+#if DISABLED(SIMULATE_ROMFONT)
+  #if ENABLED(DISPLAY_CHARSET_ISO10646_1)
+    #include "dogm_font_data_ISO10646_1.h"
+  #elif ENABLED(DISPLAY_CHARSET_ISO10646_PL)
+    #include "dogm_font_data_ISO10646_1_PL.h"
+  #elif ENABLED(DISPLAY_CHARSET_ISO10646_5)
+    #include "dogm_font_data_ISO10646_5_Cyrillic.h"
+  #elif ENABLED(DISPLAY_CHARSET_ISO10646_KANA)
+    #include "dogm_font_data_ISO10646_Kana.h"
+  #elif ENABLED(DISPLAY_CHARSET_ISO10646_GREEK)
+    #include "dogm_font_data_ISO10646_Greek.h"
+  #elif ENABLED(DISPLAY_CHARSET_ISO10646_CN)
+    #include "dogm_font_data_ISO10646_CN.h"
+  #elif ENABLED(DISPLAY_CHARSET_ISO10646_TR)
+    #include "dogm_font_data_ISO10646_1_tr.h"
+  #else // fall-back
+    #include "dogm_font_data_ISO10646_1.h"
+  #endif
+#else // SIMULATE_ROMFONT
+  #if DISPLAY_CHARSET_HD44780 == JAPANESE
+    #include "dogm_font_data_HD44780_J.h"
+  #elif DISPLAY_CHARSET_HD44780 == WESTERN
+    #include "dogm_font_data_HD44780_W.h"
+  #elif DISPLAY_CHARSET_HD44780 == CYRILLIC
+    #include "dogm_font_data_HD44780_C.h"
+  #else // fall-back
+    #include "dogm_font_data_ISO10646_1.h"
+  #endif
+#endif // SIMULATE_ROMFONT
+
+uint16_t lcd_contrast;
+char currentfont = 0;
+
+// The current graphical page being rendered
+u8g_page_t &page = ((u8g_pb_t *)((u8g.getU8g())->dev->dev_mem))->p;
+
+void lcd_setFont(const char font_nr) {
+  switch (font_nr) {
+    case FONT_STATUSMENU : {u8g.setFont(FONT_STATUSMENU_NAME); currentfont = FONT_STATUSMENU;}; break;
+    case FONT_MENU       : {u8g.setFont(FONT_MENU_NAME); currentfont = FONT_MENU;}; break;
+    case FONT_SPECIAL    : {u8g.setFont(FONT_SPECIAL_NAME); currentfont = FONT_SPECIAL;}; break;
+    case FONT_MENU_EDIT  : {u8g.setFont(FONT_MENU_EDIT_NAME); currentfont = FONT_MENU_EDIT;}; break;
+    break;
+  }
+}
+
+void lcd_print(const char c) {
+  if (WITHIN(c, 1, LCD_STR_SPECIAL_MAX)) {
+    u8g.setFont(FONT_SPECIAL_NAME);
+    u8g.print(c);
+    lcd_setFont(currentfont);
+  }
+  else charset_mapper(c);
+}
+
+char lcd_print_and_count(const char c) {
+  if (WITHIN(c, 1, LCD_STR_SPECIAL_MAX)) {
+    u8g.setFont(FONT_SPECIAL_NAME);
+    u8g.print(c);
+    lcd_setFont(currentfont);
+    return 1;
+  }
+  else return charset_mapper(c);
+}
+
+/**
+ * Core LCD printing functions
+ * On DOGM all strings go through a filter for utf
+ * But only use lcd_print_utf and lcd_printPGM_utf for translated text
+ */
+void lcd_print(const char *str) { while (*str) lcd_print(*str++); }
+void lcd_printPGM(const char *str) { while (const char c = pgm_read_byte(str)) lcd_print(c), ++str; }
+
+void lcd_print_utf(const char *str, uint8_t n=LCD_WIDTH) {
+  char c;
+  while (n && (c = *str)) n -= charset_mapper(c), ++str;
+}
+
+void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
+  char c;
+  while (n && (c = pgm_read_byte(str))) n -= charset_mapper(c), ++str;
+}
+
+// Initialize or re-initialize the LCD
+void lcd_implementation_init() {
+
+  #if PIN_EXISTS(LCD_BACKLIGHT) // Enable LCD backlight
+    OUT_WRITE(LCD_BACKLIGHT_PIN, HIGH);
+  #endif
+
+  #if PIN_EXISTS(LCD_RESET)
+    OUT_WRITE(LCD_RESET_PIN, LOW); // perform a clean hardware reset
+    _delay_ms(5);
+    OUT_WRITE(LCD_RESET_PIN, HIGH);
+    _delay_ms(5); // delay to allow the display to initalize
+    u8g.begin(); // re-initialize the display
+  #endif
+
+  #if DISABLED(MINIPANEL) // setContrast not working for Mini Panel
+    u8g.setContrast(lcd_contrast);
+  #endif
+
+  #if ENABLED(LCD_SCREEN_ROT_90)
+    u8g.setRot90();   // Rotate screen by 90°
+  #elif ENABLED(LCD_SCREEN_ROT_180)
+    u8g.setRot180();  // Rotate screen by 180°
+  #elif ENABLED(LCD_SCREEN_ROT_270)
+    u8g.setRot270();  // Rotate screen by 270°
+  #endif
+
+  #if ENABLED(SHOW_BOOTSCREEN)
+    static bool show_bootscreen = true;
+
+    #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
+      if (show_bootscreen) {
+        u8g.firstPage();
+        do {
+          u8g.drawBitmapP(
+            (128 - (CUSTOM_BOOTSCREEN_BMPWIDTH))  /2,
+            ( 64 - (CUSTOM_BOOTSCREEN_BMPHEIGHT)) /2,
+            CEILING(CUSTOM_BOOTSCREEN_BMPWIDTH, 8), CUSTOM_BOOTSCREEN_BMPHEIGHT, custom_start_bmp);
+        } while (u8g.nextPage());
+        safe_delay(CUSTOM_BOOTSCREEN_TIMEOUT);
+      }
+    #endif // SHOW_CUSTOM_BOOTSCREEN
+
+    const uint8_t offx = (u8g.getWidth() - (START_BMPWIDTH)) / 2;
+
+    #if ENABLED(START_BMPHIGH)
+      constexpr uint8_t offy = 0;
+    #else
+      constexpr uint8_t offy = DOG_CHAR_HEIGHT;
+    #endif
+
+    const uint8_t txt1X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE1) - 1) * (DOG_CHAR_WIDTH)) / 2;
+
+    if (show_bootscreen) {
+      u8g.firstPage();
+      do {
+        u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
+        lcd_setFont(FONT_MENU);
+        #ifndef STRING_SPLASH_LINE2
+          u8g.drawStr(txt1X, u8g.getHeight() - (DOG_CHAR_HEIGHT), STRING_SPLASH_LINE1);
+        #else
+          const uint8_t txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1) * (DOG_CHAR_WIDTH)) / 2;
+          u8g.drawStr(txt1X, u8g.getHeight() - (DOG_CHAR_HEIGHT) * 3 / 2, STRING_SPLASH_LINE1);
+          u8g.drawStr(txt2X, u8g.getHeight() - (DOG_CHAR_HEIGHT) * 1 / 2, STRING_SPLASH_LINE2);
+        #endif
+      } while (u8g.nextPage());
+    }
+
+    show_bootscreen = false;
+
+  #endif // SHOW_BOOTSCREEN
+}
+
+
+// The kill screen is displayed for unrecoverable conditions
+void lcd_kill_screen() {
+  lcd_setFont(FONT_MENU);
+  u8g.setPrintPos(0, u8g.getHeight()/4*1);
+  lcd_print_utf(lcd_status_message);
+  u8g.setPrintPos(0, u8g.getHeight()/4*2);
+  lcd_printPGM(PSTR(MSG_HALTED));
+  u8g.setPrintPos(0, u8g.getHeight()/4*3);
+  lcd_printPGM(PSTR(MSG_PLEASE_RESET));
+}
+
+void lcd_implementation_clear() { } // Automatically cleared by Picture Loop
+
+void _draw_centered_temp(const int temp, const uint8_t x, const uint8_t y) {
+  const uint8_t degsize = 6 * (temp >= 100 ? 3 : temp >= 10 ? 2 : 1); // number's pixel width
+  u8g.setPrintPos(x - (18 - degsize) / 2, y); // move left if shorter
+  lcd_print(itostr3(temp));
+  lcd_printPGM(PSTR(LCD_STR_DEGREE " "));
+}
+
+void _draw_heater_status(const uint8_t x, const int8_t heater, const bool blink) {
+  #if HAS_TEMP_BED
+    bool isBed = heater < 0;
+  #else
+    const bool isBed = false;
+  #endif
+
+  if (PAGE_UNDER(7)) {
+    #if HEATER_IDLE_HANDLER
+      const bool is_idle = (!isBed ? thermalManager.is_heater_idle(heater) :
+      #if HAS_TEMP_BED
+        thermalManager.is_bed_idle()
+      #else
+        false
+      #endif
+      );
+
+      if (blink || !is_idle)
+    #endif
+    _draw_centered_temp((isBed ? thermalManager.degTargetBed() : thermalManager.degTargetHotend(heater)) + 0.5, x, 7); }
+
+  if (PAGE_CONTAINS(21, 28))
+    _draw_centered_temp((isBed ? thermalManager.degBed() : thermalManager.degHotend(heater)) + 0.5, x, 28);
+
+  if (PAGE_CONTAINS(17, 20)) {
+    const uint8_t h = isBed ? 7 : 8,
+                  y = isBed ? 18 : 17;
+    if (isBed ? thermalManager.isHeatingBed() : thermalManager.isHeatingHotend(heater)) {
+      u8g.setColorIndex(0); // white on black
+      u8g.drawBox(x + h, y, 2, 2);
+      u8g.setColorIndex(1); // black on white
+    }
+    else {
+      u8g.drawBox(x + h, y, 2, 2);
+    }
+  }
+}
+
+void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink) {
+  if (blink)
+    lcd_printPGM(pstr);
+  else {
+    if (!axis_homed[axis])
+      u8g.print('?');
+    else {
+      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
+        if (!axis_known_position[axis])
+          u8g.print(' ');
+        else
+      #endif
+      lcd_printPGM(pstr);
+    }
+  }
+}
+
+void lcd_implementation_status_message(const bool blink) {
+  #if ENABLED(STATUS_MESSAGE_SCROLLING)
+    static bool last_blink = false;
+    const uint8_t slen = lcd_strlen(lcd_status_message);
+    const char *stat = lcd_status_message + status_scroll_pos;
+    if (slen <= LCD_WIDTH)
+      lcd_print_utf(stat);                                      // The string isn't scrolling
+    else {
+      if (status_scroll_pos <= slen - LCD_WIDTH)
+        lcd_print_utf(stat);                                    // The string fills the screen
+      else {
+        uint8_t chars = LCD_WIDTH;
+        if (status_scroll_pos < slen) {                         // First string still visible
+          lcd_print_utf(stat);                                  // The string leaves space
+          chars -= slen - status_scroll_pos;                    // Amount of space left
+        }
+        u8g.print('.');                                         // Always at 1+ spaces left, draw a dot
+        if (--chars) {
+          if (status_scroll_pos < slen + 1)                     // Draw a second dot if there's space
+            --chars, u8g.print('.');
+          if (chars) lcd_print_utf(lcd_status_message, chars);  // Print a second copy of the message
+        }
+      }
+      if (last_blink != blink) {
+        last_blink = blink;
+        // Skip any non-printing bytes
+        if (status_scroll_pos < slen) while (!PRINTABLE(lcd_status_message[status_scroll_pos])) status_scroll_pos++;
+        if (++status_scroll_pos >= slen + 2) status_scroll_pos = 0;
+      }
+    }
+  #else
+    lcd_print_utf(lcd_status_message);
+  #endif
+}
 
 #endif //ULTRA_LCD

--- a/Marlin/ultralcd_impl_DOGM.cpp
+++ b/Marlin/ultralcd_impl_DOGM.cpp
@@ -32,8 +32,6 @@
   #include <U8glib.h>
 #else
   #include "ultralcd_impl_HD44780.h"
-  #include "utf_mapper.h"
 #endif
 
 #endif //ULTRA_LCD
-

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -189,9 +189,14 @@ extern uint16_t lcd_contrast;
 extern char currentfont;
 
 // The current graphical page being rendered
-extern u8g_t u8g;
-extern u8g_dev_t *dev
+extern u8g_dev_t *dev;
 extern u8g_page_t page;
+
+void lcd_implementation_init(
+//  #if ENABLED(LCD_PROGRESS_BAR)  // no progress bar for DOGM displays
+//    const bool info_screen_charset = true
+//  #endif
+);
 
 // For selective rendering within a Y range
 #define PAGE_UNDER(yb) (u8g.getU8g()->current_page.y0 <= (yb))
@@ -214,7 +219,7 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH);
 
 // The kill screen is displayed for unrecoverable conditions
 void lcd_kill_screen();
-void lcd_implementation_clear() { } // Automatically cleared by Picture Loop
+void lcd_implementation_clear();  // Automatically cleared by Picture Loop
 
 //
 // Status Screen

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -65,54 +65,40 @@
 #endif
 
 #if ENABLED(USE_SMALL_INFOFONT)
-  #include "dogm_font_data_6x9_marlin.h"
   #define FONT_STATUSMENU_NAME u8g_font_6x9
 #else
   #define FONT_STATUSMENU_NAME FONT_MENU_NAME
 #endif
 
-#include "dogm_font_data_Marlin_symbols.h"   // The Marlin special symbols
 #define FONT_SPECIAL_NAME Marlin_symbols
 
 #if DISABLED(SIMULATE_ROMFONT)
   #if ENABLED(DISPLAY_CHARSET_ISO10646_1)
-    #include "dogm_font_data_ISO10646_1.h"
     #define FONT_MENU_NAME ISO10646_1_5x7
   #elif ENABLED(DISPLAY_CHARSET_ISO10646_PL)
-    #include "dogm_font_data_ISO10646_1_PL.h"
     #define FONT_MENU_NAME ISO10646_1_PL_5x7
   #elif ENABLED(DISPLAY_CHARSET_ISO10646_5)
-    #include "dogm_font_data_ISO10646_5_Cyrillic.h"
     #define FONT_MENU_NAME ISO10646_5_Cyrillic_5x7
   #elif ENABLED(DISPLAY_CHARSET_ISO10646_KANA)
-    #include "dogm_font_data_ISO10646_Kana.h"
     #define FONT_MENU_NAME ISO10646_Kana_5x7
   #elif ENABLED(DISPLAY_CHARSET_ISO10646_GREEK)
-    #include "dogm_font_data_ISO10646_Greek.h"
     #define FONT_MENU_NAME ISO10646_Greek_5x7
   #elif ENABLED(DISPLAY_CHARSET_ISO10646_CN)
-    #include "dogm_font_data_ISO10646_CN.h"
     #define FONT_MENU_NAME ISO10646_CN
     #define TALL_FONT_CORRECTION 1
   #elif ENABLED(DISPLAY_CHARSET_ISO10646_TR)
-    #include "dogm_font_data_ISO10646_1_tr.h"
     #define FONT_MENU_NAME ISO10646_TR
   #else // fall-back
-    #include "dogm_font_data_ISO10646_1.h"
     #define FONT_MENU_NAME ISO10646_1_5x7
   #endif
 #else // SIMULATE_ROMFONT
   #if DISPLAY_CHARSET_HD44780 == JAPANESE
-    #include "dogm_font_data_HD44780_J.h"
     #define FONT_MENU_NAME HD44780_J_5x7
   #elif DISPLAY_CHARSET_HD44780 == WESTERN
-    #include "dogm_font_data_HD44780_W.h"
     #define FONT_MENU_NAME HD44780_W_5x7
   #elif DISPLAY_CHARSET_HD44780 == CYRILLIC
-    #include "dogm_font_data_HD44780_C.h"
     #define FONT_MENU_NAME HD44780_C_5x7
   #else // fall-back
-    #include "dogm_font_data_ISO10646_1.h"
     #define FONT_MENU_NAME ISO10646_1_5x7
   #endif
 #endif // SIMULATE_ROMFONT
@@ -199,249 +185,45 @@
 
 #include "utf_mapper.h"
 
-uint16_t lcd_contrast;
-static char currentfont = 0;
+extern uint16_t lcd_contrast;
+extern char currentfont;
 
 // The current graphical page being rendered
-u8g_page_t &page = ((u8g_pb_t *)((u8g.getU8g())->dev->dev_mem))->p;
+extern u8g_t u8g;
+extern u8g_dev_t *dev
+extern u8g_page_t page;
 
 // For selective rendering within a Y range
 #define PAGE_UNDER(yb) (u8g.getU8g()->current_page.y0 <= (yb))
 #define PAGE_CONTAINS(ya, yb) (PAGE_UNDER(yb) && u8g.getU8g()->current_page.y1 >= (ya))
 
-static void lcd_setFont(const char font_nr) {
-  switch (font_nr) {
-    case FONT_STATUSMENU : {u8g.setFont(FONT_STATUSMENU_NAME); currentfont = FONT_STATUSMENU;}; break;
-    case FONT_MENU       : {u8g.setFont(FONT_MENU_NAME); currentfont = FONT_MENU;}; break;
-    case FONT_SPECIAL    : {u8g.setFont(FONT_SPECIAL_NAME); currentfont = FONT_SPECIAL;}; break;
-    case FONT_MENU_EDIT  : {u8g.setFont(FONT_MENU_EDIT_NAME); currentfont = FONT_MENU_EDIT;}; break;
-    break;
-  }
-}
-
-void lcd_print(const char c) {
-  if (WITHIN(c, 1, LCD_STR_SPECIAL_MAX)) {
-    u8g.setFont(FONT_SPECIAL_NAME);
-    u8g.print(c);
-    lcd_setFont(currentfont);
-  }
-  else charset_mapper(c);
-}
-
-char lcd_print_and_count(const char c) {
-  if (WITHIN(c, 1, LCD_STR_SPECIAL_MAX)) {
-    u8g.setFont(FONT_SPECIAL_NAME);
-    u8g.print(c);
-    lcd_setFont(currentfont);
-    return 1;
-  }
-  else return charset_mapper(c);
-}
+void lcd_setFont(const char font_nr);
+void lcd_print(const char c);
+char lcd_print_and_count(const char c);
 
 /**
  * Core LCD printing functions
  * On DOGM all strings go through a filter for utf
  * But only use lcd_print_utf and lcd_printPGM_utf for translated text
  */
-void lcd_print(const char *str) { while (*str) lcd_print(*str++); }
-void lcd_printPGM(const char *str) { while (const char c = pgm_read_byte(str)) lcd_print(c), ++str; }
+void lcd_print(const char *str);
+void lcd_printPGM(const char *str);
+void lcd_print_utf(const char *str, uint8_t n=LCD_WIDTH);
+void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH);
 
-void lcd_print_utf(const char *str, uint8_t n=LCD_WIDTH) {
-  char c;
-  while (n && (c = *str)) n -= charset_mapper(c), ++str;
-}
-
-void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
-  char c;
-  while (n && (c = pgm_read_byte(str))) n -= charset_mapper(c), ++str;
-}
-
-// Initialize or re-initialize the LCD
-static void lcd_implementation_init() {
-
-  #if PIN_EXISTS(LCD_BACKLIGHT) // Enable LCD backlight
-    OUT_WRITE(LCD_BACKLIGHT_PIN, HIGH);
-  #endif
-
-  #if PIN_EXISTS(LCD_RESET)
-    OUT_WRITE(LCD_RESET_PIN, LOW); // perform a clean hardware reset
-    _delay_ms(5);
-    OUT_WRITE(LCD_RESET_PIN, HIGH);
-    _delay_ms(5); // delay to allow the display to initalize
-    u8g.begin(); // re-initialize the display
-  #endif
-
-  #if DISABLED(MINIPANEL) // setContrast not working for Mini Panel
-    u8g.setContrast(lcd_contrast);
-  #endif
-
-  #if ENABLED(LCD_SCREEN_ROT_90)
-    u8g.setRot90();   // Rotate screen by 90°
-  #elif ENABLED(LCD_SCREEN_ROT_180)
-    u8g.setRot180();  // Rotate screen by 180°
-  #elif ENABLED(LCD_SCREEN_ROT_270)
-    u8g.setRot270();  // Rotate screen by 270°
-  #endif
-
-  #if ENABLED(SHOW_BOOTSCREEN)
-    static bool show_bootscreen = true;
-
-    #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
-      if (show_bootscreen) {
-        u8g.firstPage();
-        do {
-          u8g.drawBitmapP(
-            (128 - (CUSTOM_BOOTSCREEN_BMPWIDTH))  /2,
-            ( 64 - (CUSTOM_BOOTSCREEN_BMPHEIGHT)) /2,
-            CEILING(CUSTOM_BOOTSCREEN_BMPWIDTH, 8), CUSTOM_BOOTSCREEN_BMPHEIGHT, custom_start_bmp);
-        } while (u8g.nextPage());
-        safe_delay(CUSTOM_BOOTSCREEN_TIMEOUT);
-      }
-    #endif // SHOW_CUSTOM_BOOTSCREEN
-
-    const uint8_t offx = (u8g.getWidth() - (START_BMPWIDTH)) / 2;
-
-    #if ENABLED(START_BMPHIGH)
-      constexpr uint8_t offy = 0;
-    #else
-      constexpr uint8_t offy = DOG_CHAR_HEIGHT;
-    #endif
-
-    const uint8_t txt1X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE1) - 1) * (DOG_CHAR_WIDTH)) / 2;
-
-    if (show_bootscreen) {
-      u8g.firstPage();
-      do {
-        u8g.drawBitmapP(offx, offy, START_BMPBYTEWIDTH, START_BMPHEIGHT, start_bmp);
-        lcd_setFont(FONT_MENU);
-        #ifndef STRING_SPLASH_LINE2
-          u8g.drawStr(txt1X, u8g.getHeight() - (DOG_CHAR_HEIGHT), STRING_SPLASH_LINE1);
-        #else
-          const uint8_t txt2X = (u8g.getWidth() - (sizeof(STRING_SPLASH_LINE2) - 1) * (DOG_CHAR_WIDTH)) / 2;
-          u8g.drawStr(txt1X, u8g.getHeight() - (DOG_CHAR_HEIGHT) * 3 / 2, STRING_SPLASH_LINE1);
-          u8g.drawStr(txt2X, u8g.getHeight() - (DOG_CHAR_HEIGHT) * 1 / 2, STRING_SPLASH_LINE2);
-        #endif
-      } while (u8g.nextPage());
-    }
-
-    show_bootscreen = false;
-
-  #endif // SHOW_BOOTSCREEN
-}
 
 // The kill screen is displayed for unrecoverable conditions
-void lcd_kill_screen() {
-  lcd_setFont(FONT_MENU);
-  u8g.setPrintPos(0, u8g.getHeight()/4*1);
-  lcd_print_utf(lcd_status_message);
-  u8g.setPrintPos(0, u8g.getHeight()/4*2);
-  lcd_printPGM(PSTR(MSG_HALTED));
-  u8g.setPrintPos(0, u8g.getHeight()/4*3);
-  lcd_printPGM(PSTR(MSG_PLEASE_RESET));
-}
-
+void lcd_kill_screen();
 void lcd_implementation_clear() { } // Automatically cleared by Picture Loop
 
 //
 // Status Screen
 //
 
-FORCE_INLINE void _draw_centered_temp(const int16_t temp, const uint8_t x, const uint8_t y) {
-  const uint8_t degsize = 6 * (temp >= 100 ? 3 : temp >= 10 ? 2 : 1); // number's pixel width
-  u8g.setPrintPos(x - (18 - degsize) / 2, y); // move left if shorter
-  lcd_print(itostr3(temp));
-  lcd_printPGM(PSTR(LCD_STR_DEGREE " "));
-}
-
-FORCE_INLINE void _draw_heater_status(const uint8_t x, const int8_t heater, const bool blink) {
-  #if HAS_TEMP_BED
-    bool isBed = heater < 0;
-  #else
-    const bool isBed = false;
-  #endif
-
-  if (PAGE_UNDER(7)) {
-    #if HEATER_IDLE_HANDLER
-      const bool is_idle = (!isBed ? thermalManager.is_heater_idle(heater) :
-      #if HAS_TEMP_BED
-        thermalManager.is_bed_idle()
-      #else
-        false
-      #endif
-      );
-
-      if (blink || !is_idle)
-    #endif
-    _draw_centered_temp((isBed ? thermalManager.degTargetBed() : thermalManager.degTargetHotend(heater)) + 0.5, x, 7); }
-
-  if (PAGE_CONTAINS(21, 28))
-    _draw_centered_temp((isBed ? thermalManager.degBed() : thermalManager.degHotend(heater)) + 0.5, x, 28);
-
-  if (PAGE_CONTAINS(17, 20)) {
-    const uint8_t h = isBed ? 7 : 8,
-                  y = isBed ? 18 : 17;
-    if (isBed ? thermalManager.isHeatingBed() : thermalManager.isHeatingHotend(heater)) {
-      u8g.setColorIndex(0); // white on black
-      u8g.drawBox(x + h, y, 2, 2);
-      u8g.setColorIndex(1); // black on white
-    }
-    else {
-      u8g.drawBox(x + h, y, 2, 2);
-    }
-  }
-}
-
-FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink) {
-  if (blink)
-    lcd_printPGM(pstr);
-  else {
-    if (!axis_homed[axis])
-      u8g.print('?');
-    else {
-      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
-        if (!axis_known_position[axis])
-          u8g.print(' ');
-        else
-      #endif
-      lcd_printPGM(pstr);
-    }
-  }
-}
-
-inline void lcd_implementation_status_message(const bool blink) {
-  #if ENABLED(STATUS_MESSAGE_SCROLLING)
-    static bool last_blink = false;
-    const uint8_t slen = lcd_strlen(lcd_status_message);
-    const char *stat = lcd_status_message + status_scroll_pos;
-    if (slen <= LCD_WIDTH)
-      lcd_print_utf(stat);                                      // The string isn't scrolling
-    else {
-      if (status_scroll_pos <= slen - LCD_WIDTH)
-        lcd_print_utf(stat);                                    // The string fills the screen
-      else {
-        uint8_t chars = LCD_WIDTH;
-        if (status_scroll_pos < slen) {                         // First string still visible
-          lcd_print_utf(stat);                                  // The string leaves space
-          chars -= slen - status_scroll_pos;                    // Amount of space left
-        }
-        u8g.print('.');                                         // Always at 1+ spaces left, draw a dot
-        if (--chars) {
-          if (status_scroll_pos < slen + 1)                     // Draw a second dot if there's space
-            --chars, u8g.print('.');
-          if (chars) lcd_print_utf(lcd_status_message, chars);  // Print a second copy of the message
-        }
-      }
-      if (last_blink != blink) {
-        last_blink = blink;
-        // Skip any non-printing bytes
-        if (status_scroll_pos < slen) while (!PRINTABLE(lcd_status_message[status_scroll_pos])) status_scroll_pos++;
-        if (++status_scroll_pos >= slen + 2) status_scroll_pos = 0;
-      }
-    }
-  #else
-    lcd_print_utf(lcd_status_message);
-  #endif
-}
+void _draw_centered_temp(const int temp, const uint8_t x, const uint8_t y);
+void _draw_heater_status(const uint8_t x, const int8_t heater, const bool blink);
+void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink);
+void lcd_implementation_status_message(const bool blink);
 
 //#define DOGM_SD_PERCENT
 

--- a/Marlin/ultralcd_impl_HD44780.cpp
+++ b/Marlin/ultralcd_impl_HD44780.cpp
@@ -1,0 +1,6 @@
+#if ENABLED(DOGLCD)
+  #include "ultralcd_impl_DOGM.h"
+  #include <U8glib.h>
+#else
+  #include "ultralcd_impl_HD44780.h"
+#endif

--- a/Marlin/ultralcd_impl_HD44780.cpp
+++ b/Marlin/ultralcd_impl_HD44780.cpp
@@ -1,6 +1,39 @@
+#include "ultralcd.h"
+#if ENABLED(ULTRA_LCD)
+#include "Marlin.h"
+#include "language.h"
+#include "cardreader.h"
+#include "temperature.h"
+#include "planner.h"
+#include "stepper.h"
+#include "configuration_store.h"
+#include "utility.h"
+
+#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
+  #include "buzzer.h"
+#endif
+
+#if ENABLED(PRINTCOUNTER)
+  #include "printcounter.h"
+  #include "duration_t.h"
+#endif
+
+#if ENABLED(BLTOUCH)
+  #include "endstops.h"
+#endif
+
+#if ENABLED(AUTO_BED_LEVELING_UBL)
+  #include "ubl.h"
+  bool ubl_lcd_map_control = false;
+#endif
+
 #if ENABLED(DOGLCD)
   #include "ultralcd_impl_DOGM.h"
   #include <U8glib.h>
 #else
   #include "ultralcd_impl_HD44780.h"
+  #include "utf_mapper.h"
 #endif
+
+#endif //ULTRA_LCD
+

--- a/Marlin/ultralcd_impl_HD44780.cpp
+++ b/Marlin/ultralcd_impl_HD44780.cpp
@@ -1,6 +1,6 @@
+#include "Marlin.h"
 #include "ultralcd.h"
 #if ENABLED(ULTRA_LCD)
-#include "Marlin.h"
 #include "language.h"
 #include "cardreader.h"
 #include "temperature.h"

--- a/Marlin/ultralcd_impl_HD44780.cpp
+++ b/Marlin/ultralcd_impl_HD44780.cpp
@@ -32,8 +32,6 @@
   #include <U8glib.h>
 #else
   #include "ultralcd_impl_HD44780.h"
-  #include "utf_mapper.h"
 #endif
 
 #endif //ULTRA_LCD
-

--- a/Marlin/ultralcd_st7920_u8glib_rrd.cpp
+++ b/Marlin/ultralcd_st7920_u8glib_rrd.cpp
@@ -1,0 +1,114 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Marlin.h"
+
+#if ENABLED(U8GLIB_ST7920)
+
+#include "ultralcd_st7920_u8glib_rrd.h"
+
+#include <U8glib.h>
+
+static void ST7920_SWSPI_SND_8BIT(uint8_t val) {
+  ST7920_SND_BIT; // 1
+  ST7920_SND_BIT; // 2
+  ST7920_SND_BIT; // 3
+  ST7920_SND_BIT; // 4
+  ST7920_SND_BIT; // 5
+  ST7920_SND_BIT; // 6
+  ST7920_SND_BIT; // 7
+  ST7920_SND_BIT; // 8
+}
+
+
+
+uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
+  uint8_t i, y;
+  switch (msg) {
+    case U8G_DEV_MSG_INIT: {
+      OUT_WRITE(ST7920_CS_PIN, LOW);
+      OUT_WRITE(ST7920_DAT_PIN, LOW);
+      OUT_WRITE(ST7920_CLK_PIN, HIGH);
+
+      ST7920_CS();
+      u8g_Delay(120);                 //initial delay for boot up
+      ST7920_SET_CMD();
+      ST7920_WRITE_BYTE(0x08);       //display off, cursor+blink off
+      ST7920_WRITE_BYTE(0x01);       //clear CGRAM ram
+      u8g_Delay(15);                 //delay for CGRAM clear
+      ST7920_WRITE_BYTE(0x3E);       //extended mode + GDRAM active
+      for (y = 0; y < (LCD_PIXEL_HEIGHT) / 2; y++) { //clear GDRAM
+        ST7920_WRITE_BYTE(0x80 | y); //set y
+        ST7920_WRITE_BYTE(0x80);     //set x = 0
+        ST7920_SET_DAT();
+        for (i = 0; i < 2 * (LCD_PIXEL_WIDTH) / 8; i++) //2x width clears both segments
+          ST7920_WRITE_BYTE(0);
+        ST7920_SET_CMD();
+      }
+      ST7920_WRITE_BYTE(0x0C); //display on, cursor+blink off
+      ST7920_NCS();
+    }
+    break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT: {
+      uint8_t* ptr;
+      u8g_pb_t* pb = (u8g_pb_t*)(dev->dev_mem);
+      y = pb->p.page_y0;
+      ptr = (uint8_t*)pb->buf;
+
+      ST7920_CS();
+      for (i = 0; i < PAGE_HEIGHT; i ++) {
+        ST7920_SET_CMD();
+        if (y < 32) {
+          ST7920_WRITE_BYTE(0x80 | y);       //y
+          ST7920_WRITE_BYTE(0x80);           //x=0
+        }
+        else {
+          ST7920_WRITE_BYTE(0x80 | (y - 32)); //y
+          ST7920_WRITE_BYTE(0x80 | 8);       //x=64
+        }
+        ST7920_SET_DAT();
+        ST7920_WRITE_BYTES(ptr, (LCD_PIXEL_WIDTH) / 8); //ptr is incremented inside of macro
+        y++;
+      }
+      ST7920_NCS();
+    }
+    break;
+  }
+  #if PAGE_HEIGHT == 8
+    return u8g_dev_pb8h1_base_fn(u8g, dev, msg, arg);
+  #elif PAGE_HEIGHT == 16
+    return u8g_dev_pb16h1_base_fn(u8g, dev, msg, arg);
+  #else
+    return u8g_dev_pb32h1_base_fn(u8g, dev, msg, arg);
+  #endif
+}
+
+uint8_t   u8g_dev_st7920_128x64_rrd_buf[(LCD_PIXEL_WIDTH) * (PAGE_HEIGHT) / 8];
+u8g_pb_t  u8g_dev_st7920_128x64_rrd_pb = {{PAGE_HEIGHT, LCD_PIXEL_HEIGHT, 0, 0, 0}, LCD_PIXEL_WIDTH, u8g_dev_st7920_128x64_rrd_buf};
+u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi = {u8g_dev_rrd_st7920_128x64_fn, &u8g_dev_st7920_128x64_rrd_pb, &u8g_com_null_fn};
+
+#pragma GCC reset_options
+
+#endif // U8GLIB_ST7920
+

--- a/Marlin/ultralcd_st7920_u8glib_rrd.h
+++ b/Marlin/ultralcd_st7920_u8glib_rrd.h
@@ -88,17 +88,6 @@
   WRITE(ST7920_CLK_PIN, HIGH);       ST7920_DELAY_3; \
   val <<= 1
 
-static void ST7920_SWSPI_SND_8BIT(uint8_t val) {
-  ST7920_SND_BIT; // 1
-  ST7920_SND_BIT; // 2
-  ST7920_SND_BIT; // 3
-  ST7920_SND_BIT; // 4
-  ST7920_SND_BIT; // 5
-  ST7920_SND_BIT; // 6
-  ST7920_SND_BIT; // 7
-  ST7920_SND_BIT; // 8
-}
-
 #if defined(DOGM_SPI_DELAY_US) && DOGM_SPI_DELAY_US > 0
   #define U8G_DELAY() delayMicroseconds(DOGM_SPI_DELAY_US)
 #else
@@ -112,72 +101,11 @@ static void ST7920_SWSPI_SND_8BIT(uint8_t val) {
 #define ST7920_WRITE_BYTE(a)     { ST7920_SWSPI_SND_8BIT((uint8_t)((a)&0xF0u)); ST7920_SWSPI_SND_8BIT((uint8_t)((a)<<4u)); U8G_DELAY(); }
 #define ST7920_WRITE_BYTES(p,l)  { for (uint8_t i = l + 1; --i;) { ST7920_SWSPI_SND_8BIT(*p&0xF0); ST7920_SWSPI_SND_8BIT(*p<<4); p++; } U8G_DELAY(); }
 
-uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
-  uint8_t i, y;
-  switch (msg) {
-    case U8G_DEV_MSG_INIT: {
-      OUT_WRITE(ST7920_CS_PIN, LOW);
-      OUT_WRITE(ST7920_DAT_PIN, LOW);
-      OUT_WRITE(ST7920_CLK_PIN, HIGH);
+uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 
-      ST7920_CS();
-      u8g_Delay(120);                 //initial delay for boot up
-      ST7920_SET_CMD();
-      ST7920_WRITE_BYTE(0x08);       //display off, cursor+blink off
-      ST7920_WRITE_BYTE(0x01);       //clear CGRAM ram
-      u8g_Delay(15);                 //delay for CGRAM clear
-      ST7920_WRITE_BYTE(0x3E);       //extended mode + GDRAM active
-      for (y = 0; y < (LCD_PIXEL_HEIGHT) / 2; y++) { //clear GDRAM
-        ST7920_WRITE_BYTE(0x80 | y); //set y
-        ST7920_WRITE_BYTE(0x80);     //set x = 0
-        ST7920_SET_DAT();
-        for (i = 0; i < 2 * (LCD_PIXEL_WIDTH) / 8; i++) //2x width clears both segments
-          ST7920_WRITE_BYTE(0);
-        ST7920_SET_CMD();
-      }
-      ST7920_WRITE_BYTE(0x0C); //display on, cursor+blink off
-      ST7920_NCS();
-    }
-    break;
-    case U8G_DEV_MSG_STOP:
-      break;
-    case U8G_DEV_MSG_PAGE_NEXT: {
-      uint8_t* ptr;
-      u8g_pb_t* pb = (u8g_pb_t*)(dev->dev_mem);
-      y = pb->p.page_y0;
-      ptr = (uint8_t*)pb->buf;
-
-      ST7920_CS();
-      for (i = 0; i < PAGE_HEIGHT; i ++) {
-        ST7920_SET_CMD();
-        if (y < 32) {
-          ST7920_WRITE_BYTE(0x80 | y);       //y
-          ST7920_WRITE_BYTE(0x80);           //x=0
-        }
-        else {
-          ST7920_WRITE_BYTE(0x80 | (y - 32)); //y
-          ST7920_WRITE_BYTE(0x80 | 8);       //x=64
-        }
-        ST7920_SET_DAT();
-        ST7920_WRITE_BYTES(ptr, (LCD_PIXEL_WIDTH) / 8); //ptr is incremented inside of macro
-        y++;
-      }
-      ST7920_NCS();
-    }
-    break;
-  }
-  #if PAGE_HEIGHT == 8
-    return u8g_dev_pb8h1_base_fn(u8g, dev, msg, arg);
-  #elif PAGE_HEIGHT == 16
-    return u8g_dev_pb16h1_base_fn(u8g, dev, msg, arg);
-  #else
-    return u8g_dev_pb32h1_base_fn(u8g, dev, msg, arg);
-  #endif
-}
-
-uint8_t   u8g_dev_st7920_128x64_rrd_buf[(LCD_PIXEL_WIDTH) * (PAGE_HEIGHT) / 8] U8G_NOCOMMON;
-u8g_pb_t  u8g_dev_st7920_128x64_rrd_pb = {{PAGE_HEIGHT, LCD_PIXEL_HEIGHT, 0, 0, 0}, LCD_PIXEL_WIDTH, u8g_dev_st7920_128x64_rrd_buf};
-u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi = {u8g_dev_rrd_st7920_128x64_fn, &u8g_dev_st7920_128x64_rrd_pb, &u8g_com_null_fn};
+extern uint8_t   u8g_dev_st7920_128x64_rrd_buf[(LCD_PIXEL_WIDTH) * (PAGE_HEIGHT) / 8];
+extern u8g_pb_t  u8g_dev_st7920_128x64_rrd_pb;
+extern u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi;
 
 class U8GLIB_ST7920_128X64_RRD : public U8GLIB {
  public:
@@ -185,6 +113,6 @@ class U8GLIB_ST7920_128X64_RRD : public U8GLIB {
 };
 
 #pragma GCC reset_options
-
 #endif // U8GLIB_ST7920
 #endif // ULCDST7920_H
+


### PR DESCRIPTION
Do Not Merge -- Work in Progress.    We are trying to clean up the LCD Panel code.  The first phase of the work is to separate the Graphical and character (20x4) based code sections.    The first phase hopes to have no code generation being done in the .h files.   And to allow an LCD Panel .h file to be included by more than one .cpp file.     (That is currently not the case!)

Once that is accomplished there will be room for further clean up and improvements.   
- ultralcd.cpp probably will continue to hold code common to both Graphical and Character based displays.
- helper classes for ultralcd_impl_DOGM and ultralcd_impl_ULTIPANEL can be constructed to facilitate more sophisticated classes
- Simplify the menu construction and macro usage.

The first phase is just to do the surgery to separate the tangled mess and provide a foundation for later efforts.

PS.  This needs to be a Pull Request because we need to see what Travis is reporting about the current state of the code.  We don't have an easy way to get those results without having a Pull Request active.
