### PR TITLE
[1.1.x] Fix M303 thermal protection #8103

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -396,7 +396,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
         temp_ms = ms + 2000UL;
       } // every 2 seconds
       // Timeout after 20 minutes since the last undershoot/overshoot cycle
-      if (((ms - t1) + (ms - t2)) > (10L * 60L * 1000L * 2L)) {
+      if (((ms - t1) + (ms - t2)) > (20L * 60L * 1000L)) {
         SERIAL_PROTOCOLLNPGM(MSG_PID_TIMEOUT);
         break;
       }

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -384,8 +384,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
       #define MAX_OVERSHOOT_PID_AUTOTUNE 20
       if (input > temp + MAX_OVERSHOOT_PID_AUTOTUNE) {
         SERIAL_PROTOCOLLNPGM(MSG_PID_TEMP_TOO_HIGH);
-        disable_all_heaters();
-        return;
+        break;
       }
       // Every 2 seconds...
       if (ELAPSED(ms, temp_ms)) {
@@ -399,8 +398,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
       // Timeout after 20 minutes since the last undershoot/overshoot cycle
       if (((ms - t1) + (ms - t2)) > (10L * 60L * 1000L * 2L)) {
         SERIAL_PROTOCOLLNPGM(MSG_PID_TIMEOUT);
-        disable_all_heaters();
-        return;
+        break;
       }
       if (cycles > ncycles) {
         SERIAL_PROTOCOLLNPGM(MSG_PID_AUTOTUNE_FINISHED);
@@ -449,7 +447,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
       }
       lcd_update();
     }
-    if (!wait_for_heatup) disable_all_heaters();
+    disable_all_heaters();
   }
 
 #endif // HAS_PID_HEATING

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -2067,11 +2067,11 @@ void Temperature::isr() {
 
     for (uint8_t e = 0; e < COUNT(temp_dir); e++) {
       const int16_t tdir = temp_dir[e], rawtemp = current_temperature_raw[e] * tdir;
-      const bool heater_on =
+      const bool heater_on = 0 <
         #if ENABLED(PIDTEMP)
-          soft_pwm_amount[e] > 0
+          soft_pwm_amount[e]
         #else
-          target_temperature[e] > 0
+          target_temperature[e]
         #endif
       ;
       if (rawtemp > maxttemp_raw[e] * tdir && heater_on) max_temp_error(e);
@@ -2093,11 +2093,11 @@ void Temperature::isr() {
       #else
         #define GEBED >=
       #endif
-      const bool bed_on =
+      const bool bed_on = 0 <
         #if ENABLED(PIDTEMPBED)
-          soft_pwm_amount_bed > 0
+          soft_pwm_amount_bed
         #else
-          target_temperature_bed > 0
+          target_temperature_bed
         #endif
       ;
       if (current_temperature_bed_raw GEBED bed_maxttemp_raw && bed_on) max_temp_error(-1);

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -2067,12 +2067,13 @@ void Temperature::isr() {
 
     for (uint8_t e = 0; e < COUNT(temp_dir); e++) {
       const int16_t tdir = temp_dir[e], rawtemp = current_temperature_raw[e] * tdir;
-      bool heater_on =
-        # if ENABLED(PIDTEMP)
-          soft_pwm_amount[e] > 0;
-        # else
-          target_temperature[e] > 0;
-        # endif
+      const bool heater_on =
+        #if ENABLED(PIDTEMP)
+          soft_pwm_amount[e] > 0
+        #else
+          target_temperature[e] > 0
+        #endif
+      ;
       if (rawtemp > maxttemp_raw[e] * tdir && heater_on) max_temp_error(e);
       if (rawtemp < minttemp_raw[e] * tdir && !is_preheating(e) && heater_on) {
         #ifdef MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED
@@ -2092,12 +2093,13 @@ void Temperature::isr() {
       #else
         #define GEBED >=
       #endif
-      bool bed_on =
-        # if ENABLED(PIDTEMPBED)
-          soft_pwm_amount_bed > 0;
-        # else
-          target_temperature_bed > 0;
-        # endif
+      const bool bed_on =
+        #if ENABLED(PIDTEMPBED)
+          soft_pwm_amount_bed > 0
+        #else
+          target_temperature_bed > 0
+        #endif
+      ;
       if (current_temperature_bed_raw GEBED bed_maxttemp_raw && bed_on) max_temp_error(-1);
       if (bed_minttemp_raw GEBED current_temperature_bed_raw && bed_on) min_temp_error(-1);
     #endif


### PR DESCRIPTION
The temperature sanity checking logic was not applied during M303
(pid autotuning) because instead of setting a target temperature, PID_autotune
directly manipulated the pwm values.  When PIDTEMP/PIDTEMPBED is
enabled, PWM values rather than the target temperature determine whether
the heater is on.  I changed the temperature sanity checking logic to look directly at the PWM values
when pid is enabled.

I tested M303 with the changes and they fix #8103 .

Edit: I also added calls to disable the heaters if PID_autotune errors out.