### PR TITLE
Fix: M406 not updating feedrate multiplier

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9241,7 +9241,10 @@ inline void gcode_M400() { stepper.synchronize(); }
   /**
    * M406: Turn off filament sensor for control
    */
-  inline void gcode_M406() { filament_sensor = false; }
+  inline void gcode_M406() {
+    filament_sensor = false;
+    calculate_volumetric_multipliers();   // Restore correct 'volumetric_multiplier' value
+  }
 
   /**
    * M407: Get measured filament diameter on serial output


### PR DESCRIPTION
Spacing tweak of #7558, for merge

When `M405` is used it changes `volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]` value. When `M406` disables `M405` it leaves the value unchanged.
This PR applies `calculate_volumetric_multipliers` in `M406` instead of resetting it to 1.0 because `M200` may not be compatible with `M405` hence I'm sure to restore anyway with correct value.