### PR TITLE
CNC workspace planes for G5

### DIFF
--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -160,6 +160,7 @@
 #define MSG_ERR_MATERIAL_INDEX              "M145 S<index> out of range (0-1)"
 #define MSG_ERR_M355_NONE                   "No case light"
 #define MSG_ERR_M421_PARAMETERS             "M421 incorrect parameter usage"
+#define MSG_ERR_BAD_PLANE_MODE              "G5 requires XY plane mode"
 #define MSG_ERR_MESH_XY                     "Mesh point cannot be resolved"
 #define MSG_ERR_ARC_ARGS                    "G2/G3 bad parameters"
 #define MSG_ERR_PROTECTED_PIN               "Protected Pin"


### PR DESCRIPTION
According to LinuxCNC, G5 should throw an error if the current plane mode isn't XY.

- Also, a more explicit `count` name in `plan_arc`