### PR TITLE
Support travis new "trusty" build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: precise
+dist: trusty
+sudo: false
 
 language: python
 python:
@@ -24,7 +25,7 @@ before_install:
   #
   # Publish the buildroot script folder
   - chmod +x ${TRAVIS_BUILD_DIR}/buildroot/bin/*
-  - ln -s ${TRAVIS_BUILD_DIR}/buildroot/bin/ ~/bin
+  - export PATH=${TRAVIS_BUILD_DIR}/buildroot/bin/:${PATH} 
 
 install:
   - pip install -U platformio


### PR DESCRIPTION
move from legacy precise to trusty build image
fix PATH not including buildroot/bin
remove symolic link to ~/bin as trusty travis image doesn't include it in PATH anyway