### PR TITLE
Separate software endstops into multiple axis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -787,8 +787,19 @@
 
 // If enabled, axes won't move below MIN_POS in response to movement commands.
 #define MIN_SOFTWARE_ENDSTOPS
+#if ENABLED(MIN_SOFTWARE_ENDSTOPS)
+  #define SOFT_ENDSTOPS_MIN_X
+  #define SOFT_ENDSTOPS_MIN_Y
+  #define SOFT_ENDSTOPS_MIN_Z
+#endif
+
 // If enabled, axes won't move above MAX_POS in response to movement commands.
 #define MAX_SOFTWARE_ENDSTOPS
+#if ENABLED(MAX_SOFTWARE_ENDSTOPS)
+  #define SOFT_ENDSTOPS_MAX_X
+  #define SOFT_ENDSTOPS_MAX_Y
+  #define SOFT_ENDSTOPS_MAX_Z
+#endif
 
 /**
  * Filament Runout Sensor
@@ -1588,7 +1599,7 @@
  * Adds the M150 command to set the LED (or LED strip) color.
  * If pins are PWM capable (e.g., 4, 5, 6, 11) then a range of
  * luminance values can be set from 0 to 255.
- * For Neopixel LED overall brightness parameters is also available 
+ * For Neopixel LED overall brightness parameters is also available
  *
  * *** CAUTION ***
  *  LED Strips require a MOFSET Chip between PWM lines and LEDs,

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -281,6 +281,8 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
 
 #if HAS_SOFTWARE_ENDSTOPS
   extern bool soft_endstops_enabled;
+  extern bool soft_endstops_min_enabled[XYZ];
+  extern bool soft_endstops_max_enabled[XYZ];
   void clamp_to_software_endstops(float target[XYZ]);
 #else
   #define soft_endstops_enabled false

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -473,6 +473,40 @@ float filament_size[EXTRUDERS], volumetric_multiplier[EXTRUDERS];
 // Software Endstops are based on the configured limits.
 #if HAS_SOFTWARE_ENDSTOPS
   bool soft_endstops_enabled = true;
+    bool soft_endstops_min_enabled[XYZ] = {
+    #if ENABLED(SOFT_ENDSTOPS_MIN_X)
+      true,
+    #else
+      false,
+    #endif
+    #if ENABLED(SOFT_ENDSTOPS_MIN_Y)
+      true,
+    #else
+      false,
+    #endif
+    #if ENABLED(SOFT_ENDSTOPS_MIN_Z)
+      true
+    #else
+      false
+    #endif
+    };
+    bool soft_endstops_max_enabled[XYZ] = {
+    #if ENABLED(SOFT_ENDSTOPS_MAX_X)
+      true,
+    #else
+      false,
+    #endif 
+    #if ENABLED(SOFT_ENDSTOPS_MAX_Y)
+      true,
+    #else
+      false,
+    #endif  
+    #if ENABLED(SOFT_ENDSTOPS_MAX_Z)
+      true
+    #else
+      false
+    #endif  
+  };
 #endif
 float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
       soft_endstop_max[XYZ] = { X_MAX_BED, Y_MAX_BED, Z_MAX_POS };
@@ -11745,20 +11779,28 @@ void ok_to_send() {
 
   void clamp_to_software_endstops(float target[XYZ]) {
     if (!soft_endstops_enabled) return;
-    #if ENABLED(MIN_SOFTWARE_ENDSTOPS)
       #if DISABLED(DELTA)
-        NOLESS(target[X_AXIS], soft_endstop_min[X_AXIS]);
-        NOLESS(target[Y_AXIS], soft_endstop_min[Y_AXIS]);
+        if (soft_endstops_min_enabled[X_AXIS]) {
+          NOLESS(target[X_AXIS], soft_endstop_min[X_AXIS]);
+        }
+        if (soft_endstops_min_enabled[Y_AXIS]) {
+          NOLESS(target[Y_AXIS], soft_endstop_min[Y_AXIS]);
+        }
       #endif
-      NOLESS(target[Z_AXIS], soft_endstop_min[Z_AXIS]);
-    #endif
-    #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
+      if (soft_endstops_min_enabled[Z_AXIS]) {
+        NOLESS(target[Z_AXIS], soft_endstop_min[Z_AXIS]);
+      }
       #if DISABLED(DELTA)
-        NOMORE(target[X_AXIS], soft_endstop_max[X_AXIS]);
-        NOMORE(target[Y_AXIS], soft_endstop_max[Y_AXIS]);
+        if (soft_endstops_max_enabled[X_AXIS]) {
+          NOMORE(target[X_AXIS], soft_endstop_max[X_AXIS]);
+        }
+        if (soft_endstops_max_enabled[Y_AXIS]) {
+          NOMORE(target[Y_AXIS], soft_endstop_max[Y_AXIS]);
+        }
       #endif
-      NOMORE(target[Z_AXIS], soft_endstop_max[Z_AXIS]);
-    #endif
+      if (soft_endstops_max_enabled[Z_AXIS]) {
+        NOMORE(target[Z_AXIS], soft_endstop_max[Z_AXIS]);
+      }
   }
 
 #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2834,12 +2834,12 @@ void kill_screen(const char* lcd_msg) {
       #if HAS_SOFTWARE_ENDSTOPS
         // Limit to software endstops, if enabled
         if (soft_endstops_enabled) {
-          #if ENABLED(MIN_SOFTWARE_ENDSTOPS)
+          if (soft_endstops_min_enabled[axis]) {
             min = soft_endstop_min[axis];
-          #endif
-          #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
+          }
+          if (soft_endstops_max_enabled[axis]) {
             max = soft_endstop_max[axis];
-          #endif
+          }
         }
       #endif
 


### PR DESCRIPTION
This change enables toggling software endstops for axis individually.
Useful for bed leveling.
This change does not alter the Gcode, but should probably be considered
for a future revision.