### PR TITLE
[2.0.x] Add MKS MINI 12864 support to GT2560

### DIFF
--- a/Marlin/src/pins/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/pins_GT2560_REV_A.h
@@ -98,18 +98,23 @@
 
   #if ENABLED(NEWPANEL)
 
-    #define LCD_PINS_RS    20
-    #define LCD_PINS_ENABLE 17
-    #define LCD_PINS_D4    16
-    #define LCD_PINS_D5    21
-    #define LCD_PINS_D6     5
-    #define LCD_PINS_D7     6
+    #if ENABLED(MKS_MINI_12864)
+      #define DOGLCD_A0     5
+      #define DOGLCD_CS    21
+      #define BTN_EN1      40
+      #define BTN_EN2      42
+    #else
+      #define LCD_PINS_RS  20
+      #define LCD_PINS_ENABLE 17
+      #define LCD_PINS_D4  16
+      #define LCD_PINS_D5  21
+      #define LCD_PINS_D6   5
+      #define LCD_PINS_D7   6
+      #define BTN_EN1      42
+      #define BTN_EN2      40
+    #endif
 
-    // Buttons are directly attached
-    #define BTN_EN1        42
-    #define BTN_EN2        40
     #define BTN_ENC        19
-
     #define SD_DETECT_PIN  38
 
   #else // !NEWPANEL


### PR DESCRIPTION
Based on #8048

Add pins supporting the MKS MINI 12864 LCD on the GT2560 Rev.A board.