### PR TITLE
[2.0.x] Fix broken M600 resume_print

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -268,6 +268,8 @@ void resume_print(const float &load_length/*=0*/, const float &initial_extrude_l
     filament_change_beep(max_beep_count, true);
   #endif
 
+  set_destination_to_current();
+
   if (load_length != 0) {
     #if ENABLED(ULTIPANEL)
       // Show "insert filament"

--- a/Marlin/src/gcode/feature/caselight/M355.cpp
+++ b/Marlin/src/gcode/feature/caselight/M355.cpp
@@ -46,7 +46,7 @@ void GcodeSuite::M355() {
     if (parser.seenval('P')) {
       ++args, case_light_brightness = parser.value_byte();
       case_light_arg_flag = false;
-    }  
+    }
     if (parser.seenval('S')) {
       ++args, case_light_on = parser.value_bool();
       case_light_arg_flag = true;

--- a/platformio.ini
+++ b/platformio.ini
@@ -148,4 +148,3 @@ debug_server =
   -speed
   auto
   -noir
-  


### PR DESCRIPTION
Derived from #7811 and #7779

Expected behaviour: while (auto)extruding the new filament, the nozzle should not move. It should move (from filament replacement position to printing position) only after the user has confirmed the successful filament replacement and extrusion.

Actual behaviour: while (auto)extruding the new filament, the nozzle moves from filament replacement position back to printing position. So the extrusion step is mixed with the movement required to go back to the printing position.

---
The original fix in #7779 by @MasterPIC backs up `destination`, then sets it to `current_position` before the E move. After the E move, it restores the original `destination` value.

When I examined the code to see what `destination` was supposed to be, I found that `destination` wasn't being set at all before or within `resume_print` before it was used. This PR offers another possible solution by calling `set_destination_to_current` ahead of the E move.