### PR TITLE
Add link to correct library for LCD controller LCD_I2C_SAINSMART_YWROBOT (Configuration.h)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1389,7 +1389,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/CL-260/Configuration.h
+++ b/Marlin/example_configurations/CL-260/Configuration.h
@@ -1386,7 +1386,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -1383,7 +1383,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1367,7 +1367,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -1367,7 +1367,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
@@ -1389,7 +1389,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -1375,7 +1375,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -1378,7 +1378,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1417,7 +1417,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -1385,7 +1385,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -1385,7 +1385,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/M150/Configuration.h
+++ b/Marlin/example_configurations/M150/Configuration.h
@@ -1412,7 +1412,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1385,7 +1385,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1385,7 +1385,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1400,7 +1400,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -1404,7 +1404,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -1441,7 +1441,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -1375,7 +1375,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1385,7 +1385,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1506,7 +1506,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -1507,7 +1507,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1496,7 +1496,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1499,7 +1499,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1504,7 +1504,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1562,7 +1562,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
@@ -1401,7 +1401,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1388,7 +1388,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1380,7 +1380,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -1390,7 +1390,8 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
-//#define LCD_I2C_SAINSMART_YWROBOT
+//#define LCD_I2C_SAINSMART_YWROBOT  // This board requires a different LiquidCrystal library. Download and
+                                     // install https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
 
 //
 // Generic LCM1602 LCD adapter


### PR DESCRIPTION
The link to the correct library for LCD_I2C_SAINSMART_YWROBOT is buried in Conditionals_LCD.h.  This PR adds that link to the Configuration.h files.

This oversight was the cause of issue #7115.