### PR TITLE
Correct has_value() when FASTER_GCODE_PARSER is enabled

### DIFF
--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -36,7 +36,11 @@
 //#define DEBUG_GCODE_PARSER
 
 #if ENABLED(DEBUG_GCODE_PARSER)
-  #include "hex_print_routines.h"
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    extern char* hex_address(const void * const w);
+  #else  
+    #include "hex_print_routines.h"
+  #endif
   #include "serial.h"
 #endif
 
@@ -132,7 +136,7 @@ public:
       const uint8_t ind = LETTER_OFF(c);
       if (ind >= COUNT(param)) return false; // Only A-Z
       const bool b = TEST(codebits[PARAM_IND(ind)], PARAM_BIT(ind));
-      if (b) value_ptr = command_ptr + param[ind];
+      if (b) value_ptr = param[ind] ? command_ptr + param[ind] : (char*)NULL;
       return b;
     }
 


### PR DESCRIPTION
Here's the function definitions involved in this issue:
```
bool  boolval(const char c, const bool dval=false)   { return seen(c)    ? value_bool()  : dval; }
  bool value_bool() { return !has_value() || value_byte(); }
   bool has_value() { return value_ptr != NULL; }
```

Right now `boolval` returns FALSE for the "C" parameter in "G26 C O2.5" if FASTER_GCODE_PARSER is enabled and TRUE if FASTER_GCODE_PARSER is disabled.

This is because `value_ptr` is never set to NULL by the FASTER_GCODE_PARSER version of the "seen" function.

This change takes care of the problem in Issue #7164.


----

Also corrected compile issue when DEBUG_GCODE_PARSER and AUTO_BED_LEVELING_UBL are both enabled.