### PR TITLE
2.0.x - pins_RAMPS_RE_ARM.h - add mega2560 pin numbers

### DIFF
--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -34,6 +34,8 @@
  *
  */
 
+// numbers in parenthesis () are the mega2560 equivalent pin numbers
+
 #ifndef TARGET_LPC1768
   #error "Oops!  Make sure you have LPC1768 selected."
 #endif
@@ -47,60 +49,60 @@
 //
 // Servos
 //
-#define SERVO0_PIN         P1_20
-#define SERVO1_PIN         P1_21  // also on J5-1
-#define SERVO2_PIN         P1_19
-#define SERVO3_PIN         P1_18  // 5V output - PWM capable
+#define SERVO0_PIN         P1_20  // (11)
+#define SERVO1_PIN         P1_21  // ( 6) also on J5-1
+#define SERVO2_PIN         P1_19  // ( 5)
+#define SERVO3_PIN         P1_18  // ( 4) 5V output
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN          P1_24  //10k pullup to 3.3V, 1K series
-#define X_MAX_PIN          P1_25  //10k pullup to 3.3V, 1K series
-#define Y_MIN_PIN          P1_26  //10k pullup to 3.3V, 1K series
-#define Y_MAX_PIN          P1_27  //10k pullup to 3.3V, 1K series
-#define Z_MIN_PIN          P1_29  //10k pullup to 3.3V, 1K series
-#define Z_MAX_PIN          P1_28  //10k pullup to 3.3V, 1K series
+#define X_MIN_PIN          P1_24  // ( 3) 10k pullup to 3.3V, 1K series
+#define X_MAX_PIN          P1_25  // ( 2) 10k pullup to 3.3V, 1K series
+#define Y_MIN_PIN          P1_26  // (14) 10k pullup to 3.3V, 1K series
+#define Y_MAX_PIN          P1_27  // (15) 10k pullup to 3.3V, 1K series
+#define Z_MIN_PIN          P1_29  // (18) 10k pullup to 3.3V, 1K series
+#define Z_MAX_PIN          P1_28  // (19) 10k pullup to 3.3V, 1K series
 
 //
 // Steppers
 //
-#define X_STEP_PIN         P2_1
-#define X_DIR_PIN          P0_11
-#define X_ENABLE_PIN       P0_10
+#define X_STEP_PIN         P2_1   // (54)
+#define X_DIR_PIN          P0_11  // (55)
+#define X_ENABLE_PIN       P0_10  // (38)
 
-#define Y_STEP_PIN         P2_2
-#define Y_DIR_PIN          P0_20
-#define Y_ENABLE_PIN       P0_19
+#define Y_STEP_PIN         P2_2   // (60)
+#define Y_DIR_PIN          P0_20  // (61)
+#define Y_ENABLE_PIN       P0_19  // (56)
 
-#define Z_STEP_PIN         P2_3
-#define Z_DIR_PIN          P0_22
-#define Z_ENABLE_PIN       P0_21
+#define Z_STEP_PIN         P2_3   // (46)
+#define Z_DIR_PIN          P0_22  // (48)
+#define Z_ENABLE_PIN       P0_21  // (62)
 
-#define E0_STEP_PIN        P2_0
-#define E0_DIR_PIN         P0_5
-#define E0_ENABLE_PIN      P0_4
+#define E0_STEP_PIN        P2_0   // (26)
+#define E0_DIR_PIN         P0_5   // (28)
+#define E0_ENABLE_PIN      P0_4   // (24)
 
-#define E1_STEP_PIN        P2_8
-#define E1_DIR_PIN         P2_13
-#define E1_ENABLE_PIN      P4_29
+#define E1_STEP_PIN        P2_8   // (36)
+#define E1_DIR_PIN         P2_13  // (34)
+#define E1_ENABLE_PIN      P4_29  // (30)
 
-#define E2_STEP_PIN        P2_8
-#define E2_DIR_PIN         P2_13
-#define E2_ENABLE_PIN      P4_29
+#define E2_STEP_PIN        P2_8   // (36)
+#define E2_DIR_PIN         P2_13  // (34)
+#define E2_ENABLE_PIN      P4_29  // (30)
 
 //
 // Temperature Sensors
 //  3.3V max when defined as an analog input
 //
