### PR TITLE
Fix G10/G11 with synchronize

### DIFF
--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -30,6 +30,11 @@
 #include "../inc/MarlinConfig.h"
 
 class FWRetract {
+private:
+  #if EXTRUDERS > 1
+    static bool retracted_swap[EXTRUDERS];         // Which extruders are swap-retracted
+  #endif
+
 public:
   static bool autoretract_enabled,                 // M209 S - Autoretract switch
               retracted[EXTRUDERS];                // Which extruders are currently retracted
@@ -42,22 +47,24 @@ public:
                swap_retract_recover_length,        // M208 W - G11 Swap Recover length
                swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
 
-  #if EXTRUDERS > 1
-    static bool retracted_swap[EXTRUDERS];         // Which extruders are swap-retracted
-  #else
-    static bool constexpr retracted_swap[1] = { false };
-  #endif
-
-  FWRetract() {}
+  FWRetract() { reset(); }
 
   static void reset();
+
+  static void refresh_autoretract() {
+    for (uint8_t i = 0; i < EXTRUDERS; i++) retracted[i] = false;
+  }
+
+  static void enable_autoretract(const bool enable) {
+    autoretract_enabled = enable;
+    refresh_autoretract();
+  }
 
   static void retract(const bool retracting
     #if EXTRUDERS > 1
       , bool swapping = false
     #endif
   );
-
 };
 
 extern FWRetract fwretract;

--- a/Marlin/src/gcode/feature/fwretract/G10_G11.cpp
+++ b/Marlin/src/gcode/feature/fwretract/G10_G11.cpp
@@ -34,7 +34,6 @@
 void GcodeSuite::G10() {
   #if EXTRUDERS > 1
     const bool rs = parser.boolval('S');
-    fwretract.retracted_swap[active_extruder] = rs; // Use 'S' for swap, default to false
   #endif
   fwretract.retract(true
     #if EXTRUDERS > 1

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -65,8 +65,7 @@ void GcodeSuite::M208() {
 void GcodeSuite::M209() {
   if (MIN_AUTORETRACT <= MAX_AUTORETRACT) {
     if (parser.seen('S')) {
-      fwretract.autoretract_enabled = parser.value_bool();
-      for (uint8_t i = 0; i < EXTRUDERS; i++) fwretract.retracted[i] = false;
+      fwretract.enable_autoretract(parser.value_bool());
     }
   }
 }

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3557,7 +3557,7 @@ void kill_screen(const char* lcd_msg) {
     void lcd_control_retract_menu() {
       START_MENU();
       MENU_BACK(MSG_CONTROL);
-      MENU_ITEM_EDIT(bool, MSG_AUTORETRACT, &fwretract.autoretract_enabled);
+      MENU_ITEM_EDIT_CALLBACK(bool, MSG_AUTORETRACT, &fwretract.autoretract_enabled, fwretract.refresh_autoretract);
       MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT, &fwretract.retract_length, 0, 100);
       #if EXTRUDERS > 1
         MENU_ITEM_EDIT(float52, MSG_CONTROL_RETRACT_SWAP, &fwretract.swap_retract_length, 0, 100);

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -247,6 +247,10 @@ void MarlinSettings::postprocess() {
   #if HAS_MOTOR_CURRENT_PWM
     stepper.refresh_motor_power();
   #endif
+
+  #if ENABLED(FWRETRACT)
+    fwretract.refresh_autoretract();
+  #endif
 }
 
 #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
This PR contains all the non-controversial parts of #7792 by @tcm0116.

Although `G10` / `G11` adds moves to the end of the planner queue, it still needs to synchronize so that its extra logic doesn't stomp on the planner position at the moment the commands are executed. This PR fixes that issue and does a little more encapsulation in the `FWRetract` class.

----
In terms of Marlin's gradual move from a "C++ with functions" format to its current form, the initial emphasis was to take advantage of `class` embodiment as a way to encapsulate globals into more-than-just-namespaces and to start thinking of which units should encapsulate which data members. At the time, most developers were dearth to overhaul the code due to the risk of breaking something. So extra care was taken to `class`ify the code without altering either the linkage or the behavior. For the most part we succeeded in being non-disruptive.

The choice to create a dummy instance has two purposes: It fires the constructor, and it gives us dot-notation, which is simply a matter of stylistic preference. `Planner::buffer_line` does exactly what `planner.buffer_line` does. Some coders have simply come to prefer using dot-notation when possible due to its portability to several other languages.

In a near-future continuation of the refactor, some G-code handlers will migrate into the classes that they most relate with. It makes sense for classes like `Stepper`, `Planner`, `GCodeParser`, etc., to be accessible to all handlers, since these are the central facilities that handlers need to use. So, when there's a `FWRetract::G10_G11` method, it will be able to drop `fwretract.` prefixes, but will gain `gcode.` prefixes.

This isn't happening now, as the emphasis is on patching up the first-stage refactor, doing issue patches for 1.1.x, and duplicating those patches in 2.0.x. Vice-versa also applies. If this issue needs to be patched in 1.1.x, that's what comes next.