### PR TITLE
MKS 1.3+: Add pin mapping for PS_ON

### DIFF
--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -44,6 +44,16 @@
 #include "pins_RAMPS.h"
 
 //
+// PSU / SERVO
+// In case of use ATX like PSU or 12v LED PSU with SSR:
+// Set PS_ON_PIN to SERVO3 pin.
+
+#if POWER_SUPPLY > 0
+   #define PS_ON_PIN   4
+   #define SERVO3_PIN -1
+#endif
+
+//
 // LCD / Controller
 //
 #if ENABLED(VIKI2) || ENABLED(miniVIKI)


### PR DESCRIPTION
This allow to use D4 pin as PS_ON since MKS Gen doesnt have
PS_ON pin. However this effectevely allows only 3 servo (instead of 4)

Signed-off-by: Alexey Shvetsov <alexxy@gentoo.org>