### PR TITLE
[2.0] Allow to use ZPROBE pin as Zmin or Zmax on MKS Gen

### DIFF
--- a/Marlin/src/pins/pins_MKS_13.h
+++ b/Marlin/src/pins/pins_MKS_13.h
@@ -53,6 +53,10 @@
 
 #include "pins_RAMPS.h"
 
+#ifdef Z_MIN_PROBE_ENDSTOP
+  #undef Z_MIN_PROBE_ENDSTOP
+#endif
+
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
   #if  ENABLED(USE_ZMIN_PLUG)
     #define Z_MAX_PIN -1

--- a/Marlin/src/pins/pins_MKS_13.h
+++ b/Marlin/src/pins/pins_MKS_13.h
@@ -53,6 +53,16 @@
 
 #include "pins_RAMPS.h"
 
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #if  ENABLED(USE_ZMIN_PLUG)
+    #define Z_MAX_PIN -1
+    #define Z_MIN_PROBE_PIN 19
+  #elif ENABLED(USE_ZMAX_PLUG)
+    #define Z_MIN_PIN -1
+    #define Z_MIN_PROBE_PIN 18
+  #endif
+#endif
+
 //
 // LCD / Controller
 //


### PR DESCRIPTION
Allow to use Zprobe (tested with bltouch) on MKS Gen

Zprobe pin depends on what endstop is enabled Zmin or Zmax
So Zprobe will be on unused Z pin