### PR TITLE
Marlin 2.0.x - M355 fixes & LCD improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,9 @@ src/.vs/
 #Visual Studio Code
 .vscode
 
+#Visual Studio Code
+.vscode
+
 #cmake
 CMakeLists.txt
 src/CMakeLists.txt

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1233,8 +1233,9 @@
  * SD CARD: SPI SPEED
  *
  * Enable one of the following items for a slower SPI transfer speed.
- * This may be required to resolve "volume init" errors.
+ * This may be required to resolve "volume init" errors or LCD issues.
  */
+ 
 //#define SPI_SPEED SPI_HALF_SPEED
 //#define SPI_SPEED SPI_QUARTER_SPEED
 //#define SPI_SPEED SPI_EIGHTH_SPEED

--- a/Marlin/src/HAL/HAL.h
+++ b/Marlin/src/HAL/HAL.h
@@ -29,53 +29,7 @@
 #ifndef _HAL_H
 #define _HAL_H
 
-#include <stdint.h>
-
-/**
- * SPI speed where 0 <= index <= 6
- *
- * Approximate rates :
- *
- *  0 :  8 - 10 MHz
- *  1 :  4 - 5 MHz
- *  2 :  2 - 2.5 MHz
- *  3 :  1 - 1.25 MHz
- *  4 :  500 - 625 kHz
- *  5 :  250 - 312 kHz
- *  6 :  125 - 156 kHz
- *
- *  On AVR, actual speed is F_CPU/2^(1 + index).
- *  On other platforms, speed should be in range given above where possible.
- */
-
-/** Set SCK to max rate */
-uint8_t const SPI_FULL_SPEED = 0;
-/** Set SCK rate to half max rate. */
-uint8_t const SPI_HALF_SPEED = 1;
-/** Set SCK rate to quarter max rate. */
-uint8_t const SPI_QUARTER_SPEED = 2;
-/** Set SCK rate to 1/8 max rate. */
-uint8_t const SPI_EIGHTH_SPEED = 3;
-/** Set SCK rate to 1/16 of max rate. */
-uint8_t const SPI_SIXTEENTH_SPEED = 4;
-/** Set SCK rate to 1/32 of max rate. */
-uint8_t const SPI_SPEED_5 = 5;
-/** Set SCK rate to 1/64 of max rate. */
-uint8_t const SPI_SPEED_6 = 6;
-
-// Standard SPI functions
-/** Initialise SPI bus */
-void spiBegin(void);
-/** Configure SPI for specified SPI speed */
-void spiInit(uint8_t spiRate);
-/** Write single byte to SPI */
-void spiSend(uint8_t b);
-/** Read single byte from SPI */
-uint8_t spiRec(void);
-/** Read from SPI into buffer */
-void spiRead(uint8_t* buf, uint16_t nbyte);
-/** Write token and then write from 512 byte buffer to SPI (for SD card) */
-void spiSendBlock(uint8_t token, const uint8_t* buf);
+#include "src/inc/SPI.h"
 
 #ifdef __AVR__
   #include "HAL_AVR/HAL_AVR.h"

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_spi.cpp
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -30,13 +30,32 @@
  * For TARGET_LPC1768
  */
 
+/**
+ * Hardware SPI and a software SPI implementations are included in this file.
+ * The hardware SPI runs faster and has higher throughput but is not compatible
+ * with some LCD interfaces/adapters.
+ *
+ * Control of the slave select pin(s) is handled by the calling routines.
+ *
+ * Some of the LCD interfaces/adapters result in the LCD SPI and the SD card
+ * SPI sharing pins. The SCK, MOSI & MISO pins can NOT be set/cleared with
+ * WRITE nor digitalWrite when the hardware SPI module within the LPC17xx is
+ * active.  If any of these pins are shared then the software SPI must be used.
+ *
+ * A more sophisticated hardware SPI can be found at the following link.  This
+ * implementation has not been fully debugged.
+ * https://github.com/MarlinFirmware/Marlin/tree/071c7a78f27078fd4aee9a3ef365fcf5e143531e
+ */
+
 #ifdef TARGET_LPC1768
 
 // --------------------------------------------------------------------------
 // Includes
 // --------------------------------------------------------------------------
 
-#include "../../inc/MarlinConfig.h"
+//#include "../../../MarlinConfig.h"  //works except in U8g
+#include "spi_pins.h"
+#include "fastio.h"
 
 // --------------------------------------------------------------------------
 // Public Variables
@@ -47,87 +66,122 @@
 // Public functions
 // --------------------------------------------------------------------------
 
-#if ENABLED(SOFTWARE_SPI)
+#if ENABLED(LPC_SOFTWARE_SPI)
   // --------------------------------------------------------------------------
   // software SPI
   // --------------------------------------------------------------------------
