### PR TITLE
[2.0.x] Serial double echo fix

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
@@ -482,8 +482,6 @@
   #else // TX_BUFFER_SIZE == 0
 
     void MarlinSerial::write(const uint8_t c) {
-      while (!TEST(M_UCSRxA, M_UDREx)) { /* nada */ }
-      M_UDRx = c;
       #if ENABLED(SERIAL_XON_XOFF)
         // Do a priority insertion of an XON/XOFF char, if needed.
         const uint8_t state = xon_xoff_state;


### PR DESCRIPTION
Fix double character sent when TX buffer size is 0 on mega2560