### PR TITLE
[2.0.x] Clean up some HAL code

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/watchdog_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/watchdog_AVR.cpp
@@ -22,11 +22,13 @@
 
 #ifdef ARDUINO_ARCH_AVR
 
-#include "../../../Marlin.h"
+#include "../../../MarlinConfig.h"
 
 #if ENABLED(USE_WATCHDOG)
 
 #include "watchdog_AVR.h"
+
+#include "../../../Marlin.h"
 
 // Initialize watchdog with a 4 sec interrupt time
 void watchdog_init() {

--- a/Marlin/src/HAL/HAL_AVR/watchdog_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/watchdog_AVR.h
@@ -23,8 +23,6 @@
 #ifndef WATCHDOG_AVR_H
 #define WATCHDOG_AVR_H
 
-//#include "../../../Marlin.h"
-
 #include <avr/wdt.h>
 
 // Initialize watchdog with a 4 second interrupt time
@@ -34,4 +32,4 @@ void watchdog_init();
 // first watchdog_init or AVR will go into emergency procedures.
 inline void watchdog_reset() { wdt_reset(); }
 
-#endif
+#endif // WATCHDOG_AVR_H

--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.cpp
@@ -94,8 +94,8 @@ uint8_t HAL_get_reset_source (void) {
 }
 
 void _delay_ms(int delay_ms) {
-  //todo: port for Due?
-  delay (delay_ms);
+  // todo: port for Due?
+  delay(delay_ms);
 }
 
 extern "C" {

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
@@ -91,7 +91,6 @@ const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
   Timer_clock4: Prescaler 128 -> 656.25kHz
 */
 
-
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
   Tc *tc = TimerConfig[timer_num].pTimerRegs;
   IRQn_Type irq = TimerConfig[timer_num].IRQ_Id;

--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -431,5 +431,4 @@ pins
 #define DIO100_PIN 11
 #define DIO100_WPORT PIOC
 
-
 #endif // _FASTIO_DUE_H

--- a/Marlin/src/HAL/HAL_LPC1768/LPC1768_PWM.h
+++ b/Marlin/src/HAL/HAL_LPC1768/LPC1768_PWM.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * The class Servo uses the PWM class to implement it's functions
+ * The class Servo uses the PWM class to implement its functions
  *
  * All PWMs use the same repetition rate - 20mS because that's the normal servo rate
 */
@@ -489,7 +489,7 @@ return;
  *          writes to the LER register
  *          sets the PWM_table_swap flag active
  *          re-enables the ISR
- *     7) On the next interrupt the ISR changes it's pointer to the work table which is now the old, 
+ *     7) On the next interrupt the ISR changes its pointer to the work table which is now the old, 
  *        unmodified, active table.
  *     8) On the next MR0 interrupt the ISR:
  *          switches over to the active table

--- a/Marlin/src/HAL/HAL_LPC1768/LPC1768_Servo.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/LPC1768_Servo.cpp
@@ -1,84 +1,78 @@
 /**
-  * Marlin 3D Printer Firmware
-  * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
-  *
-  * Based on Sprinter and grbl.
-  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
-  *
-  * This program is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * This program is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
-  *
-*/
-
-/**
-  * Based on servo.cpp - Interrupt driven Servo library for Arduino using 16 bit
-  * timers- Version 2  Copyright (c) 2009 Michael Margolis.  All right reserved.
-*/
-
-/**
-  * A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
-  * The servos are pulsed in the background using the value most recently written using the write() method
-  *
-  * Note that analogWrite of PWM on pins associated with the timer are disabled when the first servo is attached.
-  * Timers are seized as needed in groups of 12 servos - 24 servos use two timers, 48 servos will use four.
-  *
-  * The methods are:
-  *
-  * Servo - Class for manipulating servo motors connected to Arduino pins.
-  *
-  * attach(pin)           - Attach a servo motor to an i/o pin.
-  * attach(pin, min, max) - Attach to a pin, setting min and max values in microseconds
-  *                         Default min is 544, max is 2400
-  *
-  * write()               - Set the servo angle in degrees. (Invalid angles —over MIN_PULSE_WIDTH— are treated as µs.)
-  * writeMicroseconds()   - Set the servo pulse width in microseconds.
-  * move(pin, angle)      - Sequence of attach(pin), write(angle), delay(SERVO_DELAY).
-  *                         With DEACTIVATE_SERVOS_AFTER_MOVE it detaches after SERVO_DELAY.
-  * read()                - Get the last-written servo pulse width as an angle between 0 and 180.
-  * readMicroseconds()    - Get the last-written servo pulse width in microseconds.
-  * attached()            - Return true if a servo is attached.
-  * detach()              - Stop an attached servo from pulsing its i/o pin.
-  *
-*/
-
-/**
- *  The only time that this library wants physical movement is when a WRITE
- *  command is issued.  Before that all the attach & detach activity is solely
- *  within the data base.
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
- *  The PWM output is inactive until the first WRITE.  After that it stays active
- *  unless DEACTIVATE_SERVOS_AFTER_MOVE is enabled and a MOVE command was issued.
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 
-#ifdef TARGET_LPC1768
+/**
+ * Based on servo.cpp - Interrupt driven Servo library for Arduino using 16 bit
+ * timers- Version 2  Copyright (c) 2009 Michael Margolis.  All right reserved.
+ */
 
