### PR TITLE
[1.1.x] Fix broken M600 resume_print

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5662,7 +5662,7 @@ void home_all_axes() { gcode_G28(true); }
           float a_sum = 0.0;
           LOOP_XYZ(axis) a_sum += delta_tower_angle_trim[axis];
           LOOP_XYZ(axis) delta_tower_angle_trim[axis] -= a_sum / 3.0;
-          
+
           // adjust delta_height and endstops by the max amount
           const float z_temp = MAX3(endstop_adj[A_AXIS], endstop_adj[B_AXIS], endstop_adj[C_AXIS]);
           home_offset[Z_AXIS] -= z_temp;
@@ -8564,7 +8564,7 @@ inline void gcode_M205() {
     #endif
     LOOP_XYZ(i) {
       if (parser.seen(axis_codes[i])) {
-        if (parser.value_linear_units() * Z_HOME_DIR <= 0)         
+        if (parser.value_linear_units() * Z_HOME_DIR <= 0)
           endstop_adj[i] = parser.value_linear_units();
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6353,6 +6353,8 @@ inline void gcode_M17() {
       filament_change_beep(max_beep_count, true);
     #endif
 
+    set_destination_to_current();
+
     if (load_length != 0) {
       #if ENABLED(ULTIPANEL)
         // Show "insert filament"

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -790,11 +790,11 @@ static void lcd_implementation_status_screen() {
     lcd.setCursor(LCD_WIDTH - 8, 1);
     _draw_axis_label(Z_AXIS, PSTR(MSG_Z), blink);
     lcd.print(ftostr52sp(FIXFLOAT(current_position[Z_AXIS])));
-    
+
     #if HAS_LEVELING
       lcd.write(leveling_is_active() || blink ? '_' : ' ');
     #endif
-  
+
   #endif // LCD_HEIGHT > 2
 
   //


### PR DESCRIPTION
Expected behaviour: while (auto)extruding the new filament, the nozzle should not move. It should move (from filament replacement position to printing position) only after the user has confirmed the successful filament replacement and extrusion.

Actual behaviour: while (auto)extruding the new filament, the nozzle moves from filament replacement position back to printing position. So the extrusion step is mixed with the movement required to go back to the printing position.

---
The original fix in #7779 by @MasterPIC backs up `destination`, then sets it to `current_position` before the E move. After the E move, it restores the original `destination` value.

When I examined the code to see what `destination` was supposed to be, I found that `destination` wasn't being set at all before or within `resume_print` before it was used. This PR offers another possible solution by calling `set_destination_to_current` ahead of the E move.