### PR TITLE
Add AZSMZ Mini

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -123,14 +123,14 @@
 #define BOARD_RAMPS4DUE_EEF    1546  // RAMPS4DUE (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS4DUE_SF     1548  // RAMPS4DUE (Power outputs: Spindle, Controller Fan)
 #define BOARD_ALLIGATOR        1602  // Alligator Board R2
-#define BOARD_RAMPS_14_RE_ARM_EFB      1743   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_14_RE_ARM_EEB      1744   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_14_RE_ARM_EFF      1745   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_14_RE_ARM_EEF      1746   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_14_RE_ARM_SF       1748   // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
-#define BOARD_STM32F1R         		   1800   // STM3R Libmaple based stm32f1 controller
-#define BOARD_MKS_SBASE        		   1850   // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
-#define BOARD_AZSMZ_MINI               1860   // AZSMZ Mini
+#define BOARD_RAMPS_14_RE_ARM_EFB 1743   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_14_RE_ARM_EEB 1744   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_14_RE_ARM_EFF 1745   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_14_RE_ARM_EEF 1746   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_14_RE_ARM_SF  1748   // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
+#define BOARD_STM32F1R         1800   // STM3R Libmaple based STM32F1 controller
+#define BOARD_MKS_SBASE        1801   // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_AZSMZ_MINI       1802   // AZSMZ Mini
 
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -128,9 +128,9 @@
 #define BOARD_RAMPS_14_RE_ARM_EFF 1745   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
 #define BOARD_RAMPS_14_RE_ARM_EEF 1746   // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS_14_RE_ARM_SF  1748   // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
+#define BOARD_MKS_SBASE           1750   // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_AZSMZ_MINI          1751   // AZSMZ Mini
 #define BOARD_STM32F1R         1800   // STM3R Libmaple based STM32F1 controller
-#define BOARD_MKS_SBASE        1801   // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
-#define BOARD_AZSMZ_MINI       1802   // AZSMZ Mini
 
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -130,7 +130,7 @@
 #define BOARD_RAMPS_14_RE_ARM_SF       1748   // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
 #define BOARD_STM32F1R         		   1800   // STM3R Libmaple based stm32f1 controller
 #define BOARD_MKS_SBASE        		   1850   // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
-
+#define BOARD_AZSMZ_MINI               1860   // AZSMZ Mini
 
 
 #define MB(board) (MOTHERBOARD==BOARD_##board)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -300,8 +300,10 @@
   #include "pins_ALLIGATOR_R2.h"
 #elif MB(STM32F1R)
   #include "pins_STM32F1R.h"
-  #elif MB(MKS_SBASE)
+#elif MB(MKS_SBASE)
   #include "pins_MKS_SBASE.h"
+#elif MB(AZSMZ_MINI)
+  #include "pins_AZSMZ_MINI.h"
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif

--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -1,0 +1,146 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * AZSMZ MINI pin assignments
+ */
+
+//#if !defined(TARGET_LPC1768)
+#if DISABLED(IS_REARM)
+  #error "Oops!  Make sure you have Re-Arm selected."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "AZSMZ MINI"
+#endif
+
+#define LARGE_FLASH true
+
+//
+// Servos
+//
+#define SERVO0_PIN         53
+    
+//
+// Limit Switches
+//
+#define X_MIN_PIN           3
+#define Y_MIN_PIN          14
+#define Z_MIN_PIN          18
+#define Z_MAX_PIN          19
+
+//
+// Steppers
+//
+#define X_STEP_PIN         26
+#define X_DIR_PIN          28
+#define X_ENABLE_PIN       24
+
+#define Y_STEP_PIN         54
+#define Y_DIR_PIN          55
+#define Y_ENABLE_PIN       38
+
+#define Z_STEP_PIN         60
+#define Z_DIR_PIN          61
+#define Z_ENABLE_PIN       56
+
+#define E0_STEP_PIN        46
+#define E0_DIR_PIN         48
+#define E0_ENABLE_PIN      62
+
+#define E1_STEP_PIN        36
+#define E1_DIR_PIN         34
+#define E1_ENABLE_PIN      30
+
+//
+// Temperature Sensors
+//  3.3V max when defined as an analog input
+//
+#define TEMP_0_PIN          0  //A0 (TH1)
+#define TEMP_BED_PIN        1  //A1 (TH2)
+#define TEMP_1_PIN          2  //A2 (TH3)
+
+//
+// Heaters / Fans
+//
+// EFB
+#define HEATER_BED_PIN      10
+#define HEATER_0_PIN        8
+#define FAN_PIN             9
+#define FAN1_PIN            63
+
+#if ENABLED(AZSMZ_12864)
+  #define BEEPER_PIN       37
+  #define DOGLCD_A0        59
+  #define DOGLCD_CS        41
+  #define BTN_EN1          13
+  #define BTN_EN2          15
+  #define BTN_ENC          31
+  #define LCD_SDSS         16
+  #define SD_DETECT_PIN    33
+#endif
+
+//
+// Ethernet pins
+//
+#define ENET_MDIO     71
+#define ENET_RX_ER    73
+#define ENET_RXD1     75
+#define ENET_MOC      70
+#define REF_CLK       72
+#define ENET_RXD0     74
+#define ENET_CRS      76
+#define ENET_TX_EN    77
+#define ENET_TXD0     78
+#define ENET_TXD1     79
+
+/**
+ *  PWMS
+ *
+ *  There are 6 PWMS.  Each PWM can be assigned to one of two pins.
+ *
+ *  SERVO2 does NOT have a PWM assigned to it.
+ *
+ *  PWM1.1   DIO4    SERVO3_PIN       FIL_RUNOUT_PIN   5V output, PWM
+ *  PWM1.1   DIO26   E0_STEP_PIN
+ *  PWM1.2   DIO11   SERVO0_PIN
+ *  PWM1.2   DIO54   X_STEP_PIN
+ *  PWM1.3   DIO6    SERVO1_PIN       J5-1
+ *  PWM1.3   DIO60   Y_STEP_PIN
+ *  PWM1.4   DIO53   SDSS(SSEL0)      J3-5  AUX-3
+ *  PWM1.4   DIO46   Z_STEP_PIN
+ *  PWM1.5   DIO3    X_MIN_PIN        10K PULLUP TO 3.3v, 1K SERIES
+ *  PWM1.5   DIO9    RAMPS_D9_PIN
+ *  PWM1.6   DIO14   Y_MIN_PIN        10K PULLUP TO 3.3v, 1K SERIES
+ *  PWM1.6   DIO10   RAMPS_D10_PIN
+ */
+
+
+ /**
+  * special pins
+  *   D37 - not 5V tolerant
+  *   D49 - not 5V tolerant
+  *   D57 - open collector
+  *   D58 - open collector
+  *
+ */

