### PR TITLE
Fixes for FWRETRACT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,8 @@ script:
   - build_marlin
   #
   # Test 2 extruders (one MAX6675) and heated bed on basic RAMPS 1.4
-  #  plus a "Fix Mounted" Probe with Safe Homing and some arc options
+  # Test a "Fix Mounted" Probe with Safe Homing, some arc options,
+  # linear bed leveling, M48, leveling debug, and firmware retraction.
   #
   - opt_set MOTHERBOARD BOARD_RAMPS_14_EEB
   - opt_set EXTRUDERS 2
@@ -84,12 +85,10 @@ script:
   - opt_set TEMP_SENSOR_1 1
   - opt_set TEMP_SENSOR_BED 1
   - opt_enable PIDTEMPBED FIX_MOUNTED_PROBE Z_SAFE_HOMING ARC_P_CIRCLES CNC_WORKSPACE_PLANES
+  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT EEPROM_SETTINGS
   - opt_enable BLINKM PCA9632 RGB_LED NEOPIXEL_RGBW_LED
-  - build_marlin
-  #
-  # ...with AUTO_BED_LEVELING_LINEAR, Z_MIN_PROBE_REPEATABILITY_TEST, and DEBUG_LEVELING_FEATURE
-  #
   - opt_enable AUTO_BED_LEVELING_LINEAR Z_MIN_PROBE_REPEATABILITY_TEST DEBUG_LEVELING_FEATURE
+  - opt_enable_adv FWRETRACT
   - opt_set ABL_GRID_POINTS_X 16
   - opt_set ABL_GRID_POINTS_Y 16
   - build_marlin

--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -190,6 +190,13 @@
   #endif
 
   /**
+   * Provide a MAX_AUTORETRACT for older configs
+   */
+  #if ENABLED(FWRETRACT) && !defined(MAX_AUTORETRACT)
+    #define MAX_AUTORETRACT 99
+  #endif
+
+  /**
    * MAX_STEP_FREQUENCY differs for TOSHIBA
    */
   #if ENABLED(CONFIG_STEPPERS_TOSHIBA)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -383,10 +383,15 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
 #endif
 
 #if ENABLED(FWRETRACT)
-  extern bool autoretract_enabled;
-  extern bool retracted[EXTRUDERS]; // extruder[n].retracted
-  extern float retract_length, retract_length_swap, retract_feedrate_mm_s, retract_zlift;
-  extern float retract_recover_length, retract_recover_length_swap, retract_recover_feedrate_mm_s;
+  extern bool autoretract_enabled;                 // M209 S - Autoretract switch
+  extern float retract_length,                     // M207 S - G10 Retract length
+               retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
+               retract_zlift,                      // M207 Z - G10 Retract hop size
+               retract_recover_length,             // M208 S - G11 Recover length
+               retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
+               retract_length_swap,                // M207 W - G10 Swap Retract length
+               retract_recover_length_swap,        // M208 W - G11 Swap Recover length
+               swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
 #endif
 
 // Print job timer

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -389,8 +389,8 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
                retract_zlift,                      // M207 Z - G10 Retract hop size
                retract_recover_length,             // M208 S - G11 Recover length
                retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
