### PR TITLE
[2.0.x] Move FILAMENT_RUNOUT_SENSOR to a feature

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -126,6 +126,10 @@
   #include "feature/pause.h"
 #endif
 
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #include "feature/runout.h"
+#endif
+
 #if ENABLED(TEMP_STAT_LEDS)
   #include "feature/leds/tempstat.h"
 #endif
@@ -178,10 +182,6 @@ volatile bool wait_for_heatup = true;
 // Inactivity shutdown
 millis_t max_inactive_time = 0,
          stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
-
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  static bool filament_ran_out = false;
-#endif
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
   AdvancedPauseMenuResponse advanced_pause_menu_response;
@@ -306,18 +306,6 @@ void quickstop_stepper() {
   set_current_from_steppers_for_axis(ALL_AXES);
   SYNC_PLAN_POSITION_KINEMATIC();
 }
-
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-
-  void handle_filament_runout() {
-    if (!filament_ran_out) {
-      filament_ran_out = true;
-      enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
-      stepper.synchronize();
-    }
-  }
-
-#endif // FILAMENT_RUNOUT_SENSOR
 
 void enable_all_steppers() {
   enable_X();

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -166,10 +166,6 @@ void kill(const char*);
 
 void quickstop_stepper();
 
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  void handle_filament_runout();
-#endif
-
 extern bool Running;
 inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -37,6 +37,10 @@
 #include "../module/printcounter.h"
 #include "../module/temperature.h"
 
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #include "../feature/runout.h"
+#endif
+
 #if ENABLED(ULTIPANEL)
   #include "../lcd/ultralcd.h"
 #endif

--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -1,0 +1,44 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * feature/runout.cpp - Runout sensor support
+ */
+
+#include "../inc/MarlinConfig.h"
+
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+
+#include "../module/stepper.h"
+#include "../gcode/queue.h"
+
+bool filament_ran_out = false;
+
+void handle_filament_runout() {
+  if (!filament_ran_out) {
+    filament_ran_out = true;
+    enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
+    stepper.synchronize();
+  }
+}
+
+#endif // FILAMENT_RUNOUT_SENSOR

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -1,0 +1,34 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * feature/runout.h - Runout sensor support
+ */
+
+#ifndef _RUNOUT_H_
+#define _RUNOUT_H_
+
+extern bool filament_ran_out;
+
+void handle_filament_runout();
+
+#endif // _RUNOUT_H_


### PR DESCRIPTION
More complete solution to #7887, inspired by #7893.

Allow 2.0.x to compile with `FILAMENT_RUNOUT_SENSOR` enabled.