### PR TITLE
Creality ultralcd fixes

### DIFF
--- a/Marlin/example_configurations/Creality/CR-10/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration.h
@@ -1390,6 +1390,16 @@
 //
 #define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 
+//Fixes for ultralcd related bugs
+#define DELAY_0_NOP  NOOP
+#define DELAY_1_NOP  __asm__("nop\n\t")
+#define DELAY_2_NOP  __asm__("nop\n\t" "nop\n\t")
+#define DELAY_3_NOP  __asm__("nop\n\t" "nop\n\t" "nop\n\t")
+#define DELAY_4_NOP  __asm__("nop\n\t" "nop\n\t" "nop\n\t" "nop\n\t")
+#define ST7920_DELAY_1 DELAY_2_NOP
+#define ST7920_DELAY_2 DELAY_2_NOP
+#define ST7920_DELAY_3 DELAY_2_NOP
+
 //
 // MakerLab Mini Panel with graphic
 // controller and SD support - http://reprap.org/wiki/Mini_panel

--- a/Marlin/pins_MELZI_CREALITY.h
+++ b/Marlin/pins_MELZI_CREALITY.h
@@ -33,19 +33,22 @@
 
 #undef LCD_SDSS
 #undef LED_PIN
-
 #undef LCD_PINS_RS
 #undef LCD_PINS_ENABLE
-
-#define LCD_PINS_RS     28 // st9720 CS
-#define LCD_PINS_ENABLE 17 // st9720 DAT
-
 #undef LCD_PINS_D4
 #undef LCD_PINS_D5
 #undef LCD_PINS_D6
 #undef LCD_PINS_D7
+#undef FIL_RUNOUT_PIN
 
+#define LCD_SDSS		31 // Smart Controller SD card reader rather than the Melzi
+#define LCD_PINS_RS     28 // st9720 CS
+#define LCD_PINS_ENABLE 17 // st9720 DAT
 #define LCD_PINS_D4     30 // st9720 CLK
+#define LCD_PINS_D5     -1
+#define LCD_PINS_D6     -1
+#define LCD_PINS_D7     -1
+#define FIL_RUNOUT_PIN	-1 //Filament Runout Pin - Uses Beeper/LED Pin Pulled to GND
 
 /**
   PIN:   0   Port: B0        E0_DIR_PIN                  protected


### PR DESCRIPTION
Minor changes to resolve issues I was having with the stock Creality LCD after flashing Marlin bugfix-1.1.x related to defines in ultralcd_st7920_u8glib_rrd.h.