### PR TITLE
[1.1.x] Fix NO_MOTION_BEFORE_HOMING unwanted behaviour

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3412,7 +3412,7 @@ inline void gcode_G0_G1(
   #endif
 ) {
   #if ENABLED(NO_MOTION_BEFORE_HOMING)
-    if ((parser.seen('X') || parser.seen('Y') || parser.seen('Z')) && axis_unhomed_error()) return;
+    if (axis_unhomed_error(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))) return;
   #endif
 
   if (IsRunning()) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3412,7 +3412,8 @@ inline void gcode_G0_G1(
   #endif
 ) {
   #if ENABLED(NO_MOTION_BEFORE_HOMING)
-    if (axis_unhomed_error()) return;
+    const bool cartesianInvolved = (parser.seen('X') || parser.seen('Y') || parser.seen('Z'));
+    if (axis_unhomed_error(cartesianInvolved, cartesianInvolved, cartesianInvolved)) return;
   #endif
 
   if (IsRunning()) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3412,8 +3412,7 @@ inline void gcode_G0_G1(
   #endif
 ) {
   #if ENABLED(NO_MOTION_BEFORE_HOMING)
-    const bool cartesianInvolved = (parser.seen('X') || parser.seen('Y') || parser.seen('Z'));
-    if (axis_unhomed_error(cartesianInvolved, cartesianInvolved, cartesianInvolved)) return;
+    if ((parser.seen('X') || parser.seen('Y') || parser.seen('Z')) && axis_unhomed_error()) return;
   #endif
 
   if (IsRunning()) {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3403,6 +3403,12 @@ void gcode_get_destination() {
  ***************** GCode Handlers *****************
  **************************************************/
 
+#if ENABLED(NO_MOTION_BEFORE_HOMING)
+  #define G0_G1_CONDITION !axis_unhomed_error(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))
+#else
+  #define G0_G1_CONDITION true
+#endif
+
 /**
  * G0, G1: Coordinated movement of X Y Z E axes
  */
@@ -3411,11 +3417,7 @@ inline void gcode_G0_G1(
     bool fast_move=false
   #endif
 ) {
-  #if ENABLED(NO_MOTION_BEFORE_HOMING)
-    if (axis_unhomed_error(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))) return;
-  #endif
-
-  if (IsRunning()) {
+  if (IsRunning() && G0_G1_CONDITION) {
     gcode_get_destination(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT)


### PR DESCRIPTION
NO_MOTION_BEFORE_HOMING should prevent XYZ movements only when homing is not done.
E axes should be allowed