### PR TITLE
Added scrolling to long filenames in the SD menu (FR #7595)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -222,7 +222,7 @@
 
 /**
  * Part-Cooling Fan Multiplexer
- * 
+ *
  * This feature allows you to digitally multiplex the fan output.
  * The multiplexer is automatically switched at tool-change.
  * Set FANMUX[012]_PINs below for up to 2, 4, or 8 multiplexed fans.
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -281,6 +281,15 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
 #endif
 
 /**
+ * Scroll long file names in SD card
+ */
+#if ENABLED(SCROLL_LONG_FILE_NAMES)
+  #if DISABLED(SDSUPPORT)
+    #error "SCROLL_LONG_FILE_NAMES requires SDSUPPORT."
+  #endif
+#endif
+
+/**
  * I2C Position Encoders
  */
 #if ENABLED(I2C_POSITION_ENCODERS)

--- a/Marlin/SdFatConfig.h
+++ b/Marlin/SdFatConfig.h
@@ -125,7 +125,11 @@
   * Defines for long (vfat) filenames
   */
   /** Number of VFAT entries used. Every entry has 13 UTF-16 characters */
-  #define MAX_VFAT_ENTRIES (2)
+  #if ENABLED(SCROLL_LONG_FILE_NAMES)
+    #define MAX_VFAT_ENTRIES (5)
+  #else
+    #define MAX_VFAT_ENTRIES (2)
+  #endif
   /** Total size of the buffer used to store the long filenames */
   #define LONG_FILENAME_LENGTH (FILENAME_LENGTH*MAX_VFAT_ENTRIES+1)
 #endif  // SdFatConfig_h

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Folger Tech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/Folger Tech/i3-2020/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
@@ -564,6 +564,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
@@ -588,6 +588,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -577,6 +577,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -577,6 +577,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -577,6 +577,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -577,6 +577,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -582,6 +582,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -577,6 +577,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -575,6 +575,9 @@
   // Enable this option and reduce the value to optimize screen updates.
   // The normal delay is 10µs. Use the lowest value that still gives a reliable display.
   //#define DOGM_SPI_DELAY_US 5
+
+  // Enable this option to cause long filenames on the SD card menu to scroll.
+  //#define SCROLL_LONG_FILE_NAMES
 #endif // DOGLCD
 
 // @section safety

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -4492,6 +4492,17 @@ void lcd_update() {
       lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
     }
 
+    #if ENABLED(SCROLL_LONG_FILE_NAMES)
+      // If scrolling of long file names is enabled and we are in the sd card menu,
+      // cause a refresh to occur until all the text has scrolled into view.
+      if(currentScreen == lcd_sdcard_menu && scroll_offset < scroll_max && !lcd_status_update_delay--) {
+        lcd_status_update_delay = 6;
+        lcdDrawUpdate = LCDVIEW_REDRAW_NOW;
+        scroll_offset++;
+        return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;
+      }
+    #endif
+
     // then we want to use 1/2 of the time only.
     uint16_t bbr2 = planner.block_buffer_runtime() >> 1;
 

--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -933,6 +933,11 @@ static void lcd_implementation_status_screen() {
   }
 
   #if ENABLED(SDSUPPORT)
+    #if defined(SCROLL_LONG_FILE_NAMES)
+      static int        scroll_offset;
+      static int        scroll_max;
+      static int        scroll_row;
+    #endif
 
     static void _drawmenu_sd(const bool isSelected, const uint8_t row, const char* const pstr, const char* filename, char* const longFilename, const bool isDir) {
       UNUSED(pstr);
@@ -944,14 +949,22 @@ static void lcd_implementation_status_screen() {
       uint8_t n = LCD_WIDTH - (START_COL) - 1;
       if (longFilename[0]) {
         filename = longFilename;
-        longFilename[n] = '\0';
+        #if defined(SCROLL_LONG_FILE_NAMES)
+          if (isSelected) {
+            if(scroll_row != row) {
+              scroll_max    = max(0, strlen(longFilename) - n);
+              scroll_row    = row;
+              scroll_offset = 0;
+            }
+            filename += scroll_offset;
+          }
+        #endif
       }
 
       if (isDir) lcd_print(LCD_STR_FOLDER[0]);
 
-      while (char c = *filename) {
-        n -= lcd_print_and_count(c);
-        filename++;
+      for(const char *c = filename; *c && n > 0; c++) {
+        n -= lcd_print_and_count(*c);
       }
       while (n--) u8g.print(' ');
     }


### PR DESCRIPTION
When SCROLL_LONG_FILE_NAMES is enabled and when using a
graphical LCD, long filenames in the SD card will scroll into view
when highlighted so that they become fully visible.

This addresses Feature Request #7595