### PR TITLE
Allow user commands to stay in User Menu

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1251,6 +1251,7 @@
 //#define CUSTOM_USER_MENUS
 #if ENABLED(CUSTOM_USER_MENUS)
   #define USER_SCRIPT_DONE "M117 User Script Done"
+  #define CUSTOM_USER_MENU_RETURN  // disable to stay in custom user menu once command is complete
 
   #define USER_DESC_1 "Home & UBL Info"
   #define USER_GCODE_1 "G28\nG29 W"

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -834,7 +834,9 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     void _lcd_user_gcode(const char * const cmd) {
-      lcd_return_to_status();
+      #ifdef CUSTOM_USER_MENU_RETURN
+        lcd_return_to_status();
+      #endif
       enqueue_and_echo_commands_P(cmd);
     }
 


### PR DESCRIPTION
When a user executes a User Menu command, the LCD returns to the main
menu. If the user has multiple menu items they want to run, such as one
menu item per bed leveling corner, then it's more convenient to allow
the user to stay in the User Menu rather than return to the main menu.

Add an option not to return to the main menu, but keep the default
behaviour which currently returns to the main menu.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>