### PR TITLE
LPC1768 Pin Mapping and M43 cleanup

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
@@ -26,101 +26,161 @@
 
 typedef int16_t pin_t;
 
-const uint8_t PIN_FEATURE_INTERRUPT = 1 << 0;
-const uint8_t PIN_FEATURE_PWM = 1 << 1;
-constexpr uint8_t PIN_FEATURE_ADC(const int8_t chan) { return (((chan + 1) & 0b1111) << 2); }
+#define PORT_0  000
+#define PORT_1  001
+#define PORT_2  010
+#define PORT_3  011
+#define PORT_4  100
 
-constexpr pin_t LPC1768_PIN(const uint8_t port, const uint8_t pin, const uint8_t feat = 0) {
-  return (((pin_t)feat << 8) | (((pin_t)port & 0x7) << 5) | ((pin_t)pin & 0x1F));
-}
+#define PORT_(p)  PORT_##p
+#define PORT(p)   PORT_(p)
+
+#define PIN_0  00000
+#define PIN_1  00001
+#define PIN_2  00010
+#define PIN_3  00011
+#define PIN_4  00100
+#define PIN_5  00101
+#define PIN_6  00110
+#define PIN_7  00111
+#define PIN_8  01000
+#define PIN_9  01001
+#define PIN_10 01010
+#define PIN_11 01011
+#define PIN_12 01100
+#define PIN_13 01101
+#define PIN_14 01110
+#define PIN_15 01111
+#define PIN_16 10000
+#define PIN_17 10001
+#define PIN_18 10010
+#define PIN_19 10011
+#define PIN_20 10100
+#define PIN_21 10101
+#define PIN_22 10110
+#define PIN_23 10111
+#define PIN_24 11000
+#define PIN_25 11001
+#define PIN_26 11010
+#define PIN_27 11011
+#define PIN_28 11100
+#define PIN_29 11101
+#define PIN_30 11110
+#define PIN_31 11111
+
+#define PIN_(p) PIN_##p
+#define PIN(p)  PIN_(p)
+
+#define ADC_NONE    0000
+#define ADC_CHAN_0  0001
+#define ADC_CHAN_1  0010
+#define ADC_CHAN_2  0011
+#define ADC_CHAN_3  0100
+#define ADC_CHAN_4  0101
+#define ADC_CHAN_5  0110
+#define ADC_CHAN_6  0111
+#define ADC_CHAN_7  1000
+
+#define ADC_CHAN_(c)  ADC_CHAN_##c
+#define ADC_CHAN(p)   ADC_CHAN_(p)
+
+#define BOOL_0 0
+#define BOOL_1 1
+#define BOOL_(b)      BOOL_##b
+
+#define INTERRUPT(b)  BOOL_(b)
+#define PWM(b)        BOOL_(b)
+
+#define LPC1768_PIN_(port, pin, int, pwm, adc)  0b00##adc##pwm##int##port##pin
+#define LPC1768_PIN(port, pin, int, pwm, adc)   LPC1768_PIN_(port, pin, int, pwm, adc)
 
 constexpr uint8_t LPC1768_PIN_PORT(const pin_t pin) { return ((uint8_t)((pin >> 5) & 0b111)); }
 constexpr uint8_t LPC1768_PIN_PIN(const pin_t pin) { return ((uint8_t)(pin & 0b11111)); }
-constexpr bool LPC1768_PIN_INTERRUPT(const pin_t pin) { return (((pin >> 8) & PIN_FEATURE_INTERRUPT) != 0); }
-constexpr bool LPC1768_PIN_PWM(const pin_t pin) { return (((pin >> 8) & PIN_FEATURE_PWM) != 0); }
+constexpr bool LPC1768_PIN_INTERRUPT(const pin_t pin) { return (((pin >> 8) & 0b1) != 0); }
+constexpr bool LPC1768_PIN_PWM(const pin_t pin) { return (((pin >> 9) & 0b1) != 0); }
 constexpr int8_t LPC1768_PIN_ADC(const pin_t pin) { return (int8_t)((pin >> 10) & 0b1111) - 1; }
 
 // ******************
 // Runtime pinmapping
 // ******************
 #if SERIAL_PORT != 3
-  const pin_t P0_0  = LPC1768_PIN(0,  0, PIN_FEATURE_INTERRUPT);
-  const pin_t P0_1  = LPC1768_PIN(0,  1, PIN_FEATURE_INTERRUPT);
+  #define P0_0   LPC1768_PIN(PORT(0), PIN(0), INTERRUPT(1), PWM(0), ADC_NONE)
+  #define P0_1   LPC1768_PIN(PORT(0), PIN(1), INTERRUPT(1), PWM(0), ADC_NONE)
 #endif
 #if SERIAL_PORT != 0
