### PR TITLE
Adding M217 command to send text to serial

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -163,6 +163,7 @@
  * M209 - Turn Automatic Retract Detection on/off: S<0|1> (For slicers that don't support G10/11). (Requires FWRETRACT)
           Every normal extrude-only move will be classified as retract depending on the direction.
  * M211 - Enable, Disable, and/or Report software endstops: S<0|1> (Requires MIN_SOFTWARE_ENDSTOPS or MAX_SOFTWARE_ENDSTOPS)
+ * M217 - Send text to serial output.  Text is preceeded by "//".
  * M218 - Set a tool offset: "M218 T<index> X<offset> Y<offset>". (Requires 2 or more extruders)
  * M220 - Set Feedrate Percentage: "M220 S<percent>" (i.e., "FR" on the LCD)
  * M221 - Set Flow Percentage: "M221 S<percent>"
@@ -8434,6 +8435,21 @@ inline void gcode_M211() {
   SERIAL_ECHOLNPAIR(" " MSG_Z, soft_endstop_max[Z_AXIS]);
 }
 
+/**
+ * M217: Send text to serial output
+ *
+ * Usage: M217 some text
+ * Text must be prefixed by "//" and this will be prepended if it is not present
+ */
+inline void gcode_M217() {
+  if (strncmp(parser.string_arg, "//", 2) == 0) {
+    SERIAL_ECHOLN(parser.string_arg);
+  } 
+  else {
+    SERIAL_ECHOLNPAIR("// ", parser.string_arg);
+  } 
+}
+
 #if HOTENDS > 1
 
   /**
@@ -10822,6 +10838,10 @@ void process_next_command() {
 
       case 211: // M211: Enable, Disable, and/or Report software endstops
         gcode_M211();
+        break;
+
+      case 217: // M217: Echo string to serial output
+        gcode_M217();
         break;
 
       #if HOTENDS > 1

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -150,7 +150,7 @@ void GCodeParser::parse(char *p) {
   #endif
 
   // Only use string_arg for these M codes
-  if (letter == 'M') switch (codenum) { case 23: case 28: case 30: case 117: case 928: string_arg = p; return; default: break; }
+  if (letter == 'M') switch (codenum) { case 23: case 28: case 30: case 117: case 217: case 928: string_arg = p; return; default: break; }
 
   #if ENABLED(DEBUG_GCODE_PARSER)
     const bool debug = codenum == 800;


### PR DESCRIPTION
Allows the user to send text to the serial console in order to communicate with a host - sending debuging information or action commands, for example.  Text must begin with '//' and this is added if it is not already present at the beginning of the string.