### PR TITLE
Marlin 2.0.x LCD controllers - want feedback

### DIFF
--- a/Marlin/src/HAL/HAL_LCD_defines.h
+++ b/Marlin/src/HAL/HAL_LCD_defines.h
@@ -1,0 +1,68 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * The U8glib-ARM has multiple hooks in it to facilitate adding ARM/HAL specific
+ * routines to the library.  This file selects the appropriate definition file based
+ * on the platform being compiled.
+ *
+ * The U8glib-ARM system usually selects the appropriate software via a long chain of
+ * "if this platform then .." terminated by a "if not defined yet then use the default/dummy
+ * option".  As long as the ARM/HAL definition is in place before the start of the chain
+ * then it's what'll be used.  It can't be done after the chain is completed.
+ *
+ * The hooks the U8glib-ARM library are all prefaced with "defined(__arm__)".  They are:
+ *  u8g.h - enables the U8G_WITH_PINLIST routines
+ *        - just after the data structures are defined and before the chains start, this
+ *          file gets pulled in.  Here we define the pointers to the code needed by supporting
+ *          files and here is were we define any custom communication and/or device drivers
+ *          and where we define what drivers will be used.
+ *  u8g_com_io.c - pulls in the "HAL_LCD_pin_manipulation" file which contains the low level
+ *                 pin setup and pin write routines.
+ *  u8g_delay.c - pulls in the "HAL_LCD_delay" file which provides the delay funtions.
+ *
+ * You will also find "defined(__arm__)" is used by Teensy to pull in their custom code.  These
+ * are always buried inside other qualifiers so the ARM/HAL and the Teensy items are independent
+ * of each other.
+*/
+
+
+#ifndef HAL_LCD_DEFINES_H_
+#define HAL_LCD_DEFINES_H_
+
+#ifdef ARDUINO_ARCH_SAM
+//  #include "HAL_DUE/HAL_DUE_LCD_defines.h"
+
+#elif defined(IS_32BIT_TEENSY)
+//  #include "HAL_TEENSY35_36/HAL_TEENSY_LCD_defines.h"
+
+#elif defined(ARDUINO_ARCH_AVR)
+//  #include "HAL_AVR/HAL_ARDUINO_LCD_defines.h"
+
+#elif defined(TARGET_LPC1768)
+  #include "HAL_LPC1768/HAL_LPC1768_LCD_defines.h"
+
+#else
+  #error "Unsupported Platform!"
+#endif
+
+#endif // HAL_LCD_DEFINES_H_

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_I2C_routines.c
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_I2C_routines.c
@@ -1,0 +1,182 @@
+/**
+  * Marlin 3D Printer Firmware
+  * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+  *
+  * Based on Sprinter and grbl.
+  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+  *
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  *
+*/
+
+// adapted from  I2C/master/master.c example
+
+
+#if defined(TARGET_LPC1768)
+  
+  #ifdef __cplusplus
+    extern "C" {
+  #endif
+    
+  #include <lpc17xx_i2c.h>
+  #include <lpc17xx_pinsel.h>
+  #include <lpc17xx_libcfg_default.h>
+  
+  ////////////////////////////////////////////////////////////////////////////////////// 
+  
+  // These two routines are exact copies of the lpc17xx_i2c.c routines.  Couldn't link to
+  // to the lpc17xx_i2c.c routines so had to copy them into this file & rename them.
+  
+  static uint32_t _I2C_Start (LPC_I2C_TypeDef *I2Cx)
+  {
+    // Reset STA, STO, SI
+    I2Cx->I2CONCLR = I2C_I2CONCLR_SIC|I2C_I2CONCLR_STOC|I2C_I2CONCLR_STAC;
+    
+    // Enter to Master Transmitter mode
+    I2Cx->I2CONSET = I2C_I2CONSET_STA;
+    
+    // Wait for complete
+    while (!(I2Cx->I2CONSET & I2C_I2CONSET_SI));
+    I2Cx->I2CONCLR = I2C_I2CONCLR_STAC;
+    return (I2Cx->I2STAT & I2C_STAT_CODE_BITMASK);
+  }
+  
+  static void _I2C_Stop (LPC_I2C_TypeDef *I2Cx)
+  {
+    
+    /* Make sure start bit is not active */
+    if (I2Cx->I2CONSET & I2C_I2CONSET_STA)
+    {
+      I2Cx->I2CONCLR = I2C_I2CONCLR_STAC;
+    }
+    
+    I2Cx->I2CONSET = I2C_I2CONSET_STO|I2C_I2CONSET_AA;
+    
+    I2Cx->I2CONCLR = I2C_I2CONCLR_SIC;
+  }
+  
+  
+  //////////////////////////////////////////////////////////////////////////////////////  
+  
+  #define U8G_I2C_OPT_FAST 16  // from u8g.h
+  
+  #define USEDI2CDEV_M            1
+  
+  #define I2CDEV_S_ADDR   0x78  // from SSD1306  //actual address is 0x3C - shift left 1 with LSB set to 0 to indicate write
+  
+  #define BUFFER_SIZE                     0x1  // only do single byte transfers with LCDs
+  
+  #if (USEDI2CDEV_M == 0)
+    #define I2CDEV_M LPC_I2C0
+  #elif (USEDI2CDEV_M == 1)
+    #define I2CDEV_M LPC_I2C1
+  #elif (USEDI2CDEV_M == 2)
+    #define I2CDEV_M LPC_I2C2
+  #else
+    #error "Master I2C device not defined!"
+  #endif
+  
+  
+  PINSEL_CFG_Type PinCfg;
+  I2C_M_SETUP_Type transferMCfg;
+  
+  #define I2C_status (LPC_I2C1->I2STAT & I2C_STAT_CODE_BITMASK)
+  
+  
+  uint8_t u8g_i2c_start(uint8_t sla) {  // send slave address and write bit -  hardwired to 0x78
+    
+    // Sometimes TX data ACK or NAK status is returned.  That means the start state didn't
+    // happen which means only the value of the slave address was send.  Keep looping until
+    // the slave address and write bit are actually sent. 
+    
+    do{   
+      _I2C_Stop(I2CDEV_M); // output stop state on I2C bus
+      _I2C_Start(I2CDEV_M); // output start state on I2C bus
+      while ((I2C_status != I2C_I2STAT_M_TX_START)
+          && (I2C_status != I2C_I2STAT_M_TX_RESTART)
+          && (I2C_status != I2C_I2STAT_M_TX_DAT_ACK)
+          && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK));  //wait for start to be asserted
+      
+      LPC_I2C1->I2CONCLR = I2C_I2CONCLR_STAC; // clear start state before tansmitting slave address
+      LPC_I2C1->I2DAT = I2CDEV_S_ADDR & I2C_I2DAT_BITMASK; // transmit slave address & write bit
+      LPC_I2C1->I2CONSET = I2C_I2CONSET_AA;
+      LPC_I2C1->I2CONCLR = I2C_I2CONCLR_SIC;
+      while ((I2C_status != I2C_I2STAT_M_TX_SLAW_ACK)
+          && (I2C_status != I2C_I2STAT_M_TX_SLAW_NACK)
+          && (I2C_status != I2C_I2STAT_M_TX_DAT_ACK)
+          && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK));  //wait for slaw to finish
+    }while ( (I2C_status == I2C_I2STAT_M_TX_DAT_ACK) ||  (I2C_status == I2C_I2STAT_M_TX_DAT_NACK));
+    return 1;
+  }
+  
+  
+  void u8g_i2c_init(uint8_t clock_option) {
+
+    /*
+      * Init I2C pin connect
+    */
+    PinCfg.OpenDrain = 0;
+    PinCfg.Pinmode = 0;
+    #if ((USEDI2CDEV_M == 0))
+      PinCfg.Funcnum = 1;
+      PinCfg.Pinnum = 27;
+      PinCfg.Portnum = 0;
+      PINSEL_ConfigPin(&PinCfg); // SDA0 / D57  AUX-1
+      PinCfg.Pinnum = 28;
+      PINSEL_ConfigPin(&PinCfg); // SCL0 / D58  AUX-1
+    #endif
+    #if ((USEDI2CDEV_M == 1))
+      PinCfg.Funcnum = 3;
+      PinCfg.Pinnum = 0;
+      PinCfg.Portnum = 0;
+      PINSEL_ConfigPin(&PinCfg);  // SDA1 / D20 SCA
+      PinCfg.Pinnum = 1;
+      PINSEL_ConfigPin(&PinCfg);  // SCL1 / D21 SCL
+    #endif
+    #if ((USEDI2CDEV_M == 2))
+      PinCfg.Funcnum = 2;
+      PinCfg.Pinnum = 10;
+      PinCfg.Portnum = 0;
+      PINSEL_ConfigPin(&PinCfg); // SDA2 / D38  X_ENABLE_PIN
+      PinCfg.Pinnum = 11;
+      PINSEL_ConfigPin(&PinCfg); // SCL2 / D55  X_DIR_PIN
+    #endif
+    // Initialize I2C peripheral
+    I2C_Init(I2CDEV_M, (clock_option & U8G_I2C_OPT_FAST) ? 400000: 100000);
+    
+    /* Enable Master I2C operation */
+    I2C_Cmd(I2CDEV_M, I2C_MASTER_MODE, ENABLE);
+    
+    u8g_i2c_start(0); // send slave address and write bit
+  }
+  
+  
+  uint8_t u8g_i2c_send_byte(uint8_t data) {
+    
+    LPC_I2C1->I2DAT = data & I2C_I2DAT_BITMASK; // transmit data
+    LPC_I2C1->I2CONSET = I2C_I2CONSET_AA;
+    LPC_I2C1->I2CONCLR = I2C_I2CONCLR_SIC;
+    while ((I2C_status != I2C_I2STAT_M_TX_DAT_ACK) && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK));  // wait for xmit to finish
+    return 1;
+  }
+  
+  
+  void u8g_i2c_stop(void) {
+  }
+  
+  
+  #ifdef __cplusplus
+    }
+  #endif
+#endif

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_I2C_routines.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_I2C_routines.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -20,14 +20,23 @@
  *
  */
 