-  const pin_t P0_2  = LPC1768_PIN(0,  2, PIN_FEATURE_INTERRUPT | PIN_FEATURE_ADC(7));
-  const pin_t P0_3  = LPC1768_PIN(0,  3, PIN_FEATURE_INTERRUPT | PIN_FEATURE_ADC(6));
+  #define P0_2   LPC1768_PIN(PORT(0), PIN(2), INTERRUPT(1), PWM(0), ADC_CHAN(7))
+  #define P0_3   LPC1768_PIN(PORT(0), PIN(3), INTERRUPT(1), PWM(0), ADC_CHAN(6))
 #endif
-const pin_t P0_4  = LPC1768_PIN(0,  4, PIN_FEATURE_INTERRUPT);
-const pin_t P0_5  = LPC1768_PIN(0,  5, PIN_FEATURE_INTERRUPT);
-const pin_t P0_6  = LPC1768_PIN(0,  6, PIN_FEATURE_INTERRUPT);
-const pin_t P0_7  = LPC1768_PIN(0,  7, PIN_FEATURE_INTERRUPT);
-const pin_t P0_8  = LPC1768_PIN(0,  8, PIN_FEATURE_INTERRUPT);
-const pin_t P0_9  = LPC1768_PIN(0,  9, PIN_FEATURE_INTERRUPT);
+#define P0_4   LPC1768_PIN(PORT(0), PIN(4), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_5   LPC1768_PIN(PORT(0), PIN(5), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_6   LPC1768_PIN(PORT(0), PIN(6), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_7   LPC1768_PIN(PORT(0), PIN(7), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_8   LPC1768_PIN(PORT(0), PIN(8), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_9   LPC1768_PIN(PORT(0), PIN(9), INTERRUPT(1), PWM(0), ADC_NONE)
 #if SERIAL_PORT != 2
-  const pin_t P0_10 = LPC1768_PIN(0, 10, PIN_FEATURE_INTERRUPT);
-  const pin_t P0_11 = LPC1768_PIN(0, 11, PIN_FEATURE_INTERRUPT);
+  #define P0_10  LPC1768_PIN(PORT(0), PIN(10), INTERRUPT(1), PWM(0), ADC_NONE)
+  #define P0_11  LPC1768_PIN(PORT(0), PIN(11), INTERRUPT(1), PWM(0), ADC_NONE)
 #endif
 #if SERIAL_PORT != 1
-  const pin_t P0_15 = LPC1768_PIN(0, 15, PIN_FEATURE_INTERRUPT);
-  const pin_t P0_16 = LPC1768_PIN(0, 16, PIN_FEATURE_INTERRUPT);
+  #define P0_15  LPC1768_PIN(PORT(0), PIN(15), INTERRUPT(1), PWM(0), ADC_NONE)
+  #define P0_16  LPC1768_PIN(PORT(0), PIN(16), INTERRUPT(1), PWM(0), ADC_NONE)
 #endif
