### PR TITLE
Use lcd_bootscreen for both

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -13034,11 +13034,16 @@ void setup() {
   #endif
 
   lcd_init();
+
   #if ENABLED(SHOW_BOOTSCREEN)
-    #if ENABLED(DOGLCD)
-      safe_delay(BOOTSCREEN_TIMEOUT);
+    #if ENABLED(DOGLCD)                           // On DOGM the first bootscreen is already drawn
+      #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
+        safe_delay(CUSTOM_BOOTSCREEN_TIMEOUT);    // Custom boot screen pause
+        lcd_bootscreen();                         // Show Marlin boot screen
+      #endif
+      safe_delay(BOOTSCREEN_TIMEOUT);             // Pause
     #elif ENABLED(ULTRA_LCD)
-      bootscreen();
+      lcd_bootscreen();
       #if DISABLED(SDSUPPORT)
         lcd_init();
       #endif

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -124,7 +124,7 @@ public:
         if (debug) {
           SERIAL_ECHOPAIR("Set bit ", (int)PARAM_BIT(ind));
           SERIAL_ECHOPAIR(" of index ", (int)PARAM_IND(ind));
-          SERIAL_ECHOLNPAIR(" | param = ", hex_address((void*)param[ind]));
+          SERIAL_ECHOLNPAIR(" | param = ", (int)param[ind]);
         }
       #endif
     }

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -64,8 +64,10 @@
   #if ENABLED(DOGLCD)
     extern uint16_t lcd_contrast;
     void set_lcd_contrast(const uint16_t value);
-  #elif ENABLED(SHOW_BOOTSCREEN)
-    void bootscreen();
+  #endif
+
+  #if ENABLED(SHOW_BOOTSCREEN)
+    void lcd_bootscreen();
   #endif
 
   #define LCD_UPDATE_INTERVAL 100

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -443,7 +443,7 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
     lcd.setCursor(indent, 2); lcd.write('\x02'); lcd_printPGM(PSTR( "------" ));  lcd.write('\x03');
   }
 
-  void bootscreen() {
+  void lcd_bootscreen() {
     const static PROGMEM byte corner[4][8] = { {
       B00000,
       B00000,


### PR DESCRIPTION
Add `lcd_bootscreen` to allow moving the `safe_delay` between boot screens up two levels to `setup()`. May solve SD initialization issue #7155.

- Rename `bootscreen()` to match.