### PR TITLE
Fix freeze during filament change

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2412,7 +2412,7 @@ void kill_screen(const char* lcd_msg) {
     // Change filament
     //
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
-      if (!thermalManager.tooColdToExtrude(active_extruder))
+      if (!thermalManager.tooColdToExtrude(active_extruder) && !card.sdprinting)
         MENU_ITEM(function, MSG_FILAMENTCHANGE, lcd_enqueue_filament_change);
     #endif
 


### PR DESCRIPTION
Filament change causes freeze during paused print. This PR disables Filament change in the prepare menu when a print from SD Card is paused. See #7395