### PR TITLE
Changes to EEPROM emulation

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -81,7 +81,7 @@ int main(void) {
     delay(50);
     TOGGLE(13);     // Flash fast while USB initialisation completes
   }
-
+  delay(200);
   debug_frmwrk_init();
   usb_serial.printf("\n\nRe-ARM (LPC1768 @ %dMhz) UART0 Initialised\n", SystemCoreClock / 1000000);
 

--- a/Marlin/src/HAL/HAL_LPC1768/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/persistent_store_impl.cpp
@@ -18,34 +18,62 @@ namespace PersistentStore {
 
 FATFS fat_fs;
 FIL eeprom_file;
+#define _EEPROM_SIZE 4096
+char eeprom_content[_EEPROM_SIZE];
 
 bool access_start() {
+  UINT bytes_read = 0;
   f_mount(&fat_fs, "", 1);
   FRESULT res = f_open(&eeprom_file, "eeprom.dat", FA_OPEN_ALWAYS | FA_WRITE | FA_READ);
+  if (res == FR_OK) {
+    res = f_read(&eeprom_file, eeprom_content, _EEPROM_SIZE, &bytes_read);
+  }
+  for (; bytes_read < _EEPROM_SIZE; bytes_read++){
+    eeprom_content[bytes_read] = 0;
+  }
   return (res == FR_OK);
 }
 
 bool access_finish(){
+  UINT bytes_written = 0;
+  f_lseek(&eeprom_file, 0);
+  f_write(&eeprom_file, eeprom_content, _EEPROM_SIZE, &bytes_written);
+
   f_close(&eeprom_file);
   f_unmount("");
-  return true;
+  return (bytes_written == _EEPROM_SIZE);
 }
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+  for (int i = 0; i < size; i++){
+    eeprom_content[pos + i] = value[i];
+  }
+  crc16(crc, value, size);
+  pos = pos + size;
+  return true;
+/*
   UINT bytes_written = 0;
   f_lseek(&eeprom_file, pos);
   f_write(&eeprom_file, (void *)value, size, &bytes_written);
   crc16(crc, value, size);
   pos = pos + size;
   return (bytes_written == size);
+*/
 }
 
 void read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
+  for (int i = 0; i < size; i++){
+    value[i] = eeprom_content[pos + i];
+  }
+  crc16(crc, value, size);
+  pos = pos + size;
+/*
   UINT bytes_read = 0;
   f_lseek(&eeprom_file, pos);
   f_read(&eeprom_file, (void *)value, size, &bytes_read);
   crc16(crc, value, size);
   pos = pos + size;
+*/
 }
 
 }


### PR DESCRIPTION
With this changes the EEPROM file content is cached, reducing the number of reads and writes. Also 200ms delay is inserted right after the USB port is connected.
Now the board can boot from power down or reset successfully, and can save and read configuration values from the EEPROM file.
The file is auto read succesfully on boot up.