### PR TITLE
Let users disable autocooldown when manually stopping an sdcard printjob

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -478,6 +478,8 @@
   #define SD_FINISHED_STEPPERRELEASE true  //if sd support and the file is finished: disable steppers?
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
 
+  #define SDCARD_COOLDOWN_ON_STOP   //automatically turn off heaters when users manually stop a print job
+  
   #define SDCARD_RATHERRECENTFIRST  //reverse file order of sd card menu display. Its sorted practically after the file system block order.
   // if a file is deleted, it frees a block. hence, the order is not purely chronological. To still have auto0.g accessible, there is again the option to do that.
   // using:

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -774,7 +774,11 @@ void kill_screen(const char* lcd_msg) {
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();
+	  
+#ifdef SDCARD_COOLDOWN_ON_STOP
       thermalManager.disable_all_heaters();
+#endif
+
       #if FAN_COUNT > 0
         for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
       #endif


### PR DESCRIPTION
Added a new option in configuration_adv.h (enabled by default), SDCARD_COOLDOWN_ON_STOP, which controls whether Marlin automatically cools down the printer when the user selects 'stop print' from the LCD menu.

Addresses issue #8223