### PR TITLE
Code reduction with some configurations

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -13484,7 +13484,7 @@ void setup() {
     setup_endstop_interrupts();
   #endif
 
-  #if ENABLED(SWITCHING_EXTRUDER)
+  #if ENABLED(SWITCHING_EXTRUDER) && !DONT_SWITCH
     move_extruder_servo(0);  // Initialize extruder servo
   #endif
 


### PR DESCRIPTION
When switching noozle and extruder but these operations are done by the same servo in 'setup' function there is a unnecessary call