### PR TITLE
MKS 1.3+: Add pin mapping for PS_ON

### DIFF
--- a/Marlin/pins_MKS_13.h
+++ b/Marlin/pins_MKS_13.h
@@ -41,6 +41,16 @@
 // Power outputs EFBF or EFBE
 #define MOSFET_D_PIN 7
 
+//
+// PSU / SERVO
+//
+// If POWER_SUPPLY is specified, always hijack Servo 3
+//
+#if POWER_SUPPLY > 0
+  #define SERVO3_PIN      -1
+  #define PS_ON_PIN        4
+#endif
+
 #include "pins_RAMPS.h"
 
 //

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -64,7 +64,9 @@
 #endif
 #define SERVO1_PIN          6
 #define SERVO2_PIN          5
-#define SERVO3_PIN          4
+#ifndef SERVO3_PIN
+  #define SERVO3_PIN        4
+#endif
 
 //
 // Limit Switches
@@ -203,7 +205,9 @@
 // define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
 #define FIL_RUNOUT_PIN      4
 
-#define PS_ON_PIN          12
+#ifndef PS_ON_PIN
+  #define PS_ON_PIN        12
+#endif
 
 #if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT) && !defined(SPINDLE_LASER_ENABLE_PIN)
   #if !defined(NUM_SERVOS) || NUM_SERVOS == 0 // try to use servo connector first


### PR DESCRIPTION
Based on #7329 by @alexxy

---
This allow to use D4 pin as PS_ON since MKS Gen doesn't have
PS_ON pin. However this effectively allows only 3 servos (instead of 4)

Signed-off-by: Alexey Shvetsov <alexxy@gentoo.org>