### PR TITLE
Update InterruptVectors_Due.cpp

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/InterruptVectors_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/InterruptVectors_Due.cpp
@@ -74,7 +74,7 @@ static pfnISR_Handler* get_relocated_table_addr(void) {
 
 pfnISR_Handler install_isr(IRQn_Type irq, pfnISR_Handler newHandler) {
   // Get the address of the relocated table
-  const pfnISR_Handler *isrtab = get_relocated_table_addr();
+  pfnISR_Handler *isrtab = get_relocated_table_addr();
 
   // Disable global interrupts
   CRITICAL_SECTION_START;


### PR DESCRIPTION
`const pfnISR_Handler *isrtab = get_relocated_table_addr();`
...
`isrtab[irq + 16] = newHandler;`

What compiler do you use? Arduino 1.8.5 can't compile with this "const".