### PR TITLE
Simplify3D compatibility with M20 & M23

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6243,8 +6243,15 @@ inline void gcode_M17() {
 
   /**
    * M23: Open a file
+   *
+   *  Simplify3D will send the file size along with the file name because M20 defaults
+   *  to that format.  The work around is to terminates the file name at first space
+   *  if any are present.  This is OK because M23 only supports DOS 8.3 file names.
    */
-  inline void gcode_M23() { card.openFile(parser.string_arg, true); }
+  inline void gcode_M23() { 
+    for (uint8_t i = 0; !(parser.string_arg[i] == 0); i++) if (parser.string_arg[i] == ' ') parser.string_arg[i] = 0;
+    card.openFile(parser.string_arg, true); 
+  }
 
   /**
    * M24: Start or Resume SD Print

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6221,10 +6221,13 @@ inline void gcode_M17() {
 
   /**
    * M20: List SD card to serial output
+   *
+   *    Defaults to list with file size
+   *    M20 S0 will create the list without file size
    */
   inline void gcode_M20() {
     SERIAL_PROTOCOLLNPGM(MSG_BEGIN_FILE_LIST);
-    card.ls();
+    parser.boolval('S', true) ? card.ls(LS_SerialPrint) : card.ls(LS_SerialPrint_Without_Size);
     SERIAL_PROTOCOLLNPGM(MSG_END_FILE_LIST);
   }
 

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -75,6 +75,7 @@ char *createFilename(char *buffer, const dir_t &p) { //buffer > 12characters
  *   LS_Count       - Add +1 to nrFiles for every file within the parent
  *   LS_GetFilename - Get the filename of the file indexed by nrFiles
  *   LS_SerialPrint - Print the full path and size of each file to serial output
+ *   LS_SerialPrint_Without_Size - Print the full path but NOT the size of each file to serial output
  */
 void CardReader::lsDive(const char *prepend, SdFile parent, const char * const match/*=NULL*/) {
   dir_t p;
@@ -83,7 +84,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
   // Read the next entry from a directory
   while (parent.readDir(p, longFilename) > 0) {
 
-    // If the entry is a directory and the action is LS_SerialPrint
+    // If the entry is a directory and the action is LS_SerialPrint or LS_SerialPrint_Without_Size
     if (DIR_IS_SUBDIR(&p) && lsAction != LS_Count && lsAction != LS_GetFilename) {
 
       // Get the short name for the item, which we know is a folder
@@ -108,7 +109,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
       // and dive recursively into it.
       SdFile dir;
       if (!dir.open(parent, lfilename, O_READ)) {
-        if (lsAction == LS_SerialPrint) {
+        if (lsAction == LS_SerialPrint || lsAction == LS_SerialPrint_Without_Size) {
           SERIAL_ECHO_START();
           SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
           SERIAL_ECHOLN(lfilename);
@@ -141,6 +142,12 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
           SERIAL_PROTOCOLCHAR(' ');
           SERIAL_PROTOCOLLN(p.fileSize);
           break;
+          
+        case LS_SerialPrint_Without_Size:
+          createFilename(filename, p);
+          SERIAL_PROTOCOL(prepend);
+          SERIAL_PROTOCOLLN(filename);
+          break;  
 
         case LS_GetFilename:
           createFilename(filename, p);
@@ -156,8 +163,8 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
   } // while readDir
 }
 
-void CardReader::ls() {
-  lsAction = LS_SerialPrint;
+void CardReader::ls(const LsAction action = LS_SerialPrint) {
+  lsAction = action;
   root.rewind();
   lsDive("", root);
 }

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -64,7 +64,7 @@ public:
 
   void getAbsFilename(char *t);
 
-  void ls();
+  void ls(const LsAction);
   void chdir(const char *relpath);
   void updir();
   void setroot();

--- a/Marlin/enum.h
+++ b/Marlin/enum.h
@@ -154,7 +154,7 @@ enum EndstopEnum {
 /**
  * SD Card
  */
-enum LsAction { LS_SerialPrint, LS_Count, LS_GetFilename };
+enum LsAction { LS_SerialPrint, LS_SerialPrint_Without_Size, LS_Count, LS_GetFilename };
 
 /**
  * Ultra LCD


### PR DESCRIPTION
See the end of issue #6723 for details.

Simplify3D is having problems with Marlin because it feeds the M20 result directly into the M23 command.  

M20 outputs the file name, a space and then the file size.  M23 takes that string and says it can't find that file.  

Example: 
**M20** output: `TEST1234.GCO 3268`
Simplify3D sends: `M23 TEST1234.GCO 3268`
**M23** says it can't find `TEST1234.GCO 3268`

This PR contains two methods to fix the issue:
1. Add an option to M20 to output only the file name.  The proposed code outputs the file name only if M20 S0 is sent.  Anything else gives file name plus size.  Simplify3D can be configured to use the M20 S0 command.
2. Modify M23 so the parser string is truncated at the first space.

The M23 mod is just a demonstration of concept.  I'm sure there are better ways to implement it.  FYI - Currently M23 can not open any files that have a space in the name.

I picked S0 for the M20 mod because the [RepRap gcode Wiki](http://reprap.org/wiki/G-code) says "Snnn Output style".  The Wiki only shows S2 as being currently defined.
