### PR TITLE
[1.1.x] Add MKS GEN L board

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -95,6 +95,7 @@
 #define BOARD_LEAPFROG          999  // Leapfrog
 #define BOARD_MKS_BASE          40   // MKS BASE 1.0
 #define BOARD_MKS_13            47   // MKS v1.3 or 1.4 (maybe higher)
+#define BOARD_MKS_GEN_L         53   // MKS GEN L
 #define BOARD_SAINSMART_2IN1    49   // Sainsmart 2-in-1 board
 #define BOARD_BAM_DICE          401  // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402  // 2PrintBeta BAM&DICE Due with STK drivers

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -91,7 +91,7 @@
 #elif MB(MKS_13)
   #include "pins_MKS_13.h"            // ATmega1280, ATmega2560
 #elif MB(MKS_GEN_L)
-  #include "pins_MKS_GEN_L.h"            // ATmega1280, ATmega2560
+  #include "pins_MKS_GEN_L.h"         // ATmega1280, ATmega2560
 #elif MB(ZRIB_V20)
   #include "pins_ZRIB_V20.h"          // ATmega1280, ATmega2560 (MKS_13)
 #elif MB(FELIX2)

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -90,6 +90,8 @@
   #include "pins_MKS_BASE.h"          // ATmega1280, ATmega2560
 #elif MB(MKS_13)
   #include "pins_MKS_13.h"            // ATmega1280, ATmega2560
+#elif MB(MKS_GEN_L)
+  #include "pins_MKS_GEN_L.h"            // ATmega1280, ATmega2560
 #elif MB(ZRIB_V20)
   #include "pins_ZRIB_V20.h"          // ATmega1280, ATmega2560 (MKS_13)
 #elif MB(FELIX2)

--- a/Marlin/pins_MKS_GEN_L.h
+++ b/Marlin/pins_MKS_GEN_L.h
@@ -1,0 +1,41 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MKS BASE 1.0 – Arduino Mega2560 with RAMPS v1.4 pin assignments
+ *
+ * Rev B - Override pin definitions for CASE_LIGHT and M3/M4/M5 spindle control
+ */
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "MKS BASE 1.0 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_NAME "MKS GEN L"
+
+//
+// Heaters / Fans
+//
+// Power outputs EFBF or EFBE
+#define MOSFET_D_PIN 7
+
+#include "pins_RAMPS.h"

--- a/Marlin/pins_MKS_GEN_L.h
+++ b/Marlin/pins_MKS_GEN_L.h
@@ -21,13 +21,11 @@
  */
 
 /**
- * MKS BASE 1.0 – Arduino Mega2560 with RAMPS v1.4 pin assignments
- *
- * Rev B - Override pin definitions for CASE_LIGHT and M3/M4/M5 spindle control
+ * MKS GEN L – Arduino Mega2560 with RAMPS v1.4 pin assignments
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS BASE 1.0 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS GEN L supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
 #define BOARD_NAME "MKS GEN L"


### PR DESCRIPTION
MKS Base has pin defs that interfered, and this will show the correct board in queries.