### PR TITLE
[1.1.x] Fix PlatformIO dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,8 @@ tags
 
 # PlatformIO files/dirs
 .pio*
+.pioenvs
+.piolibdeps
 lib/readme.txt
 
 #Visual Studio
@@ -131,6 +133,7 @@ Marlin/.vs/
 
 #VScode
 .vscode
+.vscode/c_cpp_properties.json
 
 #cmake
 CMakeLists.txt

--- a/Marlin/MarlinSPI.h
+++ b/Marlin/MarlinSPI.h
@@ -20,8 +20,8 @@
  *
  */
 
-#ifndef __SPI_H__
-#define __SPI_H__
+#ifndef __MARLIN_SPI_H__
+#define __MARLIN_SPI_H__
 
 #include <stdint.h>
 #include "softspi.h"
@@ -54,4 +54,4 @@ class SPI<MISO_PIN, MOSI_PIN, SCK_PIN> {
 
 };
 
-#endif // __SPI_H__
+#endif // __MARLIN_SPI_H__

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10325,25 +10325,30 @@ inline void gcode_M502() {
     SERIAL_ECHOLNPGM(" prewarn flag cleared");
   }
 
-  static void tmc2130_get_pwmthrs(TMC2130Stepper &st, const char name, const uint16_t spmm) {
-    SERIAL_CHAR(name);
-    SERIAL_ECHOPGM(" stealthChop max speed set to ");
-    SERIAL_ECHOLN(12650000UL * st.microsteps() / (256 * st.stealth_max_speed() * spmm));
-  }
-  static void tmc2130_set_pwmthrs(TMC2130Stepper &st, const char name, const int32_t thrs, const uint32_t spmm) {
-    st.stealth_max_speed(12650000UL * st.microsteps() / (256 * thrs * spmm));
-    tmc2130_get_pwmthrs(st, name, spmm);
-  }
+  #if ENABLED(HYBRID_THRESHOLD)
+    static void tmc2130_get_pwmthrs(TMC2130Stepper &st, const char name, const uint16_t spmm) {
+      SERIAL_CHAR(name);
+      SERIAL_ECHOPGM(" stealthChop max speed set to ");
+      SERIAL_ECHOLN(12650000UL * st.microsteps() / (256 * st.stealth_max_speed() * spmm));
+    }
 
-  static void tmc2130_get_sgt(TMC2130Stepper &st, const char name) {
-    SERIAL_CHAR(name);
-    SERIAL_ECHOPGM(" driver homing sensitivity set to ");
-    SERIAL_ECHOLN(st.sgt());
-  }
-  static void tmc2130_set_sgt(TMC2130Stepper &st, const char name, const int8_t sgt_val) {
-    st.sgt(sgt_val);
-    tmc2130_get_sgt(st, name);
-  }
+    static void tmc2130_set_pwmthrs(TMC2130Stepper &st, const char name, const int32_t thrs, const uint32_t spmm) {
+      st.stealth_max_speed(12650000UL * st.microsteps() / (256 * thrs * spmm));
+      tmc2130_get_pwmthrs(st, name, spmm);
+    }
+  #endif
+
+  #if ENABLED(SENSORLESS_HOMING)
+    static void tmc2130_get_sgt(TMC2130Stepper &st, const char name) {
+      SERIAL_CHAR(name);
+      SERIAL_ECHOPGM(" driver homing sensitivity set to ");
+      SERIAL_ECHOLN(st.sgt());
+    }
+    static void tmc2130_set_sgt(TMC2130Stepper &st, const char name, const int8_t sgt_val) {
+      st.sgt(sgt_val);
+      tmc2130_get_sgt(st, name);
+    }
+  #endif
 
   /**
    * M906: Set motor current in milliamps using axis codes X, Y, Z, E

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -32,7 +32,7 @@
 #include "language.h"
 
 #if ENABLED(HEATER_0_USES_MAX6675)
-  #include "spi.h"
+  #include "MarlinSPI.h"
 #endif
 
 #if ENABLED(BABYSTEPPING)

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,7 +19,12 @@ libdeps_dir = .piolibdeps
 env_default = megaatmega2560
 
 [common]
-lib_deps = U8glib@1.19.1
+lib_deps =
+  U8glib@1.19.1
+  TMC2130Stepper
+  Adafruit NeoPixel
+  https://github.com/lincomatic/LiquidTWI2.git
+  https://github.com/trinamic/TMC26XStepper.git
 
 [env:megaatmega2560]
 platform = atmelavr


### PR DESCRIPTION
The PlatformIO configuration for 1.1.x was missing most of the library dependencies, so options such as the TMC2130 drivers wouldn't compile.

Additionally, there was a strange issue where PlatformIO was trying to compile the TMC2130 library using spi.h from within the Marlin code, even though the library was including SPI.h from the Arduino framework. I'm not really sure why the case sensitivity was an issue (especially on my Mac), but the easiest solution was to rename Marlin/spi.h to Marlin/MarlinSPI.h and fix the include in temperature.cpp.

One dependency that I didn't add is Arduino-L6470 as it doesn't even appear to compile correctly in the Arduino IDE due to stepper_indirection.cpp attempting to call `L6470::init()` with a parameter even though the function does not accept a parameter. I checked the history of the library, and it doesn't appear that the function ever accepted a parameter. I'm not sure how that ever worked.