### PR TITLE
LPC1768: Travis default config (Re-ARM) test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -436,3 +436,14 @@ script:
   - pins_set RAMPS X_MAX_PIN -1
   - opt_set_adv Z2_MAX_PIN 2
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+  #############################
+  # LPC1768 default config test
+  #############################
+
+  - export TEST_PLATFORM="-e LPC1768"
+  - restore_configs
+  - opt_set MOTHERBOARD BOARD_RAMPS_14_RE_ARM_EFB
+  - cp Marlin/Configuration.h Marlin/src/config/default/Configuration.h
+  - cp Marlin/Configuration_adv.h Marlin/src/config/default/Configuration_adv.h
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}


### PR DESCRIPTION
Add a single default travis test for lpc1768 (Re-ARM pins file) to catch global build errors. 

We should test all config options that are functional at some point , but I thought it important to get this merged to stop the LPC1768 platform getting silently broken.