### PR TITLE
Addressing [FR] #7254

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -376,11 +376,6 @@
       #define NUM_SERVOS (Z_ENDSTOP_SERVO_NR + 1)
     #endif
     #undef DEACTIVATE_SERVOS_AFTER_MOVE
-    #undef SERVO_DELAY
-    #define SERVO_DELAY 50
-    #ifndef BLTOUCH_DELAY
-      #define BLTOUCH_DELAY 375
-    #endif
     #undef Z_SERVO_ANGLES
     #define Z_SERVO_ANGLES { BLTOUCH_DEPLOY, BLTOUCH_STOW }
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1595,7 +1595,7 @@
 // Delay (in milliseconds) before the next move will start, to give the servo time to reach its target angle.
 // 300ms is a good value but you can try less delay.
 // If the servo can't reach the requested position, increase it.
-#define SERVO_DELAY 300
+#define SERVO_DELAY { 300 }
 
 // Servo deactivation
 //

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2103,7 +2103,6 @@ static void clean_up_after_endstop_or_probe_move() {
 
     void bltouch_command(int angle) {
       servo[Z_ENDSTOP_SERVO_NR].move(angle);  // Give the BL-Touch the command and wait
-      safe_delay(BLTOUCH_DELAY);
     }
 
     void set_bltouch_deployed(const bool deploy) {
@@ -6711,10 +6710,8 @@ inline void gcode_M42() {
       bool deploy_state, stow_state;
       for (uint8_t i = 0; i < 4; i++) {
         servo[probe_index].move(z_servo_angle[0]); //deploy
-        safe_delay(500);
         deploy_state = READ(PROBE_TEST_PIN);
         servo[probe_index].move(z_servo_angle[1]); //stow
-        safe_delay(500);
         stow_state = READ(PROBE_TEST_PIN);
       }
       if (probe_inverting != deploy_state) SERIAL_PROTOCOLLNPGM("WARNING - INVERTING setting probably backwards");
@@ -10173,7 +10170,6 @@ inline void gcode_M999() {
     #endif
     {
       MOVE_SERVO(_SERVO_NR, angles[e]);
-      safe_delay(500);
     }
   }
 #endif // SWITCHING_EXTRUDER
@@ -10183,7 +10179,6 @@ inline void gcode_M999() {
     const int16_t angles[2] = SWITCHING_NOZZLE_SERVO_ANGLES;
     stepper.synchronize();
     MOVE_SERVO(SWITCHING_NOZZLE_SERVO_NR, angles[e]);
-    safe_delay(500);
   }
 #endif
 

--- a/Marlin/servo.cpp
+++ b/Marlin/servo.cpp
@@ -68,6 +68,7 @@
 
 static ServoInfo_t servo_info[MAX_SERVOS];                  // static array of servo info structures
 static volatile int8_t Channel[_Nbr_16timers ];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
+static uint16_t servo_delay[NUM_SERVOS] = SERVO_DELAY;
 
 uint8_t ServoCount = 0;                                     // the total number of attached servos
 
@@ -310,7 +311,7 @@ bool Servo::attached() { return servo_info[this->servoIndex].Pin.isActive; }
 void Servo::move(int value) {
   if (this->attach(0) >= 0) {
     this->write(value);
-    delay(SERVO_DELAY);
+    delay(servo_delay[this->servoIndex]);
     #if ENABLED(DEACTIVATE_SERVOS_AFTER_MOVE)
       this->detach();
     #endif


### PR DESCRIPTION
With this modify each servo has its own delay.
It add only 330 bytes of code, with 2 servos, and "2*servos" bytes in global variables.
I also removed delay_safe after every servo move call since their value can be added directly in SERVO_DELAY array (eg BLTOUCH had 50ms in servo::move and 375 after, now one can set SERVO_DELAY to 425).

Just one question. Why after move is used delay_safe and inside servo::move is used delay?
SERVO_DELAY may be a big time (300 by default) and if thermal manager has to be called it also need to be called inside servo:move.