### PR TITLE
[1.1] Fix G92 for native workspace

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6270,10 +6270,8 @@ void home_all_axes() { gcode_G28(true); }
  * G92: Set current position to given X Y Z E
  */
 inline void gcode_G92() {
-  bool didXYZ = false,
-       didE = parser.seenval('E');
 
-  if (!didE) stepper.synchronize();
+  stepper.synchronize();
 
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
     switch (parser.subcode) {
@@ -6298,24 +6296,27 @@ inline void gcode_G92() {
     #define IS_G92_0 true
   #endif
 
+  bool didXYZ = false, didE = false;
+
   if (IS_G92_0) LOOP_XYZE(i) {
     if (parser.seenval(axis_codes[i])) {
-      #if IS_SCARA
-        if (i != E_AXIS) didXYZ = true;
-      #else
-        #if HAS_POSITION_SHIFT
-          const float p = current_position[i];
-        #endif
-        const float v = parser.value_axis_units((AxisEnum)i);
-
-        if (i != E_AXIS) {
-          didXYZ = true;
-          #if HAS_POSITION_SHIFT
-            position_shift[i] += v - p; // Offset the coordinate space
+      const float v = parser.value_axis_units((AxisEnum)i),
+                  d = current_position[i] - v;
+      if (d) {
+        if (i == E_AXIS) didE = true; else didXYZ = true;
+        #if IS_SCARA
+          current_position[i] = v;        // For SCARA just set the position directly
+        #elif HAS_POSITION_SHIFT
+          if (i == E_AXIS)
+            current_position[E_AXIS] = v; // When using coordinate spaces, only E is set directly
+          else {
+            position_shift[i] += d;       // Other axes simply offset the coordinate space
             update_software_endstops((AxisEnum)i);
-          #endif
-        }
-      #endif
+          }
+        #else
+          current_position[i] = v;        // Without workspaces revert to Marlin 1.0 behavior
+        #endif
+      }
     }
   }
 


### PR DESCRIPTION
Addressing #8307

`G92` internal behavior changes following the native workspace update.
- The E position is always set directly
- When `position_shift` exists, `G92` only modifies `position_shift` for XYZ.
- Without `position_shift` (`NO_WORKSPACE_OFFSETS`) `G92` works like Marlin 1.0.
- Always do a `stepper.synchronize` at the start of `G92`.