-#ifndef __HAL_PINMAPPING_H__
-#define __HAL_PINMAPPING_H__
-#include "src/core/macros.h"
+#if defined(TARGET_LPC1768)
+  
+  #ifdef __cplusplus
+      extern "C" {
+  #endif
 
-#if defined(IS_REARM)
-  #include "pinmap_re_arm.h"
-#else
-  #error "HAL: LPC1768: No defined pin-mapping"
+  void u8g_i2c_init(uint8_t options);
+  
+  uint8_t u8g_i2c_wait(uint8_t mask, uint8_t pos);
+  
+  uint8_t u8g_i2c_start(uint8_t sla);
+  
+  uint8_t u8g_i2c_send_byte(uint8_t data);
+  
+  void u8g_i2c_stop(void);
+
+  #ifdef __cplusplus
+    }
+  #endif
 #endif
-
-#endif // __HAL_PINMAPPING_H__

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_SPI_routines.c
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_SPI_routines.c
@@ -1,0 +1,116 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Low level pin manipulation routines - used by all the drivers.
+ *
+ * These are based on the LPC1768 pinMode, digitalRead & digitalWrite routines.
+ *
+ * Couldn't just call exact copies because the overhead killed the LCD update speed
+ * With an intermediate level the softspi was running in the 10-20kHz range which
+ * resulted in using about about 25% of the CPU's time.
+ */
+
+#if defined(TARGET_LPC1768)
+
+  #include <LPC17xx.h>
+  #include <lpc17xx_pinsel.h>
+  #include "src/core/macros.h"
+  #include "pinmapping.h"
+
+
+  #define LPC_PORT_OFFSET         (0x0020)
+  #define LPC_PIN(pin)            (1UL << pin)
+  #define LPC_GPIO(port)          ((volatile LPC_GPIO_TypeDef *)(LPC_GPIO0_BASE + LPC_PORT_OFFSET * port))
+
+  #define INPUT 0
+  #define OUTPUT 1
+  #define INPUT_PULLUP 2
+
+  #ifdef __cplusplus
+      extern "C" {
+  #endif
+
+  // IO functions
+  // As defined by Arduino INPUT(0x0), OUPUT(0x1), INPUT_PULLUP(0x2)
+  void pinMode_LCD(int pin, int mode) {
+    if (!WITHIN(pin, 0, NUM_DIGITAL_PINS - 1) || pin_map[pin].port == 0xFF)
+      return;
+
+    PINSEL_CFG_Type config = { pin_map[pin].port,
+                               pin_map[pin].pin,
+                               PINSEL_FUNC_0,
+                               PINSEL_PINMODE_TRISTATE,
+                               PINSEL_PINMODE_NORMAL };
+    switch(mode) {
+    case INPUT:
+      LPC_GPIO(pin_map[pin].port)->FIODIR &= ~LPC_PIN(pin_map[pin].pin);
+      PINSEL_ConfigPin(&config);
+      break;
+    case OUTPUT:
+      LPC_GPIO(pin_map[pin].port)->FIODIR |=  LPC_PIN(pin_map[pin].pin);
+      PINSEL_ConfigPin(&config);
+      break;
+    case INPUT_PULLUP:
+      LPC_GPIO(pin_map[pin].port)->FIODIR &= ~LPC_PIN(pin_map[pin].pin);
+      config.Pinmode = PINSEL_PINMODE_PULLUP;
+      PINSEL_ConfigPin(&config);
+      break;
+    default:
+      break;
+    }
+  }
+
+
+  void u8g_SetPinOutput(uint8_t internal_pin_number) {
+     pinMode_LCD(internal_pin_number, 1);  // OUTPUT
+  }
+
+  void u8g_SetPinInput(uint8_t internal_pin_number) {
+     pinMode_LCD(internal_pin_number, 0);  // INPUT
+  }
+
+
+
+  void u8g_SetPinLevel(uint8_t  pin, uint8_t  pin_status) {
+    if (!WITHIN(pin, 0, NUM_DIGITAL_PINS - 1) || pin_map[pin].port == 0xFF)
+      return;
+
+    if (pin_status)
+      LPC_GPIO(pin_map[pin].port)->FIOSET = LPC_PIN(pin_map[pin].pin);
+    else
+      LPC_GPIO(pin_map[pin].port)->FIOCLR = LPC_PIN(pin_map[pin].pin);
+  }
+
+  uint8_t u8g_GetPinLevel(uint8_t pin) {
+    if (!WITHIN(pin, 0, NUM_DIGITAL_PINS - 1) || pin_map[pin].port == 0xFF) {
+      return 0;  // false
+    }
+    return (uint32_t)LPC_GPIO(pin_map[pin].port)->FIOPIN & (uint32_t)LPC_PIN(pin_map[pin].pin) ? 1 : 0;
+  }
+
+
+  #ifdef __cplusplus
+    }
+  #endif
+
+#endif

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_SPI_routines.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_SPI_routines.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -20,14 +20,32 @@
  *
  */
 
-#ifndef __HAL_PINMAPPING_H__
-#define __HAL_PINMAPPING_H__
-#include "src/core/macros.h"
+/**
+ * Low level pin manipulation routines - used by all the drivers.
+ *
+ * These are based on the LPC1768 pinMode, digitalRead & digitalWrite routines.
+ *
+ * Couldn't just call exact copies because the overhead killed the LCD update speed
+ * With an intermediate level the softspi was running in the 10-20kHz range which
+ * resulted in using about about 25% of the CPU's time.
+ */
 
-#if defined(IS_REARM)
-  #include "pinmap_re_arm.h"
-#else
-  #error "HAL: LPC1768: No defined pin-mapping"
+
+
+#ifdef __cplusplus
+    extern "C" {
 #endif
 
-#endif // __HAL_PINMAPPING_H__
+void u8g_SetPinOutput(uint8_t internal_pin_number);
+
+void u8g_SetPinInput(uint8_t internal_pin_number);
+
+void u8g_SetPinLevel(uint8_t  pin, uint8_t  pin_status);
+
+uint8_t u8g_GetPinLevel(uint8_t pin);
+
+#ifdef __cplusplus
+  }
+#endif
+
+

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_class.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_class.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -20,14 +20,22 @@
  *
  */
 
