### PR TITLE
Force legacy "precise" build dist for TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
----
+dist: precise
+  #
 language: c
   #
 notifications:


### PR DESCRIPTION
TravisCI "trusty" build dist isn't picking up build path causing travis checks to fail.  Reverting to legacy "precise" dist while we investigate