### PR TITLE
[1.1.x] Add delta_height variable in lieu of using home_offset

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -1030,7 +1030,7 @@
   // Updated G92 behavior shifts the workspace
   #define HAS_POSITION_SHIFT DISABLED(NO_WORKSPACE_OFFSETS)
   // The home offset also shifts the coordinate space
-  #define HAS_HOME_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) || ENABLED(DELTA))
+  #define HAS_HOME_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) && DISABLED(DELTA))
   // Either offset yields extra calculations on all moves
   #define HAS_WORKSPACE_OFFSET (HAS_POSITION_SHIFT || HAS_HOME_OFFSET)
   // M206 doesn't apply to DELTA

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -304,7 +304,8 @@ void report_current_position();
 #endif
 
 #if ENABLED(DELTA)
-  extern float delta_endstop_adj[ABC],
+  extern float delta_height,
+               delta_endstop_adj[ABC],
                delta_radius,
                delta_diagonal_rod,
                delta_calibration_radius,

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -627,7 +627,8 @@ static uint8_t target_extruder;
   float delta[ABC];
 
   // Initialized by settings.load()
-  float delta_endstop_adj[ABC] = { 0 },
+  float delta_height,
+        delta_endstop_adj[ABC] = { 0 },
         delta_radius,
         delta_tower_angle_trim[ABC],
         delta_tower[ABC][2],
@@ -1443,6 +1444,12 @@ bool get_target_extruder_from_command(const uint16_t code) {
           soft_endstop_max[axis] = base_max_pos(axis) + offs;
         }
       }
+    #elif ENABLED(DELTA)
+      soft_endstop_min[axis] = base_min_pos(axis) + offs;
+      soft_endstop_max[axis] = (axis == Z_AXIS ? delta_height : base_max_pos(axis)) + offs;
+    #else
+      soft_endstop_min[axis] = base_min_pos(axis) + offs;
+      soft_endstop_max[axis] = base_max_pos(axis) + offs;
     #endif
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -1567,6 +1574,10 @@ static void set_axis_is_at_home(const AxisEnum axis) {
       soft_endstop_min[axis] = base_min_pos(axis); // + (cartes[axis] - base_home_pos(axis));
       soft_endstop_max[axis] = base_max_pos(axis); // + (cartes[axis] - base_home_pos(axis));
     }
