### PR TITLE
Update LPC persistent store to initialize eeprom.dat with FF

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/persistent_store_impl.cpp
@@ -16,8 +16,25 @@ FATFS fat_fs;
 FIL eeprom_file;
 
 bool access_start() {
+  UINT file_size = 0;
+  UINT bytes_written = 0;
+  const char eeprom_zero = 0xFF;
   f_mount(&fat_fs, "", 1);
   FRESULT res = f_open(&eeprom_file, "eeprom.dat", FA_OPEN_ALWAYS | FA_WRITE | FA_READ);
+    if (res == FR_OK) {
+    file_size = f_size(&eeprom_file);
+  }
+  if (res == FR_OK) {
+    f_lseek(&eeprom_file, file_size);
+    while ((file_size < E2END) && (res == FR_OK)) {
+      res = f_write(&eeprom_file, &eeprom_zero, 1, &bytes_written);
+      file_size++;
+    }
+  }
+  if (res == FR_OK){
+    f_lseek(&eeprom_file, 0);
+    f_sync(&eeprom_file);
+  }
   return (res == FR_OK);
 }
 


### PR DESCRIPTION
This change initialize any data in eeprom.dat beyond the current file size to FF.
That way if eeprom.dat is deleted and created again, it doesn't take the old values or random ones, but rather starts with FF in all positions as a real brand new or erased eeprom.dat
Currently if you delete eeprom.dat and restart the board, the new file is created in the same sector with the same content, since FAT does not actually delete the data, just marks the sector as free. I tested by deleting the file, and then rebooting the board, and checking the file content.
The change can be tested in the same way, deleting, rebooting the board, and then the new content should be all FF.

If an eeprom file already exist with data on it, but smaller than E2END, it will be padded with FF on first access, so it will not have random or old content appended.