### PR TITLE
[2.0.x] Operate in Native Machine Space

### DIFF
--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -365,10 +365,10 @@ void safe_delay(millis_t ms) {
 
       SERIAL_ECHOPGM("Mesh Bed Leveling");
       if (planner.leveling_active) {
-        float lz = current_position[Z_AXIS];
-        planner.apply_leveling(current_position[X_AXIS], current_position[Y_AXIS], lz);
+        float rz = current_position[Z_AXIS];
+        planner.apply_leveling(current_position[X_AXIS], current_position[Y_AXIS], rz);
         SERIAL_ECHOLNPGM(" (enabled)");
-        SERIAL_ECHOPAIR("MBL Adjustment Z", lz);
+        SERIAL_ECHOPAIR("MBL Adjustment Z", rz);
       }
       else
         SERIAL_ECHOPGM(" (disabled)");

--- a/Marlin/src/feature/bedlevel/abl/abl.h
+++ b/Marlin/src/feature/bedlevel/abl/abl.h
@@ -32,7 +32,7 @@
   extern int bilinear_grid_spacing[2], bilinear_start[2];
   extern float bilinear_grid_factor[2],
                z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-  float bilinear_z_offset(const float logical[XYZ]);
+  float bilinear_z_offset(const float raw[XYZ]);
 
   void extrapolate_unprobed_bed_level();
   void print_bilinear_leveling_grid();

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -256,18 +256,18 @@ void reset_bed_level() {
 
 #if ENABLED(MESH_BED_LEVELING) || ENABLED(PROBE_MANUALLY)
 
-  void _manual_goto_xy(const float &x, const float &y) {
+  void _manual_goto_xy(const float &rx, const float &ry) {
     const float old_feedrate_mm_s = feedrate_mm_s;
     #if MANUAL_PROBE_HEIGHT > 0
       const float prev_z = current_position[Z_AXIS];
       feedrate_mm_s = homing_feedrate(Z_AXIS);
-      current_position[Z_AXIS] = LOGICAL_Z_POSITION(MANUAL_PROBE_HEIGHT);
+      current_position[Z_AXIS] = MANUAL_PROBE_HEIGHT;
       line_to_current_position();
     #endif
 
     feedrate_mm_s = MMM_TO_MMS(XY_PROBE_SPEED);
-    current_position[X_AXIS] = LOGICAL_X_POSITION(x);
-    current_position[Y_AXIS] = LOGICAL_Y_POSITION(y);
+    current_position[X_AXIS] = rx;
+    current_position[Y_AXIS] = ry;
     line_to_current_position();
 
     #if MANUAL_PROBE_HEIGHT > 0

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -57,10 +57,10 @@
    * splitting the move where it crosses mesh borders.
    */
   void mesh_line_to_destination(const float fr_mm_s, uint8_t x_splits, uint8_t y_splits) {
-    int cx1 = mbl.cell_index_x(RAW_CURRENT_POSITION(X)),
-        cy1 = mbl.cell_index_y(RAW_CURRENT_POSITION(Y)),
-        cx2 = mbl.cell_index_x(RAW_X_POSITION(destination[X_AXIS])),
-        cy2 = mbl.cell_index_y(RAW_Y_POSITION(destination[Y_AXIS]));
+    int cx1 = mbl.cell_index_x(current_position[X_AXIS]),
+        cy1 = mbl.cell_index_y(current_position[Y_AXIS]),
+        cx2 = mbl.cell_index_x(destination[X_AXIS]),
+        cy2 = mbl.cell_index_y(destination[Y_AXIS]);
     NOMORE(cx1, GRID_MAX_POINTS_X - 2);
     NOMORE(cy1, GRID_MAX_POINTS_Y - 2);
     NOMORE(cx2, GRID_MAX_POINTS_X - 2);
@@ -81,14 +81,14 @@
     const int8_t gcx = max(cx1, cx2), gcy = max(cy1, cy2);
     if (cx2 != cx1 && TEST(x_splits, gcx)) {
       COPY(end, destination);
-      destination[X_AXIS] = LOGICAL_X_POSITION(mbl.index_to_xpos[gcx]);
+      destination[X_AXIS] = mbl.index_to_xpos[gcx];
       normalized_dist = (destination[X_AXIS] - current_position[X_AXIS]) / (end[X_AXIS] - current_position[X_AXIS]);
       destination[Y_AXIS] = MBL_SEGMENT_END(Y);
       CBI(x_splits, gcx);
     }
     else if (cy2 != cy1 && TEST(y_splits, gcy)) {
       COPY(end, destination);
-      destination[Y_AXIS] = LOGICAL_Y_POSITION(mbl.index_to_ypos[gcy]);
+      destination[Y_AXIS] = mbl.index_to_ypos[gcy];
       normalized_dist = (destination[Y_AXIS] - current_position[Y_AXIS]) / (end[Y_AXIS] - current_position[Y_AXIS]);
       destination[X_AXIS] = MBL_SEGMENT_END(X);
       CBI(y_splits, gcy);

--- a/Marlin/src/feature/bedlevel/ubl/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/G26_Mesh_Validation_Tool.cpp
@@ -276,7 +276,7 @@ void unified_bed_leveling::G26() {
 
       // If this mesh location is outside the printable_radius, skip it.
 
-      if (!position_is_reachable_raw_xy(circle_x, circle_y)) continue;
+      if (!position_is_reachable(circle_x, circle_y)) continue;
 
       xi = location.x_index;  // Just to shrink the next few lines and make them easier to understand
       yi = location.y_index;
@@ -325,16 +325,16 @@ void unified_bed_leveling::G26() {
         if (tmp_div_30 < 0) tmp_div_30 += 360 / 30;
         if (tmp_div_30 > 11) tmp_div_30 -= 360 / 30;
 
-        float x = circle_x + cos_table[tmp_div_30],    // for speed, these are now a lookup table entry
-              y = circle_y + sin_table[tmp_div_30],
+        float rx = circle_x + cos_table[tmp_div_30],    // for speed, these are now a lookup table entry
+              ry = circle_y + sin_table[tmp_div_30],
               xe = circle_x + cos_table[tmp_div_30 + 1],
               ye = circle_y + sin_table[tmp_div_30 + 1];
         #if IS_KINEMATIC
           // Check to make sure this segment is entirely on the bed, skip if not.
-          if (!position_is_reachable_raw_xy(x, y) || !position_is_reachable_raw_xy(xe, ye)) continue;
+          if (!position_is_reachable(rx, ry) || !position_is_reachable(xe, ye)) continue;
         #else                                              // not, we need to skip
-          x  = constrain(x, X_MIN_POS + 1, X_MAX_POS - 1); // This keeps us from bumping the endstops
-          y  = constrain(y, Y_MIN_POS + 1, Y_MAX_POS - 1);
+          rx = constrain(rx, X_MIN_POS + 1, X_MAX_POS - 1); // This keeps us from bumping the endstops
+          ry = constrain(ry, Y_MIN_POS + 1, Y_MAX_POS - 1);
           xe = constrain(xe, X_MIN_POS + 1, X_MAX_POS - 1);
           ye = constrain(ye, Y_MIN_POS + 1, Y_MAX_POS - 1);
         #endif
@@ -350,7 +350,7 @@ void unified_bed_leveling::G26() {
         //  debug_current_and_destination(seg_msg);
         //}
 
-        print_line_from_here_to_there(LOGICAL_X_POSITION(x), LOGICAL_Y_POSITION(y), g26_layer_height, LOGICAL_X_POSITION(xe), LOGICAL_Y_POSITION(ye), g26_layer_height);
+        print_line_from_here_to_there(rx, ry, g26_layer_height, xe, ye, g26_layer_height);
 
       }
       if (look_for_lines_to_connect())
@@ -456,7 +456,7 @@ bool unified_bed_leveling::look_for_lines_to_connect() {
             sy = ey = constrain(mesh_index_to_ypos(j), Y_MIN_POS + 1, Y_MAX_POS - 1);
             ex = constrain(ex, X_MIN_POS + 1, X_MAX_POS - 1);
 
-            if (position_is_reachable_raw_xy(sx, sy) && position_is_reachable_raw_xy(ex, ey)) {
+            if (position_is_reachable(sx, sy) && position_is_reachable(ex, ey)) {
 
               if (g26_debug_flag) {
                 SERIAL_ECHOPAIR(" Connecting with horizontal line (sx=", sx);
@@ -468,7 +468,7 @@ bool unified_bed_leveling::look_for_lines_to_connect() {
                 //debug_current_and_destination(PSTR("Connecting horizontal line."));
               }
 
-              print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), g26_layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), g26_layer_height);
+              print_line_from_here_to_there(sx, sy, g26_layer_height, ex, ey, g26_layer_height);
             }
             bit_set(horizontal_mesh_line_flags, i, j);   // Mark it as done so we don't do it again, even if we skipped it
           }
@@ -490,7 +490,7 @@ bool unified_bed_leveling::look_for_lines_to_connect() {
               sy = constrain(sy, Y_MIN_POS + 1, Y_MAX_POS - 1);
               ey = constrain(ey, Y_MIN_POS + 1, Y_MAX_POS - 1);
 
-              if (position_is_reachable_raw_xy(sx, sy) && position_is_reachable_raw_xy(ex, ey)) {
+              if (position_is_reachable(sx, sy) && position_is_reachable(ex, ey)) {
 
                 if (g26_debug_flag) {
                   SERIAL_ECHOPAIR(" Connecting with vertical line (sx=", sx);
@@ -501,7 +501,7 @@ bool unified_bed_leveling::look_for_lines_to_connect() {
                   SERIAL_EOL();
                   debug_current_and_destination(PSTR("Connecting vertical line."));
                 }
-                print_line_from_here_to_there(LOGICAL_X_POSITION(sx), LOGICAL_Y_POSITION(sy), g26_layer_height, LOGICAL_X_POSITION(ex), LOGICAL_Y_POSITION(ey), g26_layer_height);
+                print_line_from_here_to_there(sx, sy, g26_layer_height, ex, ey, g26_layer_height);
               }
               bit_set(vertical_mesh_line_flags, i, j);   // Mark it as done so we don't do it again, even if skipped
             }
@@ -513,11 +513,11 @@ bool unified_bed_leveling::look_for_lines_to_connect() {
   return false;
 }
 
-void unified_bed_leveling::move_to(const float &x, const float &y, const float &z, const float &e_delta) {
+void unified_bed_leveling::move_to(const float &rx, const float &ry, const float &z, const float &e_delta) {
   float feed_value;
   static float last_z = -999.99;
 
-  bool has_xy_component = (x != current_position[X_AXIS] || y != current_position[Y_AXIS]); // Check if X or Y is involved in the movement.
+  bool has_xy_component = (rx != current_position[X_AXIS] || ry != current_position[Y_AXIS]); // Check if X or Y is involved in the movement.
 
   if (z != last_z) {
     last_z = z;
@@ -540,8 +540,8 @@ void unified_bed_leveling::move_to(const float &x, const float &y, const float &
 
   if (g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to() feed_value for XY:", feed_value);
 
-  destination[X_AXIS] = x;
-  destination[Y_AXIS] = y;
+  destination[X_AXIS] = rx;
+  destination[Y_AXIS] = ry;
   destination[E_AXIS] += e_delta;
 
   G26_line_to_destination(feed_value);
@@ -734,9 +734,9 @@ bool unified_bed_leveling::parse_G26_parameters() {
     return UBL_ERR;
   }
 
-  g26_x_pos = parser.linearval('X', current_position[X_AXIS]);
-  g26_y_pos = parser.linearval('Y', current_position[Y_AXIS]);
-  if (!position_is_reachable_xy(g26_x_pos, g26_y_pos)) {
+  g26_x_pos = parser.seenval('X') ? RAW_X_POSITION(parser.value_linear_units()) : current_position[X_AXIS];
+  g26_y_pos = parser.seenval('Y') ? RAW_X_POSITION(parser.value_linear_units()) : current_position[Y_AXIS];
+  if (!position_is_reachable(g26_x_pos, g26_y_pos)) {
     SERIAL_PROTOCOLLNPGM("?Specified X,Y coordinate out of bounds.");
     return UBL_ERR;
   }

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -108,14 +108,14 @@ class unified_bed_leveling {
     static bool g29_parameter_parsing();
     static void find_mean_mesh_height();
     static void shift_mesh_height();
-    static void probe_entire_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
+    static void probe_entire_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
     static void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
     static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
     static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
     static void g29_what_command();
     static void g29_eeprom_dump();
     static void g29_compare_current_mesh_to_stored_mesh();
-    static void fine_tune_mesh(const float &lx, const float &ly, const bool do_ubl_mesh_map);
+    static void fine_tune_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map);
     static bool smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir);
     static void smart_fill_mesh();
 
@@ -243,12 +243,12 @@ class unified_bed_leveling {
      * z_correction_for_x_on_horizontal_mesh_line is an optimization for
      * the case where the printer is making a vertical line that only crosses horizontal mesh lines.
      */
-    inline static float z_correction_for_x_on_horizontal_mesh_line(const float &lx0, const int x1_i, const int yi) {
+    inline static float z_correction_for_x_on_horizontal_mesh_line(const float &rx0, const int x1_i, const int yi) {
       if (!WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 2) || !WITHIN(yi, 0, GRID_MAX_POINTS_Y - 1)) {
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             serialprintPGM( !WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) ? PSTR("x1l_i") : PSTR("yi") );
-            SERIAL_ECHOPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(lx0=", lx0);
+            SERIAL_ECHOPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0);
             SERIAL_ECHOPAIR(",x1_i=", x1_i);
             SERIAL_ECHOPAIR(",yi=", yi);
             SERIAL_CHAR(')');
@@ -258,7 +258,7 @@ class unified_bed_leveling {
         return NAN;
       }
 
-      const float xratio = (RAW_X_POSITION(lx0) - mesh_index_to_xpos(x1_i)) * (1.0 / (MESH_X_DIST)),
+      const float xratio = (rx0 - mesh_index_to_xpos(x1_i)) * (1.0 / (MESH_X_DIST)),
                   z1 = z_values[x1_i][yi];
 
       return z1 + xratio * (z_values[x1_i + 1][yi] - z1);
@@ -267,12 +267,12 @@ class unified_bed_leveling {
     //
     // See comments above for z_correction_for_x_on_horizontal_mesh_line
     //
-    inline static float z_correction_for_y_on_vertical_mesh_line(const float &ly0, const int xi, const int y1_i) {
+    inline static float z_correction_for_y_on_vertical_mesh_line(const float &ry0, const int xi, const int y1_i) {
       if (!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(y1_i, 0, GRID_MAX_POINTS_Y - 2)) {
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             serialprintPGM( !WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) ? PSTR("xi") : PSTR("yl_i") );
-            SERIAL_ECHOPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ly0=", ly0);
+            SERIAL_ECHOPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0);
             SERIAL_ECHOPAIR(", xi=", xi);
             SERIAL_ECHOPAIR(", y1_i=", y1_i);
             SERIAL_CHAR(')');
@@ -282,7 +282,7 @@ class unified_bed_leveling {
         return NAN;
       }
 
-      const float yratio = (RAW_Y_POSITION(ly0) - mesh_index_to_ypos(y1_i)) * (1.0 / (MESH_Y_DIST)),
+      const float yratio = (ry0 - mesh_index_to_ypos(y1_i)) * (1.0 / (MESH_Y_DIST)),
                   z1 = z_values[xi][y1_i];
 
       return z1 + yratio * (z_values[xi][y1_i + 1] - z1);
@@ -294,14 +294,14 @@ class unified_bed_leveling {
      * Z-Height at both ends. Then it does a linear interpolation of these heights based
      * on the Y position within the cell.
      */
-    static float get_z_correction(const float &lx0, const float &ly0) {
-      const int8_t cx = get_cell_index_x(RAW_X_POSITION(lx0)),
-                   cy = get_cell_index_y(RAW_Y_POSITION(ly0));
+    static float get_z_correction(const float &rx0, const float &ry0) {
+      const int8_t cx = get_cell_index_x(rx0),
+                   cy = get_cell_index_y(ry0);
 
       if (!WITHIN(cx, 0, GRID_MAX_POINTS_X - 2) || !WITHIN(cy, 0, GRID_MAX_POINTS_Y - 2)) {
 
-        SERIAL_ECHOPAIR("? in get_z_correction(lx0=", lx0);
-        SERIAL_ECHOPAIR(", ly0=", ly0);
+        SERIAL_ECHOPAIR("? in get_z_correction(rx0=", rx0);
+        SERIAL_ECHOPAIR(", ry0=", ry0);
         SERIAL_CHAR(')');
         SERIAL_EOL();
 
@@ -312,23 +312,23 @@ class unified_bed_leveling {
         return NAN;
       }
 
-      const float z1 = calc_z0(RAW_X_POSITION(lx0),
+      const float z1 = calc_z0(rx0,
                                mesh_index_to_xpos(cx), z_values[cx][cy],
                                mesh_index_to_xpos(cx + 1), z_values[cx + 1][cy]);
 
-      const float z2 = calc_z0(RAW_X_POSITION(lx0),
+      const float z2 = calc_z0(rx0,
                                mesh_index_to_xpos(cx), z_values[cx][cy + 1],
                                mesh_index_to_xpos(cx + 1), z_values[cx + 1][cy + 1]);
 
-      float z0 = calc_z0(RAW_Y_POSITION(ly0),
+      float z0 = calc_z0(ry0,
                          mesh_index_to_ypos(cy), z1,
                          mesh_index_to_ypos(cy + 1), z2);
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(MESH_ADJUST)) {
-          SERIAL_ECHOPAIR(" raw get_z_correction(", lx0);
+          SERIAL_ECHOPAIR(" raw get_z_correction(", rx0);
           SERIAL_CHAR(',');
-          SERIAL_ECHO(ly0);
+          SERIAL_ECHO(ry0);
           SERIAL_ECHOPGM(") = ");
           SERIAL_ECHO_F(z0, 6);
         }
@@ -350,9 +350,9 @@ class unified_bed_leveling {
 
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(MESH_ADJUST)) {
-            SERIAL_ECHOPAIR("??? Yikes!  NAN in get_z_correction(", lx0);
+            SERIAL_ECHOPAIR("??? Yikes!  NAN in get_z_correction(", rx0);
             SERIAL_CHAR(',');
-            SERIAL_ECHO(ly0);
+            SERIAL_ECHO(ry0);
             SERIAL_CHAR(')');
             SERIAL_EOL();
           }
@@ -369,7 +369,7 @@ class unified_bed_leveling {
       return i < GRID_MAX_POINTS_Y ? pgm_read_float(&_mesh_index_to_ypos[i]) : MESH_MIN_Y + i * (MESH_Y_DIST);
     }
 
-    static bool prepare_segmented_line_to(const float ltarget[XYZE], const float &feedrate);
+    static bool prepare_segmented_line_to(const float rtarget[XYZE], const float &feedrate);
     static void line_to_destination_cartesian(const float &fr, uint8_t e);
 
     #define _CMPZ(a,b) (z_values[a][b] == z_values[a][b+1])

--- a/Marlin/src/gcode/bedlevel/G42.cpp
+++ b/Marlin/src/gcode/bedlevel/G42.cpp
@@ -56,8 +56,8 @@ void GcodeSuite::G42() {
     #endif
 
     set_destination_from_current();
-    if (hasI) destination[X_AXIS] = LOGICAL_X_POSITION(_GET_MESH_X(ix));
-    if (hasJ) destination[Y_AXIS] = LOGICAL_Y_POSITION(_GET_MESH_Y(iy));
+    if (hasI) destination[X_AXIS] = _GET_MESH_X(ix);
+    if (hasJ) destination[Y_AXIS] = _GET_MESH_Y(iy);
     if (parser.boolval('P')) {
       if (hasI) destination[X_AXIS] -= X_PROBE_OFFSET_FROM_EXTRUDER;
       if (hasJ) destination[Y_AXIS] -= Y_PROBE_OFFSET_FROM_EXTRUDER;

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -46,7 +46,7 @@ void mesh_probing_done() {
   gcode.home_all_axes();
   set_bed_leveling_enabled(true);
   #if ENABLED(MESH_G28_REST_ORIGIN)
-    current_position[Z_AXIS] = LOGICAL_Z_POSITION(Z_MIN_POS);
+    current_position[Z_AXIS] = Z_MIN_POS;
     set_destination_from_current();
     line_to_destination(homing_feedrate(Z_AXIS));
     stepper.synchronize();
@@ -139,7 +139,7 @@ void GcodeSuite::G29() {
       }
       else {
         // One last "return to the bed" (as originally coded) at completion
-        current_position[Z_AXIS] = LOGICAL_Z_POSITION(Z_MIN_POS) + MANUAL_PROBE_HEIGHT;
+        current_position[Z_AXIS] = Z_MIN_POS + MANUAL_PROBE_HEIGHT;
         line_to_current_position();
         stepper.synchronize();
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -86,8 +86,8 @@
     /**
      * Move the Z probe (or just the nozzle) to the safe homing point
      */
-    destination[X_AXIS] = LOGICAL_X_POSITION(Z_SAFE_HOMING_X_POINT);
-    destination[Y_AXIS] = LOGICAL_Y_POSITION(Z_SAFE_HOMING_Y_POINT);
+    destination[X_AXIS] = Z_SAFE_HOMING_X_POINT;
+    destination[Y_AXIS] = Z_SAFE_HOMING_Y_POINT;
     destination[Z_AXIS] = current_position[Z_AXIS]; // Z is already at the right height
 
     #if HOMING_Z_WITH_PROBE
@@ -95,7 +95,7 @@
       destination[Y_AXIS] -= Y_PROBE_OFFSET_FROM_EXTRUDER;
     #endif
 
-    if (position_is_reachable_xy(destination[X_AXIS], destination[Y_AXIS])) {
+    if (position_is_reachable(destination[X_AXIS], destination[Y_AXIS])) {
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) DEBUG_POS("Z_SAFE_HOMING", destination);
@@ -209,7 +209,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
       if (home_all || homeX || homeY) {
         // Raise Z before homing any other axes and z is not already high enough (never lower z)
-        destination[Z_AXIS] = LOGICAL_Z_POSITION(Z_HOMING_HEIGHT);
+        destination[Z_AXIS] = Z_HOMING_HEIGHT;
         if (destination[Z_AXIS] > current_position[Z_AXIS]) {
 
           #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -251,7 +251,7 @@ void GcodeSuite::G28(const bool always_home_all) {
         HOMEAXIS(X);
 
         // Remember this extruder's position for later tool change
-        inactive_extruder_x_pos = RAW_X_POSITION(current_position[X_AXIS]);
+        inactive_extruder_x_pos = current_position[X_AXIS];
 
         // Home the 1st (left) extruder
         active_extruder = 0;

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -459,7 +459,7 @@ void GcodeSuite::G33() {
     LOOP_CAL_RAD(axis) {
       const float a = RADIANS(210 + (360 / NPP) *  (axis - 1)),
                   r = delta_calibration_radius * (1 + (_7p_9_centre ? 0.1 : 0.0));
-      if (!position_is_reachable_xy(cos(a) * r, sin(a) * r)) {
+      if (!position_is_reachable(cos(a) * r, sin(a) * r)) {
         SERIAL_PROTOCOLLNPGM("?(M665 B)ed radius is implausible.");
         return;
       }

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -82,16 +82,16 @@ void GcodeSuite::M48() {
               Y_probe_location = parser.linearval('Y', Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER);
 
   #if DISABLED(DELTA)
-    if (!WITHIN(X_probe_location, LOGICAL_X_POSITION(MIN_PROBE_X), LOGICAL_X_POSITION(MAX_PROBE_X))) {
+    if (!WITHIN(X_probe_location, MIN_PROBE_X, MAX_PROBE_X)) {
       out_of_range_error(PSTR("X"));
       return;
     }
-    if (!WITHIN(Y_probe_location, LOGICAL_Y_POSITION(MIN_PROBE_Y), LOGICAL_Y_POSITION(MAX_PROBE_Y))) {
+    if (!WITHIN(Y_probe_location, MIN_PROBE_Y, MAX_PROBE_Y)) {
       out_of_range_error(PSTR("Y"));
       return;
     }
   #else
-    if (!position_is_reachable_by_probe_xy(X_probe_location, Y_probe_location)) {
+    if (!position_is_reachable_by_probe(X_probe_location, Y_probe_location)) {
       SERIAL_PROTOCOLLNPGM("? (X,Y) location outside of probeable radius.");
       return;
     }
@@ -184,7 +184,7 @@ void GcodeSuite::M48() {
           #else
             // If we have gone out too far, we can do a simple fix and scale the numbers
             // back in closer to the origin.
-            while (!position_is_reachable_by_probe_xy(X_current, Y_current)) {
+            while (!position_is_reachable_by_probe(X_current, Y_current)) {
               X_current *= 0.8;
               Y_current *= 0.8;
               if (verbose_level > 3) {

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -89,7 +89,7 @@ bool GcodeSuite::get_target_extruder_from_command() {
 void GcodeSuite::get_destination_from_command() {
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i]))
-      destination[i] = parser.value_axis_units((AxisEnum)i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0);
+      destination[i] = LOGICAL_TO_NATIVE(parser.value_axis_units((AxisEnum)i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0), i);
     else
       destination[i] = current_position[i];
   }

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -67,7 +67,7 @@ void GcodeSuite::M428() {
   LOOP_XYZ(i) {
     if (axis_homed[i]) {
       const float base = (current_position[i] > (soft_endstop_min[i] + soft_endstop_max[i]) * 0.5) ? base_home_pos((AxisEnum)i) : 0,
-                  diff = base - RAW_POSITION(current_position[i], i);
+                  diff = base - current_position[i];
       if (WITHIN(diff, -20, 20)) {
         set_home_offset((AxisEnum)i, diff);
       }

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -46,11 +46,15 @@
     stepper.synchronize();
 
     SERIAL_PROTOCOLPGM("\nLogical:");
-    report_xyze(current_position);
+    const float logical[XYZ] = {
+      LOGICAL_X_POSITION(current_position[X_AXIS]),
+      LOGICAL_Y_POSITION(current_position[Y_AXIS]),
+      LOGICAL_Z_POSITION(current_position[Z_AXIS])
+    };
+    report_xyze(logical);
 
     SERIAL_PROTOCOLPGM("Raw:    ");
-    const float raw[XYZ] = { RAW_X_POSITION(current_position[X_AXIS]), RAW_Y_POSITION(current_position[Y_AXIS]), RAW_Z_POSITION(current_position[Z_AXIS]) };
-    report_xyz(raw);
+    report_xyz(current_position);
 
     SERIAL_PROTOCOLPGM("Leveled:");
     float leveled[XYZ] = { current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] };

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -44,7 +44,7 @@
  * options for G2/G3 arc generation. In future these options may be GCode tunable.
  */
 void plan_arc(
-  float logical[XYZE], // Destination position
+  float rtarget[XYZE], // Destination position
   float *offset,       // Center of rotation relative to current_position
   uint8_t clockwise    // Clockwise?
 ) {
@@ -65,10 +65,10 @@ void plan_arc(
   const float radius = HYPOT(r_P, r_Q),
               center_P = current_position[p_axis] - r_P,
               center_Q = current_position[q_axis] - r_Q,
-              rt_X = logical[p_axis] - center_P,
-              rt_Y = logical[q_axis] - center_Q,
-              linear_travel = logical[l_axis] - current_position[l_axis],
-              extruder_travel = logical[E_AXIS] - current_position[E_AXIS];
+              rt_X = rtarget[p_axis] - center_P,
+              rt_Y = rtarget[q_axis] - center_Q,
+              linear_travel = rtarget[l_axis] - current_position[l_axis],
+              extruder_travel = rtarget[E_AXIS] - current_position[E_AXIS];
 
   // CCW angle of rotation between position and target from the circle center. Only one atan2() trig computation required.
   float angular_travel = ATAN2(r_P * rt_Y - r_Q * rt_X, r_P * rt_X + r_Q * rt_Y);
@@ -76,7 +76,7 @@ void plan_arc(
   if (clockwise) angular_travel -= RADIANS(360);
 
   // Make a circle if the angular rotation is 0 and the target is current position
-  if (angular_travel == 0 && current_position[p_axis] == logical[p_axis] && current_position[q_axis] == logical[q_axis])
+  if (angular_travel == 0 && current_position[p_axis] == rtarget[p_axis] && current_position[q_axis] == rtarget[q_axis])
     angular_travel = RADIANS(360);
 
   const float mm_of_travel = HYPOT(angular_travel * radius, FABS(linear_travel));
@@ -176,7 +176,7 @@ void plan_arc(
   }
 
   // Ensure last segment arrives at target location.
-  planner.buffer_line_kinematic(logical, fr_mm_s, active_extruder);
+  planner.buffer_line_kinematic(rtarget, fr_mm_s, active_extruder);
 
   // As far as the parser is concerned, the position is now == target. In reality the
   // motion control system might still be processing the action and the real tool position

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -42,7 +42,7 @@ void GcodeSuite::G30() {
   const float xpos = parser.linearval('X', current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER),
               ypos = parser.linearval('Y', current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER);
 
-  if (!position_is_reachable_by_probe_xy(xpos, ypos)) return;
+  if (!position_is_reachable_by_probe(xpos, ypos)) return;
 
   // Disable leveling so the planner won't mess with us
   #if HAS_LEVELING

--- a/Marlin/src/gcode/scara/M360-M364.cpp
+++ b/Marlin/src/gcode/scara/M360-M364.cpp
@@ -32,8 +32,8 @@
 inline bool SCARA_move_to_cal(const uint8_t delta_a, const uint8_t delta_b) {
   if (IsRunning()) {
     forward_kinematics_SCARA(delta_a, delta_b);
-    destination[X_AXIS] = LOGICAL_X_POSITION(cartes[X_AXIS]);
-    destination[Y_AXIS] = LOGICAL_Y_POSITION(cartes[Y_AXIS]);
+    destination[X_AXIS] = cartes[X_AXIS];
+    destination[Y_AXIS] = cartes[Y_AXIS];
     destination[Z_AXIS] = current_position[Z_AXIS];
     prepare_move_to_destination();
     return true;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1679,7 +1679,7 @@ void kill_screen(const char* lcd_msg) {
      */
     static int8_t bed_corner;
     void _lcd_goto_next_corner() {
-      line_to_z(LOGICAL_Z_POSITION(4.0));
+      line_to_z(4.0);
       switch (bed_corner) {
         case 0:
           current_position[X_AXIS] = X_MIN_BED + 10;
@@ -1696,7 +1696,7 @@ void kill_screen(const char* lcd_msg) {
           break;
       }
       planner.buffer_line_kinematic(current_position, MMM_TO_MMS(manual_feedrate_mm_m[X_AXIS]), active_extruder);
-      line_to_z(LOGICAL_Z_POSITION(0.0));
+      line_to_z(0.0);
       if (++bed_corner > 3) bed_corner = 0;
     }
 
@@ -1742,7 +1742,7 @@ void kill_screen(const char* lcd_msg) {
     //
     void _lcd_after_probing() {
       #if MANUAL_PROBE_HEIGHT > 0
-        line_to_z(LOGICAL_Z_POSITION(Z_MIN_POS) + MANUAL_PROBE_HEIGHT);
+        line_to_z(Z_MIN_POS + MANUAL_PROBE_HEIGHT);
       #endif
       // Display "Done" screen and wait for moves to complete
       #if MANUAL_PROBE_HEIGHT > 0 || ENABLED(MESH_BED_LEVELING)
@@ -1757,13 +1757,13 @@ void kill_screen(const char* lcd_msg) {
     #if ENABLED(MESH_BED_LEVELING)
 
       // Utility to go to the next mesh point
-      inline void _manual_probe_goto_xy(float x, float y) {
+      inline void _manual_probe_goto_xy(const float &rx, const float &ry) {
         #if MANUAL_PROBE_HEIGHT > 0
           const float prev_z = current_position[Z_AXIS];
-          line_to_z(LOGICAL_Z_POSITION(Z_MIN_POS) + MANUAL_PROBE_HEIGHT);
+          line_to_z(Z_MIN_POS + MANUAL_PROBE_HEIGHT);
         #endif
-        current_position[X_AXIS] = LOGICAL_X_POSITION(x);
-        current_position[Y_AXIS] = LOGICAL_Y_POSITION(y);
+        current_position[X_AXIS] = rx;
+        current_position[Y_AXIS] = ry;
         planner.buffer_line_kinematic(current_position, MMM_TO_MMS(XY_PROBE_SPEED), active_extruder);
         #if MANUAL_PROBE_HEIGHT > 0
           line_to_z(prev_z);
@@ -1893,10 +1893,7 @@ void kill_screen(const char* lcd_msg) {
         mbl.zigzag(manual_probe_index, px, py);
 
         // Controls the loop until the move is done
-        _manual_probe_goto_xy(
-          LOGICAL_X_POSITION(mbl.index_to_xpos[px]),
-          LOGICAL_Y_POSITION(mbl.index_to_ypos[py])
-        );
+        _manual_probe_goto_xy(mbl.index_to_xpos[px], mbl.index_to_ypos[py]);
 
         // After the blocking function returns, change menus
         lcd_goto_screen(_lcd_level_bed_get_z);
@@ -2377,8 +2374,8 @@ void kill_screen(const char* lcd_msg) {
      * UBL LCD Map Movement
      */
     void ubl_map_move_to_xy() {
-      current_position[X_AXIS] = LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]));
-      current_position[Y_AXIS] = LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]));
+      current_position[X_AXIS] = pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]);
+      current_position[Y_AXIS] = pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]);
       planner.buffer_line_kinematic(current_position, MMM_TO_MMS(XY_PROBE_SPEED), active_extruder);
     }
 
@@ -2712,17 +2709,17 @@ void kill_screen(const char* lcd_msg) {
       lcd_goto_screen(_lcd_calibrate_homing);
     }
 
-    void _man_probe_pt(const float &lx, const float &ly) {
+    void _man_probe_pt(const float &rx, const float &ry) {
       #if HAS_LEVELING
         reset_bed_level(); // After calibration bed-level data is no longer valid
       #endif
 
-      float z_dest = LOGICAL_Z_POSITION((Z_CLEARANCE_BETWEEN_PROBES) + (DELTA_PRINTABLE_RADIUS) / 5);
+      float z_dest = (Z_CLEARANCE_BETWEEN_PROBES) + (DELTA_PRINTABLE_RADIUS) / 5;
       line_to_z(z_dest);
-      current_position[X_AXIS] = LOGICAL_X_POSITION(lx);
-      current_position[Y_AXIS] = LOGICAL_Y_POSITION(ly);
+      current_position[X_AXIS] = rx;
+      current_position[Y_AXIS] = ry;
       line_to_current_z();
-      z_dest = LOGICAL_Z_POSITION(Z_CLEARANCE_BETWEEN_PROBES);
+      z_dest = Z_CLEARANCE_BETWEEN_PROBES;
       line_to_z(z_dest);
 
       lcd_synchronize();
@@ -2730,8 +2727,8 @@ void kill_screen(const char* lcd_msg) {
       lcd_goto_screen(lcd_move_z);
     }
 
-    float lcd_probe_pt(const float &lx, const float &ly) {
-      _man_probe_pt(lx, ly);
+    float lcd_probe_pt(const float &rx, const float &ry) {
+      _man_probe_pt(rx, ry);
       KEEPALIVE_STATE(PAUSED_FOR_USER);
       defer_return_to_status = true;
       wait_for_user = true;

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -119,7 +119,7 @@
     #endif
 
     #if ENABLED(DELTA_CALIBRATION_MENU)
-      float lcd_probe_pt(const float &lx, const float &ly);
+      float lcd_probe_pt(const float &rx, const float &ry);
     #endif
 
   #else

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -649,9 +649,9 @@ static void lcd_implementation_status_screen() {
 
   // At the first page, regenerate the XYZ strings
   if (page.page == 0) {
-    strcpy(xstring, ftostr4sign(current_position[X_AXIS]));
-    strcpy(ystring, ftostr4sign(current_position[Y_AXIS]));
-    strcpy(zstring, ftostr52sp(FIXFLOAT(current_position[Z_AXIS])));
+    strcpy(xstring, ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])));
+    strcpy(ystring, ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])));
+    strcpy(zstring, ftostr52sp(FIXFLOAT(LOGICAL_Z_POSITION(current_position[Z_AXIS]))));
     #if ENABLED(FILAMENT_LCD_DISPLAY) && DISABLED(SDSUPPORT)
       strcpy(wstring, ftostr12ns(filament_width_meas));
       strcpy(mstring, itostr3(100.0 * planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]));

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -621,7 +621,9 @@ FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, co
   lcd.print(itostr3(t1 + 0.5));
   lcd.write('/');
 
-  #if HEATER_IDLE_HANDLER
+  #if !HEATER_IDLE_HANDLER
+    UNUSED(blink);
+  #else
     const bool is_idle = (!isBed ? thermalManager.is_heater_idle(heater) :
       #if HAS_TEMP_BED
         thermalManager.is_bed_idle()
@@ -779,12 +781,12 @@ static void lcd_implementation_status_screen() {
         // When everything is ok you see a constant 'X'.
 
         _draw_axis_label(X_AXIS, PSTR(MSG_X), blink);
-        lcd.print(ftostr4sign(current_position[X_AXIS]));
+        lcd.print(ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])));
 
         lcd.write(' ');
 
         _draw_axis_label(Y_AXIS, PSTR(MSG_Y), blink);
-        lcd.print(ftostr4sign(current_position[Y_AXIS]));
+        lcd.print(ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])));
 
       #endif // HOTENDS > 1 || TEMP_SENSOR_BED != 0
 
@@ -842,11 +844,11 @@ static void lcd_implementation_status_screen() {
 
   #if ENABLED(LCD_PROGRESS_BAR)
 
+    // Draw the progress bar if the message has shown long enough
+    // or if there is no message set.
     #if DISABLED(LCD_SET_PROGRESS_MANUALLY)
       const uint8_t progress_bar_percent = card.percentDone();
     #endif
-    // Draw the progress bar if the message has shown long enough
-    // or if there is no message set.
     if (progress_bar_percent > 2 && (ELAPSED(millis(), progress_bar_ms + PROGRESS_BAR_MSG_TIME) || !lcd_status_message[0]))
       return lcd_draw_progress_bar(progress_bar_percent);
 
@@ -1168,9 +1170,9 @@ static void lcd_implementation_status_screen() {
       return ret_val;
     }
 
-    coordinate pixel_location(uint8_t x, uint8_t y) { return pixel_location((int16_t)x, (int16_t)y); }
+    inline coordinate pixel_location(const uint8_t x, const uint8_t y) { return pixel_location((int16_t)x, (int16_t)y); }
 
-    void lcd_implementation_ubl_plot(uint8_t x, uint8_t inverted_y) {
+    void lcd_implementation_ubl_plot(const uint8_t x, const uint8_t inverted_y) {
 
       #if LCD_WIDTH >= 20
         #define _LCD_W_POS 12

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -72,7 +72,7 @@ void recalc_delta_settings(const float radius, const float diagonal_rod, const f
 /**
  * Delta Inverse Kinematics
  *
- * Calculate the tower positions for a given logical
+ * Calculate the tower positions for a given machine
  * position, storing the result in the delta[] array.
  *
  * This is an expensive calculation, requiring 3 square
@@ -117,8 +117,8 @@ void recalc_delta_settings(const float radius, const float diagonal_rod, const f
     SERIAL_ECHOLNPAIR(" C:", delta[C_AXIS]);      \
   }while(0)
 
-void inverse_kinematics(const float logical[XYZ]) {
-  DELTA_LOGICAL_IK();
+void inverse_kinematics(const float raw[XYZ]) {
+  DELTA_RAW_IK();
   // DELTA_DEBUG();
 }
 
@@ -127,14 +127,10 @@ void inverse_kinematics(const float logical[XYZ]) {
  * effector has the full range of XY motion.
  */
 float delta_safe_distance_from_top() {
-  float cartesian[XYZ] = {
-    LOGICAL_X_POSITION(0),
-    LOGICAL_Y_POSITION(0),
-    LOGICAL_Z_POSITION(0)
-  };
+  float cartesian[XYZ] = { 0, 0, 0 };
   inverse_kinematics(cartesian);
   float distance = delta[A_AXIS];
-  cartesian[Y_AXIS] = LOGICAL_Y_POSITION(DELTA_PRINTABLE_RADIUS);
+  cartesian[Y_AXIS] = DELTA_PRINTABLE_RADIUS;
   inverse_kinematics(cartesian);
   return FABS(distance - delta[A_AXIS]);
 }

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -47,7 +47,7 @@ void recalc_delta_settings(const float radius, const float diagonal_rod, const f
 /**
  * Delta Inverse Kinematics
  *
- * Calculate the tower positions for a given logical
+ * Calculate the tower positions for a given machine
  * position, storing the result in the delta[] array.
  *
  * This is an expensive calculation, requiring 3 square
@@ -88,16 +88,7 @@ void recalc_delta_settings(const float radius, const float diagonal_rod, const f
   delta[C_AXIS] = DELTA_Z(C_AXIS); \
 }while(0)
 
-#define DELTA_LOGICAL_IK() do {      \
-  const float raw[XYZ] = {           \
-    RAW_X_POSITION(logical[X_AXIS]), \
-    RAW_Y_POSITION(logical[Y_AXIS]), \
-    RAW_Z_POSITION(logical[Z_AXIS])  \
-  };                                 \
-  DELTA_RAW_IK();                    \
-}while(0)
-
-void inverse_kinematics(const float logical[XYZ]);
+void inverse_kinematics(const float raw[XYZ]);
 
 /**
  * Calculate the highest Z position where the

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -202,7 +202,7 @@ class Planner {
     static uint32_t cutoff_long;
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      static float last_raw_lz;
+      static float last_fade_z;
     #endif
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
@@ -275,21 +275,20 @@ class Planner {
        *  Returns 1.0 if planner.z_fade_height is 0.0.
        *  Returns 0.0 if Z is past the specified 'Fade Height'.
        */
-      inline static float fade_scaling_factor_for_z(const float &lz) {
+      inline static float fade_scaling_factor_for_z(const float &rz) {
         static float z_fade_factor = 1.0;
         if (z_fade_height) {
-          const float raw_lz = RAW_Z_POSITION(lz);
-          if (raw_lz >= z_fade_height) return 0.0;
-          if (last_raw_lz != raw_lz) {
-            last_raw_lz = raw_lz;
-            z_fade_factor = 1.0 - raw_lz * inverse_z_fade_height;
+          if (rz >= z_fade_height) return 0.0;
+          if (last_fade_z != rz) {
+            last_fade_z = rz;
+            z_fade_factor = 1.0 - rz * inverse_z_fade_height;
           }
           return z_fade_factor;
         }
         return 1.0;
       }
 
-      FORCE_INLINE static void force_fade_recalc() { last_raw_lz = -999.999; }
+      FORCE_INLINE static void force_fade_recalc() { last_fade_z = -999.999; }
 
       FORCE_INLINE static void set_z_fade_height(const float &zfh) {
         z_fade_height = zfh > 0 ? zfh : 0;
@@ -297,40 +296,40 @@ class Planner {
         force_fade_recalc();
       }
 
-      FORCE_INLINE static bool leveling_active_at_z(const float &lz) {
-        return !z_fade_height || RAW_Z_POSITION(lz) < z_fade_height;
+      FORCE_INLINE static bool leveling_active_at_z(const float &rz) {
+        return !z_fade_height || rz < z_fade_height;
       }
 
     #else
 
-      FORCE_INLINE static float fade_scaling_factor_for_z(const float &lz) {
-        UNUSED(lz);
+      FORCE_INLINE static float fade_scaling_factor_for_z(const float &rz) {
+        UNUSED(rz);
         return 1.0;
       }
 
-      FORCE_INLINE static bool leveling_active_at_z(const float &lz) { UNUSED(lz); return true; }
+      FORCE_INLINE static bool leveling_active_at_z(const float &rz) { UNUSED(rz); return true; }
 
     #endif
 
     #if PLANNER_LEVELING
 
-      #define ARG_X float lx
-      #define ARG_Y float ly
-      #define ARG_Z float lz
+      #define ARG_X float rx
+      #define ARG_Y float ry
+      #define ARG_Z float rz
 
       /**
        * Apply leveling to transform a cartesian position
        * as it will be given to the planner and steppers.
        */
-      static void apply_leveling(float &lx, float &ly, float &lz);
-      static void apply_leveling(float logical[XYZ]) { apply_leveling(logical[X_AXIS], logical[Y_AXIS], logical[Z_AXIS]); }
-      static void unapply_leveling(float logical[XYZ]);
+      static void apply_leveling(float &rx, float &ry, float &rz);
+      static void apply_leveling(float raw[XYZ]) { apply_leveling(raw[X_AXIS], raw[Y_AXIS], raw[Z_AXIS]); }
+      static void unapply_leveling(float raw[XYZ]);
 
     #else
 
-      #define ARG_X const float &lx
-      #define ARG_Y const float &ly
-      #define ARG_Z const float &lz
+      #define ARG_X const float &rx
+      #define ARG_Y const float &ry
+      #define ARG_Z const float &rz
 
     #endif
 
@@ -357,15 +356,15 @@ class Planner {
      * Kinematic machines should call buffer_line_kinematic (for leveled moves).
      * (Cartesians may also call buffer_line_kinematic.)
      *
-     *  lx,ly,lz,e   - target position in mm or degrees
+     *  rx,ry,rz,e   - target position in mm or degrees
      *  fr_mm_s      - (target) speed of the move (mm/s)
      *  extruder     - target extruder
      */
     static FORCE_INLINE void buffer_line(ARG_X, ARG_Y, ARG_Z, const float &e, const float &fr_mm_s, const uint8_t extruder) {
       #if PLANNER_LEVELING && IS_CARTESIAN
-        apply_leveling(lx, ly, lz);
+        apply_leveling(rx, ry, rz);
       #endif
-      _buffer_line(lx, ly, lz, e, fr_mm_s, extruder);
+      _buffer_line(rx, ry, rz, e, fr_mm_s, extruder);
     }
 
     /**
@@ -373,22 +372,22 @@ class Planner {
      * The target is cartesian, it's translated to delta/scara if
      * needed.
      *
-     *  ltarget  - x,y,z,e CARTESIAN target in mm
+     *  rtarget  - x,y,z,e CARTESIAN target in mm
      *  fr_mm_s  - (target) speed of the move (mm/s)
      *  extruder - target extruder
      */
-    static FORCE_INLINE void buffer_line_kinematic(const float ltarget[XYZE], const float &fr_mm_s, const uint8_t extruder) {
+    static FORCE_INLINE void buffer_line_kinematic(const float rtarget[XYZE], const float &fr_mm_s, const uint8_t extruder) {
       #if PLANNER_LEVELING
-        float lpos[XYZ] = { ltarget[X_AXIS], ltarget[Y_AXIS], ltarget[Z_AXIS] };
+        float lpos[XYZ] = { rtarget[X_AXIS], rtarget[Y_AXIS], rtarget[Z_AXIS] };
         apply_leveling(lpos);
       #else
-        const float * const lpos = ltarget;
+        const float * const lpos = rtarget;
       #endif
       #if IS_KINEMATIC
         inverse_kinematics(lpos);
-        _buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], ltarget[E_AXIS], fr_mm_s, extruder);
+        _buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], rtarget[E_AXIS], fr_mm_s, extruder);
       #else
-        _buffer_line(lpos[X_AXIS], lpos[Y_AXIS], lpos[Z_AXIS], ltarget[E_AXIS], fr_mm_s, extruder);
+        _buffer_line(lpos[X_AXIS], lpos[Y_AXIS], lpos[Z_AXIS], rtarget[E_AXIS], fr_mm_s, extruder);
       #endif
     }
 
@@ -403,9 +402,9 @@ class Planner {
      */
     static FORCE_INLINE void set_position_mm(ARG_X, ARG_Y, ARG_Z, const float &e) {
       #if PLANNER_LEVELING && IS_CARTESIAN
-        apply_leveling(lx, ly, lz);
+        apply_leveling(rx, ry, rz);
       #endif
-      _set_position_mm(lx, ly, lz, e);
+      _set_position_mm(rx, ry, rz, e);
     }
     static void set_position_mm_kinematic(const float position[NUM_AXIS]);
     static void set_position_mm(const AxisEnum axis, const float &v);

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -106,8 +106,8 @@ inline void do_probe_raise(const float z_raise) {
 
 #elif ENABLED(Z_PROBE_ALLEN_KEY)
 
-  FORCE_INLINE void do_blocking_move_to(const float logical[XYZ], const float &fr_mm_s) {
-    do_blocking_move_to(logical[X_AXIS], logical[Y_AXIS], logical[Z_AXIS], fr_mm_s);
+  FORCE_INLINE void do_blocking_move_to(const float raw[XYZ], const float &fr_mm_s) {
+    do_blocking_move_to(raw[X_AXIS], raw[Y_AXIS], raw[Z_AXIS], fr_mm_s);
   }
 
   void run_deploy_moves_script() {
@@ -564,7 +564,7 @@ static float run_z_probe(const bool short_move=true) {
     }
   #endif
 
-  return RAW_CURRENT_POSITION(Z) + zprobe_zoffset
+  return current_position[Z_AXIS] + zprobe_zoffset
     #if ENABLED(DELTA)
       + home_offset[Z_AXIS] // Account for delta height adjustment
     #endif
@@ -580,22 +580,22 @@ static float run_z_probe(const bool short_move=true) {
  *   - Raise to the BETWEEN height
  * - Return the probed Z position
  */
-float probe_pt(const float &lx, const float &ly, const bool stow, const uint8_t verbose_level, const bool printable/*=true*/) {
+float probe_pt(const float &rx, const float &ry, const bool stow, const uint8_t verbose_level, const bool printable/*=true*/) {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOPAIR(">>> probe_pt(", lx);
-      SERIAL_ECHOPAIR(", ", ly);
+      SERIAL_ECHOPAIR(">>> probe_pt(", LOGICAL_X_POSITION(rx));
+      SERIAL_ECHOPAIR(", ", LOGICAL_Y_POSITION(ry));
       SERIAL_ECHOPAIR(", ", stow ? "" : "no ");
       SERIAL_ECHOLNPGM("stow)");
       DEBUG_POS("", current_position);
     }
   #endif
 
-  const float nx = lx - (X_PROBE_OFFSET_FROM_EXTRUDER), ny = ly - (Y_PROBE_OFFSET_FROM_EXTRUDER);
+  const float nx = rx - (X_PROBE_OFFSET_FROM_EXTRUDER), ny = ry - (Y_PROBE_OFFSET_FROM_EXTRUDER);
 
   if (printable
-    ? !position_is_reachable_xy(nx, ny)
-    : !position_is_reachable_by_probe_xy(lx, ly)
+    ? !position_is_reachable(nx, ny)
+    : !position_is_reachable_by_probe(rx, ry)
   ) return NAN;
 
 
@@ -634,9 +634,9 @@ float probe_pt(const float &lx, const float &ly, const bool stow, const uint8_t 
 
   if (verbose_level > 2) {
     SERIAL_PROTOCOLPGM("Bed X: ");
-    SERIAL_PROTOCOL_F(lx, 3);
+    SERIAL_PROTOCOL_F(LOGICAL_X_POSITION(rx), 3);
     SERIAL_PROTOCOLPGM(" Y: ");
-    SERIAL_PROTOCOL_F(ly, 3);
+    SERIAL_PROTOCOL_F(LOGICAL_Y_POSITION(ry), 3);
     SERIAL_PROTOCOLPGM(" Z: ");
     SERIAL_PROTOCOL_F(measured_z, 3);
     SERIAL_EOL();

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -30,7 +30,7 @@
 #include "../inc/MarlinConfig.h"
 
 bool set_probe_deployed(const bool deploy);
-float probe_pt(const float &lx, const float &ly, const bool, const uint8_t, const bool printable=true);
+float probe_pt(const float &rx, const float &ry, const bool, const uint8_t, const bool printable=true);
 
 #if HAS_BED_PROBE
   extern float zprobe_zoffset;

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -36,14 +36,14 @@ float delta_segments_per_second = SCARA_SEGMENTS_PER_SECOND;
 
 void scara_set_axis_is_at_home(const AxisEnum axis) {
   if (axis == Z_AXIS)
-    current_position[Z_AXIS] = LOGICAL_POSITION(Z_HOME_POS, Z_AXIS);
+    current_position[Z_AXIS] = Z_HOME_POS;
   else {
 
     /**
      * SCARA homes XY at the same time
      */
     float homeposition[XYZ];
-    LOOP_XYZ(i) homeposition[i] = LOGICAL_POSITION(base_home_pos((AxisEnum)i), i);
+    LOOP_XYZ(i) homeposition[i] = base_home_pos((AxisEnum)i);
 
     // SERIAL_ECHOPAIR("homeposition X:", homeposition[X_AXIS]);
     // SERIAL_ECHOLNPAIR(" Y:", homeposition[Y_AXIS]);
@@ -58,7 +58,7 @@ void scara_set_axis_is_at_home(const AxisEnum axis) {
     // SERIAL_ECHOPAIR("Cartesian X:", cartes[X_AXIS]);
     // SERIAL_ECHOLNPAIR(" Y:", cartes[Y_AXIS]);
 
-    current_position[axis] = LOGICAL_POSITION(cartes[axis], axis);
+    current_position[axis] = cartes[axis];
 
     /**
      * SCARA home positions are based on configuration since the actual
@@ -104,12 +104,12 @@ void forward_kinematics_SCARA(const float &a, const float &b) {
  * Maths and first version by QHARLEY.
  * Integrated into Marlin and slightly restructured by Joachim Cerny.
  */
-void inverse_kinematics(const float logical[XYZ]) {
+void inverse_kinematics(const float raw[XYZ]) {
 
   static float C2, S2, SK1, SK2, THETA, PSI;
 
-  float sx = RAW_X_POSITION(logical[X_AXIS]) - SCARA_OFFSET_X,  // Translate SCARA to standard X Y
-        sy = RAW_Y_POSITION(logical[Y_AXIS]) - SCARA_OFFSET_Y;  // With scaling factor.
+  float sx = raw[X_AXIS] - SCARA_OFFSET_X,  // Translate SCARA to standard X Y
+        sy = raw[Y_AXIS] - SCARA_OFFSET_Y;  // With scaling factor.
 
   if (L1 == L2)
     C2 = HYPOT2(sx, sy) / L1_2_2 - 1;
@@ -132,10 +132,10 @@ void inverse_kinematics(const float logical[XYZ]) {
 
   delta[A_AXIS] = DEGREES(THETA);        // theta is support arm angle
   delta[B_AXIS] = DEGREES(THETA + PSI);  // equal to sub arm angle (inverted motor)
-  delta[C_AXIS] = logical[Z_AXIS];
+  delta[C_AXIS] = raw[Z_AXIS];
 
   /*
-    DEBUG_POS("SCARA IK", logical);
+    DEBUG_POS("SCARA IK", raw);
     DEBUG_POS("SCARA IK", delta);
     SERIAL_ECHOPAIR("  SCARA (x,y) ", sx);
     SERIAL_ECHOPAIR(",", sy);

--- a/Marlin/src/module/scara.h
+++ b/Marlin/src/module/scara.h
@@ -38,7 +38,7 @@ float constexpr L1 = SCARA_LINKAGE_1, L2 = SCARA_LINKAGE_2,
 
 void scara_set_axis_is_at_home(const AxisEnum axis);
 
-void inverse_kinematics(const float logical[XYZ]);
+void inverse_kinematics(const float raw[XYZ]);
 void forward_kinematics_SCARA(const float &a, const float &b);
 
 void scara_report_positions();

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -240,9 +240,9 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           switch (dual_x_carriage_mode) {
             case DXC_FULL_CONTROL_MODE:
               // New current position is the position of the activated extruder
-              current_position[X_AXIS] = LOGICAL_X_POSITION(inactive_extruder_x_pos);
+              current_position[X_AXIS] = inactive_extruder_x_pos;
               // Save the inactive extruder's position (from the old current_position)
-              inactive_extruder_x_pos = RAW_X_POSITION(destination[X_AXIS]);
+              inactive_extruder_x_pos = destination[X_AXIS];
               break;
             case DXC_AUTO_PARK_MODE:
               // record raised toolhead position for use by unpark
@@ -260,10 +260,10 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
               active_extruder_parked = (active_extruder == 0);
 
               if (active_extruder_parked)
-                current_position[X_AXIS] = LOGICAL_X_POSITION(inactive_extruder_x_pos);
+                current_position[X_AXIS] = inactive_extruder_x_pos;
               else
                 current_position[X_AXIS] = destination[X_AXIS] + duplicate_extruder_x_offset;
-              inactive_extruder_x_pos = RAW_X_POSITION(destination[X_AXIS]);
+              inactive_extruder_x_pos = destination[X_AXIS];
               extruder_duplication_enabled = false;
               #if ENABLED(DEBUG_LEVELING_FEATURE)
                 if (DEBUGGING(LEVELING)) {


### PR DESCRIPTION
Based on #8229

**Background:** Marlin operates internally using coordinates offset by the current workspace origin. As a result, in order to perform operations that are workspace-agnostic —such as moving to a machine-relative point, doing bed leveling, etc— Marlin must subtract the workspace origin first. This can significantly increase overhead, especially when using segmented moves, as we do with Delta (and as we will be doing more as a standard aspect of mesh leveling).

**Proposal:** Internally, always work in native machine space, but subtract the workspace offset in `gcode_get_destination` (and other parameters that take coordinates), and add the workspace offset when reporting current position to the LCD or host.

From the user perspective there will be no change whatsoever.

An extra advantage of this approach is that it will be possible to use the fixed-point planner (due to be added soon) even when custom workspaces are enabled.

Suggested by @GMagician  in response to #8200.

----
@MarlinFirmware/testers-cartesian-team 
@MarlinFirmware/testers-corexy-team
@MarlinFirmware/testers-delta-team 