### PR TITLE
[1.1] Patch abuse of sprintf_P in G33

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6063,7 +6063,7 @@ void home_all_axes() { gcode_G28(true); }
               }
             SERIAL_EOL();
             char mess[21];
-            sprintf_P(mess, PSTR("Calibration sd:"));
+            strcpy_P(mess, PSTR("Calibration sd:"));
             if (zero_std_dev_min < 1)
               sprintf_P(&mess[15], PSTR("0.%03i"), (int)round(zero_std_dev_min * 1000.0));
             else
@@ -6078,7 +6078,7 @@ void home_all_axes() { gcode_G28(true); }
             if (iterations < 31)
               sprintf_P(mess, PSTR("Iteration : %02i"), (int)iterations);
             else
-              sprintf_P(mess, PSTR("No convergence"));
+              strcpy_P(mess, PSTR("No convergence"));
             SERIAL_PROTOCOL(mess);
             SERIAL_PROTOCOL_SP(32);
             SERIAL_PROTOCOLPGM("std dev:");
@@ -6097,8 +6097,8 @@ void home_all_axes() { gcode_G28(true); }
           SERIAL_EOL();
 
           char mess[21];
-          sprintf_P(mess, enddryrun);
-          sprintf_P(&mess[11], PSTR(" sd:"));
+          strcpy_P(mess, enddryrun);
+          strcpy_P(&mess[11], PSTR(" sd:"));
           if (zero_std_dev < 1)
             sprintf_P(&mess[15], PSTR("0.%03i"), (int)round(zero_std_dev * 1000.0));
           else


### PR DESCRIPTION
Addressing #8277

Some platforms define `sprintf_P` to require a minimum of three arguments. This PR removes all instances of `sprintf_P` taking only two, where `strcpy_P` should have been used.