### PR TITLE
2.0.x - U8G HAL LCD support - Arduino IDE compatibility

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_hw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_hw_spi.cpp
@@ -64,7 +64,7 @@
 //  #include "src/core/macros.h"
 //  #include "Configuration.h"
 
-  #include <lib/u8g.h>
+  #include <U8glib.h>
 
   #define SPI_FULL_SPEED 0
   #define SPI_HALF_SPEED 1

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_ssd_hw_i2c.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_ssd_hw_i2c.cpp
@@ -77,7 +77,7 @@
 
 #ifdef TARGET_LPC1768
 
-  #include <lib/u8g.h>
+  #include <U8glib.h>
 
   #define I2C_SLA         (0x3c*2)
   //#define I2C_CMD_MODE  0x080

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_ssd_sw_i2c.cpp  under construction
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_ssd_sw_i2c.cpp  under construction
@@ -64,7 +64,7 @@
 
 #ifdef TARGET_LPC1768
 
-  #include <lib/u8g.h>
+  #include <U8glib.h>
 
 void delayMicroseconds(uint32_t us);
 //void pinMode(int16_t pin, uint8_t mode);

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_st7920_hw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_st7920_hw_spi.cpp
@@ -62,7 +62,7 @@
 //  #include "src/core/macros.h"
 //  #include "Configuration.h"
 
-  #include <lib/u8g.h>
+  #include <U8glib.h>
 
   #define SPI_FULL_SPEED 0
   #define SPI_HALF_SPEED 1

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_st7920_sw_spi.cpp
@@ -57,7 +57,7 @@
 
 #ifdef TARGET_LPC1768
 
-  #include <lib/u8g.h>
+  #include <U8glib.h>
 
   #include <lpc17xx_pinsel.h>
 

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -60,7 +60,6 @@
 #if defined (TARGET_LPC1768)
 
 
-#include <lib/u8g.h>
 #include <U8glib.h>
 
 #include <lpc17xx_pinsel.h>

--- a/Marlin/src/lcd/dogm/u8g_dev_ssd1306_sh1106_128x64_I2C.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_ssd1306_sh1106_128x64_I2C.cpp
@@ -69,8 +69,8 @@
  * beginning.
  */
 
-#include <lib/u8g.h>
-#include <src/lcd/dogm/HAL_LCD_com_defines.h>
+#include <U8glib.h>
+#include "HAL_LCD_com_defines.h"
 
 #define WIDTH 128
 #define HEIGHT 64
@@ -150,11 +150,6 @@ uint8_t u8g_dev_sh1106_128x64_2x_2_wire_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
 }
 
 
-uint8_t u8g_dev_sh1106_128x64_2x_buf[WIDTH*2] U8G_NOCOMMON ;
-u8g_pb_t u8g_dev_sh1106_128x64_2x_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_sh1106_128x64_2x_buf};
-u8g_dev_t u8g_dev_sh1106_128x64_2x_i2c = { u8g_dev_sh1106_128x64_2x_2_wire_fn, &u8g_dev_sh1106_128x64_2x_pb, U8G_COM_SSD_I2C_HAL };
-
-
 uint8_t u8g_dev_sh1106_128x64_2x_i2c_2_wire_buf[WIDTH*2] U8G_NOCOMMON ;
 u8g_pb_t u8g_dev_sh1106_128x64_2x_i2c_2_wire_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_sh1106_128x64_2x_i2c_2_wire_buf};
 u8g_dev_t u8g_dev_sh1106_128x64_2x_i2c_2_wire = { u8g_dev_sh1106_128x64_2x_2_wire_fn, &u8g_dev_sh1106_128x64_2x_i2c_2_wire_pb, U8G_COM_SSD_I2C_HAL };
@@ -227,11 +222,6 @@ uint8_t u8g_dev_ssd1306_128x64_2x_2_wire_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t 
   }
   return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
 }
-
-
-uint8_t u8g_dev_ssd1306_128x64_2x_buf[WIDTH*2] U8G_NOCOMMON ;
-u8g_pb_t u8g_dev_ssd1306_128x64_2x_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_ssd1306_128x64_2x_buf};
-u8g_dev_t u8g_dev_ssd1306_128x64_2x_i2c = { u8g_dev_ssd1306_128x64_2x_2_wire_fn, &u8g_dev_ssd1306_128x64_2x_pb, U8G_COM_SSD_I2C_HAL };
 
 
 uint8_t u8g_dev_ssd1306_128x64_2x_i2c_2_wire_buf[WIDTH*2] U8G_NOCOMMON ;

--- a/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
@@ -57,9 +57,9 @@
 
 */
 
