### PR TITLE
[2.0.x] Auto-enable DISABLE_REDUCED_ACCURACY_WARNING if HOME_AFTER_DEACTIVATE enabled

### DIFF
--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -430,10 +430,12 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
     if (!axis_homed[axis])
       u8g.print('?');
     else {
-      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
-        if (!axis_known_position[axis])
-          u8g.print(' ');
-        else
+      #if DISABLED(HOME_AFTER_DEACTIVATE)
+        #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
+          if (!axis_known_position[axis])
+            u8g.print(' ');
+          else
+        #endif
       #endif
       lcd_printPGM(pstr);
     }

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -430,14 +430,12 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
     if (!axis_homed[axis])
       u8g.print('?');
     else {
-      #if DISABLED(HOME_AFTER_DEACTIVATE)
-        #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
-          if (!axis_known_position[axis])
-            u8g.print(' ');
-          else
-        #endif
+      #if DISABLED(HOME_AFTER_DEACTIVATE) && DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
+        if (!axis_known_position[axis])
+          u8g.print(' ');
+        else
       #endif
-      lcd_printPGM(pstr);
+          lcd_printPGM(pstr);
     }
   }
 }

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -600,10 +600,12 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
     if (!axis_homed[axis])
       lcd.write('?');
     else {
-      #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
-        if (!axis_known_position[axis])
-          lcd.write(' ');
-        else
+      #if DISABLED(HOME_AFTER_DEACTIVATE)
+        #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
+          if (!axis_known_position[axis])
+            lcd.write(' ');
+          else
+        #endif
       #endif
       lcd_printPGM(pstr);
     }

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -600,14 +600,12 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
     if (!axis_homed[axis])
       lcd.write('?');
     else {
-      #if DISABLED(HOME_AFTER_DEACTIVATE)
-        #if DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
-          if (!axis_known_position[axis])
-            lcd.write(' ');
-          else
-        #endif
+      #if DISABLED(HOME_AFTER_DEACTIVATE) && DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
+        if (!axis_known_position[axis])
+          lcd.write(' ');
+        else
       #endif
-      lcd_printPGM(pstr);
+          lcd_printPGM(pstr);
     }
   }
 }


### PR DESCRIPTION
If HOME_AFTER_DEACTIVATE, there is no need to warn on LCD since printer will home prior to starting move. Saves 60 bytes PROGMEM on AVR with U8g LCD.