### PR TITLE
Add A (action) and E (echo) parameters to M118

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7994,9 +7994,13 @@ inline void gcode_M117() { lcd_setstatus(parser.string_arg); }
 
 /**
  * M118: Display a message in the host console.
+ *
+ *  A  Append '// ' for an action command, as in OctoPrint
+ *  E  Have the host 'echo:' the text
  */
 inline void gcode_M118() {
-  SERIAL_ECHO_START();
+  if (parser.boolval('E')) SERIAL_ECHO_START();
+  if (parser.boolval('A')) SERIAL_ECHOPGM("// ");
   SERIAL_ECHOLN(parser.string_arg);
 }
 


### PR DESCRIPTION
Followup to #7168
- The `A` parameter indicates the text is an "action command" as with OctoPrint.
- The `E` parameter indicates the text should have `echo:` prepended.
