### PR TITLE
Fixing SWITCHING_EXTRUDER feature to work with HOTENDS > 1

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10350,21 +10350,19 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
       UNUSED(fr_mm_s);
       UNUSED(no_move);
 
-      #if ENABLED(SWITCHING_EXTRUDER) && !DONT_SWITCH
-
-        stepper.synchronize();
-        move_extruder_servo(tmp_extruder);
-
-      #elif ENABLED(MK2_MULTIPLEXER)
-
+      #if ENABLED(MK2_MULTIPLEXER)
         if (tmp_extruder >= E_STEPPERS)
           return invalid_extruder_error(tmp_extruder);
 
         select_multiplexed_stepper(tmp_extruder);
-
       #endif
 
     #endif // HOTENDS <= 1
+
+    #if ENABLED(SWITCHING_EXTRUDER) && !DONT_SWITCH
+      stepper.synchronize();
+      move_extruder_servo(tmp_extruder);
+    #endif
 
     active_extruder = tmp_extruder;
 


### PR DESCRIPTION
`SWITCHING_EXTRUDER `checking in tool change block moved and does not depend on the number of `HOTENDS`.

Without this `SWITCHING_EXTRUDER ` checking occur only if HOTENDS <= 1