### PR TITLE
(bug fix) 1.1.x - save 1400 bytes of FLASH by using reduced font for some languages

### DIFF
--- a/Marlin/language_fr_utf8.h
+++ b/Marlin/language_fr_utf8.h
@@ -27,8 +27,8 @@
  * See also http://marlinfw.org/docs/development/lcd_language.html
  *
  */
-#ifndef LANGUAGE_FR_H
-#define LANGUAGE_FR_H
+#ifndef LANGUAGE_FR_UTF_H
+#define LANGUAGE_FR_UTF_H
 
 #define MAPPER_C2C3
 #define DISPLAY_CHARSET_ISO10646_1
@@ -341,4 +341,4 @@
   #define MSG_FILAMENT_CHANGE_RESUME_1      _UxGT("Reprise...")
 #endif // LCD_HEIGHT < 4
 
-#endif // LANGUAGE_FR_H
+#endif // LANGUAGE_FR_UTF_H


### PR DESCRIPTION
Changing the name within **language_fr_utf8.h** from **LANGUAGE_FR_H**  to **LANGUAGE_FR_UTF_H**.

Currently **language_fr_utf8.h** and **language_fr.h** both had **LANGUAGE_FR_H** as their name.  This meant that the logic at the beginning of **dogm_font_data_ISO10646_1.h** would use the reduced font size version for **language_fr_utf8.h** which meant all the extended characters were not available.





