### PR TITLE
Finish SERVO_DELAY changes

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -376,8 +376,10 @@
       #define NUM_SERVOS (Z_ENDSTOP_SERVO_NR + 1)
     #endif
     #undef DEACTIVATE_SERVOS_AFTER_MOVE
-    #undef SERVO_DELAY
-    #define SERVO_DELAY { 50 }
+    #if NUM_SERVOS = 1
+      #undef SERVO_DELAY
+      #define SERVO_DELAY { 50 }
+	#endif
     #ifndef BLTOUCH_DELAY
       #define BLTOUCH_DELAY 375
     #endif

--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -379,7 +379,7 @@
     #if NUM_SERVOS == 1
       #undef SERVO_DELAY
       #define SERVO_DELAY { 50 }
-	#endif
+    #endif
     #ifndef BLTOUCH_DELAY
       #define BLTOUCH_DELAY 375
     #endif

--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -376,7 +376,7 @@
       #define NUM_SERVOS (Z_ENDSTOP_SERVO_NR + 1)
     #endif
     #undef DEACTIVATE_SERVOS_AFTER_MOVE
-    #if NUM_SERVOS = 1
+    #if NUM_SERVOS == 1
       #undef SERVO_DELAY
       #define SERVO_DELAY { 50 }
 	#endif


### PR DESCRIPTION
#7504 integration has missed this part.
When more than 1 servo is used with bltouch it's impossible to predefine default servo delay for it.
In my original fix I completely removed this part but maybe this is a better compromise