### PR TITLE
matrix names update

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -304,7 +304,7 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
                delta_segments_per_second,
                delta_tower_angle_trim[ABC],
                delta_clip_start_height;
-  void recalc_delta_settings(float radius, float diagonal_rod);
+  void recalc_delta_settings(float radius, float diagonal_rod, float tower_angle_trim[ABC]);
 #elif IS_SCARA
   void forward_kinematics_SCARA(const float &a, const float &b);
 #endif

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -302,7 +302,7 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
                delta_diagonal_rod,
                delta_calibration_radius,
                delta_segments_per_second,
-               delta_tower_angle_trim[2],
+               delta_tower_angle_trim[ABC],
                delta_clip_start_height;
   void recalc_delta_settings(float radius, float diagonal_rod);
 #elif IS_SCARA

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5582,21 +5582,20 @@ void home_all_axes() { gcode_G28(true); }
 
           float e_delta[XYZ] = { 0.0 }, r_delta = 0.0, t_alpha = 0.0, t_beta = 0.0;
           const float r_diff = delta_radius - delta_calibration_radius,
-                      h_factor = 1.00 + r_diff * 0.001,                          //1.02 for r_diff = 20mm
-                      r_factor = -(1.75 + 0.005 * r_diff + 0.001 * sq(r_diff)),  //2.25 for r_diff = 20mm
-                      a_factor = 100.0 / delta_calibration_radius;               //1.25 for cal_rd = 80mm
-
+                      h_factor = 1.00 + r_diff * 0.001,                          //1.020 for r_diff = 20mm
+                      r_factor = -(1.75 + 0.005 * r_diff + 0.001 * sq(r_diff)),  //2.250 for r_diff = 20mm
+                      a_factor = 100.0 / delta_calibration_radius * 2.0 / 3.0;   //0.833 for cal_rd = 80mm
           #define ZP(N,I) ((N) * z_at_pt[I])
           #define Z1000(I) ZP(1.00, I)
-          #define Z1050(I) ZP(h_factor, I)
-          #define Z0700(I) ZP(h_factor * 2.0 / 3.00, I)
-          #define Z0350(I) ZP(h_factor / 3.00, I)
-          #define Z0175(I) ZP(h_factor / 6.00, I)
+          #define Z1020(I) ZP(h_factor, I)
+          #define Z0680(I) ZP(h_factor * 2.00 / 3.00, I)
+          #define Z0340(I) ZP(h_factor / 3.00, I)
+          #define Z0170(I) ZP(h_factor / 6.00, I)
           #define Z2250(I) ZP(r_factor, I)
           #define Z0750(I) ZP(r_factor / 3.00, I)
           #define Z0375(I) ZP(r_factor / 6.00, I)
-          #define Z0444(I) ZP(a_factor * 4.0 / 9.0, I)
-          #define Z0888(I) ZP(a_factor * 8.0 / 9.0, I)
+          #define Z0833(I) ZP(a_factor, I)
+          #define Z1666(I) ZP(a_factor * 2.00, I)
 
           #if ENABLED(PROBE_MANUALLY)
             test_precision = 0.00; // forced end
@@ -5610,28 +5609,28 @@ void home_all_axes() { gcode_G28(true); }
 
             case 2:
               if (towers_set) {
-                e_delta[X_AXIS] = Z1050(0) + Z0700(1) - Z0350(5) - Z0350(9);
-                e_delta[Y_AXIS] = Z1050(0) - Z0350(1) + Z0700(5) - Z0350(9);
-                e_delta[Z_AXIS] = Z1050(0) - Z0350(1) - Z0350(5) + Z0700(9);
+                e_delta[X_AXIS] = Z1020(0) + Z0680(1) - Z0340(5) - Z0340(9);
+                e_delta[Y_AXIS] = Z1020(0) - Z0340(1) + Z0680(5) - Z0340(9);
+                e_delta[Z_AXIS] = Z1020(0) - Z0340(1) - Z0340(5) + Z0680(9);
                 r_delta         = Z2250(0) - Z0750(1) - Z0750(5) - Z0750(9);
               }
               else {
-                e_delta[X_AXIS] = Z1050(0) - Z0700(7) + Z0350(11) + Z0350(3);
-                e_delta[Y_AXIS] = Z1050(0) + Z0350(7) - Z0700(11) + Z0350(3);
-                e_delta[Z_AXIS] = Z1050(0) + Z0350(7) + Z0350(11) - Z0700(3);
+                e_delta[X_AXIS] = Z1020(0) - Z0680(7) + Z0340(11) + Z0340(3);
+                e_delta[Y_AXIS] = Z1020(0) + Z0340(7) - Z0680(11) + Z0340(3);
+                e_delta[Z_AXIS] = Z1020(0) + Z0340(7) + Z0340(11) - Z0680(3);
                 r_delta         = Z2250(0) - Z0750(7) - Z0750(11) - Z0750(3);
               }
               break;
 
             default:
