### PR TITLE
[2.0.x] Cleanup after SD Print Again, whitespace, tabs

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3745,22 +3745,45 @@ void kill_screen(const char* lcd_msg) {
      * "Print from SD" submenu
      *
      */
+
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-      uint32_t saved_encoderPosition = 0;
-      static millis_t assume_print_finished = 0;
+      uint32_t last_sdfile_encoderPosition = 0xFFFF;
+
+      void lcd_reselect_last_file() {
+        if (last_sdfile_encoderPosition == 0xFFFF) return;
+        #if ENABLED(DOGLCD)
+          // Some of this is a hack to force the screen update to work.
+          // TODO: Fix the real issue that causes this!
+          lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;
+          _lcd_synchronize();
+          safe_delay(50);
+          _lcd_synchronize();
+          lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;
+          drawing_screen = screen_changed = true;
+        #endif
+
+        lcd_goto_screen(lcd_sdcard_menu, last_sdfile_encoderPosition);
+        defer_return_to_status = true;
+        last_sdfile_encoderPosition == 0xFFFF;
+
+        #if ENABLED(DOGLCD)
+          lcd_update();
+        #endif
+      }
     #endif
 
     void lcd_sdcard_menu() {
       ENCODER_DIRECTION_MENUS();
 
       #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
+        static millis_t assume_print_finished = 0;
         if (ELAPSED(millis(), assume_print_finished)) { // if the printer has been busy printing, lcd_sdcard_menu() should not
           lcdDrawUpdate = LCDVIEW_REDRAW_NOW;           // have been active for 5 seconds.  In this case, restore the previous
-          encoderPosition = saved_encoderPosition;      // encoderPosition to the last selected item.
+          encoderPosition = last_sdfile_encoderPosition;      // encoderPosition to the last selected item.
           assume_print_finished = millis() + 5000;
         }
-        saved_encoderPosition = encoderPosition;
-        defer_return_to_status = true;
+        last_sdfile_encoderPosition = encoderPosition;   // needed as a workaround for the 5s timer
+        //defer_return_to_status = true;           // already done in lcd_reselect_last_file
       #endif
 
       const uint16_t fileCnt = card.getnrfilenames();
@@ -4414,7 +4437,7 @@ void kill_screen(const char* lcd_msg) {
 
     void menu_action_sdfile(const char* filename, char* longFilename) {
       #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-        saved_encoderPosition = encoderPosition;  // Save which file was selected for later use
+        last_sdfile_encoderPosition = encoderPosition;  // Save which file was selected for later use
       #endif
       UNUSED(longFilename);
       card.openAndPrintFile(filename);
@@ -4722,16 +4745,18 @@ void lcd_update() {
     // then we want to use 1/2 of the time only.
     uint16_t bbr2 = planner.block_buffer_runtime() >> 1;
 
-    #if ENABLED(DOGLCD)
-      if ((lcdDrawUpdate || drawing_screen) && (!bbr2 || (bbr2 > max_display_update_time)
-      #if ENABLED(SDSUPPORT)
-        || (currentScreen == lcd_sdcard_menu)
+    if (
+      #if ENABLED(DOGLCD)
+        (lcdDrawUpdate || drawing_screen) && (
+          !bbr2 || (bbr2 > max_display_update_time)
+          #if ENABLED(SDSUPPORT)
+            || currentScreen == lcd_sdcard_menu
+          #endif
+        )
+      #else
+        lcdDrawUpdate && (!bbr2 || (bbr2 > max_display_update_time))
       #endif
-      ))
-    #else
-      if (lcdDrawUpdate && (!bbr2 || (bbr2 > max_display_update_time)))
-    #endif
-    {
+    ) {
       #if ENABLED(DOGLCD)
         if (!drawing_screen)
       #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3783,7 +3783,6 @@ void kill_screen(const char* lcd_msg) {
           assume_print_finished = millis() + 5000;
         }
         last_sdfile_encoderPosition = encoderPosition;   // needed as a workaround for the 5s timer
-        //defer_return_to_status = true;           // already done in lcd_reselect_last_file
       #endif
 
       const uint16_t fileCnt = card.getnrfilenames();
@@ -4806,12 +4805,7 @@ void lcd_update() {
 
       // Return to Status Screen after a timeout
       if (currentScreen == lcd_status_screen || defer_return_to_status)
-        #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-          if (currentScreen != lcd_sdcard_menu)                // lcd_sdcard_menu() does not time out if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-            return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;  // When the printer finishes a file, it will wait with the file selected for
-        #else                                                  // a re-print.
         return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS;
-        #endif
       else if (ELAPSED(ms, return_to_status_ms))
         lcd_return_to_status();
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -223,4 +223,8 @@ void lcd_reset_status();
   #define BUZZ(d,f) lcd_buzz(d, f)
 #endif
 
+#if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
+  void lcd_reselect_last_file();
+#endif
+
 #endif // ULTRALCD_H

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -892,15 +892,6 @@ uint16_t CardReader::get_num_Files() {
   ;
 }
 
-#if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-  typedef void (*screenFunc_t)();
-  extern void lcd_sdcard_menu();
-  extern void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder = 0);
-  extern uint32_t saved_encoderPosition;
-  extern bool screen_changed, drawing_screen, defer_return_to_status;
-  void _lcd_synchronize();  // Not declared in any LCD header file.  Probably, that should be changed.
-#endif
-
 void CardReader::printingHasFinished() {
   stepper.synchronize();
   file.close();
@@ -922,15 +913,7 @@ void CardReader::printingHasFinished() {
     #endif
 
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-      lcdDrawUpdate  = LCDVIEW_CALL_REDRAW_NEXT;
-      _lcd_synchronize();
-      safe_delay(50);
-      _lcd_synchronize();
-      lcdDrawUpdate  = LCDVIEW_CALL_REDRAW_NEXT;
-      drawing_screen = screen_changed = true;
-      lcd_goto_screen(lcd_sdcard_menu, saved_encoderPosition);
-      defer_return_to_status = true;
-      lcd_update();
+      lcd_reselect_last_file();
     #endif
   }
 }


### PR DESCRIPTION
Followup to #8106

- Move LCD-oriented code from `cardreader.cpp` to `utlralcd.cpp`
- ~~Add a test commit to with code that's _supposed_ to work~~