### PR TITLE
Marlin 2.0.x - fix LPC1768 stepper hang and limit maximum stepper ISR spacing

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -79,8 +79,16 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 
 static FORCE_INLINE void HAL_timer_set_count(const uint8_t timer_num, const HAL_TIMER_TYPE count) {
   switch (timer_num) {
-    case 0: LPC_TIM0->MR0 = count; break;
-    case 1: LPC_TIM1->MR0 = count; break;
+    case 0:
+      LPC_TIM0->MR0 = count;
+      if (LPC_TIM0->TC > count)
+        LPC_TIM0->TC = count - 5; // generate an immediate stepper ISR
+      break;
+    case 1:
+      LPC_TIM1->MR0 = count;
+      if (LPC_TIM1->TC > count)
+        LPC_TIM1->TC = count - 5; // make sure we don't have one extra long period
+      break;
   }
 }
 


### PR DESCRIPTION
The timer mod eliminates a 3 second pause in printing.  This was caused by setting the MR0 match register to a value less than the timer counter.  When that happened the counter had to overflow before the match could be made.  The time to do the overflow is about 3 seconds.  The fix is to check AFTER MR0 is written that it's greater than the counter.  If not then the counter is written with a value that will result in an almost immediate interrupt.

The SPLIT function is being enabled in the stepper ISR code.  It runs no matter what options are selected.

The reasons the SPLIT function is being enabled are:
a) Guarantee detection of the 5mS BLTouch pulse by making sure at least two ISRs are run within the 5mS pulse.
b) By running this all the time, 16 bit timers can be used to generate the stepper interrupts.  This is a help to the STM32 folks.