### PR TITLE
Fix for G26 spam output

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -785,9 +785,10 @@
               if (ubl_lcd_clicked()) return exit_from_g26();
             #endif
 
-            if (PENDING(millis(), next)) {
+            if (ELAPSED(millis(), next)) {
               next = millis() + 5000UL;
               print_heaterstates();
+              SERIAL_EOL();
             }
             idle();
           }
@@ -806,9 +807,10 @@
         if (ubl_lcd_clicked()) return exit_from_g26();
       #endif
 
-      if (PENDING(millis(), next)) {
+      if (ELAPSED(millis(), next)) {
         next = millis() + 5000UL;
         print_heaterstates();
+        SERIAL_EOL();
       }
       idle();
     }


### PR DESCRIPTION
while heating, G26 will continuously spam the heater states instead of printing it out every 5000ms. Added missing SERIAL_EOL() after the print_heaterstates(), since we'd have to modify every location in Marlin to remove the following SERIAL_EOL() call which should actually be encased in the print_heaterstates() function.