-const pin_t P0_17 = LPC1768_PIN(0, 17, PIN_FEATURE_INTERRUPT);
-const pin_t P0_18 = LPC1768_PIN(0, 18, PIN_FEATURE_INTERRUPT);
-const pin_t P0_19 = LPC1768_PIN(0, 19, PIN_FEATURE_INTERRUPT);
-const pin_t P0_20 = LPC1768_PIN(0, 20, PIN_FEATURE_INTERRUPT);
-const pin_t P0_21 = LPC1768_PIN(0, 21, PIN_FEATURE_INTERRUPT);
-const pin_t P0_22 = LPC1768_PIN(0, 22, PIN_FEATURE_INTERRUPT);
-const pin_t P0_23 = LPC1768_PIN(0, 23, PIN_FEATURE_INTERRUPT | PIN_FEATURE_ADC(0));
-const pin_t P0_24 = LPC1768_PIN(0, 24, PIN_FEATURE_INTERRUPT | PIN_FEATURE_ADC(1));
-const pin_t P0_25 = LPC1768_PIN(0, 25, PIN_FEATURE_INTERRUPT | PIN_FEATURE_ADC(2));
-const pin_t P0_26 = LPC1768_PIN(0, 26, PIN_FEATURE_INTERRUPT | PIN_FEATURE_ADC(3));
-const pin_t P0_27 = LPC1768_PIN(0, 27, PIN_FEATURE_INTERRUPT);
-const pin_t P0_28 = LPC1768_PIN(0, 28, PIN_FEATURE_INTERRUPT);
-const pin_t P0_29 = LPC1768_PIN(0, 29, PIN_FEATURE_INTERRUPT);
-const pin_t P0_30 = LPC1768_PIN(0, 30, PIN_FEATURE_INTERRUPT);
-const pin_t P1_0  = LPC1768_PIN(1,  0);
-const pin_t P1_1  = LPC1768_PIN(1,  1);
-const pin_t P1_4  = LPC1768_PIN(1,  4);
-const pin_t P1_8  = LPC1768_PIN(1,  8);
-const pin_t P1_9  = LPC1768_PIN(1,  9);
-const pin_t P1_10 = LPC1768_PIN(1, 10);
-const pin_t P1_14 = LPC1768_PIN(1, 14);
-const pin_t P1_15 = LPC1768_PIN(1, 15);
-const pin_t P1_16 = LPC1768_PIN(1, 16);
-const pin_t P1_17 = LPC1768_PIN(1, 17);
-const pin_t P1_18 = LPC1768_PIN(1, 18, PIN_FEATURE_PWM);
-const pin_t P1_19 = LPC1768_PIN(1, 19);
-const pin_t P1_20 = LPC1768_PIN(1, 20, PIN_FEATURE_PWM);
-const pin_t P1_21 = LPC1768_PIN(1, 21, PIN_FEATURE_PWM);
-const pin_t P1_22 = LPC1768_PIN(1, 22);
-const pin_t P1_23 = LPC1768_PIN(1, 23, PIN_FEATURE_PWM);
-const pin_t P1_24 = LPC1768_PIN(1, 24, PIN_FEATURE_PWM);
-const pin_t P1_25 = LPC1768_PIN(1, 25);
-const pin_t P1_26 = LPC1768_PIN(1, 26, PIN_FEATURE_PWM);
-const pin_t P1_27 = LPC1768_PIN(1, 27);
-const pin_t P1_28 = LPC1768_PIN(1, 28);
-const pin_t P1_29 = LPC1768_PIN(1, 29);
-const pin_t P1_30 = LPC1768_PIN(1, 30, PIN_FEATURE_ADC(4));
-const pin_t P1_31 = LPC1768_PIN(1, 31, PIN_FEATURE_ADC(5));
-const pin_t P2_0  = LPC1768_PIN(2,  0, PIN_FEATURE_INTERRUPT | PIN_FEATURE_PWM);
-const pin_t P2_1  = LPC1768_PIN(2,  1, PIN_FEATURE_INTERRUPT | PIN_FEATURE_PWM);
-const pin_t P2_2  = LPC1768_PIN(2,  2, PIN_FEATURE_INTERRUPT | PIN_FEATURE_PWM);
-const pin_t P2_3  = LPC1768_PIN(2,  3, PIN_FEATURE_INTERRUPT | PIN_FEATURE_PWM);
-const pin_t P2_4  = LPC1768_PIN(2,  4, PIN_FEATURE_INTERRUPT | PIN_FEATURE_PWM);
-const pin_t P2_5  = LPC1768_PIN(2,  5, PIN_FEATURE_INTERRUPT | PIN_FEATURE_PWM);
-const pin_t P2_6  = LPC1768_PIN(2,  6, PIN_FEATURE_INTERRUPT);
-const pin_t P2_7  = LPC1768_PIN(2,  7, PIN_FEATURE_INTERRUPT);
-const pin_t P2_8  = LPC1768_PIN(2,  8, PIN_FEATURE_INTERRUPT);
-const pin_t P2_9  = LPC1768_PIN(2,  9, PIN_FEATURE_INTERRUPT);
-const pin_t P2_10 = LPC1768_PIN(2, 10, PIN_FEATURE_INTERRUPT);
-const pin_t P2_11 = LPC1768_PIN(2, 11, PIN_FEATURE_INTERRUPT);
-const pin_t P2_12 = LPC1768_PIN(2, 12, PIN_FEATURE_INTERRUPT);
-const pin_t P2_13 = LPC1768_PIN(2, 13, PIN_FEATURE_INTERRUPT);
-const pin_t P3_25 = LPC1768_PIN(3, 25, PIN_FEATURE_PWM);
-const pin_t P3_26 = LPC1768_PIN(3, 26, PIN_FEATURE_PWM);
-const pin_t P4_28 = LPC1768_PIN(4, 28);
-const pin_t P4_29 = LPC1768_PIN(4, 29);
+#define P0_17  LPC1768_PIN(PORT(0), PIN(17), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_18  LPC1768_PIN(PORT(0), PIN(18), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_19  LPC1768_PIN(PORT(0), PIN(19), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_20  LPC1768_PIN(PORT(0), PIN(20), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_21  LPC1768_PIN(PORT(0), PIN(21), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_22  LPC1768_PIN(PORT(0), PIN(22), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_23  LPC1768_PIN(PORT(0), PIN(23), INTERRUPT(1), PWM(0), ADC_CHAN(0))
+#define P0_24  LPC1768_PIN(PORT(0), PIN(24), INTERRUPT(1), PWM(0), ADC_CHAN(1))
+#define P0_25  LPC1768_PIN(PORT(0), PIN(25), INTERRUPT(1), PWM(0), ADC_CHAN(2))
+#define P0_26  LPC1768_PIN(PORT(0), PIN(26), INTERRUPT(1), PWM(0), ADC_CHAN(3))
+#define P0_27  LPC1768_PIN(PORT(0), PIN(27), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_28  LPC1768_PIN(PORT(0), PIN(28), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_29  LPC1768_PIN(PORT(0), PIN(29), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P0_30  LPC1768_PIN(PORT(0), PIN(30), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P1_0   LPC1768_PIN(PORT(1), PIN(0), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_1   LPC1768_PIN(PORT(1), PIN(1), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_4   LPC1768_PIN(PORT(1), PIN(4), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_8   LPC1768_PIN(PORT(1), PIN(8), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_9   LPC1768_PIN(PORT(1), PIN(9), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_10  LPC1768_PIN(PORT(1), PIN(10), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_14  LPC1768_PIN(PORT(1), PIN(14), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_15  LPC1768_PIN(PORT(1), PIN(15), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_16  LPC1768_PIN(PORT(1), PIN(16), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_17  LPC1768_PIN(PORT(1), PIN(17), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_18  LPC1768_PIN(PORT(1), PIN(18), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P1_19  LPC1768_PIN(PORT(1), PIN(19), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_20  LPC1768_PIN(PORT(1), PIN(20), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P1_21  LPC1768_PIN(PORT(1), PIN(21), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P1_22  LPC1768_PIN(PORT(1), PIN(22), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_23  LPC1768_PIN(PORT(1), PIN(23), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P1_24  LPC1768_PIN(PORT(1), PIN(24), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P1_25  LPC1768_PIN(PORT(1), PIN(25), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_26  LPC1768_PIN(PORT(1), PIN(26), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P1_27  LPC1768_PIN(PORT(1), PIN(27), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_28  LPC1768_PIN(PORT(1), PIN(28), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_29  LPC1768_PIN(PORT(1), PIN(29), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P1_30  LPC1768_PIN(PORT(1), PIN(30), INTERRUPT(0), PWM(0), ADC_CHAN(4))
+#define P1_31  LPC1768_PIN(PORT(1), PIN(31), INTERRUPT(0), PWM(0), ADC_CHAN(5))
+#define P2_0   LPC1768_PIN(PORT(2), PIN(0), INTERRUPT(1), PWM(1), ADC_NONE)
+#define P2_1   LPC1768_PIN(PORT(2), PIN(1), INTERRUPT(1), PWM(1), ADC_NONE)
+#define P2_2   LPC1768_PIN(PORT(2), PIN(2), INTERRUPT(1), PWM(1), ADC_NONE)
+#define P2_3   LPC1768_PIN(PORT(2), PIN(3), INTERRUPT(1), PWM(1), ADC_NONE)
+#define P2_4   LPC1768_PIN(PORT(2), PIN(4), INTERRUPT(1), PWM(1), ADC_NONE)
+#define P2_5   LPC1768_PIN(PORT(2), PIN(5), INTERRUPT(1), PWM(1), ADC_NONE)
+#define P2_6   LPC1768_PIN(PORT(2), PIN(6), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_7   LPC1768_PIN(PORT(2), PIN(7), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_8   LPC1768_PIN(PORT(2), PIN(8), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_9   LPC1768_PIN(PORT(2), PIN(9), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_10  LPC1768_PIN(PORT(2), PIN(10), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_11  LPC1768_PIN(PORT(2), PIN(11), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_12  LPC1768_PIN(PORT(2), PIN(12), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P2_13  LPC1768_PIN(PORT(2), PIN(13), INTERRUPT(1), PWM(0), ADC_NONE)
+#define P3_25  LPC1768_PIN(PORT(3), PIN(25), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P3_26  LPC1768_PIN(PORT(3), PIN(26), INTERRUPT(0), PWM(1), ADC_NONE)
+#define P4_28  LPC1768_PIN(PORT(4), PIN(28), INTERRUPT(0), PWM(0), ADC_NONE)
+#define P4_29  LPC1768_PIN(PORT(4), PIN(29), INTERRUPT(0), PWM(0), ADC_NONE)
 
 constexpr bool VALID_PIN(const pin_t p) {
   return (

--- a/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
@@ -38,7 +38,7 @@ constexpr uint8_t LPC1768_PIN_PORT(const pin_t pin) { return ((uint8_t)((pin >> 
 constexpr uint8_t LPC1768_PIN_PIN(const pin_t pin) { return ((uint8_t)(pin & 0b11111)); }
 constexpr bool LPC1768_PIN_INTERRUPT(const pin_t pin) { return (((pin >> 8) & PIN_FEATURE_INTERRUPT) != 0); }
 constexpr bool LPC1768_PIN_PWM(const pin_t pin) { return (((pin >> 8) & PIN_FEATURE_PWM) != 0); }
-constexpr int8_t LPC1768_PIN_ADC(const pin_t pin) { return (int8_t)((pin >> 8) & 0b1111) - 1; }
+constexpr int8_t LPC1768_PIN_ADC(const pin_t pin) { return (int8_t)((pin >> 10) & 0b1111) - 1; }
 
 // ******************
 // Runtime pinmapping

--- a/Marlin/src/HAL/HAL_LPC1768/pinsDebug_LPC1768.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinsDebug_LPC1768.h
@@ -24,18 +24,32 @@
  * Support routines for LPC1768
 */
 
+/**
+ * translation of routines & variables used by pinsDebug.h
+ */
+
+#define pwm_details(pin) pin = pin    // do nothing  // print PWM details
+#define pwm_status(pin) false //Print a pin's PWM status. Return true if it's currently a PWM pin.
+#define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P) >= 0 ? 1 : 0)
+#define digitalRead_mod(p)  digitalRead(p)
+#define digitalPinToPort_DEBUG(p)  0
+#define digitalPinToBitMask_DEBUG(pin) 0
+#define PRINT_PORT(p) SERIAL_ECHO_SP(10);
+#define GET_ARRAY_PIN(p) pin_array[p].pin
+#define NAME_FORMAT(p) PSTR("%-##p##s")
+#define PRINT_ARRAY_NAME(x)  do {sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer);} while (0)
+#define PRINT_PIN(p) do {sprintf_P(buffer, PSTR("%d.%02d"), LPC1768_PIN_PORT(p), LPC1768_PIN_PIN(p)); SERIAL_ECHO(buffer);} while (0)
+
 // active ADC function/mode/code values for PINSEL registers
-int8_t ADC_pin_mode(pin_t pin) {
-  uint8_t pin_port = LPC1768_PIN_PORT(pin);
-  uint8_t pin_port_pin = LPC1768_PIN_PIN(pin);
-  return (pin_port == 0 && pin_port_pin == 2  ? 2 :
-          pin_port == 0 && pin_port_pin == 3  ? 2 :
-          pin_port == 0 && pin_port_pin == 23 ? 1 :
-          pin_port == 0 && pin_port_pin == 24 ? 1 :
-          pin_port == 0 && pin_port_pin == 25 ? 1 :
-          pin_port == 0 && pin_port_pin == 26 ? 1 :
-          pin_port == 1 && pin_port_pin == 30 ? 3 :
-          pin_port == 1 && pin_port_pin == 31 ? 3 : -1);
+constexpr int8_t ADC_pin_mode(pin_t pin) {
+  return (LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 2  ? 2 :
+          LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 3  ? 2 :
+          LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 23 ? 1 :
+          LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 24 ? 1 :
+          LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 25 ? 1 :
+          LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 26 ? 1 :
+          LPC1768_PIN_PORT(pin) == 1 && LPC1768_PIN_PIN(pin) == 30 ? 3 :
+          LPC1768_PIN_PORT(pin) == 1 && LPC1768_PIN_PIN(pin) == 31 ? 3 : -1);
 }
 
 int8_t get_pin_mode(pin_t pin) {
@@ -56,7 +70,7 @@ int8_t get_pin_mode(pin_t pin) {
 
 bool GET_PINMODE(pin_t pin) {
   int8_t pin_mode = get_pin_mode(pin);
-  if (pin_mode == -1 || (pin_mode && pin_mode == ADC_pin_mode(pin))) // found an invalid pin or active analog pin
+  if (pin_mode == -1 || pin_mode == ADC_pin_mode(pin)) // found an invalid pin or active analog pin
     return false;
 
   uint32_t * FIO_reg[5] PROGMEM = {(uint32_t*) 0x2009C000,(uint32_t*)  0x2009C020,(uint32_t*)  0x2009C040,(uint32_t*)  0x2009C060,(uint32_t*)  0x2009C080};
@@ -64,23 +78,5 @@ bool GET_PINMODE(pin_t pin) {
 }
 
 bool GET_ARRAY_IS_DIGITAL(pin_t pin) {
-  int8_t pin_mode = get_pin_mode(pin);
-  return (pin_mode != -1 && (!get_pin_mode(pin) || pin_mode != ADC_pin_mode(pin)));
+  return (!IS_ANALOG(pin) || get_pin_mode(pin) != ADC_pin_mode(pin));
 }
-
-/**
- * translation of routines & variables used by pinsDebug.h
- */
-
-#define pwm_details(pin) pin = pin    // do nothing  // print PWM details
-#define pwm_status(pin) false //Print a pin's PWM status. Return true if it's currently a PWM pin.
-#define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P) >= 0 ? 1 : 0)
-#define digitalRead_mod(p)  digitalRead(p)
-#define digitalPinToPort_DEBUG(p)  0
-#define digitalPinToBitMask_DEBUG(pin) 0
-#define PRINT_PORT(p) SERIAL_ECHO_SP(10);
-#define GET_ARRAY_PIN(p) pin_array[p].pin
-#define NAME_FORMAT(p) PSTR("%-##p##s")
-//  #define PRINT_ARRAY_NAME(x)  do {sprintf_P(buffer, NAME_FORMAT(MAX_NAME_LENGTH) , pin_array[x].name); SERIAL_ECHO(buffer);} while (0)
-#define PRINT_ARRAY_NAME(x)  do {sprintf_P(buffer, PSTR("%-35s") , pin_array[x].name); SERIAL_ECHO(buffer);} while (0)
-#define PRINT_PIN(p) do {sprintf_P(buffer, PSTR("%d.%02d "), LPC1768_PIN_PORT(p), LPC1768_PIN_PIN(p)); SERIAL_ECHO(buffer);} while (0)

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -20,8 +20,8 @@
  *
  */
 
-#define MAX_NAME_LENGTH  35    // one place to specify the format of all the sources of names
-                               // "-" left justify, "35" minimum width of name, pad with blanks
+#define MAX_NAME_LENGTH  39    // one place to specify the format of all the sources of names
+                               // "-" left justify, "39" minimum width of name, pad with blanks
 
 /**
  *  This routine minimizes RAM usage by creating a FLASH resident array to
@@ -110,7 +110,7 @@ static void print_input_or_output(const bool isout) {
 
 // pretty report with PWM info
 inline void report_pin_state_extended(pin_t pin, bool ignore, bool extended = false, const char *start_string = "") {
-  char buffer[30];   // for the sprintf statements
+  char buffer[MAX_NAME_LENGTH + 1];   // for the sprintf statements
   bool found = false, multi_name_pin = false;
 
   for (uint8_t x = 0; x < COUNT(pin_array); x++)  {    // scan entire array and report all instances of this pin
@@ -151,7 +151,7 @@ inline void report_pin_state_extended(pin_t pin, bool ignore, bool extended = fa
             else
           #endif
           {
-            if (!GET_ARRAY_IS_DIGITAL(x)) {
+            if (!GET_ARRAY_IS_DIGITAL(pin)) {
               sprintf_P(buffer, PSTR("Analog in = %5d"), analogRead(DIGITAL_PIN_TO_ANALOG_PIN(pin)));
               SERIAL_ECHO(buffer);
             }


### PR DESCRIPTION
This PR fixes a few issues with M43 that weren't addressed in #8063.

UPDATE: Due to issues pointed out by @xC0000005 with the STM32 HAL, I've updated the pinmapping.h file to declare the pins using `#define` and some preprocessor binary magic to allow the pin definitions to be properly compared by the preprocessor. Preprocessors directives like `#if X_STEP_PIN != Y_STEP_PIN` will now work properly since the pin values (`P0_0`, `P1_30`, etc) are now recognizable by the preprocessor as integer values.