### PR TITLE
UBL radar map corrections

### DIFF
--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -45,9 +45,7 @@
     void lcd_mesh_edit_setup(float initial);
     float lcd_mesh_edit();
     void lcd_z_offset_edit_setup(float);
-    #if ENABLED(DOGLCD)
-      extern void _lcd_ubl_output_map_lcd();
-    #endif
+    extern void _lcd_ubl_output_map_lcd();
     float lcd_z_offset_edit();
   #endif
 
@@ -1522,7 +1520,7 @@
           idle();
         } while (!ubl_lcd_clicked());
 
-        lcd_return_to_status();
+        if (!ubl_lcd_map_control) lcd_return_to_status();
 
         // The technique used here generates a race condition for the encoder click.
         // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune) or here.
@@ -1569,11 +1567,8 @@
       LCD_MESSAGEPGM(MSG_UBL_DONE_EDITING_MESH);
       SERIAL_ECHOLNPGM("Done Editing Mesh");
 
-      if (ubl_lcd_map_control) {
-        #if ENABLED(DOGLCD)
-          lcd_goto_screen(_lcd_ubl_output_map_lcd);
-        #endif
-      }
+      if (ubl_lcd_map_control)
+        lcd_goto_screen(_lcd_ubl_output_map_lcd);
       else lcd_return_to_status();
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -547,6 +547,15 @@ uint16_t max_display_update_time = 0;
 
 void lcd_status_screen() {
 
+  #if DISABLED(DOGLCD) && ENABLED(AUTO_BED_LEVELING_UBL)
+    if(!ubl_lcd_map_control)
+      lcd_set_custom_characters(
+       #if ENABLED(LCD_PROGRESS_BAR)
+        const bool info_screen_charset = true
+       #endif
+      );
+  #endif
+
   #if ENABLED(ULTIPANEL)
     ENCODER_DIRECTION_NORMAL();
     ENCODER_RATE_MULTIPLY(false);
@@ -2158,8 +2167,6 @@ void kill_screen(const char* lcd_msg) {
     void _lcd_ubl_map_lcd_edit_cmd() {
       char ubl_lcd_gcode [50], str[10], str2[10];
 
-      ubl_lcd_map_control = true; // Used for returning to the map screen
-
       dtostrf(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]), 0, 2, str);
       dtostrf(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]), 0, 2, str2);
       snprintf_P(ubl_lcd_gcode, sizeof(ubl_lcd_gcode), PSTR("G29 P4 X%s Y%s R%i"), str, str2, n_edit_pts);
@@ -2253,6 +2260,7 @@ void kill_screen(const char* lcd_msg) {
      * UBL Homing before LCD map
      */
     void _lcd_ubl_output_map_lcd_cmd() {
+      ubl_lcd_map_control = true; // Used for returning to the map screen
       if (!(axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]))
         enqueue_and_echo_commands_P(PSTR("G28"));
       lcd_goto_screen(_lcd_ubl_map_homing);
@@ -2393,6 +2401,8 @@ void kill_screen(const char* lcd_msg) {
         if (!g29_in_progress)
       #endif
       MENU_ITEM(submenu, MSG_BED_LEVELING, lcd_bed_leveling);
+    #elif PLANNER_LEVELING
+      MENU_ITEM(gcode, MSG_BED_LEVELING, PSTR("G28\nG29"));
     #endif
 
     #if HAS_M206_COMMAND


### PR DESCRIPTION
Correction to the radar map for ULTIPANELs.
Status screen characters were not being loaded before the status screen is shown.

Also added the lcd option `bed leveling` for other leveling schemes. This disappeared at some point.