### PR TITLE
Fix #ifdef AVR_AT90USB1286_FAMILY in pinsDebug

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6438,7 +6438,7 @@ inline void gcode_M42() {
       }
       else {
         report_pin_state_extended(pin, I_flag, true, "Pulsing   ");
-        #ifdef AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
+        #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
           if (pin == 46) {
             SET_OUTPUT(46);
             for (int16_t j = 0; j < repeat; j++) {

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -484,7 +484,7 @@ inline void report_pin_state_extended(int8_t pin, bool ignore, bool extended = f
         if (pin_is_protected(pin) && !ignore)
           SERIAL_ECHOPGM("protected ");
         else {
-          #ifdef AVR_AT90USB1286_FAMILY //Teensy IDEs don't know about these pins so must use FASTIO
+          #if AVR_AT90USB1286_FAMILY //Teensy IDEs don't know about these pins so must use FASTIO
             if (pin == 46 || pin == 47) {
               if (pin == 46) {
                 print_input_or_output(GET_OUTPUT(46));
@@ -539,7 +539,7 @@ inline void report_pin_state_extended(int8_t pin, bool ignore, bool extended = f
       SERIAL_ECHO_SP(8);   // add padding if not an analog pin
     SERIAL_ECHOPGM("<unused/unknown>");
     if (extended) {
-      #ifdef AVR_AT90USB1286_FAMILY  //Teensy IDEs don't know about these pins so must use FASTIO
+      #if AVR_AT90USB1286_FAMILY  //Teensy IDEs don't know about these pins so must use FASTIO
         if (pin == 46 || pin == 47) {
           SERIAL_PROTOCOL_SP(12);
           if (pin == 46) {


### PR DESCRIPTION
Can't compile with PINS_DEBUGING enabled on Atmega1284p because it tries to enumerate pins 46 and 47 (which don't exist) because `#ifdef AVR_AT90USB1286_FAMILY ` doesn't work as expected.  Addresses #7151.