### PR TITLE
Support travis new "trusty" build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: precise
+dist: trusty
+sudo: true 
   #
 language: c
   #
@@ -12,7 +13,7 @@ before_install:
   #
   # Publish the buildroot script folder
   - chmod +x ${TRAVIS_BUILD_DIR}/buildroot/bin/*
-  - ln -s ${TRAVIS_BUILD_DIR}/buildroot/bin/ ~/bin
+  - export PATH=${TRAVIS_BUILD_DIR}/buildroot/bin/:${PATH}
   #
   # Start fb X server
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"


### PR DESCRIPTION
-move from legacy precise to trusty build image
-fix PATH not including buildroot/bin
-remove symolic link to ~/bin trusty travis image doesn't include it in PATH by default anyway
-enable  sudo build env (forces full virtualized env instead of containerized)
-avr requires sudo to download external libraries