-  // bitbanging transfer
-  // run at ~100KHz (necessary for init)
-  static uint8_t spiTransfer(uint8_t b) { // using Mode 0
-    for (int bits = 0; bits < 8; bits++) {
-      if (b & 0x80) {
-        WRITE(MOSI_PIN, HIGH);
-      }
-      else {
-        WRITE(MOSI_PIN, LOW);
-      }
-      b <<= 1;
 
-      WRITE(SCK_PIN, HIGH);
-      delayMicroseconds(3U);
+  /**
+   * This software SPI runs at three rates. The SD software provides an index
+   * (spiRate) of 0-6. The mapping is:
+   *     0-1 - about 5 MHz peak
+   *     2-3 - about 2 MHz peak
+   *     all others - about 250 KHz
+   */
 
-      if (READ(MISO_PIN)) {
-        b |= 1;
+  static uint8_t SPI_speed = 0;
+
+  static uint8_t spiTransfer(uint8_t b) {
+
+    if (!SPI_speed) {       // fastest - about 5 MHz peak
+      for (int bits = 0; bits < 8; bits++) {
+        if (b & 0x80) {
+          WRITE(MOSI_PIN, HIGH);
+          WRITE(MOSI_PIN, HIGH);  // delay to (hopefully) guarantee setup time
+        }
+        else {
+          WRITE(MOSI_PIN, LOW);
+          WRITE(MOSI_PIN, LOW);  // delay to (hopefully) guarantee setup time
+        }
+        b <<= 1;
+        WRITE(SCK_PIN, HIGH);
+        if (READ(MISO_PIN)) {
+          b |= 1;
+        }
+        WRITE(SCK_PIN, LOW);
       }
-      WRITE(SCK_PIN, LOW);
-      delayMicroseconds(3U);
+    }
+    else if (SPI_speed == 1) { // medium - about 1 MHz
+      for (int bits = 0; bits < 8; bits++) {
+        if (b & 0x80) {
+          for (uint8_t i = 0; i < 8; i++) WRITE(MOSI_PIN, HIGH);
+        }
+        else {
+          for (uint8_t i = 0; i < 8; i++) WRITE(MOSI_PIN, LOW);
+        }
+        b <<= 1;
+
+        for (uint8_t i = 0; i < 6; i++) WRITE(SCK_PIN, HIGH);
+
+        if (READ(MISO_PIN)) {
+          b |= 1;
+        }
+        WRITE(SCK_PIN, LOW);
+      }
+    }
+    else { // slow - about 250 KHz
+      for (int bits = 0; bits < 8; bits++) {
+        if (b & 0x80) {
+          WRITE(MOSI_PIN, HIGH);
+        }
+        else {
+          WRITE(MOSI_PIN, LOW);
+        }
+        b <<= 1;
+        delayMicroseconds(1U);
+        WRITE(SCK_PIN, HIGH);
+        delayMicroseconds(2U);
+
+        if (READ(MISO_PIN)) {
+          b |= 1;
+        }
+        WRITE(SCK_PIN, LOW);
+        delayMicroseconds(1U);
+      }
     }
     return b;
   }
 
   void spiBegin() {
-    SET_OUTPUT(SS_PIN);
-    WRITE(SS_PIN, HIGH);
     SET_OUTPUT(SCK_PIN);
     SET_INPUT(MISO_PIN);
     SET_OUTPUT(MOSI_PIN);
   }
 
   void spiInit(uint8_t spiRate) {
-    UNUSED(spiRate);
-    WRITE(SS_PIN, HIGH);
+    SPI_speed = spiRate >> 1;
     WRITE(MOSI_PIN, HIGH);
     WRITE(SCK_PIN, LOW);
   }
 
   uint8_t spiRec() {
-    WRITE(SS_PIN, LOW);
     uint8_t b = spiTransfer(0xff);
-    WRITE(SS_PIN, HIGH);
     return b;
   }
 
   void spiRead(uint8_t*buf, uint16_t nbyte) {
     if (nbyte == 0) return;
-    WRITE(SS_PIN, LOW);
     for (int i = 0; i < nbyte; i++) {
       buf[i] = spiTransfer(0xff);
     }
-    WRITE(SS_PIN, HIGH);
   }
 
   void spiSend(uint8_t b) {
-    WRITE(SS_PIN, LOW);
     uint8_t response = spiTransfer(b);
     UNUSED(response);
-    WRITE(SS_PIN, HIGH);
   }
 
   static void spiSend(const uint8_t* buf, size_t n) {
     uint8_t response;
     if (n == 0) return;
-    WRITE(SS_PIN, LOW);
     for (uint16_t i = 0; i < n; i++) {
       response = spiTransfer(buf[i]);
     }
     UNUSED(response);
-    WRITE(SS_PIN, HIGH);
   }
 
   void spiSendBlock(uint8_t token, const uint8_t* buf) {
     uint8_t response;
-
-    WRITE(SS_PIN, LOW);
     response = spiTransfer(token);
 
     for (uint16_t i = 0; i < 512; i++) {
@@ -136,29 +190,97 @@
     UNUSED(response);
     WRITE(SS_PIN, HIGH);
   }
+
 #else
-  void spiBegin() {
+
+  // hardware SPI
+
+  #include <lpc17xx_pinsel.h>
+  #include <lpc17xx_ssp.h>
+  #include <lpc17xx_clkpwr.h>
+
+  void spiBegin() {  // setup SCK, MOSI & MISO pins for SSP0
+
+    PINSEL_CFG_Type PinCfg;  // data structure to hold init values
+    PinCfg.Funcnum = 2;
+    PinCfg.OpenDrain = 0;
+    PinCfg.Pinmode = 0;
+    PinCfg.Pinnum = pin_map[SCK_PIN].pin;
+    PinCfg.Portnum = pin_map[SCK_PIN].port;
+    PINSEL_ConfigPin(&PinCfg);
+    SET_OUTPUT(SCK_PIN);
+
+    PinCfg.Pinnum = pin_map[MISO_PIN].pin;
+    PinCfg.Portnum = pin_map[MISO_PIN].port;
+    PINSEL_ConfigPin(&PinCfg);
+    SET_INPUT(MISO_PIN);
+
+    PinCfg.Pinnum = pin_map[MOSI_PIN].pin;
+    PinCfg.Portnum = pin_map[MOSI_PIN].port;
+    PINSEL_ConfigPin(&PinCfg);
+    SET_OUTPUT(MOSI_PIN);
   }
+
 
   void spiInit(uint8_t spiRate) {
+
+   // table to convert Marlin spiRates (0-5 plus default) into bit rates
+    uint32_t Marlin_speed[7]; // CPSR is always 2
+    Marlin_speed[0] = 8333333; //(SCR:  2)  desired: 8,000,000  actual: 8,333,333  +4.2%  SPI_FULL_SPEED
+    Marlin_speed[1] = 4166667; //(SCR:  5)  desired: 4,000,000  actual: 4,166,667  +4.2%  SPI_HALF_SPEED
+    Marlin_speed[2] = 2083333; //(SCR: 11)  desired: 2,000,000  actual: 2,083,333  +4.2%  SPI_QUARTER_SPEED
+    Marlin_speed[3] = 1000000; //(SCR: 24)  desired: 1,000,000  actual: 1,000,000         SPI_EIGHTH_SPEED
+    Marlin_speed[4] =  500000; //(SCR: 49)  desired:   500,000  actual:   500,000         SPI_SPEED_5
+    Marlin_speed[5] =  250000; //(SCR: 99)  desired:   250,000  actual:   250,000         SPI_SPEED_6
+    Marlin_speed[6] =  125000; //(SCR:199)  desired:   125,000  actual:   125,000         Default from HAL.h
+
+
+   // select 50MHz PCLK for SSP0
+    CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_SSP0, CLKPWR_PCLKSEL_CCLK_DIV_2);
+
+   // setup for SPI mode
+    SSP_CFG_Type HW_SPI_init; // data structure to hold init values
+    SSP_ConfigStructInit(&HW_SPI_init);  // set values for SPI mode
+    HW_SPI_init.ClockRate = Marlin_speed[MIN(spiRate, 6)]; // put in the specified bit rate
+    SSP_Init(LPC_SSP0, &HW_SPI_init);  // puts the values into the proper bits in the SSP0 registers
+
+    SSP_Cmd(LPC_SSP0, ENABLE);  // start SSP0 running
   }
 
-  void spiSend(byte b) {
+  void spiSend(uint8_t b) {
+    while (!SSP_GetStatus(LPC_SSP0, SSP_STAT_TXFIFO_NOTFULL));   // wait for room in the buffer
+    SSP_SendData(LPC_SSP0, b & 0x00FF);
+    while (SSP_GetStatus(LPC_SSP0, SSP_STAT_BUSY));  // wait for it to finish
   }
+
 
   void spiSend(const uint8_t* buf, size_t n) {
+    if (n == 0) return;
+    for (uint16_t i = 0; i < n; i++) {
+      while (!SSP_GetStatus(LPC_SSP0, SSP_STAT_TXFIFO_NOTFULL));   // wait for room in the buffer
+      SSP_SendData(LPC_SSP0, buf[i] & 0x00FF);
+    }
+    while (SSP_GetStatus(LPC_SSP0, SSP_STAT_BUSY));  // wait for it to finish
   }
 
   void spiSend(uint32_t chan, byte b) {
   }
 
   void spiSend(uint32_t chan, const uint8_t* buf, size_t n) {
+  }
 
+
+  uint8_t get_one_byte() {
+   // send a dummy byte so can clock in receive data
+    SSP_SendData(LPC_SSP0,0x00FF);
+    while (SSP_GetStatus(LPC_SSP0, SSP_STAT_BUSY));  // wait for it to finish
+    return SSP_ReceiveData(LPC_SSP0) & 0x00FF;
   }
 
   // Read single byte from SPI
   uint8_t spiRec() {
-    return 0;
+    while (SSP_GetStatus(LPC_SSP0, SSP_STAT_RXFIFO_NOTEMPTY) || SSP_GetStatus(LPC_SSP0, SSP_STAT_BUSY)) SSP_ReceiveData(LPC_SSP0);  //flush the receive buffer
+    return get_one_byte();
   }
 
   uint8_t spiRec(uint32_t chan) {
@@ -167,11 +289,17 @@
 
   // Read from SPI into buffer
   void spiRead(uint8_t*buf, uint16_t nbyte) {
+    while (SSP_GetStatus(LPC_SSP0, SSP_STAT_RXFIFO_NOTEMPTY) || SSP_GetStatus(LPC_SSP0, SSP_STAT_BUSY)) SSP_ReceiveData(LPC_SSP0);  //flush the receive buffer
+    if (nbyte == 0) return;
+    for (int i = 0; i < nbyte; i++) {
+      buf[i] = get_one_byte();
+    }
   }
 
   // Write from buffer to SPI
   void spiSendBlock(uint8_t token, const uint8_t* buf) {
   }
-#endif // ENABLED(SOFTWARE_SPI)
+#endif // ENABLED(LPC_SOFTWARE_SPI)
 
 #endif // TARGET_LPC1768
+

--- a/Marlin/src/HAL/HAL_LPC1768/LPC1768_PWM.h
+++ b/Marlin/src/HAL/HAL_LPC1768/LPC1768_PWM.h
@@ -399,6 +399,16 @@ bool LPC1768_PWM_detach_pin(uint8_t pin) {
   return 1;
 }
 
+
+bool useable_hardware_PWM(uint8_t pin) {
+  COPY_ACTIVE_TABLE;  // copy active table into work table
+  for (uint8_t i = 0; i < NUM_PWMS; i++)         // see if it's already setup
+    if (work_table[i].logical_pin == pin && work_table[i].sequence) return true;
+  for (uint8_t i = 0; i < NUM_PWMS; i++)         // see if there is an empty slot
+    if (!work_table[i].sequence) return true;
+  return false;    // only get here if neither the above are true
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 #define HAL_PWM_LPC1768_ISR  extern "C" void PWM1_IRQHandler(void)

--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -38,6 +38,9 @@
 #include "arduino.h"
 #include "pinmapping.h"
 
+bool useable_hardware_PWM(uint8_t pin);
+#define USEABLE_HARDWARE_PWM(pin) useable_hardware_PWM(pin)
+
 #define LPC_PORT_OFFSET         (0x0020)
 #define LPC_PIN(pin)            (1UL << pin)
 #define LPC_GPIO(port)          ((volatile LPC_GPIO_TypeDef *)(LPC_GPIO0_BASE + LPC_PORT_OFFSET * port))

--- a/Marlin/src/HAL/HAL_LPC1768/spi_pins.h
+++ b/Marlin/src/HAL/HAL_LPC1768/spi_pins.h
@@ -23,7 +23,8 @@
 #ifndef SPI_PINS_LPC1768_H
 #define SPI_PINS_LPC1768_H
 
-#define SOFTWARE_SPI
+#define LPC_SOFTWARE_SPI
+
 /** onboard SD card */
 //#define SCK_PIN           P0_7
 //#define MISO_PIN          P0_8
@@ -34,4 +35,10 @@
 #define MISO_PIN          50 //P0_17
 #define MOSI_PIN          51 //P0_18
 #define SS_PIN            53 //P1_23
+#define SDSS              SS_PIN
+
+#if (defined(IS_REARM) && !(defined(LPC_SOFTWARE_SPI)))   // signal LCDs that they need to use the hardware SPI
+  #define SHARED_SPI
+#endif
+
 #endif /* SPI_PINS_LPC1768_H */

--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -27,19 +27,38 @@
 uint8_t case_light_brightness = CASE_LIGHT_DEFAULT_BRIGHTNESS;
 bool case_light_on = CASE_LIGHT_DEFAULT_ON;
 
+/**
+ * The following are needed because ARM chips ignore a "WRITE(CASE_LIGHT_PIN,x)" command to the pins that
+ * are directly controlled by the PWM module. In order to turn them off the brightness level needs to be
+ * set to off.  Since we can't use the pwm register to save the last brightness level we need a variable
+ * to save it.
+ */
+uint8_t case_light_brightness_sav;   // saves brighness info so can restore when "M355 S1" received
+bool case_light_arg_flag;  // flag to notify if S or P arguement type
+
 #ifndef INVERT_CASE_LIGHT
   #define INVERT_CASE_LIGHT false
 #endif
 
 void update_case_light() {
   SET_OUTPUT(CASE_LIGHT_PIN);
+
+  if (!(case_light_arg_flag && !case_light_on))
+    case_light_brightness_sav = case_light_brightness;  // save brightness except if this is an S0 arguement
+  if (case_light_arg_flag && case_light_on)
+    case_light_brightness = case_light_brightness_sav;  // restore last brightens if this is an S1 arguement
+
   if (case_light_on) {
     if (USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN)) {
       analogWrite(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? 255 - case_light_brightness : case_light_brightness );
     }
     else WRITE(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? LOW : HIGH);
   }
-  else WRITE(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? HIGH : LOW);
+  else {
+    if (USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN))
+      analogWrite(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? 255 : 0 );  // turn the light off
+    WRITE(CASE_LIGHT_PIN, INVERT_CASE_LIGHT ? HIGH : LOW);
+  }
 }
 
 #endif // HAS_CASE_LIGHT

--- a/Marlin/src/feature/caselight.h
+++ b/Marlin/src/feature/caselight.h
@@ -25,6 +25,8 @@
 
 extern uint8_t case_light_brightness;
 extern bool case_light_on;
+extern uint8_t case_light_brightness_sav;   // saves brighness info when case_light_on is false
+extern bool case_light_arg_flag;  // flag to notify if S or P arguement type
 
 void update_case_light();
 

--- a/Marlin/src/gcode/feature/caselight/M355.cpp
+++ b/Marlin/src/gcode/feature/caselight/M355.cpp
@@ -43,8 +43,14 @@
 void GcodeSuite::M355() {
   #if HAS_CASE_LIGHT
     uint8_t args = 0;
-    if (parser.seenval('P')) ++args, case_light_brightness = parser.value_byte();
-    if (parser.seenval('S')) ++args, case_light_on = parser.value_bool();
+    if (parser.seenval('P')) {
+      ++args, case_light_brightness = parser.value_byte();
+      case_light_arg_flag = false;
+    }  
+    if (parser.seenval('S')) {
+      ++args, case_light_on = parser.value_bool();
+      case_light_arg_flag = true;
+    }
     if (args) update_case_light();
 
     // always report case light status

--- a/Marlin/src/inc/MarlinConfig.h
+++ b/Marlin/src/inc/MarlinConfig.h
@@ -26,6 +26,7 @@
 #include "../core/boards.h"
 #include "../core/macros.h"
 #include "Version.h"
+#include "SPI.h"
 #include "../../Configuration.h"
 #include "Conditionals_LCD.h"
 #include "../../Configuration_adv.h"

--- a/Marlin/src/inc/SPI.h
+++ b/Marlin/src/inc/SPI.h
@@ -1,0 +1,52 @@
+#include <stdint.h>
+
+
+#if !defined(SPI_FULL_SPEED)
+
+/**
+ * SPI speed where 0 <= index <= 6
+ *
+ * Approximate rates :
+ *
+ *  0 :  8 - 10 MHz
+ *  1 :  4 - 5 MHz
+ *  2 :  2 - 2.5 MHz
+ *  3 :  1 - 1.25 MHz
+ *  4 :  500 - 625 kHz
+ *  5 :  250 - 312 kHz
+ *  6 :  125 - 156 kHz
+ *
+ *  On AVR, actual speed is F_CPU/2^(1 + index).
+ *  On other platforms, speed should be in range given above where possible.
+ */
+
+/** Set SCK to max rate */
+#define SPI_FULL_SPEED 0
+/** Set SCK rate to half max rate. */
+#define SPI_HALF_SPEED 1
+/** Set SCK rate to quarter max rate. */
+#define SPI_QUARTER_SPEED 2
+/** Set SCK rate to 1/8 max rate. */
+#define SPI_EIGHTH_SPEED 3
+/** Set SCK rate to 1/16 of max rate. */
+#define SPI_SIXTEENTH_SPEED 4
+/** Set SCK rate to 1/32 of max rate. */
+#define SPI_SPEED_5 5
+/** Set SCK rate to 1/64 of max rate. */
+#define SPI_SPEED_6 6
+
+// Standard SPI functions
+/** Initialise SPI bus */
+void spiBegin(void);
+/** Configure SPI for specified SPI speed */
+void spiInit(uint8_t spiRate);
+/** Write single byte to SPI */
+void spiSend(uint8_t b);
+/** Read single byte from SPI */
+uint8_t spiRec(void);
+/** Read from SPI into buffer */
+void spiRead(uint8_t* buf, uint16_t nbyte);
+/** Write token and then write from 512 byte buffer to SPI (for SD card) */
+void spiSendBlock(uint8_t token, const uint8_t* buf);
+
+#endif

--- a/Marlin/src/lcd/dogm/ultralcd_st7565_u8glib_VIKI.h
+++ b/Marlin/src/lcd/dogm/ultralcd_st7565_u8glib_VIKI.h
@@ -23,19 +23,20 @@
 #ifndef ULCDST7565_H
 #define ULCDST7565_H
 
-#include "../../inc/MarlinConfig.h"
+#include <src/Marlin.h>
 
-#if !( defined(DOGLCD_SCK) && DOGLCD_SCK >= 0 \
-    && defined(DOGLCD_MOSI) && DOGLCD_MOSI >= 0 \
-    && defined(DOGLCD_CS) && DOGLCD_CS >= 0 \
-    && defined(DOGLCD_A0) && DOGLCD_A0 >= 0 )
-  #error "DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, and DOGLCD_A0 are required for VIKI."
-#endif
+#if ENABLED(U8GLIB_ST7565_64128N)
+
 
 #define ST7565_CLK_PIN  DOGLCD_SCK
 #define ST7565_DAT_PIN  DOGLCD_MOSI
 #define ST7565_CS_PIN   DOGLCD_CS
 #define ST7565_A0_PIN   DOGLCD_A0
+
+
+
+
+
 
 #include <U8glib.h>
 
@@ -91,23 +92,34 @@
   #define ST7565_DELAY_3 CPU_ST7565_DELAY_3
 #endif
 
-#define ST7565_SND_BIT \
-  WRITE(ST7565_CLK_PIN, LOW);        ST7565_DELAY_1; \
-  WRITE(ST7565_DAT_PIN, val & 0x80); ST7565_DELAY_2; \
-  WRITE(ST7565_CLK_PIN, HIGH);       ST7565_DELAY_3; \
-  WRITE(ST7565_CLK_PIN, LOW);\
-  val <<= 1
 
-static void ST7565_SWSPI_SND_8BIT(uint8_t val) {
-  ST7565_SND_BIT; // 1
-  ST7565_SND_BIT; // 2
-  ST7565_SND_BIT; // 3
-  ST7565_SND_BIT; // 4
-  ST7565_SND_BIT; // 5
-  ST7565_SND_BIT; // 6
-  ST7565_SND_BIT; // 7
-  ST7565_SND_BIT; // 8
-}
+#if ENABLED(SHARED_SPI)  // Re-ARM requires that the LCD and the SD card share a single SPI
+
+  #define ST7565_WRITE_BYTE(a)                 { spiSend((uint8_t)a); U8G_DELAY; }
+  #define ST7560_WriteSequence(count, pointer) { uint8_t *ptr = pointer; for (uint8_t i = 0; i <  count; i++) {spiSend( *ptr++);} DELAY_10US; }
+
+#else
+  #define ST7565_SND_BIT \
+    WRITE(ST7565_CLK_PIN, LOW);        ST7565_DELAY_1; \
+    WRITE(ST7565_DAT_PIN, val & 0x80); ST7565_DELAY_2; \
+    WRITE(ST7565_CLK_PIN, HIGH);       ST7565_DELAY_3; \
+    WRITE(ST7565_CLK_PIN, LOW);\
+    val <<= 1
+
+  static void ST7565_SWSPI_SND_8BIT(uint8_t val) {
+    ST7565_SND_BIT; // 1
+    ST7565_SND_BIT; // 2
+    ST7565_SND_BIT; // 3
+    ST7565_SND_BIT; // 4
+    ST7565_SND_BIT; // 5
+    ST7565_SND_BIT; // 6
+    ST7565_SND_BIT; // 7
+    ST7565_SND_BIT; // 8
+  }
+
+  #define ST7565_WRITE_BYTE(a)                 { ST7565_SWSPI_SND_8BIT((uint8_t)a); U8G_DELAY; }
+  #define ST7560_WriteSequence(count, pointer) { uint8_t *ptr = pointer; for (uint8_t i = 0; i <  count; i++) {ST7565_SWSPI_SND_8BIT( *ptr++);} DELAY_10US; }
+#endif
 
 #if defined(DOGM_SPI_DELAY_US) && DOGM_SPI_DELAY_US > 0
   #define U8G_DELAY delayMicroseconds(DOGM_SPI_DELAY_US)
@@ -115,116 +127,128 @@ static void ST7565_SWSPI_SND_8BIT(uint8_t val) {
   #define U8G_DELAY u8g_10MicroDelay()
 #endif
 
-#define ST7565_CS()                          do{ WRITE(ST7565_CS_PIN, HIGH); U8G_DELAY; }while(0)
-#define ST7565_NCS()                         WRITE(ST7565_CS_PIN, LOW)
-#define ST7565_A0()                          do{ WRITE(ST7565_A0_PIN, HIGH); U8G_DELAY; }while(0)
-#define ST7565_NA0()                         WRITE(ST7565_A0_PIN, LOW)
-#define ST7565_WRITE_BYTE(a)                 do{ ST7565_SWSPI_SND_8BIT((uint8_t)a); U8G_DELAY; }while(0)
-#define ST7560_WriteSequence(count, pointer) do{ uint8_t *ptr = pointer; for (uint8_t i = 0; i < count; ++i) { ST7565_SWSPI_SND_8BIT(*ptr++); } DELAY_10US; }while(0)
+#define ST7565_CS()                          { WRITE(ST7565_CS_PIN,1); U8G_DELAY; }
+#define ST7565_NCS()                         { WRITE(ST7565_CS_PIN,0); }
+#define ST7565_A0()                          { WRITE(ST7565_A0_PIN,1); U8G_DELAY; }
+#define ST7565_NA0()                         { WRITE(ST7565_A0_PIN,0); }
 
 
 uint8_t u8g_dev_st7565_64128n_2x_VIKI_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
   switch (msg) {
-    case U8G_DEV_MSG_INIT: {
+    case U8G_DEV_MSG_INIT:
+    {
       OUT_WRITE(ST7565_CS_PIN, LOW);
-      OUT_WRITE(ST7565_DAT_PIN, LOW);
-      OUT_WRITE(ST7565_CLK_PIN, LOW);
+      #if ENABLED(SHARED_SPI)
+        u8g_Delay(250);
+        spiBegin();
+        #ifndef SPI_SPEED
+          #define SPI_SPEED SPI_FULL_SPEED  // use same SPI speed as SD card
+        #endif
+        spiInit(SPI_SPEED);
+      #else
+        OUT_WRITE(ST7565_DAT_PIN, LOW);
+        OUT_WRITE(ST7565_CLK_PIN, LOW);
+      #endif
       OUT_WRITE(ST7565_A0_PIN, LOW);
 
-      ST7565_CS();                      // disable chip
-      ST7565_NA0();                     // instruction mode
-      ST7565_NCS();                     // enable chip
+      ST7565_CS();                      /* disable chip */
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
 
-      ST7565_WRITE_BYTE(0xA2);          // 0xA2: LCD bias 1/9 (according to Displaytech 64128N datasheet)
-      ST7565_WRITE_BYTE(0xA0);          // Normal ADC Select (according to Displaytech 64128N datasheet)
 
-      ST7565_WRITE_BYTE(0xC8);          // common output mode: set scan direction normal operation/SHL Select; 0xC0 --> SHL = 0; normal; 0xC8 --> SHL = 1
-      ST7565_WRITE_BYTE(0x40);          // Display start line for Displaytech 64128N
+      ST7565_WRITE_BYTE(0x0A2);         /* 0x0a2: LCD bias 1/9 (according to Displaytech 64128N datasheet) */
+      ST7565_WRITE_BYTE(0x0A0);         /* Normal ADC Select (according to Displaytech 64128N datasheet) */
 
-      ST7565_WRITE_BYTE(0x28 | 0x04);   // power control: turn on voltage converter
-      //U8G_ESC_DLY(50);                  // delay 50 ms - hangs after a reset if used
+      ST7565_WRITE_BYTE(0x0c8);         /* common output mode: set scan direction normal operation/SHL Select; 0x0c0 --> SHL = 0; normal; 0x0c8 --> SHL = 1 */
+      ST7565_WRITE_BYTE(0x040);         /* Display start line for Displaytech 64128N */
 
-      ST7565_WRITE_BYTE(0x28 | 0x06);   // power control: turn on voltage regulator
-      //U8G_ESC_DLY(50);                  // delay 50 ms - hangs after a reset if used
+      ST7565_WRITE_BYTE(0x028 | 0x04);  /* power control: turn on voltage converter */
+//    U8G_ESC_DLY(50);                  /* delay 50 ms - hangs after a reset if used */
 
-      ST7565_WRITE_BYTE(0x28 | 0x07);   // power control: turn on voltage follower
-      //U8G_ESC_DLY(50);                  // delay 50 ms - hangs after a reset if used
+      ST7565_WRITE_BYTE(0x028 | 0x06);  /* power control: turn on voltage regulator */
+//    U8G_ESC_DLY(50);                  /* delay 50 ms - hangs after a reset if used */
 
-      ST7565_WRITE_BYTE(0x10);          // Set V0 voltage resistor ratio. Setting for controlling brightness of Displaytech 64128N
+      ST7565_WRITE_BYTE(0x028 | 0x07);  /* power control: turn on voltage follower */
+//   U8G_ESC_DLY(50);                   /* delay 50 ms - hangs after a reset if used */
 
-      ST7565_WRITE_BYTE(0xA6);          // display normal, bit val 0: LCD pixel off.
 
-      ST7565_WRITE_BYTE(0x81);          // set contrast
-      ST7565_WRITE_BYTE(0x1E);          // Contrast value. Setting for controlling brightness of Displaytech 64128N
+      ST7565_WRITE_BYTE(0x010);         /* Set V0 voltage resistor ratio. Setting for controlling brightness of Displaytech 64128N */
 
-      ST7565_WRITE_BYTE(0xAF);          // display on
+      ST7565_WRITE_BYTE(0x0a6);         /* display normal, bit val 0: LCD pixel off. */
 
-      U8G_ESC_DLY(100);                 // delay 100 ms
-      ST7565_WRITE_BYTE(0xA5);          // display all points; ST7565
-      U8G_ESC_DLY(100);                 // delay 100 ms
-      U8G_ESC_DLY(100);                 // delay 100 ms
-      ST7565_WRITE_BYTE(0xA4);          // normal display
-      ST7565_CS();                      // disable chip
-    }                                   // end of sequence
+      ST7565_WRITE_BYTE(0x081);         /* set contrast */
+      ST7565_WRITE_BYTE(0x01e);         /* Contrast value. Setting for controlling brightness of Displaytech 64128N */
+
+
+      ST7565_WRITE_BYTE(0x0af);         /* display on */
+
+      U8G_ESC_DLY(100);                 /* delay 100 ms */
+      ST7565_WRITE_BYTE(0x0a5);         /* display all points; ST7565 */
+      U8G_ESC_DLY(100);                 /* delay 100 ms */
+      U8G_ESC_DLY(100);                 /* delay 100 ms */
+      ST7565_WRITE_BYTE(0x0a4);         /* normal display */
+      ST7565_CS();                      /* disable chip */
+    }                                   /* end of sequence */
       break;
     case U8G_DEV_MSG_STOP:
       break;
-    case U8G_DEV_MSG_PAGE_NEXT: {
-      u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
-      ST7565_CS();                      // disable chip
-      ST7565_NA0();                     // instruction mode
-      ST7565_NCS();                     // enable chip
-      ST7565_WRITE_BYTE(0x10);          // set upper 4 bit of the col adr to 0x10
-      ST7565_WRITE_BYTE(0x00);          // set lower 4 bit of the col adr to 0x00. Changed for DisplayTech 64128N
-                                        // end of sequence
-      ST7565_WRITE_BYTE(0xB0 | (2 * pb->p.page)); // select current page (ST7565R)
-      ST7565_A0();                      // data mode
-      ST7560_WriteSequence((uint8_t)pb->width, (uint8_t*)pb->buf);
-      ST7565_CS();                      // disable chip
-      ST7565_NA0();                     // instruction mode
-      ST7565_NCS();                     // enable chip
-      ST7565_WRITE_BYTE(0x10);          // set upper 4 bit of the col adr to 0x10
-      ST7565_WRITE_BYTE(0x00);          // set lower 4 bit of the col adr to 0x00. Changed for DisplayTech 64128N
-                                        // end of sequence
-      ST7565_WRITE_BYTE(0xB0 | (2 * pb->p.page + 1)); // select current page (ST7565R)
-      ST7565_A0();                      // data mode
-      ST7560_WriteSequence((uint8_t)pb->width, (uint8_t*)(pb->buf)+pb->width);
-      ST7565_CS();                      // disable chip
+    case U8G_DEV_MSG_PAGE_NEXT:
+    { u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+      ST7565_CS();                      /* disable chip */
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x010);         /* set upper 4 bit of the col adr to 0x10 */
+      ST7565_WRITE_BYTE(0x000);         /* set lower 4 bit of the col adr to 0x00. Changed for DisplayTech 64128N */
+                                        /* end of sequence */
+      ST7565_WRITE_BYTE(0x0b0 | (2*pb->p.page));; /* select current page (ST7565R) */
+      ST7565_A0();                      /* data mode */
+      ST7560_WriteSequence( (uint8_t) pb->width, (uint8_t *)pb->buf);
+      ST7565_CS();                      /* disable chip */
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x010);         /* set upper 4 bit of the col adr to 0x10 */
+      ST7565_WRITE_BYTE(0x000);         /* set lower 4 bit of the col adr to 0x00. Changed for DisplayTech 64128N */
+                                        /* end of sequence */
+      ST7565_WRITE_BYTE(0x0b0 | (2*pb->p.page+1)); /* select current page (ST7565R) */
+      ST7565_A0();                      /* data mode */
+      ST7560_WriteSequence( (uint8_t) pb->width, (uint8_t *)(pb->buf)+pb->width);
+      ST7565_CS();                      /* disable chip */
     }
       break;
     case U8G_DEV_MSG_CONTRAST:
       ST7565_NCS();
-      ST7565_NA0();                     // instruction mode
-      ST7565_WRITE_BYTE(0x81);
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_WRITE_BYTE(0x081);
       ST7565_WRITE_BYTE((*(uint8_t *)arg) >> 2);
-      ST7565_CS();                      // disable chip
+      ST7565_CS();                      /* disable chip */
       return 1;
     case U8G_DEV_MSG_SLEEP_ON:
-      ST7565_NA0();                     // instruction mode
-      ST7565_NCS();                     // enable chip
-      ST7565_WRITE_BYTE(0xAC);          // static indicator off
-      ST7565_WRITE_BYTE(0x00);          // indicator register set (not sure if this is required)
-      ST7565_WRITE_BYTE(0xAE);          // display off
-      ST7565_WRITE_BYTE(0xA5);          // all points on
-      ST7565_CS();                      // disable chip , bugfix 12 nov 2014
-                                        // end of sequence
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x0ac);         /* static indicator off */
+      ST7565_WRITE_BYTE(0x000);         /* indicator register set (not sure if this is required) */
+      ST7565_WRITE_BYTE(0x0ae);         /* display off */
+      ST7565_WRITE_BYTE(0x0a5);         /* all points on */
+      ST7565_CS();                      /* disable chip , bugfix 12 nov 2014 */
+                                        /* end of sequence */
       return 1;
     case U8G_DEV_MSG_SLEEP_OFF:
-      ST7565_NA0();                     // instruction mode
-      ST7565_NCS();                     // enable chip
-      ST7565_WRITE_BYTE(0xA4);          // all points off
-      ST7565_WRITE_BYTE(0xAF);          // display on
-      U8G_ESC_DLY(50);                  // delay 50 ms
-      ST7565_CS();                      // disable chip ,  bugfix 12 nov 2014
-                                        // end of sequence
+      ST7565_NA0();                     /* instruction mode */
+      ST7565_NCS();                     /* enable chip */
+      ST7565_WRITE_BYTE(0x0a4);         /* all points off */
+      ST7565_WRITE_BYTE(0x0af);         /* display on */
+      U8G_ESC_DLY(50);                  /* delay 50 ms */
+      ST7565_CS();                      /* disable chip ,  bugfix 12 nov 2014 */
+                                        /* end of sequence */
       return 1;
   }
   return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
 }
 
-uint8_t u8g_dev_st7565_64128n_2x_VIKI_buf[WIDTH*2] U8G_NOCOMMON;
-u8g_pb_t u8g_dev_st7565_64128n_2x_VIKI_pb = { { 16, HEIGHT, 0, 0, 0 }, WIDTH, u8g_dev_st7565_64128n_2x_VIKI_buf };
-u8g_dev_t u8g_dev_st7565_64128n_2x_VIKI_sw_spi = { u8g_dev_st7565_64128n_2x_VIKI_fn, &u8g_dev_st7565_64128n_2x_VIKI_pb, &u8g_com_null_fn };
+uint8_t u8g_dev_st7565_64128n_2x_VIKI_buf[WIDTH*2] U8G_NOCOMMON ;
+u8g_pb_t u8g_dev_st7565_64128n_2x_VIKI_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_st7565_64128n_2x_VIKI_buf};
+u8g_dev_t u8g_dev_st7565_64128n_2x_VIKI_sw_spi = { u8g_dev_st7565_64128n_2x_VIKI_fn, &u8g_dev_st7565_64128n_2x_VIKI_pb, &u8g_com_null_fn};
+
 
 class U8GLIB_ST7565_64128n_2x_VIKI : public U8GLIB {
   public:
@@ -236,6 +260,9 @@ class U8GLIB_ST7565_64128n_2x_VIKI : public U8GLIB {
     {  }
 };
 
+
+
 #pragma GCC reset_options
 
+#endif // U8GLIB_ST7565
 #endif // ULCDST7565_H

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd.h
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd.h
@@ -23,7 +23,9 @@
 #ifndef ULCDST7920_H
 #define ULCDST7920_H
 
-#include "../../Marlin.h"
+#include <src/Marlin.h>
+
+#if ENABLED(U8GLIB_ST7920)
 
 #define ST7920_CLK_PIN  LCD_PINS_D4
 #define ST7920_DAT_PIN  LCD_PINS_ENABLE
@@ -80,43 +82,63 @@
   #define ST7920_DELAY_3 CPU_ST7920_DELAY_3
 #endif
 
-#define ST7920_SND_BIT \
-  WRITE(ST7920_CLK_PIN, LOW);        ST7920_DELAY_1; \
-  WRITE(ST7920_DAT_PIN, val & 0x80); ST7920_DELAY_2; \
-  WRITE(ST7920_CLK_PIN, HIGH);       ST7920_DELAY_3; \
-  val <<= 1
-
-static void ST7920_SWSPI_SND_8BIT(uint8_t val) {
-  ST7920_SND_BIT; // 1
-  ST7920_SND_BIT; // 2
-  ST7920_SND_BIT; // 3
-  ST7920_SND_BIT; // 4
-  ST7920_SND_BIT; // 5
-  ST7920_SND_BIT; // 6
-  ST7920_SND_BIT; // 7
-  ST7920_SND_BIT; // 8
-}
-
 #if defined(DOGM_SPI_DELAY_US) && DOGM_SPI_DELAY_US > 0
   #define U8G_DELAY() delayMicroseconds(DOGM_SPI_DELAY_US)
 #else
   #define U8G_DELAY() u8g_10MicroDelay()
 #endif
 
+#if ENABLED(SHARED_SPI)   // Re-ARM requires that the LCD and the SD card share a single SPI
+
+  #define ST7920_SET_CMD()         { spiSend(0xF8); U8G_DELAY(); }
+  #define ST7920_SET_DAT()         { spiSend(0xFA); U8G_DELAY(); }
+  #define ST7920_WRITE_BYTE(a)     { spiSend((uint8_t)((a)&0xF0u)); U8G_DELAY(); spiSend((uint8_t)((a)<<4u)); U8G_DELAY(); }
+  #define ST7920_WRITE_BYTES(p,l)  { for (uint8_t i = l + 1; --i;) { spiSend(*p&0xF0); spiSend(*p<<4); p++; } U8G_DELAY(); }
+
+#else
+
+  #define ST7920_SND_BIT \
+    WRITE(ST7920_CLK_PIN, LOW);        ST7920_DELAY_1; \
+    WRITE(ST7920_DAT_PIN, val & 0x80); ST7920_DELAY_2; \
+    WRITE(ST7920_CLK_PIN, HIGH);       ST7920_DELAY_3; \
+    val <<= 1
+
+  static void ST7920_SWSPI_SND_8BIT(uint8_t val) {
+    ST7920_SND_BIT; // 1
+    ST7920_SND_BIT; // 2
+    ST7920_SND_BIT; // 3
+    ST7920_SND_BIT; // 4
+    ST7920_SND_BIT; // 5
+    ST7920_SND_BIT; // 6
+    ST7920_SND_BIT; // 7
+    ST7920_SND_BIT; // 8
+  }
+
+  #define ST7920_SET_CMD()         { ST7920_SWSPI_SND_8BIT(0xF8); U8G_DELAY(); }
+  #define ST7920_SET_DAT()         { ST7920_SWSPI_SND_8BIT(0xFA); U8G_DELAY(); }
+  #define ST7920_WRITE_BYTE(a)     { ST7920_SWSPI_SND_8BIT((uint8_t)((a)&0xF0u)); ST7920_SWSPI_SND_8BIT((uint8_t)((a)<<4u)); U8G_DELAY(); }
+  #define ST7920_WRITE_BYTES(p,l)  { for (uint8_t i = l + 1; --i;) { ST7920_SWSPI_SND_8BIT(*p&0xF0); ST7920_SWSPI_SND_8BIT(*p<<4); p++; } U8G_DELAY(); }
+#endif
+
 #define ST7920_CS()              { WRITE(ST7920_CS_PIN,1); U8G_DELAY(); }
 #define ST7920_NCS()             { WRITE(ST7920_CS_PIN,0); }
-#define ST7920_SET_CMD()         { ST7920_SWSPI_SND_8BIT(0xF8); U8G_DELAY(); }
-#define ST7920_SET_DAT()         { ST7920_SWSPI_SND_8BIT(0xFA); U8G_DELAY(); }
-#define ST7920_WRITE_BYTE(a)     { ST7920_SWSPI_SND_8BIT((uint8_t)((a)&0xF0u)); ST7920_SWSPI_SND_8BIT((uint8_t)((a)<<4u)); U8G_DELAY(); }
-#define ST7920_WRITE_BYTES(p,l)  { for (uint8_t i = l + 1; --i;) { ST7920_SWSPI_SND_8BIT(*p&0xF0); ST7920_SWSPI_SND_8BIT(*p<<4); p++; } U8G_DELAY(); }
+
+
 
 uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
   uint8_t i, y;
   switch (msg) {
     case U8G_DEV_MSG_INIT: {
       OUT_WRITE(ST7920_CS_PIN, LOW);
-      OUT_WRITE(ST7920_DAT_PIN, LOW);
-      OUT_WRITE(ST7920_CLK_PIN, HIGH);
+
+      #if ENABLED(SHARED_SPI)
+        u8g_Delay(250);
+        spiBegin();
+        spiInit(SPI_EIGHTH_SPEED);  // run LCD at 1 MHz - garbled display if run at 2 MHz
+      #else
+        OUT_WRITE(ST7920_DAT_PIN, LOW);
+        OUT_WRITE(ST7920_CLK_PIN, HIGH);
+      #endif
 
       ST7920_CS();
       u8g_Delay(120);                 //initial delay for boot up
@@ -133,13 +155,23 @@ uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
           ST7920_WRITE_BYTE(0);
         ST7920_SET_CMD();
       }
+
       ST7920_WRITE_BYTE(0x0C); //display on, cursor+blink off
+      #if ENABLED(SHARED_SPI)
+        #ifndef SPI_SPEED
+            #define SPI_SPEED SPI_FULL_SPEED  // switch SPI speed back to SD card speed
+        #endif
+        spiInit(SPI_SPEED);
+      #endif
       ST7920_NCS();
     }
     break;
     case U8G_DEV_MSG_STOP:
       break;
     case U8G_DEV_MSG_PAGE_NEXT: {
+      #if ENABLED(SHARED_SPI)
+        spiInit(SPI_EIGHTH_SPEED);  // run LCD at 1 MHz - garbled display if run at 2 MHz
+      #endif
       uint8_t* ptr;
       u8g_pb_t* pb = (u8g_pb_t*)(dev->dev_mem);
       y = pb->p.page_y0;
@@ -160,6 +192,9 @@ uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
         ST7920_WRITE_BYTES(ptr, (LCD_PIXEL_WIDTH) / 8); //ptr is incremented inside of macro
         y++;
       }
+      #if ENABLED(SHARED_SPI)
+        spiInit(SPI_SPEED);   // switch SPI speed back to SD card speed
+      #endif
       ST7920_NCS();
     }
     break;
@@ -184,4 +219,5 @@ class U8GLIB_ST7920_128X64_RRD : public U8GLIB {
 
 #pragma GCC reset_options
 
+#endif // U8GLIB_ST7920
 #endif // ULCDST7920_H

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -403,9 +403,6 @@
 #ifndef SDPOWER
   #define SDPOWER -1
 #endif
-#ifndef SDSS
-  #define SDSS -1
-#endif
 #ifndef LED_PIN
   #define LED_PIN -1
 #endif

--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -105,7 +105,7 @@
 #define TEMP_1_PIN         2  //A2 (T2) - D69 - TEMP_1_PIN
 #define TEMP_2_PIN         3  //A3 - D63 - J5-3 & AUX-2
 #define TEMP_3_PIN         4  //A4 - D37 - BUZZER_PIN
-#define TEMP_4_PIN         5  //A5 - D49 - SD_DETECT_PIN
+//#define TEMP_4_PIN         5  //A5 - D49 - SD_DETECT_PIN
 //#define ??               6  //A6 - D0  - RXD0 - J4-4 & AUX-1
 #define FILWIDTH_PIN       7  //A7 - D1  - TXD0 - J4-5 & AUX-1
 
@@ -287,8 +287,6 @@
 
  #if ENABLED(VIKI2) || ENABLED(miniVIKI)
 //    #define LCD_SCREEN_ROT_180
-
-    #define SOFTWARE_SPI  // temp to see if it fixes the  "not found" error
 
     #undef  BEEPER_PIN
     #define BEEPER_PIN          37  // may change if cable changes

--- a/buildroot/bin/build_marlin_teensy35
+++ b/buildroot/bin/build_marlin_teensy35
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+arduino --verify --board teensy:avr:teensy35:usb=serial,speed=120,opt=o1std,keys=en-us Marlin/Marlin.ino

--- a/debug_extra_script.py
+++ b/debug_extra_script.py
@@ -1,0 +1,21 @@
+Import("env")
+
+env.AddPostAction(
+    "$BUILD_DIR/firmware.hex",
+    env.VerboseAction(" ".join([
+        "sed", "-i.bak",
+        "s/:10040000FFFFFFFFFFFFFFFFFFFFFFFFDEF9FFFF23/:10040000FFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFD/",
+        "$BUILD_DIR/firmware.hex"
+    ]), "Fixing $BUILD_DIR/firmware.hex secure flash flags"))
+env.AddPreAction(
+    "upload",
+     env.VerboseAction(" ".join([
+         "echo",
+         "'h\\nloadfile $BUILD_DIR/firmware.hex\\nr\\nq\\n'",
+         ">$BUILD_DIR/aux.jlink"
+     ]), "Creating auxiliary files"))
+
+env.Replace(
+    UPLOADHEXCMD=
+    'JLinkExe -device MK20DX256xxx7 -speed 4000 -if swd -autoconnect 1 -CommanderScript $BUILD_DIR/aux.jlink -SkipProgOnCRCMatch = 1 -VerifyDownload = 1'
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,3 +121,31 @@ lib_ldf_mode = off
 lib_extra_dirs = frameworks
 lib_deps = U8glib-ARM, CMSIS-LPC1768
 extra_scripts = Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+
+
+[env:Re-ARM_debug_and_upload]
+# Segger JLink
+platform = nxplpc
+#framework = mbed
+board = lpc1768
+board_f_cpu = 100000000L
+build_flags = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+lib_ldf_mode = off
+lib_deps = U8glib-ARM
+src_filter =
+extra_scripts = debug_extra_script.py,  Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+debug_tool = custom
+debug_server =
+  C:\Program Files (x86)\SEGGER\JLink_V618d\JLinkGDBServerCL.exe
+  -select
+  USB
+  -port
+  2331
+  -device
+  LPC1768
+  -if
+  JTAG
+  -speed
+  auto
+  -noir
+  


### PR DESCRIPTION
Changes:
- M355 - fixed "USEABLE_HARDWARE_PWM" problem and made S0, S1 commands work with ARM
- LCD & SD card - added faster SPI and moved defines so that the SD card access speed selection worked (previously SD card accesses were all at 250k). This is the PR #7587 changes ported over to the re-organized structure.  See  PR #7587 for details.
- added JLink debugger environment

VIKI2 and RepRap Discount Full Graphic displays run much faster now.

Defines & some pin settings had to be moved to support these changes.