### PR TITLE
[bf20ng] Resolve undefined references to probing functions compile errors

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -47,6 +47,14 @@ float probe_pt(const float &lx, const float &ly, const bool, const uint8_t, cons
   void servo_probe_init();
 #endif
 
+#if QUIET_PROBING
+  void probing_pause(const bool p);
+#endif
+
+#if ENABLED(PROBING_FANS_OFF)
+  void fans_pause(const bool p);
+#endif
+
 #if ENABLED(BLTOUCH)
   void bltouch_command(int angle);
   bool set_bltouch_deployed(const bool deploy);


### PR DESCRIPTION
Resolves #7688 

[Scott, is there some more elegant way to resolve this ?  It appears to be fallout from breaking these out from Marlin_main.cpp]