--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -1,6 +1,5 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
@@ -141,5 +140,4 @@
   *   D49 - not 5V tolerant
   *   D57 - open collector
   *   D58 - open collector
-  *
   */

--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -76,18 +76,18 @@
 // Temperature Sensors
 //  3.3V max when defined as an analog input
 //
-#define TEMP_0_PIN          0  //A0 (TH1)
-#define TEMP_BED_PIN        1  //A1 (TH2)
-#define TEMP_1_PIN          2  //A2 (TH3)
+#define TEMP_0_PIN          0  // A0 (TH1)
+#define TEMP_BED_PIN        1  // A1 (TH2)
+#define TEMP_1_PIN          2  // A2 (TH3)
 
 //
 // Heaters / Fans
 //
 // EFB
-#define HEATER_BED_PIN      10
 #define HEATER_0_PIN        8
+#define HEATER_BED_PIN     10
 #define FAN_PIN             9
-#define FAN1_PIN            63
+#define FAN1_PIN           63
 
 #if ENABLED(AZSMZ_12864)
   #define BEEPER_PIN       37
@@ -103,21 +103,21 @@
 //
 // Ethernet pins
 //
-#define ENET_MDIO     71
-#define ENET_RX_ER    73
-#define ENET_RXD1     75
-#define ENET_MOC      70
-#define REF_CLK       72
-#define ENET_RXD0     74
-#define ENET_CRS      76
-#define ENET_TX_EN    77
-#define ENET_TXD0     78
-#define ENET_TXD1     79
+#define ENET_MDIO          71
+#define ENET_RX_ER         73
+#define ENET_RXD1          75
+#define ENET_MOC           70
+#define REF_CLK            72
+#define ENET_RXD0          74
+#define ENET_CRS           76
+#define ENET_TX_EN         77
+#define ENET_TXD0          78
+#define ENET_TXD1          79
 
 /**
- *  PWMS
+ *  PWMs
  *
- *  There are 6 PWMS.  Each PWM can be assigned to one of two pins.
+ *  There are 6 PWMs.  Each PWM can be assigned to one of two pins.
  *
  *  SERVO2 does NOT have a PWM assigned to it.
  *
@@ -135,12 +135,11 @@
  *  PWM1.6   DIO10   RAMPS_D10_PIN
  */
 
-
  /**
-  * special pins
+  * Special pins
   *   D37 - not 5V tolerant
   *   D49 - not 5V tolerant
   *   D57 - open collector
   *   D58 - open collector
   *
- */
+  */


### PR DESCRIPTION
Copied off the MKS SBASE work since they are pretty similar.

The endstop pins are not labelled on this board. And there are 4 of them, so I wasn't quite sure how to label them. 

The heater outputs are labelled D8, D9, D10 like the RAMPS, so a few variants could probably be made. I just went with EFB for now.

Haven't actually put this into my printer yet to test. But the LCD and SD card support work.