### PR TITLE
[2.0.x] Fix DUAL_X_CARRIAGE manual move

### DIFF
--- a/Marlin/src/feature/tmc2130.cpp
+++ b/Marlin/src/feature/tmc2130.cpp
@@ -125,9 +125,6 @@ void tmc2130_checkOverTemp(void) {
     #if ENABLED(E4_IS_TMC2130)
       automatic_current_control(stepperE4, "E4");
     #endif
-    #if ENABLED(E4_IS_TMC2130)
-      automatic_current_control(stepperE4);
-    #endif
   }
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2750,9 +2750,13 @@ void kill_screen(const char* lcd_msg) {
       , int8_t eindex=-1
     #endif
   ) {
-    #if E_MANUAL > 1
-      if (axis == E_AXIS) manual_move_e_index = eindex >= 0 ? eindex : active_extruder;
+    #if ENABLED(DUAL_X_CARRIAGE) || E_MANUAL > 1
+      #if E_MANUAL > 1
+        if (axis == E_AXIS)
+      #endif
+          manual_move_e_index = eindex >= 0 ? eindex : active_extruder;
     #endif
+
     manual_move_start_time = millis() + (move_menu_scale < 0.99 ? 0UL : 250UL); // delay for bigger moves
     manual_move_axis = (int8_t)axis;
   }
@@ -2963,7 +2967,7 @@ void kill_screen(const char* lcd_msg) {
     else
       MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
 
-    #if ENABLED(SWITCHING_EXTRUDER)
+    #if ENABLED(SWITCHING_EXTRUDER) || ENABLED(DUAL_X_CARRIAGE)
       if (active_extruder)
         MENU_ITEM(gcode, MSG_SELECT " " MSG_E1, PSTR("T0"));
       else

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -212,7 +212,7 @@ uint16_t max_display_update_time = 0;
   void _menu_action_back();
   void menu_action_submenu(screenFunc_t data);
   void menu_action_gcode(const char* pgcode);
-  void menu_action_function(screenFunc_t data);
+  void menu_action_function(menuAction_t data);
 
   #define DECLARE_MENU_EDIT_TYPE(_type, _name) \
     bool _menu_edit_ ## _name(); \

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -84,6 +84,7 @@
 
     // Function pointer to menu functions.
     typedef void (*screenFunc_t)();
+    typedef void (*menuAction_t)();
 
     void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder=0);
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -769,7 +769,7 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
           break;
       }
     }
-    return false;
+    return prepare_move_to_destination_cartesian();
   }
 
 #endif // DUAL_X_CARRIAGE
@@ -811,7 +811,7 @@ void prepare_move_to_destination() {
     #elif IS_KINEMATIC
       prepare_kinematic_move_to(destination)
     #elif ENABLED(DUAL_X_CARRIAGE)
-      prepare_move_to_destination_dualx() || prepare_move_to_destination_cartesian()
+      prepare_move_to_destination_dualx()
     #else
       prepare_move_to_destination_cartesian()
     #endif


### PR DESCRIPTION
As pointed out in #7745, Dual X Carriage manual moves are broken. This PR fixes the issue by making sure to include the `active_extruder` with XYZ moves on dual X configurations.

Additionally, it adds a tool-switch option to the "Move Axis" submenu for Dual X Carriage, which sends "T0" or "T1" to the parser.

See also #7828