-#ifndef __HAL_PINMAPPING_H__
-#define __HAL_PINMAPPING_H__
-#include "src/core/macros.h"
+/**
+* class declarations for new devices
+*/
 
-#if defined(IS_REARM)
-  #include "pinmap_re_arm.h"
-#else
-  #error "HAL: LPC1768: No defined pin-mapping"
-#endif
 
-#endif // __HAL_PINMAPPING_H__
+class U8GLIB_SH1106_128X64_2X_I2C_2_WIRE : public U8GLIB {
+  public:
+    U8GLIB_SH1106_128X64_2X_I2C_2_WIRE(uint8_t options = U8G_I2C_OPT_NONE) 
+    : U8GLIB(&u8g_dev_sh1106_128x64_2x_i2c_2_wire, options)
+    {  }
+};
+
+class U8GLIB_SSD1306_128X64_2X_I2C_2_WIRE : public U8GLIB {
+  public:
+    U8GLIB_SSD1306_128X64_2X_I2C_2_WIRE(uint8_t options = U8G_I2C_OPT_NONE) 
+    : U8GLIB(&u8g_dev_ssd1306_128x64_2x_i2c_2_wire, options)
+    {  }
+};
+

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_delay.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LCD_delay.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -20,14 +20,27 @@
  *
  */
 
-#ifndef __HAL_PINMAPPING_H__
-#define __HAL_PINMAPPING_H__
-#include "src/core/macros.h"
+/**
+ * LCD delay routines - used by all the drivers.
+ *
+ * These are based on the LPC1768 routines.
+ *
+ * Couldn't just call exact copies because the overhead resulted in the
+ * one microsecond delay being about 4uS.
+ */
 
-#if defined(IS_REARM)
-  #include "pinmap_re_arm.h"
-#else
-  #error "HAL: LPC1768: No defined pin-mapping"
+
+
+#ifdef __cplusplus
+  extern "C" {
 #endif
 
-#endif // __HAL_PINMAPPING_H__
+void U8g_delay(int msec);
+
+void u8g_MicroDelay(void);
+
+void u8g_10MicroDelay(void);
+
+#ifdef __cplusplus
+  }
+#endif

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_LPC1768_LCD_defines.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_LPC1768_LCD_defines.h
@@ -1,0 +1,61 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+* LPC1768 LCD specific defines
+*/
+
+#if defined(TARGET_LPC1768)
+  
+  // pointers to low level routines - must always supply these
+//  #define U8G_HAL_LINKS
+  #define HAL_LCD_SPI_routines "HAL_LPC1768/HAL_LCD_SPI_routines.h"
+  #define HAL_LCD_I2C_routines  "HAL_LPC1768/HAL_LCD_I2C_routines.h"
+  #define HAL_LCD_delay "HAL_LPC1768/HAL_LCD_delay.h"
+  #define HAL_LCD_class "HAL_LPC1768/HAL_LCD_class.h"
+
+  // The following are optional depending on the platform.
+
+  // definitions of HAL specific com and device drivers.
+  uint8_t u8g_com_LPC1768_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+  uint8_t u8g_com_LPC1768_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+  uint8_t u8g_com_LPC1768_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+  uint8_t u8g_com_LPC1768_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+
+  // connect U8g com generic com names to the desired driver
+  #define U8G_COM_HW_SPI u8g_com_LPC1768_hw_spi_fn  // use LPC1768 specific hardware SPI routine
+  #define U8G_COM_SW_SPI u8g_com_LPC1768_sw_spi_fn  // use LPC1768 specific software SPI routine
+  #define U8G_COM_ST7920_HW_SPI u8g_com_LPC1768_st7920_hw_spi_fn
+  #define U8G_COM_SSD_I2C u8g_com_LPC1768_ssd_i2c_fn
+
+  // let these default for now
+  #define U8G_COM_PARALLEL u8g_com_null_fn
+  #define U8G_COM_T6963 u8g_com_null_fn
+  #define U8G_COM_FAST_PARALLEL u8g_com_null_fn
+  #define U8G_COM_UC_I2C u8g_com_null_fn
+  #define U8G_COM_ST7920_SW_SPI u8g_com_null_fn
+
+//add I2C 2 wire devices
+extern u8g_dev_t u8g_dev_sh1106_128x64_2x_i2c_2_wire;
+extern u8g_dev_t u8g_dev_ssd1306_128x64_2x_i2c_2_wire;
+
+#endif

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_spi.cpp
@@ -301,5 +301,14 @@
   }
 #endif // ENABLED(LPC_SOFTWARE_SPI)
 
