### PR TITLE
Use FastIO for spindle, probe test, and case light

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5854,7 +5854,7 @@ inline void gcode_G92() {
         WRITE(SPINDLE_LASER_ENABLE_PIN, !SPINDLE_LASER_ENABLE_INVERT);  // turn spindle off
         delay_for_power_down();
       }
-      digitalWrite(SPINDLE_DIR_PIN, rotation_dir);
+      WRITE(SPINDLE_DIR_PIN, rotation_dir);
     #endif
 
     /**
@@ -6569,10 +6569,10 @@ inline void gcode_M42() {
       for (uint8_t i = 0; i < 4; i++) {
         servo[probe_index].move(z_servo_angle[0]); //deploy
         safe_delay(500);
-        deploy_state = digitalRead(PROBE_TEST_PIN);
+        deploy_state = READ(PROBE_TEST_PIN);
         servo[probe_index].move(z_servo_angle[1]); //stow
         safe_delay(500);
-        stow_state = digitalRead(PROBE_TEST_PIN);
+        stow_state = READ(PROBE_TEST_PIN);
       }
       if (probe_inverting != deploy_state) SERIAL_PROTOCOLLNPGM("WARNING - INVERTING setting probably backwards");
 
@@ -6607,9 +6607,9 @@ inline void gcode_M42() {
           if (0 == j % (500 * 1)) // keep cmd_timeout happy
             refresh_cmd_timeout();
 
-          if (deploy_state != digitalRead(PROBE_TEST_PIN)) { // probe triggered
+          if (deploy_state != READ(PROBE_TEST_PIN)) { // probe triggered
 
-            for (probe_counter = 1; probe_counter < 50 && deploy_state != digitalRead(PROBE_TEST_PIN); ++probe_counter)
+            for (probe_counter = 1; probe_counter < 50 && deploy_state != READ(PROBE_TEST_PIN); ++probe_counter)
               safe_delay(2);
 
             if (probe_counter == 50)
@@ -9876,9 +9876,9 @@ inline void gcode_M907() {
       if (USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN)) {
         analogWrite(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? 255 - case_light_brightness : case_light_brightness );
       }
-      else digitalWrite(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? LOW : HIGH );
+      else WRITE(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? LOW : HIGH);
     }
-    else digitalWrite(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? HIGH : LOW);
+    else WRITE(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? HIGH : LOW);
   }
 #endif // HAS_CASE_LIGHT
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5280,7 +5280,7 @@ void home_all_axes() { gcode_G28(true); }
       #if DISABLED(PROBE_MANUALLY)
         home_offset[Z_AXIS] -= probe_pt(dx, dy, stow_after_each, 1, false); // 1st probe to set height
       #endif
-      
+
       do {
 
         float z_at_pt[13] = { 0.0 };
@@ -5380,7 +5380,7 @@ void home_all_axes() { gcode_G28(true); }
           #if ENABLED(PROBE_MANUALLY)
             test_precision = 0.00; // forced end
           #endif
-          
+
           switch (probe_points) {
             case 1:
               test_precision = 0.00; // forced end
@@ -6259,7 +6259,7 @@ inline void gcode_M17() {
   inline void gcode_M23() {
     // Simplify3D includes the size, so zero out all spaces (#7227)
     for (char *fn = parser.string_arg; *fn; ++fn) if (*fn == ' ') *fn = '\0';
-    card.openFile(parser.string_arg, true); 
+    card.openFile(parser.string_arg, true);
   }
 
   /**
@@ -12877,7 +12877,7 @@ void kill(const char* lcd_msg) {
   #if defined(ACTION_ON_KILL)
     SERIAL_ECHOLNPGM("//action:" ACTION_ON_KILL);
   #endif
-  
+
   #if HAS_POWER_SWITCH
     SET_INPUT(PS_ON_PIN);
   #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6474,20 +6474,20 @@ inline void gcode_M42() {
       else {
         report_pin_state_extended(pin, I_flag, true, "Pulsing   ");
         #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
-          if (pin == 46) {
-            SET_OUTPUT(46);
+          if (pin == TEENSY_E2) {
+            SET_OUTPUT(TEENSY_E2);
             for (int16_t j = 0; j < repeat; j++) {
-              WRITE(46, 0); safe_delay(wait);
-              WRITE(46, 1); safe_delay(wait);
-              WRITE(46, 0); safe_delay(wait);
+              WRITE(TEENSY_E2, LOW);  safe_delay(wait);
+              WRITE(TEENSY_E2, HIGH); safe_delay(wait);
+              WRITE(TEENSY_E2, LOW);  safe_delay(wait);
             }
           }
-          else if (pin == 47) {
-            SET_OUTPUT(47);
+          else if (pin == TEENSY_E3) {
+            SET_OUTPUT(TEENSY_E3);
             for (int16_t j = 0; j < repeat; j++) {
-              WRITE(47, 0); safe_delay(wait);
-              WRITE(47, 1); safe_delay(wait);
-              WRITE(47, 0); safe_delay(wait);
+              WRITE(TEENSY_E3, LOW);  safe_delay(wait);
+              WRITE(TEENSY_E3, HIGH); safe_delay(wait);
+              WRITE(TEENSY_E3, LOW);  safe_delay(wait);
             }
           }
           else
@@ -6671,7 +6671,7 @@ inline void gcode_M42() {
     if (parser.seen('E')) {
       endstop_monitor_flag = parser.value_bool();
       SERIAL_PROTOCOLPGM("endstop monitor ");
-      SERIAL_PROTOCOL(endstop_monitor_flag ? "en" : "dis");
+      serialprintPGM(endstop_monitor_flag ? PSTR("en") : PSTR("dis"));
       SERIAL_PROTOCOLLNPGM("abled");
       return;
     }

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -497,7 +497,7 @@
 
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS 101.0 //mm  Get this value from auto calibrate
-  
+
   // Trim adjustments for individual towers
   // tower angle corrections for X and Y tower / rotate XYZ so Z tower angle = 0
   // measured in degrees anticlockwise looking from above the printer

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -497,7 +497,7 @@
 
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS 101.0 //mm  Get this value from auto calibrate
-  
+
   // Trim adjustments for individual towers
   // tower angle corrections for X and Y tower / rotate XYZ so Z tower angle = 0
   // measured in degrees anticlockwise looking from above the printer

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -487,7 +487,7 @@
 
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS 124.0 //mm  Get this value from auto calibrate
-  
+
   // Trim adjustments for individual towers
   // tower angle corrections for X and Y tower / rotate XYZ so Z tower angle = 0
   // measured in degrees anticlockwise looking from above the printer

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -487,7 +487,7 @@
 
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS 105.2 //mm  Get this value from auto calibrate
-  
+
   // Trim adjustments for individual towers
   // tower angle corrections for X and Y tower / rotate XYZ so Z tower angle = 0
   // measured in degrees anticlockwise looking from above the printer

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -473,7 +473,7 @@
 
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS 152.357 //mm  Get this value from auto calibrate
-  
+
   // Trim adjustments for individual towers
   // tower angle corrections for X and Y tower / rotate XYZ so Z tower angle = 0
   // measured in degrees anticlockwise looking from above the printer

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -491,7 +491,7 @@
 
   // Horizontal distance bridged by diagonal push rods when effector is centered.
   #define DELTA_RADIUS 174.1 //mm  Get this value from auto calibrate
-  
+
   // Trim adjustments for individual towers
   // tower angle corrections for X and Y tower / rotate XYZ so Z tower angle = 0
   // measured in degrees anticlockwise looking from above the printer

--- a/Marlin/fastio_AT90USB.h
+++ b/Marlin/fastio_AT90USB.h
@@ -382,6 +382,10 @@
 #define DIO47_WPORT PORTE
 #define DIO47_PWM   NULL
 #define DIO47_DDR   DDRE
+
+#define TEENSY_E2   46
+#define TEENSY_E3   47
+
 //-- end not supported by Teensyduino
 
 #undef PA0

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -32,9 +32,9 @@
  *
  *  Teensyduino - http://www.pjrc.com/teensy/teensyduino.html
  *    Installation instructions are at the above URL.
- *    
+ *
  *    Select Teensy++ 2.0 in Arduino IDE from the 'Tools -> Boards' menu
- *    
+ *
  *    Note: With Teensyduino extension, the Arduino IDE will report 130048 bytes of program storage space available,
  *    but there is actually only 122880 bytes due to the larger DFU bootloader shipped by default on all Printrboard RevF.
  *
@@ -99,8 +99,8 @@
 #define DAC_STEPPER_CURRENT
 
 // Set default drive strength percents if not already defined - X, Y, Z, E axis
-#ifndef DAC_MOTOR_CURRENT_DEFAULT 
-  #define DAC_MOTOR_CURRENT_DEFAULT { 70, 70, 50, 70 }    
+#ifndef DAC_MOTOR_CURRENT_DEFAULT
+  #define DAC_MOTOR_CURRENT_DEFAULT { 70, 70, 50, 70 }
 #endif
 
 // Number of channels available for DAC
@@ -170,17 +170,17 @@
 
 #if ENABLED(MINIPANEL)
   #if ENABLED(USE_INTERNAL_SD)
-    //      PIN       FASTIO PIN#  ATUSB90 PIN# Teensy2.0++ PIN# 
-    #define SDSS               20  //        10               B0  
+    //      PIN       FASTIO PIN#  ATUSB90 PIN# Teensy2.0++ PIN#
+    #define SDSS               20  //        10               B0
     #define SD_DETECT_PIN      -1  // no auto-detect SD insertion on built-in Printrboard SD reader
   #else
-    //      PIN       FASTIO PIN#  ATUSB90 PIN# Teensy2.0++ PIN#  Printrboard RevF Conn.   MKSLCD12864 PIN#  
+    //      PIN       FASTIO PIN#  ATUSB90 PIN# Teensy2.0++ PIN#  Printrboard RevF Conn.   MKSLCD12864 PIN#
     #define SDSS               11  //        36               C1                EXP2-13             EXP2-07
     #define SD_DETECT_PIN       9  //        34               E1                EXP2-11             EXP2-04
   #endif
-  
-    //      PIN       FASTIO PIN#  ATUSB90 PIN# Teensy2.0++ PIN#  Printrboard RevF Conn.   MKSLCD12864 PIN#  
-    #define DOGLCD_A0           4  //        29               D4                EXP2-05             EXP1-04      
+
+    //      PIN       FASTIO PIN#  ATUSB90 PIN# Teensy2.0++ PIN#  Printrboard RevF Conn.   MKSLCD12864 PIN#
+    #define DOGLCD_A0           4  //        29               D4                EXP2-05             EXP1-04
     #define DOGLCD_CS           5  //        30               D5                EXP2-06             EXP1-05
     #define BTN_ENC             6  //        31               D6                EXP2-07             EXP1-09
     #define BEEPER_PIN          7  //        32               D7                EXP2-08             EXP1-10
@@ -190,8 +190,8 @@
   //#define LCD_BACKLIGHT_PIN  43  //        56               F5                EXP1-12     Not Implemented
   //#define SCK                21  //        11               B1                ICSP-04             EXP2-09
   //#define MOSI               22  //        12               B2                ICSP-03             EXP2-05
-  //#define MISO               23  //        13               B3                ICSP-06             EXP2-05            
-  
+  //#define MISO               23  //        13               B3                ICSP-06             EXP2-05
+
   // encoder connections present
   #define BLEN_A 0
   #define BLEN_B 1

--- a/buildroot/share/git/mfup
+++ b/buildroot/share/git/mfup
@@ -2,10 +2,10 @@
 #
 # mfup
 #
-# - Fetch latest upstream and replace the PR Target branch with 
+# - Fetch latest upstream and replace the PR Target branch with
 # - Rebase the (current or specified) branch on the PR Target
 # - Force-push the branch to 'origin'
-# - 
+# -
 #
 
 [[ $# < 2 ]] || { echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1; }


### PR DESCRIPTION
`digitalRead` and `digitalWrite` should only be used with non-constant pin numbers, because these functions will break when building Marlin for `AT90USB` processors using a non-Arduino core.

Also: 
- Remove trailing whitespace droppings
- Give names to Teensy pins 46 and 47