### PR TITLE
Force legacy "pristine" build dist for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: pristine
+
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
TravisCI "trusty" build dist isn't picking up build path causing travis checks to fail.  Reverting to legacy "pristine" dist while we investigate