-#define TEMP_0_PIN         0  //A0 (T0) - D67 - TEMP_0_PIN
-#define TEMP_BED_PIN       1  //A1 (T1) - D68 - TEMP_BED_PIN
-#define TEMP_1_PIN         2  //A2 (T2) - D69 - TEMP_1_PIN
-#define TEMP_2_PIN         3  //A3 - D63 - J5-3 & AUX-2
-#define TEMP_3_PIN         4  //A4 - D37 - BUZZER_PIN
-//#define TEMP_4_PIN         5  //A5 - D49 - SD_DETECT_PIN
-//#define ??               6  //A6 - D0  - RXD0 - J4-4 & AUX-1
-#define FILWIDTH_PIN       7  //A7 - D1  - TXD0 - J4-5 & AUX-1
+#define TEMP_0_PIN         0  //A0 (T0) - (67) - TEMP_0_PIN
+#define TEMP_BED_PIN       1  //A1 (T1) - (68) - TEMP_BED_PIN
+#define TEMP_1_PIN         2  //A2 (T2) - (69) - TEMP_1_PIN
+#define TEMP_2_PIN         3  //A3 - (63) - J5-3 & AUX-2
+#define TEMP_3_PIN         4  //A4 - (37) - BUZZER_PIN
+//#define TEMP_4_PIN         5  //A5 - (49) - SD_DETECT_PIN
+//#define ??               6  //A6 - ( 0)  - RXD0 - J4-4 & AUX-1
+#define FILWIDTH_PIN       7  //A7 - ( 1)  - TXD0 - J4-5 & AUX-1
 
 
 //
@@ -127,13 +129,13 @@
   #define MOSFET_D_PIN   -1
 #endif
 #ifndef RAMPS_D8_PIN
-  #define RAMPS_D8_PIN   P2_7
+  #define RAMPS_D8_PIN   P2_7  // (8)
 #endif
 #ifndef RAMPS_D9_PIN
-  #define RAMPS_D9_PIN   P2_4
+  #define RAMPS_D9_PIN   P2_4  // (9)
 #endif
 #ifndef RAMPS_D10_PIN
-  #define RAMPS_D10_PIN  P2_5
+  #define RAMPS_D10_PIN  P2_5  // (10)
 #endif
 
 #define HEATER_0_PIN     RAMPS_D10_PIN
@@ -163,22 +165,22 @@
 #endif
 
 #ifndef FAN_PIN
-  #define FAN_PIN         P1_18 // IO pin. Buffer needed
+  #define FAN_PIN         P1_18 // (4) IO pin. Buffer needed
 #endif
 
 //
 // Misc. Functions
 //
-#define LED_PIN           P4_28
+#define LED_PIN           P4_28 // (13)
 
 // define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
-#define FIL_RUNOUT_PIN    P1_18
+#define FIL_RUNOUT_PIN    P1_18  // (4)
 
-#define PS_ON_PIN         P2_12
+#define PS_ON_PIN         P2_12 // (12)
 
 #if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT) && !defined(SPINDLE_LASER_ENABLE_PIN)
   #if !defined(NUM_SERVOS) || NUM_SERVOS < 4 // try to use servo connector
-    #define CASE_LIGHT_PIN    P1_18 // MUST BE HARDWARE PWM
+    #define CASE_LIGHT_PIN    P1_18 // (4) MUST BE HARDWARE PWM
   #endif
 #endif
 
@@ -190,17 +192,17 @@
     #undef  SERVO1
     #undef  SERVO2
     #undef  SERVO3
-    #define SPINDLE_LASER_ENABLE_PIN  P1_21  // Pin should have a pullup/pulldown!
-    #define SPINDLE_LASER_PWM_PIN     P1_18  // MUST BE HARDWARE PWM
-    #define SPINDLE_DIR_PIN           P1_19
+    #define SPINDLE_LASER_ENABLE_PIN  P1_21   // (6) Pin should have a pullup/pulldown!
+    #define SPINDLE_LASER_PWM_PIN     P1_18   // (4) MUST BE HARDWARE PWM
+    #define SPINDLE_DIR_PIN           P1_19   // (5)
   #endif
 #endif
 //
 // Průša i3 MK2 Multiplexer Support
 //
