### PR TITLE
[2.0.x] Fix Delta EEPROM

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -873,8 +873,6 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(delta_segments_per_second); // 1 float
         EEPROM_READ(delta_calibration_radius);  // 1 float
         EEPROM_READ(delta_tower_angle_trim);    // 3 floats
-        dummy = 0.0f;
-        for (uint8_t q=2; q--;) EEPROM_READ(dummy);
 
       #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
 


### PR DESCRIPTION
#8141 removed the unnecessary writes from `MarlinSettings::save()`, but did not remove the corresponding reads from `MarlinSettings::load()`, which broke the EEPROM for Delta machines.