### PR TITLE
[1.1.x] Remove obsolete UBL z_offset

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,13 +36,13 @@
  *
  */
 
-#define EEPROM_VERSION "V41"
+#define EEPROM_VERSION "V42"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
 
 /**
- * V41 EEPROM Layout:
+ * V42 EEPROM Layout:
  *
  *  100  Version                                    (char x4)
  *  104  EEPROM CRC16                               (uint16_t)
@@ -89,8 +89,7 @@
  *
  * AUTO_BED_LEVELING_UBL:                           6 bytes
  *  324  G29 A     ubl.state.active                 (bool)
- *  325  G29 Z     ubl.state.z_offset               (float)
- *  329  G29 S     ubl.state.storage_slot           (int8_t)
+ *  325  G29 S     ubl.state.storage_slot           (int8_t)
  *
  * DELTA:                                           48 bytes
  *  348  M666 XYZ  endstop_adj                      (float x3)
@@ -437,14 +436,11 @@ void MarlinSettings::postprocess() {
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
       EEPROM_WRITE(ubl.state.active);
-      EEPROM_WRITE(ubl.state.z_offset);
       EEPROM_WRITE(ubl.state.storage_slot);
     #else
       const bool ubl_active = false;
-      dummy = 0.0f;
       const int8_t storage_slot = -1;
       EEPROM_WRITE(ubl_active);
-      EEPROM_WRITE(dummy);
       EEPROM_WRITE(storage_slot);
     #endif // AUTO_BED_LEVELING_UBL
 
@@ -829,12 +825,10 @@ void MarlinSettings::postprocess() {
 
       #if ENABLED(AUTO_BED_LEVELING_UBL)
         EEPROM_READ(ubl.state.active);
-        EEPROM_READ(ubl.state.z_offset);
         EEPROM_READ(ubl.state.storage_slot);
       #else
         uint8_t dummyui8;
         EEPROM_READ(dummyb);
-        EEPROM_READ(dummy);
         EEPROM_READ(dummyui8);
       #endif // AUTO_BED_LEVELING_UBL
 
@@ -1609,13 +1603,7 @@ void MarlinSettings::reset() {
       if (!forReplay) {
         SERIAL_EOL();
         ubl.report_state();
-
         SERIAL_ECHOLNPAIR("\nActive Mesh Slot: ", ubl.state.storage_slot);
-
-        SERIAL_ECHOPGM("z_offset: ");
-        SERIAL_ECHO_F(ubl.state.z_offset, 6);
-        SERIAL_EOL();
-
         SERIAL_ECHOPAIR("EEPROM can hold ", calc_num_meshes());
         SERIAL_ECHOLNPGM(" meshes.\n");
       }

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -533,9 +533,9 @@ void Planner::check_axes_activity() {
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         // if z_fade_height enabled (nonzero) and raw_z above it, no leveling required
         if (planner.z_fade_height && planner.z_fade_height <= RAW_Z_POSITION(lz)) return;
-        lz += ubl.state.z_offset + ubl.get_z_correction(lx, ly) * ubl.fade_scaling_factor_for_z(lz);
+        lz += ubl.get_z_correction(lx, ly) * ubl.fade_scaling_factor_for_z(lz);
       #else // no fade
-        lz += ubl.state.z_offset + ubl.get_z_correction(lx, ly);
+        lz += ubl.get_z_correction(lx, ly);
       #endif // FADE
     #endif // UBL
 
@@ -598,22 +598,22 @@ void Planner::check_axes_activity() {
 
         const float z_physical = RAW_Z_POSITION(logical[Z_AXIS]),
                     z_correct = ubl.get_z_correction(logical[X_AXIS], logical[Y_AXIS]),
-                    z_virtual = z_physical - ubl.state.z_offset - z_correct;
+                    z_virtual = z_physical - z_correct;
               float z_logical = LOGICAL_Z_POSITION(z_virtual);
 
         #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
-          // for P=physical_z, L=logical_z, M=mesh_z, O=z_offset, H=fade_height,
-          // Given P=L+O+M(1-L/H) (faded mesh correction formula for L<H)
-          //  then L=P-O-M(1-L/H)
-          //    so L=P-O-M+ML/H
-          //    so L-ML/H=P-O-M
-          //    so L(1-M/H)=P-O-M
-          //    so L=(P-O-M)/(1-M/H) for L<H
+          // for P=physical_z, L=logical_z, M=mesh_z, H=fade_height,
+          // Given P=L+M(1-L/H) (faded mesh correction formula for L<H)
+          //  then L=P-M(1-L/H)
+          //    so L=P-M+ML/H
+          //    so L-ML/H=P-M
+          //    so L(1-M/H)=P-M
+          //    so L=(P-M)/(1-M/H) for L<H
 
           if (planner.z_fade_height) {
             if (z_logical >= planner.z_fade_height)
-              z_logical = LOGICAL_Z_POSITION(z_physical - ubl.state.z_offset);
+              z_logical = LOGICAL_Z_POSITION(z_physical);
             else
               z_logical /= 1.0 - z_correct * planner.inverse_z_fade_height;
           }

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -84,7 +84,6 @@
 
   void unified_bed_leveling::reset() {
     set_bed_leveling_enabled(false);
-    state.z_offset = 0;
     state.storage_slot = -1;
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       planner.z_fade_height = 10.0;
@@ -95,11 +94,10 @@
 
   void unified_bed_leveling::invalidate() {
     set_bed_leveling_enabled(false);
-    state.z_offset = 0;
     set_all_mesh_points_to_value(NAN);
   }
 
-  void unified_bed_leveling::set_all_mesh_points_to_value(float value) {
+  void unified_bed_leveling::set_all_mesh_points_to_value(const float value) {
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
         z_values[x][y] = value;

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -78,7 +78,6 @@
 
   typedef struct {
     bool active = false;
-    float z_offset = 0.0;
     int8_t storage_slot = -1;
   } ubl_state;
 
@@ -158,7 +157,7 @@
       static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, uint16_t[16], bool);
       static void reset();
       static void invalidate();
-      static void set_all_mesh_points_to_value(float);
+      static void set_all_mesh_points_to_value(const float);
       static bool sanity_check();
 
       static void G29() _O0;                          // O0 for no optimization
@@ -310,7 +309,7 @@
             strcpy(lcd_status_message, "get_z_correction() indexes out of range.");
             lcd_quick_feedback();
           #endif
-          return NAN; // this used to return state.z_offset
+          return NAN;
         }
 
         const float z1 = calc_z0(RAW_X_POSITION(lx0),
@@ -359,7 +358,7 @@
             }
           #endif
         }
-        return z0; // there used to be a +state.z_offset on this line
+        return z0;
       }
 
       /**

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -669,65 +669,6 @@
     if (parser.seen('T'))
       display_map(parser.has_value() ? parser.value_int() : 0);
 
-    /**
-     * This code may not be needed...  Prepare for its removal...
-     *
-     */
-    #if 0
-    if (parser.seen('Z')) {
-      if (parser.has_value())
-        state.z_offset = parser.value_float();   // do the simple case. Just lock in the specified value
-      else {
-        save_ubl_active_state_and_disable();
-        //float measured_z = probe_pt(g29_x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, g29_y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER, ProbeDeployAndStow, g29_verbose_level);
-
-        has_control_of_lcd_panel = true;     // Grab the LCD Hardware
-        float measured_z = 1.5;
-        do_blocking_move_to_z(measured_z);  // Get close to the bed, but leave some space so we don't damage anything
-                                            // The user is not going to be locking in a new Z-Offset very often so
-                                            // it won't be that painful to spin the Encoder Wheel for 1.5mm
-        lcd_refresh();
-        lcd_z_offset_edit_setup(measured_z);
-
-        KEEPALIVE_STATE(PAUSED_FOR_USER);
-
-        do {
-          measured_z = lcd_z_offset_edit();
-          idle();
-          do_blocking_move_to_z(measured_z);
-        } while (!ubl_lcd_clicked());
-
-        has_control_of_lcd_panel = true;   // There is a race condition for the encoder click.
-                                               // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune)
-                                               // or here. So, until we are done looking for a long encoder press,
-                                               // we need to take control of the panel
-
-        KEEPALIVE_STATE(IN_HANDLER);
-
-        lcd_return_to_status();
-
-        const millis_t nxt = millis() + 1500UL;
-        while (ubl_lcd_clicked()) { // debounce and watch for abort
-          idle();
-          if (ELAPSED(millis(), nxt)) {
-            SERIAL_PROTOCOLLNPGM("\nZ-Offset Adjustment Stopped.");
-            do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
-            LCD_MESSAGEPGM(MSG_UBL_Z_OFFSET_STOPPED);
-            restore_ubl_active_state_and_leave();
-            goto LEAVE;
-          }
-        }
-        has_control_of_lcd_panel = false;
-        safe_delay(20); // We don't want any switch noise.
-
-        state.z_offset = measured_z;
-
-        lcd_refresh();
-        restore_ubl_active_state_and_leave();
-      }
-    }
-    #endif
-
     LEAVE:
 
     #if ENABLED(NEWPANEL)

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -153,7 +153,7 @@
         // Note: There is no Z Correction in this case. We are off the grid and don't know what
         // a reasonable correction would be.
 
