### PR TITLE
Better comments for MIN_POS.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -777,7 +777,7 @@
 #define X_BED_SIZE 200
 #define Y_BED_SIZE 200
 
-// Travel limits (mm) after homing, corresponding to endstop positions.
+// Travel limits (mm) after homing. Setting MIN_POS values to a negative value allows the head to move behind the home coordinates.
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0


### PR DESCRIPTION
Reference to #8027 

I'm unsure on the behaviour if, for example, X_MIN_POS was set past the X limit switch.

Also, unsure if we should add a comment where Z_MIN_POS anything other then zero probably makes no sense and will crash the head?