### PR TITLE
Support for RGB NEOPIXEL LED Strip

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1576,7 +1576,12 @@
 #if ENABLED(NEOPIXEL_RGBW_LED)
   #define NEOPIXEL_PIN    4       // D4 (EXP2-5 on Printrboard)
   #define NEOPIXEL_PIXELS 3
-  //#define NEOPIXEL_STARTUP_TEST // Cycle through colors at startup
+
+  #define NEOPIXEL_NOWHITE        // RGB olny - no White channel in LED strip e.g WS2812B
+  #define NEOPIXEL_BRIGHTNESS 255 // initial brightness
+  #define NEOPIXEL_ISSEQ          // sequence display for temperature change - LED by LED
+
+//#define NEOPIXEL_STARTUP_TEST // Cycle through colors at startup
 #endif
 
 /**

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -7559,7 +7559,7 @@ inline void gcode_M109() {
         const uint8_t blue = map(constrain(temp, start_temp, target_temp), start_temp, target_temp, 255, 0);
         if (blue != old_blue) {
           old_blue = blue;
-            set_led_color(red, 0, 255
+            set_led_color(255, 0, blue
             #if ENABLED(NEOPIXEL_RGBW_LED)
               , 0, pixels.getBrightness()
               #if ENABLED(NEOPIXEL_ISSEQ)
@@ -7609,6 +7609,7 @@ inline void gcode_M109() {
           set_led_color(0, 0, 0, 255);  // Turn on the WHITE LED
         #else
           set_led_color(255, 255, 255); // Set LEDs All On
+        #endif
       #else
         set_led_color(255, 255, 255); // Set LEDs All On
       #endif
@@ -13638,4 +13639,3 @@ void loop() {
   endstops.report_state();
   idle();
 }
-

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -142,7 +142,7 @@
  * M140 - Set bed target temp. S<temp>
  * M145 - Set heatup values for materials on the LCD. H<hotend> B<bed> F<fan speed> for S<material> (0=PLA, 1=ABS)
  * M149 - Set temperature units. (Requires TEMPERATURE_UNITS_SUPPORT)
- * M150 - Set Status LED Color as R<red> U<green> B<blue>. Values 0-255. (Requires BLINKM, RGB_LED, RGBW_LED, or PCA9632)
+ * M150 - Set Status LED Color as R<red> U<green> B<blue> and <P>brightness. Values 0-255. (Requires BLINKM, RGB_LED, RGBW_LED, or PCA9632). Brightness is set for NEOPIXEL ONLY
  * M155 - Auto-report temperatures with interval of S<seconds>. (Requires AUTO_REPORT_TEMPERATURES)
  * M163 - Set a single proportion for a mixing extruder. (Requires MIXING_EXTRUDER)
  * M164 - Save the mix as a virtual extruder. (Requires MIXING_EXTRUDER and MIXING_VIRTUAL_TOOLS)
@@ -8360,9 +8360,11 @@ inline void gcode_M121() { endstops.enable_globally(false); }
 
   /**
    * M150: Set Status LED Color - Use R-U-B-W for R-G-B-W
+   *       and Brightness       - Use P (for NEOPIXEL only)
    *
    * Always sets all 3 or 4 components. If a component is left out, set to 0.
-   *
+   *                                    If brightness is left out, no value changed
+   *       
    * Examples:
    *
    *   M150 R255       ; Turn LED red
@@ -8370,7 +8372,8 @@ inline void gcode_M121() { endstops.enable_globally(false); }
    *   M150            ; Turn LED off
    *   M150 R U B      ; Turn LED white
    *   M150 W          ; Turn LED white using a white LED
-   *
+   *   M150 P127       ; Set LED 50% brightness 
+   *   M150 P          ; Set LED full brightness 
    */
   inline void gcode_M150() {
     set_led_color(
@@ -8379,6 +8382,9 @@ inline void gcode_M121() { endstops.enable_globally(false); }
       parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0
       #if ENABLED(RGBW_LED) || ENABLED(NEOPIXEL_RGBW_LED)
         , parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0
+        #if ENABLED(NEOPIXEL_RGBW_LED)
+          , parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : pixels.getBrightness()
+        #endif
       #endif
     );
   }


### PR DESCRIPTION
I have the simple RGB NEOPIXEL LED strip based on latest WS2812B driver. With minor changes to the code this LED strip is fully supported. Adafruit NeoPixel library has all support included.

I have the 60 LEDs/m strip and full brightness is too intensive in my quite dark workshop. So I added the two things 
- #define NEOPIXEL_BRIGHTNESS 255 - default start-up brightness for the strip
- P parameter to M150 "M" code to set brightness (similar to M355)

And the last thing. I have 600W bed heater - from zero to 100C runs in 30-40 seconds. So if I have sequential LED changes on my 40 LED strip, there is no chance to observe the nice blue to violet transition ;-). Next setup parameter was added to configuration.h #define NEOPIXEL_ISSEQ.