### PR TITLE
UBL radar map corrections

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -273,6 +273,12 @@
     #define LCD_FEEDRATE_CHAR    0x06
     #define LCD_CLOCK_CHAR       0x07
     #define LCD_STR_ARROW_RIGHT ">"  /* from the default character set */
+
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      #define LCD_UBL_BOXTOP_CHAR 0x01
+      #define LCD_UBL_BOXBOT_CHAR 0x02
+    #endif
+
   #endif
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -333,7 +333,6 @@
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "ubl.h"
   extern bool defer_return_to_status;
-  extern bool ubl_lcd_map_control;
   unified_bed_leveling ubl;
   #define UBL_MESH_VALID !( ( ubl.z_values[0][0] == ubl.z_values[0][1] && ubl.z_values[0][1] == ubl.z_values[0][2] \
                            && ubl.z_values[1][0] == ubl.z_values[1][1] && ubl.z_values[1][1] == ubl.z_values[1][2] \
@@ -7742,11 +7741,9 @@ inline void gcode_M18_M84() {
       #endif
     }
 
-    #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  //only needed if have an LCD
-      ubl_lcd_map_control = false;
-      defer_return_to_status = false;
+    #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  // Only needed with an LCD
+      ubl_lcd_map_control = defer_return_to_status = false;
     #endif
-
   }
 }
 
@@ -12637,9 +12634,8 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     #if ENABLED(DISABLE_INACTIVE_E)
       disable_e_steppers();
     #endif
-    #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  //only needed if have an LCD
-      ubl_lcd_map_control = false;
-      defer_return_to_status = false;
+    #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  // Only needed with an LCD
+      ubl_lcd_map_control = defer_return_to_status = false;
     #endif
   }
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -54,7 +54,6 @@
   extern float probe_pt(const float &x, const float &y, bool, int);
   extern bool set_probe_deployed(bool);
   extern void set_bed_leveling_enabled(bool);
-  extern bool ubl_lcd_map_control;
   typedef void (*screenFunc_t)();
   extern void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0);
 
@@ -1569,7 +1568,8 @@
 
       if (ubl_lcd_map_control)
         lcd_goto_screen(_lcd_ubl_output_map_lcd);
-      else lcd_return_to_status();
+      else
+        lcd_return_to_status();
     }
 
   #endif // NEWPANEL

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -45,9 +45,7 @@
     void lcd_mesh_edit_setup(float initial);
     float lcd_mesh_edit();
     void lcd_z_offset_edit_setup(float);
-    #if ENABLED(DOGLCD)
-      extern void _lcd_ubl_output_map_lcd();
-    #endif
+    extern void _lcd_ubl_output_map_lcd();
     float lcd_z_offset_edit();
   #endif
 
@@ -1522,7 +1520,7 @@
           idle();
         } while (!ubl_lcd_clicked());
 
-        lcd_return_to_status();
+        if (!ubl_lcd_map_control) lcd_return_to_status();
 
         // The technique used here generates a race condition for the encoder click.
         // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune) or here.
@@ -1569,11 +1567,8 @@
       LCD_MESSAGEPGM(MSG_UBL_DONE_EDITING_MESH);
       SERIAL_ECHOLNPGM("Done Editing Mesh");
 
-      if (ubl_lcd_map_control) {
-        #if ENABLED(DOGLCD)
-          lcd_goto_screen(_lcd_ubl_output_map_lcd);
-        #endif
-      }
+      if (ubl_lcd_map_control)
+        lcd_goto_screen(_lcd_ubl_output_map_lcd);
       else lcd_return_to_status();
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -547,6 +547,15 @@ uint16_t max_display_update_time = 0;
 
 void lcd_status_screen() {
 
+  #if DISABLED(DOGLCD) && ENABLED(AUTO_BED_LEVELING_UBL)
+    if(!ubl_lcd_map_control)
+      lcd_set_custom_characters(
+       #if ENABLED(LCD_PROGRESS_BAR)
+        const bool info_screen_charset = true
+       #endif
+      );
+  #endif
+
   #if ENABLED(ULTIPANEL)
     ENCODER_DIRECTION_NORMAL();
     ENCODER_RATE_MULTIPLY(false);
@@ -2158,8 +2167,6 @@ void kill_screen(const char* lcd_msg) {
     void _lcd_ubl_map_lcd_edit_cmd() {
       char ubl_lcd_gcode [50], str[10], str2[10];
 
-      ubl_lcd_map_control = true; // Used for returning to the map screen
-
       dtostrf(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]), 0, 2, str);
       dtostrf(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]), 0, 2, str2);
       snprintf_P(ubl_lcd_gcode, sizeof(ubl_lcd_gcode), PSTR("G29 P4 X%s Y%s R%i"), str, str2, n_edit_pts);
