### PR TITLE
intermittent AT90USB & G26 compile problem (proposal)

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -135,12 +135,13 @@
   #endif
   extern float destination[XYZE];
   void set_destination_to_current();
-  void set_current_to_destination();
   void prepare_move_to_destination();
   #if AVR_AT90USB1286_FAMILY  // Teensyduino & Printrboard IDE extensions have compile errors without this
     inline void sync_plan_position_e() { planner.set_e_position_mm(current_position[E_AXIS]); }
+    inline void set_current_to_destination() { COPY(current_position, destination); }
   #else
     void sync_plan_position_e();
+    void set_current_to_destination();
   #endif
   #if ENABLED(NEWPANEL)
     void lcd_setstatusPGM(const char* const message, const int8_t level);

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -31,7 +31,12 @@
   #include <math.h>
 
   extern float destination[XYZE];
-  extern void set_current_to_destination();
+  
+  #if AVR_AT90USB1286_FAMILY  // Teensyduino & Printrboard IDE extensions have compile errors without this
+    inline void set_current_to_destination() { COPY(current_position, destination); }
+  #else
+    extern void set_current_to_destination();
+  #endif
 
 #if ENABLED(DELTA)
 


### PR DESCRIPTION
There's been an intermittent G26 compile error with `set_current_to_destination()` when both AT90USB & UBL are enabled. 

This PR proposes a fix similar to the one for `sync_plan_position_e()` on PR #7062.

I don't understand why  `set_current_to_destination()` and `sync_plan_position_e()` have issues.  On top of that `set_destination_to_current()` has the same setup but doesn't seem to have a problem.

With any luck someone might have an explanation and maybe a fix for the root cause.

See Issue #7015 and PR #7062 for the history of the `set_current_to_destination()` problem.

----

UPDATE - Dave says that ubl_motion.cpp also has this issue.