### PR TITLE
G26 output corrected

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -785,7 +785,7 @@
               if (ubl_lcd_clicked()) return exit_from_g26();
             #endif
 
-            if (PENDING(millis(), next)) {
+            if (ELAPSED(millis(), next)) {
               next = millis() + 5000UL;
               print_heaterstates();
             }
@@ -806,7 +806,7 @@
         if (ubl_lcd_clicked()) return exit_from_g26();
       #endif
 
-      if (PENDING(millis(), next)) {
+      if (ELAPSED(millis(), next)) {
         next = millis() + 5000UL;
         print_heaterstates();
       }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7081,7 +7081,8 @@ inline void gcode_M104() {
     SERIAL_PROTOCOLCHAR(
       #if HAS_TEMP_BED && HAS_TEMP_HOTEND
         e == -1 ? 'B' : 'T'
-      #elif HAS_TEMP_HOTEND
+
+                #elif HAS_TEMP_HOTEND
         'T'
       #else
         'B'

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7097,6 +7097,7 @@ inline void gcode_M104() {
       SERIAL_PROTOCOLPAIR(" (", r / OVERSAMPLENR);
       SERIAL_PROTOCOLCHAR(')');
     #endif
+    SERIAL_EOL();
   }
 
   void print_heaterstates() {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7097,7 +7097,6 @@ inline void gcode_M104() {
       SERIAL_PROTOCOLPAIR(" (", r / OVERSAMPLENR);
       SERIAL_PROTOCOLCHAR(')');
     #endif
-    SERIAL_EOL();
   }
 
   void print_heaterstates() {
@@ -7137,6 +7136,7 @@ inline void gcode_M104() {
         SERIAL_PROTOCOL(thermalManager.getHeaterPower(e));
       }
     #endif
+    SERIAL_EOL();
   }
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7081,8 +7081,7 @@ inline void gcode_M104() {
     SERIAL_PROTOCOLCHAR(
       #if HAS_TEMP_BED && HAS_TEMP_HOTEND
         e == -1 ? 'B' : 'T'
-
-                #elif HAS_TEMP_HOTEND
+      #elif HAS_TEMP_HOTEND
         'T'
       #else
         'B'


### PR DESCRIPTION
G26 output was displaying the heater state multiple times.. couple of hundred in fact. so changed the macro used from PENDING to ELAPSED which corrected the output to only print every 5000ms.. This exposed another small "feature" with "busy: processing" appearing on the EOL. Adding SERIAL_EOL() to the print_heaterstates() at the end, fixed this and as there should always be at least one heater on a 3d printer, it doesn't need to be wrapped in a #if/#endif.