### PR TITLE
gitignorefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,10 +150,10 @@ Marlin/*/*/*/*/readme.txt
 *.sln
 *.vcxproj
 *.vcxproj.filters
-src/Release/
-src/Debug/
-src/__vm/
-src/.vs/
+Release/
+Debug/
+__vm/
+.vs/
 
 #Visual Studio Code
 .vscode


### PR DESCRIPTION
When you use platformio to create visualstudio project (VS15) this project is created in main Marlin folder (the same where platformio.ini resides).
This automatic created project, when compiling is executed, will create 'Debug', 'Release', '.vs' folder in the same path, not 'src'

.Gitignore has been adapted for this reason

N.B. to create project, from main Marlin folder type:
  platformio init --ide visualstudio --board myboard
to get supported boards type:
  platformio boards