-        planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + state.z_offset, end[E_AXIS], feed_rate, extruder);
+        planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS], end[E_AXIS], feed_rate, extruder);
         set_current_to_destination();
 
         if (g26_debug_flag)
@@ -197,7 +197,7 @@
        */
       if (isnan(z0)) z0 = 0.0;
 
-      planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + z0 + state.z_offset, end[E_AXIS], feed_rate, extruder);
+      planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS] + z0, end[E_AXIS], feed_rate, extruder);
 
       if (g26_debug_flag)
         debug_current_and_destination(PSTR("FINAL_MOVE in ubl.line_to_destination()"));
@@ -302,7 +302,7 @@
             z_position = end[Z_AXIS];
           }
 
-          planner._buffer_line(x, y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
+          planner._buffer_line(x, y, z_position + z0, e_position, feed_rate, extruder);
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
@@ -367,7 +367,7 @@
             z_position = end[Z_AXIS];
           }
 
-          planner._buffer_line(x, y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
+          planner._buffer_line(x, y, z_position + z0, e_position, feed_rate, extruder);
         } //else printf("FIRST MOVE PRUNED  ");
       }
 
@@ -430,7 +430,7 @@
           e_position = end[E_AXIS];
           z_position = end[Z_AXIS];
         }