+
+  #define WITHIN_HAL_SPI  // flag to make sure the following file is only compile from within HAL_spi.h
+
+  #include "HAL_u8g_com_LPC1768_hw_spi.c"  //easiest way to get all the linkages to work.
+                                     // kept getting undefined references to the SPI routines if
+                                     // this was stand alone.  Including HAL_spi.cpp within this file
+                                     // just resulted in other errors.
+  #include "HAL_u8g_com_LPC1768_st7920_hw_spi.c"
+
 #endif // TARGET_LPC1768
 

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_hw_spi.c
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_hw_spi.c
@@ -1,0 +1,161 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/*
+
+  based on u8g_com_msp430_hw_spi.c
+
+  Universal 8bit Graphics Library
+
+  Copyright (c) 2012, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list
+  of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+
+#if  defined(WITHIN_HAL_SPI)  // mechanism to keep this file from being compiled twice
+
+  #ifdef __cplusplus
+    extern "C" {
+  #endif
+
+  #if !defined(U8G_LPC1768_HW_SPI)
+    #define U8G_LPC1768_HW_SPI
+
+    #include <inttypes.h>
+
+    #include "src/core/macros.h"
+    #include "Configuration.h"
+
+    #include <lib/u8g.h>
+
+    #define SPI_FULL_SPEED 0
+    #define SPI_HALF_SPEED 1
+    #define SPI_QUARTER_SPEED 2
+    #define SPI_EIGHTH_SPEED 3
+    #define SPI_SIXTEENTH_SPEED 4
+    #define SPI_SPEED_5 5
+    #define SPI_SPEED_6 6
+
+    uint8_t u8g_com_LPC1768_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      switch(msg)
+      {
+        case U8G_COM_MSG_STOP:
+          break;
+
+        case U8G_COM_MSG_INIT:
+          u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+          u8g_SetPILevel(u8g, U8G_PI_A0, 1);
+          u8g_SetPILevel(u8g, U8G_PI_RESET, 1);
+          u8g_SetPIOutput(u8g, U8G_PI_CS);
+          u8g_SetPIOutput(u8g, U8G_PI_A0);
+          u8g_SetPIOutput(u8g, U8G_PI_RESET);
+          u8g_Delay(5);
+          spiBegin();
+          #ifndef SPI_SPEED
+            #define SPI_SPEED SPI_FULL_SPEED  // use same SPI speed as SD card
+          #endif
+          spiInit(SPI_SPEED);
+          break;
+
+        case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+          u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+          break;
+
+        case U8G_COM_MSG_CHIP_SELECT:
+          u8g_SetPILevel(u8g, U8G_PI_CS, (arg_val ? 0 : 1));
+          break;
+
+        case U8G_COM_MSG_RESET:
+          u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+          break;
+
+        case U8G_COM_MSG_WRITE_BYTE:
+          spiSend((uint8_t)arg_val);
+          break;
+
+        case U8G_COM_MSG_WRITE_SEQ:
+          {
+            uint8_t *ptr = (uint8_t*) arg_ptr;
+            while( arg_val > 0 )
+            {
+              spiSend(*ptr++);
+              arg_val--;
+            }
+          }
+          break;
+
+        case U8G_COM_MSG_WRITE_SEQ_P:
+          {
+            uint8_t *ptr = (uint8_t*) arg_ptr;
+            while( arg_val > 0 )
+            {
+              spiSend(*ptr++);
+              arg_val--;
+            }
+          }
+          break;
+      }
+      return 1;
+    }
+
+  #else
+
+    uint8_t u8g_com_LPC1768_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      return 1;
+    }
+
+  #endif
+
+
+  #ifdef __cplusplus
+    }
+  #endif
+
+#endif

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_ssd_i2c.c
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_ssd_i2c.c
@@ -1,0 +1,222 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/*
+  
+  based on u8g_com_arduino_ssd_i2c.c
+  
+  com interface for arduino (AND atmega) and the SSDxxxx chip (SOLOMON) variant 
+  I2C protocol 
+  
+  ToDo: Rename this to u8g_com_avr_ssd_i2c.c
+  
+  Universal 8bit Graphics Library
+  
+  Copyright (c) 2012, olikraus@gmail.com
+  All rights reserved.
+  
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+  
+  * Redistributions of source code must retain the above copyright notice, this list 
+  of conditions and the following disclaimer.
+  
+  * Redistributions in binary form must reproduce the above copyright notice, this 
+  list of conditions and the following disclaimer in the documentation and/or other 
+  materials provided with the distribution.
+  
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+  
+  Special pin usage:
+  U8G_PI_I2C_OPTION	additional options
+  U8G_PI_A0_STATE	used to store the last value of the command/data register selection
+  U8G_PI_SET_A0		1: Signal request to update I2C device with new A0_STATE, 0: Do nothing, A0_STATE matches I2C device
+  U8G_PI_SCL		clock line (NOT USED)
+  U8G_PI_SDA		data line (NOT USED)
+  
+  U8G_PI_RESET		reset line (currently disabled, see below)
+  
+  Protocol:
+  SLA, Cmd/Data Selection, Arguments
+  The command/data register is selected by a special instruction byte, which is sent after SLA
+  
+  The continue bit is always 0 so that a (re)start is equired for the change from cmd to/data mode
+*/
+
+#if defined(TARGET_LPC1768)
+
+  #include <lib/u8g.h>
+
+  #if defined(U8G_WITH_PINLIST)
+    #ifdef __cplusplus
+        extern "C" {
+    #endif    
+    
+    #define I2C_SLA         (0x3c*2)
+    //#define I2C_CMD_MODE  0x080
+    #define I2C_CMD_MODE    0x000
+    #define I2C_DATA_MODE   0x040
+    
+//    #define U8G_I2C_OPT_FAST 16
+    
+    uint8_t u8g_com_arduino_ssd_start_sequence(u8g_t *u8g)
+    {
+      /* are we requested to set the a0 state? */
+      if ( u8g->pin_list[U8G_PI_SET_A0] == 0 )
+        return 1;
+      
+      /* setup bus, might be a repeated start */
+      if ( u8g_i2c_start(I2C_SLA) == 0 )
+        return 0;
+      if ( u8g->pin_list[U8G_PI_A0_STATE] == 0 )
+      {
+        if ( u8g_i2c_send_byte(I2C_CMD_MODE) == 0 )
+          return 0;
+      }
+      else
+      {
+        if ( u8g_i2c_send_byte(I2C_DATA_MODE) == 0 )
+          return 0;
+      }
+      
+      u8g->pin_list[U8G_PI_SET_A0] = 0;
+        return 1;
+    }
+    
+    uint8_t u8g_com_LPC1768_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      switch(msg)
+      {
+        case U8G_COM_MSG_INIT:
+        //u8g_com_arduino_digital_write(u8g, U8G_PI_SCL, HIGH);
+        //u8g_com_arduino_digital_write(u8g, U8G_PI_SDA, HIGH);
+        //u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: unknown mode */
+        
+        u8g_i2c_init(u8g->pin_list[U8G_PI_I2C_OPTION]);
+u8g_com_arduino_ssd_start_sequence(u8g);
+        break;
+        
+        case U8G_COM_MSG_STOP:
+        break;
+        
+        case U8G_COM_MSG_RESET:
+          /* Currently disabled, but it could be enable. Previous restrictions have been removed */
+          /* u8g_com_arduino_digital_write(u8g, U8G_PI_RESET, arg_val); */
+          break;
+          
+          case U8G_COM_MSG_CHIP_SELECT:
+          u8g->pin_list[U8G_PI_A0_STATE] = 0;
+          u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again, also forces start condition */
+          if ( arg_val == 0 )
+          {
+            /* disable chip, send stop condition */
+            u8g_i2c_stop();
+          }
+          else
+          {
+            /* enable, do nothing: any byte writing will trigger the i2c start */
+          }
+          break;
+        
+        case U8G_COM_MSG_WRITE_BYTE:
+          //u8g->pin_list[U8G_PI_SET_A0] = 1;
+//          if ( u8g_com_arduino_ssd_start_sequence(u8g) == 0 )
+//            return u8g_i2c_stop(), 0;
+          if ( u8g_i2c_send_byte(arg_val) == 0 )
+            return u8g_i2c_stop(), 0;
+          // u8g_i2c_stop();
+          break;
+        
+        case U8G_COM_MSG_WRITE_SEQ:
+          //u8g->pin_list[U8G_PI_SET_A0] = 1;
+          if ( u8g_com_arduino_ssd_start_sequence(u8g) == 0 )
+            return u8g_i2c_stop(), 0;
+          {
+            register uint8_t *ptr = arg_ptr;
+            while( arg_val > 0 )
+            {
+              if ( u8g_i2c_send_byte(*ptr++) == 0 )
+                return u8g_i2c_stop(), 0;
+              arg_val--;
+            }
+          }
+          // u8g_i2c_stop();
+          break;
+        
+        case U8G_COM_MSG_WRITE_SEQ_P:
+          //u8g->pin_list[U8G_PI_SET_A0] = 1;
+          if ( u8g_com_arduino_ssd_start_sequence(u8g) == 0 )
+            return u8g_i2c_stop(), 0;
+          {
+            register uint8_t *ptr = arg_ptr;
+            while( arg_val > 0 )
+            {
+              if ( u8g_i2c_send_byte(u8g_pgm_read(ptr)) == 0 )
+                return 0;
+              ptr++;
+              arg_val--;
+            }
+          }
+          // u8g_i2c_stop();
+          break;
+        
+        case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+          u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+          u8g->pin_list[U8G_PI_SET_A0] = 1;		/* force a0 to set again */
+          
+          u8g_i2c_start(0); // send slave address and write bit
+          if (arg_val)
+            u8g_i2c_send_byte(0x40);  // write to graphics DRAM mode 
+          else
+            u8g_i2c_send_byte(0x80);  //command mode 
+          break;
+      }
+      return 1;
+    }
+    
+  #else  /* defined(U8G_WITH_PINLIST) */
+    
+    uint8_t u8g_com_LPC1768_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      return 1;
+    }
+    
+    
+    #ifdef __cplusplus
+      }
+    #endif
+    
+  #endif /* defined(U8G_WITH_PINLIST) */
+#endif // TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_st7920_hw_spi.c
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_st7920_hw_spi.c
@@ -1,0 +1,179 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/*
+
+  based on u8g_com_LPC1768_st7920_hw_spi.c
+
+  Universal 8bit Graphics Library
+
+  Copyright (c) 2011, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list
+    of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice, this
+    list of conditions and the following disclaimer in the documentation and/or other
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#if  defined(WITHIN_HAL_SPI)  // mechanism to keep this file from being compiled twice
+
+  #ifdef __cplusplus
+    extern "C" {
+  #endif
+
+  #if !defined(U8G_LPC1768_st7920_HW_SPI)
+    #define U8G_LPC1768_st7920_HW_SPI
+
+    #include <inttypes.h>
+
+    #include "src/core/macros.h"
+    #include "Configuration.h"
+
+    #include <lib/u8g.h>
+
+    #define SPI_FULL_SPEED 0
+    #define SPI_HALF_SPEED 1
+    #define SPI_QUARTER_SPEED 2
+    #define SPI_EIGHTH_SPEED 3
+    #define SPI_SIXTEENTH_SPEED 4
+    #define SPI_SPEED_5 5
+    #define SPI_SPEED_6 6
+
+    static void u8g_com_LPC1768_st7920_write_byte_hw_spi(uint8_t rs, uint8_t val)
+    {
+      uint8_t i;
+
+      if ( rs == 0 )
+      {
+        /* command */
+        spiSend(0x0f8);
+      }
+      else if ( rs == 1 )
+      {
+        /* data */
+        spiSend(0x0fa);
+      }
+
+      spiSend(val & 0x0f0);
+      spiSend(val << 4);
+
+      for( i = 0; i < 4; i++ )   // give the controller some time to process the data
+        u8g_10MicroDelay();      // 2 is bad, 3 is OK, 4 is safe
+    }
+
+
+    uint8_t u8g_com_LPC1768_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      switch(msg)
+      {
+        case U8G_COM_MSG_INIT:
+          u8g_SetPILevel(u8g, U8G_PI_CS, 0);
+          u8g_SetPIOutput(u8g, U8G_PI_CS);
+          u8g_Delay(5);
+          spiBegin();
+          #ifndef SPI_SPEED
+            #define SPI_SPEED SPI_FULL_SPEED  // use same SPI speed as SD card
+          #endif
+          spiInit(SPI_SPEED);
+          u8g->pin_list[U8G_PI_A0_STATE] = 0;       /* inital RS state: command mode */
+          break;
+
+        case U8G_COM_MSG_STOP:
+          break;
+
+        case U8G_COM_MSG_RESET:
+          u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+          break;
+
+        case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+          u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
+          break;
+
+        case U8G_COM_MSG_CHIP_SELECT:
+          u8g_SetPILevel(u8g, U8G_PI_CS, arg_val);  //note: the st7920 has an active high chip select
+          break;
+
+        case U8G_COM_MSG_WRITE_BYTE:
+          u8g_com_LPC1768_st7920_write_byte_hw_spi(u8g->pin_list[U8G_PI_A0_STATE], arg_val);
+          break;
+
+        case U8G_COM_MSG_WRITE_SEQ:
+          {
+            uint8_t *ptr = (uint8_t*) arg_ptr;
+            while( arg_val > 0 )
+            {
+              u8g_com_LPC1768_st7920_write_byte_hw_spi(u8g->pin_list[U8G_PI_A0_STATE], *ptr++);
+              arg_val--;
+            }
+          }
+          break;
+
+          case U8G_COM_MSG_WRITE_SEQ_P:
+          {
+            uint8_t *ptr = (uint8_t*) arg_ptr;
+            while( arg_val > 0 )
+            {
+              u8g_com_LPC1768_st7920_write_byte_hw_spi(u8g->pin_list[U8G_PI_A0_STATE], *ptr++);
+              arg_val--;
+            }
+          }
+          break;
+      }
+      return 1;
+    }
+
+  #else
+
+    uint8_t u8g_com_LPC1768_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      return 1;
+    }
+  #endif
+
+
+  #ifdef __cplusplus
+    }
+  #endif
+
+#endif
+

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_sw_spi.c
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_u8g_com_LPC1768_sw_spi.c
@@ -1,0 +1,191 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/*
+  
+  based on u8g_com_std_sw_spi.c
+
+  Universal 8bit Graphics Library
+  
+  Copyright (c) 2015, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list 
+    of conditions and the following disclaimer.
+    
+  * Redistributions in binary form must reproduce the above copyright notice, this 
+    list of conditions and the following disclaimer in the documentation and/or other 
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+  
+*/
+
+
+
+// set SPI_speed for desired peak bit rate
+
+#if defined(TARGET_LPC1768)
+
+  #include <lib/u8g.h>
+
+
+  #if defined(U8G_WITH_PINLIST)
+    
+    #ifdef __cplusplus
+      extern "C" {
+    #endif  
+    
+
+
+    static void u8g_LPC1768_sw_spi_shift_out(uint8_t dataPin, uint8_t clockPin, uint8_t val) 
+    {
+      #define SPI_speed 0  // set this define for the desired speed
+                           // 0 -  800KHz peak, 1+ - 250KHz peak
+
+      if (!SPI_speed) {   // about 800KHz
+        for (int bits = 0; bits < 8; bits++) {
+          if (val & 0x80) u8g_SetPinLevel(dataPin, 1);
+          else u8g_SetPinLevel(dataPin, 0);
+          val <<= 1;
+          u8g_SetPinLevel(clockPin, 1);
+          u8g_SetPinLevel(clockPin, 0);
+        }
+      }
+      else { // about 250 KHz
+        for (int bits = 0; bits < 8; bits++) {
+          if (val & 0x80) {
+            u8g_SetPinLevel(dataPin, 1);
+          }
+          else {
+            u8g_SetPinLevel(dataPin, 0);
+          }
+          val <<= 1;
+          u8g_MicroDelay();
+          u8g_SetPinLevel(clockPin, 1);
+          u8g_MicroDelay();
+
+          u8g_SetPinLevel(clockPin, 0);
+          u8g_MicroDelay();
+        }
+      }
+    }
+
+    uint8_t u8g_com_LPC1768_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      switch(msg)
+      {
+        case U8G_COM_MSG_INIT:
+          u8g_SetPIOutput(u8g, U8G_PI_SCK);
+          u8g_SetPIOutput(u8g, U8G_PI_MOSI);
+          u8g_SetPIOutput(u8g, U8G_PI_RESET);
+          u8g_SetPIOutput(u8g, U8G_PI_CS);
+          u8g_SetPIOutput(u8g, U8G_PI_A0);
+          u8g_SetPILevel(u8g, U8G_PI_SCK, 0);
+          u8g_SetPILevel(u8g, U8G_PI_MOSI, 0);
+          break;
+        
+        case U8G_COM_MSG_STOP:
+          break;
+
+        case U8G_COM_MSG_RESET:
+          u8g_SetPILevel(u8g, U8G_PI_RESET, arg_val);
+          break;
+          
+        case U8G_COM_MSG_CHIP_SELECT:
+          if ( arg_val == 0 )
+          {
+            /* disable */
+            u8g_SetPILevel(u8g, U8G_PI_CS, 1);
+          }
+          else
+          {
+            /* enable */
+            u8g_SetPILevel(u8g, U8G_PI_SCK, 0);
+            u8g_SetPILevel(u8g, U8G_PI_CS, 0);
+          }
+          break;
+
+        case U8G_COM_MSG_WRITE_BYTE:
+          u8g_LPC1768_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], arg_val);
+          break;
+        
+        case U8G_COM_MSG_WRITE_SEQ:
+          {
+            uint8_t *ptr = (uint8_t*) arg_ptr;
+            while( arg_val > 0 )
+            {
+              u8g_LPC1768_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], *ptr++);
+              arg_val--;
+            }
+          }
+          break;
+
+          case U8G_COM_MSG_WRITE_SEQ_P:
+          {
+            uint8_t *ptr = (uint8_t*) arg_ptr;
+            while( arg_val > 0 )
+            {
+              u8g_LPC1768_sw_spi_shift_out(u8g->pin_list[U8G_PI_MOSI], u8g->pin_list[U8G_PI_SCK], u8g_pgm_read(ptr));
+              ptr++;
+              arg_val--;
+            }
+          }
+          break;
+          
+        case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+          u8g_SetPILevel(u8g, U8G_PI_A0, arg_val);
+          break;
+      }
+      return 1;
+    }
+
+    #else
+
+
+    uint8_t u8g_com_LPC1768_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+    {
+      return 1;
+    }
+
+    #ifdef __cplusplus
+      }
+    #endif
+
+  #endif
+#endif

