### PR TITLE
[1.1.x] Define a default SERVO0_PIN for Anet 1.0

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8797,7 +8797,7 @@ inline void gcode_M204() {
 inline void gcode_M205() {
   if (parser.seen('S')) planner.min_feedrate_mm_s = parser.value_linear_units();
   if (parser.seen('T')) planner.min_travel_feedrate_mm_s = parser.value_linear_units();
-  if (parser.seen('B')) planner.min_segment_time = parser.value_millis();
+  if (parser.seen('B')) planner.min_segment_time_us = parser.value_ulong();
   if (parser.seen('X')) planner.max_jerk[X_AXIS] = parser.value_linear_units();
   if (parser.seen('Y')) planner.max_jerk[Y_AXIS] = parser.value_linear_units();
   if (parser.seen('Z')) planner.max_jerk[Z_AXIS] = parser.value_linear_units();

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -56,7 +56,7 @@
  *  163  M204 T    planner.travel_acceleration      (float)
  *  167  M205 S    planner.min_feedrate_mm_s        (float)
  *  171  M205 T    planner.min_travel_feedrate_mm_s (float)
- *  175  M205 B    planner.min_segment_time         (ulong)
+ *  175  M205 B    planner.min_segment_time_us      (ulong)
  *  179  M205 X    planner.max_jerk[X_AXIS]         (float)
  *  183  M205 Y    planner.max_jerk[Y_AXIS]         (float)
  *  187  M205 Z    planner.max_jerk[Z_AXIS]         (float)
@@ -335,7 +335,7 @@ void MarlinSettings::postprocess() {
     EEPROM_WRITE(planner.travel_acceleration);
     EEPROM_WRITE(planner.min_feedrate_mm_s);
     EEPROM_WRITE(planner.min_travel_feedrate_mm_s);
-    EEPROM_WRITE(planner.min_segment_time);
+    EEPROM_WRITE(planner.min_segment_time_us);
     EEPROM_WRITE(planner.max_jerk);
     #if !HAS_HOME_OFFSET
       const float home_offset[XYZ] = { 0 };
@@ -749,7 +749,7 @@ void MarlinSettings::postprocess() {
       EEPROM_READ(planner.travel_acceleration);
       EEPROM_READ(planner.min_feedrate_mm_s);
       EEPROM_READ(planner.min_travel_feedrate_mm_s);
-      EEPROM_READ(planner.min_segment_time);
+      EEPROM_READ(planner.min_segment_time_us);
       EEPROM_READ(planner.max_jerk);
 
       #if !HAS_HOME_OFFSET
@@ -1219,7 +1219,7 @@ void MarlinSettings::reset() {
   planner.retract_acceleration = DEFAULT_RETRACT_ACCELERATION;
   planner.travel_acceleration = DEFAULT_TRAVEL_ACCELERATION;
   planner.min_feedrate_mm_s = DEFAULT_MINIMUMFEEDRATE;
-  planner.min_segment_time = DEFAULT_MINSEGMENTTIME;
+  planner.min_segment_time_us = DEFAULT_MINSEGMENTTIME;
   planner.min_travel_feedrate_mm_s = DEFAULT_MINTRAVELFEEDRATE;
   planner.max_jerk[X_AXIS] = DEFAULT_XJERK;
   planner.max_jerk[Y_AXIS] = DEFAULT_YJERK;
@@ -1585,12 +1585,12 @@ void MarlinSettings::reset() {
 
     if (!forReplay) {
       CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Advanced: S<min_feedrate> T<min_travel_feedrate> B<min_segment_time_ms> X<max_xy_jerk> Z<max_z_jerk> E<max_e_jerk>");
+      SERIAL_ECHOLNPGM("Advanced: S<min_feedrate> T<min_travel_feedrate> B<min_segment_time_us> X<max_xy_jerk> Z<max_z_jerk> E<max_e_jerk>");
     }
     CONFIG_ECHO_START;
     SERIAL_ECHOPAIR("  M205 S", LINEAR_UNIT(planner.min_feedrate_mm_s));
     SERIAL_ECHOPAIR(" T", LINEAR_UNIT(planner.min_travel_feedrate_mm_s));
-    SERIAL_ECHOPAIR(" B", planner.min_segment_time);
+    SERIAL_ECHOPAIR(" B", planner.min_segment_time_us);
     SERIAL_ECHOPAIR(" X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
     SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
     SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -88,7 +88,7 @@
  *   Many thanks to Hans Raaf (@oderwat) for developing the Anet-specific software and supporting the Anet community.
 */
 
-#if !defined(__AVR_ATmega1284P__)
+#ifndef __AVR_ATmega1284P__
   #error "Oops!  Make sure you have 'Anet V1.0', 'Anet V1.0 (Optiboot)' or 'Sanguino' selected from the 'Tools -> Boards' menu."
 #endif
 
@@ -155,36 +155,38 @@
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
   #define LCD_SDSS           28
   #if ENABLED(ADC_KEYPAD)
-    #define SERVO0_PIN         27 // free for BLTouch/3D-Touch
-    #define LCD_PINS_RS        28
-    #define LCD_PINS_ENABLE    29
-    #define LCD_PINS_D4        10
-    #define LCD_PINS_D5        11
-    #define LCD_PINS_D6        16
-    #define LCD_PINS_D7        17
-    #define BTN_EN1            -1
-    #define BTN_EN2            -1
-    #define BTN_ENC            -1
-    #define ADC_KEYPAD_PIN      1
+    #define SERVO0_PIN       27 // free for BLTouch/3D-Touch
+    #define LCD_PINS_RS      28
+    #define LCD_PINS_ENABLE  29
+    #define LCD_PINS_D4      10
+    #define LCD_PINS_D5      11
+    #define LCD_PINS_D6      16
+    #define LCD_PINS_D7      17
+    #define BTN_EN1          -1
+    #define BTN_EN2          -1
+    #define BTN_ENC          -1
+    #define ADC_KEYPAD_PIN    1
     #define ENCODER_FEEDRATE_DEADZONE 2
   #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) || ENABLED(ANET_FULL_GRAPHICS_LCD)
     // Pin definitions for the Anet A6 Full Graphics display and the RepRapDiscount Full Graphics
     // display using an adapter board  // https://go.aisler.net/benlye/anet-lcd-adapter/pcb
     // See below for alternative pin definitions for use with https://www.thingiverse.com/thing:2103748
-    #define SERVO0_PIN         29 // free for BLTouch/3D-Touch
-    #define BEEPER_PIN         17
-    #define LCD_PINS_RS        27
-    #define LCD_PINS_ENABLE    28
-    #define LCD_PINS_D4        30
-    #define BTN_EN1            11
-    #define BTN_EN2            10
-    #define BTN_ENC            16
+    #define SERVO0_PIN       29 // free for BLTouch/3D-Touch
+    #define BEEPER_PIN       17
+    #define LCD_PINS_RS      27
+    #define LCD_PINS_ENABLE  28
+    #define LCD_PINS_D4      30
+    #define BTN_EN1          11
+    #define BTN_EN2          10
+    #define BTN_ENC          16
     #define ST7920_DELAY_1 DELAY_0_NOP
     #define ST7920_DELAY_2 DELAY_1_NOP
     #define ST7920_DELAY_3 DELAY_2_NOP
     #define STD_ENCODER_PULSES_PER_STEP 4
     #define STD_ENCODER_STEPS_PER_MENU_ITEM 1
   #endif
+#else
+  #define SERVO0_PIN         27
 #endif  // ULTRA_LCD && NEWPANEL
 
 /**

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -119,7 +119,7 @@ typedef struct {
     uint8_t valve_pressure, e_to_p_pressure;
   #endif
 
-  uint32_t segment_time;
+  uint32_t segment_time_us;
 
 } block_t;
 
@@ -144,9 +144,9 @@ class Planner {
                  axis_steps_per_mm[XYZE_N],
                  steps_to_mm[XYZE_N];
     static uint32_t max_acceleration_steps_per_s2[XYZE_N],
-                    max_acceleration_mm_per_s2[XYZE_N]; // Use M201 to override by software
+                    max_acceleration_mm_per_s2[XYZE_N]; // Use M201 to override
 
-    static millis_t min_segment_time;
+    static uint32_t min_segment_time_us; // Use 'M205 B<µs>' to override
     static float min_feedrate_mm_s,
                  acceleration,         // Normal acceleration mm/s^2  DEFAULT ACCELERATION for all printing moves. M204 SXXXX
                  retract_acceleration, // Retract acceleration mm/s^2 filament pull-back and push-forward while standing still in the other axes M204 TXXXX
@@ -204,11 +204,11 @@ class Planner {
 
     #ifdef XY_FREQUENCY_LIMIT
       // Used for the frequency limit
-      #define MAX_FREQ_TIME long(1000000.0/XY_FREQUENCY_LIMIT)
+      #define MAX_FREQ_TIME_US (uint32_t)(1000000.0 / XY_FREQUENCY_LIMIT)
       // Old direction bits. Used for speed calculations
       static unsigned char old_direction_bits;
       // Segment times (in µs). Used for speed calculations
-      static long axis_segment_time[2][3];
+      static uint32_t axis_segment_time_us[2][3];
     #endif
 
     #if ENABLED(LIN_ADVANCE)
@@ -419,7 +419,7 @@ class Planner {
       if (blocks_queued()) {
         block_t* block = &block_buffer[block_buffer_tail];
         #if ENABLED(ULTRA_LCD)
-          block_buffer_runtime_us -= block->segment_time; //We can't be sure how long an active block will take, so don't count it.
+          block_buffer_runtime_us -= block->segment_time_us; // We can't be sure how long an active block will take, so don't count it.
         #endif
         SBI(block->flag, BLOCK_BIT_BUSY);
         return block;

--- a/Marlin/watchdog.cpp
+++ b/Marlin/watchdog.cpp
@@ -26,16 +26,22 @@
 
 #include "watchdog.h"
 
-// Initialize watchdog with a 4 sec interrupt time
+// Initialize watchdog with 8s timeout, if possible. Otherwise, make it 4s.
 void watchdog_init() {
+  #if ENABLED(WATCHDOG_DURATION_8S) && defined(WDTO_8S)
+    #define WDTO_NS WDTO_8S
+  #else
+    #define WDTO_NS WDTO_4S
+  #endif
   #if ENABLED(WATCHDOG_RESET_MANUAL)
     // We enable the watchdog timer, but only for the interrupt.
-    // Take care, as this requires the correct order of operation, with interrupts disabled. See the datasheet of any AVR chip for details.
+    // Take care, as this requires the correct order of operation, with interrupts disabled.
+    // See the datasheet of any AVR chip for details.
     wdt_reset();
     _WD_CONTROL_REG = _BV(_WD_CHANGE_BIT) | _BV(WDE);
-    _WD_CONTROL_REG = _BV(WDIE) | WDTO_4S;
+    _WD_CONTROL_REG = _BV(WDIE) | WDTO_NS;
   #else
-    wdt_enable(WDTO_4S);
+    wdt_enable(WDTO_NS);
   #endif
 }
 

--- a/buildroot/share/git/mfpub
+++ b/buildroot/share/git/mfpub
@@ -45,6 +45,9 @@ git clean -d -f
 # Push 'master' to the fork and make a proper PR...
 if [[ $BRANCH == "master" ]]; then
 
+  # Don't lose upstream changes!
+  mfup
+
   # Allow working directly with the main fork
   echo
   echo -n "Pushing to origin/master... "


### PR DESCRIPTION
I noticed in this overview on setting up BLTouch, an instruction is given to set the SERVO0_PIN.

https://youtu.be/WWDkZtWwd6I?t=5m37s

This PR adds a definition for `SERVO0_PIN` in cases where the graphical display or Anet keypad is not enabled.

Also:
- Correct/add time units to planner vars (µs)
- Fix `M205 B` and settings report
- Tweak documentation publishing script
- Add a hidden option to use an 8s watchdog timer