### PR TITLE
[1.1.x] Simplify SD_REPRINT_LAST_SELECTED_FILE

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2910,6 +2910,7 @@ void kill_screen(const char* lcd_msg) {
               max = soft_endstop_max[Z_AXIS];
             #endif
             break;
+          default: break;
         }
       #endif // MIN_SOFTWARE_ENDSTOPS || MAX_SOFTWARE_ENDSTOPS
 


### PR DESCRIPTION
Followup patch for #8098. Parity with #8113.

_**As a general rule, if you find yourself hacking core code or being too clever, you're probably doing it wrong. In most cases there is one right way to do things. Ask @thinkyhead for help if you find yourself cursing Marlin for not doing what you want.**_

- "`defer_return_to_status`" works as designed, so no need to hack it.
- The encoder position is saved when print starts, so no 5s time check needed.
- With no 5s time check, no special case force-call of the screen needs to be added.

Compliments earlier changes in compliance with good coding practices:

- Remove lcd-oriented code and `extern` references from `cardreader.cpp`, moving all that code to the `lcd_reselect_last_file` function, which is externally exposed in `ultralcd.h`. This represents the best-practice of "_encapsulation_."

Still to do:

- Continue to strip code out of `lcd_reselect_last_file` to determine the minimum required "bump" needed to get a complete graphical screen redraw when jumping to the SD menu.