@@ -2253,6 +2260,7 @@ void kill_screen(const char* lcd_msg) {
      * UBL Homing before LCD map
      */
     void _lcd_ubl_output_map_lcd_cmd() {
+      ubl_lcd_map_control = true; // Used for returning to the map screen
       if (!(axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]))
         enqueue_and_echo_commands_P(PSTR("G28"));
       lcd_goto_screen(_lcd_ubl_map_homing);
@@ -2393,6 +2401,8 @@ void kill_screen(const char* lcd_msg) {
         if (!g29_in_progress)
       #endif
       MENU_ITEM(submenu, MSG_BED_LEVELING, lcd_bed_leveling);
+    #elif PLANNER_LEVELING
+      MENU_ITEM(gcode, MSG_BED_LEVELING, PSTR("G28\nG29"));
     #endif
 
     #if HAS_M206_COMMAND

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -188,6 +188,7 @@
 void lcd_reset_status();
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
+  extern bool ubl_lcd_map_control;
   void lcd_mesh_edit_setup(float initial);
   float lcd_mesh_edit();
   void lcd_z_offset_edit_setup(float);

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -1134,8 +1134,8 @@ static void lcd_implementation_status_screen() {
           B00000,
           B11111
         };
-        createChar_P(1, _lcd_box_top);
-        createChar_P(2, _lcd_box_bottom);
+        createChar_P(LCD_UBL_BOXTOP_CHAR, _lcd_box_top);
+        createChar_P(LCD_UBL_BOXBOT_CHAR, _lcd_box_bottom);
       #endif
     }
 
@@ -1178,8 +1178,8 @@ static void lcd_implementation_status_screen() {
          * Draw the Mesh Map Box
          */
         uint8_t m;
-        lcd.setCursor(_MAP_X, 0); for (m = 0; m < 5; m++) lcd.write(1); // Top
-        lcd.setCursor(_MAP_X, 3); for (m = 0; m < 5; m++) lcd.write(2); // Bottom
+        lcd.setCursor(_MAP_X, 0); for (m = 0; m < 5; m++) lcd.write(LCD_UBL_BOXTOP_CHAR); // Top
+        lcd.setCursor(_MAP_X, 3); for (m = 0; m < 5; m++) lcd.write(LCD_UBL_BOXBOT_CHAR); // Bottom
         for (m = 0; m <= 3; m++) {
           lcd.setCursor(2, m); lcd.write('|'); // Left
           lcd.setCursor(8, m); lcd.write('|'); // Right

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -1085,151 +1085,151 @@ static void lcd_implementation_status_screen() {
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
 
-    /* 
-     * These are just basic data for the 20x4 LCD work that
-     * is coming up very soon.
-     * Soon this will morph into a map code.
-     */
+  /* 
+   * These are just basic data for the 20x4 LCD work that
+   * is coming up very soon.
+   * Soon this will morph into a map code.
+   */
 
-    /**
-    Possible map screens:
+  /**
+  Possible map screens:
 
-    16x2   |X000.00  Y000.00|
-           |(00,00)  Z00.000|
+  16x2   |X000.00  Y000.00|
+         |(00,00)  Z00.000|
 
-    20x2   | X:000.00  Y:000.00 |
-           | (00,00)   Z:00.000 |
+  20x2   | X:000.00  Y:000.00 |
+         | (00,00)   Z:00.000 |
 
-    16x4   |+-------+(00,00)|
-           ||       |X000.00|
-           ||       |Y000.00|
-           |+-------+Z00.000|
+  16x4   |+-------+(00,00)|
+         ||       |X000.00|
+         ||       |Y000.00|
+         |+-------+Z00.000|
 
-    20x4   | +-------+  (00,00) |
-           | |       |  X:000.00|
-           | |       |  Y:000.00|
-           | +-------+  Z:00.000|
-    */
+  20x4   | +-------+  (00,00) |
+         | |       |  X:000.00|
+         | |       |  Y:000.00|
+         | +-------+  Z:00.000|
+  */
 
-    void lcd_set_ubl_map_plot_chars() {
-      #if LCD_HEIGHT > 3
-        //#include "_ubl_lcd_map_characters.h"
-        const static byte _lcd_box_top[8] PROGMEM = {
-          B11111,
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B00000
-        };
-        const static byte _lcd_box_bottom[8] PROGMEM = {
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B00000,
-          B11111
-        };
-        createChar_P(LCD_UBL_BOXTOP_CHAR, _lcd_box_top);
-        createChar_P(LCD_UBL_BOXBOT_CHAR, _lcd_box_bottom);
-      #endif
-    }
+  void lcd_set_ubl_map_plot_chars() {
+    #if LCD_HEIGHT > 3
+      //#include "_ubl_lcd_map_characters.h"
+      const static byte _lcd_box_top[8] PROGMEM = {
+        B11111,
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B00000
+      };
+      const static byte _lcd_box_bottom[8] PROGMEM = {
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B00000,
+        B11111
+      };
+      createChar_P(LCD_UBL_BOXTOP_CHAR, _lcd_box_top);
+      createChar_P(LCD_UBL_BOXBOT_CHAR, _lcd_box_bottom);
+    #endif
+  }
 
-    void lcd_implementation_ubl_plot(const uint8_t x_plot, const uint8_t y_plot) {
+  void lcd_implementation_ubl_plot(const uint8_t x_plot, const uint8_t y_plot) {
 
-      #if LCD_WIDTH >= 20
-        #define _LCD_W_POS 12
-        #define _PLOT_X 1
-        #define _MAP_X 3
-        #define _LABEL(C,X,Y) lcd.setCursor(X, Y); lcd.print(C)
-        #define _XLABEL(X,Y) _LABEL("X:",X,Y)
-        #define _YLABEL(X,Y) _LABEL("Y:",X,Y)
-        #define _ZLABEL(X,Y) _LABEL("Z:",X,Y)
-      #else
-        #define _LCD_W_POS 8
-        #define _PLOT_X 0
-        #define _MAP_X 1
-        #define _LABEL(X,Y,C) lcd.setCursor(X, Y); lcd.write(C)
-        #define _XLABEL(X,Y) _LABEL('X',X,Y)
-        #define _YLABEL(X,Y) _LABEL('Y',X,Y)
-        #define _ZLABEL(X,Y) _LABEL('Z',X,Y)
-      #endif
+    #if LCD_WIDTH >= 20
+      #define _LCD_W_POS 12
+      #define _PLOT_X 1
+      #define _MAP_X 3
+      #define _LABEL(C,X,Y) lcd.setCursor(X, Y); lcd.print(C)
+      #define _XLABEL(X,Y) _LABEL("X:",X,Y)
+      #define _YLABEL(X,Y) _LABEL("Y:",X,Y)
+      #define _ZLABEL(X,Y) _LABEL("Z:",X,Y)
+    #else
+      #define _LCD_W_POS 8
+      #define _PLOT_X 0
+      #define _MAP_X 1
+      #define _LABEL(X,Y,C) lcd.setCursor(X, Y); lcd.write(C)
+      #define _XLABEL(X,Y) _LABEL('X',X,Y)
+      #define _YLABEL(X,Y) _LABEL('Y',X,Y)
+      #define _ZLABEL(X,Y) _LABEL('Z',X,Y)
+    #endif
 
-      #if LCD_HEIGHT <= 3   // 16x2 or 20x2 display
-
-        /**
-         * Show X and Y positions
-         */
-        _XLABEL(_PLOT_X, 0);
-        lcd.print(ftostr32(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]))));
-
-        _YLABEL(_LCD_W_POS, 0);
-        lcd.print(ftostr32(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]))));
-
-        lcd.setCursor(_PLOT_X, 0);
-
-      #else                 // 16x4 or 20x4 display
-
-        /**
-         * Draw the Mesh Map Box
-         */
-        uint8_t m;
-        lcd.setCursor(_MAP_X, 0); for (m = 0; m < 5; m++) lcd.write(LCD_UBL_BOXTOP_CHAR); // Top
-        lcd.setCursor(_MAP_X, 3); for (m = 0; m < 5; m++) lcd.write(LCD_UBL_BOXBOT_CHAR); // Bottom
-        for (m = 0; m <= 3; m++) {
-          lcd.setCursor(2, m); lcd.write('|'); // Left
-          lcd.setCursor(8, m); lcd.write('|'); // Right
-        }
-
-        lcd.setCursor(_LCD_W_POS, 0);
-
-      #endif
+    #if LCD_HEIGHT <= 3   // 16x2 or 20x2 display
 
       /**
-       * Print plot position
+       * Show X and Y positions
        */
