### PR TITLE
(2.0.x) Neopixel Startup Fix

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -44,13 +44,13 @@ void setup_neopixel() {
   pixels.show(); // initialize to all off
 
   #if ENABLED(NEOPIXEL_STARTUP_TEST)
-    delay(2000);
+    ssafe_delay(2000);
     set_neopixel_color(pixels.Color(255, 0, 0, 0));  // red
-    delay(2000);
+    ssafe_delay(2000);
     set_neopixel_color(pixels.Color(0, 255, 0, 0));  // green
-    delay(2000);
+    ssafe_delay(2000);
     set_neopixel_color(pixels.Color(0, 0, 255, 0));  // blue
-    delay(2000);
+    ssafe_delay(2000);
   #endif
   set_neopixel_color(pixels.Color(0, 0, 0, 255));    // white
 }


### PR DESCRIPTION
Correction to prevent the bootloops due to watchdog timeout. Ref: #8036