### PR TITLE
[1.1.x] Fix NO_MOTION_BEFORE_HOMING unwanted behavior (Addressing #8127)

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3412,7 +3412,7 @@ inline void gcode_G0_G1(
   #endif
 ) {
   #if ENABLED(NO_MOTION_BEFORE_HOMING)
-    if (axis_unhomed_error()) return;
+    if (axis_unhomed_error(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))) return;
   #endif
 
   if (IsRunning()) {


### PR DESCRIPTION
Option should prevent XYZ movements when system is not homed but allows E movements