### PR TITLE
[2.0.x] Fix Temperature::setPwmFrequency() prototype to match source

### DIFF
--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -547,7 +547,7 @@ class Temperature {
   private:
 
     #if ENABLED(FAST_PWM_FAN)
-      static void setPwmFrequency(const uint8_t pin, int val);
+      static void setPwmFrequency(const pin_t pin, int val);
     #endif
 
     static void set_current_temp_raw();


### PR DESCRIPTION
Introduced with #8446
Resolves compile failure when FAST_PWM_FAN enabled:

```
Marlin/src/module/temperature.cpp:1274:8: error: prototype for 'void Temperature::setPwmFrequency(pin_t, int)' does not match any in class 'Temperature'
void Temperature::setPwmFrequency(const pin_t pin, int val) {
^
In file included from Marlin/src/module/temperature.cpp:27:0:
Marlin/src/module/temperature.h:550:19: error: candidate is: static void Temperature::setPwmFrequency(uint8_t, int)
static void setPwmFrequency(const uint8_t pin, int val);
^
*** [.pioenvs/teensy20/src/src/module/temperature.o] Error 1
========================== [ERROR] Took 6.06 seconds ==========================
```