### PR TITLE
[bf20ng] Resolve vsnprintf undefined on Due compile issue

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.h
@@ -74,6 +74,10 @@
   #define strncpy_P(dest, src, num) strncpy((dest), (src), (num))
 #endif
 
+#ifndef vsnprintf_P
+  #define vsnprintf_P vsnprintf
+#endif
+
 // Fix bug in pgm_read_ptr
 #undef pgm_read_ptr
 #define pgm_read_ptr(addr) (*(addr))


### PR DESCRIPTION
Resolves #7687 compile errors due to vsprintf not defined for Due HAL but does not resolve LCD not working.

These compile warnings are probably very relevant but I'm unsure how to resolve:


```
n file included from /Users/speedster/Library/Arduino15/packages/arduino/hardware/sam/1.6.11/cores/arduino/Arduino.h:31:0,
                 from /var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/../../inc/../HAL/HAL_DUE/HAL_Due.h:38,
                 from /var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/../../inc/../HAL/HAL.h:84,
                 from /var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/../../inc/MarlinConfig.h:32,
                 from /var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/../gcode.h:243,
                 from /var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/M111.cpp:23:
/var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/M111.cpp: In static member function 'static void GcodeSuite::M111()':
/Users/speedster/Library/Arduino15/packages/arduino/hardware/sam/1.6.11/cores/arduino/avr/pgmspace.h:103:61: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
                                                             ^
/var/folders/q1/g9l9mqmn319fh27k43yqpy440000gr/T/arduino_build_170758/sketch/src/gcode/control/M111.cpp:55:31: note: in expansion of macro 'pgm_read_word'
         serialprintPGM((char*)pgm_read_word(&debug_strings[i]));
                               ^
```
and...
```
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c: In function 'u8g_com_arduino_fast_parallel_init':
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:104:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[0] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D0]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:106:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[1] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D1]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:108:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[2] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D2]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:110:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[3] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D3]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:113:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[4] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D4]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:115:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[5] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D5]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:117:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[6] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D6]));
                    ^
/Users/speedster/Documents/Arduino/libraries/U8glib/src/clib/u8g_com_arduino_fast_parallel.c:119:20: warning: assignment from incompatible pointer type [enabled by default]
   u8g_data_port[7] =  portOutputRegister(digitalPinToPort(u8g->pin_list[U8G_PI_D7]));
                    ^
```

and more...