-#if HAS_SERVOS
+/**
+ * A servo is activated by creating an instance of the Servo class passing the desired pin to the attach() method.
+ * The servos are pulsed in the background using the value most recently written using the write() method
+ *
+ * Note that analogWrite of PWM on pins associated with the timer are disabled when the first servo is attached.
+ * Timers are seized as needed in groups of 12 servos - 24 servos use two timers, 48 servos will use four.
+ *
+ * The methods are:
+ *
+ * Servo - Class for manipulating servo motors connected to Arduino pins.
+ *
+ * attach(pin)           - Attach a servo motor to an i/o pin.
+ * attach(pin, min, max) - Attach to a pin, setting min and max values in microseconds
+ *                         Default min is 544, max is 2400
+ *
+ * write()               - Set the servo angle in degrees. (Invalid angles —over MIN_PULSE_WIDTH— are treated as µs.)
+ * writeMicroseconds()   - Set the servo pulse width in microseconds.
+ * move(pin, angle)      - Sequence of attach(pin), write(angle), delay(SERVO_DELAY).
+ *                         With DEACTIVATE_SERVOS_AFTER_MOVE it detaches after SERVO_DELAY.
+ * read()                - Get the last-written servo pulse width as an angle between 0 and 180.
+ * readMicroseconds()    - Get the last-written servo pulse width in microseconds.
+ * attached()            - Return true if a servo is attached.
+ * detach()              - Stop an attached servo from pulsing its i/o pin.
+ *
+ */
 
+/**
+ * The only time that this library wants physical movement is when a WRITE
+ * command is issued.  Before that all the attach & detach activity is solely
+ * within the data base.
+ *
+ * The PWM output is inactive until the first WRITE.  After that it stays active
+ * unless DEACTIVATE_SERVOS_AFTER_MOVE is enabled and a MOVE command was issued.
+ */
 
-#include "LPC1768_Servo.h"
-#include "servo_private.h"
+#include "../../../MarlinConfig.h"
 
+#if HAS_SERVOS && defined(TARGET_LPC1768)
+
+  #include "LPC1768_Servo.h"
+  #include "servo_private.h"
 
   extern bool LPC1768_PWM_attach_pin(uint8_t, uint32_t, uint32_t, uint8_t);
   extern bool LPC1768_PWM_write(uint8_t, uint32_t);
   extern bool LPC1768_PWM_detach_pin(uint8_t);
 
-
-
   ServoInfo_t servo_info[MAX_SERVOS];                  // static array of servo info structures
   uint8_t ServoCount = 0;                              // the total number of attached servos
-
 
   #define US_TO_PULSE_WIDTH(p) p
   #define PULSE_WIDTH_TO_US(p) p
@@ -106,7 +100,6 @@
     if (pin > 0) servo_info[this->servoIndex].Pin.nbr = pin;  // only assign a pin value if the pin info is
                                                               // greater than zero. This way the init routine can
                                                               // assign the pin and the MOVE command only needs the value.
-
 
     this->min = MIN_PULSE_WIDTH; //resolution of min/max is 1 uS
     this->max = MAX_PULSE_WIDTH;
