### PR TITLE
Fix so that "auto0.g" executes (Issue: #7636)

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -532,7 +532,7 @@ void CardReader::write_command(char *buf) {
 }
 
 void CardReader::checkautostart(bool force) {
-  if (!force && (!autostart_stilltocheck || ELAPSED(millis(), next_autostart_ms)))
+  if (!force && (!autostart_stilltocheck || ! ELAPSED(millis(), next_autostart_ms)))
     return;
 
   autostart_stilltocheck = false;


### PR DESCRIPTION
It looks like the logic got messed up a little bit. The function should keep returning while the startup delay has *not* yet elapsed and should proceed once that delay *has* elapsed.