### PR TITLE
[2.0.x] G33 raw_delta_height

### DIFF
--- a/Marlin/src/gcode/calibrate/M665.cpp
+++ b/Marlin/src/gcode/calibrate/M665.cpp
@@ -30,7 +30,6 @@
 #if ENABLED(DELTA)
 
   #include "../../module/delta.h"
-
   /**
    * M665: Set delta configurations
    *
@@ -44,10 +43,7 @@
    *    Z = Rotate A and B by this angle
    */
   void GcodeSuite::M665() {
-    if (parser.seen('H')) {
-      delta_height = parser.value_linear_units();
-      update_software_endstops(Z_AXIS);
-    }
+    if (parser.seen('H')) delta_height                   = parser.value_linear_units();
     if (parser.seen('L')) delta_diagonal_rod             = parser.value_linear_units();
     if (parser.seen('R')) delta_radius                   = parser.value_linear_units();
     if (parser.seen('S')) delta_segments_per_second      = parser.value_float();

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -36,13 +36,13 @@
  *
  */
 
-#define EEPROM_VERSION "V45"
+#define EEPROM_VERSION "V46"
 
 // Change EEPROM version if these are changed:
 #define EEPROM_OFFSET 100
 
 /**
- * V44 EEPROM Layout:
+ * V46 EEPROM Layout:
  *
  *  100  Version                                    (char x4)
  *  104  EEPROM CRC16                               (uint16_t)
@@ -93,81 +93,82 @@
  *
  * DELTA:                                           44 bytes
  *  352  M666 H    delta_height                     (float)
- *  364  M666 XYZ  delta_endstop_adj                (float x3)
- *  368  M665 R    delta_radius                     (float)
- *  372  M665 L    delta_diagonal_rod               (float)
- *  376  M665 S    delta_segments_per_second        (float)
- *  380  M665 B    delta_calibration_radius         (float)
- *  384  M665 X    delta_tower_angle_trim[A]        (float)
- *  388  M665 Y    delta_tower_angle_trim[B]        (float)
- *  392  M665 Z    delta_tower_angle_trim[C]        (float)
+ *  356            raw_delta_height                 (float)
+ *  360  M666 XYZ  delta_endstop_adj                (float x3)
+ *  372  M665 R    delta_radius                     (float)
+ *  376  M665 L    delta_diagonal_rod               (float)
+ *  380  M665 S    delta_segments_per_second        (float)
+ *  384  M665 B    delta_calibration_radius         (float)
+ *  388  M665 X    delta_tower_angle_trim[A]        (float)
+ *  392  M665 Y    delta_tower_angle_trim[B]        (float)
+ *  396  M665 Z    delta_tower_angle_trim[C]        (float)
  *
  * [XYZ]_DUAL_ENDSTOPS:                             12 bytes
- *  352  M666 X    endstops.x_endstop_adj           (float)
- *  356  M666 Y    endstops.y_endstop_adj           (float)
- *  360  M666 Z    endstops.z_endstop_adj           (float)
+ *  352  M666 X    x_endstop_adj                    (float)
+ *  356  M666 Y    y_endstop_adj                    (float)
+ *  360  M666 Z    z_endstop_adj                    (float)
  *
  * ULTIPANEL:                                       6 bytes
- *  396  M145 S0 H lcd_preheat_hotend_temp          (int x2)
- *  400  M145 S0 B lcd_preheat_bed_temp             (int x2)
- *  404  M145 S0 F lcd_preheat_fan_speed            (int x2)
+ *  400  M145 S0 H lcd_preheat_hotend_temp          (int x2)
+ *  404  M145 S0 B lcd_preheat_bed_temp             (int x2)
+ *  408  M145 S0 F lcd_preheat_fan_speed            (int x2)
  *
  * PIDTEMP:                                         82 bytes
- *  408  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]   (float x4)
- *  428  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]   (float x4)
- *  440  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]   (float x4)
- *  456  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
- *  472  M301 E4 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
- *  488  M301 L        lpq_len                      (int)
+ *  412  M301 E0 PIDC  Kp[0], Ki[0], Kd[0], Kc[0]   (float x4)
+ *  432  M301 E1 PIDC  Kp[1], Ki[1], Kd[1], Kc[1]   (float x4)
+ *  444  M301 E2 PIDC  Kp[2], Ki[2], Kd[2], Kc[2]   (float x4)
+ *  460  M301 E3 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
+ *  476  M301 E4 PIDC  Kp[3], Ki[3], Kd[3], Kc[3]   (float x4)
+ *  492  M301 L        lpq_len                      (int)
  *
  * PIDTEMPBED:                                      12 bytes
- *  490  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
+ *  494  M304 PID  thermalManager.bedKp, .bedKi, .bedKd (float x3)
  *
  * DOGLCD:                                          2 bytes
- *  502  M250 C    lcd_contrast                     (uint16_t)
+ *  506  M250 C    lcd_contrast                     (uint16_t)
  *
  * FWRETRACT:                                       33 bytes
- *  504  M209 S    autoretract_enabled              (bool)
- *  505  M207 S    retract_length                   (float)
- *  509  M207 F    retract_feedrate_mm_s            (float)
- *  513  M207 Z    retract_zlift                    (float)
- *  517  M208 S    retract_recover_length           (float)
- *  521  M208 F    retract_recover_feedrate_mm_s    (float)
- *  525  M207 W    swap_retract_length              (float)
- *  529  M208 W    swap_retract_recover_length      (float)
- *  533  M208 R    swap_retract_recover_feedrate_mm_s (float)
+ *  508  M209 S    autoretract_enabled              (bool)
+ *  509  M207 S    retract_length                   (float)
+ *  513  M207 F    retract_feedrate_mm_s            (float)
+ *  517  M207 Z    retract_zlift                    (float)
+ *  521  M208 S    retract_recover_length           (float)
+ *  525  M208 F    retract_recover_feedrate_mm_s    (float)
+ *  529  M207 W    swap_retract_length              (float)
+ *  533  M208 W    swap_retract_recover_length      (float)
+ *  537  M208 R    swap_retract_recover_feedrate_mm_s (float)
  *
  * Volumetric Extrusion:                            21 bytes
- *  537  M200 D    parser.volumetric_enabled        (bool)
- *  538  M200 T D  planner.filament_size            (float x5) (T0..3)
+ *  541  M200 D    parser.volumetric_enabled        (bool)
+ *  542  M200 T D  planner.filament_size            (float x5) (T0..3)
  *
  * HAVE_TMC2130:                                    22 bytes
- *  558  M906 X    Stepper X current                (uint16_t)
- *  560  M906 Y    Stepper Y current                (uint16_t)
- *  562  M906 Z    Stepper Z current                (uint16_t)
- *  564  M906 X2   Stepper X2 current               (uint16_t)
- *  566  M906 Y2   Stepper Y2 current               (uint16_t)
- *  568  M906 Z2   Stepper Z2 current               (uint16_t)
- *  570  M906 E0   Stepper E0 current               (uint16_t)
- *  572  M906 E1   Stepper E1 current               (uint16_t)
- *  574  M906 E2   Stepper E2 current               (uint16_t)
- *  576  M906 E3   Stepper E3 current               (uint16_t)
- *  578  M906 E4   Stepper E4 current               (uint16_t)
+ *  562  M906 X    Stepper X current                (uint16_t)
+ *  564  M906 Y    Stepper Y current                (uint16_t)
+ *  566  M906 Z    Stepper Z current                (uint16_t)
+ *  568  M906 X2   Stepper X2 current               (uint16_t)
+ *  570  M906 Y2   Stepper Y2 current               (uint16_t)
+ *  572  M906 Z2   Stepper Z2 current               (uint16_t)
+ *  574  M906 E0   Stepper E0 current               (uint16_t)
+ *  576  M906 E1   Stepper E1 current               (uint16_t)
+ *  578  M906 E2   Stepper E2 current               (uint16_t)
+ *  580  M906 E3   Stepper E3 current               (uint16_t)
+ *  582  M906 E4   Stepper E4 current               (uint16_t)
  *
  * LIN_ADVANCE:                                     8 bytes
- *  580  M900 K    extruder_advance_k               (float)
- *  584  M900 WHD  advance_ed_ratio                 (float)
+ *  584  M900 K    extruder_advance_k               (float)
+ *  588  M900 WHD  advance_ed_ratio                 (float)
  *
  * HAS_MOTOR_CURRENT_PWM:
- *  588  M907 X    Stepper XY current               (uint32_t)
- *  592  M907 Z    Stepper Z current                (uint32_t)
- *  596  M907 E    Stepper E current                (uint32_t)
+ *  592  M907 X    Stepper XY current               (uint32_t)
+ *  596  M907 Z    Stepper Z current                (uint32_t)
+ *  600  M907 E    Stepper E current                (uint32_t)
  *
  * CNC_COORDINATE_SYSTEMS                           108 bytes
- *  600  G54-G59.3 coordinate_system                (float x 27)
+ *  604  G54-G59.3 coordinate_system                (float x 27)
  *
  *  708                                Minimum end-point
- * 2025 (704 + 36 + 9 + 288 + 988)     Maximum end-point
+ * 2029 (708 + 36 + 9 + 288 + 988)     Maximum end-point
  *
  * ========================================================================
  * meshes_begin (between max and min end-point, directly above)
@@ -422,9 +423,13 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(storage_slot);
     #endif // AUTO_BED_LEVELING_UBL
 
-    // 10 floats for DELTA / [XYZ]_DUAL_ENDSTOPS
+    // 11 floats for DELTA / [XYZ]_DUAL_ENDSTOPS
     #if ENABLED(DELTA)
       EEPROM_WRITE(delta_height);              // 1 float
+      #if DISABLED(DELTA_AUTO_CALIBRATION)
+        float raw_delta_height = NAN;
+      #endif
+      EEPROM_WRITE(raw_delta_height);          // 1 float
       EEPROM_WRITE(delta_endstop_adj);         // 3 floats
       EEPROM_WRITE(delta_radius);              // 1 float
       EEPROM_WRITE(delta_diagonal_rod);        // 1 float
@@ -453,11 +458,11 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(dummy);
       #endif
 
-      for (uint8_t q = 7; q--;) EEPROM_WRITE(dummy);
+      for (uint8_t q = 8; q--;) EEPROM_WRITE(dummy);
 
     #else
       dummy = 0.0f;
-      for (uint8_t q = 10; q--;) EEPROM_WRITE(dummy);
+      for (uint8_t q = 11; q--;) EEPROM_WRITE(dummy);
     #endif
 
     #if DISABLED(ULTIPANEL)
@@ -851,6 +856,10 @@ void MarlinSettings::postprocess() {
 
       #if ENABLED(DELTA)
         EEPROM_READ(delta_height);              // 1 float
+        #if DISABLED(DELTA_AUTO_CALIBRATION)
+          float raw_delta_height;
+        #endif
+        EEPROM_READ(raw_delta_height);          // 1 float
         EEPROM_READ(delta_endstop_adj);         // 3 floats
         EEPROM_READ(delta_radius);              // 1 float
         EEPROM_READ(delta_diagonal_rod);        // 1 float
@@ -876,11 +885,11 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(dummy);
         #endif
 
-        for (uint8_t q=7; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=8; q--;) EEPROM_READ(dummy);
 
       #else
 
-        for (uint8_t q=10; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=11; q--;) EEPROM_READ(dummy);
 
       #endif
 
@@ -1318,6 +1327,9 @@ void MarlinSettings::reset() {
     const float adj[ABC] = DELTA_ENDSTOP_ADJ,
                 dta[ABC] = DELTA_TOWER_ANGLE_TRIM;
     delta_height = DELTA_HEIGHT;
+    #if ENABLED(DELTA_AUTO_CALIBRATION)
+      raw_delta_height = NAN;
+    #endif
     COPY(delta_endstop_adj, adj);
     delta_radius = DELTA_RADIUS;
     delta_diagonal_rod = DELTA_DIAGONAL_ROD;

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -37,6 +37,10 @@
 #include "../lcd/ultralcd.h"
 #include "../Marlin.h"
 
+// Initialized by G33
+#if ENABLED(DELTA_AUTO_CALIBRATION)
+  float raw_delta_height;
+#endif
 // Initialized by settings.load()
 float delta_height,
       delta_endstop_adj[ABC] = { 0 },

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -27,6 +27,9 @@
 #ifndef __DELTA_H__
 #define __DELTA_H__
 
+#if ENABLED(DELTA_AUTO_CALIBRATION)
+  extern float raw_delta_height;
+#endif
 extern float delta_height,
              delta_endstop_adj[ABC],
              delta_radius,


### PR DESCRIPTION
Replaces #8489

The probe_pt routine is rewritten with an optional bool parameter that does probing according to what bedlevelling is expecting or to what delta calibration is expecting.

G33 expects to probe with the nozzle at X, Y; so no X,Y probe offsets are to be applied and the is_reachable testing only needs to be done at the nozzle; G33 wants to have returned the raw z_height measured from the home position, so calibration can be done independently to whatever zprobe_zoffset was set. The calibration integrity will as such not be disturbed by M851.

G33 calibrates the printer independently of any X,Y or Z probe offsets and calibrates a raw_delta_height (the height difference between the triggered home position and the triggered z_probe position) which is saved, stored, initialized alongside the real delta_height.

At exit of G33 the real delta_height is normalized as such that the Z=0 reported by G30 (measured from the probe trigger point) is the same as the Z=0 used by G1 (measured from the home trigger point).

So no more smartness to overcome the shortcomings of routines that only have Cartesian printers in mind. The probe_pt function has now two functional modes Cartesian G29 and Delta G33 set by the bedlevelprobe parameter (default = true)

If for one reason or another (and it beats me why) one would like G30 to report a different height as used by G1, DO NOT CALIBRATE your printer with G33 auto-calibrate, but use M851 and M665 instead.

And if this is still disturbing to people who do not want to calibrate the delta_hight
 that an auto-calibration routine calibrates things, add if parser.boolval('S') return at the beginning of the G33 code. 🤣 so they can run G33 with the optional (S)ilent or S(tupid) parameter.