### PR TITLE
minimize SD card reads when using SDCARD_SORT_ALPHA (Re-ARM board)

### DIFF
--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -69,6 +69,8 @@ public:
   void updir();
   void setroot();
 
+  uint16_t get_num_Files();
+  
   #if ENABLED(SDCARD_SORT_ALPHA)
     void presort();
     void getfilename_sorted(const uint16_t nr);

--- a/Marlin/pins_RAMPS_RE_ARM.h
+++ b/Marlin/pins_RAMPS_RE_ARM.h
@@ -52,7 +52,7 @@
 //
 // Servos
 //
-#define SERVO0_PIN         11  
+#define SERVO0_PIN         11
 #define SERVO1_PIN          6  // also on J5-1
 #define SERVO2_PIN          5
 #define SERVO3_PIN          4  // 5V output - PWM capable
@@ -194,11 +194,9 @@
 //
 #if ENABLED(SPINDLE_LASER_ENABLE) && !PIN_EXISTS(SPINDLE_LASER_ENABLE)
   #if !defined(NUM_SERVOS) || NUM_SERVOS == 1 // must use servo connector
-    #undef  SERVO0
     #undef  SERVO1
     #undef  SERVO2
     #undef  SERVO3
-    #define SERVO0    4
     #define SPINDLE_LASER_ENABLE_PIN  6  // Pin should have a pullup/pulldown!
     #define SPINDLE_LASER_PWM_PIN     4  // MUST BE HARDWARE PWM
     #define SPINDLE_DIR_PIN           5
@@ -214,16 +212,20 @@
 /**
  * LCD / Controller
  *
+ * All controllers can use J3 and J5 on the Re-ARM board.  Custom cabling will be required.
+ */
+
+/**
+ * Smart LCD adapter
+ *
  * The Smart LCD adapter can be used for the two 10 pin LCD controllers such as
  * REPRAP_DISCOUNT_SMART_CONTROLLER.  It can't be used for controllers that use
  * DOGLCD_A0, DOGLCD_CS, LCD_PINS_D5, LCD_PINS_D6 or LCD_PINS_D7. A custom cable
  * is needed to pick up 5V for the EXP1 connection.
  *
- * All controllers can use J3 and J5 on the Re-ARM board.  Custom cabling will be required.
- *
- * SD card on the LCD is not yet supported.
- *
- * SD card on the LCD uses the same SPI signals as the LCD.
+ * SD card on the LCD uses the same SPI signals as the LCD. This results in garbage/lines
+ * on the LCD display during accesses of the SD card. The menus/code has been arranged so
+ * that the garbage/lines are erased immediately after the SD card accesses are completed.
  */
 
 #if ENABLED(ULTRA_LCD)
@@ -241,6 +243,24 @@
     //#define SHIFT_LD            33  // J3-4 & AUX-4
     //#define SHIFT_OUT           35  // J3-3 & AUX-4
     //#define SHIFT_EN            41  // J5-4 & AUX-4
+  #endif
+
+  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) && ENABLED(SDSUPPORT)
+    #define SDCARD_SORT_ALPHA           // Using SORT feature to keep one directory level in RAM
+                                        // When going up/down directory levels the SD card is
+                                        // accessed but the garbage/lines are removed when the
+                                        // LCD updates
+
+    // SD Card Sorting options
+    #if ENABLED(SDCARD_SORT_ALPHA)
+      #define SDSORT_LIMIT       255    // Maximum number of sorted items (10-256).
+      #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
+      #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 g-code.
+      #define SDSORT_USES_RAM    true   // Pre-allocate a static array for faster pre-sorting.
+      #define SDSORT_USES_STACK  false  // Prefer the stack for pre-sorting to give back some SRAM. (Negated by next 2 options.)
+      #define SDSORT_CACHE_NAMES true   // Keep sorted items in RAM longer for speedy performance. Most expensive option.
+      #define SDSORT_DYNAMIC_RAM false  // Use dynamic allocation (within SD menus). Least expensive option. Set SDSORT_LIMIT before use!
+    #endif
   #endif
 
   #define BTN_EN1             31  // J3-2 & AUX-4
@@ -266,7 +286,7 @@
   //#define MOSI                51  // system defined J3-10 & AUX-3
   //#define SCK                 52  // system defined J3-9 & AUX-3
   //#define SS_PIN              53  // system defined J3-5 & AUX-3 - sometimes called SDSS
- 
+
 
   #if ENABLED(VIKI2) || ENABLED(miniVIKI)
     #define LCD_SCREEN_ROT_180
@@ -300,6 +320,26 @@
 #define ENET_TXD0   78  // J12-11
 #define ENET_TXD1   79  // J12-12
 
