### PR TITLE
fix 'axis_unhomed_error' not defined error

### DIFF
--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -27,6 +27,7 @@
 #include "../../../feature/pause.h"
 
 #include "../../gcode.h"
+#include "../../../module/motion.h"
 #include "../../parser.h"
 
 #include "../../../module/printcounter.h"


### PR DESCRIPTION
Fix 'axis_unhomed_error' not defined error when pause with unhomed status