### PR TITLE
[bf20ng] Improve AVR arch detection

### DIFF
--- a/Marlin/src/HAL/HAL.h
+++ b/Marlin/src/HAL/HAL.h
@@ -23,7 +23,7 @@
  *
  * Supports platforms :
  *    ARDUINO_ARCH_SAM : For Arduino Due and other boards based on Atmel SAM3X8E
- *    ARDUINO_ARCH_AVR : For all Atmel AVR boards
+ *    __AVR__ : For all Atmel AVR boards
  */
 
 #ifndef _HAL_H
@@ -77,7 +77,7 @@ void spiRead(uint8_t* buf, uint16_t nbyte);
 /** Write token and then write from 512 byte buffer to SPI (for SD card) */
 void spiSendBlock(uint8_t token, const uint8_t* buf);
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #include "HAL_AVR/HAL_AVR.h"
 #elif defined(ARDUINO_ARCH_SAM)
   #define CPU_32_BIT

--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.cpp
@@ -23,11 +23,11 @@
 /**
  * Description: HAL for AVR
  *
- * For ARDUINO_ARCH_AVR
+ * For __AVR__
  */
 
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -22,7 +22,7 @@
 /**
  * Description: HAL for AVR
  *
- * For ARDUINO_ARCH_AVR
+ * For __AVR__
  */
 
 

--- a/Marlin/src/HAL/HAL_AVR/HAL_spi_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/HAL_spi_AVR.cpp
@@ -28,10 +28,10 @@
 /**
  * Description: HAL for AVR - SPI functions
  *
- * For ARDUINO_ARCH_AVR
+ * For __AVR__
  */
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 // --------------------------------------------------------------------------
 // Includes
@@ -210,4 +210,4 @@ void spiBegin (void) {
 #endif  // SOFTWARE_SPI
 
 
-#endif // ARDUINO_ARCH_AVR
+#endif // __AVR__

--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
@@ -28,7 +28,7 @@
  * Modified 28 September 2010 by Mark Sproul
  * Modified 14 February 2016 by Andreas Hardtung (added tx buffer)
  */
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 #include "MarlinSerial.h"
 #include "../../Marlin.h"

--- a/Marlin/src/HAL/HAL_AVR/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_AVR/persistent_store_impl.cpp
@@ -1,4 +1,4 @@
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 #include "../persistent_store_api.h"
 
@@ -52,4 +52,4 @@ void read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
 }
 
 #endif // EEPROM_SETTINGS
-#endif // ARDUINO_ARCH_AVR
+#endif // __AVR__

--- a/Marlin/src/HAL/HAL_AVR/servo_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/servo_AVR.cpp
@@ -51,7 +51,7 @@
  *
  */
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 #include "../../inc/MarlinConfig.h"
 
