### PR TITLE
[2.0.x] Only show custom bootscreen once

### DIFF
--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -278,6 +278,8 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
 
 #if ENABLED(SHOW_BOOTSCREEN)
 
+  bool show_bootscreen = true;
+
   #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
 
     void lcd_custom_bootscreen() {
@@ -293,8 +295,6 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
   #endif // SHOW_CUSTOM_BOOTSCREEN
 
   void lcd_bootscreen() {
-
-    static bool show_bootscreen = true;
 
     if (show_bootscreen) {
       show_bootscreen = false;
@@ -353,11 +353,13 @@ static void lcd_implementation_init() {
   #endif
 
   #if ENABLED(SHOW_BOOTSCREEN)
-    #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
-      lcd_custom_bootscreen();
-    #else
-      lcd_bootscreen();
-    #endif
+    if (show_bootscreen) {
+      #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)
+        lcd_custom_bootscreen();
+      #else
+        lcd_bootscreen();
+      #endif
+    }
   #endif
 }
 


### PR DESCRIPTION
On some LCD controllers, the controller is reset in response to clicks. This leads to the custom bootscreen appearing before the menu appears. This PR prevents the boot screen from appearing more than once.

Addressing #8146