### PR TITLE
Fix DUAL_X_CARRIAGE movement

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12251,7 +12251,7 @@ void prepare_move_to_destination() {
     #elif IS_KINEMATIC
       prepare_kinematic_move_to(destination)
     #elif ENABLED(DUAL_X_CARRIAGE)
-      prepare_move_to_destination_dualx()
+      prepare_move_to_destination_dualx() || prepare_move_to_destination_cartesian()
     #else
       prepare_move_to_destination_cartesian()
     #endif


### PR DESCRIPTION
Broken by 91841d75c9a473e15932bd4589d64ee59efe947e (between 1.1.1 and 1.1.2).
Search for DUAL_X_CARRIAGE in that commit and the error is obvious (removed line in the #if chain).
The old code was:
```cpp
  #if IS_KINEMATIC
    if (prepare_kinematic_move_to(destination)) return;
  #else
    #if ENABLED(DUAL_X_CARRIAGE)
      if (prepare_move_to_destination_dualx()) return;
    #endif
    if (prepare_move_to_destination_cartesian()) return;
  #endif
```
…and was changed, in error, to…
```cpp
   if (
     #if UBL_DELTA // Also works for CARTESIAN (smaller segments follow mesh more closely)
       ubl.prepare_segmented_line_to(destination, feedrate_mm_s)
      #elif IS_KINEMATIC
        prepare_kinematic_move_to(destination)
      #elif ENABLED(DUAL_X_CARRIAGE)
        prepare_move_to_destination_dualx()
      #else
        prepare_move_to_destination_cartesian()
      #endif
   ) return;
```
Fixes #6956, fixes #7050 and fixes #7291