### PR TITLE
Software stop by axis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -785,10 +785,20 @@
 #define Y_MAX_POS Y_BED_SIZE
 #define Z_MAX_POS 200
 
+// fine software endstop settings: Individual limits.
 // If enabled, axes won't move below MIN_POS in response to movement commands.
-#define MIN_SOFTWARE_ENDSTOPS
+//#define MIN_SOFTWARE_ENDSTOP_X
+//#define MIN_SOFTWARE_ENDSTOP_Y
+//#define MIN_SOFTWARE_ENDSTOP_Z
 // If enabled, axes won't move above MAX_POS in response to movement commands.
-#define MAX_SOFTWARE_ENDSTOPS
+//#define MAX_SOFTWARE_ENDSTOP_X
+//#define MAX_SOFTWARE_ENDSTOP_Y
+//#define MAX_SOFTWARE_ENDSTOP_Z
+
+// coarse Software Endstop Settings
+#define MIN_SOFTWARE_ENDSTOPS // Equivalend to X,Y and Z. (only Z on Delta printers).
+#define MAX_SOFTWARE_ENDSTOPS // Equivalend to X,Y and Z. (only Z on Delta printers).
+
 
 /**
  * Filament Runout Sensor

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -515,6 +515,25 @@
   #endif
 
   /**
+   * Set the software endstops fine settings
+   */
+  #if ENABLED(MIN_SOFTWARE_ENDSTOPS)
+    #define MIN_SOFTWARE_ENDSTOP_Z
+    #if DISABLED(DELTA)
+      #define MIN_SOFTWARE_ENDSTOP_X
+      #define MIN_SOFTWARE_ENDSTOP_Y
+    #endif
+  #endif
+
+  #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
+    #define MAX_SOFTWARE_ENDSTOP_Z
+    #if DISABLED(DELTA)
+      #define MAX_SOFTWARE_ENDSTOP_X
+      #define MAX_SOFTWARE_ENDSTOP_Y
+    #endif
+  #endif
+
+  /**
    * Shorthand for pin tests, used wherever needed
    */
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2847,6 +2847,7 @@ void kill_screen(const char* lcd_msg) {
           {
             min = soft_endstop_min[axis];
           }
+        #endif
         #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
           if (Z_AXIS == axis)
           {
@@ -2864,6 +2865,7 @@ void kill_screen(const char* lcd_msg) {
           {
             max = soft_endstop_max[axis];
           }
+        #endif
         #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
           if (Z_AXIS == axis)
           {

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2834,17 +2834,43 @@ void kill_screen(const char* lcd_msg) {
       float min = current_position[axis] - 1000,
             max = current_position[axis] + 1000;
 
-      #if HAS_SOFTWARE_ENDSTOPS
-        // Limit to software endstops, if enabled
-        if (soft_endstops_enabled) {
-          #if ENABLED(MIN_SOFTWARE_ENDSTOPS)
+      // Limit to software endstops, if enabled
+      if (soft_endstops_enabled) {
+        #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
+          if (X_AXIS == axis)
+          {
             min = soft_endstop_min[axis];
-          #endif
-          #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
+          }
+        #endif
+        #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
+          if (Y_AXIS == axis)
+          {
+            min = soft_endstop_min[axis];
+          }
+        #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
+          if (Z_AXIS == axis)
+          {
+            min = soft_endstop_min[axis];
+          }
+        #endif
+        #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
+          if (X_AXIS == axis)
+          {
             max = soft_endstop_max[axis];
-          #endif
-        }
-      #endif
+          }
+        #endif
+        #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
+          if (Y_AXIS == axis)
+          {
+            max = soft_endstop_max[axis];
+          }
+        #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
+          if (Z_AXIS == axis)
+          {
+            max = soft_endstop_max[axis];
+          }
+        #endif
+      }
 
       // Delta limits XY based on the current offset from center
       // This assumes the center is 0,0

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -467,18 +467,22 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
 
   void clamp_to_software_endstops(float target[XYZ]) {
     if (!soft_endstops_enabled) return;
-    #if ENABLED(MIN_SOFTWARE_ENDSTOPS)
-      #if DISABLED(DELTA)
-        NOLESS(target[X_AXIS], soft_endstop_min[X_AXIS]);
-        NOLESS(target[Y_AXIS], soft_endstop_min[Y_AXIS]);
-      #endif
+    #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
+      NOLESS(target[X_AXIS], soft_endstop_min[X_AXIS]);
+    #endif
+    #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
+      NOLESS(target[Y_AXIS], soft_endstop_min[Y_AXIS]);
+    #endif
+    #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
       NOLESS(target[Z_AXIS], soft_endstop_min[Z_AXIS]);
     #endif
-    #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
-      #if DISABLED(DELTA)
-        NOMORE(target[X_AXIS], soft_endstop_max[X_AXIS]);
-        NOMORE(target[Y_AXIS], soft_endstop_max[Y_AXIS]);
-      #endif
+    #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
+      NOMORE(target[X_AXIS], soft_endstop_max[X_AXIS]);
+    #endif
+    #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
+      NOMORE(target[Y_AXIS], soft_endstop_max[Y_AXIS]);
+    #endif
+    #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
       NOMORE(target[Z_AXIS], soft_endstop_max[Z_AXIS]);
     #endif
   }


### PR DESCRIPTION
Sort of an orthogonal change to #7943, but that change _inspired_ this feature.

Basically, with a CNC, we'll want to be able to set the software limits for X,Y, so they don't clobber our endstops, but we'll use a touchplate to set Z=0, and then want to cut into the work (Z<0). So this will allow us to set:
```cpp
#define MIN_SOFTWARE_X
#define MIN_SOFTWARE_Y
```
and not set the Z axis.

I don't have a machine to test this on, but it does compile. I'll see if I can convince @Allted to try this on his machine.