### PR TITLE
[1.1.x]  tool change bad behaviours

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11122,21 +11122,21 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
         // Move to the "old position" (move the extruder into place)
         if (!no_move && IsRunning()) {
+          #if ENABLED(SWITCHING_NOZZLE)
+            if (z_raise != z_diff)
+              destination[Z_AXIS] += z_diff;  // Include the Z restore with the "move back"
+          #endif
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
           #endif
-          prepare_move_to_destination();
+          // Move back to the original (or tweaked) position
+          do_blocking_move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]);
         }
-
         #if ENABLED(SWITCHING_NOZZLE)
           // Move back down, if needed. (Including when the new tool is higher.)
-          if (z_raise != z_diff) {
-            destination[Z_AXIS] += z_diff;
-            feedrate_mm_s = planner.max_feedrate_mm_s[Z_AXIS];
-            prepare_move_to_destination();
-          }
+          else if (z_raise != z_diff)
+            do_blocking_move_to_z(destination[Z_AXIS] + z_diff, planner.max_feedrate_mm_s[Z_AXIS]);
         #endif
-
       } // (tmp_extruder != active_extruder)
 
       stepper.synchronize();
@@ -13285,23 +13285,23 @@ void prepare_move_to_destination() {
         case TIMER0B:                           //_SET_CS(0, val);
                                                   break;
       #endif
-      #ifdef TCCR1A 
+      #ifdef TCCR1A
         case TIMER1A: case TIMER1B:             //_SET_CS(1, val);
                                                   break;
       #endif
-      #ifdef TCCR2 
+      #ifdef TCCR2
         case TIMER2: case TIMER2:                 _SET_CS(2, val); break;
       #endif
-      #ifdef TCCR2A 
+      #ifdef TCCR2A
         case TIMER2A: case TIMER2B:               _SET_CS(2, val); break;
       #endif
-      #ifdef TCCR3A 
+      #ifdef TCCR3A
         case TIMER3A: case TIMER3B: case TIMER3C: _SET_CS(3, val); break;
       #endif
-      #ifdef TCCR4A 
+      #ifdef TCCR4A
         case TIMER4A: case TIMER4B: case TIMER4C: _SET_CS(4, val); break;
       #endif
-      #ifdef TCCR5A 
+      #ifdef TCCR5A
         case TIMER5A: case TIMER5B: case TIMER5C: _SET_CS(5, val); break;
       #endif
     }


### PR DESCRIPTION
This PR will address two issues reported in #8492. Just one is left because I don't know if it is an issue or not

1) when no home is done ("no_move" is set) tool change should never move X & Y because... I don't know where I am...only Z should be adjusted to avoid bed collision if other nozzle is lower than current.
2) Since no move no bed level matrix should be applied
    When SWITCHING_NOZZLE is enabled and system is homed there are two movements to go to destination, but first can move Z to older position and then crash on the bed