-      lcd.write('(');
-      lcd.print(x_plot);
-      lcd.write(',');
-      lcd.print(y_plot);
-      lcd.write(')');
+      _XLABEL(_PLOT_X, 0);
+      lcd.print(ftostr32(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]))));
 
-      #if LCD_HEIGHT <= 3   // 16x2 or 20x2 display
+      _YLABEL(_LCD_W_POS, 0);
+      lcd.print(ftostr32(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]))));
 
-        /**
-         * Print Z values
-         */
-        _ZLABEL(_LCD_W_POS, 1);
-        if (!isnan(ubl.z_values[x_plot][y_plot]))
-          lcd.print(ftostr43sign(ubl.z_values[x_plot][y_plot]));
-        else
-          lcd_printPGM(PSTR(" -----"));
+      lcd.setCursor(_PLOT_X, 0);
 
-      #else                 // 16x4 or 20x4 display
+    #else                 // 16x4 or 20x4 display
 
-        /**
-         * Show all values at right of screen
-         */
-        _XLABEL(_LCD_W_POS, 1);
-        lcd.print(ftostr32(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]))));
-        _YLABEL(_LCD_W_POS, 2);
-        lcd.print(ftostr32(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]))));
+      /**
+       * Draw the Mesh Map Box
+       */
+      uint8_t m;
+      lcd.setCursor(_MAP_X, 0); for (m = 0; m < 5; m++) lcd.write(LCD_UBL_BOXTOP_CHAR); // Top
+      lcd.setCursor(_MAP_X, 3); for (m = 0; m < 5; m++) lcd.write(LCD_UBL_BOXBOT_CHAR); // Bottom
+      for (m = 0; m <= 3; m++) {
+        lcd.setCursor(2, m); lcd.write('|'); // Left
+        lcd.setCursor(8, m); lcd.write('|'); // Right
+      }
 
