### PR TITLE
Clean up whitespace, trailing space, bad tab conversion, etc.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: true 
+sudo: true
   #
 language: c
   #

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -384,18 +384,12 @@
         FORCE_INLINE static float fade_scaling_factor_for_z(const float &lz) { return 1.0; }
       #endif
 
-      FORCE_INLINE static float mesh_index_to_xpos(const uint8_t i) { 
-        if (i<GRID_MAX_POINTS_X) 
-          return pgm_read_float(&_mesh_index_to_xpos[i]); 
-        else  
-          return UBL_MESH_MIN_X + i * (MESH_X_DIST);
+      FORCE_INLINE static float mesh_index_to_xpos(const uint8_t i) {
+        return i < GRID_MAX_POINTS_X ? pgm_read_float(&_mesh_index_to_xpos[i]) : UBL_MESH_MIN_X + i * (MESH_X_DIST);
       }
 
-      FORCE_INLINE static float mesh_index_to_ypos(const uint8_t i) { 
-        if (i<GRID_MAX_POINTS_Y) 
-          return pgm_read_float(&_mesh_index_to_ypos[i]); 
-        else  
-          return UBL_MESH_MIN_Y + i * (MESH_Y_DIST);
+      FORCE_INLINE static float mesh_index_to_ypos(const uint8_t i) {
+        return i < GRID_MAX_POINTS_Y ? pgm_read_float(&_mesh_index_to_ypos[i]) : UBL_MESH_MIN_Y + i * (MESH_Y_DIST);
       }
 
       static bool prepare_segmented_line_to(const float ltarget[XYZE], const float &feedrate);

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -176,26 +176,17 @@
       const float xratio = (RAW_X_POSITION(end[X_AXIS]) - mesh_index_to_xpos(cell_dest_xi)) * (1.0 / (MESH_X_DIST));
 
       float z1 = z_values[cell_dest_xi    ][cell_dest_yi    ] + xratio *
-                      (z_values[cell_dest_xi + 1][cell_dest_yi    ] - z_values[cell_dest_xi][cell_dest_yi    ]),
-                  z2 = z_values[cell_dest_xi    ][cell_dest_yi + 1] + xratio *
-                      (z_values[cell_dest_xi + 1][cell_dest_yi + 1] - z_values[cell_dest_xi][cell_dest_yi + 1]);
+                (z_values[cell_dest_xi + 1][cell_dest_yi    ] - z_values[cell_dest_xi][cell_dest_yi    ]),
+            z2 = z_values[cell_dest_xi    ][cell_dest_yi + 1] + xratio *
+                (z_values[cell_dest_xi + 1][cell_dest_yi + 1] - z_values[cell_dest_xi][cell_dest_yi + 1]);
 
-      if ( cell_dest_xi >= GRID_MAX_POINTS_X-1) {
-        z1 = 0.0;
-        z2 = 0.0;
-      }
+      if (cell_dest_xi >= GRID_MAX_POINTS_X - 1) z1 = z2 = 0.0;
 
       // we are done with the fractional X distance into the cell. Now with the two Z-Heights we have calculated, we
       // are going to apply the Y-Distance into the cell to interpolate the final Z correction.
 
       const float yratio = (RAW_Y_POSITION(end[Y_AXIS]) - mesh_index_to_ypos(cell_dest_yi)) * (1.0 / (MESH_Y_DIST));
-
-      float z0 = z1 + (z2 - z1) * yratio;
-
-      if ( cell_dest_yi >= GRID_MAX_POINTS_Y-1) 
-        z0 = 0.0;
-
-      z0 *= fade_scaling_factor_for_z(end[Z_AXIS]);
+      float z0 = cell_dest_yi < GRID_MAX_POINTS_Y - 1 ? z1 + (z2 - z1) * yratio * fade_scaling_factor_for_z(end[Z_AXIS]) : 0.0;
 
       /**
        * If part of the Mesh is undefined, it will show up as NAN


### PR DESCRIPTION

Contributors…

To reiterate once more: Please change your editor settings to use spaces, and not tabs. Marlin uses 2 space indentation, not tabs. Your editor must be set to use 2 spaces for indentation. Do not use tabs. If using an editor that tends to promote bad habits (e.g., leaving whitespace at the ends of lines, bad tab conversion, etc.) such as Emacs, Vi, or Vim —and if you aren't meticulous enough to clean up after your editor— please switch to a modern editor.