@@ -165,7 +158,4 @@
     }
   }
 
-#endif // HAS_SERVOS
-
-#endif // TARGET_LPC1768
-
+#endif // HAS_SERVOS && TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/LPC1768_Servo.h
+++ b/Marlin/src/HAL/HAL_LPC1768/LPC1768_Servo.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * The class Servo uses the PWM class to implement it's functions
+ * The class Servo uses the PWM class to implement its functions
  *
  * The PWM1 module is only used to generate interrups at specified times. It
  * is NOT used to directly toggle pins. The ISR writes to the pin assigned to
@@ -31,39 +31,32 @@
  *
  */
 
-#ifndef LPC1768_SERVO_h
-  #define LPC1768_SERVO_h
+#ifndef LPC1768_SERVO_H
+#define LPC1768_SERVO_H
 
-  #ifdef TARGET_LPC1768
-    #include <inttypes.h>
+#include <inttypes.h>
 
+class Servo {
+  public:
+    Servo();
+    int8_t attach(int pin);            // attach the given pin to the next free channel, set pinMode, return channel number (-1 on fail)
+    int8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
+    void detach();
+    void write(int value);             // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
+    void writeMicroseconds(int value); // write pulse width in microseconds
+    void move(int value);              // attach the servo, then move to value
+                                       // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
+                                       // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY, then detach
+    int read();                        // returns current pulse width as an angle between 0 and 180 degrees
+    int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
+    bool attached();                   // return true if this servo is attached, otherwise false
 
-    class Servo {
-      public:
-        Servo();
-        int8_t attach(int pin);            // attach the given pin to the next free channel, set pinMode, return channel number (-1 on fail)
-        int8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
-        void detach();
-        void write(int value);             // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
-        void writeMicroseconds(int value); // write pulse width in microseconds
-        void move(int value);              // attach the servo, then move to value
-                                           // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
-                                           // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY, then detach
-        int read();                        // returns current pulse width as an angle between 0 and 180 degrees
-        int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
-        bool attached();                   // return true if this servo is attached, otherwise false
+  private:
+    uint8_t servoIndex;               // index into the channel data for this servo
+    int min;
+    int max;
+};
 
-      private:
-        uint8_t servoIndex;               // index into the channel data for this servo
-        int min;
-        int max;
-    };
+#define HAL_SERVO_LIB Servo
 
-
-    #define HAL_SERVO_LIB Servo
-
-  #endif
-#endif
-
-
-
+#endif // LPC1768_SERVO_H

--- a/Marlin/src/HAL/HAL_pinsDebug.h
+++ b/Marlin/src/HAL/HAL_pinsDebug.h
@@ -21,19 +21,18 @@
  */
 
 #ifndef HAL_PINSDEBUG_H
+#define HAL_PINSDEBUG_H
 
-#if defined(PINS_DEBUGGING)
-  #ifdef ARDUINO_ARCH_AVR
-    #include "HAL_AVR/pinsDebug_AVR_8_bit.h"
-  #elif defined(ARDUINO_ARCH_SAM)
-    #include "HAL_DUE/HAL_pinsDebug_Due.h"
-  #elif IS_32BIT_TEENSY
-    #include "HAL_TEENSY35_36/HAL_pinsDebug_Teensy.h"
-  #elif defined(TARGET_LPC1768)
-    #include "HAL_LPC1768/pinsDebug_Re_ARM.h"
-  #else
-    #error Unsupported Platform!
-  #endif
-#endif  
-
+#ifdef ARDUINO_ARCH_AVR
+  #include "HAL_AVR/pinsDebug_AVR_8_bit.h"
+#elif defined(ARDUINO_ARCH_SAM)
+  #include "HAL_DUE/HAL_pinsDebug_Due.h"
+#elif IS_32BIT_TEENSY
+  #include "HAL_TEENSY35_36/HAL_pinsDebug_Teensy.h"
+#elif defined(TARGET_LPC1768)
+  #include "HAL_LPC1768/pinsDebug_Re_ARM.h"
+#else
+  #error Unsupported Platform!
 #endif
+
+#endif // HAL_PINSDEBUG_H