--- a/Marlin/src/HAL/HAL_LPC1768/pinmap_re_arm.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmap_re_arm.h
@@ -27,6 +27,10 @@
 // Runtime pinmapping
 // ******************
 
+typedef struct  { int port, pin; } pin_data;
+typedef struct  { uint8_t port, pin, adc; } adc_pin_data;
+
+
 #define NUM_ANALOG_INPUTS 8
 
 const adc_pin_data adc_pin_map[] = {

--- a/Marlin/src/lcd/dogm/u8g_dev_ssd1306_sh1106_128x64_I2C.c
+++ b/Marlin/src/lcd/dogm/u8g_dev_ssd1306_sh1106_128x64_I2C.c
@@ -1,0 +1,299 @@
+/*
+
+  u8g_dev_ssd1306_128x64.c
+
+  Universal 8bit Graphics Library
+  
+  Copyright (c) 2011, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification, 
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list 
+    of conditions and the following disclaimer.
+    
+  * Redistributions in binary form must reproduce the above copyright notice, this 
+    list of conditions and the following disclaimer in the documentation and/or other 
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND 
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, 
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR 
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, 
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF 
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  
+  
+  
+*/
+
+/**
+  * These routines are meant for two wire I2C interfaces.
+ *
+ * Three and four wire I2C interfaces have an A0 line.  That line is
+ * used to switch between command and data modes.
+ *
+ * The two wire LCDs use an instruction byte to signal if data or
+ * command info is to follow.  The command stream needs the instruction
+ * byte between eack command byte.  The data stream needs one at the
+ * beginning.
+ */
+
+#include <lib/u8g.h>
+
+#define WIDTH 128
+#define HEIGHT 64
+#define PAGE_HEIGHT 8
+
+uint8_t u8g_WriteEscSeqP_2_wire(u8g_t *u8g, u8g_dev_t *dev, const uint8_t *esc_seq);
+
+// The sh1106 is compatible to the ssd1306, but is 132x64. 128x64 display area is centered within
+// the 132x64.
+
+
+static const uint8_t u8g_dev_sh1106_128x64_data_start_2_wire[] PROGMEM = {
+  0x040,		// start line - may not be needed
+  0x010,		// set upper 4 bit of the col adr to 0 
+  0x002,		// set lower 4 bit of the col adr to 2 (centered display with ssd1306)  
+  U8G_ESC_END                // end of sequence 
+};
+
+
+static const uint8_t u8g_dev_sh1106_128x64_init_seq_2_wire[] PROGMEM = {
+  U8G_ESC_ADR(0),  // initiate command mode
+  0x0ae,				/* display off, sleep mode */
+  0x0a8, 0x03f,		/* mux ratio */
+  0x0d3, 0x00,		/* display offset */
+  0x040,				/* start line */
+  0x0a1,				/* segment remap a0/a1*/
+  0x0c8,				/* c0: scan dir normal, c8: reverse */ 
+  0x0da, 0x012,		/* com pin HW config, sequential com pin config (bit 4), disable left/right remap (bit 5) */
+  0x081, 0x0cf,		/* [2] set contrast control */
+  0x020, 0x002,		/* 2012-05-27: page addressing mode */
+  0x21, 2, 0x81,   // set column range from 0 through 131
+  0x22, 0, 7,   // set page range from 0 through 7
+  0x0d9, 0x0f1,		/* [2] pre-charge period 0x022/f1*/
+  0x0db, 0x040,		/* vcomh deselect level */
+  0x0a4,				/* output ram to display */
+  0x0a6,				/* none inverted normal display mode */  
+  0x0d5, 0x080,		/* clock divide ratio (0x00=1) and oscillator frequency (0x8) */
+  0x08d, 0x014,		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */  
+  0x02e,				/* 2012-05-27: Deactivate scroll */ 
+  0x0af,				/* display on */ 
+  U8G_ESC_END                /* end of sequence */
+};
+
+
+uint8_t u8g_dev_sh1106_128x64_2x_2_wire_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  switch(msg)
+  {
+    case U8G_DEV_MSG_INIT:
+      u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
+      u8g_WriteEscSeqP_2_wire(u8g, dev, u8g_dev_sh1106_128x64_init_seq_2_wire);
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      {
+        u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+        u8g_SetAddress(u8g, dev, 0);           // instruction mode 		
+        u8g_WriteEscSeqP_2_wire(u8g, dev, u8g_dev_sh1106_128x64_data_start_2_wire);    
+        u8g_WriteByte(u8g, dev, 0x0b0 | (pb->p.page*2)); // select current page 
+        u8g_SetAddress(u8g, dev, 1);           // data mode 
+        u8g_WriteSequence(u8g, dev, pb->width, pb->buf); 
+        u8g_SetChipSelect(u8g, dev, 0);
+        u8g_SetAddress(u8g, dev, 0);           // instruction mode 	
+        u8g_WriteEscSeqP_2_wire(u8g, dev, u8g_dev_sh1106_128x64_data_start_2_wire);    
+        u8g_WriteByte(u8g, dev, 0x0b0 | (pb->p.page*2+1)); // select current page 
+        u8g_SetAddress(u8g, dev, 1);           // data mode 
+        u8g_WriteSequence(u8g, dev, pb->width, (uint8_t *)(pb->buf)+pb->width); 
+        u8g_SetChipSelect(u8g, dev, 0);
+      }
+      break;
+    case U8G_DEV_MSG_SLEEP_ON:
+      return 1;
+    case U8G_DEV_MSG_SLEEP_OFF:
+      return 1;
+  }
+  return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
+}
+
+
+uint8_t u8g_dev_sh1106_128x64_2x_buf[WIDTH*2] U8G_NOCOMMON ; 
+u8g_pb_t u8g_dev_sh1106_128x64_2x_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_sh1106_128x64_2x_buf}; 
+u8g_dev_t u8g_dev_sh1106_128x64_2x_i2c = { u8g_dev_sh1106_128x64_2x_2_wire_fn, &u8g_dev_sh1106_128x64_2x_pb, U8G_COM_SSD_I2C };
+
+
+uint8_t u8g_dev_sh1106_128x64_2x_i2c_2_wire_buf[WIDTH*2] U8G_NOCOMMON ; 
+u8g_pb_t u8g_dev_sh1106_128x64_2x_i2c_2_wire_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_sh1106_128x64_2x_i2c_2_wire_buf}; 
+u8g_dev_t u8g_dev_sh1106_128x64_2x_i2c_2_wire = { u8g_dev_sh1106_128x64_2x_2_wire_fn, &u8g_dev_sh1106_128x64_2x_i2c_2_wire_pb, U8G_COM_SSD_I2C };
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+static const uint8_t u8g_dev_ssd1306_128x64_data_start_2_wire[] PROGMEM = {
+  0x040,		// start line - may not be needed
+  0x010,		// set upper 4 bit of the col adr to 0 
+  0x000,		// set lower 4 bit of the col adr to 0  
+  U8G_ESC_END                // end of sequence 
+};
+
+
+static const uint8_t u8g_dev_ssd1306_128x64_init_seq_2_wire[] PROGMEM = {
+  U8G_ESC_ADR(0),  // initiate command mode
+  0x0ae,				/* display off, sleep mode */
+  0x0a8, 0x03f,		/* mux ratio */
+  0x0d3, 0x00,		/* display offset */
+  0x040,				/* start line */
+  0x0a1,				/* segment remap a0/a1*/
+  0x0c8,				/* c0: scan dir normal, c8: reverse */ 
+  0x0da, 0x012,		/* com pin HW config, sequential com pin config (bit 4), disable left/right remap (bit 5) */
+  0x081, 0x0cf,		/* [2] set contrast control */
+  0x020, 0x002,		/* 2012-05-27: page addressing mode */
+  0x21, 0, 0x7f,   // set column range from 0 through 127
+  0x22, 0, 7,   // set page range from 0 through 7
+  0x0d9, 0x0f1,		/* [2] pre-charge period 0x022/f1*/
+  0x0db, 0x040,		/* vcomh deselect level */
+  0x0a4,				/* output ram to display */
+  0x0a6,				/* none inverted normal display mode */  
+  0x0d5, 0x080,		/* clock divide ratio (0x00=1) and oscillator frequency (0x8) */
+  0x08d, 0x014,		/* [2] charge pump setting (p62): 0x014 enable, 0x010 disable */  
+  0x02e,				/* 2012-05-27: Deactivate scroll */ 
+  0x0af,				/* display on */ 
+  U8G_ESC_END                /* end of sequence */
+};
+
+
+uint8_t u8g_dev_ssd1306_128x64_2x_2_wire_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  switch(msg)
+  {
+    case U8G_DEV_MSG_INIT:
+      u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
+      u8g_WriteEscSeqP_2_wire(u8g, dev, u8g_dev_ssd1306_128x64_init_seq_2_wire);
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      {
+        u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+        u8g_SetAddress(u8g, dev, 0);           // instruction mode 		
+        u8g_WriteEscSeqP_2_wire(u8g, dev, u8g_dev_ssd1306_128x64_data_start_2_wire);    
+        u8g_WriteByte(u8g, dev, 0x0b0 | (pb->p.page*2)); // select current page 
+        u8g_SetAddress(u8g, dev, 1);           // data mode 
+        u8g_WriteSequence(u8g, dev, pb->width, pb->buf); 
+        u8g_SetChipSelect(u8g, dev, 0);
+        u8g_SetAddress(u8g, dev, 0);           // instruction mode 	
+        u8g_WriteEscSeqP_2_wire(u8g, dev, u8g_dev_ssd1306_128x64_data_start_2_wire);    
+        u8g_WriteByte(u8g, dev, 0x0b0 | (pb->p.page*2+1)); // select current page 
+        u8g_SetAddress(u8g, dev, 1);           // data mode 
+        u8g_WriteSequence(u8g, dev, pb->width, (uint8_t *)(pb->buf)+pb->width); 
+        u8g_SetChipSelect(u8g, dev, 0);
+      }
+      break;
+    case U8G_DEV_MSG_SLEEP_ON:
+      return 1;
+    case U8G_DEV_MSG_SLEEP_OFF:
+      return 1;
+  }
+  return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
+}
+
+
+uint8_t u8g_dev_ssd1306_128x64_2x_buf[WIDTH*2] U8G_NOCOMMON ; 
+u8g_pb_t u8g_dev_ssd1306_128x64_2x_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_ssd1306_128x64_2x_buf}; 
+u8g_dev_t u8g_dev_ssd1306_128x64_2x_i2c = { u8g_dev_ssd1306_128x64_2x_2_wire_fn, &u8g_dev_ssd1306_128x64_2x_pb, U8G_COM_SSD_I2C };
+
+
+uint8_t u8g_dev_ssd1306_128x64_2x_i2c_2_wire_buf[WIDTH*2] U8G_NOCOMMON ; 
+u8g_pb_t u8g_dev_ssd1306_128x64_2x_i2c_2_wire_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_ssd1306_128x64_2x_i2c_2_wire_buf}; 
+u8g_dev_t u8g_dev_ssd1306_128x64_2x_i2c_2_wire = { u8g_dev_ssd1306_128x64_2x_2_wire_fn, &u8g_dev_ssd1306_128x64_2x_i2c_2_wire_pb, U8G_COM_SSD_I2C };
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+
+// This routine adds the instruction byte in between the command bytes.  This makes the init
+// sequences a lot easier to read.
+
+#define I2C_CMD_MODE    0x080
+
+uint8_t u8g_WriteEscSeqP_2_wire(u8g_t *u8g, u8g_dev_t *dev, const uint8_t *esc_seq)
+{
+  uint8_t is_escape = 0;
+  uint8_t value;
+  for(;;)
+  {
+    value = u8g_pgm_read(esc_seq);
+    if ( is_escape == 0 )
+    {
+      if ( value != 255 )
+      {
+        if ( u8g_WriteByte(u8g, dev, value) == 0 )
+          return 0;
+        if ( u8g_WriteByte(u8g, dev, I2C_CMD_MODE) == 0 ) 
+          return 0;
+      }
+      else
+      {
+        is_escape = 1;
+      }
+    }
+    else
+    {
+      if ( value == 255 )
+      {
+        if ( u8g_WriteByte(u8g, dev, value) == 0 )
+          return 0;
+        if ( u8g_WriteByte(u8g, dev, I2C_CMD_MODE) == 0 ) 
+          return 0;  
+      }
+      else if ( value == 254 )
+      {
+        break;
+      }
+      else if ( value >= 0x0f0 )
+      {
+        /* not yet used, do nothing */
+      }
+      else if ( value >= 0xe0  )
+      {
+        u8g_SetAddress(u8g, dev, value & 0x0f);
+      }
+      else if ( value >= 0xd0 )
+      {
+        u8g_SetChipSelect(u8g, dev, value & 0x0f);
+      }
+      else if ( value >= 0xc0 )
+      {
+        u8g_SetResetLow(u8g, dev);
+        value &= 0x0f;
+        value <<= 4;
+        value+=2;
+        u8g_Delay(value);
+        u8g_SetResetHigh(u8g, dev);
+        u8g_Delay(value);
+      }
+      else if ( value >= 0xbe )
+      {
+	/* not yet implemented */
+        /* u8g_SetVCC(u8g, dev, value & 0x01); */
+      }
+      else if ( value <= 127 )
+      {
+        u8g_Delay(value);
+      }
+      is_escape = 0;
+    }
+    esc_seq++;
+  }
+  return 1;
+}
+  
+  

