### PR TITLE
Update pins.h for RAMPS-FD v1 and v2

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -262,7 +262,7 @@
   #include "pins_DUE3DOM_MINI.h"
 #elif MB(RADDS)
   #include "pins_RADDS.h"
-#elif MB(RAMPS_FD_V1)
+#elif MB(RAMPS_FD)
   #include "pins_RAMPS_FD.h"
 #elif MB(RAMPS_FD_V2)
   #include "pins_RAMPS_FD_V2.h"
@@ -298,9 +298,6 @@
   #include "pins_RAMPS4DUE.h"
 #elif MB(ALLIGATOR)
   #include "pins_ALLIGATOR_R2.h"
-#elif MB(RAMPS_FD_V1) || MB(RAMPS_FD_V2)
-  #include "pins_RAMPS_FD_v1.h"
-
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif


### PR DESCRIPTION
update for include RAMPS-FD v1 and v2 pins. I removed "v1" form definition to be consistent with file names pins_RAMPS_FD.h and pins_RAMPS_FD_V2.h . Other way is to rename file names.