### PR TITLE
Stay in User Menu after command. Add feedback.

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -834,8 +834,8 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     void _lcd_user_gcode(const char * const cmd) {
-      lcd_return_to_status();
       enqueue_and_echo_commands_P(cmd);
+      lcd_completion_feedback();
     }
 
     #if defined(USER_DESC_1) && defined(USER_GCODE_1)


### PR DESCRIPTION
When a user executes a User Menu command, the LCD returns to the main menu. If the user has multiple menu items they want to run, such as one menu item per bed leveling corner, then it's better to stay in the User Menu rather than return to the main menu.

This PR modifies Marlin to stay in the User Menu after a command, and gives audible feedback that the command has been accepted.

From #7263