--- a/Marlin/src/lcd/dogm/ultralcd_st7565_u8glib_VIKI.h
+++ b/Marlin/src/lcd/dogm/ultralcd_st7565_u8glib_VIKI.h
@@ -26,7 +26,7 @@
 #include <src/Marlin.h>
 
 #if ENABLED(U8GLIB_ST7565_64128N)
-
+#if ( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(DOGLCD_MOSI) &&  DOGLCD_MOSI >= 0) &&  (defined(DOGLCD_SCK) &&  DOGLCD_SCK >= 0))
 
 #define ST7565_CLK_PIN  DOGLCD_SCK
 #define ST7565_DAT_PIN  DOGLCD_MOSI
@@ -171,7 +171,6 @@ uint8_t u8g_dev_st7565_64128n_2x_VIKI_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg
       ST7565_WRITE_BYTE(0x028 | 0x07);  /* power control: turn on voltage follower */
 //   U8G_ESC_DLY(50);                   /* delay 50 ms - hangs after a reset if used */
 
-
       ST7565_WRITE_BYTE(0x010);         /* Set V0 voltage resistor ratio. Setting for controlling brightness of Displaytech 64128N */
 
       ST7565_WRITE_BYTE(0x0a6);         /* display normal, bit val 0: LCD pixel off. */