-              e_delta[X_AXIS] = Z1050(0) + Z0350(1) - Z0175(5) - Z0175(9) - Z0350(7) + Z0175(11) + Z0175(3);
-              e_delta[Y_AXIS] = Z1050(0) - Z0175(1) + Z0350(5) - Z0175(9) + Z0175(7) - Z0350(11) + Z0175(3);
-              e_delta[Z_AXIS] = Z1050(0) - Z0175(1) - Z0175(5) + Z0350(9) + Z0175(7) + Z0175(11) - Z0350(3);
+              e_delta[X_AXIS] = Z1020(0) + Z0340(1) - Z0170(5) - Z0170(9) - Z0340(7) + Z0170(11) + Z0170(3);
+              e_delta[Y_AXIS] = Z1020(0) - Z0170(1) + Z0340(5) - Z0170(9) + Z0170(7) - Z0340(11) + Z0170(3);
+              e_delta[Z_AXIS] = Z1020(0) - Z0170(1) - Z0170(5) + Z0340(9) + Z0170(7) + Z0170(11) - Z0340(3);
               r_delta         = Z2250(0) - Z0375(1) - Z0375(5) - Z0375(9) - Z0375(7) - Z0375(11) - Z0375(3);
 
               if (towers_set) {
-                t_alpha = Z0444(1) - Z0888(5) + Z0444(9) + Z0444(7) - Z0888(11) + Z0444(3);
-                t_beta  = Z0888(1) - Z0444(5) - Z0444(9) + Z0888(7) - Z0444(11) - Z0444(3);
+                t_alpha          = Z0833(1) - Z1666(5) + Z0833(9) + Z0833(7) - Z1666(11) + Z0833(3);
+                t_beta           = Z1666(1) - Z0833(5) - Z0833(9) + Z1666(7) - Z0833(11) - Z0833(3);
               }
               break;
           }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5423,11 +5423,12 @@ void home_all_axes() { gcode_G28(true); }
 
       const bool towers_set           = parser.boolval('T', true),
                  stow_after_each      = parser.boolval('E'),
+                 _0p_calibration      = probe_points == 0,
                  _1p_calibration      = probe_points == 1,
                  _4p_calibration      = probe_points == 2,
                  _4p_towers_points    = _4p_calibration && towers_set,
                  _4p_opposite_points  = _4p_calibration && !towers_set,
