### PR TITLE
[2.0.x] Fix NO_MOTION_BEFORE_HOMING unwanted behaviour

### DIFF
--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -47,7 +47,7 @@ void GcodeSuite::G0_G1(
     bool fast_move/*=false*/
   #endif
 ) {
-  if (IsRunning() && G0_G1_CONDITIONS) {
+  if (IsRunning() && G0_G1_CONDITION) {
     get_destination_from_command(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT)

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -33,6 +33,12 @@
 
 extern float destination[XYZE];
 
+#if ENABLED(NO_MOTION_BEFORE_HOMING)
+  #define G0_G1_CONDITION !axis_unhomed_error(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))
+#else
+  #define G0_G1_CONDITION true
+#endif
+
 /**
  * G0, G1: Coordinated movement of X Y Z E axes
  */
@@ -41,8 +47,7 @@ void GcodeSuite::G0_G1(
     bool fast_move/*=false*/
   #endif
 ) {
-  const bool cartesianInvolved = (parser.seen('X') || parser.seen('Y') || parser.seen('Z'));
-  if (IsRunning() && !axis_unhomed_error(cartesianInvolved, cartesianInvolved, cartesianInvolved)) {
+  if (IsRunning() && G0_G1_CONDITIONS) {
     get_destination_from_command(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT)

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -41,7 +41,8 @@ void GcodeSuite::G0_G1(
     bool fast_move/*=false*/
   #endif
 ) {
-  if (MOTION_CONDITIONS) {
+  const bool cartesianInvolved = (parser.seen('X') || parser.seen('Y') || parser.seen('Z'));
+  if (IsRunning() && !axis_unhomed_error(cartesianInvolved, cartesianInvolved, cartesianInvolved)) {
     get_destination_from_command(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT)


### PR DESCRIPTION
NO_MOTION_BEFORE_HOMING should prevent XYZ movements only when homing is not done.
E axes should be allowed