+    else
+  #elif ENABLED(DELTA)
+    if (axis == Z_AXIS)
+      current_position[axis] = delta_height;
     else
   #endif
   {
@@ -2378,11 +2389,7 @@ static void clean_up_after_endstop_or_probe_move() {
       }
     #endif
 
-    return current_position[Z_AXIS] + zprobe_zoffset
-      #if ENABLED(DELTA)
-        + home_offset[Z_AXIS] // Account for delta height adjustment
-      #endif
-    ;
+    return current_position[Z_AXIS] + zprobe_zoffset;
   }
 
   /**
@@ -3931,14 +3938,13 @@ inline void gcode_G4() {
     sync_plan_position();
 
     // Move all carriages together linearly until an endstop is hit.
-    current_position[X_AXIS] = current_position[Y_AXIS] = current_position[Z_AXIS] = (DELTA_HEIGHT + home_offset[Z_AXIS] + 10);
+    current_position[X_AXIS] = current_position[Y_AXIS] = current_position[Z_AXIS] = (delta_height + 10);
     feedrate_mm_s = homing_feedrate(X_AXIS);
     line_to_current_position();
     stepper.synchronize();
 
     // If an endstop was not hit, then damage can occur if homing is continued.
-    // This can occur if the delta height (DELTA_HEIGHT + home_offset[Z_AXIS]) is
-    // not set correctly.
+    // This can occur if the delta height not set correctly.
     if (!(Endstops::endstop_hit_bits & (_BV(X_MAX) | _BV(Y_MAX) | _BV(Z_MAX)))) {
       LCD_MESSAGEPGM(MSG_ERR_HOMING_FAILED);
       SERIAL_ERROR_START();
@@ -5483,7 +5489,7 @@ void home_all_axes() { gcode_G28(true); }
   }
 
   static void print_G33_settings(const bool end_stops, const bool tower_angles) {
-    SERIAL_PROTOCOLPAIR(".Height:", DELTA_HEIGHT + home_offset[Z_AXIS]);
+    SERIAL_PROTOCOLPAIR(".Height:", delta_height);
     if (end_stops) {
       print_signed_float(PSTR("Ex"), delta_endstop_adj[A_AXIS]);
       print_signed_float(PSTR("Ey"), delta_endstop_adj[B_AXIS]);
@@ -5731,7 +5737,7 @@ void home_all_axes() { gcode_G28(true); }
         delta_endstop_adj[(axis + 1) % 3] -= 1.0 / 4.5;
         delta_endstop_adj[(axis + 2) % 3] += 1.0 / 4.5;
         z_temp = MAX3(delta_endstop_adj[A_AXIS], delta_endstop_adj[B_AXIS], delta_endstop_adj[C_AXIS]);
-        home_offset[Z_AXIS] -= z_temp;
+        delta_height -= z_temp;
         LOOP_XYZ(axis) delta_endstop_adj[axis] -= z_temp;
         recalc_delta_settings(delta_radius, delta_diagonal_rod, delta_tower_angle_trim);
 
@@ -5751,7 +5757,7 @@ void home_all_axes() { gcode_G28(true); }
         delta_endstop_adj[(axis+1) % 3] += 1.0/4.5;
         delta_endstop_adj[(axis+2) % 3] -= 1.0/4.5;
         z_temp = MAX3(delta_endstop_adj[A_AXIS], delta_endstop_adj[B_AXIS], delta_endstop_adj[C_AXIS]);
-        home_offset[Z_AXIS] -= z_temp;
+        delta_height -= z_temp;
         LOOP_XYZ(axis) delta_endstop_adj[axis] -= z_temp;
         recalc_delta_settings(delta_radius, delta_diagonal_rod, delta_tower_angle_trim);
         switch (axis) {
@@ -5860,7 +5866,7 @@ void home_all_axes() { gcode_G28(true); }
             delta_endstop_adj[C_AXIS]
           },
           dr_old = delta_radius,
-          zh_old = home_offset[Z_AXIS],
+          zh_old = delta_height,
           ta_old[ABC] = {
             delta_tower_angle_trim[A_AXIS],
             delta_tower_angle_trim[B_AXIS],
@@ -5939,7 +5945,7 @@ void home_all_axes() { gcode_G28(true); }
         if (zero_std_dev < zero_std_dev_min) {
           COPY(e_old, delta_endstop_adj);
           dr_old = delta_radius;
-          zh_old = home_offset[Z_AXIS];
+          zh_old = delta_height;
           COPY(ta_old, delta_tower_angle_trim);
         }
 
@@ -6023,7 +6029,7 @@ void home_all_axes() { gcode_G28(true); }
       else if (zero_std_dev >= test_precision) {   // step one back
         COPY(delta_endstop_adj, e_old);
         delta_radius = dr_old;
-        home_offset[Z_AXIS] = zh_old;
+        delta_height = zh_old;
         COPY(delta_tower_angle_trim, ta_old);
       }
 
@@ -6037,7 +6043,7 @@ void home_all_axes() { gcode_G28(true); }
 
         // adjust delta_height and endstops by the max amount
         const float z_temp = MAX3(delta_endstop_adj[A_AXIS], delta_endstop_adj[B_AXIS], delta_endstop_adj[C_AXIS]);
-        home_offset[Z_AXIS] -= z_temp;
+        delta_height -= z_temp;
         LOOP_XYZ(axis) delta_endstop_adj[axis] -= z_temp;
       }
       recalc_delta_settings(delta_radius, delta_diagonal_rod, delta_tower_angle_trim);
@@ -8993,7 +8999,7 @@ inline void gcode_M205() {
    */
   inline void gcode_M665() {
     if (parser.seen('H')) {
-      home_offset[Z_AXIS] = parser.value_linear_units() - DELTA_HEIGHT;
+      delta_height = parser.value_linear_units();
       update_software_endstops(Z_AXIS);
     }
     if (parser.seen('L')) delta_diagonal_rod             = parser.value_linear_units();
@@ -10101,7 +10107,7 @@ inline void gcode_M502() {
       #endif
 
       #if ENABLED(DELTA) // correct the delta_height
-        home_offset[Z_AXIS] -= diff;
+        delta_height -= diff;
       #endif
     }
 

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -36,7 +36,7 @@
  *
  */
 
-#define EEPROM_VERSION "V44"
+#define EEPROM_VERSION "V45"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
@@ -91,15 +91,16 @@
  *  324  G29 A     planner.leveling_active          (bool)
  *  325  G29 S     ubl.storage_slot                 (int8_t)
  *
- * DELTA:                                           40 bytes
- *  352  M666 XYZ  delta_endstop_adj                (float x3)
- *  364  M665 R    delta_radius                     (float)
- *  368  M665 L    delta_diagonal_rod               (float)
- *  372  M665 S    delta_segments_per_second        (float)
- *  376  M665 B    delta_calibration_radius         (float)
- *  380  M665 X    delta_tower_angle_trim[A]        (float)
- *  384  M665 Y    delta_tower_angle_trim[B]        (float)
- *  388  M665 Z    delta_tower_angle_trim[C]        (float)
+ * DELTA:                                           44 bytes
+ *  352  M666 H    delta_height                     (float)
+ *  364  M666 XYZ  delta_endstop_adj                (float x3)
+ *  368  M665 R    delta_radius                     (float)
+ *  372  M665 L    delta_diagonal_rod               (float)
+ *  376  M665 S    delta_segments_per_second        (float)
+ *  380  M665 B    delta_calibration_radius         (float)
+ *  384  M665 X    delta_tower_angle_trim[A]        (float)
+ *  388  M665 Y    delta_tower_angle_trim[B]        (float)
+ *  392  M665 Z    delta_tower_angle_trim[C]        (float)
  *
  * [XYZ]_DUAL_ENDSTOPS:                             12 bytes
  *  352  M666 X    x_endstop_adj                    (float)
@@ -107,65 +108,65 @@
  *  360  M666 Z    z_endstop_adj                    (float)
  *
  * ULTIPANEL:                                       6 bytes
- *  392  M145 S0 H lcd_preheat_hotend_temp          (int x2)
- *  396  M145 S0 B lcd_preheat_bed_temp             (int x2)
- *  400  M145 S0 F lcd_preheat_fan_speed            (int x2)
+ *  396  M145 S0 H lcd_preheat_hotend_temp          (int x2)
+ *  400  M145 S0 B lcd_preheat_bed_temp             (int x2)
+ *  404  M145 S0 F lcd_preheat_fan_speed            (int x2)
  *
  * PIDTEMP:                                         82 bytes
- *  404  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]   (float x4)
- *  420  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]   (float x4)
- *  436  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]   (float x4)
- *  452  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
- *  468  M301 E4 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
- *  484  M301 L        lpq_len                      (int)
+ *  408  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]   (float x4)
+ *  428  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]   (float x4)
+ *  440  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]   (float x4)
+ *  456  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
+ *  472  M301 E4 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
+ *  488  M301 L        lpq_len                      (int)
  *
  * PIDTEMPBED:                                      12 bytes