-                 _7p_calibration      = probe_points >= 3 || probe_points == 0,
+                 _7p_calibration      = probe_points >= 3 || _0p_calibration,
                  _7p_half_circle      = probe_points == 3,
                  _7p_double_circle    = probe_points == 5,
                  _7p_triple_circle    = probe_points == 6,

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5604,7 +5604,7 @@ void home_all_axes() { gcode_G28(true); }
           switch (probe_points) {
             case 1:
               test_precision = 0.00; // forced end
-              LOOP_XYZ(i) e_delta[i] = Z1(0);
+              LOOP_XYZ(axis) e_delta[axis] = Z1(0);
               break;
 
             case 2:

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3093,7 +3093,7 @@ static void homeaxis(const AxisEnum axis) {
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("endstop_adj:");
       #endif
-      do_homing_move(axis, endstop_adj[axis] - 0.1);
+      do_homing_move(axis, endstop_adj[axis] - 0.1 * Z_HOME_DIR);
     }
 
   #else
@@ -8554,7 +8554,8 @@ inline void gcode_M205() {
     #endif
     LOOP_XYZ(i) {
       if (parser.seen(axis_codes[i])) {
-        endstop_adj[i] = parser.value_linear_units();
+        if (parser.value_linear_units() * Z_HOME_DIR <= 0)         
+          endstop_adj[i] = parser.value_linear_units();
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOPAIR("endstop_adj[", axis_codes[i]);
@@ -8568,10 +8569,6 @@ inline void gcode_M205() {
         SERIAL_ECHOLNPGM("<<< gcode_M666");
       }
     #endif
-    // normalize endstops so all are <=0; set the residue to delta height
-    const float z_temp = MAX3(endstop_adj[A_AXIS], endstop_adj[B_AXIS], endstop_adj[C_AXIS]);
-    home_offset[Z_AXIS] -= z_temp;
-    LOOP_XYZ(i) endstop_adj[i] -= z_temp;
   }
 
 #elif IS_SCARA

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5640,10 +5640,10 @@ void home_all_axes() { gcode_G28(true); }
           delta_radius += r_delta;
           LOOP_XYZ(axis) delta_tower_angle_trim[axis] += t_delta[axis];
           
-          // normalise angles
-          float a_max = MAX3(delta_tower_angle_trim[A_AXIS], delta_tower_angle_trim[B_AXIS], delta_tower_angle_trim[C_AXIS]),
-                a_min = MIN3(delta_tower_angle_trim[A_AXIS], delta_tower_angle_trim[B_AXIS], delta_tower_angle_trim[C_AXIS]);
-          LOOP_XYZ(axis) delta_tower_angle_trim[axis] -= (a_max + a_min)/2;
+          // normalise angles to least squares
+          float a_sum = 0.0;
+          LOOP_XYZ(axis) a_sum += delta_tower_angle_trim[axis];
+          LOOP_XYZ(axis) delta_tower_angle_trim[axis] -= a_sum / 3.0;
           
           // adjust delta_height and endstops by the max amount
           const float z_temp = MAX3(endstop_adj[A_AXIS], endstop_adj[B_AXIS], endstop_adj[C_AXIS]);

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -215,7 +215,7 @@ void MarlinSettings::postprocess() {
   // Make sure delta kinematics are updated before refreshing the
   // planner position so the stepper counts will be set correctly.
   #if ENABLED(DELTA)
-    recalc_delta_settings(delta_radius, delta_diagonal_rod);
+    recalc_delta_settings(delta_radius, delta_diagonal_rod, delta_tower_angle_trim);
   #endif
 
   // Refresh steps_to_mm with the reciprocal of axis_steps_per_mm

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,13 +36,13 @@
  *
  */
 
-#define EEPROM_VERSION "V40"
+#define EEPROM_VERSION "V41"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
 
 /**
- * V39 EEPROM Layout:
+ * V41 EEPROM Layout:
  *
  *  100  Version                                    (char x4)
  *  104  EEPROM CRC16                               (uint16_t)
@@ -100,7 +100,7 @@
  *  372  M665 B    delta_calibration_radius         (float)
  *  376  M665 X    delta_tower_angle_trim[A]        (float)
  *  380  M665 Y    delta_tower_angle_trim[B]        (float)
- *  ---  M665 Z    delta_tower_angle_trim[C]        (float) is always 0.0
+ *  384  M665 Z    delta_tower_angle_trim[C]        (float)
  *
  * Z_DUAL_ENDSTOPS:                                 48 bytes
  *  348  M666 Z    z_endstop_adj                    (float)
@@ -448,16 +448,16 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(storage_slot);
     #endif // AUTO_BED_LEVELING_UBL
 
-    // 9 floats for DELTA / Z_DUAL_ENDSTOPS
+    // 10 floats for DELTA / Z_DUAL_ENDSTOPS
     #if ENABLED(DELTA)
       EEPROM_WRITE(endstop_adj);               // 3 floats
       EEPROM_WRITE(delta_radius);              // 1 float
       EEPROM_WRITE(delta_diagonal_rod);        // 1 float
       EEPROM_WRITE(delta_segments_per_second); // 1 float
       EEPROM_WRITE(delta_calibration_radius);  // 1 float
-      EEPROM_WRITE(delta_tower_angle_trim);    // 2 floats
+      EEPROM_WRITE(delta_tower_angle_trim);    // 3 floats
       dummy = 0.0f;
-      for (uint8_t q = 3; q--;) EEPROM_WRITE(dummy);
+      for (uint8_t q = 2; q--;) EEPROM_WRITE(dummy);
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       EEPROM_WRITE(z_endstop_adj);             // 1 float
       dummy = 0.0f;
@@ -844,9 +844,9 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(delta_diagonal_rod);        // 1 float
         EEPROM_READ(delta_segments_per_second); // 1 float
         EEPROM_READ(delta_calibration_radius);  // 1 float
-        EEPROM_READ(delta_tower_angle_trim);    // 2 floats
+        EEPROM_READ(delta_tower_angle_trim);    // 3 floats
         dummy = 0.0f;
-        for (uint8_t q=3; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=2; q--;) EEPROM_READ(dummy);
       #elif ENABLED(Z_DUAL_ENDSTOPS)
         EEPROM_READ(z_endstop_adj);
         dummy = 0.0f;
@@ -1233,8 +1233,7 @@ void MarlinSettings::reset() {
     delta_diagonal_rod = DELTA_DIAGONAL_ROD;
     delta_segments_per_second = DELTA_SEGMENTS_PER_SECOND;
     delta_calibration_radius = DELTA_CALIBRATION_RADIUS;
-    delta_tower_angle_trim[A_AXIS] = dta[A_AXIS] - dta[C_AXIS];
-    delta_tower_angle_trim[B_AXIS] = dta[B_AXIS] - dta[C_AXIS];
+    COPY(delta_tower_angle_trim, dta);
     home_offset[Z_AXIS] = 0;
 
   #elif ENABLED(Z_DUAL_ENDSTOPS)
@@ -1657,7 +1656,7 @@ void MarlinSettings::reset() {
       SERIAL_ECHOPAIR(" B", LINEAR_UNIT(delta_calibration_radius));
       SERIAL_ECHOPAIR(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
       SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
-      SERIAL_ECHOPAIR(" Z", 0.00);
+      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS]));
       SERIAL_EOL();
     #elif ENABLED(Z_DUAL_ENDSTOPS)
       if (!forReplay) {

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -44,7 +44,7 @@
                endstop_adj[ABC];
 
   extern float delta_radius,
-               delta_tower_angle_trim[2],
+               delta_tower_angle_trim[ABC],
                delta_tower[ABC][2],
                delta_diagonal_rod,
                delta_calibration_radius,

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2673,7 +2673,7 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM_EDIT(float52, MSG_DELTA_RADIUS, &delta_radius, DELTA_RADIUS - 5.0, DELTA_RADIUS + 5.0);
       MENU_ITEM_EDIT(float43, "Tx", &delta_tower_angle_trim[A_AXIS], -5.0, 5.0);
       MENU_ITEM_EDIT(float43, "Ty", &delta_tower_angle_trim[B_AXIS], -5.0, 5.0);
-      MENU_ITEM_EDIT(float43, "Tz", &Tz, -5.0, 5.0);
+      MENU_ITEM_EDIT(float43, "Tz", &delta_tower_angle_trim[C_AXIS], -5.0, 5.0);
       END_MENU();
     }
 


### PR DESCRIPTION
- simplified matrix names (see https://github.com/LVD-AC/Marlin-AC/blob/1.1.x-AC/documentation/auto%20calibrate.xls)
- new angle least squares normalization
- no normalizing on end stops M665 and tower angles M666
- P0 normalize only (no probing)
- various small cleanup