### PR TITLE
M111: no args reports current flags

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -28,6 +28,10 @@
 #ifndef CONDITIONALS_POST_H
 #define CONDITIONALS_POST_H
 
+  #define IS_SCARA (ENABLED(MORGAN_SCARA) || ENABLED(MAKERARM_SCARA))
+  #define IS_KINEMATIC (ENABLED(DELTA) || IS_SCARA)
+  #define IS_CARTESIAN !IS_KINEMATIC
+
   /**
    * Axis lengths and center
    */
@@ -43,6 +47,12 @@
     #define Y_BED_SIZE Y_MAX_LENGTH
   #endif
 
+  // Require 0,0 bed center for Delta and SCARA
+  #if IS_KINEMATIC
+    #define BED_CENTER_AT_0_0
+  #endif
+
+  // Define center values for future use
   #if ENABLED(BED_CENTER_AT_0_0)
     #define X_CENTER 0
     #define Y_CENTER 0
@@ -52,6 +62,7 @@
   #endif
   #define Z_CENTER ((Z_MIN_POS + Z_MAX_POS) / 2)
 
+  // Get the linear boundaries of the bed
   #define X_MIN_BED (X_CENTER - (X_BED_SIZE) / 2)
   #define X_MAX_BED (X_CENTER + (X_BED_SIZE) / 2)
   #define Y_MIN_BED (Y_CENTER - (Y_BED_SIZE) / 2)
@@ -84,10 +95,6 @@
       #define CORESIGN(n) (n)
     #endif
   #endif
-
-  #define IS_SCARA (ENABLED(MORGAN_SCARA) || ENABLED(MAKERARM_SCARA))
-  #define IS_KINEMATIC (ENABLED(DELTA) || IS_SCARA)
-  #define IS_CARTESIAN !IS_KINEMATIC
 
   /**
    * No adjustable bed on non-cartesians

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5559,7 +5559,7 @@ void home_all_axes() { gcode_G28(true); }
             N++;
           }
         zero_std_dev_old = zero_std_dev;
-        zero_std_dev = round(sqrt(S2 / N) * 1000.0) / 1000.0 + 0.00001;
+        zero_std_dev = round(SQRT(S2 / N) * 1000.0) / 1000.0 + 0.00001;
 
         // Solve matrices
 
@@ -7745,16 +7745,17 @@ inline void gcode_M110() {
  * M111: Set the debug level
  */
 inline void gcode_M111() {
-  marlin_debug_flags = parser.byteval('S', (uint8_t)DEBUG_NONE);
+  if (parser.seen('S')) marlin_debug_flags = parser.byteval('S');
 
-  const static char str_debug_1[] PROGMEM = MSG_DEBUG_ECHO;
-  const static char str_debug_2[] PROGMEM = MSG_DEBUG_INFO;
-  const static char str_debug_4[] PROGMEM = MSG_DEBUG_ERRORS;
-  const static char str_debug_8[] PROGMEM = MSG_DEBUG_DRYRUN;
-  const static char str_debug_16[] PROGMEM = MSG_DEBUG_COMMUNICATION;
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    const static char str_debug_32[] PROGMEM = MSG_DEBUG_LEVELING;
-  #endif
+  const static char str_debug_1[] PROGMEM = MSG_DEBUG_ECHO,
+                    str_debug_2[] PROGMEM = MSG_DEBUG_INFO,
+                    str_debug_4[] PROGMEM = MSG_DEBUG_ERRORS,
+                    str_debug_8[] PROGMEM = MSG_DEBUG_DRYRUN,
+                    str_debug_16[] PROGMEM = MSG_DEBUG_COMMUNICATION
+                    #if ENABLED(DEBUG_LEVELING_FEATURE)
+                      , str_debug_32[] PROGMEM = MSG_DEBUG_LEVELING
+                    #endif
+                    ;
 
   const static char* const debug_strings[] PROGMEM = {
     str_debug_1, str_debug_2, str_debug_4, str_debug_8, str_debug_16


### PR DESCRIPTION
The `M111` code by itself ought to report debug flags instead of clearing them.

Also,
- Add a conditional to set `BED_CENTER_AT_0_0` if forgotten in configuration
- Replace `sqrt` with `SQRT` for `2.0.x` compliance
