### PR TITLE
change to better (more clear) names

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -502,7 +502,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
     if (delayed_move_time && ELAPSED(ms, delayed_move_time + 1000UL) && IsRunning()) {
       // travel moves have been received so enact them
       delayed_move_time = 0xFFFFFFFFUL; // force moves to be done
-      set_destination_to_current();
+      set_destination_from_current();
       prepare_move_to_destination();
     }
   #endif

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -378,7 +378,7 @@ float bilinear_z_offset(const float logical[XYZ]) {
     if (cx1 == cx2 && cy1 == cy2) {
       // Start and end on same mesh square
       line_to_destination(fr_mm_s);
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 
@@ -405,7 +405,7 @@ float bilinear_z_offset(const float logical[XYZ]) {
     else {
       // Already split on a border
       line_to_destination(fr_mm_s);
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -69,7 +69,7 @@
     if (cx1 == cx2 && cy1 == cy2) {
       // Start and end on same mesh square
       line_to_destination(fr_mm_s);
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 
@@ -96,7 +96,7 @@
     else {
       // Already split on a border
       line_to_destination(fr_mm_s);
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 

--- a/Marlin/src/feature/bedlevel/ubl/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/G26_Mesh_Validation_Tool.cpp
@@ -222,7 +222,7 @@ void unified_bed_leveling::G26() {
   if (current_position[Z_AXIS] < Z_CLEARANCE_BETWEEN_PROBES) {
     do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
     stepper.synchronize();
-    set_current_to_destination();
+    set_current_from_destination();
   }
 
   if (turn_on_heaters()) goto LEAVE;
@@ -247,7 +247,7 @@ void unified_bed_leveling::G26() {
   ZERO(vertical_mesh_line_flags);
 
   // Move nozzle to the specified height for the first layer
-  set_destination_to_current();
+  set_destination_from_current();
   destination[Z_AXIS] = g26_layer_height;
   move_to(destination, 0.0);
   move_to(destination, g26_ooze_amount);
@@ -531,7 +531,7 @@ void unified_bed_leveling::move_to(const float &x, const float &y, const float &
     G26_line_to_destination(feed_value);
 
     stepper.synchronize();
-    set_destination_to_current();
+    set_destination_from_current();
   }
 
   // Check if X or Y is involved in the movement.
@@ -547,7 +547,7 @@ void unified_bed_leveling::move_to(const float &x, const float &y, const float &
   G26_line_to_destination(feed_value);
 
   stepper.synchronize();
-  set_destination_to_current();
+  set_destination_from_current();
 
 }
 
@@ -829,7 +829,7 @@ bool unified_bed_leveling::prime_nozzle() {
       lcd_setstatusPGM(PSTR("User-Controlled Prime"), 99);
       chirp_at_user();
 
-      set_destination_to_current();
+      set_destination_from_current();
 
       recover_filament(destination); // Make sure G26 doesn't think the filament is retracted().
 
@@ -846,7 +846,7 @@ bool unified_bed_leveling::prime_nozzle() {
                                   // but because the planner has a buffer, we won't be able
                                   // to stop as quickly. So we put up with the less smooth
                                   // action to give the user a more responsive 'Stop'.
-        set_destination_to_current();
+        set_destination_from_current();
         idle();
       }
 
@@ -870,11 +870,11 @@ bool unified_bed_leveling::prime_nozzle() {
       lcd_setstatusPGM(PSTR("Fixed Length Prime."), 99);
       lcd_quick_feedback();
     #endif
-    set_destination_to_current();
+    set_destination_from_current();
     destination[E_AXIS] += g26_prime_length;
     G26_line_to_destination(planner.max_feedrate_mm_s[E_AXIS] / 15.0);
     stepper.synchronize();
-    set_destination_to_current();
+    set_destination_from_current();
     retract_filament(destination);
   }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -39,9 +39,9 @@
   extern float destination[XYZE];
 
   #if AVR_AT90USB1286_FAMILY  // Teensyduino & Printrboard IDE extensions have compile errors without this
-    inline void set_current_to_destination() { COPY(current_position, destination); }
+    inline void set_current_from_destination() { COPY(current_position, destination); }
   #else
-    extern void set_current_to_destination();
+    extern void set_current_from_destination();
   #endif
 
   static void debug_echo_axis(const AxisEnum axis) {
@@ -141,7 +141,7 @@
         // a reasonable correction would be.
 
         planner._buffer_line(end[X_AXIS], end[Y_AXIS], end[Z_AXIS], end[E_AXIS], feed_rate, extruder);
-        set_current_to_destination();
+        set_current_from_destination();
 
         if (g26_debug_flag)
           debug_current_and_destination(PSTR("out of bounds in ubl.line_to_destination()"));
@@ -189,7 +189,7 @@
       if (g26_debug_flag)
         debug_current_and_destination(PSTR("FINAL_MOVE in ubl.line_to_destination()"));
 
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 
@@ -301,7 +301,7 @@
       if (current_position[X_AXIS] != end[X_AXIS] || current_position[Y_AXIS] != end[Y_AXIS])
         goto FINAL_MOVE;
 
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 
@@ -362,7 +362,7 @@
       if (current_position[X_AXIS] != end[X_AXIS] || current_position[Y_AXIS] != end[Y_AXIS])
         goto FINAL_MOVE;
 
-      set_current_to_destination();
+      set_current_from_destination();
       return;
     }
 
@@ -456,7 +456,7 @@
     if (current_position[X_AXIS] != end[X_AXIS] || current_position[Y_AXIS] != end[Y_AXIS])
       goto FINAL_MOVE;
 
-    set_current_to_destination();
+    set_current_from_destination();
   }
 
   #if UBL_DELTA
@@ -598,7 +598,7 @@
 
         } while (segments);
 
-        return false; // moved but did not set_current_to_destination();
+        return false; // moved but did not set_current_from_destination();
       }
 
       // Otherwise perform per-segment leveling
@@ -681,7 +681,7 @@
           ubl_buffer_segment_raw( seg_rx, seg_ry, seg_rz + z_cxcy, seg_le, feedrate );
 
           if (segments == 0 )                       // done with last segment
-            return false;                           // did not set_current_to_destination()
+            return false;                           // did not set_current_from_destination()
 
           seg_rx += seg_dx;
           seg_ry += seg_dy;

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -129,7 +129,7 @@ void FWRetract::retract(const bool retracting
   planner.flow_percentage[active_extruder] = 100;
 
   // The current position will be the destination for E and Z moves
-  set_destination_to_current();
+  set_destination_from_current();
 
   stepper.synchronize();  // Wait for buffered moves to complete
 

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -146,7 +146,7 @@ bool pause_print(const float &retract, const float &z_lift, const float &x_pos, 
 
   if (retract) {
     // Initial retract before move to filament change position
-    set_destination_to_current();
+    set_destination_from_current();
     destination[E_AXIS] += retract;
     RUNPLAN(PAUSE_PARK_RETRACT_FEEDRATE);
     stepper.synchronize();
@@ -168,7 +168,7 @@ bool pause_print(const float &retract, const float &z_lift, const float &x_pos, 
     }
 
     // Unload filament
-    set_destination_to_current();
+    set_destination_from_current();
     destination[E_AXIS] += unload_length;
     RUNPLAN(FILAMENT_CHANGE_UNLOAD_FEEDRATE);
     stepper.synchronize();
@@ -272,7 +272,7 @@ void resume_print(const float &load_length/*=0*/, const float &initial_extrude_l
     filament_change_beep(max_beep_count, true);
   #endif
 
-  set_destination_to_current();
+  set_destination_from_current();
 
   if (load_length != 0) {
     #if ENABLED(ULTIPANEL)

--- a/Marlin/src/gcode/bedlevel/G42.cpp
+++ b/Marlin/src/gcode/bedlevel/G42.cpp
@@ -55,7 +55,7 @@ void GcodeSuite::G42() {
       #define _GET_MESH_Y(J) mbl.index_to_ypos[J]
     #endif
 
-    set_destination_to_current();
+    set_destination_from_current();
     if (hasI) destination[X_AXIS] = LOGICAL_X_POSITION(_GET_MESH_X(ix));
     if (hasJ) destination[Y_AXIS] = LOGICAL_Y_POSITION(_GET_MESH_Y(iy));
     if (parser.boolval('P')) {

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -47,7 +47,7 @@ void mesh_probing_done() {
   set_bed_leveling_enabled(true);
   #if ENABLED(MESH_G28_REST_ORIGIN)
     current_position[Z_AXIS] = LOGICAL_Z_POSITION(Z_MIN_POS);
-    set_destination_to_current();
+    set_destination_from_current();
     line_to_destination(homing_feedrate(Z_AXIS));
     stepper.synchronize();
   #endif

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -194,7 +194,7 @@ void GcodeSuite::G28(const bool always_home_all) {
                homeZ = always_home_all || parser.seen('Z'),
                home_all = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
 
-    set_destination_to_current();
+    set_destination_from_current();
 
     #if Z_HOME_DIR > 0  // If homing away from BED do Z first
 

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -181,7 +181,7 @@ void plan_arc(
   // As far as the parser is concerned, the position is now == target. In reality the
   // motion control system might still be processing the action and the real tool position
   // in any intermediate location.
-  set_current_to_destination();
+  set_current_from_destination();
 } // plan_arc
 
 /**

--- a/Marlin/src/gcode/motion/G5.cpp
+++ b/Marlin/src/gcode/motion/G5.cpp
@@ -33,7 +33,7 @@ void plan_cubic_move(const float offset[4]) {
   // As far as the parser is concerned, the position is now == destination. In reality the
   // motion control system might still be processing the action and the real tool position
   // in any intermediate location.
-  set_current_to_destination();
+  set_current_from_destination();
 }
 
 /**

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -64,7 +64,7 @@ static bool G38_run_probe() {
 
     #if ENABLED(PROBE_DOUBLE_TOUCH)
       // Move away by the retract distance
-      set_destination_to_current();
+      set_destination_from_current();
       LOOP_XYZ(i) destination[i] += retract_mm[i];
       endstops.enable(false);
       prepare_move_to_destination();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2810,7 +2810,7 @@ void kill_screen(const char* lcd_msg) {
         #endif
 
         // Set movement on a single axis
-        set_destination_to_current();
+        set_destination_from_current();
         destination[manual_move_axis] += manual_move_offset;
 
         // Reset for the next move
@@ -2819,7 +2819,7 @@ void kill_screen(const char* lcd_msg) {
 
         // Set a blocking flag so no new moves can be added until all segments are done
         processing_manual_move = true;
-        prepare_move_to_destination(); // will call set_current_to_destination
+        prepare_move_to_destination(); // will call set_current_from_destination()
         processing_manual_move = false;
 
         feedrate_mm_s = old_feedrate;

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -82,7 +82,7 @@ float current_position[XYZE] = { 0.0 };
 /**
  * Cartesian Destination
  *   A temporary position, usually applied to 'current_position'.
- *   Set with 'get_destination_from_command' or 'set_destination_to_current'.
+ *   Set with 'get_destination_from_command' or 'set_destination_from_current'.
  *   'line_to_destination' sets 'current_position' to 'destination'.
  */
 float destination[XYZE] = { 0.0 };
@@ -279,7 +279,7 @@ void line_to_destination(const float fr_mm_s) {
       planner.buffer_line_kinematic(destination, MMS_SCALED(fr_mm_s ? fr_mm_s : feedrate_mm_s), active_extruder);
     #endif
 
-    set_current_to_destination();
+    set_current_from_destination();
   }
 
 #endif // IS_KINEMATIC
@@ -301,10 +301,10 @@ void do_blocking_move_to(const float &lx, const float &ly, const float &lz, cons
 
     feedrate_mm_s = fr_mm_s ? fr_mm_s : XY_PROBE_FEEDRATE_MM_S;
 
-    set_destination_to_current();          // sync destination at the start
+    set_destination_from_current();          // sync destination at the start
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("set_destination_to_current", destination);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("set_destination_from_current", destination);
     #endif
 
     // when in the danger zone
@@ -313,7 +313,7 @@ void do_blocking_move_to(const float &lx, const float &ly, const float &lz, cons
         destination[X_AXIS] = lx;           // move directly (uninterpolated)
         destination[Y_AXIS] = ly;
         destination[Z_AXIS] = lz;
-        prepare_uninterpolated_move_to_destination(); // set_current_to_destination
+        prepare_uninterpolated_move_to_destination(); // set_current_from_destination()
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) DEBUG_POS("danger zone move", current_position);
         #endif
@@ -321,7 +321,7 @@ void do_blocking_move_to(const float &lx, const float &ly, const float &lz, cons
       }
       else {
         destination[Z_AXIS] = delta_clip_start_height;
-        prepare_uninterpolated_move_to_destination(); // set_current_to_destination
+        prepare_uninterpolated_move_to_destination(); // set_current_from_destination()
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) DEBUG_POS("zone border move", current_position);
         #endif
@@ -330,7 +330,7 @@ void do_blocking_move_to(const float &lx, const float &ly, const float &lz, cons
 
     if (lz > current_position[Z_AXIS]) {    // raising?
       destination[Z_AXIS] = lz;
-      prepare_uninterpolated_move_to_destination();   // set_current_to_destination
+      prepare_uninterpolated_move_to_destination();   // set_current_from_destination()
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) DEBUG_POS("z raise move", current_position);
       #endif
@@ -338,14 +338,14 @@ void do_blocking_move_to(const float &lx, const float &ly, const float &lz, cons
 
     destination[X_AXIS] = lx;
     destination[Y_AXIS] = ly;
-    prepare_move_to_destination();         // set_current_to_destination
+    prepare_move_to_destination();         // set_current_from_destination()
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) DEBUG_POS("xy move", current_position);
     #endif
 
     if (lz < current_position[Z_AXIS]) {    // lowering?
       destination[Z_AXIS] = lz;
-      prepare_uninterpolated_move_to_destination();   // set_current_to_destination
+      prepare_uninterpolated_move_to_destination();   // set_current_from_destination()
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) DEBUG_POS("z lower move", current_position);
       #endif
@@ -355,7 +355,7 @@ void do_blocking_move_to(const float &lx, const float &ly, const float &lz, cons
 
     if (!position_is_reachable_xy(lx, ly)) return;
 
-    set_destination_to_current();
+    set_destination_from_current();
 
     // If Z needs to raise, do it before moving XY
     if (destination[Z_AXIS] < lz) {
@@ -701,7 +701,7 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
             // Skip it, but keep track of the current position
             // (so it can be used as the start of the next non-travel move)
             if (delayed_move_time != 0xFFFFFFFFUL) {
-              set_current_to_destination();
+              set_current_from_destination();
               NOLESS(raised_parked_position[Z_AXIS], destination[Z_AXIS]);
               delayed_move_time = millis();
               return true;
@@ -807,7 +807,7 @@ void prepare_move_to_destination() {
     #endif
   ) return;
 
-  set_current_to_destination();
+  set_current_from_destination();
 }
 
 #if HAS_AXIS_UNHOMED_ERR

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -106,8 +106,8 @@ XYZ_DEFS(signed char, home_dir, HOME_DIR);
 
 void report_current_position();
 
-inline void set_current_to_destination() { COPY(current_position, destination); }
-inline void set_destination_to_current() { COPY(destination, current_position); }
+inline void set_current_from_destination() { COPY(current_position, destination); }
+inline void set_destination_from_current() { COPY(destination, current_position); }
 
 void get_cartesian_from_steppers();
 void set_current_from_steppers_for_axis(const AxisEnum axis);

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -176,7 +176,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         }
 
         // Save current position to destination, for use later
-        set_destination_to_current();
+        set_destination_from_current();
 
         #if ENABLED(DUAL_X_CARRIAGE)
 


### PR DESCRIPTION
In response to: https://github.com/MarlinFirmware/Marlin/issues/8025#issuecomment-338320769

set_destination_to_current() changed to set_destination_from_current()

set_current_to_destination() changed to set_current_from_destination()