-        planner._buffer_line(x, next_mesh_line_y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
+        planner._buffer_line(x, next_mesh_line_y, z_position + z0, e_position, feed_rate, extruder);
         current_yi += dyi;
         yi_cnt--;
       }
@@ -459,7 +459,7 @@
           z_position = end[Z_AXIS];
         }
 
-        planner._buffer_line(next_mesh_line_x, y, z_position + z0 + state.z_offset, e_position, feed_rate, extruder);
+        planner._buffer_line(next_mesh_line_x, y, z_position + z0, e_position, feed_rate, extruder);
         current_xi += dxi;
         xi_cnt--;
       }
@@ -605,8 +605,6 @@
 
       if (!state.active || above_fade_height) {   // no mesh leveling
 
-        const float z_offset = state.active ? state.z_offset : 0.0;
-
         do {
 
           if (--segments) {     // not the last segment
@@ -621,7 +619,7 @@
             seg_le = ltarget[E_AXIS];
           }
 
-          ubl_buffer_segment_raw( seg_rx, seg_ry, seg_rz + z_offset, seg_le, feedrate );
+          ubl_buffer_segment_raw( seg_rx, seg_ry, seg_rz, seg_le, feedrate );
 
         } while (segments);
 
@@ -697,8 +695,6 @@
           #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
             z_cxcy *= fade_scaling_factor;          // apply fade factor to interpolated mesh height
           #endif
-
-          z_cxcy += state.z_offset;                 // add fixed mesh offset from G29 Z
 
           if (--segments == 0) {                    // if this is last segment, use ltarget for exact
             seg_rx = RAW_X_POSITION(ltarget[X_AXIS]);


### PR DESCRIPTION
Since the `z_offset` is always zero and slated to be removed anyway, this should help to optimize UBL a little bit.