@@ -264,5 +263,6 @@ class U8GLIB_ST7565_64128n_2x_VIKI : public U8GLIB {
 
 #pragma GCC reset_options
 
+#endif //#if ( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(DOGLCD_MOSI) &&  DOGLCD_MOSI >= 0) &&  (defined(DOGLCD_SCK) &&  DOGLCD_SCK >= 0))
 #endif // U8GLIB_ST7565
 #endif // ULCDST7565_H

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd.h
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd.h
@@ -23,9 +23,10 @@
 #ifndef ULCDST7920_H
 #define ULCDST7920_H
 
-#include "../../Marlin.h"
+#include <src/Marlin.h>
 
 #if ENABLED(U8GLIB_ST7920)
+#if ( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(LCD_PINS_D4) &&  LCD_PINS_D4 >= 0) &&  (defined(LCD_PINS_ENABLE) &&  LCD_PINS_ENABLE >= 0))
 
 #define ST7920_CLK_PIN  LCD_PINS_D4
 #define ST7920_DAT_PIN  LCD_PINS_ENABLE
@@ -219,5 +220,6 @@ class U8GLIB_ST7920_128X64_RRD : public U8GLIB {
 
 #pragma GCC reset_options
 
+#endif //( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(LCD_PINS_D4) &&  LCD_PINS_D4 >= 0) &&  (defined(LCD_PINS_ENABLE) &&  LCD_PINS_ENABLE >= 0))
 #endif // U8GLIB_ST7920
 #endif // ULCDST7920_H

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -51,7 +51,7 @@
 #if ENABLED(SDSUPPORT)
   #include "../libs/duration_t.h"
 #endif
-
+ 
 #include <U8glib.h>
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -157,13 +157,15 @@
   U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_RS); // 2 stripes
   // U8GLIB_ST7920_128X64 u8g(LCD_PINS_RS); // 8 stripes
 #elif ENABLED(U8GLIB_ST7920)
-  //U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes
-                                                                            // No 4 stripe device available from u8glib.
-  //U8GLIB_ST7920_128X64_1X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS);    // Original u8glib device. 8 stripes
-  U8GLIB_ST7920_128X64_RRD u8g(0); // Number of stripes can be adjusted in ultralcd_st7920_u8glib_rrd.h with PAGE_HEIGHT
+  #if ( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(LCD_PINS_D4) &&  LCD_PINS_D4 >= 0) &&  (defined(LCD_PINS_ENABLE) &&  LCD_PINS_ENABLE >= 0))    // using SW-SPI or using Re-ARM SPI
+    U8GLIB_ST7920_128X64_RRD u8g(0); // Number of stripes can be adjusted in ultralcd_st7920_u8glib_rrd.h with PAGE_HEIGHT
+  #else
+//    U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes
+    U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_RS);  //HW SPI, 2 stipes
+  #endif
 #elif ENABLED(CARTESIO_UI)
   // The CartesioUI display