-               retract_length_swap,                // M207 W - G10 Swap Retract length
-               retract_recover_length_swap,        // M208 W - G11 Swap Recover length
+               swap_retract_length,                // M207 W - G10 Swap Retract length
+               swap_retract_recover_length,        // M208 W - G11 Swap Recover length
                swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3150,6 +3150,10 @@ static void homeaxis(const AxisEnum axis) {
     const bool has_zhop = retract_zlift > 0.01;     // Is there a hop set?
 
     const float old_feedrate_mm_s = feedrate_mm_s;
+    const int16_t old_flow = flow_percentage[active_extruder];
+
+    // Don't apply flow multiplication to retract/recover
+    flow_percentage[active_extruder] = 100;
 
     // The current position will be the destination for E and Z moves
     set_destination_to_current();
@@ -3192,6 +3196,8 @@ static void homeaxis(const AxisEnum axis) {
       prepare_move_to_destination();  // Recover E
     }
 
+    // Restore flow and feedrate
+    flow_percentage[active_extruder] = old_flow;
     feedrate_mm_s = old_feedrate_mm_s;
 
     // The active extruder is now retracted or recovered

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3281,7 +3281,7 @@ inline void gcode_G0_G1(
       if (autoretract_enabled && !(parser.seen('X') || parser.seen('Y') || parser.seen('Z')) && parser.seen('E')) {
         const float echange = destination[E_AXIS] - current_position[E_AXIS];
         // Is this move an attempt to retract or recover?
-        if ((echange < -(MIN_RETRACT) && !retracted[active_extruder]) || (echange > MIN_RETRACT && retracted[active_extruder])) {
+        if (WITHIN(FABS(echange), MIN_AUTORETRACT, MAX_AUTORETRACT) && retracted[active_extruder] == (echange > 0.0)) {
           current_position[E_AXIS] = destination[E_AXIS]; // hide the slicer-generated retract/recover from calculations
           sync_plan_position_e();  // AND from the planner
           retract(!retracted[active_extruder]);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -557,20 +557,22 @@ static uint8_t target_extruder;
           baricuda_e_to_p_pressure = 0;
 #endif
 
-#if ENABLED(FWRETRACT)
-
-  bool autoretract_enabled = false;
-  bool retracted[EXTRUDERS] = { false };
-  bool retracted_swap[EXTRUDERS] = { false };
-
-  float retract_length = RETRACT_LENGTH;
-  float retract_length_swap = RETRACT_LENGTH_SWAP;
-  float retract_feedrate_mm_s = RETRACT_FEEDRATE;
-  float retract_zlift = RETRACT_ZLIFT;
-  float retract_recover_length = RETRACT_RECOVER_LENGTH;
-  float retract_recover_length_swap = RETRACT_RECOVER_LENGTH_SWAP;
-  float retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE;
-
+#if ENABLED(FWRETRACT)                      // Initialized by settings.load()...
+  bool  autoretract_enabled,                // M209 S - Autoretract switch
+        retracted[EXTRUDERS] = { false };   // Which extruders are currently retracted
+  float retract_length,                     // M207 S - G10 Retract length
+        retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
+        retract_zlift,                      // M207 Z - G10 Retract hop size
+        retract_recover_length,             // M208 S - G11 Recover length
+        retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
+        retract_length_swap,                // M207 W - G10 Swap Retract length
+        retract_recover_length_swap,        // M208 W - G11 Swap Recover length
+        swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
+  #if EXTRUDERS > 1
+    bool retracted_swap[EXTRUDERS] = { false }; // Which extruders are swap-retracted
+  #else
+    constexpr bool retracted_swap[1] = { false };
+  #endif
 #endif // FWRETRACT
 
 #if HAS_POWER_SWITCH
@@ -3100,54 +3102,119 @@ static void homeaxis(const AxisEnum axis) {
 
 #if ENABLED(FWRETRACT)
 
-  void retract(const bool retracting, const bool swapping = false) {
+  /**
+   * Retract or recover according to firmware settings
+   *
+   * This function handles retract/recover moves for G10 and G11,
+   * plus auto-retract moves sent from G0/G1 when E-only moves are done.
+   *
+   * To simplify the logic, doubled retract/recover moves are ignored.
+   *
+   * Note: Z lift is done transparently to the planner. Aborting
+   *       a print between G10 and G11 may corrupt the Z position.
+   *
+   * Note: Auto-retract will apply the set Z hop in addition to any Z hop
+   *       included in the G-code. Use M207 Z0 to to prevent double hop.
+   */
+  void retract(const bool retracting
+    #if EXTRUDERS > 1
+      , bool swapping = false
+    #endif
+  ) {
 
-    static float hop_height;
+    static float hop_height,        // Remember where the Z height started
+                 hop_amount = 0.0;  // Total amount lifted, for use in recover
 
-    if (retracting == retracted[active_extruder]) return;
+    // Simply never allow two retracts or recovers in a row
+    if (retracted[active_extruder] == retracting) return;
+
+    #if EXTRUDERS < 2
+      bool swapping = false;
+    #endif
+    if (!retracting) swapping = retracted_swap[active_extruder];
+
+    /* // debugging
+      SERIAL_ECHOLNPAIR("retracting ", retracting);
+      SERIAL_ECHOLNPAIR("swapping ", swapping);
+      SERIAL_ECHOLNPAIR("active extruder ", active_extruder);
+      for (uint8_t i = 0; i < EXTRUDERS; ++i) {
+        SERIAL_ECHOPAIR("retracted[", i);
+        SERIAL_ECHOLNPAIR("] ", retracted[i]);
+        SERIAL_ECHOPAIR("retracted_swap[", i);
+        SERIAL_ECHOLNPAIR("] ", retracted_swap[i]);
+      }
+      SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);
+      SERIAL_ECHOLNPAIR("hop_amount ", hop_amount);
+    //*/
+
+    const bool has_zhop = retract_zlift > 0.01;     // Is there a hop set?
 
     const float old_feedrate_mm_s = feedrate_mm_s;
 
+    // The current position will be the destination for E and Z moves
     set_destination_to_current();
 
     if (retracting) {
+      // Remember the Z height since G-code may include its own Z-hop
+      // For best results turn off Z hop if G-code already includes it
+      hop_height = destination[Z_AXIS];
 
+      // Retract by moving from a faux E position back to the current E position
       feedrate_mm_s = retract_feedrate_mm_s;
       current_position[E_AXIS] += (swapping ? retract_length_swap : retract_length) / volumetric_multiplier[active_extruder];
       sync_plan_position_e();
       prepare_move_to_destination();
 
-      if (retract_zlift > 0.01) {
-        hop_height = current_position[Z_AXIS];
-        // Pretend current position is lower
-        current_position[Z_AXIS] -= retract_zlift;
-        SYNC_PLAN_POSITION_KINEMATIC();
-        // Raise up to the old current_position
-        prepare_move_to_destination();
+      // Is a Z hop set, and has the hop not yet been done?
+      if (has_zhop) {
+        hop_amount += retract_zlift;                // Carriage is raised for retraction hop
+        current_position[Z_AXIS] -= retract_zlift;  // Pretend current pos is lower. Next move raises Z.
+        SYNC_PLAN_POSITION_KINEMATIC();             // Set the planner to the new position
+        prepare_move_to_destination();              // Raise up to the old current pos
       }
     }
     else {
-
-      // If the height hasn't been lowered, undo the Z hop
-      if (retract_zlift > 0.01 && hop_height <= current_position[Z_AXIS]) {
-        // Pretend current position is higher. Z will lower on the next move
-        current_position[Z_AXIS] += retract_zlift;
-        SYNC_PLAN_POSITION_KINEMATIC();
-        // Lower Z
-        prepare_move_to_destination();
+      // If a hop was done and Z hasn't changed, undo the Z hop
+      if (hop_amount && NEAR(hop_height, destination[Z_AXIS])) {
+        current_position[Z_AXIS] += hop_amount;     // Pretend current pos is higher. Next move lowers Z.
+        SYNC_PLAN_POSITION_KINEMATIC();             // Set the planner to the new position
+        prepare_move_to_destination();              // Lower to the old current pos
+        hop_amount = 0.0;
       }
 
-      feedrate_mm_s = retract_recover_feedrate_mm_s;
+      // A retract multiplier has been added here to get faster swap recovery
+      feedrate_mm_s = swapping ? swap_retract_recover_feedrate_mm_s : retract_recover_feedrate_mm_s;
+
       const float move_e = swapping ? retract_length_swap + retract_recover_length_swap : retract_length + retract_recover_length;
       current_position[E_AXIS] -= move_e / volumetric_multiplier[active_extruder];
       sync_plan_position_e();
 
-      // Recover E
-      prepare_move_to_destination();
+      prepare_move_to_destination();  // Recover E
     }
 
     feedrate_mm_s = old_feedrate_mm_s;
+
+    // The active extruder is now retracted or recovered
     retracted[active_extruder] = retracting;
+
+    // If swap retract/recover then update the retracted_swap flag too
+    #if EXTRUDERS > 1
+      if (swapping) retracted_swap[active_extruder] = retracting;
+    #endif
+
+    /* // debugging
+      SERIAL_ECHOLNPAIR("retracting ", retracting);
+      SERIAL_ECHOLNPAIR("swapping ", swapping);
+      SERIAL_ECHOLNPAIR("active_extruder ", active_extruder);
+      for (uint8_t i = 0; i < EXTRUDERS; ++i) {
+        SERIAL_ECHOPAIR("retracted[", i);
+        SERIAL_ECHOLNPAIR("] ", retracted[i]);
+        SERIAL_ECHOPAIR("retracted_swap[", i);
+        SERIAL_ECHOLNPAIR("] ", retracted_swap[i]);
+      }
+      SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);
+      SERIAL_ECHOLNPAIR("hop_amount ", hop_amount);
+    //*/
 
   } // retract()
 
@@ -3277,18 +3344,16 @@ inline void gcode_G0_G1(
     gcode_get_destination(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT)
-
-      if (autoretract_enabled && !(parser.seen('X') || parser.seen('Y') || parser.seen('Z')) && parser.seen('E')) {
+      // When M209 Autoretract is enabled, convert E-only moves to firmware retract/recover moves
+      if (autoretract_enabled && parser.seen('E') && !(parser.seen('X') || parser.seen('Y') || parser.seen('Z'))) {
         const float echange = destination[E_AXIS] - current_position[E_AXIS];
-        // Is this move an attempt to retract or recover?
+        // Is this a retract or recover move?
         if (WITHIN(FABS(echange), MIN_AUTORETRACT, MAX_AUTORETRACT) && retracted[active_extruder] == (echange > 0.0)) {
-          current_position[E_AXIS] = destination[E_AXIS]; // hide the slicer-generated retract/recover from calculations
-          sync_plan_position_e();  // AND from the planner
-          retract(!retracted[active_extruder]);
-          return;
+          current_position[E_AXIS] = destination[E_AXIS]; // Hide a G1-based retract/recover from calculations
+          sync_plan_position_e();                         // AND from the planner
+          return retract(echange < 0.0);                  // Firmware-based retract/recover (double-retract ignored)
         }
       }
-
     #endif // FWRETRACT
 
     #if IS_SCARA
@@ -8489,9 +8554,7 @@ inline void gcode_M205() {
     if (parser.seen('S')) retract_length = parser.value_axis_units(E_AXIS);
     if (parser.seen('F')) retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
     if (parser.seen('Z')) retract_zlift = parser.value_linear_units();
-    #if EXTRUDERS > 1
-      if (parser.seen('W')) retract_length_swap = parser.value_axis_units(E_AXIS);
-    #endif
+    if (parser.seen('W')) retract_length_swap = parser.value_axis_units(E_AXIS);
   }
 
   /**
@@ -8500,13 +8563,13 @@ inline void gcode_M205() {
    *   S[+units]    retract_recover_length (in addition to M207 S*)
    *   W[+units]    retract_recover_length_swap (multi-extruder)
    *   F[units/min] retract_recover_feedrate_mm_s
+   *   R[units/min] swap_retract_recover_feedrate_mm_s
    */
   inline void gcode_M208() {
     if (parser.seen('S')) retract_recover_length = parser.value_axis_units(E_AXIS);
     if (parser.seen('F')) retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-    #if EXTRUDERS > 1
-      if (parser.seen('W')) retract_recover_length_swap = parser.value_axis_units(E_AXIS);
-    #endif
+    if (parser.seen('R')) swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
+    if (parser.seen('W')) retract_recover_length_swap = parser.value_axis_units(E_AXIS);
   }
 
   /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -565,8 +565,8 @@ static uint8_t target_extruder;
         retract_zlift,                      // M207 Z - G10 Retract hop size
         retract_recover_length,             // M208 S - G11 Recover length
         retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
-        retract_length_swap,                // M207 W - G10 Swap Retract length
-        retract_recover_length_swap,        // M208 W - G11 Swap Recover length
+        swap_retract_length,                // M207 W - G10 Swap Retract length
+        swap_retract_recover_length,        // M208 W - G11 Swap Recover length
         swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
   #if EXTRUDERS > 1
     bool retracted_swap[EXTRUDERS] = { false }; // Which extruders are swap-retracted
@@ -3165,7 +3165,7 @@ static void homeaxis(const AxisEnum axis) {
 
       // Retract by moving from a faux E position back to the current E position
       feedrate_mm_s = retract_feedrate_mm_s;
-      current_position[E_AXIS] += (swapping ? retract_length_swap : retract_length) / volumetric_multiplier[active_extruder];
+      current_position[E_AXIS] += (swapping ? swap_retract_length : retract_length) / volumetric_multiplier[active_extruder];
       sync_plan_position_e();
       prepare_move_to_destination();
 
@@ -3189,7 +3189,7 @@ static void homeaxis(const AxisEnum axis) {
       // A retract multiplier has been added here to get faster swap recovery
       feedrate_mm_s = swapping ? swap_retract_recover_feedrate_mm_s : retract_recover_feedrate_mm_s;
 
-      const float move_e = swapping ? retract_length_swap + retract_recover_length_swap : retract_length + retract_recover_length;
+      const float move_e = swapping ? swap_retract_length + swap_retract_recover_length : retract_length + retract_recover_length;
       current_position[E_AXIS] -= move_e / volumetric_multiplier[active_extruder];
       sync_plan_position_e();
 
@@ -8554,7 +8554,7 @@ inline void gcode_M205() {
    * M207: Set firmware retraction values
    *
    *   S[+units]    retract_length
-   *   W[+units]    retract_length_swap (multi-extruder)
+   *   W[+units]    swap_retract_length (multi-extruder)
    *   F[units/min] retract_feedrate_mm_s
    *   Z[units]     retract_zlift
    */
@@ -8562,14 +8562,14 @@ inline void gcode_M205() {
     if (parser.seen('S')) retract_length = parser.value_axis_units(E_AXIS);
     if (parser.seen('F')) retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
     if (parser.seen('Z')) retract_zlift = parser.value_linear_units();
-    if (parser.seen('W')) retract_length_swap = parser.value_axis_units(E_AXIS);
+    if (parser.seen('W')) swap_retract_length = parser.value_axis_units(E_AXIS);
   }
 
   /**
    * M208: Set firmware un-retraction values
    *
    *   S[+units]    retract_recover_length (in addition to M207 S*)
-   *   W[+units]    retract_recover_length_swap (multi-extruder)
+   *   W[+units]    swap_retract_recover_length (multi-extruder)
    *   F[units/min] retract_recover_feedrate_mm_s
    *   R[units/min] swap_retract_recover_feedrate_mm_s
    */
@@ -8577,7 +8577,7 @@ inline void gcode_M205() {
     if (parser.seen('S')) retract_recover_length = parser.value_axis_units(E_AXIS);
     if (parser.seen('F')) retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
     if (parser.seen('R')) swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-    if (parser.seen('W')) retract_recover_length_swap = parser.value_axis_units(E_AXIS);
+    if (parser.seen('W')) swap_retract_recover_length = parser.value_axis_units(E_AXIS);
   }
 
   /**

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -206,6 +206,8 @@
   #error "Replace SLED_PIN with SOL1_PIN (applies to both Z_PROBE_SLED and SOLENOID_PROBE)."
 #elif defined(CONTROLLERFAN_PIN)
   #error "CONTROLLERFAN_PIN is now CONTROLLER_FAN_PIN, enabled with USE_CONTROLLER_FAN. Please update your Configuration_adv.h."
+#elif defined(MIN_RETRACT)
+  #error "MIN_RETRACT is now MIN_AUTORETRACT and MAX_AUTORETRACT. Please update your Configuration_adv.h."
 #endif
 
 /**

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1762,7 +1762,7 @@ void MarlinSettings::reset() {
 
       if (!forReplay) {
         CONFIG_ECHO_START;
-        SERIAL_ECHOLNPGM("Auto-Retract: S=0 to disable, 1 to interpret extrude-only moves as retracts or recoveries");
+        SERIAL_ECHOLNPGM("Auto-Retract: S=0 to disable, 1 to interpret E-only moves as retract/recover");
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOLNPAIR("  M209 S", autoretract_enabled ? 1 : 0);

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -132,8 +132,8 @@
  *  513  M207 Z    retract_zlift                    (float)
  *  517  M208 S    retract_recover_length           (float)
  *  521  M208 F    retract_recover_feedrate_mm_s    (float)
- *  525  M207 W    retract_length_swap              (float)
- *  529  M208 W    retract_recover_length_swap      (float)
+ *  525  M207 W    swap_retract_length              (float)
+ *  529  M208 W    swap_retract_recover_length      (float)
  *  533  M208 R    swap_retract_recover_feedrate_mm_s (float)
  *
  * Volumetric Extrusion:                            21 bytes
@@ -528,8 +528,8 @@ void MarlinSettings::postprocess() {
                   retract_zlift = 0,
                   retract_recover_length = 0,
                   retract_recover_feedrate_mm_s = 0,
-                  retract_length_swap = 13,
-                  retract_recover_length_swap = 0,
+                  swap_retract_length = 13,
+                  swap_retract_recover_length = 0,
                   swap_retract_recover_feedrate_mm_s = 8;
     #endif
     EEPROM_WRITE(autoretract_enabled);
@@ -538,8 +538,8 @@ void MarlinSettings::postprocess() {
     EEPROM_WRITE(retract_zlift);
     EEPROM_WRITE(retract_recover_length);
     EEPROM_WRITE(retract_recover_feedrate_mm_s);
-    EEPROM_WRITE(retract_length_swap);
-    EEPROM_WRITE(retract_recover_length_swap);
+    EEPROM_WRITE(swap_retract_length);
+    EEPROM_WRITE(swap_retract_recover_length);
     EEPROM_WRITE(swap_retract_recover_feedrate_mm_s);
 
     EEPROM_WRITE(volumetric_enabled);
@@ -920,8 +920,8 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(retract_zlift);
         EEPROM_READ(retract_recover_length);
         EEPROM_READ(retract_recover_feedrate_mm_s);
-        EEPROM_READ(retract_length_swap);
-        EEPROM_READ(retract_recover_length_swap);
+        EEPROM_READ(swap_retract_length);
+        EEPROM_READ(swap_retract_recover_length);
         EEPROM_READ(swap_retract_recover_feedrate_mm_s);
       #else
         EEPROM_READ(dummyb);
@@ -1292,8 +1292,8 @@ void MarlinSettings::reset() {
     retract_zlift = RETRACT_ZLIFT;
     retract_recover_length = RETRACT_RECOVER_LENGTH;
     retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE;
-    retract_length_swap = RETRACT_LENGTH_SWAP;
-    retract_recover_length_swap = RETRACT_RECOVER_LENGTH_SWAP;
+    swap_retract_length = RETRACT_LENGTH_SWAP;
+    swap_retract_recover_length = RETRACT_RECOVER_LENGTH_SWAP;
     swap_retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE_SWAP;
   #endif // FWRETRACT
 
@@ -1747,7 +1747,7 @@ void MarlinSettings::reset() {
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M207 S", LINEAR_UNIT(retract_length));
-      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(retract_length_swap));
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(swap_retract_length));
       SERIAL_ECHOPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(retract_feedrate_mm_s)));
       SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(retract_zlift));
 
@@ -1757,7 +1757,7 @@ void MarlinSettings::reset() {
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M208 S", LINEAR_UNIT(retract_recover_length));
-      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(retract_recover_length_swap));
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(swap_retract_recover_length));
       SERIAL_ECHOLNPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(retract_recover_feedrate_mm_s)));
 
       if (!forReplay) {

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,7 +36,7 @@
  *
  */
 
-#define EEPROM_VERSION "V39"
+#define EEPROM_VERSION "V40"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
@@ -125,44 +125,45 @@
  * DOGLCD:                                          2 bytes
  *  502  M250 C    lcd_contrast                     (uint16_t)
  *
- * FWRETRACT:                                       29 bytes
+ * FWRETRACT:                                       33 bytes
  *  504  M209 S    autoretract_enabled              (bool)
  *  505  M207 S    retract_length                   (float)
- *  509  M207 W    retract_length_swap              (float)
- *  513  M207 F    retract_feedrate_mm_s            (float)
- *  517  M207 Z    retract_zlift                    (float)
- *  521  M208 S    retract_recover_length           (float)
- *  525  M208 W    retract_recover_length_swap      (float)
- *  529  M208 F    retract_recover_feedrate_mm_s    (float)
+ *  509  M207 F    retract_feedrate_mm_s            (float)
+ *  513  M207 Z    retract_zlift                    (float)
+ *  517  M208 S    retract_recover_length           (float)
+ *  521  M208 F    retract_recover_feedrate_mm_s    (float)
+ *  525  M207 W    retract_length_swap              (float)
+ *  529  M208 W    retract_recover_length_swap      (float)
+ *  533  M208 R    swap_retract_recover_feedrate_mm_s (float)
  *
  * Volumetric Extrusion:                            21 bytes
- *  533  M200 D    volumetric_enabled               (bool)
- *  534  M200 T D  filament_size                    (float x5) (T0..3)
+ *  537  M200 D    volumetric_enabled               (bool)
+ *  538  M200 T D  filament_size                    (float x5) (T0..3)
  *
  * HAVE_TMC2130:                                    20 bytes
- *  554  M906 X    Stepper X current                (uint16_t)
- *  556  M906 Y    Stepper Y current                (uint16_t)
- *  558  M906 Z    Stepper Z current                (uint16_t)
- *  560  M906 X2   Stepper X2 current               (uint16_t)
- *  562  M906 Y2   Stepper Y2 current               (uint16_t)
- *  564  M906 Z2   Stepper Z2 current               (uint16_t)
- *  566  M906 E0   Stepper E0 current               (uint16_t)
- *  568  M906 E1   Stepper E1 current               (uint16_t)
- *  570  M906 E2   Stepper E2 current               (uint16_t)
- *  572  M906 E3   Stepper E3 current               (uint16_t)
- *  576  M906 E4   Stepper E4 current               (uint16_t)
+ *  558  M906 X    Stepper X current                (uint16_t)
+ *  560  M906 Y    Stepper Y current                (uint16_t)
+ *  562  M906 Z    Stepper Z current                (uint16_t)
+ *  564  M906 X2   Stepper X2 current               (uint16_t)
+ *  566  M906 Y2   Stepper Y2 current               (uint16_t)
+ *  568  M906 Z2   Stepper Z2 current               (uint16_t)
+ *  570  M906 E0   Stepper E0 current               (uint16_t)
+ *  572  M906 E1   Stepper E1 current               (uint16_t)
+ *  574  M906 E2   Stepper E2 current               (uint16_t)
+ *  576  M906 E3   Stepper E3 current               (uint16_t)
+ *  580  M906 E4   Stepper E4 current               (uint16_t)
  *
  * LIN_ADVANCE:                                     8 bytes
- *  580  M900 K    extruder_advance_k               (float)
- *  584  M900 WHD  advance_ed_ratio                 (float)
+ *  584  M900 K    extruder_advance_k               (float)
+ *  588  M900 WHD  advance_ed_ratio                 (float)
  *
  * HAS_MOTOR_CURRENT_PWM:
- *  588  M907 X    Stepper XY current               (uint32_t)
- *  592  M907 Z    Stepper Z current                (uint32_t)
- *  596  M907 E    Stepper E current                (uint32_t)
+ *  592  M907 X    Stepper XY current               (uint32_t)
+ *  596  M907 Z    Stepper Z current                (uint32_t)
+ *  600  M907 E    Stepper E current                (uint32_t)
  *
- *  600                                Minimum end-point
- * 1921 (600 + 36 + 9 + 288 + 988)     Maximum end-point
+ *  604                                Minimum end-point
+ * 1925 (604 + 36 + 9 + 288 + 988)     Maximum end-point
  *
  * ========================================================================
  * meshes_begin (between max and min end-point, directly above)
@@ -520,26 +521,26 @@ void MarlinSettings::postprocess() {
     #endif
     EEPROM_WRITE(lcd_contrast);
 
-    #if ENABLED(FWRETRACT)
-      EEPROM_WRITE(autoretract_enabled);
-      EEPROM_WRITE(retract_length);
-      #if EXTRUDERS > 1
-        EEPROM_WRITE(retract_length_swap);
-      #else
-        dummy = 0.0f;
-        EEPROM_WRITE(dummy);
-      #endif
-      EEPROM_WRITE(retract_feedrate_mm_s);
-      EEPROM_WRITE(retract_zlift);
-      EEPROM_WRITE(retract_recover_length);
-      #if EXTRUDERS > 1
-        EEPROM_WRITE(retract_recover_length_swap);
-      #else
-        dummy = 0.0f;
-        EEPROM_WRITE(dummy);
-      #endif
-      EEPROM_WRITE(retract_recover_feedrate_mm_s);
-    #endif // FWRETRACT
+    #if DISABLED(FWRETRACT)
+      const bool autoretract_enabled = false;
+      const float retract_length = 3,
+                  retract_feedrate_mm_s = 45,
+                  retract_zlift = 0,
+                  retract_recover_length = 0,
+                  retract_recover_feedrate_mm_s = 0,
+                  retract_length_swap = 13,
+                  retract_recover_length_swap = 0,
+                  swap_retract_recover_feedrate_mm_s = 8;
+    #endif
+    EEPROM_WRITE(autoretract_enabled);
+    EEPROM_WRITE(retract_length);
+    EEPROM_WRITE(retract_feedrate_mm_s);
+    EEPROM_WRITE(retract_zlift);
+    EEPROM_WRITE(retract_recover_length);
+    EEPROM_WRITE(retract_recover_feedrate_mm_s);
+    EEPROM_WRITE(retract_length_swap);
+    EEPROM_WRITE(retract_recover_length_swap);
+    EEPROM_WRITE(swap_retract_recover_feedrate_mm_s);
 
     EEPROM_WRITE(volumetric_enabled);
 
@@ -620,7 +621,7 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(val);
     #else
       val = 0;
-      for (uint8_t q = 0; q < 11; ++q) EEPROM_WRITE(val);
+      for (uint8_t q = 11; q--;) EEPROM_WRITE(val);
     #endif
 
     //
@@ -701,6 +702,7 @@ void MarlinSettings::postprocess() {
     }
     else {
       float dummy = 0;
+      bool dummyb;
 
       working_crc = 0; //clear before reading first "real data"
 
@@ -830,7 +832,6 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(ubl.state.z_offset);
         EEPROM_READ(ubl.state.storage_slot);
       #else
-        bool dummyb;
         uint8_t dummyui8;
         EEPROM_READ(dummyb);
         EEPROM_READ(dummy);
@@ -915,21 +916,17 @@ void MarlinSettings::postprocess() {
       #if ENABLED(FWRETRACT)
         EEPROM_READ(autoretract_enabled);
         EEPROM_READ(retract_length);
-        #if EXTRUDERS > 1
-          EEPROM_READ(retract_length_swap);
-        #else
-          EEPROM_READ(dummy);
-        #endif
         EEPROM_READ(retract_feedrate_mm_s);
         EEPROM_READ(retract_zlift);
         EEPROM_READ(retract_recover_length);
-        #if EXTRUDERS > 1
-          EEPROM_READ(retract_recover_length_swap);
-        #else
-          EEPROM_READ(dummy);
-        #endif
         EEPROM_READ(retract_recover_feedrate_mm_s);
-      #endif // FWRETRACT
+        EEPROM_READ(retract_length_swap);
+        EEPROM_READ(retract_recover_length_swap);
+        EEPROM_READ(swap_retract_recover_feedrate_mm_s);
+      #else
+        EEPROM_READ(dummyb);
+        for (uint8_t q=8; q--;) EEPROM_READ(dummy);
+      #endif
 
       EEPROM_READ(volumetric_enabled);
 
@@ -1291,17 +1288,14 @@ void MarlinSettings::reset() {
   #if ENABLED(FWRETRACT)
     autoretract_enabled = false;
     retract_length = RETRACT_LENGTH;
-    #if EXTRUDERS > 1
-      retract_length_swap = RETRACT_LENGTH_SWAP;
-    #endif
     retract_feedrate_mm_s = RETRACT_FEEDRATE;
     retract_zlift = RETRACT_ZLIFT;
     retract_recover_length = RETRACT_RECOVER_LENGTH;
-    #if EXTRUDERS > 1
-      retract_recover_length_swap = RETRACT_RECOVER_LENGTH_SWAP;
-    #endif
     retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE;
-  #endif
+    retract_length_swap = RETRACT_LENGTH_SWAP;
+    retract_recover_length_swap = RETRACT_RECOVER_LENGTH_SWAP;
+    swap_retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE_SWAP;
+  #endif // FWRETRACT
 
   volumetric_enabled =
     #if ENABLED(VOLUMETRIC_DEFAULT_ON)
@@ -1753,9 +1747,7 @@ void MarlinSettings::reset() {
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M207 S", LINEAR_UNIT(retract_length));
-      #if EXTRUDERS > 1
-        SERIAL_ECHOPAIR(" W", LINEAR_UNIT(retract_length_swap));
-      #endif
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(retract_length_swap));
       SERIAL_ECHOPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(retract_feedrate_mm_s)));
       SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(retract_zlift));
 
@@ -1765,9 +1757,7 @@ void MarlinSettings::reset() {
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M208 S", LINEAR_UNIT(retract_recover_length));
-      #if EXTRUDERS > 1
-        SERIAL_ECHOPAIR(" W", LINEAR_UNIT(retract_recover_length_swap));
-      #endif
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(retract_recover_length_swap));
       SERIAL_ECHOLNPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(retract_recover_feedrate_mm_s)));
 
       if (!forReplay) {

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
@@ -740,7 +740,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -750,7 +750,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Folger Tech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/Folger Tech/i3-2020/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
@@ -754,7 +754,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -764,7 +764,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 35             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -760,7 +760,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -770,7 +770,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
@@ -770,7 +770,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -780,7 +780,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -762,7 +762,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -772,7 +772,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -761,7 +761,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -771,7 +771,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -759,7 +759,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -769,7 +769,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -759,7 +759,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -769,7 +769,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -759,7 +759,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -769,7 +769,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -757,7 +757,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -767,7 +767,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -764,7 +764,7 @@
  * Use M207 and M208 to define parameters for retract / recover.
  *
  * Use M209 to enable or disable auto-retract.
- * With auto-retract enabled, all G1 E moves over the MIN_RETRACT length
+ * With auto-retract enabled, all G1 E moves within the set range
  * will be converted to firmware-based retract/recover moves.
  *
  * Be sure to turn off auto-retract during filament change.
@@ -774,7 +774,8 @@
  */
 //#define FWRETRACT  // ONLY PARTIALLY TESTED
 #if ENABLED(FWRETRACT)
-  #define MIN_RETRACT 0.1                 // A retract/recover of this length or longer can be converted to auto-retract
+  #define MIN_AUTORETRACT 0.1             // When auto-retract is on, convert E moves of this length and over
+  #define MAX_AUTORETRACT 10.0            // Upper limit for auto-retract conversion
   #define RETRACT_LENGTH 3                // Default retract length (positive mm)
   #define RETRACT_LENGTH_SWAP 13          // Default swap retract length (positive mm), for extruder change
   #define RETRACT_FEEDRATE 45             // Default feedrate for retracting (mm/s)

--- a/Marlin/language_zh_CN.h
+++ b/Marlin/language_zh_CN.h
@@ -134,11 +134,11 @@
 #define MSG_KILLED                          _UxGT("已杀掉")  //"KILLED. "
 #define MSG_STOPPED                         _UxGT("已停止")  //"STOPPED. "
 #define MSG_CONTROL_RETRACT                 _UxGT("回抽长度mm")  //"Retract mm" retract_length, retract length (positive mm)
-#define MSG_CONTROL_RETRACT_SWAP            _UxGT("换手回抽长度mm")  //"Swap Re.mm" retract_length_swap, swap retract length (positive mm), for extruder change
+#define MSG_CONTROL_RETRACT_SWAP            _UxGT("换手回抽长度mm")  //"Swap Re.mm" swap_retract_length, swap retract length (positive mm), for extruder change
 #define MSG_CONTROL_RETRACTF                _UxGT("回抽速率mm/s")  //"Retract  V" retract_feedrate_mm_s, feedrate for retracting (mm/s)
 #define MSG_CONTROL_RETRACT_ZLIFT           _UxGT("Hop mm")  //"Hop mm" retract_zlift, retract Z-lift
 #define MSG_CONTROL_RETRACT_RECOVER         _UxGT("回抽恢复长度mm")  //"UnRet +mm" retract_recover_length, additional recover length (mm, added to retract length when recovering)
-#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("换手回抽恢复长度mm")  //"S UnRet+mm" retract_recover_length_swap, additional swap recover length (mm, added to retract length when recovering from extruder change)
+#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("换手回抽恢复长度mm")  //"S UnRet+mm" swap_retract_recover_length, additional swap recover length (mm, added to retract length when recovering from extruder change)
 #define MSG_CONTROL_RETRACT_RECOVERF        _UxGT("回抽恢复后进料速率mm/s")  //"UnRet  V" retract_recover_feedrate_mm_s, feedrate for recovering from retraction (mm/s)
 #define MSG_AUTORETRACT                     _UxGT("自动抽回")  //"AutoRetr." autoretract_enabled,
 #define MSG_FILAMENTCHANGE                  _UxGT("更换丝料")  //"Change filament"

--- a/Marlin/language_zh_TW.h
+++ b/Marlin/language_zh_TW.h
@@ -134,11 +134,11 @@
 #define MSG_KILLED                          _UxGT("已殺掉")  //"KILLED. "
 #define MSG_STOPPED                         _UxGT("已停止")  //"STOPPED. "
 #define MSG_CONTROL_RETRACT                 _UxGT("回抽長度mm")  //"Retract mm" retract_length, retract length (positive mm)
-#define MSG_CONTROL_RETRACT_SWAP            _UxGT("換手回抽長度mm")  //"Swap Re.mm" retract_length_swap, swap retract length (positive mm), for extruder change
+#define MSG_CONTROL_RETRACT_SWAP            _UxGT("換手回抽長度mm")  //"Swap Re.mm" swap_retract_length, swap retract length (positive mm), for extruder change
 #define MSG_CONTROL_RETRACTF                _UxGT("回抽速率mm/s")  //"Retract  V" retract_feedrate_mm_s, feedrate for retracting (mm/s)
 #define MSG_CONTROL_RETRACT_ZLIFT           _UxGT("Hop mm")  //"Hop mm" retract_zlift, retract Z-lift
 #define MSG_CONTROL_RETRACT_RECOVER         _UxGT("回抽恢複長度mm")  //"UnRet +mm" retract_recover_length, additional recover length (mm, added to retract length when recovering)
-#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("換手回抽恢複長度mm")  //"S UnRet+mm" retract_recover_length_swap, additional swap recover length (mm, added to retract length when recovering from extruder change)
+#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("換手回抽恢複長度mm")  //"S UnRet+mm" swap_retract_recover_length, additional swap recover length (mm, added to retract length when recovering from extruder change)
 #define MSG_CONTROL_RETRACT_RECOVERF        _UxGT("回抽恢複後進料速率mm/s")  //"UnRet  V" retract_recover_feedrate_mm_s, feedrate for recovering from retraction (mm/s)
 #define MSG_AUTORETRACT                     _UxGT("自動抽回")  //"AutoRetr." autoretract_enabled,
 #define MSG_FILAMENTCHANGE                  _UxGT("更換絲料")  //"Change filament"

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3373,13 +3373,13 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM_EDIT(bool, MSG_AUTORETRACT, &autoretract_enabled);
       MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT, &retract_length, 0, 100);
       #if EXTRUDERS > 1
-        MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_SWAP, &retract_length_swap, 0, 100);
+        MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_SWAP, &swap_retract_length, 0, 100);
       #endif
       MENU_ITEM_EDIT(float3, MSG_CONTROL_RETRACTF, &retract_feedrate_mm_s, 1, 999);
       MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_ZLIFT, &retract_zlift, 0, 999);
       MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_RECOVER, &retract_recover_length, -100, 100);
       #if EXTRUDERS > 1
-        MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_RECOVER_SWAP, &retract_recover_length_swap, -100, 100);
+        MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_RECOVER_SWAP, &swap_retract_recover_length, -100, 100);
       #endif
       MENU_ITEM_EDIT(float3, MSG_CONTROL_RETRACT_RECOVERF, &retract_recover_feedrate_mm_s, 1, 999);
       END_MENU();


### PR DESCRIPTION
Add a new feedrate for swap recovery and clarify `FWRETRACT` documentation as suggested by @studiodyne in issue #7198.

- Add `swap_retract_recover_feedrate_mm_s` and `RETRACT_RECOVER_FEEDRATE_SWAP`.
  - Apply to `G10` and `G11`, derived from sample code in #7198.
  - Implement setting of the new value with `M208 R`.
  - Add to EEPROM and bump the EEPROM version to V40.
- Write a default EEPROM block when `FWRETRACT` is disabled.
- Allow setting swap options with `M207` / `M208` even with 1 extruder.
  - In future a swap retract may be permitted with 1 extruder.
- Don't allow flow percentage to affect retract/recover.
- Rename `MIN_RETRACT` to `MIN_AUTORETRACT`.
- If `MIN_AUTORETRACT` is set to 100 or greater, auto-retract is disabled in firmware.

---
#### Notes on auto-retract

In normal usage, the slicer will either produce normal E-only (`G0`) retract/recover moves or it will output firmware retract `G10`/`G11` codes. If the slicer is using `G10`/`G11` then it should also include `M209 S0` to turn off auto-retract. If it fails to turn off auto-retract, results will be unpredictable.

Currently, the status of `M209` is persistent and if saved to EEPROM it persists across reboot. It is expected that once you settle on a preference for firmware retraction then you'll set the machine and keep it on or off. The safer option is to leave it off, unless using legacy G-code where the retraction is poorly set and you need auto-retraction. (Perhaps it makes sense to disable auto-retract any time `G10` is received.)

Auto-retract has a `MIN_RETRACT` setting, but it has no `MAX_RETRACT` setting. So long `G0` moves for manual filament change may be seen as retract/recover moves when auto-retract is enabled. We advise turning it off, but it may not be obvious that auto-retract is involved when the feedrate is slow on E-only moves.

Also note that currently, after any auto-retraction or `G10`, the retracted extruder is marked as retracted (`G10 S1` marks it as swap-retracted). If auto-retract is enabled, the next large enough forward E move will be assumed to be a recover move (even if there were intervening smaller E forward moves).

It's tricky to avoid the side-effects of auto-retract, but we could try to make sure it's disabled more of the time. Some things that could help:
- Don't save auto-retract enabled state to EEPROM. Always have it off at reboot.
- Always turn off auto-retract in `G28`.
- Always turn off auto-retract in `G10`.

And our advice should be: **Avoid using auto-retract unless absolutely needed!**

---
We can do some things to work around the side-effects of auto-retract, but first it's most important to make sure that `G10` and `G11` work properly when auto-retract is turned off and the slicer is generating proper output. Can we confirm at this time that `G10`, `G10 S1`, and `G11` are working harmoniously together with current slicers?

---
Testers: The code in `retract()` is simplified, but still more convoluted than I suspect it needs to be, and I would like to try to bring it down to its essence. To help with that, please provide descriptions along the lines of:

- With auto-retract on, sent "G1 E-1" then "G0 E2" and XXX happened.
- Sent "G0 E2" with no retract before it and XXX happened.
- Sent "G10" followed by "G11" and XXX happened.
- Sent "G10 S1" followed by "G11" and XXX happened.
- Sent "G10 S1" followed by "G0 E2" and XXX happened.

Uncomment the debug output code in `retract()` for extra helpful output.