-#define E_MUX0_PIN         P0_3    // Z_CS_PIN
-#define E_MUX1_PIN         P0_2    // E0_CS_PIN
-#define E_MUX2_PIN         P0_26   // E1_CS_PIN
+#define E_MUX0_PIN         P0_3    // ( 0) Z_CS_PIN
+#define E_MUX1_PIN         P0_2    // ( 1) E0_CS_PIN
+#define E_MUX2_PIN         P0_26   // (63) E1_CS_PIN
 
 /**
  * LCD / Controller
@@ -223,76 +225,76 @@
 
 #if ENABLED(ULTRA_LCD)
 
-  #define BEEPER_PIN          P1_30  // not 5V tolerant
+  #define BEEPER_PIN          P1_30  // (37) not 5V tolerant
 
-  #define BTN_EN1             P3_26  // J3-2 & AUX-4
-  #define BTN_EN2             P3_25  // J3-4 & AUX-4
-  #define BTN_ENC             P2_11  // J3-3 & AUX-4
+  #define BTN_EN1             P3_26  // (31) J3-2 & AUX-4
+  #define BTN_EN2             P3_25  // (33) J3-4 & AUX-4
+  #define BTN_ENC             P2_11  // (35) J3-3 & AUX-4
 
-  #define SD_DETECT_PIN       P1_31  // not 5V tolerant   J3-1 & AUX-3
-  #define KILL_PIN            P1_22  // J5-4 & AUX-4
-  #define LCD_PINS_RS         P0_16  // J3-7 & AUX-4
-  #define LCD_SDSS            P0_16  // J3-7 & AUX-4
-  #define LCD_BACKLIGHT_PIN   P0_16  // J3-7 & AUX-4 - only used on DOGLCD controllers
-  #define LCD_PINS_ENABLE     P0_18  // (MOSI) J3-10 & AUX-3
-  #define LCD_PINS_D4         P0_15  // (SCK)  J3-9 & AUX-3
+  #define SD_DETECT_PIN       P1_31  // (49) not 5V tolerant   J3-1 & AUX-3
+  #define KILL_PIN            P1_22  // (41) J5-4 & AUX-4
+  #define LCD_PINS_RS         P0_16  // (16) J3-7 & AUX-4
+  #define LCD_SDSS            P0_16  // (16) J3-7 & AUX-4
+  #define LCD_BACKLIGHT_PIN   P0_16  // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
+  #define LCD_PINS_ENABLE     P0_18  // (51) (MOSI) J3-10 & AUX-3
+  #define LCD_PINS_D4         P0_15  // (52) (SCK)  J3-9 & AUX-3
 
-  #define DOGLCD_A0           P2_6   // J3-8 & AUX-2
-  #define DOGLCD_CS           P0_26  // J5-3 & AUX-2
+  #define DOGLCD_A0           P2_6   // (59) J3-8 & AUX-2
+  #define DOGLCD_CS           P0_26  // (63) J5-3 & AUX-2
 
   #ifdef ULTIPANEL
-    #define LCD_PINS_D5       P1_17  // ENET_MDIO
-    #define LCD_PINS_D6       P1_14  // ENET_RX_ER
-    #define LCD_PINS_D7       P1_10  // ENET_RXD1
+    #define LCD_PINS_D5       P1_17  // (71) ENET_MDIO
+    #define LCD_PINS_D6       P1_14  // (73) ENET_RX_ER
+    #define LCD_PINS_D7       P1_10  // (75) ENET_RXD1
   #endif
 
   #if ENABLED(NEWPANEL)
     #if ENABLED(REPRAPWORLD_KEYPAD)
-      #define SHIFT_OUT         P0_18  // (MOSI) J3-10 & AUX-3
-      #define SHIFT_CLK         P0_15  // (SCK)  J3-9 & AUX-3
-      #define SHIFT_LD          P1_31  // not 5V tolerant   J3-1 & AUX-3
+      #define SHIFT_OUT         P0_18  // (51)  (MOSI) J3-10 & AUX-3
+      #define SHIFT_CLK         P0_15  // (52)  (SCK)  J3-9 & AUX-3
+      #define SHIFT_LD          P1_31  // (49)  not 5V tolerant   J3-1 & AUX-3
     #endif
   #else
-    //#define SHIFT_CLK           P3_26  // J3-2 & AUX-4
-    //#define SHIFT_LD            P3_25  // J3-4 & AUX-4
-    //#define SHIFT_OUT           P2_11  // J3-3 & AUX-4
-    //#define SHIFT_EN            P1_22  // J5-4 & AUX-4
+    //#define SHIFT_CLK           P3_26  // (31)  J3-2 & AUX-4
+    //#define SHIFT_LD            P3_25  // (33)  J3-4 & AUX-4
+    //#define SHIFT_OUT           P2_11  // (35)  J3-3 & AUX-4
+    //#define SHIFT_EN            P1_22  // (41)  J5-4 & AUX-4
   #endif
 
   #if ENABLED(VIKI2) || ENABLED(miniVIKI)
     // #define LCD_SCREEN_ROT_180
 
     #undef  BEEPER_PIN
-    #define BEEPER_PIN          P1_30  // may change if cable changes
+    #define BEEPER_PIN          P1_30  // (37) may change if cable changes
 
-    #define BTN_EN1             P3_26  // J3-2 & AUX-4
-    #define BTN_EN2             P3_25  // J3-4 & AUX-4
-    #define BTN_ENC             P2_11  // J3-3 & AUX-4
+    #define BTN_EN1             P3_26  // (31) J3-2 & AUX-4
+    #define BTN_EN2             P3_25  // (33) J3-4 & AUX-4
+    #define BTN_ENC             P2_11  // (35) J3-3 & AUX-4
 
-    #define SD_DETECT_PIN       P1_31  // not 5V tolerant   J3-1 & AUX-3
-    #define KILL_PIN            P1_22  // J5-4 & AUX-4
+    #define SD_DETECT_PIN       P1_31  // (49) not 5V tolerant   J3-1 & AUX-3
+    #define KILL_PIN            P1_22  // (41) J5-4 & AUX-4
 
     #undef  DOGLCD_CS
-    #define DOGLCD_CS           P0_16
-    #undef  LCD_BACKLIGHT_PIN   //P0_16  // J3-7 & AUX-4 - only used on DOGLCD controllers
-    #undef  LCD_PINS_ENABLE     //P0_18  // (MOSI) J3-10 & AUX-3
-    #undef  LCD_PINS_D4         //P0_15  // (SCK)  J3-9 & AUX-3
+    #define DOGLCD_CS           P0_16   // (16)
+    #undef  LCD_BACKLIGHT_PIN   //P0_16  // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
+    #undef  LCD_PINS_ENABLE     //P0_18  // (51) (MOSI) J3-10 & AUX-3
+    #undef  LCD_PINS_D4         //P0_15  // (52) (SCK)  J3-9 & AUX-3
 
-    #undef  LCD_PINS_D5         //P2_6   // J3-8 & AUX-2
-    #define DOGLCD_A0           P2_6   // J3-8 & AUX-2
-    #undef  LCD_PINS_D6         //P0_26  // J5-3 & AUX-2
-    #undef  LCD_PINS_D7         //P1_21  // (SERVO1) J5-1 & SERVO connector
+    #undef  LCD_PINS_D5         //P2_6   // (59) J3-8 & AUX-2
+    #define DOGLCD_A0           P2_6   // (59) J3-8 & AUX-2
+    #undef  LCD_PINS_D6         //P0_26  // (63) J5-3 & AUX-2
+    #undef  LCD_PINS_D7         //P1_21  // ( 6) (SERVO1) J5-1 & SERVO connector
     #define DOGLCD_SCK          SCK_PIN
     #define DOGLCD_MOSI         MOSI_PIN
 
-    #define STAT_LED_BLUE_PIN   P0_26  // may change if cable changes
-    #define STAT_LED_RED_PIN    P1_21  // may change if cable changes
+    #define STAT_LED_BLUE_PIN   P0_26  // (63)  may change if cable changes
+    #define STAT_LED_RED_PIN    P1_21  // ( 6)  may change if cable changes
   #endif
 
-  //#define MISO_PIN            P0_17  // system defined J3-10 & AUX-3
-  //#define MOSI_PIN            P0_18  // system defined J3-10 & AUX-3
-  //#define SCK_PIN             P0_15  // system defined J3-9 & AUX-3
-  //#define SS_PIN              P1_23  // system defined J3-5 & AUX-3 - sometimes called SDSS
+  //#define MISO_PIN            P0_17  // (50)  system defined J3-10 & AUX-3
+  //#define MOSI_PIN            P0_18  // (51)  system defined J3-10 & AUX-3
+  //#define SCK_PIN             P0_15  // (52)  system defined J3-9 & AUX-3
+  //#define SS_PIN              P1_23  // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
 
   #if ENABLED(MINIPANEL)
     // GLCD features
@@ -309,44 +311,70 @@
 // Ethernet pins
 //
 #ifndef ULTIPANEL
-  #define ENET_MDIO   P1_17  // J12-4
-  #define ENET_RX_ER  P1_14  // J12-6
-  #define ENET_RXD1   P1_10  // J12-8
+  #define ENET_MDIO   P1_17  // (71)  J12-4
+  #define ENET_RX_ER  P1_14  // (73)  J12-6
+  #define ENET_RXD1   P1_10  // (75)  J12-8
 #endif
-#define ENET_MOC      P1_16  // J12-3
-#define REF_CLK       P1_15  // J12-5
-#define ENET_RXD0     P1_9   // J12-7
-#define ENET_CRS      P1_8   // J12-9
-#define ENET_TX_EN    P1_4   // J12-10
-#define ENET_TXD0     P1_0   // J12-11
-#define ENET_TXD1     P1_1   // J12-12
+#define ENET_MOC      P1_16  // (70)  J12-3
+#define REF_CLK       P1_15  // (72)  J12-5
+#define ENET_RXD0     P1_9   // (74)  J12-7
+#define ENET_CRS      P1_8   // (76)  J12-9
+#define ENET_TX_EN    P1_4   // (77)  J12-10
+#define ENET_TXD0     P1_0   // (78)  J12-11
+#define ENET_TXD1     P1_1   // (79)  J12-12
 
 /**
- *  PWMS
+ *  Fast PWMS
  *
- *  There are 6 PWMS.  Each PWM can be assigned to one of two pins.
+ *  The LPC1768's hardware PWM controller has 6 channels.  Each channel
+ *  can be setup to either control a dedicated pin directly or to generate
+ *  an interrupt.  The direct method's duty cycle is accurate to within a
+ *  a microsecond.  The interrupt method's average duty cycle has the
+ *  the same accuracy but the individual cycles can vary because of higher
+ *  priority interrupts.
  *
- *  SERVO2 does NOT have a PWM assigned to it.
+ *  All Fast PWMs have a 50Hz rate.
  *
- *  PWM1.1   P0_18   SERVO3_PIN       FIL_RUNOUT_PIN   5V output, PWM
- *  PWM1.1   P2_0    E0_STEP_PIN
- *  PWM1.2   P1_20   SERVO0_PIN
- *  PWM1.2   P2_1    X_STEP_PIN
- *  PWM1.3   P1_21   SERVO1_PIN       J5-1
- *  PWM1.3   P2_2    Y_STEP_PIN
- *  PWM1.4   P1_23   SDSS(SSEL0)      J3-5  AUX-3
- *  PWM1.4   P2_3    Z_STEP_PIN
- *  PWM1.5   P1_24   X_MIN_PIN        10K PULLUP TO 3.3v, 1K SERIES
- *  PWM1.5   P2_4    RAMPS_D9_PIN
- *  PWM1.6   P1_26   Y_MIN_PIN        10K PULLUP TO 3.3v, 1K SERIES
- *  PWM1.6   P2_5    RAMPS_D10_PIN
+ *  The following pins/signals use the direct method.  All other pins use the
+ *  the interrupt method. Note that SERVO2_PIN and RAMPS_D8_PIN use the
+ *  interrupt method.
+ *     P1_20 (11)   SERVO0_PIN
+ *     P1_21 ( 6)   SERVO1_PIN       J5-1
+ *     P0_18 ( 4)   SERVO3_PIN       5V output
+ *    *P2_4  ( 9)   RAMPS_D9_PIN
+ *    *P2_5  (10)   RAMPS_D10_PIN
+ *
+ *    * - If used as a heater driver then a Fast PWM is NOT assigned.  If used as
+ *        a fan driver then enabling FAST_PWM_FAN assigns a Fast PWM to it.
  */
 
  /**
   * special pins
-  *   P1_30 - not 5V tolerant
-  *   P1_31 - not 5V tolerant
-  *   P0_27 - open collector
-  *   P0_28 - open collector
+  *   P1_30  (37) - not 5V tolerant
+  *   P1_31  (49) - not 5V tolerant
+  *   P0_27  (57) - open collector
+  *   P0_28  (58) - open collector
   *
+ */
+
+/**
+ *  The following mega2560 pins are NOT available in a Re-ARM system
+ *  7
+ *  17
+ *  22
+ *  23
+ *  25
+ *  27
+ *  29
+ *  32
+ *  39
+ *  40
+ *  42
+ *  43
+ *  44
+ *  45
+ *  47
+ *  64
+ *  65
+ *  66
  */


### PR DESCRIPTION
Personally I like having both the new and old pin numbers in **pins_RAMPS_RE_ARM.h** and I expect that a lot of the future users will also like having both.

I'm going to leave this open for a day to see if it draws any lightning bolts.  

I know there was a lot of discussion when the LPC1768 pin number system was implemented but I didn't notice anything on this subject.  If this has already been decided then I'll kill this PR.