### PR TITLE
[1.1] Add Anet Keypad LCD pins for RAMPS

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -53,6 +53,7 @@
     // this helps to implement ADC_KEYPAD menus
     #define ENCODER_PULSES_PER_STEP 1
     #define ENCODER_STEPS_PER_MENU_ITEM 1
+    #define ENCODER_FEEDRATE_DEADZONE 2
     #define REVERSE_MENU_DIRECTION
 
   #elif ENABLED(ANET_FULL_GRAPHICS_LCD)

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -166,7 +166,6 @@
     #define BTN_EN2          -1
     #define BTN_ENC          -1
     #define ADC_KEYPAD_PIN    1
-    #define ENCODER_FEEDRATE_DEADZONE 2
   #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) || ENABLED(ANET_FULL_GRAPHICS_LCD)
     // Pin definitions for the Anet A6 Full Graphics display and the RepRapDiscount Full Graphics
     // display using an adapter board  // https://go.aisler.net/benlye/anet-lcd-adapter/pcb

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -483,3 +483,17 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
+
+#if ENABLED(ANET_KEYPAD_LCD)
+  #define LCD_PINS_RS        64
+  #define LCD_PINS_ENABLE    44
+  #define LCD_PINS_D4        63
+  #define LCD_PINS_D5        40
+  #define LCD_PINS_D6        42
+  #define LCD_PINS_D7        65
+  #define ADC_KEYPAD_PIN     12
+  #define BTN_EN1            -1
+  #define BTN_EN2            -1
+  #define BTN_ENC            -1
+  // pin 29 N/C
+#endif // ANET_KEYPAD_LCD


### PR DESCRIPTION
Working pin map for Anet LCD display.
Pins 1 and 2 must be swapped on cable.