### PR TITLE
[1.1] Use blink to show more infos by LCD

### DIFF
--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -60,12 +60,12 @@
   #endif
 
   #if ENABLED(SERIAL_XON_XOFF)
-    uint8_t xon_xoff_state = XON_XOFF_CHAR_SENT | XON_CHAR;
     constexpr uint8_t XON_XOFF_CHAR_SENT = 0x80;  // XON / XOFF Character was sent
     constexpr uint8_t XON_XOFF_CHAR_MASK = 0x1F;  // XON / XOFF character to send
     // XON / XOFF character definitions
     constexpr uint8_t XON_CHAR  = 17;
     constexpr uint8_t XOFF_CHAR = 19;
+    uint8_t xon_xoff_state = XON_XOFF_CHAR_SENT | XON_CHAR;
   #endif
 
   #if ENABLED(SERIAL_STATS_DROPPED_RX)

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -811,7 +811,7 @@ static void lcd_implementation_status_screen() {
     #if LCD_WIDTH >= 20 && ENABLED(SDSUPPORT)
 
       lcd.setCursor(7, 2);
-	  if (blink) {
+      if (blink) {
         lcd_printPGM(PSTR("Fs"));
         lcd.print(itostr3(fanSpeeds[0]));
         lcd.write(' ');

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -811,12 +811,23 @@ static void lcd_implementation_status_screen() {
     #if LCD_WIDTH >= 20 && ENABLED(SDSUPPORT)
 
       lcd.setCursor(7, 2);
-      lcd_printPGM(PSTR("SD"));
-      if (IS_SD_PRINTING)
-        lcd.print(itostr3(card.percentDone()));
-      else
-        lcd_printPGM(PSTR("---"));
-      lcd.write('%');
+	  if (blink) {
+        lcd_printPGM(PSTR("Fs"));
+        lcd.print(itostr3(fanSpeeds[0]));
+        lcd.write(' ');
+      }
+      else {
+        if (IS_SD_PRINTING) {
+          lcd_printPGM(PSTR("SD"));
+          lcd.print(itostr3(card.percentDone()));
+          lcd.write('%');
+        }
+        else {
+          lcd_printPGM(PSTR("Ex"));
+          lcd.print(itostr3(flow_percentage[0]));
+          lcd.write('%');
+        }
+      }
 
     #endif // LCD_WIDTH >= 20 && SDSUPPORT
 


### PR DESCRIPTION
Show `fanSpeeds[0]` and `flow_percentage[0]` while not printing by SD.
Show `fanSpeeds[0]` and `card.percentDone()` while printing by SD.