### PR TITLE
[1.1.x] M43 end pin correction/compatibility

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6695,7 +6695,7 @@ inline void gcode_M42() {
     const bool I_flag = parser.boolval('I');
     const int repeat = parser.intval('R', 1),
               start = parser.intval('S'),
-              end = parser.intval('E', NUM_DIGITAL_PINS - 1),
+              end = parser.intval('L', NUM_DIGITAL_PINS - 1),
               wait = parser.intval('W', 500);
 
     for (uint8_t pin = start; pin <= end; pin++) {


### PR DESCRIPTION
Change M43 so that the end pin uses the "L" argument for the toggle command.  This makes it consistent with the description in the code and makes it compatible with Repetier Host. 

Currently the code uses "E" as the end pin argument for the toggle command. Repetier Host does not recognize that format.  Entering M43 T Exx Syy into Repetier Host results in M43 T0 S1 being sent to Marlin.
