### PR TITLE
Fix include path for VIKI

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_st7565_u8glib_VIKI.h
+++ b/Marlin/src/lcd/dogm/ultralcd_st7565_u8glib_VIKI.h
@@ -23,7 +23,7 @@
 #ifndef ULCDST7565_H
 #define ULCDST7565_H
 
-#include <src/Marlin.h>
+#include "../../Marlin.h"
 
 #if ENABLED(U8GLIB_ST7565_64128N)
 


### PR DESCRIPTION
Arduino IDE does not like the include path.

I replaced it with the same include path from ultralcd_st7920_u8glib_rrd.h