### PR TITLE
Addressing #7552

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9241,7 +9241,10 @@ inline void gcode_M400() { stepper.synchronize(); }
   /**
    * M406: Turn off filament sensor for control
    */
-  inline void gcode_M406() { filament_sensor = false; }
+  inline void gcode_M406() {
+    filament_sensor = false;
+    calculate_volumetric_multipliers();   // Restore correct 'volumetric_multiplier' value
+    }
 
   /**
    * M407: Get measured filament diameter on serial output


### PR DESCRIPTION
When M405 is used it changes 'volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]' value but M406 disable it but leave value changed.
I used 'Calculate_volumetric_multipliers'
instead of resetting value to 1.0 because I don't know if M200 is compatible or not with M405 hence I'm sure to restore anyway with correct value