### PR TITLE
Add VScode directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ Marlin/Debug/
 Marlin/__vm/
 Marlin/.vs/
 
+#VScode
+.vscode
+
 #cmake
 CMakeLists.txt
 Marlin/CMakeLists.txt


### PR DESCRIPTION
PlatformIO can be used with VSCode.  VSCode creates a .vscode directory which should be ignored.