### PR TITLE
[2.0] Use fastio for Alligator dac084s085, etc.

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -66,7 +66,7 @@
 // Types
 // --------------------------------------------------------------------------
 
-typedef uint16_t timer_t;
+typedef uint16_t hal_timer_t;
 #define HAL_TIMER_TYPE_MAX 0xFFFF
 
 typedef int8_t pin_t;

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -40,7 +40,7 @@
 
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
-typedef uint32_t timer_t;
+typedef uint32_t hal_timer_t;
 #define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
 
 #define STEP_TIMER_NUM 3  // index of timer to use for stepper
@@ -92,7 +92,7 @@ static FORCE_INLINE void HAL_timer_set_count(const uint8_t timer_num, const uint
   pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC = count;
 }
 
-static FORCE_INLINE timer_t HAL_timer_get_count(const uint8_t timer_num) {
+static FORCE_INLINE hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   const tTimerConfig *pConfig = &TimerConfig[timer_num];
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC;
 }

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -40,7 +40,7 @@
 
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
-typedef uint32_t timer_t;
+typedef uint32_t hal_timer_t;
 #define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
 
 #define STEP_TIMER_NUM 0  // index of timer to use for stepper
@@ -77,7 +77,7 @@ typedef uint32_t timer_t;
 void HAL_timer_init(void);
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 
-static FORCE_INLINE void HAL_timer_set_count(const uint8_t timer_num, const timer_t count) {
+static FORCE_INLINE void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
   switch (timer_num) {
     case 0:
       LPC_TIM0->MR0 = count;
@@ -92,7 +92,7 @@ static FORCE_INLINE void HAL_timer_set_count(const uint8_t timer_num, const time
   }
 }
 
-static FORCE_INLINE timer_t HAL_timer_get_count(const uint8_t timer_num) {
+static FORCE_INLINE hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return LPC_TIM0->MR0;
     case 1: return LPC_TIM1->MR0;
@@ -100,7 +100,7 @@ static FORCE_INLINE timer_t HAL_timer_get_count(const uint8_t timer_num) {
   return 0;
 }
 
-static FORCE_INLINE timer_t HAL_timer_get_current_count(const uint8_t timer_num) {
+static FORCE_INLINE hal_timer_t HAL_timer_get_current_count(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return LPC_TIM0->TC;
     case 1: return LPC_TIM1->TC;

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -43,7 +43,7 @@
  */
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
-typedef uint16_t timer_t;
+typedef uint16_t hal_timer_t;
 #define HAL_TIMER_TYPE_MAX 0xFFFF
 
 #define STEP_TIMER_NUM 5  // index of timer to use for stepper
@@ -126,8 +126,8 @@ static FORCE_INLINE void HAL_timer_set_count (uint8_t timer_num, uint32_t count)
   }
 }
 
-static FORCE_INLINE timer_t HAL_timer_get_count (uint8_t timer_num) {
-  timer_t temp;
+static FORCE_INLINE hal_timer_t HAL_timer_get_count (uint8_t timer_num) {
+  hal_timer_t temp;
   switch (timer_num) {
   case STEP_TIMER_NUM:
     temp = StepperTimer.getCompare(STEP_TIMER_CHAN);
@@ -142,8 +142,8 @@ static FORCE_INLINE timer_t HAL_timer_get_count (uint8_t timer_num) {
   return temp;
 }
 
-static FORCE_INLINE timer_t HAL_timer_get_current_count(uint8_t timer_num) {
-  timer_t temp;
+static FORCE_INLINE hal_timer_t HAL_timer_get_current_count(uint8_t timer_num) {
+  hal_timer_t temp;
   switch (timer_num) {
   case STEP_TIMER_NUM:
     temp = StepperTimer.getCount();

--- a/Marlin/src/HAL/HAL_STM32F1/endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_STM32F1/endstop_interrupts.h
@@ -51,39 +51,39 @@
 
 void setup_endstop_interrupts(void) {
   #if HAS_X_MAX
-    pinMode(X_MAX_PIN, INPUT);
+    SET_INPUT(X_MAX_PIN);
     attachInterrupt(X_MAX_PIN, endstop_ISR, CHANGE); // assign it
   #endif
   #if HAS_X_MIN
-    pinMode(X_MIN_PIN, INPUT);
+    SET_INPUT(X_MIN_PIN);
     attachInterrupt(X_MIN_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Y_MAX
-    pinMode(Y_MAX_PIN, INPUT);
+    SET_INPUT(Y_MAX_PIN);
     attachInterrupt(Y_MAX_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Y_MIN
-    pinMode(Y_MIN_PIN, INPUT);
+    SET_INPUT(Y_MIN_PIN);
     attachInterrupt(Y_MIN_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Z_MAX
-    pinMode(Z_MAX_PIN, INPUT);
+    SET_INPUT(Z_MAX_PIN);
     attachInterrupt(Z_MAX_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Z_MIN
-    pinMode(Z_MIN_PIN, INPUT);
+    SET_INPUT(Z_MIN_PIN);
     attachInterrupt(Z_MIN_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Z2_MAX
-    pinMode(Z2_MAX_PIN, INPUT);
+    SET_INPUT(Z2_MAX_PIN);
     attachInterrupt(Z2_MAX_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Z2_MIN
-    pinMode(Z2_MIN_PIN, INPUT);
+    SET_INPUT(Z2_MIN_PIN);
     attachInterrupt(Z2_MIN_PIN, endstop_ISR, CHANGE);
   #endif
   #if HAS_Z_MIN_PROBE_PIN
-    pinMode(Z_MIN_PROBE_PIN, INPUT);
+    SET_INPUT(Z_MIN_PROBE_PIN);
     attachInterrupt(Z_MIN_PROBE_PIN, endstop_ISR, CHANGE);
   #endif
 }

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
@@ -40,7 +40,7 @@
 
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
-typedef uint32_t timer_t;
+typedef uint32_t hal_timer_t;
 #define HAL_TIMER_TYPE_MAX 0xFFFFFFFF
 
 #define STEP_TIMER_NUM 0
@@ -82,7 +82,7 @@ static FORCE_INLINE void HAL_timer_set_count(const uint8_t timer_num, const uint
   }
 }
 
-static FORCE_INLINE timer_t HAL_timer_get_count(const uint8_t timer_num) {
+static FORCE_INLINE hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   switch(timer_num) {
     case 0: return FTM0_C0V;
     case 1: return FTM1_C0V;

--- a/Marlin/src/HAL/SpiEeprom.cpp
+++ b/Marlin/src/HAL/SpiEeprom.cpp
@@ -44,12 +44,12 @@ uint8_t eeprom_read_byte(uint8_t* pos) {
   eeprom_temp[0] = CMD_READ;
   eeprom_temp[1] = ((unsigned)pos>>8) & 0xFF; // addr High
   eeprom_temp[2] = (unsigned)pos& 0xFF;       // addr Low
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
-  digitalWrite(SPI_EEPROM1_CS, LOW);
+  WRITE(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, LOW);
   spiSend(SPI_CHAN_EEPROM1, eeprom_temp, 3);
 
   v = spiRec(SPI_CHAN_EEPROM1);
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, HIGH);
   return v;
 }
 
@@ -62,14 +62,14 @@ void eeprom_read_block(void* dest, const void* eeprom_address, size_t n) {
   eeprom_temp[0] = CMD_READ;
   eeprom_temp[1] = ((unsigned)eeprom_address>>8) & 0xFF; // addr High
   eeprom_temp[2] = (unsigned)eeprom_address& 0xFF;       // addr Low
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
-  digitalWrite(SPI_EEPROM1_CS, LOW);
+  WRITE(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, LOW);
   spiSend(SPI_CHAN_EEPROM1, eeprom_temp, 3);
 
   uint8_t *p_dest = (uint8_t *)dest;
   while (n--)
     *p_dest++ = spiRec(SPI_CHAN_EEPROM1);
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, HIGH);
 }
 
 void eeprom_write_byte(uint8_t* pos, uint8_t value) {
@@ -77,20 +77,20 @@ void eeprom_write_byte(uint8_t* pos, uint8_t value) {
 
   /*write enable*/
   eeprom_temp[0] = CMD_WREN;
-  digitalWrite(SPI_EEPROM1_CS, LOW);
+  WRITE(SPI_EEPROM1_CS, LOW);
   spiSend(SPI_CHAN_EEPROM1, eeprom_temp, 1);
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, HIGH);
   delay(1);
 
   /*write addr*/
   eeprom_temp[0] = CMD_WRITE;
   eeprom_temp[1] = ((unsigned)pos>>8) & 0xFF;  //addr High
   eeprom_temp[2] = (unsigned)pos & 0xFF;       //addr Low
-  digitalWrite(SPI_EEPROM1_CS, LOW);
+  WRITE(SPI_EEPROM1_CS, LOW);
   spiSend(SPI_CHAN_EEPROM1, eeprom_temp, 3);
 
   spiSend(SPI_CHAN_EEPROM1, value);
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, HIGH);
   delay(7);   // wait for page write to complete
 }
 
@@ -99,20 +99,20 @@ void eeprom_update_block(const void* src, void* eeprom_address, size_t n) {
 
   /*write enable*/
   eeprom_temp[0] = CMD_WREN;
-  digitalWrite(SPI_EEPROM1_CS, LOW);
+  WRITE(SPI_EEPROM1_CS, LOW);
   spiSend(SPI_CHAN_EEPROM1, eeprom_temp, 1);
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, HIGH);
   delay(1);
 
   /*write addr*/
   eeprom_temp[0] = CMD_WRITE;
   eeprom_temp[1] = ((unsigned)eeprom_address>>8) & 0xFF;  //addr High
   eeprom_temp[2] = (unsigned)eeprom_address & 0xFF;       //addr Low
-  digitalWrite(SPI_EEPROM1_CS, LOW);
+  WRITE(SPI_EEPROM1_CS, LOW);
   spiSend(SPI_CHAN_EEPROM1, eeprom_temp, 3);
 
   spiSend(SPI_CHAN_EEPROM1, (const uint8_t*)src, n);
-  digitalWrite(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM1_CS, HIGH);
   delay(7);   // wait for page write to complete
 }
 

--- a/Marlin/src/feature/dac/dac_dac084s085.cpp
+++ b/Marlin/src/feature/dac/dac_dac084s085.cpp
@@ -13,100 +13,85 @@
 #include "../../Marlin.h"
 #include "../../module/stepper.h"
 
-dac084s085::dac084s085() {
-  return ;
-}
+dac084s085::dac084s085() { }
 
 void dac084s085::begin() {
-  uint8_t externalDac_buf[2] = {0x20,0x00};//all off
+  uint8_t externalDac_buf[] = { 0x20, 0x00 }; // all off
 
   // All SPI chip-select HIGH
-  pinMode(DAC0_SYNC, OUTPUT);
-  digitalWrite( DAC0_SYNC , HIGH );
+  SET_OUTPUT(DAC0_SYNC);
   #if EXTRUDERS > 1
-    pinMode(DAC1_SYNC, OUTPUT);
-    digitalWrite( DAC1_SYNC , HIGH );
+    SET_OUTPUT(DAC1_SYNC);
   #endif
-  digitalWrite( SPI_EEPROM1_CS , HIGH );
-  digitalWrite( SPI_EEPROM2_CS , HIGH );
-  digitalWrite( SPI_FLASH_CS , HIGH );
-  digitalWrite( SS_PIN , HIGH );
+  cshigh();
   spiBegin();
 
   //init onboard DAC
   delayMicroseconds(2U);
-  digitalWrite( DAC0_SYNC , LOW );
+  WRITE(DAC0_SYNC, LOW);
   delayMicroseconds(2U);
-  digitalWrite( DAC0_SYNC , HIGH );
+  WRITE(DAC0_SYNC, HIGH);
   delayMicroseconds(2U);
-  digitalWrite( DAC0_SYNC , LOW );
+  WRITE(DAC0_SYNC, LOW);
 
-  spiSend(SPI_CHAN_DAC,externalDac_buf , 2);
-  digitalWrite( DAC0_SYNC , HIGH );
+  spiSend(SPI_CHAN_DAC, externalDac_buf, COUNT(externalDac_buf));
+  WRITE(DAC0_SYNC, HIGH);
 
   #if EXTRUDERS > 1
     //init Piggy DAC
     delayMicroseconds(2U);
-    digitalWrite( DAC1_SYNC , LOW );
+    WRITE(DAC1_SYNC, LOW);
     delayMicroseconds(2U);
-    digitalWrite( DAC1_SYNC , HIGH );
+    WRITE(DAC1_SYNC, HIGH);
     delayMicroseconds(2U);
-    digitalWrite( DAC1_SYNC , LOW );
+    WRITE(DAC1_SYNC, LOW);
 
-    spiSend(SPI_CHAN_DAC,externalDac_buf , 2);
-    digitalWrite( DAC1_SYNC , HIGH );
+    spiSend(SPI_CHAN_DAC, externalDac_buf, COUNT(externalDac_buf));
+    WRITE(DAC1_SYNC, HIGH);
   #endif
 
   return;
 }
 
-void dac084s085::setValue(uint8_t channel, uint8_t value) {
-  if(channel >= 7) // max channel (X,Y,Z,E0,E1,E2,E3)
-    return;
-  if(value > 255) value = 255;
+void dac084s085::setValue(const uint8_t channel, const uint8_t value) {
+  if (channel >= 7) return; // max channel (X,Y,Z,E0,E1,E2,E3)
 
-  uint8_t externalDac_buf[2] = {0x10,0x00};
-
-  if(channel > 3)
-    externalDac_buf[0] |= (7 - channel << 6);
-  else
-    externalDac_buf[0] |= (3 - channel << 6);
-
-  externalDac_buf[0] |= (value >> 4);
-  externalDac_buf[1] |= (value << 4);
+  const uint8_t externalDac_buf[] = {
+    0x10 | ((channel > 3 ? 7 : 3) - channel << 6) | (value >> 4),
+    0x00 | (value << 4)
+  };
 
   // All SPI chip-select HIGH
-  digitalWrite( DAC0_SYNC , HIGH );
-  #if EXTRUDERS > 1
-    digitalWrite( DAC1_SYNC , HIGH );
-  #endif
-  digitalWrite( SPI_EEPROM1_CS , HIGH );
-  digitalWrite( SPI_EEPROM2_CS , HIGH );
-  digitalWrite( SPI_FLASH_CS , HIGH );
-  digitalWrite( SS_PIN , HIGH );
+  cshigh();
 
-  if(channel > 3) { // DAC Piggy E1,E2,E3
-
-    digitalWrite(DAC1_SYNC , LOW);
+  if (channel > 3) {        // DAC Piggy E1,E2,E3
+    WRITE(DAC1_SYNC, LOW);
     delayMicroseconds(2U);
-    digitalWrite(DAC1_SYNC , HIGH);
+    WRITE(DAC1_SYNC, HIGH);
     delayMicroseconds(2U);
-    digitalWrite(DAC1_SYNC , LOW);
+    WRITE(DAC1_SYNC, LOW);
   }
-
-  else { // DAC onboard X,Y,Z,E0
-
-    digitalWrite(DAC0_SYNC , LOW);
+  else {                    // DAC onboard X,Y,Z,E0
+    WRITE(DAC0_SYNC, LOW);
     delayMicroseconds(2U);
-    digitalWrite(DAC0_SYNC , HIGH);
+    WRITE(DAC0_SYNC, HIGH);
     delayMicroseconds(2U);
-    digitalWrite(DAC0_SYNC , LOW);
+    WRITE(DAC0_SYNC, LOW);
   }
 
   delayMicroseconds(2U);
-  spiSend(SPI_CHAN_DAC,externalDac_buf , 2);
+  spiSend(SPI_CHAN_DAC, externalDac_buf, COUNT(externalDac_buf));
+}
 
-  return;
+void dac084s085::cshigh() {
+  WRITE(DAC0_SYNC, HIGH);
+  #if EXTRUDERS > 1
+    WRITE(DAC1_SYNC, HIGH);
+  #endif
+  WRITE(SPI_EEPROM1_CS, HIGH);
+  WRITE(SPI_EEPROM2_CS, HIGH);
+  WRITE(SPI_FLASH_CS, HIGH);
+  WRITE(SS_PIN, HIGH);
 }
 
 #endif // MB(ALLIGATOR)

--- a/Marlin/src/feature/dac/dac_dac084s085.h
+++ b/Marlin/src/feature/dac/dac_dac084s085.h
@@ -5,7 +5,9 @@ class dac084s085 {
   public:
     dac084s085();
     static void begin(void);
-    static void setValue(uint8_t channel, uint8_t value);
+    static void setValue(const uint8_t channel, const uint8_t value);
+  private:
+    static void cshigh();
 };
 
 #endif // DAC084S085_H

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -120,9 +120,9 @@ volatile uint32_t Stepper::step_events_completed = 0; // The number of step even
 
 #if ENABLED(LIN_ADVANCE)
 
-  constexpr timer_t ADV_NEVER = HAL_TIMER_TYPE_MAX;
+  constexpr hal_timer_t ADV_NEVER = HAL_TIMER_TYPE_MAX;
 
-  timer_t Stepper::nextMainISR = 0,
+  hal_timer_t Stepper::nextMainISR = 0,
          Stepper::nextAdvanceISR = ADV_NEVER,
          Stepper::eISR_Rate = ADV_NEVER;
 
@@ -137,9 +137,9 @@ volatile uint32_t Stepper::step_events_completed = 0; // The number of step even
    * This fix isn't perfect and may lose steps - but better than locking up completely
    * in future the planner should slow down if advance stepping rate would be too high
    */
-  FORCE_INLINE timer_t adv_rate(const int steps, const timer_t timer, const uint8_t loops) {
+  FORCE_INLINE hal_timer_t adv_rate(const int steps, const hal_timer_t timer, const uint8_t loops) {
     if (steps) {
-      const timer_t rate = (timer * loops) / abs(steps);
+      const hal_timer_t rate = (timer * loops) / abs(steps);
       //return constrain(rate, 1, ADV_NEVER - 1)
       return rate ? rate : 1;
     }
@@ -157,9 +157,9 @@ volatile signed char Stepper::count_direction[NUM_AXIS] = { 1, 1, 1, 1 };
   long Stepper::counter_m[MIXING_STEPPERS];
 #endif
 
-timer_t Stepper::acc_step_rate; // needed for deceleration start point
+hal_timer_t Stepper::acc_step_rate; // needed for deceleration start point
 uint8_t Stepper::step_loops, Stepper::step_loops_nominal;
-timer_t Stepper::OCR1A_nominal;
+hal_timer_t Stepper::OCR1A_nominal;
 
 volatile long Stepper::endstops_trigsteps[XYZ];
 
@@ -341,7 +341,7 @@ HAL_STEP_TIMER_ISR {
 
 void Stepper::isr() {
 
-  timer_t ocr_val;
+  hal_timer_t ocr_val;
 
   #define ENDSTOP_NOMINAL_OCR_VAL 1500 * HAL_TICKS_PER_US    // check endstops every 1.5ms to guarantee two stepper ISRs within 5ms for BLTouch
   #define OCR_VAL_TOLERANCE 500 * HAL_TICKS_PER_US           // First max delay is 2.0ms, last min delay is 0.5ms, all others 1.5ms
@@ -677,7 +677,7 @@ void Stepper::isr() {
     NOMORE(acc_step_rate, current_block->nominal_rate);
 
     // step_rate to timer interval
-    const timer_t timer = calc_timer(acc_step_rate);
+    const hal_timer_t timer = calc_timer(acc_step_rate);
 
     SPLIT(timer);  // split step into multiple ISRs if larger than  ENDSTOP_NOMINAL_OCR_VAL
     _NEXT_ISR(ocr_val);
@@ -699,7 +699,7 @@ void Stepper::isr() {
     #endif // LIN_ADVANCE
   }
   else if (step_events_completed > (uint32_t)current_block->decelerate_after) {
-    timer_t step_rate;
+    hal_timer_t step_rate;
     #ifdef CPU_32_BIT
       MultiU32X24toH32(step_rate, deceleration_time, current_block->acceleration_rate);
     #else
@@ -714,7 +714,7 @@ void Stepper::isr() {
       step_rate = current_block->final_rate;
 
     // step_rate to timer interval
-    const timer_t timer = calc_timer(step_rate);
+    const hal_timer_t timer = calc_timer(step_rate);
 
     SPLIT(timer);  // split step into multiple ISRs if larger than  ENDSTOP_NOMINAL_OCR_VAL
     _NEXT_ISR(ocr_val);
@@ -754,7 +754,7 @@ void Stepper::isr() {
   #if DISABLED(LIN_ADVANCE)
     #ifdef CPU_32_BIT
       // Make sure stepper interrupt does not monopolise CPU by adjusting count to give about 8 us room
-      timer_t stepper_timer_count = HAL_timer_get_count(STEP_TIMER_NUM),
+      hal_timer_t stepper_timer_count = HAL_timer_get_count(STEP_TIMER_NUM),
                      stepper_timer_current_count = HAL_timer_get_current_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
       HAL_timer_set_count(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
     #else

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -97,7 +97,7 @@ class Stepper {
     static volatile uint32_t step_events_completed; // The number of step events executed in the current block
 
     #if ENABLED(LIN_ADVANCE)
-      static timer_t nextMainISR, nextAdvanceISR, eISR_Rate;
+      static hal_timer_t nextMainISR, nextAdvanceISR, eISR_Rate;
       #define _NEXT_ISR(T) nextMainISR = T
 
       static volatile int e_steps[E_STEPPERS];
@@ -112,9 +112,9 @@ class Stepper {
 
     static long acceleration_time, deceleration_time;
     //unsigned long accelerate_until, decelerate_after, acceleration_rate, initial_rate, final_rate, nominal_rate;
-    static timer_t acc_step_rate; // needed for deceleration start point
+    static hal_timer_t acc_step_rate; // needed for deceleration start point
     static uint8_t step_loops, step_loops_nominal;
-    static timer_t OCR1A_nominal;
+    static hal_timer_t OCR1A_nominal;
 
     static volatile long endstops_trigsteps[XYZ];
     static volatile long endstops_stepsTotal, endstops_stepsDone;
@@ -277,8 +277,8 @@ class Stepper {
 
   private:
 
-    static FORCE_INLINE timer_t calc_timer(timer_t step_rate) {
-      timer_t timer;
+    static FORCE_INLINE hal_timer_t calc_timer(hal_timer_t step_rate) {
+      hal_timer_t timer;
 
       NOMORE(step_rate, MAX_STEP_FREQUENCY);
 


### PR DESCRIPTION
Prefer FastIO over `pinMode`/`digitalWrite`. Code size slightly reduced.

Assuming direct port manipulation is available on all platforms. Also applied to…
- STM32F1 endstop interrupts and
- HAL general SPI-based EEPROM.

Also rename `timer_t` to `hal_timer_t` to avoid a PlatformIO name collision.