### PR TITLE
2.0.x - LPC1768 - update file to new pin numbering system

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/HAL_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_spi.cpp
@@ -205,18 +205,18 @@
     PinCfg.Funcnum = 2;
     PinCfg.OpenDrain = 0;
     PinCfg.Pinmode = 0;
-    PinCfg.Pinnum = pin_map[SCK_PIN].pin;
-    PinCfg.Portnum = pin_map[SCK_PIN].port;
+  PinCfg.Pinnum = LPC1768_PIN_PIN(SCK_PIN);
+PinCfg.Portnum = LPC1768_PIN_PORT(SCK_PIN);
     PINSEL_ConfigPin(&PinCfg);
     SET_OUTPUT(SCK_PIN);
 
-    PinCfg.Pinnum = pin_map[MISO_PIN].pin;
-    PinCfg.Portnum = pin_map[MISO_PIN].port;
+PinCfg.Pinnum = LPC1768_PIN_PIN(MISO_PIN);
+PinCfg.Portnum = LPC1768_PIN_PORT(MISO_PIN);
     PINSEL_ConfigPin(&PinCfg);
     SET_INPUT(MISO_PIN);
 
-    PinCfg.Pinnum = pin_map[MOSI_PIN].pin;
-    PinCfg.Portnum = pin_map[MOSI_PIN].port;
+    PinCfg.Pinnum = LPC1768_PIN_PIN(MOSI_PIN);
+    PinCfg.Portnum = LPC1768_PIN_PORT(MOSI_PIN);
     PINSEL_ConfigPin(&PinCfg);
     SET_OUTPUT(MOSI_PIN);
   }


### PR DESCRIPTION
We missed a file when converting to the new pin numbering system.