### PR TITLE
Bugfix_2.0.x - ST7565 printer support (software SPI) - Viki2, Mini-Viki & MaKrPanel #7447 (again)

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -39,7 +39,15 @@
     #define LCD_CONTRAST_MIN 60
     #define LCD_CONTRAST_MAX 140
 
-  #elif ENABLED(MAKRPANEL) || ENABLED(MINIPANEL)
+  #elif ENABLED(MAKRPANEL)
+
+    #define DOGLCD
+    #define ULTIPANEL
+    #define NEWPANEL
+    #define DEFAULT_LCD_CONTRAST 17
+    #define U8GLIB_ST7565_64128N
+
+  #elif ENABLED(MINIPANEL)
 
     #define DOGLCD
     #define ULTIPANEL
@@ -76,8 +84,12 @@
       #define LCD_CONTRAST_MIN  75
       #define LCD_CONTRAST_MAX 115
       #define DEFAULT_LCD_CONTRAST 95
+      #define U8GLIB_ST7565_64128N
     #elif ENABLED(VIKI2)
-      #define DEFAULT_LCD_CONTRAST 40
+      #define LCD_CONTRAST_MIN 0
+      #define LCD_CONTRAST_MAX 255
+      #define DEFAULT_LCD_CONTRAST 140
+      #define U8GLIB_ST7565_64128N
     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
       #define LCD_CONTRAST_MIN  90
       #define LCD_CONTRAST_MAX 130

--- a/Marlin/pins_RAMPS_RE_ARM.h
+++ b/Marlin/pins_RAMPS_RE_ARM.h
@@ -232,6 +232,28 @@
 
   #define BEEPER_PIN          37  // not 5V tolerant
 
+  //#define BTN_EN1             31  // J3-2 & AUX-4
+  #define BTN_EN2             33  // J3-4 & AUX-4
+  #define BTN_ENC             35  // J3-3 & AUX-4
+
+  #define SD_DETECT_PIN       49  // not 5V tolerant   J3-1 & AUX-3
+  #define KILL_PIN            41  // J5-4 & AUX-4
+  #define LCD_PINS_RS         16  // J3-7 & AUX-4
+  #define LCD_SDSS            16  // J3-7 & AUX-4
+  #define LCD_BACKLIGHT_PIN   16  // J3-7 & AUX-4 - only used on DOGLCD controllers
+  #define LCD_PINS_ENABLE     51  // (MOSI) J3-10 & AUX-3
+  #define LCD_PINS_D4         52  // (SCK)  J3-9 & AUX-3
+
+  #define LCD_PINS_D5         59  // J3-8 & AUX-2
+  #define DOGLCD_A0           59  // J3-8 & AUX-2
+  #define LCD_PINS_D6         63  // J5-3 & AUX-2
+  #define DOGLCD_CS           63  // J5-3 & AUX-2
+  #define LCD_PINS_D7          6  // (SERVO1) J5-1 & SERVO connector  
+  
+  #define LCD_PINS_D5         71  // ENET_MDIO
+  #define LCD_PINS_D6         73  // ENET_RX_ER
+  #define LCD_PINS_D7         75  // ENET_RXD1
+ 
   #if ENABLED(NEWPANEL)
     #if ENABLED(REPRAPWORLD_KEYPAD)
       #define SHIFT_OUT         51  // (MOSI) J3-10 & AUX-3
@@ -245,7 +267,7 @@
     //#define SHIFT_EN            41  // J5-4 & AUX-4
   #endif
 
-  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) && ENABLED(SDSUPPORT)
+  #if ENABLED(SDSUPPORT)
     #define SDCARD_SORT_ALPHA           // Using SORT feature to keep one directory level in RAM
                                         // When going up/down directory levels the SD card is
                                         // accessed but the garbage/lines are removed when the
@@ -263,38 +285,43 @@
     #endif
   #endif
 