+/**
+ *  PWMS
+ *
+ *  There are 6 PWMS.  Each PWM can be assigned to one of two pins.
+ *
+ *  SERVO2 does NOT have a PWM assigned to it.
+ *
+ *  PWM1.1   DIO4    SERVO3_PIN       FIL_RUNOUT_PIN   5V output, PWM
+ *  PWM1.1   DIO26   E0_STEP_PIN
+ *  PWM1.2   DIO11   SERVO0_PIN
+ *  PWM1.2   DIO54   X_STEP_PIN
+ *  PWM1.3   DIO6    SERVO1_PIN       J5-1
+ *  PWM1.3   DIO60   Y_STEP_PIN
+ *  PWM1.4   DIO53   SDSS(SSEL0)      J3-5  AUX-3
+ *  PWM1.4   DIO46   Z_STEP_PIN
+ *  PWM1.5   DIO3    X_MIN_PIN        10K PULLUP TO 3.3v, 1K SERIES
+ *  PWM1.5   DIO9    RAMPS_D9_PIN
+ *  PWM1.6   DIO14   Y_MIN_PIN        10K PULLUP TO 3.3v, 1K SERIES
+ *  PWM1.6   DIO10   RAMPS_D10_PIN
+ */
 
 /**
  *  The following pins are NOT available in a Re-ARM system

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3414,7 +3414,7 @@ void kill_screen(const char* lcd_msg) {
     void lcd_sdcard_menu() {
       ENCODER_DIRECTION_MENUS();
       if (!lcdDrawUpdate && !lcd_clicked) return; // nothing to do (so don't thrash the SD card)
-      const uint16_t fileCnt = card.getnrfilenames();
+      const uint16_t fileCnt = card.get_num_Files();
       START_MENU();
       MENU_BACK(MSG_MAIN);
       card.getWorkDirName();
@@ -3427,27 +3427,29 @@ void kill_screen(const char* lcd_msg) {
         MENU_ITEM(function, LCD_STR_FOLDER "..", lcd_sd_updir);
       }
 
-      for (uint16_t i = 0; i < fileCnt; i++) {
-        if (_menuLineNr == _thisItemNr) {
-          const uint16_t nr =
-            #if ENABLED(SDCARD_RATHERRECENTFIRST) && DISABLED(SDCARD_SORT_ALPHA)
-              fileCnt - 1 -
+      if (fileCnt) {
+        for (uint16_t i = 0; i < fileCnt; i++) {
+          if (_menuLineNr == _thisItemNr) {
+            const uint16_t nr =
+              #if ENABLED(SDCARD_RATHERRECENTFIRST) && DISABLED(SDCARD_SORT_ALPHA)
+                fileCnt - 1 -
+              #endif
+            i;
+
+            #if ENABLED(SDCARD_SORT_ALPHA)
+              card.getfilename_sorted(nr);
+            #else
+              card.getfilename(nr);
             #endif
-          i;
 
-          #if ENABLED(SDCARD_SORT_ALPHA)
-            card.getfilename_sorted(nr);
-          #else
-            card.getfilename(nr);
-          #endif
-
-          if (card.filenameIsDir)
-            MENU_ITEM(sddirectory, MSG_CARD_MENU, card.filename, card.longFilename);
-          else
-            MENU_ITEM(sdfile, MSG_CARD_MENU, card.filename, card.longFilename);
-        }
-        else {
-          MENU_ITEM_DUMMY();
+            if (card.filenameIsDir)
+              MENU_ITEM(sddirectory, MSG_CARD_MENU, card.filename, card.longFilename);
+            else
+              MENU_ITEM(sdfile, MSG_CARD_MENU, card.filename, card.longFilename);
+          }
+          else {
+            MENU_ITEM_DUMMY();
+          }
         }
       }
       END_MENU();


### PR DESCRIPTION
Because of the Re-ARM card's pinout there is only one SPI connected to the RepRap Discount Full Graphic LCD display.  The LCD responds to ANY SCK transitions no matter if its enable is inactive.  The result is garbage (usually bars) on the LCD display whenever there is SD card activity.

This code minimizes this by only accessing the SD card when changing directory levels if:
- `SDCARD_SORT_ALPHA` is enabled
- `SDSORT_USES_RAM` is `true`
- `SDSORT_CACHE_NAMES` is `true`

The code changes result in file names being pulled from the ALPHA SORT memory array rather than the SD card.

The code also gives the file count and file index functions their own variables.  When they shared a common variable the index function sometimes resulted in the file count being short by 1.

NOTE - when changing directories the ALPHA SORT software accesses the SD card.  This results in bars/garbage on the LCD until the access is finished.  When the access is finished then the display is re-drawn which removes the unwanted bars/garbage.