### PR TITLE
[1.1.x] Update pin definitions for PRINTRBOARD REV F.

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -13790,7 +13790,7 @@ void setup() {
     Max7219_init();
   #endif
 
-  #ifdef DISABLE_JTAG
+  #if ENABLED(DISABLE_JTAG)
     // Disable JTAG on AT90USB chips to free up pins for IO
     MCUCR = 0x80;
     MCUCR = 0x80;

--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -74,8 +74,6 @@
 #define DEFAULT_MACHINE_NAME "Makibox"
 #define BOARD_NAME           "5DPrint D8"
 
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -96,8 +96,6 @@
   #define BOARD_NAME "Anet"
 #endif
 
-#define LARGE_FLASH true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -80,8 +80,6 @@
 
 #define BOARD_NAME         "Brainwave Pro"
 
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -29,8 +29,6 @@
 #endif
 
 #define BOARD_NAME         "Cheaptronic v1.0"
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_CHEAPTRONICv2.h
+++ b/Marlin/pins_CHEAPTRONICv2.h
@@ -31,8 +31,6 @@
 #endif
 
 #define BOARD_NAME         "Cheaptronic v2.0"
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_CNCONTROLS_11.h
+++ b/Marlin/pins_CNCONTROLS_11.h
@@ -8,8 +8,6 @@
 
 #define BOARD_NAME "CN Controls V11"
 
-//#define LARGE_FLASH true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_CNCONTROLS_12.h
+++ b/Marlin/pins_CNCONTROLS_12.h
@@ -8,8 +8,6 @@
 
 #define BOARD_NAME            "CN Controls V12"
 
-//#define LARGE_FLASH true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_GT2560_REV_A.h
+++ b/Marlin/pins_GT2560_REV_A.h
@@ -32,8 +32,6 @@
 
 #define BOARD_NAME           "GT2560 Rev.A"
 #define DEFAULT_MACHINE_NAME "Prusa i3 Pro B"
-#define LARGE_FLASH true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -29,8 +29,6 @@
 #endif
 
 #define BOARD_NAME         "Megatronics"
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -29,8 +29,6 @@
 #endif
 
 #define BOARD_NAME         "Megatronics v2.0"
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -36,8 +36,6 @@
   #define BOARD_NAME       "Megatronics v3.0"
 #endif
 
-#define LARGE_FLASH        true
-
 //
 // Servos
 //

--- a/Marlin/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/pins_MIGHTYBOARD_REVE.h
@@ -59,8 +59,6 @@
 #define DEFAULT_MACHINE_NAME    "MB Replicator"
 #define BOARD_NAME              "Mightyboard"
 
-#define LARGE_FLASH true
-
 //
 // Servos
 //

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -29,7 +29,6 @@
 #endif
 
 #define BOARD_NAME          "Mini Rambo"
-#define LARGE_FLASH         true
 
 //
 // Limit Switches

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -40,8 +40,6 @@
 #endif
 
 #define BOARD_NAME         "Minitronics v1.0 / v1.1"
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -67,8 +67,6 @@
 
 #define BOARD_NAME         "Printrboard"
 
-#define LARGE_FLASH        true
-
 // Disable JTAG pins so they can be used for the Extrudrboard
 #define DISABLE_JTAG
 

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -70,7 +70,7 @@
 #define LARGE_FLASH        true
 
 // Disable JTAG pins so they can be used for the Extrudrboard
-#define DISABLE_JTAG       true
+#define DISABLE_JTAG
 
 //
 // Limit Switches

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -71,8 +71,6 @@
 #endif
 
 #define BOARD_NAME         "Printrboard Rev F"
-#define LARGE_FLASH        true
-
 // Disable JTAG pins so EXP1 pins work correctly
 // (Its pins are used for the Extrudrboard and filament sensor, for example).
 #define DISABLE_JTAG

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -30,8 +30,8 @@
  *  There are two Arduino IDE extensions that are compatible with this board
  *  and with the mainstream Marlin software.
  *
- *  Teensyduino - http://www.pjrc.com/teensy/teensyduino.html
- *    Installation instructions are at the above URL.
+ *  Teensyduino -  https://www.pjrc.com/teensy/teensyduino.html
+ *  Installation - https://www.pjrc.com/teensy/td_download.html
  *
  *    Select Teensy++ 2.0 in Arduino IDE from the 'Tools -> Boards' menu
  *
@@ -66,8 +66,35 @@
   #error "Oops!  Make sure you have 'Teensy++ 2.0' or 'Printrboard' selected from the 'Tools -> Boards' menu."
 #endif
 
+#ifndef USBCON
+  #error "USBCON should be defined by the platform for this board."
+#endif
+
 #define BOARD_NAME         "Printrboard Rev F"
 #define LARGE_FLASH        true
+
+// Disable JTAG pins so EXP1 pins work correctly
+// (Its pins are used for the Extrudrboard and filament sensor, for example).
+#define DISABLE_JTAG
+
+/**
+ * Note that REV F6 of the Printrboard stole the A HOTEND pin and
+ * reassigned it to a second fan for the extruder heater.  It's
+ * recommended that you swap the A and B outputs on the Extrudrboard
+ * so EXTRUDERS=2 will still work on F6, using B for E1/HEATER_1/TEMP_1.
+ * See https://printrbot.zendesk.com/hc/en-us/articles/115003072346
+ *
+ * If you have REV F6 you probably also want to set E0_AUTO_FAN_PIN
+ * to PRINTRBOARD_F6_HEATER_FAN_PIN
+ *
+ * Define NO_EXTRUDRBOARD if you don't have an EXTRUDRBOARD and wish to
+ * reassign different functions to EXP1.
+ *
+ * Define NO_EXTRUDRBOARD_OUTPUT_SWAP if you have a REV F5 or lower and
+ * want to use EXTRUDRBOARD A for E1 and EXTRUDRBOARD B for E2.
+ */
+//#define NO_EXTRUDRBOARD
+//#define NO_EXTRUDRBOARD_OUTPUT_SWAP
 
 //
 // Limit Switches
@@ -95,6 +122,26 @@
 #define E0_DIR_PIN         35   // A7
 #define E0_ENABLE_PIN      13   // C3
 
+#if DISABLED(NO_EXTRUDRBOARD)
+#if DISABLED(NO_EXTRUDRBOARD_OUTPUT_SWAP)
+  #define E1_STEP_PIN      25   // B5
+  #define E1_DIR_PIN       37   // E5
+  #define E1_ENABLE_PIN    42   // F4
+
+  #define E2_STEP_PIN       2   // D2
+  #define E2_DIR_PIN        3   // D3
+  #define E2_ENABLE_PIN    43   // F5
+#else
+  #define E1_STEP_PIN       2   // D2
+  #define E1_DIR_PIN        3   // D3
+  #define E1_ENABLE_PIN    43   // F5
+
+  #define E2_STEP_PIN      25   // B5
+  #define E2_DIR_PIN       37   // E5
+  #define E2_ENABLE_PIN    42   // F4
+#endif
+#endif // NO_EXTRUDRBOARD
+
 // Enable control of stepper motor currents with the I2C based MCP4728 DAC used on Printrboard REVF
 #define DAC_STEPPER_CURRENT
 
@@ -119,13 +166,31 @@
 #define TEMP_0_PIN          1   // Analog Input (Extruder)
 #define TEMP_BED_PIN        0   // Analog Input (Bed)
 
+#if DISABLED(NO_EXTRUDRBOARD)
+#if DISABLED(NO_EXTRUDRBOARD_OUTPUT_SWAP)
+  #define TEMP_1_PIN        2   // Analog Input (Extrudrboard A THERM)
+  #define TEMP_2_PIN        3   // Analog Input (Extrudrboard B THERM)
+#else
+  #define TEMP_1_PIN        3   // Analog Input (Extrudrboard B THERM)
+  #define TEMP_2_PIN        2   // Analog Input (Extrudrboard A THERM)
+#endif
+#endif
+
 //
 // Heaters / Fans
 //
 #define HEATER_0_PIN       15   // C5 PWM3B - Extruder
-#define HEATER_1_PIN       44   // F6
-#define HEATER_2_PIN       45   // F7
 #define HEATER_BED_PIN     14   // C4 PWM3C
+
+#if DISABLED(NO_EXTRUDRBOARD)
+#if DISABLED(NO_EXTRUDRBOARD_OUTPUT_SWAP)
+  #define HEATER_1_PIN     44   // F6 - Extrudrboard A HOTEND
+  #define HEATER_2_PIN     45   // F7 - Extrudrboard B HOTEND
+#else
+  #define HEATER_1_PIN     45   // F7 - Extrudrboard B HOTEND
+  #define HEATER_2_PIN     44   // F6 - Extrudrboard A HOTEND
+#endif
+#endif
 
 #define FAN_PIN            16   // C6 PWM3A
 
@@ -201,6 +266,14 @@
 #ifndef SDSS
   #define SDSS             20  //        10               B0
 #endif
+
+/**
+ * This is EXP1-2, which is also the TEMP_A_PIN for the Extrudrboard.
+ * If using w/ Extrudrboard, cut off pin 2 on the Extrudrboard male
+ * connector to ensure this is disconnected from the A THERM pullups.
+ * You probably want to set EXTRUDERS=2 and swap the Extrudrboard outputs,
+ * which will let you use Channel B on the Extrudrboard as E1.
+ */
 #ifndef FILWIDTH_PIN
-  #define FILWIDTH_PIN      2  // Analog Input 
+  #define FILWIDTH_PIN      2   // Analog Input
 #endif

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -46,8 +46,6 @@
 
 #define BOARD_NAME "Rambo"
 
-#define LARGE_FLASH true
-
 //
 // Servos
 //

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -52,8 +52,6 @@
   #define BOARD_NAME "RAMPS 1.4"
 #endif
 
-#define LARGE_FLASH true
-
 //
 // Servos
 //

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -59,10 +59,6 @@
   #define BOARD_NAME "Sanguinololu <1.2"
 #endif
 
-#ifdef __AVR_ATmega1284P__
-  #define LARGE_FLASH true
-#endif
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -69,8 +69,6 @@
 #define DEFAULT_SOURCE_CODE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
 #define BOARD_NAME              "SAV MkI"
 
-#define LARGE_FLASH        true
-
 //
 // Servos
 //

--- a/Marlin/pins_SCOOVO_X9H.h
+++ b/Marlin/pins_SCOOVO_X9H.h
@@ -30,8 +30,6 @@
 
 #define BOARD_NAME "Scoovo X9H"
 
-#define LARGE_FLASH true
-
 //
 // Servos
 //

--- a/Marlin/pins_SILVER_GATE.h
+++ b/Marlin/pins_SILVER_GATE.h
@@ -28,8 +28,6 @@
   #define BOARD_NAME "Silver Gate"
 #endif
 
-#define LARGE_FLASH true
-
 #define X_STEP_PIN         43
 #define X_DIR_PIN          44
 #define X_ENABLE_PIN       42

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -112,8 +112,6 @@
 
 #define BOARD_NAME         "Teensy++2.0"
 
-#define LARGE_FLASH        true
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -79,8 +79,6 @@
 
 #define BOARD_NAME         "Teensylu"
 
-#define LARGE_FLASH        true
-
 
 //
 // Limit Switch definitions that match the SCHEMATIC

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -40,8 +40,6 @@
 #define DEFAULT_SOURCE_CODE_URL "https://github.com/Ultimaker/Marlin"
 #define BOARD_NAME              "Ultimaker"
 
-#define LARGE_FLASH true
-
 //
 // Servos
 //

--- a/Marlin/pins_ULTIMAKER_OLD.h
+++ b/Marlin/pins_ULTIMAKER_OLD.h
@@ -68,8 +68,6 @@
 #define DEFAULT_SOURCE_CODE_URL "https://github.com/Ultimaker/Marlin"
 #define BOARD_NAME              "Ultimaker <1.5.4"
 
-#define LARGE_FLASH true
-
 //
 // Limit Switches
 //


### PR DESCRIPTION
Allow use of Extrudrboard and REV F6.  Disable JTAG to allow additional
pins to be used, and allow swapping channel A and B of the Extrudrboard
to accomodate REV F6.