### PR TITLE
[2.0.x] Fix missing retracts and recovers

### DIFF
--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -34,20 +34,7 @@ FWRetract fwretract; // Single instance
 
 #include "../module/motion.h"
 #include "../module/planner.h"
-
-bool FWRetract::autoretract_enabled,                 // M209 S - Autoretract switch
-     FWRetract::retracted[EXTRUDERS] = { false };    // Which extruders are currently retracted
-float FWRetract::retract_length,                     // M207 S - G10 Retract length
-      FWRetract::retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
-      FWRetract::retract_zlift,                      // M207 Z - G10 Retract hop size
-      FWRetract::retract_recover_length,             // M208 S - G11 Recover length
-      FWRetract::retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
-      FWRetract::swap_retract_length,                // M207 W - G10 Swap Retract length
-      FWRetract::swap_retract_recover_length,        // M208 W - G11 Swap Recover length
-      FWRetract::swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
-#if EXTRUDERS > 1
-  bool FWRetract::retracted_swap[EXTRUDERS] = { false }; // Which extruders are swap-retracted
-#endif
+#include "../module/stepper.h"
 
 void FWRetract::reset() {
   autoretract_enabled = false;
@@ -59,6 +46,13 @@ void FWRetract::reset() {
   swap_retract_length = RETRACT_LENGTH_SWAP;
   swap_retract_recover_length = RETRACT_RECOVER_LENGTH_SWAP;
   swap_retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE_SWAP;
+
+  for (uint8_t i = 0; i < EXTRUDERS; ++i) {
+    retracted[i] = false;
+    #if EXTRUDERS > 1
+      bool retracted_swap[i] = false;
+    #endif
+  }
 }
 
 /**
@@ -87,10 +81,11 @@ void FWRetract::retract(const bool retracting
   // Simply never allow two retracts or recovers in a row
   if (retracted[active_extruder] == retracting) return;
 
-  #if EXTRUDERS < 2
-    bool swapping = false;
+  #if EXTRUDERS > 1
+    if (!retracting) swapping = retracted_swap[active_extruder];
+  #else
+    const bool swapping = false;
   #endif
-  if (!retracting) swapping = retracted_swap[active_extruder];
 
   /* // debugging
     SERIAL_ECHOLNPAIR("retracting ", retracting);
@@ -105,6 +100,8 @@ void FWRetract::retract(const bool retracting
     SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);
     SERIAL_ECHOLNPAIR("hop_amount ", hop_amount);
   //*/
+
+  stepper.synchronize();  // Wait for buffered moves to complete
 
   const bool has_zhop = retract_zlift > 0.01;     // Is there a hop set?
 

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -50,7 +50,7 @@ void FWRetract::reset() {
   for (uint8_t i = 0; i < EXTRUDERS; ++i) {
     retracted[i] = false;
     #if EXTRUDERS > 1
-      bool retracted_swap[i] = false;
+      retracted_swap[i] = false;
     #endif
   }
 }

--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -31,33 +31,39 @@
 
 class FWRetract {
 public:
-  static bool autoretract_enabled,                 // M209 S - Autoretract switch
-              retracted[EXTRUDERS];                // Which extruders are currently retracted
-  static float retract_length,                     // M207 S - G10 Retract length
-               retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
-               retract_zlift,                      // M207 Z - G10 Retract hop size
-               retract_recover_length,             // M208 S - G11 Recover length
-               retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
-               swap_retract_length,                // M207 W - G10 Swap Retract length
-               swap_retract_recover_length,        // M208 W - G11 Swap Recover length
-               swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
+  bool  autoretract_enabled;                // M209 S - Autoretract switch
+  float retract_length,                     // M207 S - G10 Retract length
+        retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
+        retract_zlift,                      // M207 Z - G10 Retract hop size
+        retract_recover_length,             // M208 S - G11 Recover length
+        retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
+        swap_retract_length,                // M207 W - G10 Swap Retract length
+        swap_retract_recover_length,        // M208 W - G11 Swap Recover length
+        swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
 
-  #if EXTRUDERS > 1
-    static bool retracted_swap[EXTRUDERS];         // Which extruders are swap-retracted
-  #else
-    static bool constexpr retracted_swap[1] = { false };
-  #endif
+  FWRetract() { reset(); }
 
-  FWRetract() {}
+  void reset();
 
-  static void reset();
+  void enable_autoretract(bool enable) {
+    autoretract_enabled = enable;
+    for (uint8_t i = 0; i < EXTRUDERS; i++) retracted[i] = false;
+  }
 
-  static void retract(const bool retracting
+  bool is_retracted(uint8_t e) { return retracted[e]; }
+
+  void retract(const bool retracting
     #if EXTRUDERS > 1
       , bool swapping = false
     #endif
   );
 
+private:
+  bool retracted[EXTRUDERS];                // Which extruders are currently retracted
+
+  #if EXTRUDERS > 1
+    bool retracted_swap[EXTRUDERS];         // Which extruders are swap-retracted
+  #endif
 };
 
 extern FWRetract fwretract;

--- a/Marlin/src/gcode/feature/fwretract/G10_G11.cpp
+++ b/Marlin/src/gcode/feature/fwretract/G10_G11.cpp
@@ -34,7 +34,6 @@
 void GcodeSuite::G10() {
   #if EXTRUDERS > 1
     const bool rs = parser.boolval('S');
-    fwretract.retracted_swap[active_extruder] = rs; // Use 'S' for swap, default to false
   #endif
   fwretract.retract(true
     #if EXTRUDERS > 1

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -65,8 +65,7 @@ void GcodeSuite::M208() {
 void GcodeSuite::M209() {
   if (MIN_AUTORETRACT <= MAX_AUTORETRACT) {
     if (parser.seen('S')) {
-      fwretract.autoretract_enabled = parser.value_bool();
-      for (uint8_t i = 0; i < EXTRUDERS; i++) fwretract.retracted[i] = false;
+      fwretract.enable_autoretract(parser.value_bool());
     }
   }
 }

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -51,7 +51,7 @@ void GcodeSuite::G0_G1(
         if (fwretract.autoretract_enabled && parser.seen('E') && !(parser.seen('X') || parser.seen('Y') || parser.seen('Z'))) {
           const float echange = destination[E_AXIS] - current_position[E_AXIS];
           // Is this a retract or recover move?
-          if (WITHIN(FABS(echange), MIN_AUTORETRACT, MAX_AUTORETRACT) && fwretract.retracted[active_extruder] == (echange > 0.0)) {
+          if (WITHIN(FABS(echange), MIN_AUTORETRACT, MAX_AUTORETRACT) && fwretract.is_retracted(active_extruder) == (echange > 0.0)) {
             current_position[E_AXIS] = destination[E_AXIS]; // Hide a G1-based retract/recover from calculations
             sync_plan_position_e();                         // AND from the planner
             return fwretract.retract(echange < 0.0);        // Firmware-based retract/recover (double-retract ignored)


### PR DESCRIPTION
I was having an issue with firmware retraction randomly missing some retracts and recovers. Upon further investigation, I determined the cause to be due to the fact that `G10` and `G11` are immediately processed regardless of if any moves are buffered in the planner. This causes the planner and the retraction to conflict, which leads to unintended behavior.

I also cleaned up the code a bit. Since a global `FWRetract` is provided, there is no need for the member variable and methods to be static. I also made the `retracted` and `retracted_swap` member variables private and added the necessary getters and setters as changing those values outside of the `FWRetract` class could lead to unintended behavior.