### PR TITLE
[1.1.x] Add M290 babystepping

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11443,13 +11443,13 @@ void process_next_command() {
           gcode_M280();
           break;
       #endif // HAS_SERVOS
-	  
+
       #if ENABLED(BABYSTEPPING)
         case 290: // M290: Z Babystepping
           gcode_M290();
           break;
       #endif // BABYSTEPPING
-	  
+
       #if HAS_BUZZER
         case 300: // M300: Play beep tone
           gcode_M300();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8965,8 +8965,14 @@ inline void gcode_M226() {
    * M290: Z Babystepping
    */
   inline void gcode_M290() {
-    if (parser.seenval('Z') || parser.seenval('S'))
-      thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
+    #if ENABLED(BABYSTEP_XY)
+      for (uint8_t a = X_AXIS; a <= Z_AXIS; a++)
+        if (parser.seenval(axis_codes[a]) || (a == Z_AXIS && parser.seenval('S')))
+          thermalManager.babystep_axis(a, parser.value_axis_units(a) * planner.axis_steps_per_mm[a]);
+    #else
+      if (parser.seenval('Z') || parser.seenval('S'))
+        thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
+    #endif
   }
 
 #endif // BABYSTEPPING

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -173,7 +173,7 @@
  * M260 - i2c Send Data (Requires EXPERIMENTAL_I2CBUS)
  * M261 - i2c Request Data (Requires EXPERIMENTAL_I2CBUS)
  * M280 - Set servo position absolute: "M280 P<index> S<angle|µs>". (Requires servos)
- * M290 - Z Babystepping (Requires BABYSTEPPING)
+ * M290 - Babystepping (Requires BABYSTEPPING)
  * M300 - Play beep sound S<frequency Hz> P<duration ms>
  * M301 - Set PID parameters P I and D. (Requires PIDTEMP)
  * M302 - Allow cold extrudes, or set the minimum extrude S<temperature>. (Requires PREVENT_COLD_EXTRUSION)
@@ -8962,7 +8962,7 @@ inline void gcode_M226() {
 #if ENABLED(BABYSTEPPING)
 
   /**
-   * M290: Z Babystepping
+   * M290: Babystepping
    */
   inline void gcode_M290() {
     #if ENABLED(BABYSTEP_XY)
@@ -11451,7 +11451,7 @@ void process_next_command() {
       #endif // HAS_SERVOS
 
       #if ENABLED(BABYSTEPPING)
-        case 290: // M290: Z Babystepping
+        case 290: // M290: Babystepping
           gcode_M290();
           break;
       #endif // BABYSTEPPING

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8967,11 +8967,28 @@ inline void gcode_M226() {
   inline void gcode_M290() {
     #if ENABLED(BABYSTEP_XY)
       for (uint8_t a = X_AXIS; a <= Z_AXIS; a++)
-        if (parser.seenval(axis_codes[a]) || (a == Z_AXIS && parser.seenval('S')))
-          thermalManager.babystep_axis(a, parser.value_axis_units(a) * planner.axis_steps_per_mm[a]);
+        if (parser.seenval(axis_codes[a]) || (a == Z_AXIS && parser.seenval('S'))) {
+          float offs = parser.value_axis_units(a);
+          constrain(offs, -2, 2);
+          #if HAS_BED_PROBE && ENABLED(BABYSTEP_ZPROBE_OFFSET)
+            if (a == Z_AXIS) {
+              zprobe_zoffset += offs;
+              refresh_zprobe_zoffset(true); // 'true' to not babystep
+            }
+          #endif
+          thermalManager.babystep_axis(a, offs * planner.axis_steps_per_mm[a]);
+        }
     #else
-      if (parser.seenval('Z') || parser.seenval('S'))
-        thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
+      if (parser.seenval('Z') || parser.seenval('S')) {
+        float offs = parser.value_axis_units(Z_AXIS);
+        constrain(offs, -2, 2);
+        #if HAS_BED_PROBE && ENABLED(BABYSTEP_ZPROBE_OFFSET)
+          zprobe_zoffset += offs;
+          refresh_zprobe_zoffset(); // This will babystep the axis
+        #else
+          thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
+        #endif
+      }
     #endif
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -173,7 +173,7 @@
  * M260 - i2c Send Data (Requires EXPERIMENTAL_I2CBUS)
  * M261 - i2c Request Data (Requires EXPERIMENTAL_I2CBUS)
  * M280 - Set servo position absolute: "M280 P<index> S<angle|µs>". (Requires servos)
- * M290 - Babystepping Z
+ * M290 - Z Babystepping (Requires BABYSTEPPING)
  * M300 - Play beep sound S<frequency Hz> P<duration ms>
  * M301 - Set PID parameters P I and D. (Requires PIDTEMP)
  * M302 - Allow cold extrudes, or set the minimum extrude S<temperature>. (Requires PREVENT_COLD_EXTRUSION)
@@ -8961,12 +8961,13 @@ inline void gcode_M226() {
 
 #if ENABLED(BABYSTEPPING)
 
-/**
- * M290: Baby stepping Z
- */
-inline void gcode_M290() {
-  if (parser.seenval('S')) thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
-}
+  /**
+   * M290: Z Babystepping
+   */
+  inline void gcode_M290() {
+    if (parser.seenval('Z') || parser.seenval('S'))
+      thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
+  }
 
 #endif // BABYSTEPPING
 
@@ -11423,7 +11424,7 @@ void process_next_command() {
         case 218: // M218: Set a tool offset
           gcode_M218();
           break;
-      #endif
+      #endif // HOTENDS > 1
 
       case 220: // M220: Set Feedrate Percentage: S<percent> ("FR" on your LCD)
         gcode_M220();
@@ -11443,11 +11444,11 @@ void process_next_command() {
           break;
       #endif // HAS_SERVOS
 	  
-	  #if ENABLED(BABYSTEPPING)
-		case 290: // M290: Baby stepping Z
-		  gcode_M290();
+      #if ENABLED(BABYSTEPPING)
+        case 290: // M290: Z Babystepping
+          gcode_M290();
           break;
-	  #endif // BABYSTEPPING
+      #endif // BABYSTEPPING
 	  
       #if HAS_BUZZER
         case 300: // M300: Play beep tone

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8970,7 +8970,7 @@ inline void gcode_M226() {
         if (parser.seenval(axis_codes[a]) || (a == Z_AXIS && parser.seenval('S'))) {
           float offs = parser.value_axis_units(a);
           constrain(offs, -2, 2);
-          #if HAS_BED_PROBE && ENABLED(BABYSTEP_ZPROBE_OFFSET)
+          #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
             if (a == Z_AXIS) {
               zprobe_zoffset += offs;
               refresh_zprobe_zoffset(true); // 'true' to not babystep
@@ -8982,7 +8982,7 @@ inline void gcode_M226() {
       if (parser.seenval('Z') || parser.seenval('S')) {
         float offs = parser.value_axis_units(Z_AXIS);
         constrain(offs, -2, 2);
-        #if HAS_BED_PROBE && ENABLED(BABYSTEP_ZPROBE_OFFSET)
+        #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
           zprobe_zoffset += offs;
           refresh_zprobe_zoffset(); // This will babystep the axis
         #else

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -173,6 +173,7 @@
  * M260 - i2c Send Data (Requires EXPERIMENTAL_I2CBUS)
  * M261 - i2c Request Data (Requires EXPERIMENTAL_I2CBUS)
  * M280 - Set servo position absolute: "M280 P<index> S<angle|µs>". (Requires servos)
+ * M290 - Babystepping Z
  * M300 - Play beep sound S<frequency Hz> P<duration ms>
  * M301 - Set PID parameters P I and D. (Requires PIDTEMP)
  * M302 - Allow cold extrudes, or set the minimum extrude S<temperature>. (Requires PREVENT_COLD_EXTRUSION)
@@ -8958,6 +8959,17 @@ inline void gcode_M226() {
 
 #endif // HAS_SERVOS
 
+#if ENABLED(BABYSTEPPING)
+
+/**
+ * M290: Baby stepping Z
+ */
+inline void gcode_M290() {
+  if (parser.seenval('S')) thermalManager.babystep_axis(Z_AXIS, parser.value_axis_units(Z_AXIS) * planner.axis_steps_per_mm[Z_AXIS]);
+}
+
+#endif // BABYSTEPPING
+
 #if HAS_BUZZER
 
   /**
@@ -11430,7 +11442,13 @@ void process_next_command() {
           gcode_M280();
           break;
       #endif // HAS_SERVOS
-
+	  
+	  #if ENABLED(BABYSTEPPING)
+		case 290: // M290: Baby stepping Z
+		  gcode_M290();
+          break;
+	  #endif // BABYSTEPPING
+	  
       #if HAS_BUZZER
         case 300: // M300: Play beep tone
           gcode_M300();


### PR DESCRIPTION
Implement `M290` for compatibility with RepRapFirmware 1.18 and later.

----
@thinkyhead additions:

- Also include the option to use `Z` instead of `S`
- Allow use of `X` and `Y` when `BABYSTEP_XY` are enabled.
- Also affects `zprobe_zoffset` (`M851`) when `BABYSTEP_ZPROBE_OFFSET` is enabled