-#include <lib/u8g.h>
+#include <U8glib.h>
 
-#include <src/lcd/dogm/HAL_LCD_com_defines.h>
+#include "HAL_LCD_com_defines.h"
 
 #define WIDTH 128
 #define HEIGHT 64

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -56,9 +56,9 @@
 
 */
 
-#include <lib/u8g.h>
+#include <U8glib.h>
 
-#include <src/lcd/dogm/HAL_LCD_com_defines.h>
+#include "HAL_LCD_com_defines.h"
 
 #define WIDTH 128
 #define HEIGHT 64

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -25,7 +25,7 @@
 
 #ifndef U8G_HAL_LINKS
 
-#include <src/Marlin.h>
+#include "../../Marlin.h"
 
 //#if ENABLED(U8GLIB_ST7920)
 //#if ( ENABLED(SHARED_SPI) || !ENABLED(SHARED_SPI) && (defined(LCD_PINS_D4) &&  LCD_PINS_D4 >= 0) &&  (defined(LCD_PINS_ENABLE) &&  LCD_PINS_ENABLE >= 0))

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -59,7 +59,7 @@
 #endif
 
 #include <U8glib.h>
-#include <src/lcd/dogm/HAL_LCD_class_defines.h>
+#include "dogm/HAL_LCD_class_defines.h"
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "../feature/bedlevel/ubl/ubl.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,7 @@ env_default = megaatmega2560
 
 [common]
 lib_deps =
-
+  U8glib-HAL
   LiquidCrystal_I2C@1.1.2
   https://github.com/lincomatic/LiquidTWI2.git
   https://github.com/teemuatlut/TMC2130Stepper.git
@@ -51,7 +51,6 @@ board       = megaatmega2560
 build_flags = -I $BUILDSRC_DIR
 board_f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
-  U8glib-HAL
 src_filter  = ${common.default_src_filter}
 
 #
@@ -64,7 +63,6 @@ board       = megaatmega1280
 build_flags = -I $BUILDSRC_DIR
 board_f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
-  U8glib-HAL
 src_filter  = ${common.default_src_filter}
 
 #
@@ -76,7 +74,6 @@ framework    = arduino
 board        = sanguino_atmega1284p
 upload_speed = 57600
 lib_deps     = ${common.lib_deps}
-  U8glib-HAL
 src_filter   = ${common.default_src_filter}
 
 #
@@ -91,7 +88,6 @@ framework   = arduino
 board       = due
 build_flags = -I $BUILDSRC_DIR
 lib_deps    = ${common.lib_deps}
-  U8glib-HAL
 src_filter  = ${common.default_src_filter}
 
 #
@@ -154,7 +150,6 @@ board       = reprap_rambo
 build_flags = -I $BUILDSRC_DIR
 board_f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
-  U8glib-HAL
 src_filter  = ${common.default_src_filter}
 
 #
@@ -165,7 +160,6 @@ platform   = atmelavr
 framework  = arduino
 board      = sanguino_atmega644p
 lib_deps   = ${common.lib_deps}
-  U8glib-HAL
 src_filter = ${common.default_src_filter}
 
 [env:STM32F1]
@@ -174,7 +168,6 @@ framework   = arduino
 board       = genericSTM32F103RE
 build_flags = !python Marlin/src/HAL/HAL_STM32F1/stm32f1_flag_script.py
 lib_deps    = ${common.lib_deps}
-  U8glib-HAL
 src_filter  = ${common.default_src_filter}
 
 #
@@ -191,7 +184,6 @@ board         = teensy20pp
 build_flags   = -I $BUILDSRC_DIR
 #board_f_cpu  = 20000000L     ; Bug in Arduino framework disallows boards running at 20Mhz
 lib_deps      = ${common.lib_deps}
-  U8glib-HAL
 src_filter    = ${common.default_src_filter}
 
 #
@@ -203,6 +195,5 @@ framework   = arduino
 board       = teensy35
 build_flags = -I $BUILDSRC_DIR
 lib_deps    = ${common.lib_deps}
-  U8glib-HAL
 lib_ignore  = Adafruit NeoPixel
 src_filter  = ${common.default_src_filter}


### PR DESCRIPTION
1) Changed includes to make Arduino IDE happy
2) Removed unused device definitions in u8g_dev_ssd1306_sh1106_128x64_I2C.cpp.  Arduino Beta correctly complained that they were duplicates of ones in the U8G library.
3) platformio.ini - Put U8glib-HAL back into the common section.  Item 1) appears to have fixed the issues that resulted in PR #8338 

This compiled with the Arduino Beta but not the Arduino nightly build.  The Arduino nightly build gave a "file name too long" error.