### PR TITLE
[2.0] Fix PROBE_MANUALLY on kinematic bots

### DIFF
--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -377,7 +377,7 @@ float bilinear_z_offset(const float raw[XYZ]) {
 
     if (cx1 == cx2 && cy1 == cy2) {
       // Start and end on same mesh square
-      line_to_destination(fr_mm_s);
+      buffer_line_to_destination(fr_mm_s);
       set_current_from_destination();
       return;
     }
@@ -404,7 +404,7 @@ float bilinear_z_offset(const float raw[XYZ]) {
     }
     else {
       // Already split on a border
-      line_to_destination(fr_mm_s);
+      buffer_line_to_destination(fr_mm_s);
       set_current_from_destination();
       return;
     }

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -27,7 +27,7 @@
 #include "bedlevel.h"
 
 #if ENABLED(MESH_BED_LEVELING) || ENABLED(PROBE_MANUALLY)
-  #include "../../module/stepper.h"
+  #include "../../module/motion.h"
 #endif
 
 #if PLANNER_LEVELING
@@ -257,27 +257,20 @@ void reset_bed_level() {
 #if ENABLED(MESH_BED_LEVELING) || ENABLED(PROBE_MANUALLY)
 
   void _manual_goto_xy(const float &rx, const float &ry) {
-    const float old_feedrate_mm_s = feedrate_mm_s;
+
     #if MANUAL_PROBE_HEIGHT > 0
       const float prev_z = current_position[Z_AXIS];
-      feedrate_mm_s = homing_feedrate(Z_AXIS);
-      current_position[Z_AXIS] = MANUAL_PROBE_HEIGHT;
-      line_to_current_position();
+      do_blocking_move_to_z(MANUAL_PROBE_HEIGHT, homing_feedrate(Z_AXIS));
     #endif
 
-    feedrate_mm_s = MMM_TO_MMS(XY_PROBE_SPEED);
-    current_position[X_AXIS] = rx;
-    current_position[Y_AXIS] = ry;
-    line_to_current_position();
+    do_blocking_move_to_xy(rx, ry, MMM_TO_MMS(XY_PROBE_SPEED));
 
     #if MANUAL_PROBE_HEIGHT > 0
-      feedrate_mm_s = homing_feedrate(Z_AXIS);
-      current_position[Z_AXIS] = prev_z; // move back to the previous Z.
-      line_to_current_position();
+      do_blocking_move_to_z(prev_z, homing_feedrate(Z_AXIS));
     #endif
 
-    feedrate_mm_s = old_feedrate_mm_s;
-    stepper.synchronize();
+    current_position[X_AXIS] = rx;
+    current_position[Y_AXIS] = ry;
 
     #if ENABLED(PROBE_MANUALLY) && ENABLED(LCD_BED_LEVELING)
       lcd_wait_for_move = false;

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -68,7 +68,7 @@
 
     if (cx1 == cx2 && cy1 == cy2) {
       // Start and end on same mesh square
-      line_to_destination(fr_mm_s);
+      buffer_line_to_destination(fr_mm_s);
       set_current_from_destination();
       return;
     }
@@ -95,7 +95,7 @@
     }
     else {
       // Already split on a border
-      line_to_destination(fr_mm_s);
+      buffer_line_to_destination(fr_mm_s);
       set_current_from_destination();
       return;
     }

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -99,7 +99,7 @@ void do_pause_e_move(const float &length, const float fr) {
   #if IS_KINEMATIC
     planner.buffer_line_kinematic(destination, fr, active_extruder);
   #else
-    line_to_destination(fr);
+    buffer_line_to_destination(fr);
   #endif
   stepper.synchronize();
 }

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -48,7 +48,7 @@ void mesh_probing_done() {
   #if ENABLED(MESH_G28_REST_ORIGIN)
     current_position[Z_AXIS] = Z_MIN_POS;
     set_destination_from_current();
-    line_to_destination(homing_feedrate(Z_AXIS));
+    buffer_line_to_destination(homing_feedrate(Z_AXIS));
     stepper.synchronize();
   #endif
 }

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -819,7 +819,7 @@ static_assert(1 >= 0
    */
 
   #if ENABLED(DELTA)
-    #error "MESH_BED_LEVELING does not yet support DELTA printers."
+    #error "MESH_BED_LEVELING is not compatible with DELTA printers."
   #elif GRID_MAX_POINTS_X > 9 || GRID_MAX_POINTS_Y > 9
     #error "GRID_MAX_POINTS_X and GRID_MAX_POINTS_Y must be less than 10 for MBL."
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -70,16 +70,16 @@ bool relative_mode = false;
 /**
  * Cartesian Current Position
  *   Used to track the native machine position as moves are queued.
- *   Used by 'line_to_current_position' to do a move after changing it.
+ *   Used by 'buffer_line_to_current_position' to do a move after changing it.
  *   Used by 'SYNC_PLAN_POSITION_KINEMATIC' to update 'planner.position'.
  */
 float current_position[XYZE] = { 0.0 };
 
 /**
  * Cartesian Destination
- *   A temporary position, usually applied to 'current_position'.
- *   Set with 'get_destination_from_command' or 'set_destination_from_current'.
- *   'line_to_destination' sets 'current_position' to 'destination'.
+ *   The destination for a move, filled in by G-code movement commands,
+ *   and expected by functions like 'prepare_move_to_destination'.
+ *   Set with 'gcode_get_destination' or 'set_destination_from_current'.
  */
 float destination[XYZE] = { 0.0 };
 
@@ -235,7 +235,7 @@ void line_to_current_position() {
  * Move the planner to the position stored in the destination array, which is
  * used by G0/G1/G2/G3/G5 and many other functions to set a destination.
  */
-void line_to_destination(const float fr_mm_s) {
+void buffer_line_to_destination(const float fr_mm_s) {
   planner.buffer_line(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS], destination[E_AXIS], fr_mm_s, active_extruder);
 }
 
@@ -667,7 +667,7 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
       }
     #endif // HAS_MESH
 
-    line_to_destination(MMS_SCALED(feedrate_mm_s));
+    buffer_line_to_destination(MMS_SCALED(feedrate_mm_s));
     return false;
   }
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -138,9 +138,7 @@ void line_to_current_position();
  * Move the planner to the position stored in the destination array, which is
  * used by G0/G1/G2/G3/G5 and many other functions to set a destination.
  */
-void line_to_destination(const float fr_mm_s);
-
-inline void line_to_destination() { line_to_destination(feedrate_mm_s); }
+void buffer_line_to_destination(const float fr_mm_s);
 
 #if IS_KINEMATIC
   void prepare_uninterpolated_move_to_destination(const float fr_mm_s=0.0);

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -376,18 +376,18 @@ class Planner {
      *  fr_mm_s  - (target) speed of the move (mm/s)
      *  extruder - target extruder
      */
-    static FORCE_INLINE void buffer_line_kinematic(const float rtarget[XYZE], const float &fr_mm_s, const uint8_t extruder) {
+    static FORCE_INLINE void buffer_line_kinematic(const float cart[XYZE], const float &fr_mm_s, const uint8_t extruder) {
       #if PLANNER_LEVELING
-        float lpos[XYZ] = { rtarget[X_AXIS], rtarget[Y_AXIS], rtarget[Z_AXIS] };
-        apply_leveling(lpos);
+        float raw[XYZ] = { cart[X_AXIS], cart[Y_AXIS], cart[Z_AXIS] };
+        apply_leveling(raw);
       #else
-        const float * const lpos = rtarget;
+        const float * const raw = cart;
       #endif
       #if IS_KINEMATIC
-        inverse_kinematics(lpos);
-        _buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], rtarget[E_AXIS], fr_mm_s, extruder);
+        inverse_kinematics(raw);
+        _buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], cart[E_AXIS], fr_mm_s, extruder);
       #else
-        _buffer_line(lpos[X_AXIS], lpos[Y_AXIS], lpos[Z_AXIS], rtarget[E_AXIS], fr_mm_s, extruder);
+        _buffer_line(raw[X_AXIS], raw[Y_AXIS], raw[Z_AXIS], cart[E_AXIS], fr_mm_s, extruder);
       #endif
     }
 


### PR DESCRIPTION
Addressing #7172

Also clarify some movement code so it's slightly clearer it is direct-to-planner, and rename vars in `Planner::buffer_line_kinematic` to clarify they are cartesian.
