### PR TITLE
[2.0.x] Fix LPC1768 USB interrupt priority

### DIFF
--- a/frameworks/CMSIS/LPC1768/lib/usb/usbhw.cpp
+++ b/frameworks/CMSIS/LPC1768/lib/usb/usbhw.cpp
@@ -153,6 +153,7 @@ void USB_Init (void) {
   while ((LPC_USB->USBClkSt & 0x1A) != 0x1A);
 
   NVIC_EnableIRQ(USB_IRQn);               /* enable USB interrupt */
+  NVIC_SetPriority(USB_IRQn, NVIC_EncodePriority(0, 5, 0));
 
   USB_Reset();
   USB_SetAddress(0);


### PR DESCRIPTION
Per @p3p's direction, this PR lowers the priority of the USB interrupt to prevent the USB interfering with the stepper and temperature ISRs.