-  #if DOGLCD_MOSI != -1 && DOGLCD_SCK != -1
+  #if (defined(DOGLCD_MOSI) &&  DOGLCD_MOSI >= 0) &&  (defined(DOGLCD_SCK) &&  DOGLCD_SCK >= 0)
     // using SW-SPI
     //U8GLIB_DOGM128 u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // 8 stripes
     U8GLIB_DOGM128_2X u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0); // 4 stripes
@@ -177,18 +179,22 @@
   U8GLIB_LM6059_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes
 #elif ENABLED(U8GLIB_ST7565_64128N)
   // The MaKrPanel, Mini Viki, and Viki 2.0, ST7565 controller
-  //U8GLIB_ST7565_64128n_2x_VIKI u8g(0);  // using SW-SPI DOGLCD_MOSI != -1 && DOGLCD_SCK
-  U8GLIB_ST7565_64128n_2x_VIKI u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // using SW-SPI
-  //U8GLIB_NHD_C12864 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
-  //U8GLIB_NHD_C12864_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes  HWSPI
+  #if ( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(DOGLCD_MOSI) &&  DOGLCD_MOSI >= 0) &&  (defined(DOGLCD_SCK) &&  DOGLCD_SCK >= 0))
+    // using SW-SPI or using Re-ARM SPI
+    U8GLIB_ST7565_64128n_2x_VIKI u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // using SW-SPI
+    //U8GLIB_64128N u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // software SPI (slower)
+  #else
+    U8GLIB_64128N_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes  HWSPI
+  #endif
 #elif ENABLED(U8GLIB_SSD1306)
   // Generic support for SSD1306 OLED I2C LCDs
   //U8GLIB_SSD1306_128X64 u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST);  // 8 stripes
-  U8GLIB_SSD1306_128X64_2X u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST); // 4 stripes
+  //U8GLIB_SSD1306_128X64_2X u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST); // 4 stripes
+  U8GLIB_SSD1306_128X64_2X_I2C_2_WIRE  u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST); // 4 stripes
 #elif ENABLED(U8GLIB_SH1106)
   // Generic support for SH1106 OLED I2C LCDs
-  //U8GLIB_SH1106_128X64 u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST);  // 8 stripes
-  U8GLIB_SH1106_128X64_2X u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST); // 4 stripes
+  //U8GLIB_SH1106_128X64_2X u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST); // 4 stripes
+  U8GLIB_SH1106_128X64_2X_I2C_2_WIRE  u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST); // 4 stripes
 #elif ENABLED(MINIPANEL)
   // The MINIPanel display
   //U8GLIB_MINI12864 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
@@ -196,7 +202,8 @@
 #else
   // for regular DOGM128 display with HW-SPI
   //U8GLIB_DOGM128 u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0  // 8 stripes
-  U8GLIB_DOGM128_2X u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0 // 4 stripes
+//  U8GLIB_DOGM128_2X u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0 // 4 stripes
+  U8GLIB_DOGM128_2X u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // SW-SPI // 4 stripes
 #endif
 
 #ifndef LCD_PIXEL_WIDTH
@@ -862,6 +869,7 @@ static void lcd_implementation_status_screen() {
 
   #define DRAWMENU_SETTING_EDIT_GENERIC(_src) lcd_implementation_drawmenu_setting_edit_generic(sel, row, pstr, _src)
   #define DRAW_BOOL_SETTING(sel, row, pstr, data) lcd_implementation_drawmenu_setting_edit_generic_P(sel, row, pstr, (*(data))?PSTR(MSG_ON):PSTR(MSG_OFF))
+
 
   void lcd_implementation_drawedit(const char* const pstr, const char* const value=NULL) {
     const uint8_t labellen = lcd_strlen_P(pstr),

--- a/platformio.ini
+++ b/platformio.ini
@@ -145,6 +145,7 @@ src_filter  = ${common.default_src_filter}
 platform        = nxplpc
 board_f_cpu     = 100000000L
 build_flags     = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+ -DU8G_HAL_LINKS
 src_build_flags = -Wall
 build_unflags   = -Wall
 lib_ldf_mode    = off
@@ -163,6 +164,7 @@ platform       = nxplpc
 board          = lpc1768
 board_f_cpu    = 100000000L
 build_flags    = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+ -DU8G_HAL_LINKS
 lib_ldf_mode   = off
 lib_extra_dirs = frameworks
 lib_deps       = U8glib-ARM, CMSIS-LPC1768


### PR DESCRIPTION
This pull request is meant to get feedback on the method(s) chosen.  One alternative is to create our own private U8G library.  Another is to write custom drivers (like ultralcd_st7565_u8glib_VIKI.h & ultralcd_st7920_u8glib_rrd.h) for every dogm type of display we want to support.

I've played with u8g2 a bit.  It also does not have hooks in place to support non-Arduino platforms.  What ever we do here will probably be repeated when we switch to u8g2.

----

These files should allow the LPC1768 to support all the displays that Marlin 1.x supports.

This was accomplished by adding hooks into U8glib-ARM to allow adding custom support files.  This required modifying five files.  The modified files are attached here because the standard Marlin git process doesn’t  archive the libraries. 
[U8glib-ARM_hooks.zip](https://github.com/MarlinFirmware/Marlin/files/1361672/U8glib-ARM_hooks.zip)


To activate the hooks I’m using a define that’s created in the platformio.ini file.  
`  build_flags    =  -DU8G_HAL_LINKS`

To support two wire I2C displays (those without  an A0 signal to select command/data modes) I’ve created new routines for the entire chain.

The I2C low level software only supports LCD displays.  It can not read from the slave and has no error retries except for the slave address & write bit (slaw).

I didn’t use the full CMSIS system for the I2C LCDs because it doesn’t have a general purpose byte oriented option.   It offers buffer oriented options and a single byte option that always sent the slaw along with the command instruction before the byte passed to it.  That would require changing how u8g handled things and would have required touching more u8g files.  An alternative would be to add a routine to CMSIS that handles single non-command bytes.  

The I2C slave address is hard wired within the low level software.  Right now there is NOT a nice way for the user to specify a different address.  If we want this capability then I suggest making it a configuration item.

We could get rid of **ultralcd_st7565_u8glib_VIKI.h** & **ultralcd_st7920_u8glib_rrd.h** if we wanted.  The u8g library versions work.

----

With **HAL_u8g_com_LPC1768_hw_spi.c** and **HAL_u8g_com_LPC1768_st7920_hw_spi.c**,I had a terrible time getting spiSend, spiBegin & spiInit to link (kept generating undefined errors).  I eventually ended up doing includes at the end of **HAL_spi.cpp**.  I’d really appreciate it if someone could tell me why the standard “void spiBegin(void);” didn’t work .