- *  486  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
+ *  490  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
  *
  * DOGLCD:                                          2 bytes
- *  498  M250 C    lcd_contrast                     (uint16_t)
+ *  502  M250 C    lcd_contrast                     (uint16_t)
  *
  * FWRETRACT:                                       33 bytes
- *  500  M209 S    autoretract_enabled              (bool)
- *  501  M207 S    retract_length                   (float)
- *  505  M207 F    retract_feedrate_mm_s            (float)
- *  509  M207 Z    retract_zlift                    (float)
- *  513  M208 S    retract_recover_length           (float)
- *  517  M208 F    retract_recover_feedrate_mm_s    (float)
- *  521  M207 W    swap_retract_length              (float)
- *  525  M208 W    swap_retract_recover_length      (float)
- *  529  M208 R    swap_retract_recover_feedrate_mm_s (float)
+ *  504  M209 S    autoretract_enabled              (bool)
+ *  505  M207 S    retract_length                   (float)
+ *  509  M207 F    retract_feedrate_mm_s            (float)
+ *  513  M207 Z    retract_zlift                    (float)
+ *  517  M208 S    retract_recover_length           (float)
+ *  521  M208 F    retract_recover_feedrate_mm_s    (float)
+ *  525  M207 W    swap_retract_length              (float)
+ *  529  M208 W    swap_retract_recover_length      (float)
+ *  533  M208 R    swap_retract_recover_feedrate_mm_s (float)
  *
  * Volumetric Extrusion:                            21 bytes