--- a/Marlin/src/HAL/HAL_spi_pins.h
+++ b/Marlin/src/HAL/HAL_spi_pins.h
@@ -41,4 +41,4 @@
   #error "Unsupported Platform!"
 #endif
 
-#endif /* HAL_SPI_PINS_H_ */
+#endif // HAL_SPI_PINS_H_

--- a/Marlin/src/HAL/servo.h
+++ b/Marlin/src/HAL/servo.h
@@ -66,48 +66,47 @@
                    With DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY and detach.
  */
 
-#ifndef servo_h
-#define servo_h
+#ifndef SERVO_H
+#define SERVO_H
 
 #if IS_32BIT_TEENSY
   #include "HAL_TEENSY35_36/HAL_Servo_Teensy.h" // Teensy HAL uses an inherited library
 
 #elif defined(TARGET_LPC1768)
-  #include "HAL_LPC1768/LPC1768_Servo.cpp"
+  #include "HAL_LPC1768/LPC1768_Servo.h"
 
 #else
+  #include <inttypes.h>
 
-#include <inttypes.h>
+  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_SAM)
+    // we're good to go
+  #else
+    #error "This library only supports boards with an AVR or SAM3X processor."
+  #endif
 
-#if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_SAM)
-  // we're good to go
-#else
-  #error "This library only supports boards with an AVR or SAM3X processor."
-#endif
+  #define Servo_VERSION           2     // software version of this library
 
-#define Servo_VERSION           2     // software version of this library
+  class Servo {
+    public:
+      Servo();
+      int8_t attach(int pin);            // attach the given pin to the next free channel, set pinMode, return channel number (-1 on fail)
+      int8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
+      void detach();
+      void write(int value);             // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
+      void writeMicroseconds(int value); // write pulse width in microseconds
+      void move(int value);              // attach the servo, then move to value
+                                         // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
+                                         // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY, then detach
+      int read();                        // returns current pulse width as an angle between 0 and 180 degrees
+      int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
+      bool attached();                   // return true if this servo is attached, otherwise false
 
-class Servo {
-  public:
-    Servo();
-    int8_t attach(int pin);            // attach the given pin to the next free channel, set pinMode, return channel number (-1 on fail)
-    int8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
-    void detach();
-    void write(int value);             // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
-    void writeMicroseconds(int value); // write pulse width in microseconds
-    void move(int value);              // attach the servo, then move to value
-                                       // if value is < 200 it is treated as an angle, otherwise as pulse width in microseconds
-                                       // if DEACTIVATE_SERVOS_AFTER_MOVE wait SERVO_DELAY, then detach
-    int read();                        // returns current pulse width as an angle between 0 and 180 degrees
-    int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
-    bool attached();                   // return true if this servo is attached, otherwise false
-
-  private:
-    uint8_t servoIndex;               // index into the channel data for this servo
-    int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH
-    int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH
-};
-
-#endif // !TEENSY
+    private:
+      uint8_t servoIndex;               // index into the channel data for this servo
+      int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH
+      int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH
+  };
 
 #endif
+
+#endif // SERVO_H

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -355,11 +355,8 @@ void Stepper::isr() {
       }
 
       _NEXT_ISR(ocr_val);
-      #ifdef CPU_32_BIT
-        //todo: HAL?
-      #else
-        NOLESS(OCR1A, TCNT1 + 16);
-      #endif
+
+      NOLESS(OCR1A, TCNT1 + 16);
 
       HAL_ENABLE_ISRs(); // re-enable ISRs
       return;


### PR DESCRIPTION
Spacing cleanups from an earlier PR that was closed, plus more cleanups as they are found in the rebase process. Changes from an earlier PR by @p3p (pertaining to persistent storage) will be posted in another PR shortly, to see if they still apply.

Things to watch out for:
- Header files should not include `.cpp` files
- Header files should have a main `#ifdef` conditional but not `#if HAS_FEATURE` applied
  to the whole header, since headers aren't compiled unless `#include`d.
- If a feature test is needed, only include `MarlinConfig.h` first, others only after the test.

As a point of making the code nicer, each HAL should have a single core include file which then includes all other needed files from the same HAL subfolder — some of which may be based on enabled features. This would eliminate the need to have so many "`../../..`" paths throughout the HAL files.