### PR TITLE
2.0.x - Restore fix for garbaged display on Re-ARM with RepRap Full Graphics Smart Controller

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3775,7 +3775,9 @@ void kill_screen(const char* lcd_msg) {
     void lcd_sdcard_menu() {
       ENCODER_DIRECTION_MENUS();
 
-      const uint16_t fileCnt = card.getnrfilenames();
+      const uint16_t fileCnt = card.get_num_Files();  // Only access SD card if sort not active
+                                                      // This minimizes garbage on RepRap Discount Full Graphics Smart Controller
+                                                      // when using the Re-ARM card.
       START_MENU();
       MENU_BACK(MSG_MAIN);
       card.getWorkDirName();

--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -24,9 +24,8 @@
  * AZSMZ MINI pin assignments
  */
 
-//#if !defined(TARGET_LPC1768)
-#if DISABLED(IS_REARM)
-  #error "Oops!  Make sure you have Re-Arm selected."
+#ifndef TARGET_LPC1768
+  #error "Oops!  Make sure you have LPC1768 selected."
 #endif
 
 #ifndef BOARD_NAME
@@ -112,6 +111,25 @@
 #define ENET_TX_EN         77
 #define ENET_TXD0          78
 #define ENET_TXD1          79
+
+
+#if (ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) && !defined(SDCARD_SORT_ALPHA)) // needed because of shared SPI
+  #define SDCARD_SORT_ALPHA         // Using SORT feature to keep one directory level in RAM
+                                    // When going up/down directory levels the SD card is
+                                    // accessed but the garbage/lines are removed when the
+                                    // LCD updates
+
+  #define SDSORT_LIMIT       256    // Maximum number of sorted items (10-256). Costs 27 bytes each.
+  #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
+  #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 g-code.
+  #define SDSORT_USES_RAM    true   // Pre-allocate a static array for faster pre-sorting.
+  #define SDSORT_USES_STACK  false  // Prefer the stack for pre-sorting to give back some SRAM. (Negated by next 2 options.)
+  #define SDSORT_CACHE_NAMES true   // Keep sorted items in RAM longer for speedy performance. Most expensive option.
+  #define SDSORT_DYNAMIC_RAM false  // Use dynamic allocation (within SD menus). Least expensive option. Set SDSORT_LIMIT before use!
+  #define SDSORT_CACHE_VFATS 2      // Maximum number of 13-byte VFAT entries to use for sorting.
+                                    // Note: Only affects SCROLL_LONG_FILENAMES with SDSORT_CACHE_NAMES but not SDSORT_DYNAMIC_RAM.
+  #define MAX_VFAT_ENTRIES SDSORT_CACHE_VFATS
+#endif
 
 /**
  *  PWMs

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -174,6 +174,25 @@
 #define ENET_TXD0          P1_0   // J12-11
 #define ENET_TXD1          P1_1   // J12-12
 
+
+#if (ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) && !defined(SDCARD_SORT_ALPHA)) // needed because of shared SPI
+  #define SDCARD_SORT_ALPHA         // Using SORT feature to keep one directory level in RAM
+                                    // When going up/down directory levels the SD card is
+                                    // accessed but the garbage/lines are removed when the
+                                    // LCD updates
+
+  #define SDSORT_LIMIT       256    // Maximum number of sorted items (10-256). Costs 27 bytes each.
+  #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
+  #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 g-code.
+  #define SDSORT_USES_RAM    true   // Pre-allocate a static array for faster pre-sorting.
+  #define SDSORT_USES_STACK  false  // Prefer the stack for pre-sorting to give back some SRAM. (Negated by next 2 options.)
+  #define SDSORT_CACHE_NAMES true   // Keep sorted items in RAM longer for speedy performance. Most expensive option.
+  #define SDSORT_DYNAMIC_RAM false  // Use dynamic allocation (within SD menus). Least expensive option. Set SDSORT_LIMIT before use!
+  #define SDSORT_CACHE_VFATS 2      // Maximum number of 13-byte VFAT entries to use for sorting.
+                                    // Note: Only affects SCROLL_LONG_FILENAMES with SDSORT_CACHE_NAMES but not SDSORT_DYNAMIC_RAM.
+  #define MAX_VFAT_ENTRIES SDSORT_CACHE_VFATS
+#endif
+
 /**
  *  PWMs
  *

--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -259,6 +259,24 @@
     //#define SHIFT_EN            P1_22  // J5-4 & AUX-4
   #endif
 
+  #if (ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) && !defined(SDCARD_SORT_ALPHA)) // needed because of shared SPI
+    #define SDCARD_SORT_ALPHA         // Using SORT feature to keep one directory level in RAM
+                                      // When going up/down directory levels the SD card is
+                                      // accessed but the garbage/lines are removed when the
+                                      // LCD updates
+
+    #define SDSORT_LIMIT       256    // Maximum number of sorted items (10-256). Costs 27 bytes each.
+    #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
+    #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 g-code.
+    #define SDSORT_USES_RAM    true   // Pre-allocate a static array for faster pre-sorting.
+    #define SDSORT_USES_STACK  false  // Prefer the stack for pre-sorting to give back some SRAM. (Negated by next 2 options.)
+    #define SDSORT_CACHE_NAMES true   // Keep sorted items in RAM longer for speedy performance. Most expensive option.
+    #define SDSORT_DYNAMIC_RAM false  // Use dynamic allocation (within SD menus). Least expensive option. Set SDSORT_LIMIT before use!
+    #define SDSORT_CACHE_VFATS 2      // Maximum number of 13-byte VFAT entries to use for sorting.
+                                      // Note: Only affects SCROLL_LONG_FILENAMES with SDSORT_CACHE_NAMES but not SDSORT_DYNAMIC_RAM.
+    #define MAX_VFAT_ENTRIES SDSORT_CACHE_VFATS
+  #endif
+
   #if ENABLED(VIKI2) || ENABLED(miniVIKI)
     // #define LCD_SCREEN_ROT_180
 

--- a/Marlin/src/sd/SdFatConfig.h
+++ b/Marlin/src/sd/SdFatConfig.h
@@ -134,6 +134,9 @@
 #define FILENAME_LENGTH 13 // Number of UTF-16 characters per entry
 
 // Number of VFAT entries used. Each entry has 13 UTF-16 characters
+#ifdef MAX_VFAT_ENTRIES
+  #undef MAX_VFAT_ENTRIES
+#endif  
 #if ENABLED(SCROLL_LONG_FILENAMES)
   #define MAX_VFAT_ENTRIES (5)
 #else

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -747,7 +747,7 @@ void CardReader::updir() {
                 strncpy(sortnames[i], LONGEST_FILENAME, SORTED_LONGNAME_MAXLEN);
                 sortnames[i][SORTED_LONGNAME_MAXLEN - 1] = '\0';
               #else
-                strcpy(sortnames[i], SORTED_LONGNAME_MAXLEN);
+                strncpy(sortnames[i], LONGEST_FILENAME, SORTED_LONGNAME_MAXLEN);
               #endif
               #if ENABLED(SDSORT_CACHE_NAMES)
                 strcpy(sortshort[i], filename);
@@ -849,7 +849,7 @@ void CardReader::updir() {
               strncpy(sortnames[0], LONGEST_FILENAME, SORTED_LONGNAME_MAXLEN);
               sortnames[0][SORTED_LONGNAME_MAXLEN - 1] = '\0';
             #else
-              strcpy(sortnames[0], SORTED_LONGNAME_MAXLEN);
+              strncpy(sortnames[0], LONGEST_FILENAME, SORTED_LONGNAME_MAXLEN);
             #endif
             #if ENABLED(SDSORT_CACHE_NAMES)
               strcpy(sortshort[0], filename);


### PR DESCRIPTION
This PR restores the fix for the garbaged display on the RepRap Full Graphics Smart Controller when used with the Re-ARM card.

On Re-Arm when using the usual LCD adapter card, the LCD and the SD card share the same SPI.  This is a problem for the RepRap Full Graphics Smart Controller because it responds to the SPI bus when its enable is inactive.  SD card access result in varying degrees of problems on the display.

The solution is:
- Use the sort function to minimize the SD card accesses.  This is enabled in **pins_RAMPS_RE_ARM.h** when the problem display is selected.
- In the Print from SD menu, get file names and number of files from SD card only as a last resort.

To eliminate the warnings/errors when compiling:
- Sanity Check - when the pre-processor gets to Sanity Check the MAX_VFAT_ENTRIES is not yet valid which results in false warnings.  The solution is to define it in **pins_RAMPS_RE_ARM.h** when the problem display is selected and then undefin it immediately before the real value is set.
- cardreader.cpp - lines 750 & 852 had an invalid argument for strcpy (had source string & sting length instead of source string & destination string).

THE CORRECTIONS TO LINES 750 & 852 NEED TO BE REVIEWED BEFORE THIS PR CAN BE MERGED.
