### PR TITLE
Allow the sampled point to be added into the Least Squares Best Fit

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4623,6 +4623,8 @@ void home_all_axes() { gcode_G28(true); }
           eqnAMatrix[abl_probe_index + 1 * abl2] = yProbe;
           eqnAMatrix[abl_probe_index + 2 * abl2] = 1;
 
+          incremental_LSF(&lsf_results, xProbe, yProbe, measured_z);
+
         #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
           z_values[xCount][yCount] = measured_z + zoffset;


### PR DESCRIPTION
Without this...  The LSF won't work because none of the sampled points
in this code block get added.