### PR TITLE
[2.0.x] Define a default SERVO0_PIN for Anet 1.0

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/watchdog_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/watchdog_AVR.cpp
@@ -30,16 +30,22 @@
 
 #include "../../Marlin.h"
 
-// Initialize watchdog with a 4 sec interrupt time
+// Initialize watchdog with 8s timeout, if possible. Otherwise, make it 4s.
 void watchdog_init() {
+  #if ENABLED(WATCHDOG_DURATION_8S) && defined(WDTO_8S)
+    #define WDTO_NS WDTO_8S
+  #else
+    #define WDTO_NS WDTO_4S
+  #endif
   #if ENABLED(WATCHDOG_RESET_MANUAL)
     // We enable the watchdog timer, but only for the interrupt.
-    // Take care, as this requires the correct order of operation, with interrupts disabled. See the datasheet of any AVR chip for details.
+    // Take care, as this requires the correct order of operation, with interrupts disabled.
+    // See the datasheet of any AVR chip for details.
     wdt_reset();
     _WD_CONTROL_REG = _BV(_WD_CHANGE_BIT) | _BV(WDE);
-    _WD_CONTROL_REG = _BV(WDIE) | WDTO_4S;
+    _WD_CONTROL_REG = _BV(WDIE) | WDTO_NS;
   #else
-    wdt_enable(WDTO_4S);
+    wdt_enable(WDTO_NS);
   #endif
 }
 

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -121,7 +121,7 @@ void GcodeSuite::M204() {
 void GcodeSuite::M205() {
   if (parser.seen('S')) planner.min_feedrate_mm_s = parser.value_linear_units();
   if (parser.seen('T')) planner.min_travel_feedrate_mm_s = parser.value_linear_units();
-  if (parser.seen('B')) planner.min_segment_time = parser.value_millis();
+  if (parser.seen('B')) planner.min_segment_time_us = parser.value_ulong();
   if (parser.seen('X')) planner.max_jerk[X_AXIS] = parser.value_linear_units();
   if (parser.seen('Y')) planner.max_jerk[Y_AXIS] = parser.value_linear_units();
   if (parser.seen('Z')) planner.max_jerk[Z_AXIS] = parser.value_linear_units();

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -56,7 +56,7 @@
  *  163  M204 T    planner.travel_acceleration      (float)
  *  167  M205 S    planner.min_feedrate_mm_s        (float)
  *  171  M205 T    planner.min_travel_feedrate_mm_s (float)
- *  175  M205 B    planner.min_segment_time         (ulong)
+ *  175  M205 B    planner.min_segment_time_us      (ulong)
  *  179  M205 X    planner.max_jerk[X_AXIS]         (float)
  *  183  M205 Y    planner.max_jerk[Y_AXIS]         (float)
  *  187  M205 Z    planner.max_jerk[Z_AXIS]         (float)
@@ -68,7 +68,7 @@
  *  219            z_fade_height                    (float)
  *
  * MESH_BED_LEVELING:                               43 bytes
- *  223  M420 S    planner.leveling_active         (bool)
+ *  223  M420 S    planner.leveling_active          (bool)
  *  224            mbl.z_offset                     (float)
  *  228            GRID_MAX_POINTS_X                (uint8_t)
  *  229            GRID_MAX_POINTS_Y                (uint8_t)
@@ -305,7 +305,7 @@ void MarlinSettings::postprocess() {
     EEPROM_WRITE(planner.travel_acceleration);
     EEPROM_WRITE(planner.min_feedrate_mm_s);
     EEPROM_WRITE(planner.min_travel_feedrate_mm_s);
-    EEPROM_WRITE(planner.min_segment_time);
+    EEPROM_WRITE(planner.min_segment_time_us);
     EEPROM_WRITE(planner.max_jerk);
     #if !HAS_HOME_OFFSET
       const float home_offset[XYZ] = { 0 };
@@ -699,7 +699,7 @@ void MarlinSettings::postprocess() {
       EEPROM_READ(planner.travel_acceleration);
       EEPROM_READ(planner.min_feedrate_mm_s);
       EEPROM_READ(planner.min_travel_feedrate_mm_s);
-      EEPROM_READ(planner.min_segment_time);
+      EEPROM_READ(planner.min_segment_time_us);
       EEPROM_READ(planner.max_jerk);
 
       #if !HAS_HOME_OFFSET
@@ -1166,7 +1166,7 @@ void MarlinSettings::reset() {
   planner.retract_acceleration = DEFAULT_RETRACT_ACCELERATION;
   planner.travel_acceleration = DEFAULT_TRAVEL_ACCELERATION;
   planner.min_feedrate_mm_s = DEFAULT_MINIMUMFEEDRATE;
-  planner.min_segment_time = DEFAULT_MINSEGMENTTIME;
+  planner.min_segment_time_us = DEFAULT_MINSEGMENTTIME;
   planner.min_travel_feedrate_mm_s = DEFAULT_MINTRAVELFEEDRATE;
   planner.max_jerk[X_AXIS] = DEFAULT_XJERK;
   planner.max_jerk[Y_AXIS] = DEFAULT_YJERK;
@@ -1504,12 +1504,12 @@ void MarlinSettings::reset() {
 
     if (!forReplay) {
       CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Advanced: S<min_feedrate> T<min_travel_feedrate> B<min_segment_time_ms> X<max_xy_jerk> Z<max_z_jerk> E<max_e_jerk>");
+      SERIAL_ECHOLNPGM("Advanced: S<min_feedrate> T<min_travel_feedrate> B<min_segment_time_us> X<max_xy_jerk> Z<max_z_jerk> E<max_e_jerk>");
     }
     CONFIG_ECHO_START;
     SERIAL_ECHOPAIR("  M205 S", LINEAR_UNIT(planner.min_feedrate_mm_s));
     SERIAL_ECHOPAIR(" T", LINEAR_UNIT(planner.min_travel_feedrate_mm_s));
-    SERIAL_ECHOPAIR(" B", planner.min_segment_time);
+    SERIAL_ECHOPAIR(" B", planner.min_segment_time_us);
     SERIAL_ECHOPAIR(" X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
     SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
     SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -112,7 +112,7 @@ float Planner::filament_size[EXTRUDERS],         // As a baseline for the multip
 uint32_t Planner::max_acceleration_steps_per_s2[XYZE_N],
          Planner::max_acceleration_mm_per_s2[XYZE_N]; // Use M201 to override by software
 
-millis_t Planner::min_segment_time;
+uint32_t Planner::min_segment_time_us;
 
 // Initialized by settings.load()
 float Planner::min_feedrate_mm_s,
@@ -159,7 +159,7 @@ float Planner::previous_speed[NUM_AXIS],
   // Old direction bits. Used for speed calculations
   unsigned char Planner::old_direction_bits = 0;
   // Segment times (in µs). Used for speed calculations
-  long Planner::axis_segment_time[2][3] = { {MAX_FREQ_TIME + 1, 0, 0}, {MAX_FREQ_TIME + 1, 0, 0} };
+  uint32_t Planner::axis_segment_time_us[2][3] = { { MAX_FREQ_TIME_US + 1, 0, 0 }, { MAX_FREQ_TIME_US + 1, 0, 0 } };
 #endif
 
 #if ENABLED(LIN_ADVANCE)
@@ -1057,15 +1057,15 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   // Slow down when the buffer starts to empty, rather than wait at the corner for a buffer refill
   #if ENABLED(SLOWDOWN) || ENABLED(ULTRA_LCD) || defined(XY_FREQUENCY_LIMIT)
     // Segment time im micro seconds
-    unsigned long segment_time = LROUND(1000000.0 / inverse_mm_s);
+    uint32_t segment_time_us = LROUND(1000000.0 / inverse_mm_s);
   #endif
   #if ENABLED(SLOWDOWN)
     if (WITHIN(moves_queued, 2, (BLOCK_BUFFER_SIZE) / 2 - 1)) {
-      if (segment_time < min_segment_time) {
+      if (segment_time_us < min_segment_time_us) {
         // buffer is draining, add extra time.  The amount of time added increases if the buffer is still emptied more.
-        inverse_mm_s = 1000000.0 / (segment_time + LROUND(2 * (min_segment_time - segment_time) / moves_queued));
+        inverse_mm_s = 1000000.0 / (segment_time_us + LROUND(2 * (min_segment_time_us - segment_time_us) / moves_queued));
         #if defined(XY_FREQUENCY_LIMIT) || ENABLED(ULTRA_LCD)
-          segment_time = LROUND(1000000.0 / inverse_mm_s);
+          segment_time_us = LROUND(1000000.0 / inverse_mm_s);
         #endif
       }
     }
@@ -1073,7 +1073,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
   #if ENABLED(ULTRA_LCD)
     CRITICAL_SECTION_START
-      block_buffer_runtime_us += segment_time;
+      block_buffer_runtime_us += segment_time_us;
     CRITICAL_SECTION_END
   #endif
 
@@ -1130,34 +1130,34 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
     // Check and limit the xy direction change frequency
     const unsigned char direction_change = block->direction_bits ^ old_direction_bits;
     old_direction_bits = block->direction_bits;
-    segment_time = LROUND((float)segment_time / speed_factor);
+    segment_time_us = LROUND((float)segment_time_us / speed_factor);
 
-    long xs0 = axis_segment_time[X_AXIS][0],
-         xs1 = axis_segment_time[X_AXIS][1],
-         xs2 = axis_segment_time[X_AXIS][2],
-         ys0 = axis_segment_time[Y_AXIS][0],
-         ys1 = axis_segment_time[Y_AXIS][1],
-         ys2 = axis_segment_time[Y_AXIS][2];
+    uint32_t xs0 = axis_segment_time_us[X_AXIS][0],
+             xs1 = axis_segment_time_us[X_AXIS][1],
+             xs2 = axis_segment_time_us[X_AXIS][2],
+             ys0 = axis_segment_time_us[Y_AXIS][0],
+             ys1 = axis_segment_time_us[Y_AXIS][1],
+             ys2 = axis_segment_time_us[Y_AXIS][2];
 
     if (TEST(direction_change, X_AXIS)) {
-      xs2 = axis_segment_time[X_AXIS][2] = xs1;
-      xs1 = axis_segment_time[X_AXIS][1] = xs0;
+      xs2 = axis_segment_time_us[X_AXIS][2] = xs1;
+      xs1 = axis_segment_time_us[X_AXIS][1] = xs0;
       xs0 = 0;
     }
-    xs0 = axis_segment_time[X_AXIS][0] = xs0 + segment_time;
+    xs0 = axis_segment_time_us[X_AXIS][0] = xs0 + segment_time_us;
 
     if (TEST(direction_change, Y_AXIS)) {
-      ys2 = axis_segment_time[Y_AXIS][2] = axis_segment_time[Y_AXIS][1];
-      ys1 = axis_segment_time[Y_AXIS][1] = axis_segment_time[Y_AXIS][0];
+      ys2 = axis_segment_time_us[Y_AXIS][2] = axis_segment_time_us[Y_AXIS][1];
+      ys1 = axis_segment_time_us[Y_AXIS][1] = axis_segment_time_us[Y_AXIS][0];
       ys0 = 0;
     }
-    ys0 = axis_segment_time[Y_AXIS][0] = ys0 + segment_time;
+    ys0 = axis_segment_time_us[Y_AXIS][0] = ys0 + segment_time_us;
 
-    const long max_x_segment_time = MAX3(xs0, xs1, xs2),
-               max_y_segment_time = MAX3(ys0, ys1, ys2),
-               min_xy_segment_time = min(max_x_segment_time, max_y_segment_time);
-    if (min_xy_segment_time < MAX_FREQ_TIME) {
-      const float low_sf = speed_factor * min_xy_segment_time / (MAX_FREQ_TIME);
+    const uint32_t max_x_segment_time = MAX3(xs0, xs1, xs2),
+                   max_y_segment_time = MAX3(ys0, ys1, ys2),
+                   min_xy_segment_time = min(max_x_segment_time, max_y_segment_time);
+    if (min_xy_segment_time < MAX_FREQ_TIME_US) {
+      const float low_sf = speed_factor * min_xy_segment_time / (MAX_FREQ_TIME_US);
       NOMORE(speed_factor, low_sf);
     }
   #endif // XY_FREQUENCY_LIMIT

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -123,7 +123,7 @@ typedef struct {
     uint8_t valve_pressure, e_to_p_pressure;
   #endif
 
-  uint32_t segment_time;
+  uint32_t segment_time_us;
 
 } block_t;
 
@@ -154,9 +154,9 @@ class Planner {
                  axis_steps_per_mm[XYZE_N],
                  steps_to_mm[XYZE_N];
     static uint32_t max_acceleration_steps_per_s2[XYZE_N],
-                    max_acceleration_mm_per_s2[XYZE_N]; // Use M201 to override by software
+                    max_acceleration_mm_per_s2[XYZE_N]; // Use M201 to override
 
-    static millis_t min_segment_time;
+    static uint32_t min_segment_time_us; // Use 'M205 B<µs>' to override
     static float min_feedrate_mm_s,
                  acceleration,         // Normal acceleration mm/s^2  DEFAULT ACCELERATION for all printing moves. M204 SXXXX
                  retract_acceleration, // Retract acceleration mm/s^2 filament pull-back and push-forward while standing still in the other axes M204 TXXXX
@@ -214,11 +214,11 @@ class Planner {
 
     #ifdef XY_FREQUENCY_LIMIT
       // Used for the frequency limit
-      #define MAX_FREQ_TIME long(1000000.0/XY_FREQUENCY_LIMIT)
+      #define MAX_FREQ_TIME_US (uint32_t)(1000000.0 / XY_FREQUENCY_LIMIT)
       // Old direction bits. Used for speed calculations
       static unsigned char old_direction_bits;
       // Segment times (in µs). Used for speed calculations
-      static long axis_segment_time[2][3];
+      static long axis_segment_time_us[2][3];
     #endif
 
     #if ENABLED(LIN_ADVANCE)
@@ -439,7 +439,7 @@ class Planner {
       if (blocks_queued()) {
         block_t* block = &block_buffer[block_buffer_tail];
         #if ENABLED(ULTRA_LCD)
-          block_buffer_runtime_us -= block->segment_time; //We can't be sure how long an active block will take, so don't count it.
+          block_buffer_runtime_us -= block->segment_time_us; //We can't be sure how long an active block will take, so don't count it.
         #endif
         SBI(block->flag, BLOCK_BIT_BUSY);
         return block;

--- a/Marlin/src/pins/pins_ANET_10.h
+++ b/Marlin/src/pins/pins_ANET_10.h
@@ -155,36 +155,38 @@
 #if ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL)
   #define LCD_SDSS           28
   #if ENABLED(ADC_KEYPAD)
-    #define SERVO0_PIN         27 // free for BLTouch/3D-Touch
-    #define LCD_PINS_RS        28
-    #define LCD_PINS_ENABLE    29
-    #define LCD_PINS_D4        10
-    #define LCD_PINS_D5        11
-    #define LCD_PINS_D6        16
-    #define LCD_PINS_D7        17
-    #define BTN_EN1            -1
-    #define BTN_EN2            -1
-    #define BTN_ENC            -1
-    #define ADC_KEYPAD_PIN      1
+    #define SERVO0_PIN       27 // free for BLTouch/3D-Touch
+    #define LCD_PINS_RS      28
+    #define LCD_PINS_ENABLE  29
+    #define LCD_PINS_D4      10
+    #define LCD_PINS_D5      11
+    #define LCD_PINS_D6      16
+    #define LCD_PINS_D7      17
+    #define BTN_EN1          -1
+    #define BTN_EN2          -1
+    #define BTN_ENC          -1
+    #define ADC_KEYPAD_PIN    1
     #define ENCODER_FEEDRATE_DEADZONE 2
   #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) || ENABLED(ANET_FULL_GRAPHICS_LCD)
     // Pin definitions for the Anet A6 Full Graphics display and the RepRapDiscount Full Graphics
     // display using an adapter board  // https://go.aisler.net/benlye/anet-lcd-adapter/pcb
     // See below for alternative pin definitions for use with https://www.thingiverse.com/thing:2103748
-    #define SERVO0_PIN         29 // free for BLTouch/3D-Touch
-    #define BEEPER_PIN         17
-    #define LCD_PINS_RS        27
-    #define LCD_PINS_ENABLE    28
-    #define LCD_PINS_D4        30
-    #define BTN_EN1            11
-    #define BTN_EN2            10
-    #define BTN_ENC            16
+    #define SERVO0_PIN       29 // free for BLTouch/3D-Touch
+    #define BEEPER_PIN       17
+    #define LCD_PINS_RS      27
+    #define LCD_PINS_ENABLE  28
+    #define LCD_PINS_D4      30
+    #define BTN_EN1          11
+    #define BTN_EN2          10
+    #define BTN_ENC          16
     #define ST7920_DELAY_1 DELAY_0_NOP
     #define ST7920_DELAY_2 DELAY_1_NOP
     #define ST7920_DELAY_3 DELAY_2_NOP
     #define STD_ENCODER_PULSES_PER_STEP 4
     #define STD_ENCODER_STEPS_PER_MENU_ITEM 1
   #endif
+#else
+  #define SERVO0_PIN         27
 #endif  // ULTRA_LCD && NEWPANEL
 
 /**

--- a/buildroot/share/git/mfpub
+++ b/buildroot/share/git/mfpub
@@ -45,6 +45,9 @@ git clean -d -f
 # Push 'master' to the fork and make a proper PR...
 if [[ $BRANCH == "master" ]]; then
 
+  # Don't lose upstream changes!
+  mfup
+
   # Allow working directly with the main fork
   echo
   echo -n "Pushing to origin/master... "


### PR DESCRIPTION
See also #8156

I noticed in this overview on setting up BLTouch, an instruction is given to set the SERVO0_PIN.

https://youtu.be/WWDkZtWwd6I?t=5m37s

This PR adds a definition for `SERVO0_PIN` in cases where the graphical display or Anet keypad is not enabled.

Also:
- Correct/add time units to planner vars (µs)
- Fix `M205 B` and settings report
- Tweak documentation publishing script
- Add a hidden option to use an 8s watchdog timer on AVR