- *  533  M200 D    volumetric_enabled               (bool)
- *  534  M200 T D  filament_size                    (float x5) (T0..3)
+ *  537  M200 D    volumetric_enabled               (bool)
+ *  538  M200 T D  filament_size                    (float x5) (T0..3)
  *
  * HAVE_TMC2130:                                    22 bytes
- *  554  M906 X    Stepper X current                (uint16_t)
- *  556  M906 Y    Stepper Y current                (uint16_t)
- *  558  M906 Z    Stepper Z current                (uint16_t)
- *  560  M906 X2   Stepper X2 current               (uint16_t)
- *  562  M906 Y2   Stepper Y2 current               (uint16_t)
- *  564  M906 Z2   Stepper Z2 current               (uint16_t)
- *  566  M906 E0   Stepper E0 current               (uint16_t)
- *  568  M906 E1   Stepper E1 current               (uint16_t)
- *  570  M906 E2   Stepper E2 current               (uint16_t)
- *  572  M906 E3   Stepper E3 current               (uint16_t)
- *  574  M906 E4   Stepper E4 current               (uint16_t)
+ *  558  M906 X    Stepper X current                (uint16_t)
+ *  560  M906 Y    Stepper Y current                (uint16_t)
+ *  562  M906 Z    Stepper Z current                (uint16_t)
+ *  564  M906 X2   Stepper X2 current               (uint16_t)
+ *  566  M906 Y2   Stepper Y2 current               (uint16_t)
+ *  568  M906 Z2   Stepper Z2 current               (uint16_t)
+ *  570  M906 E0   Stepper E0 current               (uint16_t)
+ *  572  M906 E1   Stepper E1 current               (uint16_t)
+ *  574  M906 E2   Stepper E2 current               (uint16_t)
+ *  576  M906 E3   Stepper E3 current               (uint16_t)
+ *  578  M906 E4   Stepper E4 current               (uint16_t)
  *
  * LIN_ADVANCE:                                     8 bytes
- *  576  M900 K    extruder_advance_k               (float)
- *  580  M900 WHD  advance_ed_ratio                 (float)
+ *  580  M900 K    extruder_advance_k               (float)
+ *  584  M900 WHD  advance_ed_ratio                 (float)
  *
  * HAS_MOTOR_CURRENT_PWM:
- *  584  M907 X    Stepper XY current               (uint32_t)
- *  588  M907 Z    Stepper Z current                (uint32_t)
- *  592  M907 E    Stepper E current                (uint32_t)
+ *  588  M907 X    Stepper XY current               (uint32_t)
+ *  592  M907 Z    Stepper Z current                (uint32_t)
+ *  596  M907 E    Stepper E current                (uint32_t)
  *
  * CNC_COORDINATE_SYSTEMS                           108 bytes
- *  596  G54-G59.3 coordinate_system                (float x 27)
+ *  600  G54-G59.3 coordinate_system                (float x 27)
  *
- *  704                                Minimum end-point
+ *  708                                Minimum end-point
  * 2025 (704 + 36 + 9 + 288 + 988)     Maximum end-point
  *
  * ========================================================================
