### PR TITLE
Fix automatic stepper assignment for X/Y/Z dual stepper drivers

### DIFF
--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -29,8 +29,6 @@
 
 #include "thermistor/thermistors.h"
 
-#include "../inc/MarlinConfig.h"
-
 #if ENABLED(BABYSTEPPING)
   extern bool axis_known_position[XYZ];
 #endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -329,17 +329,62 @@
 #ifndef Z_MS2_PIN
   #define Z_MS2_PIN -1
 #endif
+#ifndef E0_STEP_PIN
+  #define E0_STEP_PIN -1
+#endif
+#ifndef E0_DIR_PIN
+  #define E0_DIR_PIN -1
+#endif
+#ifndef E0_ENABLE_PIN
+  #define E0_ENABLE_PIN -1
+#endif
 #ifndef E0_MS1_PIN
   #define E0_MS1_PIN -1
 #endif
 #ifndef E0_MS2_PIN
   #define E0_MS2_PIN -1
 #endif
+#ifndef E1_STEP_PIN
+  #define E1_STEP_PIN -1
+#endif
+#ifndef E1_DIR_PIN
+  #define E1_DIR_PIN -1
+#endif
+#ifndef E1_ENABLE_PIN
+  #define E1_ENABLE_PIN -1
+#endif
 #ifndef E1_MS1_PIN
   #define E1_MS1_PIN -1
 #endif
 #ifndef E1_MS2_PIN
   #define E1_MS2_PIN -1
+#endif
+#ifndef E2_STEP_PIN
+  #define E2_STEP_PIN -1
+#endif
+#ifndef E2_DIR_PIN
+  #define E2_DIR_PIN -1
+#endif
+#ifndef E2_ENABLE_PIN
+  #define E2_ENABLE_PIN -1
+#endif
+#ifndef E3_STEP_PIN
+  #define E3_STEP_PIN -1
+#endif
+#ifndef E3_DIR_PIN
+  #define E3_DIR_PIN -1
+#endif
+#ifndef E3_ENABLE_PIN
+  #define E3_ENABLE_PIN -1
+#endif
+#ifndef E4_STEP_PIN
+  #define E4_STEP_PIN -1
+#endif
+#ifndef E4_DIR_PIN
+  #define E4_DIR_PIN -1
+#endif
+#ifndef E4_ENABLE_PIN
+  #define E4_ENABLE_PIN -1
 #endif
 
 #ifndef FAN_PIN
@@ -623,7 +668,7 @@
     #define X2_STEP_PIN   _EPIN(E_STEPPERS, STEP)
     #define X2_DIR_PIN    _EPIN(E_STEPPERS, DIR)
     #define X2_ENABLE_PIN _EPIN(E_STEPPERS, ENABLE)
-    #if X2_ENABLE_PIN == 0
+    #if E_STEPPERS > 4 || !PIN_EXISTS(X2_ENABLE)
       #error "No E stepper plug left for X2!"
     #endif
   #endif
@@ -640,7 +685,7 @@
     #define Y2_STEP_PIN   _EPIN(Y2_E_INDEX, STEP)
     #define Y2_DIR_PIN    _EPIN(Y2_E_INDEX, DIR)
     #define Y2_ENABLE_PIN _EPIN(Y2_E_INDEX, ENABLE)
-    #if Y2_ENABLE_PIN == 0
+    #if Y2_E_INDEX > 4 || !PIN_EXISTS(Y2_ENABLE)
       #error "No E stepper plug left for Y2!"
     #endif
   #endif
@@ -657,7 +702,7 @@
     #define Z2_STEP_PIN   _EPIN(Z2_E_INDEX, STEP)
     #define Z2_DIR_PIN    _EPIN(Z2_E_INDEX, DIR)
     #define Z2_ENABLE_PIN _EPIN(Z2_E_INDEX, ENABLE)
-    #if Z2_ENABLE_PIN == 0
+    #if Z2_E_INDEX > 4 || !PIN_EXISTS(Z2_ENABLE)
       #error "No E stepper plug left for Z2!"
     #endif
   #endif


### PR DESCRIPTION
This PR fixes an issue with the automatic assignment of steppers for the X/Y/Z dual stepper driver configuration options. The method previously used in pins.h would incorrectly declare the error "No E stepper plug left for [X|Y|Z]2!" even when one was available.

I verified this change against a standard RAMPS configuration, AZTEEG X3 Pro configuration, and a Re-ARM configuration. With the AZTEEG X3 Pro configuration, I varied the number of extruders with all three dual stepper options enabled, and verified that the expected error message was generated if the total number of extruders and dual steppers exceeded 5.