### PR TITLE
Add link to F. Malpartida LiquidCrystal library

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -129,8 +129,8 @@
    */
 
   #if ENABLED(LCD_I2C_SAINSMART_YWROBOT)
-    // This uses the LiquidCrystal_I2C library ( https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home )
-    // Make sure it is placed in the Arduino libraries directory.
+    // Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+    // https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
     #define LCD_I2C_TYPE_PCF8575
     #define LCD_I2C_ADDRESS 0x27   // I2C Address of the port expander
     #define ULTIPANEL

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1389,6 +1389,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/CL-260/Configuration.h
+++ b/Marlin/example_configurations/CL-260/Configuration.h
@@ -1386,6 +1386,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -1383,6 +1383,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1367,6 +1367,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -1367,6 +1367,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration.h
@@ -1389,6 +1389,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/Hephestos/Configuration.h
@@ -1375,6 +1375,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration.h
@@ -1378,6 +1378,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/K8200/Configuration.h
+++ b/Marlin/example_configurations/K8200/Configuration.h
@@ -1417,6 +1417,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/K8400/Configuration.h
+++ b/Marlin/example_configurations/K8400/Configuration.h
@@ -1385,6 +1385,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/K8400/Dual-head/Configuration.h
@@ -1385,6 +1385,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/M150/Configuration.h
+++ b/Marlin/example_configurations/M150/Configuration.h
@@ -1412,6 +1412,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1385,6 +1385,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1385,6 +1385,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1400,6 +1400,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/TAZ4/Configuration.h
@@ -1404,6 +1404,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -1441,6 +1441,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/WITBOX/Configuration.h
@@ -1375,6 +1375,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1385,6 +1385,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1506,6 +1506,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -1507,6 +1507,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1496,6 +1496,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1499,6 +1499,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1504,6 +1504,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1562,6 +1562,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration.h
@@ -1401,6 +1401,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1388,6 +1388,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1380,6 +1380,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -1390,6 +1390,9 @@
 //
 // Sainsmart YW Robot (LCM1602) LCD Display
 //
+// Note: This controller requires F.Malpartida's LiquidCrystal_I2C library
+// https://bitbucket.org/fmalpartida/new-liquidcrystal/wiki/Home
+//
 //#define LCD_I2C_SAINSMART_YWROBOT
 
 //


### PR DESCRIPTION
This library is required for the `LCD_I2C_SAINSMART_YWROBOT`.

Squashed, tweaked #7117 with more configurator-friendly comment style.