-  #define BTN_EN1             31  // J3-2 & AUX-4
-  #define BTN_EN2             33  // J3-4 & AUX-4
-  #define BTN_ENC             35  // J3-3 & AUX-4
+ #if ENABLED(VIKI2) || ENABLED(miniVIKI)
+//    #define LCD_SCREEN_ROT_180
+    
+    #define SOFTWARE_SPI  // temp to see if it fixes the  "not found" error
+    
+    #undef  BEEPER_PIN
+    #define BEEPER_PIN          37  // may change if cable changes
+    
+    #define BTN_EN1             31  // J3-2 & AUX-4
+    #define BTN_EN2             33  // J3-4 & AUX-4
+    #define BTN_ENC             35  // J3-3 & AUX-4
 
-  #define SD_DETECT_PIN       49  // not 5V tolerant   J3-1 & AUX-3
-  #define KILL_PIN            41  // J5-4 & AUX-4
-  #define LCD_PINS_RS         16  // J3-7 & AUX-4
-  #define LCD_SDSS            16  // J3-7 & AUX-4
-  #define LCD_BACKLIGHT_PIN   16  // J3-7 & AUX-4 - only used on DOGLCD controllers
-  #define LCD_PINS_ENABLE     51  // (MOSI) J3-10 & AUX-3
-  #define LCD_PINS_D4         52  // (SCK)  J3-9 & AUX-3
+    #define SD_DETECT_PIN       49  // not 5V tolerant   J3-1 & AUX-3
+    #define KILL_PIN            41  // J5-4 & AUX-4
 
-  #define LCD_PINS_D5         71  // ENET_MDIO
-  #define DOGLCD_A0           59  // J3-8 & AUX-2
-  #define LCD_PINS_D6         73  // ENET_RX_ER
-  #define DOGLCD_CS           63  // J5-3 & AUX-2
-  #define LCD_PINS_D7         75  // ENET_RXD1
+    #undef  DOGLCD_CS
+    #define DOGLCD_CS           16 
+    #undef  LCD_BACKLIGHT_PIN   //16  // J3-7 & AUX-4 - only used on DOGLCD controllers
+    #undef  LCD_PINS_ENABLE     //51  // (MOSI) J3-10 & AUX-3
+    #undef  LCD_PINS_D4         //52  // (SCK)  J3-9 & AUX-3
 
-
-  //#define MISO                50  // system defined J3-10 & AUX-3
-  //#define MOSI                51  // system defined J3-10 & AUX-3
-  //#define SCK                 52  // system defined J3-9 & AUX-3
-  //#define SS_PIN              53  // system defined J3-5 & AUX-3 - sometimes called SDSS
-
-
-  #if ENABLED(VIKI2) || ENABLED(miniVIKI)
-    #define LCD_SCREEN_ROT_180
-
-    #define STAT_LED_RED_PIN  20  // I2C connector
-    #define STAT_LED_BLUE_PIN 21  // I2C connector
+    #undef  LCD_PINS_D5         //59  // J3-8 & AUX-2
+    #define DOGLCD_A0           59  // J3-8 & AUX-2
+    #undef  LCD_PINS_D6         //63  // J5-3 & AUX-2
+    #undef  LCD_PINS_D7          //6  // (SERVO1) J5-1 & SERVO connector
+    #define DOGLCD_SCK SCK_PIN 
+    #define DOGLCD_MOSI MOSI_PIN
+ 
+    #define STAT_LED_BLUE_PIN   63  // may change if cable changes
+    #define STAT_LED_RED_PIN     6  // may change if cable changes
   #endif
-
+  //#define MISO_PIN            50  // system defined J3-10 & AUX-3
+  //#define MOSI_PIN            51  // system defined J3-10 & AUX-3
+  //#define SCK_PIN             52  // system defined J3-9 & AUX-3
+  //#define SS_PIN              53  // system defined J3-5 & AUX-3 - sometimes called SDSS
+  
+  
   #if ENABLED(MINIPANEL)
     // GLCD features
     //#define LCD_CONTRAST   190

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -44,6 +44,7 @@
  */
 #include "ultralcd.h"
 #include "ultralcd_st7920_u8glib_rrd.h"
+#include "ultralcd_st7565_u8glib_VIKI.h"
 #include "dogm_bitmaps.h"
 #include "utility.h"
 #include "duration_t.h"
@@ -171,10 +172,13 @@
   // Based on the Adafruit ST7565 (http://www.adafruit.com/products/250)
   //U8GLIB_LM6059 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
   U8GLIB_LM6059_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes
-#elif ENABLED(MAKRPANEL) || ENABLED(VIKI2) || ENABLED(miniVIKI)
-  // The MaKrPanel, Mini Viki, and Viki 2.0, ST7565 controller as well
-  //U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
-  U8GLIB_NHD_C12864_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes
+#elif ENABLED(U8GLIB_ST7565_64128N)
+  // The MaKrPanel, Mini Viki, and Viki 2.0, ST7565 controller 
+//  U8GLIB_ST7565_64128n_2x_VIKI u8g(0);  // using SW-SPI DOGLCD_MOSI != -1 && DOGLCD_SCK 
+    U8GLIB_ST7565_64128n_2x_VIKI u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // using SW-SPI 
+    //U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
+    //U8GLIB_NHD_C12864_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes  HWSPI
+  
 #elif ENABLED(U8GLIB_SSD1306)
   // Generic support for SSD1306 OLED I2C LCDs
   //U8GLIB_SSD1306_128X64 u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST);  // 8 stripes

--- a/Marlin/ultralcd_st7565_u8glib_VIKI.h
+++ b/Marlin/ultralcd_st7565_u8glib_VIKI.h
@@ -1,0 +1,248 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef ULCDST7565_H
+#define ULCDST7565_H
+
+#include "Marlin.h"
+
+#if ENABLED(U8GLIB_ST7565_64128N)
+
+
+#define ST7565_CLK_PIN  DOGLCD_SCK
+#define ST7565_DAT_PIN  DOGLCD_MOSI
+#define ST7565_CS_PIN   DOGLCD_CS
+#define ST7565_A0_PIN   DOGLCD_A0
+
+
+
+
+
+
+#include <U8glib.h>
+
+#define WIDTH 128
+#define HEIGHT 64
+#define PAGE_HEIGHT 8
+
+//set optimization so ARDUINO optimizes this file
+#pragma GCC optimize (3)
+
+// If you want you can define your own set of delays in Configuration.h
+//#define ST7565_DELAY_1 DELAY_0_NOP
+//#define ST7565_DELAY_2 DELAY_0_NOP
+//#define ST7565_DELAY_3 DELAY_0_NOP
+
+/*
+#define ST7565_DELAY_1 u8g_10MicroDelay()
+#define ST7565_DELAY_2 u8g_10MicroDelay()
+#define ST7565_DELAY_3 u8g_10MicroDelay()
+*/
+
+#if F_CPU >= 20000000
+  #define CPU_ST7565_DELAY_1 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_2 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_3 DELAY_1_NOP
+#elif (MOTHERBOARD == BOARD_3DRAG) || (MOTHERBOARD == BOARD_K8200) || (MOTHERBOARD == BOARD_K8400)
+  #define CPU_ST7565_DELAY_1 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_2 DELAY_3_NOP
+  #define CPU_ST7565_DELAY_3 DELAY_0_NOP
+#elif (MOTHERBOARD == BOARD_MINIRAMBO)
+  #define CPU_ST7565_DELAY_1 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_2 DELAY_4_NOP
+  #define CPU_ST7565_DELAY_3 DELAY_0_NOP
+#elif (MOTHERBOARD == BOARD_RAMBO)
+  #define CPU_ST7565_DELAY_1 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_2 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_3 DELAY_0_NOP
+#elif F_CPU == 16000000
+  #define CPU_ST7565_DELAY_1 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_2 DELAY_0_NOP
+  #define CPU_ST7565_DELAY_3 DELAY_1_NOP
+#else
+  #error "No valid condition for delays in 'ultralcd_st7565_u8glib_VIKI.h'"
+#endif
+
+#ifndef ST7565_DELAY_1
+  #define ST7565_DELAY_1 CPU_ST7565_DELAY_1
+#endif
+#ifndef ST7565_DELAY_2
+  #define ST7565_DELAY_2 CPU_ST7565_DELAY_2
+#endif
+#ifndef ST7565_DELAY_3
+  #define ST7565_DELAY_3 CPU_ST7565_DELAY_3
+#endif
+
+#define ST7565_SND_BIT \
+  WRITE(ST7565_CLK_PIN, LOW);        ST7565_DELAY_1; \
+  WRITE(ST7565_DAT_PIN, val & 0x80); ST7565_DELAY_2; \
+  WRITE(ST7565_CLK_PIN, HIGH);       ST7565_DELAY_3; \
+  WRITE(ST7565_CLK_PIN, LOW);\
+  val <<= 1
+
+static void ST7565_SWSPI_SND_8BIT(uint8_t val) {
+  ST7565_SND_BIT; // 1
+  ST7565_SND_BIT; // 2
+  ST7565_SND_BIT; // 3
+  ST7565_SND_BIT; // 4
+  ST7565_SND_BIT; // 5
+  ST7565_SND_BIT; // 6
+  ST7565_SND_BIT; // 7
+  ST7565_SND_BIT; // 8
+}
+
+#if defined(DOGM_SPI_DELAY_US) && DOGM_SPI_DELAY_US > 0
+  #define U8G_DELAY delayMicroseconds(DOGM_SPI_DELAY_US)
+#else
+  #define U8G_DELAY u8g_10MicroDelay()
+#endif
+
+#define ST7565_CS()                          { WRITE(ST7565_CS_PIN,1); U8G_DELAY; }
+#define ST7565_NCS()                         { WRITE(ST7565_CS_PIN,0); }
+#define ST7565_A0()                          { WRITE(ST7565_A0_PIN,1); U8G_DELAY; }
+#define ST7565_NA0()                         { WRITE(ST7565_A0_PIN,0); }
+#define ST7565_WRITE_BYTE(a)                 { ST7565_SWSPI_SND_8BIT((uint8_t)a); U8G_DELAY; }
+#define ST7560_WriteSequence(count, pointer) { uint8_t *ptr = pointer; for (uint8_t i = 0; i <  count; i++) {ST7565_SWSPI_SND_8BIT( *ptr++);} DELAY_10US; }
+
+
+uint8_t u8g_dev_st7565_64128n_2x_VIKI_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
+  switch (msg) {
+    case U8G_DEV_MSG_INIT:
+    { OUT_WRITE(ST7565_CS_PIN, LOW);
+      OUT_WRITE(ST7565_DAT_PIN, LOW);
+      OUT_WRITE(ST7565_CLK_PIN, LOW);
+      OUT_WRITE(ST7565_A0_PIN, LOW);
+
+      ST7565_CS();                      /* disable chip */
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+
+
+      ST7565_WRITE_BYTE(0x0A2);         /* 0x0a2: LCD bias 1/9 (according to Displaytech 64128N datasheet) */
+      ST7565_WRITE_BYTE(0x0A0);         /* Normal ADC Select (according to Displaytech 64128N datasheet) */
+
+      ST7565_WRITE_BYTE(0x0c8);         /* common output mode: set scan direction normal operation/SHL Select; 0x0c0 --> SHL = 0; normal; 0x0c8 --> SHL = 1 */
+      ST7565_WRITE_BYTE(0x040);         /* Display start line for Displaytech 64128N */
+
+      ST7565_WRITE_BYTE(0x028 | 0x04);  /* power control: turn on voltage converter */
+//    U8G_ESC_DLY(50);                  /* delay 50 ms - hangs after a reset if used */ 
+
+      ST7565_WRITE_BYTE(0x028 | 0x06);  /* power control: turn on voltage regulator */
+//    U8G_ESC_DLY(50);                  /* delay 50 ms - hangs after a reset if used */ 
+
+      ST7565_WRITE_BYTE(0x028 | 0x07);  /* power control: turn on voltage follower */
+//   U8G_ESC_DLY(50);                   /* delay 50 ms - hangs after a reset if used */ 
+
+      ST7565_WRITE_BYTE(0x010);         /* Set V0 voltage resistor ratio. Setting for controlling brightness of Displaytech 64128N */
+
+      ST7565_WRITE_BYTE(0x0a6);         /* display normal, bit val 0: LCD pixel off. */
+
+      ST7565_WRITE_BYTE(0x081);         /* set contrast */
+      ST7565_WRITE_BYTE(0x01e);         /* Contrast value. Setting for controlling brightness of Displaytech 64128N */
+
+
+      ST7565_WRITE_BYTE(0x0af);         /* display on */
+
+      U8G_ESC_DLY(100);                 /* delay 100 ms */
+      ST7565_WRITE_BYTE(0x0a5);         /* display all points; ST7565 */
+      U8G_ESC_DLY(100);                 /* delay 100 ms */
+      U8G_ESC_DLY(100);                 /* delay 100 ms */
+      ST7565_WRITE_BYTE(0x0a4);         /* normal display */
+      ST7565_CS();                      /* disable chip */
+    }                                   /* end of sequence */
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+    { u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+      ST7565_CS();                      /* disable chip */
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x010);         /* set upper 4 bit of the col adr to 0x10 */
+      ST7565_WRITE_BYTE(0x000);         /* set lower 4 bit of the col adr to 0x00. Changed for DisplayTech 64128N */
+                                        /* end of sequence */
+      ST7565_WRITE_BYTE(0x0b0 | (2*pb->p.page));; /* select current page (ST7565R) */
+      ST7565_A0();                      /* data mode */
+      ST7560_WriteSequence( (uint8_t) pb->width, (uint8_t *)pb->buf);
+      ST7565_CS();                      /* disable chip */
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x010);         /* set upper 4 bit of the col adr to 0x10 */
+      ST7565_WRITE_BYTE(0x000);         /* set lower 4 bit of the col adr to 0x00. Changed for DisplayTech 64128N */
+                                        /* end of sequence */
+      ST7565_WRITE_BYTE(0x0b0 | (2*pb->p.page+1)); /* select current page (ST7565R) */
+      ST7565_A0();                      /* data mode */
+      ST7560_WriteSequence( (uint8_t) pb->width, (uint8_t *)(pb->buf)+pb->width);
+      ST7565_CS();                      /* disable chip */
+    }
+      break;
+    case U8G_DEV_MSG_CONTRAST:
+      ST7565_NCS();
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_WRITE_BYTE(0x081);
+      ST7565_WRITE_BYTE((*(uint8_t *)arg) >> 2);
+      ST7565_CS();                      /* disable chip */
+      return 1;
+    case U8G_DEV_MSG_SLEEP_ON:
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x0ac);         /* static indicator off */
+      ST7565_WRITE_BYTE(0x000);         /* indicator register set (not sure if this is required) */
+      ST7565_WRITE_BYTE(0x0ae);         /* display off */
+      ST7565_WRITE_BYTE(0x0a5);         /* all points on */
+      ST7565_CS();                      /* disable chip , bugfix 12 nov 2014 */
+                                        /* end of sequence */
+      return 1;
+    case U8G_DEV_MSG_SLEEP_OFF:
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x0a4);         /* all points off */
+      ST7565_WRITE_BYTE(0x0af);         /* display on */
+      U8G_ESC_DLY(50);                  /* delay 50 ms */
+      ST7565_CS();                      /* disable chip ,  bugfix 12 nov 2014 */
+                                        /* end of sequence */
+      return 1;
+  }
+  return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
+}
+
+uint8_t u8g_dev_st7565_64128n_2x_VIKI_buf[WIDTH*2] U8G_NOCOMMON ;
+u8g_pb_t u8g_dev_st7565_64128n_2x_VIKI_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_st7565_64128n_2x_VIKI_buf};
+u8g_dev_t u8g_dev_st7565_64128n_2x_VIKI_sw_spi = { u8g_dev_st7565_64128n_2x_VIKI_fn, &u8g_dev_st7565_64128n_2x_VIKI_pb, &u8g_com_null_fn};
+
+
+class U8GLIB_ST7565_64128n_2x_VIKI : public U8GLIB {
+  public:
+  U8GLIB_ST7565_64128n_2x_VIKI(uint8_t dummy) 
+    : U8GLIB(&u8g_dev_st7565_64128n_2x_VIKI_sw_spi) 
+    {  }
+  U8GLIB_ST7565_64128n_2x_VIKI(uint8_t sck, uint8_t mosi, uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE) 
+    : U8GLIB(&u8g_dev_st7565_64128n_2x_VIKI_sw_spi) 
+    {  }  
+};
+
+
+
+#pragma GCC reset_options
+
+#endif // U8GLIB_ST7565
+#endif // ULCDST7565_H


### PR DESCRIPTION
This is the ST7565 software SPI code that was merged under PR #7447 but seems to have disappeared.