### PR TITLE
Assign -1 to LCD_PINS_D4-7 if not defined

### DIFF
--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -470,6 +470,19 @@
   #define Z_MIN_PIN          -1
 #endif
 
+#ifndef LCD_PINS_D4
+  #define LCD_PINS_D4 -1
+#endif
+#ifndef LCD_PINS_D5
+  #define LCD_PINS_D5 -1
+#endif
+#ifndef LCD_PINS_D6
+  #define LCD_PINS_D6 -1
+#endif
+#ifndef LCD_PINS_D7
+  #define LCD_PINS_D7 -1
+#endif
+
 //
 // Dual X-carriage, Dual Y, Dual Z support
 //

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -81,10 +81,6 @@
 // Cheaptronic v1.0 doesn't support LCD
 #define LCD_PINS_RS        -1
 #define LCD_PINS_ENABLE    -1
-#define LCD_PINS_D4        -1
-#define LCD_PINS_D5        -1
-#define LCD_PINS_D6        -1
-#define LCD_PINS_D7        -1
 
 // Cheaptronic v1.0 doesn't support keypad
 #define BTN_EN1            -1

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -118,10 +118,6 @@
 
   #define LCD_PINS_RS      -1
   #define LCD_PINS_ENABLE  -1
-  #define LCD_PINS_D4      -1
-  #define LCD_PINS_D5      -1
-  #define LCD_PINS_D6      -1
-  #define LCD_PINS_D7      -1
 
   // Buttons are directly attached using keypad
   #define BTN_EN1          -1

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -155,10 +155,6 @@
 #define BEEPER_PIN         -1
 #define LCD_PINS_RS        -1
 #define LCD_PINS_ENABLE    -1
-#define LCD_PINS_D4        -1
-#define LCD_PINS_D5        -1
-#define LCD_PINS_D6        -1
-#define LCD_PINS_D7        -1
 
 #if ENABLED(SAV_3DLCD)
   // For LCD SHIFT register LCD


### PR DESCRIPTION
Simplify pins by not requiring `LCD_PINS_D4` through `LCD_PINS_D7` to be defined.