### PR TITLE
Re-ARM - Set pinMode with every digitalWrite (legacy compatibility)

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/arduino.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/arduino.cpp
@@ -121,6 +121,16 @@ void digitalWrite(int pin, int pin_status) {
     LPC_GPIO(pin_map[pin].port)->FIOSET = LPC_PIN(pin_map[pin].pin);
   else
     LPC_GPIO(pin_map[pin].port)->FIOCLR = LPC_PIN(pin_map[pin].pin);
+
+  pinMode(pin, OUTPUT);  // Set pin mode on every write (Arduino version does this)
+
+    /**
+     * Must be done AFTER the output state is set. Doing this before will cause a
+     * 2uS glitch if writing a "1".
+     *
+     * When the Port Direction bit is written to a "1" the output is immediately set
+     * to the value of the FIOPIN bit which is "0" because of power up defaults.
+     */
 }
 
 bool digitalRead(int pin) {


### PR DESCRIPTION
This PR makes the digitalWrite in Bugfix_2.0.x act almost the same as in the legacy Arduino library.

It sets the pinMode everytime a digitalWrite occurs.

The only other difference remaining is the legacy routine disabled the PWM if one was attached to that pin.  That never made sense to me.  Hopefully we won't do that in 2.0 ARM code.