@@ -215,4 +215,4 @@ void finISR(timer16_Sequence_t timer) {
 
 #endif // HAS_SERVOS
 
-#endif // ARDUINO_ARCH_AVR
+#endif // __AVR__

--- a/Marlin/src/HAL/HAL_AVR/watchdog_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/watchdog_AVR.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
 #include "../../inc/MarlinConfig.h"
 
@@ -58,4 +58,4 @@ void watchdog_init() {
 #endif // WATCHDOG_RESET_MANUAL
 
 #endif // USE_WATCHDOG
-#endif // ARDUINO_ARCH_AVR
+#endif // __AVR__

--- a/Marlin/src/HAL/HAL_DUE/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_DUE/persistent_store_impl.cpp
@@ -52,4 +52,4 @@ void read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
 }
 
 #endif // EEPROM_SETTINGS
-#endif // ARDUINO_ARCH_AVR
+#endif // __AVR__

--- a/Marlin/src/HAL/HAL_SanityCheck.h
+++ b/Marlin/src/HAL/HAL_SanityCheck.h
@@ -22,7 +22,7 @@
 
 #ifndef HAL_SANITYCHECK_H
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #include "HAL_AVR/SanityCheck_AVR_8_bit.h"
 #elif defined(ARDUINO_ARCH_SAM)
   #include "HAL_DUE/SanityCheck_Due.h"

--- a/Marlin/src/HAL/HAL_endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_endstop_interrupts.h
@@ -34,7 +34,7 @@ FORCE_INLINE void endstop_ISR_worker( void ) {
 // One ISR for all EXT-Interrupts
 void endstop_ISR(void) { endstop_ISR_worker(); }
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
 
   #include "HAL_AVR/endstop_interrupts.h"
 

--- a/Marlin/src/HAL/HAL_pinsDebug.h
+++ b/Marlin/src/HAL/HAL_pinsDebug.h
@@ -23,7 +23,7 @@
 #ifndef HAL_PINSDEBUG_H
 #define HAL_PINSDEBUG_H
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #include "HAL_AVR/pinsDebug_AVR_8_bit.h"
 #elif defined(ARDUINO_ARCH_SAM)
   #include "HAL_DUE/HAL_pinsDebug_Due.h"

--- a/Marlin/src/HAL/HAL_spi_pins.h
+++ b/Marlin/src/HAL/HAL_spi_pins.h
@@ -29,7 +29,7 @@
 #elif defined(IS_32BIT_TEENSY)
   #include "HAL_TEENSY35_36/spi_pins.h"
 
-#elif defined(ARDUINO_ARCH_AVR)
+#elif defined(__AVR__)
   #include "HAL_AVR/spi_pins.h"
 
 #elif defined(TARGET_LPC1768)

--- a/Marlin/src/HAL/servo.h
+++ b/Marlin/src/HAL/servo.h
@@ -78,7 +78,7 @@
 #else
   #include <stdint.h>
 
-  #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_SAM)
+  #if defined(__AVR__) || defined(ARDUINO_ARCH_SAM)
     // we're good to go
   #else
     #error "This library only supports boards with an AVR or SAM3X processor."

--- a/Marlin/src/HAL/servo_private.h
+++ b/Marlin/src/HAL/servo_private.h
@@ -45,7 +45,7 @@
 #include <stdint.h>
 
 // Architecture specific include
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #include "HAL_AVR/ServoTimers.h"
 #elif defined(ARDUINO_ARCH_SAM)
   #include "HAL_DUE/ServoTimers.h"

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -27,7 +27,7 @@
 
 //todo: HAL: breaks encapsulation
 // For AVR only, define a serial interface based on configuration
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #ifdef USBCON
     #include "HardwareSerial.h"
     #if ENABLED(BLUETOOTH)

--- a/Marlin/src/inc/MarlinConfig.h
+++ b/Marlin/src/inc/MarlinConfig.h
@@ -31,7 +31,7 @@
 #include "../../Configuration_adv.h"
 #include "../HAL/HAL.h"
 #include "../pins/pins.h"
-#if defined(ARDUINO_ARCH_AVR) && !defined(USBCON)
+#if defined(__AVR__) && !defined(USBCON)
   #define HardwareSerial_h // trick to disable the standard HWserial
 #endif
 #include "Conditionals_post.h"

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -88,7 +88,7 @@ void recalc_delta_settings(float radius, float diagonal_rod) {
  *   (see above)
  */
 
-#if ENABLED(DELTA_FAST_SQRT) && defined(ARDUINO_ARCH_AVR)
+#if ENABLED(DELTA_FAST_SQRT) && defined(__AVR__)
   /**
    * Fast inverse sqrt from Quake III Arena
    * See: https://en.wikipedia.org/wiki/Fast_inverse_square_root

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -63,7 +63,7 @@ void recalc_delta_settings(float radius, float diagonal_rod);
  *   (see above)
  */
 
-#if ENABLED(DELTA_FAST_SQRT) && defined(ARDUINO_ARCH_AVR)
+#if ENABLED(DELTA_FAST_SQRT) && defined(__AVR__)
   /**
    * Fast inverse sqrt from Quake III Arena
    * See: https://en.wikipedia.org/wiki/Fast_inverse_square_root

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -46,7 +46,7 @@
 
 #include "stepper.h"
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #include "speed_lookuptable.h"
 #endif
 
@@ -1139,7 +1139,7 @@ void Stepper::init() {
     E_AXIS_INIT(4);
   #endif
 
-  #ifdef ARDUINO_ARCH_AVR
+  #ifdef __AVR__
     // waveform generation = 0100 = CTC
     SET_WGM(1, CTC_OCRnA);
 

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -45,7 +45,7 @@
 
 #include "stepper_indirection.h"
 
-#ifdef ARDUINO_ARCH_AVR
+#ifdef __AVR__
   #include "speed_lookuptable.h"
 #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1081,7 +1081,7 @@ void Temperature::init() {
   #endif
 
   // todo: HAL: fix abstraction
-  #ifdef ARDUINO_ARCH_AVR
+  #ifdef __AVR__
     // Use timer0 for temperature measurement
     // Interleave temperature interrupt with millies interrupt
     OCR0B = 128;


### PR DESCRIPTION
Replace `ARDUINO_ARCH_AVR` with `__AVR__` to better detect architecture for non-Arduino development environments.  Resolves compile failure in PIO for 8-bit Teensduino targets

More info:
https://forum.pjrc.com/threads/33234-Using-Teensyduino-Selecting-Teensy-3-2-3-1-board-has-incorrect-platform-define
http://www.atmel.com/webdoc/avrlibcreferencemanual/using_tools_1using_avr_gcc_mach_opt.html