### PR TITLE
[2.0.x] Add a README.h file for Arduino IDE users

### DIFF
--- a/Marlin/Marlin.ino
+++ b/Marlin/Marlin.ino
@@ -20,14 +20,6 @@
  *
  */
 
-/**
- * About Marlin
- *
- * This firmware is a mashup between Sprinter and grbl.
- *  - https://github.com/kliment/Sprinter
- *  - https://github.com/simen/grbl/tree
- */
-
 #include "src/inc/MarlinConfig.h"
 
 #if ENABLED(ULTRA_LCD)

--- a/Marlin/README.h
+++ b/Marlin/README.h
@@ -1,0 +1,53 @@
+/*
+================================================================================
+
+  Marlin Firmware
+
+  (c) 2011-2017 MarlinFirmware
+  Portions of Marlin are (c) by their respective authors.
+  All code complies with GPLv2 and/or GPLv3
+
+================================================================================
+
+Greetings! Thank you for choosing Marlin 2 as your 3D printer firmware.
+
+To configure Marlin you must edit Configuration.h and Configuration_adv.h
+located in the root 'Marlin' folder. Check the config/examples folder to see if
+there's a more suitable starting-point for your specific hardware.
+
+Before diving in, we recommend the following essential links:
+
+Marlin Firmware Official Website
+
+  - http://marlinfw.org/
+    The official Marlin Firmware website contains the most up-to-date
+    documentation. Contributions are always welcome!
+
+Configuration
+
+  - https://www.youtube.com/watch?v=3gwWVFtdg-4
+    A good 20-minute overview of Marlin configuration by Tom Sanladerer.
+    (Applies to Marlin 1.0.x, so Jerk and Acceleration should be halved.)
+    Also... https://www.google.com/search?tbs=vid%3A1&q=configure+marlin
+
+  - http://marlinfw.org/docs/configuration/configuration.html
+    Marlin's configuration options are explained in more detail here.
+
+Getting Help
+
+  - http://forums.reprap.org/list.php?415
+    The Marlin Discussion Forum is a great place to get help from other Marlin
+    users who may have experienced similar issues to your own.
+
+  - https://github.com/MarlinFirmware/Marlin/issues
+    With a free GitHub account you can provide us with feedback, bug reports,
+    and feature requests via the Marlin Issue Queue.
+
+Contributing
+
+  - http://marlinfw.org/docs/development/contributing.html
+    If you'd like to contribute to Marlin, read this first!
+
+  - http://marlinfw.org/docs/development/coding_standards.html
+    Before submitting code get to know the Coding Standards.
+*/


### PR DESCRIPTION
The `README.h` file will appear in the Arduino IDE as the last tab. If the "Use External Editor" setting is active, links in the document will be clickable.