### PR TITLE
[2.0] Fix up REPRAPWORLD_KEYPAD defines

### DIFF
--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -158,20 +158,19 @@
 
     #define REPRAPWORLD_KEYPAD_MOVE_Z_DOWN  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F3)
     #define REPRAPWORLD_KEYPAD_MOVE_Z_UP    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F2)
-    #define REPRAPWORLD_KEYPAD_MOVE_MENU    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1)
     #define REPRAPWORLD_KEYPAD_MOVE_Y_DOWN  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_DOWN)
     #define REPRAPWORLD_KEYPAD_MOVE_X_RIGHT (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_RIGHT)
-    #define REPRAPWORLD_KEYPAD_MOVE_HOME    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE)
     #define REPRAPWORLD_KEYPAD_MOVE_Y_UP    (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_UP)
     #define REPRAPWORLD_KEYPAD_MOVE_X_LEFT  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_LEFT)
 
     #if ENABLED(ADC_KEYPAD)
-      #define REPRAPWORLD_KEYPAD_MOVE_HOME  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_F1)
-      #define KEYPAD_EN_C                   EN_REPRAPWORLD_KEYPAD_MIDDLE
+      #define KEYPAD_HOME EN_REPRAPWORLD_KEYPAD_F1
+      #define KEYPAD_EN_C EN_REPRAPWORLD_KEYPAD_MIDDLE
     #else
-      #define REPRAPWORLD_KEYPAD_MOVE_HOME  (buttons_reprapworld_keypad & EN_REPRAPWORLD_KEYPAD_MIDDLE)
-      #define KEYPAD_EN_C                   EN_REPRAPWORLD_KEYPAD_F1
+      #define KEYPAD_HOME EN_REPRAPWORLD_KEYPAD_MIDDLE
+      #define KEYPAD_EN_C EN_REPRAPWORLD_KEYPAD_F1
     #endif
+    #define REPRAPWORLD_KEYPAD_MOVE_HOME    (buttons_reprapworld_keypad & KEYPAD_HOME)
     #define REPRAPWORLD_KEYPAD_MOVE_MENU    (buttons_reprapworld_keypad & KEYPAD_EN_C)
 
     #if BUTTON_EXISTS(ENC)


### PR DESCRIPTION
Based on #8411

Fix compile warnings for `REPRAPWORLD_KEYPAD_...`