### PR TITLE
LCD for Melzi support

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1437,6 +1437,14 @@
 //
 //#define OLED_PANEL_TINYBOY2
 
+// If you want you can define your own set of delays in Configuration.h (If you see garbled graphics on the screen uncomment all three)
+#define ST7920_DELAY_1 DELAY_0_NOP
+#define ST7920_DELAY_2 DELAY_3_NOP
+#define ST7920_DELAY_3 DELAY_0_NOP
+
+//LCD for MELZI (If you have a Melzi board with LCD for Melzi card uncomment this)
+#define LCD_MELZI
+
 //=============================================================================
 //=============================== Extra Features ==============================
 //=============================================================================

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -220,6 +220,15 @@
     #define LCD_SDSS            28 // Smart Controller SD card reader rather than the Melzi
   #endif // !Panelolu2
 
+    #if ENABLED(LCD_MELZI)
+	#define LCD_PINS_RS       17
+	#define LCD_PINS_ENABLE   16
+	#define LCD_PINS_D4       11
+	#define BTN_ENC           28
+	#define BTN_EN1           29
+	#define BTN_EN2           30
+  #endif // LCD MELZI
+  
   #define SD_DETECT_PIN         -1
 
 #endif // ULTRA_LCD && NEWPANEL


### PR DESCRIPTION
The definition here allows users to select and use "LCD for Melzi" Full Graphics Board with Melzi Controller.

Configuration.h

//LCD for MELZI
#define LCD_MELZI true
#define ST7920_DELAY_1 DELAY_0_NOP
#define ST7920_DELAY_2 DELAY_3_NOP
#define ST7920_DELAY_3 DELAY_0_NOP

pins_SANGUINOLOLU_11.h

#endif // !Panelolu2

#if LCD_MELZI
#define LCD_PINS_RS 17
#define LCD_PINS_ENABLE 16
#define LCD_PINS_D4 11
#define BTN_ENC 28
#define BTN_EN1 29
#define BTN_EN2 30
#endif // LCD MELZI
#define SD_DETECT_PIN -1
#endif // ULTRA_LCD && NEWPANEL

I have tested with 2 different versions of Melzi boards (3 & 4) and all worked.

Can