### PR TITLE
Python isnt always python2

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 
 #dynamic build flags for generic compile options
@@ -27,7 +28,7 @@ if __name__ == "__main__":
   for i in range(1, len(sys.argv)):
     args += " " + sys.argv[i]
 
-  print args
+  print(args)
 
 # extra script for linker options
 else:


### PR DESCRIPTION
Now lpc1768_flag_script.py script is compatible with both python versions 2 and 3

Signed-off-by: Alexey Shvetsov <alexxy@gentoo.org>