@@ -354,15 +355,7 @@ void MarlinSettings::postprocess() {
     #if !HAS_HOME_OFFSET
       const float home_offset[XYZ] = { 0 };
     #endif
-    #if ENABLED(DELTA)
-      dummy = 0.0;
-      EEPROM_WRITE(dummy);
-      EEPROM_WRITE(dummy);
-      dummy = DELTA_HEIGHT + home_offset[Z_AXIS];
-      EEPROM_WRITE(dummy);
-    #else
-      EEPROM_WRITE(home_offset);
-    #endif
+    EEPROM_WRITE(home_offset);
 
     #if HOTENDS > 1
       // Skip hotend 0 which must be 0
@@ -465,6 +458,7 @@ void MarlinSettings::postprocess() {
 
     // 10 floats for DELTA / [XYZ]_DUAL_ENDSTOPS
     #if ENABLED(DELTA)
+      EEPROM_WRITE(delta_height);              // 1 float
       EEPROM_WRITE(delta_endstop_adj);         // 3 floats
       EEPROM_WRITE(delta_radius);              // 1 float
       EEPROM_WRITE(delta_diagonal_rod);        // 1 float
@@ -786,12 +780,6 @@ void MarlinSettings::postprocess() {
       #endif
       EEPROM_READ(home_offset);
 
-      #if ENABLED(DELTA)
-        home_offset[X_AXIS] = 0.0;
-        home_offset[Y_AXIS] = 0.0;
-        home_offset[Z_AXIS] -= DELTA_HEIGHT;
-      #endif
-
       //
       // Hotend Offsets, if any
       //
@@ -897,6 +885,7 @@ void MarlinSettings::postprocess() {
       //
 
       #if ENABLED(DELTA)
+        EEPROM_READ(delta_height);              // 1 float
         EEPROM_READ(delta_endstop_adj);         // 3 floats
         EEPROM_READ(delta_radius);              // 1 float
         EEPROM_READ(delta_diagonal_rod);        // 1 float
@@ -1347,13 +1336,13 @@ void MarlinSettings::reset() {
   #if ENABLED(DELTA)
     const float adj[ABC] = DELTA_ENDSTOP_ADJ,
                 dta[ABC] = DELTA_TOWER_ANGLE_TRIM;
+    delta_height = DELTA_HEIGHT;
     COPY(delta_endstop_adj, adj);
     delta_radius = DELTA_RADIUS;
     delta_diagonal_rod = DELTA_DIAGONAL_ROD;
     delta_segments_per_second = DELTA_SEGMENTS_PER_SECOND;
     delta_calibration_radius = DELTA_CALIBRATION_RADIUS;
     COPY(delta_tower_angle_trim, dta);
-    home_offset[Z_AXIS] = 0;
 
   #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
 
@@ -1790,7 +1779,7 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_START;
       SERIAL_ECHOPAIR("  M665 L", LINEAR_UNIT(delta_diagonal_rod));
       SERIAL_ECHOPAIR(" R", LINEAR_UNIT(delta_radius));
-      SERIAL_ECHOPAIR(" H", LINEAR_UNIT(DELTA_HEIGHT + home_offset[Z_AXIS]));
+      SERIAL_ECHOPAIR(" H", LINEAR_UNIT(delta_height));
       SERIAL_ECHOPAIR(" S", delta_segments_per_second);
       SERIAL_ECHOPAIR(" B", LINEAR_UNIT(delta_calibration_radius));
       SERIAL_ECHOPAIR(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2742,19 +2742,15 @@ void kill_screen(const char* lcd_msg) {
     void _goto_tower_z() { _man_probe_pt(cos(RADIANS( 90)) * delta_calibration_radius, sin(RADIANS( 90)) * delta_calibration_radius); }
     void _goto_center()  { _man_probe_pt(0,0); }
 
-    static float _delta_height = DELTA_HEIGHT;
     void _lcd_set_delta_height() {
-      home_offset[Z_AXIS] = _delta_height - DELTA_HEIGHT;
       update_software_endstops(Z_AXIS);
     }
 
     void lcd_delta_settings() {
       START_MENU();
       MENU_BACK(MSG_DELTA_CALIBRATE);
-      float Tz = 0.00;
       MENU_ITEM_EDIT(float52, MSG_DELTA_DIAG_ROG, &delta_diagonal_rod, DELTA_DIAGONAL_ROD - 5.0, DELTA_DIAGONAL_ROD + 5.0);
-      _delta_height = DELTA_HEIGHT + home_offset[Z_AXIS];
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float52, MSG_DELTA_HEIGHT, &_delta_height, _delta_height - 10.0, _delta_height + 10.0, _lcd_set_delta_height);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float52, MSG_DELTA_HEIGHT, &delta_height, delta_height - 10.0, delta_height + 10.0, _lcd_set_delta_height);
       MENU_ITEM_EDIT(float43, "Ex", &delta_endstop_adj[A_AXIS], -5.0, 5.0);
       MENU_ITEM_EDIT(float43, "Ey", &delta_endstop_adj[B_AXIS], -5.0, 5.0);
       MENU_ITEM_EDIT(float43, "Ez", &delta_endstop_adj[C_AXIS], -5.0, 5.0);


### PR DESCRIPTION
#8344 packaged for 1.1.x.

@thinkyhead One thing I noticed while packing this up is that in `update_software_endstops`, it appeared that `soft_endstop_min` and `soft_endstop_max` were not getting updated for the non-`DUAL_X_CARRIAGE` machines. I went ahead and added that case back in, but can you confirm if it was in-fact missing?