### PR TITLE
[2.0.x] Fix NO_MOTION_BEFORE_HOMING unwanted behavior (Addressing #8127)

### DIFF
--- a/Marlin/src/gcode/bedlevel/G42.cpp
+++ b/Marlin/src/gcode/bedlevel/G42.cpp
@@ -33,7 +33,7 @@
  * G42: Move X & Y axes to mesh coordinates (I & J)
  */
 void GcodeSuite::G42() {
-  if (MOTION_CONDITIONS) {
+  if (MOTION_CONDITIONS()) {
     const bool hasI = parser.seenval('I');
     const int8_t ix = hasI ? parser.value_int() : 0;
     const bool hasJ = parser.seenval('J');

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -41,7 +41,7 @@ void GcodeSuite::G0_G1(
     bool fast_move/*=false*/
   #endif
 ) {
-  if (MOTION_CONDITIONS) {
+  if (MOTION_CONDITIONS(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))) {
     get_destination_from_command(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT)

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -211,7 +211,7 @@ void plan_arc(
  *    G3 X20 Y12 R14   ; CCW circle with r=14 ending at X20 Y12
  */
 void GcodeSuite::G2_G3(const bool clockwise) {
-  if (MOTION_CONDITIONS) {
+  if (MOTION_CONDITIONS()) {
 
     #if ENABLED(SF_ARC_FIX)
       const bool relative_mode_backup = relative_mode;

--- a/Marlin/src/gcode/motion/G5.cpp
+++ b/Marlin/src/gcode/motion/G5.cpp
@@ -50,7 +50,7 @@ void plan_cubic_move(const float offset[4]) {
  * G5: Cubic B-spline
  */
 void GcodeSuite::G5() {
-  if (MOTION_CONDITIONS) {
+  if (MOTION_CONDITIONS()) {
 
     #if ENABLED(CNC_WORKSPACE_PLANES)
       if (workspace_plane != PLANE_XY) {

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -182,9 +182,9 @@ void clean_up_after_endstop_or_probe_move();
 #endif
 
 #if ENABLED(NO_MOTION_BEFORE_HOMING)
-  #define MOTION_CONDITIONS (IsRunning() && !axis_unhomed_error())
+  #define MOTION_CONDITIONS(...) (IsRunning() && !axis_unhomed_error(__VA_ARGS__))
 #else
-  #define MOTION_CONDITIONS IsRunning()
+  #define MOTION_CONDITIONS(...) IsRunning()
 #endif
 
 void set_axis_is_at_home(const AxisEnum axis);


### PR DESCRIPTION
Option should prevent XYZ movements when system is not homed but allows E movements