-        /**
-         * Show the location value
-         */
-        _ZLABEL(_LCD_W_POS, 3);
-        if (!isnan(ubl.z_values[x_plot][y_plot]))
-          lcd.print(ftostr43sign(ubl.z_values[x_plot][y_plot]));
-        else
-          lcd_printPGM(PSTR(" -----"));
+      lcd.setCursor(_LCD_W_POS, 0);
 
-      #endif // LCD_HEIGHT > 3
-    }
+    #endif
+
+    /**
+     * Print plot position
+     */
+    lcd.write('(');
+    lcd.print(x_plot);
+    lcd.write(',');
+    lcd.print(y_plot);
+    lcd.write(')');
+
+    #if LCD_HEIGHT <= 3   // 16x2 or 20x2 display
+
+      /**
+       * Print Z values
+       */
+      _ZLABEL(_LCD_W_POS, 1);
+      if (!isnan(ubl.z_values[x_plot][y_plot]))
+        lcd.print(ftostr43sign(ubl.z_values[x_plot][y_plot]));
+      else
+        lcd_printPGM(PSTR(" -----"));
+
+    #else                 // 16x4 or 20x4 display
+
+      /**
+       * Show all values at right of screen
+       */
+      _XLABEL(_LCD_W_POS, 1);
+      lcd.print(ftostr32(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]))));
+      _YLABEL(_LCD_W_POS, 2);
+      lcd.print(ftostr32(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]))));
+
+      /**
+       * Show the location value
+       */
+      _ZLABEL(_LCD_W_POS, 3);
+      if (!isnan(ubl.z_values[x_plot][y_plot]))
+        lcd.print(ftostr43sign(ubl.z_values[x_plot][y_plot]));
+      else
+        lcd_printPGM(PSTR(" -----"));
+
+    #endif // LCD_HEIGHT > 3
+  }
 
 #endif // AUTO_BED_LEVELING_UBL
 


### PR DESCRIPTION
Fixed up from #7199 by @Tannoo 

- Apply character set change consistently in `lcd_goto_screen`
- Apply names to the map box special characters
- Fix some indentation
- Use `quickstop_stepper` instead of duplicating its code
- Remove call to `safe_delay` — the screen handler isn't called till the next lcd update

See the [Concise Diff](https://github.com/MarlinFirmware/Marlin/pull/7204/files?w=1) to hide spacing changes. #