### PR TITLE
[1.1] gitignore visual studio update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,10 +124,11 @@ lib/readme.txt
 *.sln
 *.vcxproj
 *.vcxproj.filters
-Marlin/Release/
-Marlin/Debug/
-Marlin/__vm/
-Marlin/.vs/
+Release/
+Debug/
+__vm/
+.vs/
+vc-fileutils.settings
 
 #VScode
 .vscode


### PR DESCRIPTION
aligned with marlin 2.0 gitgnore to support visual studio  community edition