### PR TITLE
[bugfix-2.0.x] Fix compiler error (issue #7730)

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -46,6 +46,10 @@
   #include "../feature/mixing.h"
 #endif
 
+#if HAS_LEVELING
+  #include "../feature/bedlevel/bedlevel.h"
+#endif
+
 #if ENABLED(SWITCHING_EXTRUDER)
 
   #if EXTRUDERS > 3


### PR DESCRIPTION
Added missing include file,
called 'leveling_is_active()' with no prototipe defined.