### PR TITLE
[1.1] Fix watchdog in WATCHDOG_RESET_MANUAL mode AVR

### DIFF
--- a/Marlin/watchdog.cpp
+++ b/Marlin/watchdog.cpp
@@ -38,11 +38,16 @@ void watchdog_init() {
     // Take care, as this requires the correct order of operation, with interrupts disabled.
     // See the datasheet of any AVR chip for details.
     wdt_reset();
+    cli();
     _WD_CONTROL_REG = _BV(_WD_CHANGE_BIT) | _BV(WDE);
-    _WD_CONTROL_REG = _BV(WDIE) | WDTO_NS;
+    _WD_CONTROL_REG = _BV(WDIE) | (WDTO_NS & 0x07) | ((WDTO_NS & 0x08) << 2); // WDTO_NS directly does not work. bit 0-2 are consecutive in the register but the highest value bit is at bit 5
+                                                                              // So worked for up to WDTO_2S
+    sei();
+    wdt_reset();
   #else
-    wdt_enable(WDTO_NS);
+    wdt_enable(WDTO_NS); // The function handles the upper bit correct.
   #endif
+  //delay(10000); // test it!
 }
 
 //===========================================================================
@@ -52,9 +57,10 @@ void watchdog_init() {
 // Watchdog timer interrupt, called if main program blocks >4sec and manual reset is enabled.
 #if ENABLED(WATCHDOG_RESET_MANUAL)
   ISR(WDT_vect) {
+    sei();  // With the interrupt driven serial we need to allow interrupts.
     SERIAL_ERROR_START();
-    SERIAL_ERRORLNPGM("Something is wrong, please turn off the printer.");
-    kill(PSTR("ERR:Please Reset")); //kill blocks //16 characters so it fits on a 16x2 display
+    SERIAL_ERRORLNPGM("Watchdog barked, please turn off the printer.");
+    kill(PSTR("ERR:Watchdog")); //kill blocks //up to 16 characters so it fits on a 16x2 display
     while (1); //wait for user or serial reset
   }
 #endif // WATCHDOG_RESET_MANUAL


### PR DESCRIPTION
Longer watchdog timeouts broke the watchdog in WATCHDOG_RESET_MANUAL for AVRs. A register structure was not matched.
The interrupt driven serial send blocked the output of the watchdog interrupt used by WATCHDOG_RESET_MANUAL.