### PR TITLE
Add configurable action command to send when printer is killed

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1268,6 +1268,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12836,6 +12836,10 @@ void kill(const char* lcd_msg) {
   _delay_ms(250); //Wait to ensure all interrupts routines stopped
   thermalManager.disable_all_heaters(); //turn off heaters again
 
+  #if defined(ACTION_ON_KILL)
+    SERIAL_ECHOLNPGM("//action:" ACTION_ON_KILL);
+  #endif
+  
   #if HAS_POWER_SWITCH
     SET_INPUT(PS_ON_PIN);
   #endif

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -1268,6 +1268,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -1268,6 +1268,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech-i3-2020/Configuration_adv.h
@@ -1274,6 +1274,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/Hephestos_2/Configuration_adv.h
@@ -1244,6 +1244,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/K8200/Configuration_adv.h
@@ -1274,6 +1274,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/K8400/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/M150/Configuration_adv.h
@@ -1268,6 +1268,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/TAZ4/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -1264,6 +1264,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/WITBOX/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1266,6 +1266,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1265,6 +1265,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -1263,6 +1263,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -1263,6 +1263,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -1268,6 +1268,13 @@
   #define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -1263,6 +1263,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate_gMax1.5+/Configuration_adv.h
@@ -1270,6 +1270,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -1261,6 +1261,13 @@
   //#define USER_GCODE_5 "G28\nM503"
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -1351,6 +1351,13 @@
 
 #endif
 
+/**
+ * Specify an action command to send to the host when the printer is killed.
+ * Will be sent in the form '//action:ACTION_ON_KILL', e.g. '//action:poweroff'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_KILL "poweroff"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================


### PR DESCRIPTION
Sends user-defined string as action command when printer is killed.

Spawned from conversation in #7137, where a couple of people thought that informing a connected host that the printer has been killed in a user-configurable, language agnostic, way would be useful.

I'm sure there are other action commands which it would be useful for the printer to send, but a 'kill' action is the one which seems most useful to me.  With that in mind, I couldn't decide if the variable should be `KILL_ACTION`, which groks easier, or `ACTION_KILL`, which lends itself to being in a list of other action definitions.  I don't feel strongly either way.