### PR TITLE
[1.1.x] Fix EEPROM CRC

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1088,7 +1088,7 @@ void MarlinSettings::postprocess() {
           stepperE4.setCurrent(val, R_SENSE, HOLD_MULTIPLIER);
         #endif
       #else
-        for (uint8_t q = 11; --q;) EEPROM_READ(val);
+        for (uint8_t q = 0; q < 11; q++) EEPROM_READ(val);
       #endif
 
       //


### PR DESCRIPTION
Changing the order in which the EEPROM is read changes the CRC.  e642a64b688b819345e5c2e91f5ab80e453160a3 changed the EEPROM read order without changing the write order.  I reverted the problematic line so that I can read from the EEPROM again.