### PR TITLE
Use parser.seenval, add shorthand functions

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -638,11 +638,11 @@
     g26_hotend_temp           = HOTEND_TEMP;
     g26_prime_flag            = 0;
 
-    g26_ooze_amount           = parser.seen('O') && parser.has_value() ? parser.value_linear_units() : OOZE_AMOUNT;
+    g26_ooze_amount           = parser.seenval('O') ? parser.value_linear_units() : OOZE_AMOUNT;
     g26_keep_heaters_on       = parser.seen('K') && parser.value_bool();
     g26_continue_with_closest = parser.seen('C') && parser.value_bool();
 
-    if (parser.seen('B')) {
+    if (parser.seenval('B')) {
       g26_bed_temp = parser.value_celsius();
       if (!WITHIN(g26_bed_temp, 15, 140)) {
         SERIAL_PROTOCOLLNPGM("?Specified bed temperature not plausible.");
@@ -650,7 +650,7 @@
       }
     }
 
-    if (parser.seen('L')) {
+    if (parser.seenval('L')) {
       g26_layer_height = parser.value_linear_units();
       if (!WITHIN(g26_layer_height, 0.0, 2.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified layer height not plausible.");
@@ -672,7 +672,7 @@
       }
     }
 
-    if (parser.seen('S')) {
+    if (parser.seenval('S')) {
       g26_nozzle = parser.value_float();
       if (!WITHIN(g26_nozzle, 0.1, 1.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified nozzle size not plausible.");
@@ -699,7 +699,7 @@
       }
     }
 
-    if (parser.seen('F')) {
+    if (parser.seenval('F')) {
       g26_filament_diameter = parser.value_linear_units();
       if (!WITHIN(g26_filament_diameter, 1.0, 4.0)) {
         SERIAL_PROTOCOLLNPGM("?Specified filament size not plausible.");
@@ -712,7 +712,7 @@
 
     g26_extrusion_multiplier *= g26_filament_diameter * sq(g26_nozzle) / sq(0.3); // Scale up by nozzle size
 
-    if (parser.seen('H')) {
+    if (parser.seenval('H')) {
       g26_hotend_temp = parser.value_celsius();
       if (!WITHIN(g26_hotend_temp, 165, 280)) {
         SERIAL_PROTOCOLLNPGM("?Specified nozzle temperature not plausible.");

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -638,9 +638,9 @@
     g26_hotend_temp           = HOTEND_TEMP;
     g26_prime_flag            = 0;
 
-    g26_ooze_amount           = parser.seenval('O') ? parser.value_linear_units() : OOZE_AMOUNT;
-    g26_keep_heaters_on       = parser.seen('K') && parser.value_bool();
-    g26_continue_with_closest = parser.seen('C') && parser.value_bool();
+    g26_ooze_amount           = parser.linearval('O', OOZE_AMOUNT);
+    g26_keep_heaters_on       = parser.boolval('K');
+    g26_continue_with_closest = parser.boolval('C');
 
     if (parser.seenval('B')) {
       g26_bed_temp = parser.value_celsius();
@@ -727,7 +727,7 @@
     }
 
     #if ENABLED(NEWPANEL)
-      g26_repeats = parser.seen('R') && parser.has_value() ? parser.value_int() : GRID_MAX_POINTS + 1;
+      g26_repeats = parser.intval('R', GRID_MAX_POINTS + 1);
     #else
       if (!parser.seen('R')) {
         SERIAL_PROTOCOLLNPGM("?(R)epeat must be specified when not using an LCD.");
@@ -741,8 +741,8 @@
       return UBL_ERR;
     }
 
-    g26_x_pos = parser.seen('X') ? parser.value_linear_units() : current_position[X_AXIS];
-    g26_y_pos = parser.seen('Y') ? parser.value_linear_units() : current_position[Y_AXIS];
+    g26_x_pos = parser.linearval('X', current_position[X_AXIS]);
+    g26_y_pos = parser.linearval('Y', current_position[Y_AXIS]);
     if (!position_is_reachable_xy(g26_x_pos, g26_y_pos)) {
       SERIAL_PROTOCOLLNPGM("?Specified X,Y coordinate out of bounds.");
       return UBL_ERR;

--- a/Marlin/M100_Free_Mem_Chk.cpp
+++ b/Marlin/M100_Free_Mem_Chk.cpp
@@ -189,19 +189,17 @@ void free_memory_pool_report(char * const ptr, const int16_t size) {
    *  This is useful to check the correctness of the M100 D and the M100 F commands.
    */
   void corrupt_free_memory(char *ptr, const uint16_t size) {
-    if (parser.seen('C')) {
-      ptr += 8;
-      const uint16_t near_top = top_of_stack() - ptr - 250, // -250 to avoid interrupt activity that's altered the stack.
-                     j = near_top / (size + 1);
+    ptr += 8;
+    const uint16_t near_top = top_of_stack() - ptr - 250, // -250 to avoid interrupt activity that's altered the stack.
+                   j = near_top / (size + 1);
 
-      SERIAL_ECHOLNPGM("Corrupting free memory block.\n");
-      for (uint16_t i = 1; i <= size; i++) {
-        char * const addr = ptr + i * j;
-        *addr = i;
-        SERIAL_ECHOPAIR("\nCorrupting address: ", hex_address(addr));
-      }
-      SERIAL_EOL();
+    SERIAL_ECHOLNPGM("Corrupting free memory block.\n");
+    for (uint16_t i = 1; i <= size; i++) {
+      char * const addr = ptr + i * j;
+      *addr = i;
+      SERIAL_ECHOPAIR("\nCorrupting address: ", hex_address(addr));
     }
+    SERIAL_EOL();
   }
 #endif // M100_FREE_MEMORY_CORRUPTOR
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1276,16 +1276,17 @@ void get_available_commands() {
  *
  * Returns TRUE if the target is invalid
  */
-bool get_target_extruder_from_command(int code) {
+bool get_target_extruder_from_command(const uint16_t code) {
   if (parser.seen('T')) {
-    if (parser.value_byte() >= EXTRUDERS) {
+    const int8_t e = parser.value_byte();
+    if (e >= EXTRUDERS) {
       SERIAL_ECHO_START();
       SERIAL_CHAR('M');
       SERIAL_ECHO(code);
-      SERIAL_ECHOLNPAIR(" " MSG_INVALID_EXTRUDER " ", parser.value_byte());
+      SERIAL_ECHOLNPAIR(" " MSG_INVALID_EXTRUDER " ", e);
       return true;
     }
-    target_extruder = parser.value_byte();
+    target_extruder = e;
   }
   else
     target_extruder = active_extruder;
@@ -5676,7 +5677,7 @@ inline void gcode_G92() {
         #if HAS_POSITION_SHIFT
           const float p = current_position[i];
         #endif
-        float v = parser.value_axis_units((AxisEnum)i);
+        const float v = parser.value_axis_units((AxisEnum)i);
 
         current_position[i] = v;
 
@@ -6405,7 +6406,7 @@ static bool pin_is_protected(const int8_t pin) {
 inline void gcode_M42() {
   if (!parser.seen('S')) return;
 
-  int pin_status = parser.value_int();
+  const int pin_status = parser.value_int();
   if (!WITHIN(pin_status, 0, 255)) return;
 
   int pin_number = parser.seen('P') ? parser.value_int() : LED_PIN;
@@ -6645,7 +6646,7 @@ inline void gcode_M42() {
    */
   inline void gcode_M43() {
 
-    if (parser.seen('T')) {   // must be first or else it's "S" and "E" parameters will execute endstop or servo test
+    if (parser.seen('T')) {   // must be first or else its "S" and "E" parameters will execute endstop or servo test
       toggle_pins();
       return;
     }
@@ -8268,10 +8269,10 @@ inline void gcode_M205() {
       home_offset[Z_AXIS] = parser.value_linear_units() - DELTA_HEIGHT;
       update_software_endstops(Z_AXIS);
     }
-    if (parser.seen('L')) delta_diagonal_rod = parser.value_linear_units();
-    if (parser.seen('R')) delta_radius = parser.value_linear_units();
-    if (parser.seen('S')) delta_segments_per_second = parser.value_float();
-    if (parser.seen('B')) delta_calibration_radius = parser.value_float();
+    if (parser.seen('L')) delta_diagonal_rod             = parser.value_linear_units();
+    if (parser.seen('R')) delta_radius                   = parser.value_linear_units();
+    if (parser.seen('S')) delta_segments_per_second      = parser.value_float();
+    if (parser.seen('B')) delta_calibration_radius       = parser.value_float();
     if (parser.seen('X')) delta_tower_angle_trim[A_AXIS] = parser.value_float();
     if (parser.seen('Y')) delta_tower_angle_trim[B_AXIS] = parser.value_float();
     if (parser.seen('Z')) { // rotate all 3 axis for Z = 0
@@ -8580,7 +8581,7 @@ inline void gcode_M226() {
    */
   inline void gcode_M280() {
     if (!parser.seen('P')) return;
-    int servo_index = parser.value_int();
+    const int servo_index = parser.value_int();
     if (WITHIN(servo_index, 0, NUM_SERVOS - 1)) {
       if (parser.seen('S'))
         MOVE_SERVO(servo_index, parser.value_int());
@@ -8753,7 +8754,7 @@ inline void gcode_M226() {
    *       M302 S170 P1 ; set min extrude temp to 170 but leave disabled
    */
   inline void gcode_M302() {
-    bool seen_S = parser.seen('S');
+    const bool seen_S = parser.seen('S');
     if (seen_S) {
       thermalManager.extrude_min_temp = parser.value_celsius();
       thermalManager.allow_cold_extrude = (thermalManager.extrude_min_temp == 0);
@@ -8960,10 +8961,12 @@ inline void gcode_M400() { stepper.synchronize(); }
    * M405: Turn on filament sensor for control
    */
   inline void gcode_M405() {
-    // This is technically a linear measurement, but since it's quantized to centimeters and is a different unit than
-    // everything else, it uses parser.value_int() instead of parser.value_linear_units().
-    if (parser.seen('D')) meas_delay_cm = parser.value_byte();
-    NOMORE(meas_delay_cm, MAX_MEASUREMENT_DELAY);
+    // This is technically a linear measurement, but since it's quantized to centimeters and is a different
+    // unit than everything else, it uses parser.value_byte() instead of parser.value_linear_units().
+    if (parser.seen('D')) {
+      meas_delay_cm = parser.value_byte();
+      NOMORE(meas_delay_cm, MAX_MEASUREMENT_DELAY);
+    }
 
     if (filwidth_delay_index[1] == -1) { // Initialize the ring buffer if not done since startup
       const uint8_t temp_ratio = thermalManager.widthFil_to_size_ratio() - 100; // -100 to scale within a signed byte

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1277,7 +1277,7 @@ void get_available_commands() {
  * Returns TRUE if the target is invalid
  */
 bool get_target_extruder_from_command(const uint16_t code) {
-  if (parser.seen('T')) {
+  if (parser.seenval('T')) {
     const int8_t e = parser.value_byte();
     if (e >= EXTRUDERS) {
       SERIAL_ECHO_START();
@@ -3135,7 +3135,7 @@ static void homeaxis(const AxisEnum axis) {
       const char* mixing_codes = "ABCDHI";
       byte mix_bits = 0;
       for (uint8_t i = 0; i < MIXING_STEPPERS; i++) {
-        if (parser.seen(mixing_codes[i])) {
+        if (parser.seenval(mixing_codes[i])) {
           SBI(mix_bits, i);
           float v = parser.value_float();
           NOLESS(v, 0.0);
@@ -3304,7 +3304,7 @@ inline void gcode_G0_G1(
       #endif
 
       float arc_offset[2] = { 0.0, 0.0 };
-      if (parser.seen('R')) {
+      if (parser.seenval('R')) {
         const float r = parser.value_linear_units(),
                     p1 = current_position[X_AXIS], q1 = current_position[Y_AXIS],
                     p2 = destination[X_AXIS], q2 = destination[Y_AXIS];
@@ -3321,8 +3321,8 @@ inline void gcode_G0_G1(
         }
       }
       else {
-        if (parser.seen('I')) arc_offset[0] = parser.value_linear_units();
-        if (parser.seen('J')) arc_offset[1] = parser.value_linear_units();
+        if (parser.seenval('I')) arc_offset[0] = parser.value_linear_units();
+        if (parser.seenval('J')) arc_offset[1] = parser.value_linear_units();
       }
 
       if (arc_offset[0] || arc_offset[1]) {
@@ -3358,8 +3358,8 @@ inline void gcode_G0_G1(
 inline void gcode_G4() {
   millis_t dwell_ms = 0;
 
-  if (parser.seen('P')) dwell_ms = parser.value_millis(); // milliseconds to wait
-  if (parser.seen('S')) dwell_ms = parser.value_millis_from_seconds(); // seconds to wait
+  if (parser.seenval('P')) dwell_ms = parser.value_millis(); // milliseconds to wait
+  if (parser.seenval('S')) dwell_ms = parser.value_millis_from_seconds(); // seconds to wait
 
   stepper.synchronize();
   refresh_cmd_timeout();
@@ -4111,7 +4111,7 @@ void home_all_axes() { gcode_G28(true); }
         break;
 
       case MeshSet:
-        if (parser.seen('X')) {
+        if (parser.seenval('X')) {
           px = parser.value_int() - 1;
           if (!WITHIN(px, 0, GRID_MAX_POINTS_X - 1)) {
             SERIAL_PROTOCOLLNPGM("X out of range (1-" STRINGIFY(GRID_MAX_POINTS_X) ").");
@@ -4123,7 +4123,7 @@ void home_all_axes() { gcode_G28(true); }
           return;
         }
 
-        if (parser.seen('Y')) {
+        if (parser.seenval('Y')) {
           py = parser.value_int() - 1;
           if (!WITHIN(py, 0, GRID_MAX_POINTS_Y - 1)) {
             SERIAL_PROTOCOLLNPGM("Y out of range (1-" STRINGIFY(GRID_MAX_POINTS_Y) ").");
@@ -4135,7 +4135,7 @@ void home_all_axes() { gcode_G28(true); }
           return;
         }
 
-        if (parser.seen('Z')) {
+        if (parser.seenval('Z')) {
           mbl.z_values[px][py] = parser.value_linear_units();
         }
         else {
@@ -4145,7 +4145,7 @@ void home_all_axes() { gcode_G28(true); }
         break;
 
       case MeshSetZOffset:
-        if (parser.seen('Z')) {
+        if (parser.seenval('Z')) {
           mbl.z_offset = parser.value_linear_units();
         }
         else {
@@ -4371,17 +4371,17 @@ void home_all_axes() { gcode_G28(true); }
             return;
           }
 
-          const float z = parser.seen('Z') && parser.has_value() ? parser.value_float() : RAW_CURRENT_POSITION(Z);
+          const float z = parser.seenval('Z') ? parser.value_float() : RAW_CURRENT_POSITION(Z);
           if (!WITHIN(z, -10, 10)) {
             SERIAL_ERROR_START();
             SERIAL_ERRORLNPGM("Bad Z value");
             return;
           }
 
-          const float x = parser.seen('X') && parser.has_value() ? parser.value_float() : NAN,
-                      y = parser.seen('Y') && parser.has_value() ? parser.value_float() : NAN;
-          int8_t i = parser.seen('I') && parser.has_value() ? parser.value_byte() : -1,
-                 j = parser.seen('J') && parser.has_value() ? parser.value_byte() : -1;
+          const float x = parser.seenval('X') ? parser.value_float() : NAN,
+                      y = parser.seenval('Y') ? parser.value_float() : NAN;
+          int8_t i = parser.seenval('I') ? parser.value_byte() : -1,
+                 j = parser.seenval('J') ? parser.value_byte() : -1;
 
           if (!isnan(x) && !isnan(y)) {
             // Get nearest i / j from x / y
@@ -4413,7 +4413,7 @@ void home_all_axes() { gcode_G28(true); }
 
       #endif
 
-      verbose_level = parser.seen('V') && parser.has_value() ? parser.value_int() : 0;
+      verbose_level = parser.seenval('V') ? parser.value_int() : 0;
       if (!WITHIN(verbose_level, 0, 4)) {
         SERIAL_PROTOCOLLNPGM("?(V)erbose level is implausible (0-4).");
         return;
@@ -4433,7 +4433,7 @@ void home_all_axes() { gcode_G28(true); }
         // These values may be saved with the completed mesh
         abl_grid_points_x = parser.seen('X') ? parser.value_int() : GRID_MAX_POINTS_X;
         abl_grid_points_y = parser.seen('Y') ? parser.value_int() : GRID_MAX_POINTS_Y;
-        if (parser.seen('P')) abl_grid_points_x = abl_grid_points_y = parser.value_int();
+        if (parser.seenval('P')) abl_grid_points_x = abl_grid_points_y = parser.value_int();
 
         if (abl_grid_points_x < 2 || abl_grid_points_y < 2) {
           SERIAL_PROTOCOLLNPGM("?Number of probe points is implausible (2 minimum).");
@@ -5595,7 +5595,7 @@ void home_all_axes() { gcode_G28(true); }
     // If any axis has enough movement, do the move
     LOOP_XYZ(i)
       if (FABS(destination[i] - current_position[i]) >= G38_MINIMUM_MOVE) {
-        if (!parser.seen('F')) feedrate_mm_s = homing_feedrate(i);
+        if (!parser.seenval('F')) feedrate_mm_s = homing_feedrate(i);
         // If G38.2 fails throw an error
         if (!G38_run_probe() && is_38_2) {
           SERIAL_ERROR_START();
@@ -5616,10 +5616,10 @@ void home_all_axes() { gcode_G28(true); }
    */
   inline void gcode_G42() {
     if (IsRunning()) {
-      const bool hasI = parser.seen('I');
-      const int8_t ix = parser.has_value() ? parser.value_int() : 0;
-      const bool hasJ = parser.seen('J');
-      const int8_t iy = parser.has_value() ? parser.value_int() : 0;
+      const bool hasI = parser.seenval('I');
+      const int8_t ix = hasI ? parser.value_int() : 0;
+      const bool hasJ = parser.seenval('J');
+      const int8_t iy = hasJ ? parser.value_int() : 0;
 
       if ((hasI && !WITHIN(ix, 0, GRID_MAX_POINTS_X - 1)) || (hasJ && !WITHIN(iy, 0, GRID_MAX_POINTS_Y - 1))) {
         SERIAL_ECHOLNPGM(MSG_ERR_MESH_XY);
@@ -5664,12 +5664,12 @@ void home_all_axes() { gcode_G28(true); }
  */
 inline void gcode_G92() {
   bool didXYZ = false,
-       didE = parser.seen('E');
+       didE = parser.seenval('E');
 
   if (!didE) stepper.synchronize();
 
   LOOP_XYZE(i) {
-    if (parser.seen(axis_codes[i])) {
+    if (parser.seenval(axis_codes[i])) {
       #if IS_SCARA
         current_position[i] = parser.value_axis_units((AxisEnum)i);
         if (i != E_AXIS) didXYZ = true;
@@ -5715,11 +5715,11 @@ inline void gcode_G92() {
 
     millis_t ms = 0;
     bool hasP = false, hasS = false;
-    if (parser.seen('P')) {
+    if (parser.seenval('P')) {
       ms = parser.value_millis(); // milliseconds to wait
       hasP = ms > 0;
     }
-    if (parser.seen('S')) {
+    if (parser.seenval('S')) {
       ms = parser.value_millis_from_seconds(); // seconds to wait
       hasS = ms > 0;
     }
@@ -6272,7 +6272,7 @@ inline void gcode_M17() {
    * M26: Set SD Card file index
    */
   inline void gcode_M26() {
-    if (card.cardOK && parser.seen('S'))
+    if (card.cardOK && parser.seenval('S'))
       card.setIndex(parser.value_long());
   }
 
@@ -6334,7 +6334,7 @@ inline void gcode_M31() {
     if (card.cardOK) {
       card.openFile(namestartpos, true, call_procedure);
 
-      if (parser.seen('S'))
+      if (parser.seenval('S'))
         card.setIndex(parser.value_long());
 
       card.startFileprint();
@@ -6370,8 +6370,8 @@ inline void gcode_M31() {
      */
     inline void gcode_M34() {
       if (parser.seen('S')) card.setSortOn(parser.value_bool());
-      if (parser.seen('F')) {
-        int v = parser.value_long();
+      if (parser.seenval('F')) {
+        const int v = parser.value_long();
         card.setSortFolders(v < 0 ? -1 : v > 0 ? 1 : 0);
       }
       //if (parser.seen('R')) card.setSortReverse(parser.value_bool());
@@ -6404,10 +6404,8 @@ static bool pin_is_protected(const int8_t pin) {
  *  S<byte> Pin status from 0 - 255
  */
 inline void gcode_M42() {
-  if (!parser.seen('S')) return;
-
-  const int pin_status = parser.value_int();
-  if (!WITHIN(pin_status, 0, 255)) return;
+  if (!parser.seenval('S')) return;
+  const byte pin_status = parser.value_byte();
 
   int pin_number = parser.seen('P') ? parser.value_int() : LED_PIN;
   if (pin_number < 0) return;
@@ -6666,8 +6664,8 @@ inline void gcode_M42() {
     }
 
     // Get the range of pins to test or watch
-    const uint8_t first_pin = parser.seen('P') ? parser.value_byte() : 0,
-                  last_pin = parser.seen('P') ? first_pin : NUM_DIGITAL_PINS - 1;
+    const uint8_t first_pin = parser.seenval('P') ? parser.value_byte() : 0,
+                  last_pin = parser.seenval('P') ? first_pin : NUM_DIGITAL_PINS - 1;
 
     if (first_pin > last_pin) return;
 
@@ -7026,7 +7024,7 @@ inline void gcode_M104() {
     if (target_extruder != active_extruder) return;
   #endif
 
-  if (parser.seen('S')) {
+  if (parser.seenval('S')) {
     const int16_t temp = parser.value_celsius();
     thermalManager.setTargetHotend(temp, target_extruder);
 
@@ -7153,7 +7151,7 @@ inline void gcode_M105() {
    * M155: Set temperature auto-report interval. M155 S<seconds>
    */
   inline void gcode_M155() {
-    if (parser.seen('S')) {
+    if (parser.seenval('S')) {
       auto_report_temp_interval = parser.value_byte();
       NOMORE(auto_report_temp_interval, 60);
       next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
@@ -7240,8 +7238,8 @@ inline void gcode_M109() {
     if (target_extruder != active_extruder) return;
   #endif
 
-  const bool no_wait_for_cooling = parser.seen('S');
-  if (no_wait_for_cooling || parser.seen('R')) {
+  const bool no_wait_for_cooling = parser.seenval('S');
+  if (no_wait_for_cooling || parser.seenval('R')) {
     const int16_t temp = parser.value_celsius();
     thermalManager.setTargetHotend(temp, target_extruder);
 
@@ -7389,8 +7387,8 @@ inline void gcode_M109() {
     if (DEBUGGING(DRYRUN)) return;
 
     LCD_MESSAGEPGM(MSG_BED_HEATING);
-    const bool no_wait_for_cooling = parser.seen('S');
-    if (no_wait_for_cooling || parser.seen('R')) {
+    const bool no_wait_for_cooling = parser.seenval('S');
+    if (no_wait_for_cooling || parser.seenval('R')) {
       thermalManager.setTargetBed(parser.value_celsius());
       #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
         if (parser.value_celsius() > BED_MINTEMP)
@@ -7497,7 +7495,7 @@ inline void gcode_M109() {
  * M110: Set Current Line Number
  */
 inline void gcode_M110() {
-  if (parser.seen('N')) gcode_LastN = parser.value_long();
+  if (parser.seenval('N')) gcode_LastN = parser.value_long();
 }
 
 /**
@@ -7547,7 +7545,7 @@ inline void gcode_M111() {
    *   S<seconds> Optional. Set the keepalive interval.
    */
   inline void gcode_M113() {
-    if (parser.seen('S')) {
+    if (parser.seenval('S')) {
       host_keepalive_interval = parser.value_byte();
       NOMORE(host_keepalive_interval, 60);
     }
@@ -7590,7 +7588,7 @@ inline void gcode_M111() {
  */
 inline void gcode_M140() {
   if (DEBUGGING(DRYRUN)) return;
-  if (parser.seen('S')) thermalManager.setTargetBed(parser.value_celsius());
+  if (parser.seenval('S')) thermalManager.setTargetBed(parser.value_celsius());
 }
 
 #if ENABLED(ULTIPANEL)
@@ -7611,16 +7609,16 @@ inline void gcode_M140() {
     }
     else {
       int v;
-      if (parser.seen('H')) {
+      if (parser.seenval('H')) {
         v = parser.value_int();
         lcd_preheat_hotend_temp[material] = constrain(v, EXTRUDE_MINTEMP, HEATER_0_MAXTEMP - 15);
       }
-      if (parser.seen('F')) {
+      if (parser.seenval('F')) {
         v = parser.value_int();
         lcd_preheat_fan_speed[material] = constrain(v, 0, 255);
       }
       #if TEMP_SENSOR_BED != 0
-        if (parser.seen('B')) {
+        if (parser.seenval('B')) {
           v = parser.value_int();
           lcd_preheat_bed_temp[material] = constrain(v, BED_MINTEMP, BED_MAXTEMP - 15);
         }
@@ -7635,9 +7633,9 @@ inline void gcode_M140() {
    * M149: Set temperature units
    */
   inline void gcode_M149() {
-         if (parser.seen('C')) parser.set_input_temp_units(TEMPUNIT_C);
-    else if (parser.seen('K')) parser.set_input_temp_units(TEMPUNIT_K);
-    else if (parser.seen('F')) parser.set_input_temp_units(TEMPUNIT_F);
+         if (parser.seenval('C')) parser.set_input_temp_units(TEMPUNIT_C);
+    else if (parser.seenval('K')) parser.set_input_temp_units(TEMPUNIT_K);
+    else if (parser.seenval('F')) parser.set_input_temp_units(TEMPUNIT_F);
   }
 #endif
 
@@ -7726,7 +7724,7 @@ inline void gcode_M83() { axis_relative_modes[E_AXIS] = true; }
  * M18, M84: Disable stepper motors
  */
 inline void gcode_M18_M84() {
-  if (parser.seen('S')) {
+  if (parser.seenval('S')) {
     stepper_inactive_time = parser.value_millis_from_seconds();
   }
   else {
@@ -8448,11 +8446,11 @@ inline void gcode_M211() {
   inline void gcode_M218() {
     if (get_target_extruder_from_command(218) || target_extruder == 0) return;
 
-    if (parser.seen('X')) hotend_offset[X_AXIS][target_extruder] = parser.value_linear_units();
-    if (parser.seen('Y')) hotend_offset[Y_AXIS][target_extruder] = parser.value_linear_units();
+    if (parser.seenval('X')) hotend_offset[X_AXIS][target_extruder] = parser.value_linear_units();
+    if (parser.seenval('Y')) hotend_offset[Y_AXIS][target_extruder] = parser.value_linear_units();
 
     #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_NOZZLE)
-      if (parser.seen('Z')) hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
+      if (parser.seenval('Z')) hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
     #endif
 
     SERIAL_ECHO_START();
@@ -8476,7 +8474,7 @@ inline void gcode_M211() {
  * M220: Set speed percentage factor, aka "Feed Rate" (M220 S95)
  */
 inline void gcode_M220() {
-  if (parser.seen('S')) feedrate_percentage = parser.value_int();
+  if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 }
 
 /**
@@ -8484,7 +8482,7 @@ inline void gcode_M220() {
  */
 inline void gcode_M221() {
   if (get_target_extruder_from_command(221)) return;
-  if (parser.seen('S'))
+  if (parser.seenval('S'))
     flow_percentage[target_extruder] = parser.value_int();
 }
 
@@ -9777,14 +9775,14 @@ inline void gcode_M907() {
    *       S# determines MS1 or MS2, X# sets the pin high/low.
    */
   inline void gcode_M351() {
-    if (parser.seen('S')) switch (parser.value_byte()) {
+    if (parser.seenval('S')) switch (parser.value_byte()) {
       case 1:
-        LOOP_XYZE(i) if (parser.seen(axis_codes[i])) stepper.microstep_ms(i, parser.value_byte(), -1);
-        if (parser.seen('B')) stepper.microstep_ms(4, parser.value_byte(), -1);
+        LOOP_XYZE(i) if (parser.seenval(axis_codes[i])) stepper.microstep_ms(i, parser.value_byte(), -1);
+        if (parser.seenval('B')) stepper.microstep_ms(4, parser.value_byte(), -1);
         break;
       case 2:
-        LOOP_XYZE(i) if (parser.seen(axis_codes[i])) stepper.microstep_ms(i, -1, parser.value_byte());
-        if (parser.seen('B')) stepper.microstep_ms(4, -1, parser.value_byte());
+        LOOP_XYZE(i) if (parser.seenval(axis_codes[i])) stepper.microstep_ms(i, -1, parser.value_byte());
+        if (parser.seenval('B')) stepper.microstep_ms(4, -1, parser.value_byte());
         break;
     }
     stepper.microstep_readings();
@@ -9827,8 +9825,8 @@ inline void gcode_M907() {
 inline void gcode_M355() {
   #if HAS_CASE_LIGHT
     uint8_t args = 0;
-    if (parser.seen('P')) ++args, case_light_brightness = parser.value_byte();
-    if (parser.seen('S')) ++args, case_light_on = parser.value_bool();
+    if (parser.seenval('P')) ++args, case_light_brightness = parser.value_byte();
+    if (parser.seenval('S')) ++args, case_light_on = parser.value_bool();
     if (args) update_case_light();
 
     // always report case light status

--- a/Marlin/SdFatStructs.h
+++ b/Marlin/SdFatStructs.h
@@ -523,7 +523,7 @@ struct directoryEntry {
   uint8_t  reservedNT;
           /**
            * The granularity of the seconds part of creationTime is 2 seconds
-           * so this field is a count of tenths of a second and its valid
+           * so this field is a count of tenths of a second and it's valid
            * value range is 0-199 inclusive. (WHG note - seems to be hundredths)
            */
   uint8_t  creationTimeTenths;

--- a/Marlin/example_configurations/K8400/README.md
+++ b/Marlin/example_configurations/K8400/README.md
@@ -2,7 +2,7 @@
 http://www.k8400.eu/
 
 Configuration files for the K8400, ported upstream from the official Velleman firmware.
-Like it's predecessor, (K8200), the K8400 is a 3Drag clone. There are some minor differences, documented in pins_K8400.h.
+Like its predecessor, (K8200), the K8400 is a 3Drag clone. There are some minor differences, documented in pins_K8400.h.
 
 Single and dual head configurations provided. Copy the correct Configuration.h and Configuration_adv.h to the /Marlin/ directory.
 

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -132,7 +132,7 @@ public:
 
     #define SEEN_TEST(L) TEST(codebits[(L - 'A') >> 3], (L - 'A') & 0x7)
 
-  #else
+  #else // !FASTER_GCODE_PARSER
 
     // Code is found in the string. If not found, value_ptr is unchanged.
     // This allows "if (seen('A')||seen('B'))" to use the last-found value.
@@ -147,7 +147,7 @@ public:
 
     #define SEEN_TEST(L) !!strchr(command_args, L)
 
-  #endif // FASTER_GCODE_PARSER
+  #endif // !FASTER_GCODE_PARSER
 
   // Populate all fields by parsing a single line of GCode
   // This uses 54 bytes of SRAM to speed up seen/value
@@ -157,7 +157,7 @@ public:
   FORCE_INLINE static bool has_value() { return value_ptr != NULL; }
 
   // Seen and has value
-  FORCE_INLINE static bool seenval(const char c) { return seen(c) && has_value(); }
+  inline static bool seenval(const char c) { return seen(c) && has_value(); }
 
   static volatile bool seen_axis() {
     return SEEN_TEST('X') || SEEN_TEST('Y') || SEEN_TEST('Z') || SEEN_TEST('E');
@@ -184,20 +184,20 @@ public:
   }
 
   // Code value as a long or ulong
-  inline          static long value_long()  { return value_ptr ? strtol(value_ptr, NULL, 10) : 0L; }
-  inline unsigned static long value_ulong() { return value_ptr ? strtoul(value_ptr, NULL, 10) : 0UL; }
+  inline static int32_t value_long() { return value_ptr ? strtol(value_ptr, NULL, 10) : 0L; }
+  inline static uint32_t value_ulong() { return value_ptr ? strtoul(value_ptr, NULL, 10) : 0UL; }
 
   // Code value for use as time
   FORCE_INLINE static millis_t value_millis() { return value_ulong(); }
   FORCE_INLINE static millis_t value_millis_from_seconds() { return value_float() * 1000UL; }
 
   // Reduce to fewer bits
-  FORCE_INLINE static int value_int()    { return (int)value_long(); }
-  FORCE_INLINE uint16_t value_ushort()   { return (uint16_t)value_long(); }
-  inline static uint8_t value_byte()     { return (uint8_t)(constrain(value_long(), 0, 255)); }
+  FORCE_INLINE static int16_t value_int() { return (int16_t)value_long(); }
+  FORCE_INLINE static uint16_t value_ushort() { return (uint16_t)value_long(); }
+  inline static uint8_t value_byte() { return (uint8_t)constrain(value_long(), 0, 255); }
 
   // Bool is true with no value or non-zero
-  inline static bool value_bool()        { return !has_value() || value_byte(); }
+  inline static bool value_bool() { return !has_value() || value_byte(); }
 
   // Units modes: Inches, Fahrenheit, Kelvin
 
@@ -282,12 +282,12 @@ public:
       }
     }
 
-  #else
+  #else // !TEMPERATURE_UNITS_SUPPORT
 
     FORCE_INLINE static float value_celsius()      { return value_float(); }
     FORCE_INLINE static float value_celsius_diff() { return value_float(); }
 
-  #endif
+  #endif // !TEMPERATURE_UNITS_SUPPORT
 
   FORCE_INLINE static float value_feedrate() { return value_linear_units(); }
 

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -293,6 +293,17 @@ public:
 
   void unknown_command_error();
 
+  // Provide simple value accessors with default option
+  FORCE_INLINE static float    floatval(const char c, const float dval=0.0)   { return seenval(c) ? value_float()        : dval; }
+  FORCE_INLINE static bool     boolval(const char c, const bool dval=false)   { return seen(c)    ? value_bool()         : dval; }
+  FORCE_INLINE static uint8_t  byteval(const char c, const uint8_t dval=0)    { return seenval(c) ? value_byte()         : dval; }
+  FORCE_INLINE static int16_t  intval(const char c, const int16_t dval=0)     { return seenval(c) ? value_int()          : dval; }
+  FORCE_INLINE static uint16_t ushortval(const char c, const uint16_t dval=0) { return seenval(c) ? value_ushort()       : dval; }
+  FORCE_INLINE static int32_t  longval(const char c, const int32_t dval=0)    { return seenval(c) ? value_long()         : dval; }
+  FORCE_INLINE static uint32_t ulongval(const char c, const uint32_t dval=0)  { return seenval(c) ? value_ulong()        : dval; }
+  FORCE_INLINE static float    linearval(const char c, const float dval=0.0)  { return seenval(c) ? value_linear_units() : dval; }
+  FORCE_INLINE static float    celsiusval(const char c, const float dval=0.0) { return seenval(c) ? value_celsius()      : dval; }
+
 };
 
 extern GCodeParser parser;

--- a/Marlin/servo.cpp
+++ b/Marlin/servo.cpp
@@ -95,7 +95,7 @@ static inline void handle_interrupts(timer16_Sequence_t timer, volatile uint16_t
   if (SERVO_INDEX(timer, Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
     *OCRnA = *TCNTn + SERVO(timer, Channel[timer]).ticks;
     if (SERVO(timer, Channel[timer]).Pin.isActive)    // check if activated
-      digitalWrite(SERVO(timer, Channel[timer]).Pin.nbr, HIGH); // its an active channel so pulse it high
+      digitalWrite(SERVO(timer, Channel[timer]).Pin.nbr, HIGH); // it's an active channel so pulse it high
   }
   else {
     // finished all channels so wait for the refresh period to expire before starting over

--- a/Marlin/twibus.h
+++ b/Marlin/twibus.h
@@ -38,18 +38,18 @@ typedef void (*twiRequestFunc_t)();
 /**
  * TWIBUS class
  *
- * This class implements a wrapper around the two wire (I2C) bus, it allows
- * Marlin to send and request data from any slave device on the bus. This is
- * an experimental feature and it's inner workings as well as public facing
- * interface are prune to change in the future.
+ * This class implements a wrapper around the two wire (I2C) bus, allowing
+ * Marlin to send and request data from any slave device on the bus.
  *
- * The two main consumers of this class are M260 and M261, where M260 allows
- * Marlin to send a I2C packet to a device (please be aware that no repeated
- * starts are possible), this can be done in caching method by calling multiple
- * times M260 B<byte-1 value in base 10> or a one liner M260, have a look at
- * the gcode_M260() function for more information. M261 allows Marlin to
- * request data from a device, the received data is then relayed into the serial
- * line for host interpretation.
+ * The two main consumers of this class are M260 and M261. M260 provides a way
+ * to send an I2C packet to a device (no repeated starts) by caching up to 32
+ * bytes in a buffer and then sending the buffer.
+ * M261 requests data from a device. The received data is relayed to serial out
+ * for the host to interpret.
+ *
+ *  For more information see
+ *    - http://marlinfw.org/docs/gcode/M260.html 
+ *    - http://marlinfw.org/docs/gcode/M261.html 
  *
  */
 class TWIBus {

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -314,7 +314,7 @@
 
     // Check for commands that require the printer to be homed
     if (axis_unhomed_error()) {
-      const int8_t p_val = parser.seen('P') && parser.has_value() ? parser.value_int() : -1;
+      const int8_t p_val = parser.seenval('P') ? parser.value_int() : -1;
       if (p_val == 1 || p_val == 2 || p_val == 4 || parser.seen('J'))
         home_all_axes();
     }
@@ -492,7 +492,7 @@
               return;
             }
 
-            const float height = parser.seen('H') && parser.has_value() ? parser.value_float() : Z_CLEARANCE_BETWEEN_PROBES;
+            const float height = parser.seenval('H') ? parser.value_float() : Z_CLEARANCE_BETWEEN_PROBES;
             manually_probe_remaining_mesh(g29_x_pos, g29_y_pos, height, g29_card_thickness, parser.seen('T'));
 
             SERIAL_PROTOCOLLNPGM("G29 P2 finished.");
@@ -1094,9 +1094,9 @@
     g29_constant = 0.0;
     g29_repetition_cnt = 0;
 
-    g29_x_flag = parser.seen('X') && parser.has_value();
+    g29_x_flag = parser.seenval('X');
     g29_x_pos = g29_x_flag ? parser.value_float() : current_position[X_AXIS];
-    g29_y_flag = parser.seen('Y') && parser.has_value();
+    g29_y_flag = parser.seenval('Y');
     g29_y_pos = g29_y_flag ? parser.value_float() : current_position[Y_AXIS];
 
     if (parser.seen('R')) {
@@ -1170,7 +1170,7 @@
       g29_constant = parser.value_float();
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      if (parser.seen('F') && parser.has_value()) {
+      if (parser.seenval('F')) {
         const float fh = parser.value_float();
         if (!WITHIN(fh, 0.0, 100.0)) {
           SERIAL_PROTOCOLLNPGM("?(F)ade height for Bed Level Correction not plausible.\n");
@@ -1180,7 +1180,7 @@
       }
     #endif
 
-    g29_map_type = parser.seen('T') && parser.has_value() ? parser.value_int() : 0;
+    g29_map_type = parser.seenval('T') ? parser.value_int() : 0;
     if (!WITHIN(g29_map_type, 0, 2)) {
       SERIAL_PROTOCOLLNPGM("Invalid map type.\n");
       return UBL_ERR;

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -314,7 +314,7 @@
 
     // Check for commands that require the printer to be homed
     if (axis_unhomed_error()) {
-      const int8_t p_val = parser.seenval('P') ? parser.value_int() : -1;
+      const int8_t p_val = parser.intval('P', -1);
       if (p_val == 1 || p_val == 2 || p_val == 4 || parser.seen('J'))
         home_all_axes();
     }
@@ -492,7 +492,7 @@
               return;
             }
 
-            const float height = parser.seenval('H') ? parser.value_float() : Z_CLEARANCE_BETWEEN_PROBES;
+            const float height = parser.floatval('H', Z_CLEARANCE_BETWEEN_PROBES);
             manually_probe_remaining_mesh(g29_x_pos, g29_y_pos, height, g29_card_thickness, parser.seen('T'));
 
             SERIAL_PROTOCOLLNPGM("G29 P2 finished.");
@@ -1180,7 +1180,7 @@
       }
     #endif
 
-    g29_map_type = parser.seenval('T') ? parser.value_int() : 0;
+    g29_map_type = parser.intval('T');
     if (!WITHIN(g29_map_type, 0, 2)) {
       SERIAL_PROTOCOLLNPGM("Invalid map type.\n");
       return UBL_ERR;


### PR DESCRIPTION
Improvements to the G-code parser.
- Add parser shorthand functions to get a parameter (or default value).
- Use `parser.seenval` for cases where a value is required.
- Patch some spacing, comments