### PR TITLE
Remove extraneous USBCON defines for AT90USB boards

### DIFF
--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -74,7 +74,6 @@
 #define DEFAULT_MACHINE_NAME "Makibox"
 #define BOARD_NAME           "5DPrint D8"
 
-#define USBCON 1286  // Disable MarlinSerial etc.
 #define LARGE_FLASH        true
 
 //

--- a/Marlin/pins_BRAINWAVE.h
+++ b/Marlin/pins_BRAINWAVE.h
@@ -73,8 +73,6 @@
 
 #define BOARD_NAME         "Brainwave"
 
-#define USBCON 646  // Disable MarlinSerial etc.
-
 //
 // Limit Switches
 //

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -80,7 +80,6 @@
 
 #define BOARD_NAME         "Brainwave Pro"
 
-#define USBCON 1286  // Disable MarlinSerial etc.
 #define LARGE_FLASH        true
 
 //

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -67,7 +67,6 @@
 
 #define BOARD_NAME         "Printrboard"
 
-#define USBCON 1286  // Disable MarlinSerial etc.
 #define LARGE_FLASH        true
 
 // Disable JTAG pins so they can be used for the Extrudrboard

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -69,7 +69,6 @@
 #define DEFAULT_SOURCE_CODE_URL "https://github.com/fmalpartida/Marlin/tree/SAV-MkI-config"
 #define BOARD_NAME              "SAV MkI"
 
-#define USBCON 1286  // Disable MarlinSerial etc.
 #define LARGE_FLASH        true
 
 //

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -112,7 +112,6 @@
 
 #define BOARD_NAME         "Teensy++2.0"
 
-#define USBCON 1286  // Disable MarlinSerial etc.
 #define LARGE_FLASH        true
 
 //

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -79,7 +79,6 @@
 
 #define BOARD_NAME         "Teensylu"
 
-#define USBCON 1286  // Disable MarlinSerial etc.
 #define LARGE_FLASH        true
 
 


### PR DESCRIPTION
USBCON is definied for supported boards within `Arduino.h` based on board selection in IDE and `Configuration.h`.  Defining in other includes has shown to cause compile issues when standard includes are not correct for a source file; removing all extraneous `USBCON` defines to potentially make it easier for future linker troubleshooting.