### PR TITLE
Clean up HAL trailing spaces, MKS SBASE pins

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/persistent_store_impl.cpp
@@ -1,3 +1,24 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
 #ifdef TARGET_LPC1768
 
 #include "../../inc/MarlinConfig.h"
@@ -19,8 +40,6 @@ FATFS fat_fs;
 FIL eeprom_file;
 
 bool access_start() {
-  UINT file_size = 0,
-       bytes_written = 0;
   const char eeprom_erase_value = 0xFF;
   MSC_Aquire_Lock();
   if (f_mount(&fat_fs, "", 1)) {
@@ -30,9 +49,8 @@ bool access_start() {
   FRESULT res = f_open(&eeprom_file, "eeprom.dat", FA_OPEN_ALWAYS | FA_WRITE | FA_READ);
   if (res) MSC_Release_Lock();
 
-  if (res == FR_OK) file_size = f_size(&eeprom_file);
-
   if (res == FR_OK) {
+    uint16_t bytes_written, file_size = f_size(&eeprom_file);
     f_lseek(&eeprom_file, file_size);
     while (file_size <= E2END && res == FR_OK) {
       res = f_write(&eeprom_file, &eeprom_erase_value, 1, &bytes_written);
@@ -56,53 +74,52 @@ bool access_finish() {
 // File function return codes for type FRESULT   This goes away soon.   But it is helpful right now to see
 // the different errors the read_data() and write_data() functions are seeing.
 //
-//typedef enum {
-//      FR_OK = 0,               /* (0) Succeeded */
-//      FR_DISK_ERR,             /* (1) A hard error occurred in the low level disk I/O layer */
-//      FR_INT_ERR,              /* (2) Assertion failed */
-//      FR_NOT_READY,            /* (3) The physical drive cannot work */
-//      FR_NO_FILE,              /* (4) Could not find the file */
-//      FR_NO_PATH,              /* (5) Could not find the path */
-//      FR_INVALID_NAME,         /* (6) The path name format is invalid */
-//      FR_DENIED,               /* (7) Access denied due to prohibited access or directory full */
-//      FR_EXIST,                /* (8) Access denied due to prohibited access */
-//      FR_INVALID_OBJECT,       /* (9) The file/directory object is invalid */
-//      FR_WRITE_PROTECTED,      /* (10) The physical drive is write protected */
-//      FR_INVALID_DRIVE,        /* (11) The logical drive number is invalid */
-//      FR_NOT_ENABLED,          /* (12) The volume has no work area */
-//      FR_NO_FILESYSTEM,        /* (13) There is no valid FAT volume */
-//      FR_MKFS_ABORTED,         /* (14) The f_mkfs() aborted due to any problem */
-//      FR_TIMEOUT,              /* (15) Could not get a grant to access the volume within defined period */
-//      FR_LOCKED,               /* (16) The operation is rejected according to the file sharing policy */
-//      FR_NOT_ENOUGH_CORE,      /* (17) LFN working buffer could not be allocated */
-//      FR_TOO_MANY_OPEN_FILES,  /* (18) Number of open files > FF_FS_LOCK */
-//      FR_INVALID_PARAMETER     /* (19) Given parameter is invalid */
-//} FRESULT;
+//  typedef enum {
+//    FR_OK = 0,               /* (0) Succeeded */
+//    FR_DISK_ERR,             /* (1) A hard error occurred in the low level disk I/O layer */
+//    FR_INT_ERR,              /* (2) Assertion failed */
+//    FR_NOT_READY,            /* (3) The physical drive cannot work */
+//    FR_NO_FILE,              /* (4) Could not find the file */
+//    FR_NO_PATH,              /* (5) Could not find the path */
+//    FR_INVALID_NAME,         /* (6) The path name format is invalid */
+//    FR_DENIED,               /* (7) Access denied due to prohibited access or directory full */
+//    FR_EXIST,                /* (8) Access denied due to prohibited access */
+//    FR_INVALID_OBJECT,       /* (9) The file/directory object is invalid */
+//    FR_WRITE_PROTECTED,      /* (10) The physical drive is write protected */
+//    FR_INVALID_DRIVE,        /* (11) The logical drive number is invalid */
+//    FR_NOT_ENABLED,          /* (12) The volume has no work area */
+//    FR_NO_FILESYSTEM,        /* (13) There is no valid FAT volume */
+//    FR_MKFS_ABORTED,         /* (14) The f_mkfs() aborted due to any problem */
+//    FR_TIMEOUT,              /* (15) Could not get a grant to access the volume within defined period */
+//    FR_LOCKED,               /* (16) The operation is rejected according to the file sharing policy */
+//    FR_NOT_ENOUGH_CORE,      /* (17) LFN working buffer could not be allocated */
+//    FR_TOO_MANY_OPEN_FILES,  /* (18) Number of open files > FF_FS_LOCK */
+//    FR_INVALID_PARAMETER     /* (19) Given parameter is invalid */
+//  } FRESULT;
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   FRESULT s;
-  UINT bytes_written = 0;
+  uint16_t bytes_written = 0;
+
   s = f_lseek(&eeprom_file, pos);
-  if ( s ) {
+  if (s) {
    SERIAL_PROTOCOLPAIR(" write_data(", pos);         // This extra chit-chat goes away soon.  But it is helpful
-   SERIAL_PROTOCOLPAIR(",", (int) value);            // right now to see errors that are happening in the 
-   SERIAL_PROTOCOLPAIR(",", (int) size);             // read_data() and write_data() functions
+   SERIAL_PROTOCOLPAIR(",", (int)value);            // right now to see errors that are happening in the
+   SERIAL_PROTOCOLPAIR(",", (int)size);             // read_data() and write_data() functions
    SERIAL_PROTOCOL("...)\n");
-   SERIAL_PROTOCOLPAIR(" f_lseek()=", (int) s);
-   SERIAL_PROTOCOL("\n");
+   SERIAL_PROTOCOLLNPAIR(" f_lseek()=", (int)s);
    return s;
   }
+
   s = f_write(&eeprom_file, (void *)value, size, &bytes_written);
-  if ( s ) {
+  if (s) {
    SERIAL_PROTOCOLPAIR(" write_data(", pos);         // This extra chit-chat goes away soon.  But it is helpful
-   SERIAL_PROTOCOLPAIR(",", (int) value);            // right now to see errors that are happening in the 
-   SERIAL_PROTOCOLPAIR(",", (int) size);             // read_data() and write_data() functions
-   SERIAL_PROTOCOL("...)\n");
-   SERIAL_PROTOCOLPAIR(" f_write()=", (int) s);
-   SERIAL_PROTOCOL("\n");
-   SERIAL_PROTOCOLPAIR(" size=",  (int) size);
-   SERIAL_PROTOCOLPAIR("\n bytes_written=",  (int) bytes_written);
-   SERIAL_PROTOCOL("\n");
+   SERIAL_PROTOCOLPAIR(",", (int)value);            // right now to see errors that are happening in the
+   SERIAL_PROTOCOLPAIR(",", size);             // read_data() and write_data() functions
+   SERIAL_PROTOCOLLN("...)");
+   SERIAL_PROTOCOLLNPAIR(" f_write()=", (int)s);
+   SERIAL_PROTOCOLPAIR(" size=", size);
+   SERIAL_PROTOCOLLNPAIR("\n bytes_written=", bytes_written);
    return s;
   }
   crc16(crc, value, size);
@@ -111,29 +128,26 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
 }
 
 bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
-  UINT bytes_read = 0;
+  uint16_t bytes_read = 0;
   FRESULT s;
   s = f_lseek(&eeprom_file, pos);
   if ( s ) {
    SERIAL_PROTOCOLPAIR(" read_data(", pos);          // This extra chit-chat goes away soon.  But it is helpful
-   SERIAL_PROTOCOLPAIR(",", (int) value);            // right now to see errors that are happening in the 
-   SERIAL_PROTOCOLPAIR(",", (int) size);             // read_data() and write_data() functions
-   SERIAL_PROTOCOL("...)\n");
-   SERIAL_PROTOCOLPAIR(" f_lseek()=", (int) s);
-   SERIAL_PROTOCOL("\n");
+   SERIAL_PROTOCOLPAIR(",", (int)value);            // right now to see errors that are happening in the
+   SERIAL_PROTOCOLPAIR(",", size);             // read_data() and write_data() functions
+   SERIAL_PROTOCOLLN("...)");
+   SERIAL_PROTOCOLLNPAIR(" f_lseek()=", (int)s);
    return true;
   }
   s = f_read(&eeprom_file, (void *)value, size, &bytes_read);
-  if ( s ) {
+  if (s) {
    SERIAL_PROTOCOLPAIR(" read_data(", pos);         // This extra chit-chat goes away soon.  But it is helpful
-   SERIAL_PROTOCOLPAIR(",", (int) value);           // right now to see errors that are happening in the 
-   SERIAL_PROTOCOLPAIR(",", (int) size);            // read_data() and write_data() functions
-   SERIAL_PROTOCOL("...)\n");
-   SERIAL_PROTOCOLPAIR(" f_write()=", (int) s);
-   SERIAL_PROTOCOL("\n");
-   SERIAL_PROTOCOLPAIR(" size=",  (int) size);
-   SERIAL_PROTOCOLPAIR("\n bytes_read=",  (int) bytes_read);
-   SERIAL_PROTOCOL("\n");
+   SERIAL_PROTOCOLPAIR(",", (int)value);           // right now to see errors that are happening in the
+   SERIAL_PROTOCOLPAIR(",", size);            // read_data() and write_data() functions
+   SERIAL_PROTOCOLLN("...)");
+   SERIAL_PROTOCOLLNPAIR(" f_write()=", (int)s);
+   SERIAL_PROTOCOLPAIR(" size=", size);
+   SERIAL_PROTOCOLLNPAIR("\n bytes_read=",  bytes_read);
    return true;
   }
   crc16(crc, value, size);

--- a/Marlin/src/HAL/HAL_LPC1768/pinmap_re_arm.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmap_re_arm.h
@@ -220,7 +220,7 @@ const pin_data pin_map[] = { // pin map for variable pin function
   {1,4},        //  DIO77                   J12-10            ENET_TX_EN
   {1,0},        //  DIO78                   J12-11            ENET_TXD0
   {1,1},        //  DIO79                   J12-12            ENET_TXD1
-  {0,14},       //  DIO80                   MKS-SBASE	J7-6 & EXP1-5	  
+  {0,14},       //  DIO80                   MKS-SBASE	J7-6 & EXP1-5
   {0,7},        //  DIO81  SD-SCK           MKS-SBASE	on board SD card and EXP2-2
   {0,8},        //  DIO82  SD-MISO          MKS-SBASE	on board SD card and EXP2-1
   {0,9},        //  DIO83  SD-MOSI          MKS-SBASE 	n board SD card and EXP2-6

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -1255,7 +1255,7 @@
  * Enable one of the following items for a slower SPI transfer speed.
  * This may be required to resolve "volume init" errors or LCD issues.
  */
- 
+
 //#define SPI_SPEED SPI_HALF_SPEED
 //#define SPI_SPEED SPI_QUARTER_SPEED
 //#define SPI_SPEED SPI_EIGHTH_SPEED

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -43,12 +43,6 @@
 #define D58               58
 */
 
-
-//
-// Servos
-//
-
-    
 //
 // Limit Switches
 //
@@ -58,8 +52,6 @@
 #define Y_MAX_PIN          15  //10k pullup to 3.3V, 1K series
 #define Z_MIN_PIN          19  //The original Mks Sbase DIO19 has a 10k pullup to 3.3V or 5V, 1K series, so when using a Zprobe we must use DIO41 (J8 P1.22)
 #define Z_MAX_PIN          18  //10k pullup to 3.3V, 1K series
-
-
 
 //
 // Steppers
@@ -84,35 +76,32 @@
 #define E1_DIR_PIN         34
 #define E1_ENABLE_PIN      30
 
-
 #define X2_STEP_PIN        36
 #define X2_DIR_PIN         34
 #define X2_ENABLE_PIN      30
 
-
 //
 // Temperature Sensors
-//  3.3V max when defined as an analog input
+// 3.3V max when defined as an analog input
 //
 
-
-#define TEMP_0_PIN          0  //A0 (TH1)
-#define TEMP_BED_PIN        1  //A1 (TH2)
-#define TEMP_1_PIN          2  //A2 (TH3)
-#define TEMP_2_PIN          3  //A3 (TH4)
+#define TEMP_0_PIN          0  // A0 (TH1)
+#define TEMP_BED_PIN        1  // A1 (TH2)
+#define TEMP_1_PIN          2  // A2 (TH3)
+#define TEMP_2_PIN          3  // A3 (TH4)
 
 
 //
 // Heaters / Fans
 //
 
-#define HEATER_BED_PIN      10
+#define HEATER_BED_PIN     10
 #define HEATER_0_PIN        8
-#define HEATER_1_PIN        59
+#define HEATER_1_PIN       59
 #define FAN_PIN             9
 
 
-#define PS_ON_PIN           69
+#define PS_ON_PIN          69
 
 
 //
@@ -122,9 +111,9 @@
 // 5V
 // NC
 // GND
-#define PIN_P0_17			50
-#define PIN_P0_16			16
-#define PIN_P0_14			80 
+#define PIN_P0_17          50
+#define PIN_P0_16          16
+#define PIN_P0_14          80
 
 
 //
@@ -132,21 +121,19 @@
 //
 
 // GND
-#define PIN_P1_22			41
-#define PIN_P1_23			53
-#define PIN_P2_12			12
-#define PIN_P2_11			35
-#define PIN_P4_28			13
-
+#define PIN_P1_22          41
+#define PIN_P1_23          53
+#define PIN_P2_12          12
+#define PIN_P2_11          35
+#define PIN_P4_28          13
 
 //
 // Prusa i3 MK2 Multi Material Multiplexer Support
 //
 
-
-#define E_MUX0_PIN          50   // J7-4
-#define E_MUX1_PIN          16   // J7-5
-#define E_MUX2_PIN          80   // J7-6
+#define E_MUX0_PIN         50   // J7-4
+#define E_MUX1_PIN         16   // J7-5
+#define E_MUX2_PIN         80   // J7-6
 
 
 /**
@@ -162,72 +149,38 @@
  * that the garbage/lines are erased immediately after the SD card accesses are completed.
  */
 
-#if ENABLED(ULTRA_LCD)		// 
-
-  #define BEEPER_PIN          49  // EXP1.1
-
-  #define BTN_ENC             37  // EXP1.2 
-  #define BTN_EN1             31  // EXP2.5
-  #define BTN_EN2             33  // EXP2.3
-  
-  #define SD_DETECT_PIN       57  // EXP2.7
-  #define KILL_PIN            -1  // Not connected
-  #define LCD_PINS_RS         16  // EXP1.4
-  #define LCD_SDSS            58  // EXP2.4
-  #define LCD_BACKLIGHT_PIN   -1  // Not connected
-  #define LCD_PINS_ENABLE     51  // EXP1.3
-  #define LCD_PINS_D4         80  // EXP1.5
-
-  #define DOGLCD_A0           -1  // Not connected
-  #define DOGLCD_CS           -1  // Not connected
-
-#ifdef ULTIPANEL
-  
-  #define LCD_PINS_D5         -1  // EXP1.6 Not connected
-  #define LCD_PINS_D6         -1  // EXP1.7 Not connected
-  #define LCD_PINS_D7         -1  // EXP1.8 Not connected
-#endif
- 
-
-  #if ENABLED(SDSUPPORT)
-    #define SDCARD_SORT_ALPHA           // Using SORT feature to keep one directory level in RAM
-                                        // When going up/down directory levels the SD card is
-                                        // accessed but the garbage/lines are removed when the
-                                        // LCD updates
-
-    // SD Card Sorting options
-    #if ENABLED(SDCARD_SORT_ALPHA)
-      #define SDSORT_LIMIT       255    // Maximum number of sorted items (10-256).
-      #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
-      #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 g-code.
-      #define SDSORT_USES_RAM    true   // Pre-allocate a static array for faster pre-sorting.
-      #define SDSORT_USES_STACK  false  // Prefer the stack for pre-sorting to give back some SRAM. (Negated by next 2 options.)
-      #define SDSORT_CACHE_NAMES true   // Keep sorted items in RAM longer for speedy performance. Most expensive option.
-      #define SDSORT_DYNAMIC_RAM false  // Use dynamic allocation (within SD menus). Least expensive option. Set SDSORT_LIMIT before use!
-    #endif
-  #endif
+#if ENABLED(ULTRA_LCD)
+  #define BEEPER_PIN       49  // EXP1.1
+  #define BTN_ENC          37  // EXP1.2
+  #define BTN_EN1          31  // EXP2.5
+  #define BTN_EN2          33  // EXP2.3
+  #define SD_DETECT_PIN    57  // EXP2.7
+  #define LCD_PINS_RS      16  // EXP1.4
+  #define LCD_SDSS         58  // EXP2.4
+  #define LCD_PINS_ENABLE  51  // EXP1.3
+  #define LCD_PINS_D4      80  // EXP1.5
 #endif // ULTRA_LCD
 
 //
 // Ethernet pins
 //
 #ifndef ULTIPANEL
-#define ENET_MDIO   71  // J12-4
-#define ENET_RX_ER  73  // J12-6
-#define ENET_RXD1   75  // J12-8
+  #define ENET_MDIO        71  // J12-4
+  #define ENET_RX_ER       73  // J12-6
+  #define ENET_RXD1        75  // J12-8
 #endif
-#define ENET_MOC    70  // J12-3
-#define REF_CLK     72  // J12-5
-#define ENET_RXD0   74  // J12-7
-#define ENET_CRS    76  // J12-9
-#define ENET_TX_EN  77  // J12-10
-#define ENET_TXD0   78  // J12-11
-#define ENET_TXD1   79  // J12-12
+#define ENET_MOC           70  // J12-3
+#define REF_CLK            72  // J12-5
+#define ENET_RXD0          74  // J12-7
+#define ENET_CRS           76  // J12-9
+#define ENET_TX_EN         77  // J12-10
+#define ENET_TXD0          78  // J12-11
+#define ENET_TXD1          79  // J12-12
 
 /**
- *  PWMS
+ *  PWMs
  *
- *  There are 6 PWMS.  Each PWM can be assigned to one of two pins.
+ *  There are 6 PWMs.  Each PWM can be assigned to one of two pins.
  *
  *  SERVO2 does NOT have a PWM assigned to it.
  *
@@ -245,12 +198,11 @@
  *  PWM1.6   DIO10   RAMPS_D10_PIN
  */
 
-
  /**
-  * special pins
+  * Special pins
   *   D37 - not 5V tolerant
   *   D49 - not 5V tolerant
   *   D57 - open collector
   *   D58 - open collector
   *
- */
+  */


### PR DESCRIPTION
Followup to #7945, merged without application of standards.

- Replace tabs with spaces
- Remove trailing whitespace
- Remove forced settings of `SDCARD_SORT_ALPHA`
  (Add to a custom config if needed!)

Also:
- Clean up some other HAL spacing/formatting