### PR TITLE
Revert back to TravisCI "precise" build env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-sudo: true
+dist: precise
   #
 language: c
   #


### PR DESCRIPTION
Travis "trusty" build env isn't trusty enough yet.

It built correctly perhaps a half-dozen commits, then broke PATH inclusion again.  Suggest we revert until TravisCI gmbh turns the lights out on "precise".  Build time on "trusty" wasn't any faster anyway, since current AVR build script relies on sudo to download/install external libraries, which requires the fully-virtualized trusty image (same as precise).