### PR TITLE
[2.0.x] Add support for Ultratronics Pro v1.0 and fix compiling for Due HAL

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
@@ -34,18 +34,22 @@
 #include "../../Marlin.h"
 
 // Based on selected port, use the proper configuration
-#if SERIAL_PORT == 0
+#if SERIAL_PORT == -1
   #define HWUART UART
   #define HWUART_IRQ UART_IRQn
   #define HWUART_IRQ_ID ID_UART
-#elif SERIAL_PORT == 1
+#elif SERIAL_PORT == 0
   #define HWUART USART0
   #define HWUART_IRQ USART0_IRQn
   #define HWUART_IRQ_ID ID_USART0
-#elif SERIAL_PORT == 2
+#elif SERIAL_PORT == 1
   #define HWUART USART1
   #define HWUART_IRQ USART1_IRQn
   #define HWUART_IRQ_ID ID_USART1
+#elif SERIAL_PORT == 2
+  #define HWUART USART2
+  #define HWUART_IRQ USART2_IRQn
+  #define HWUART_IRQ_ID ID_USART2
 #elif SERIAL_PORT == 3
   #define HWUART USART3
   #define HWUART_IRQ USART3_IRQn

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -175,6 +175,7 @@
 #define BOARD_RAMPS4DUE_EEF    1546   // RAMPS4DUE (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS4DUE_SF     1548   // RAMPS4DUE (Power outputs: Spindle, Controller Fan)
 #define BOARD_RURAMPS4D        1550   // RuRAMPS4Duo v1 (Power outputs: Hotend0, Hotend2, Hotend2, Fan0, Fan1, Bed)
+#define BOARD_ULTRATRONICS_PRO 1560   // ReprapWorld Ultratronics Pro V1.0
 #define BOARD_ARCHIM2          1590   // UltiMachine Archim2 (with TMC2130 drivers)
 #define BOARD_ALLIGATOR        1602   // Alligator Board R2
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -64,7 +64,7 @@
  * G32  - Undock sled (Z_PROBE_SLED only)
  * G33  - Delta Auto-Calibration (Requires DELTA_AUTO_CALIBRATION)
  * G38  - Probe in any direction using the Z_MIN_PROBE (Requires G38_PROBE_TARGET)
- * G42  - Coordinated move to a mesh point (Requires HAS_MESH)
+ * G42  - Coordinated move to a mesh point (Requires MESH_BED_LEVELING, AUTO_BED_LEVELING_BLINEAR, or AUTO_BED_LEVELING_UBL)
  * G90  - Use Absolute Coordinates
  * G91  - Use Relative Coordinates
  * G92  - Set current position to coordinates given

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -164,8 +164,11 @@
 
 // LCD selection
 #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+  #ifdef CPU_32_BIT // SPI too fast with 32bit?
+    U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
+  #else
     U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_RS); // 2 stripes, HW SPI
-    //U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
+  #endif
 #elif ENABLED(U8GLIB_ST7920)
   // RepRap Discount Full Graphics Smart Controller
     //U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_RS); // 2 stripes, HW SPI

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -304,6 +304,8 @@
   #include "pins_RAMPS4DUE.h"
 #elif MB(RAMPS4DUE_SF)
   #include "pins_RAMPS4DUE.h"
+#elif MB(ULTRATRONICS_PRO)
+  #include "pins_ULTRATRONICS_PRO.h"
 #elif MB(ARCHIM2)
   #include "pins_ARCHIM2.h"
 #elif MB(ALLIGATOR)

--- a/Marlin/src/pins/pins_RAMBO.h
+++ b/Marlin/src/pins/pins_RAMBO.h
@@ -55,13 +55,6 @@
 #define SERVO3_PIN          5 // PWM header pin 5
 
 //
-// Z Probe (when not Z_MIN_PIN)
-//
-#ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN  30
-#endif
-
-//
 // Limit Switches
 //
 #define X_MIN_PIN          12
@@ -70,6 +63,13 @@
 #define Y_MAX_PIN          23
 #define Z_MIN_PIN          10
 #define Z_MAX_PIN          30
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  30
+#endif
 
 //
 // Steppers

--- a/Marlin/src/pins/pins_ULTRATRONICS_PRO.h
+++ b/Marlin/src/pins/pins_ULTRATRONICS_PRO.h
@@ -1,0 +1,151 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * ReprapWorld ULTRATRONICS v1.0
+ */
+
+#define KNOWN_BOARD
+#define BOARD_NAME "Ultratronics v1.0"
+
+#ifndef ARDUINO_ARCH_SAM
+  #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
+#endif
+
+//
+// Servos
+//
+#if NUM_SERVOS > 0
+  #define SERVO0_PIN     11
+  #if NUM_SERVOS > 1
+    #define SERVO1_PIN   12
+  #endif
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN        31
+#define X_MAX_PIN        30
+#define Y_MIN_PIN        12
+#define Y_MAX_PIN        11
+#define Z_MIN_PIN        29
+#define Z_MAX_PIN        28
+
+//
+// Steppers
+//
+#define X_STEP_PIN       35
+#define X_DIR_PIN        34
+#define X_ENABLE_PIN     37
+
+#define Y_STEP_PIN       22
+#define Y_DIR_PIN        23
+#define Y_ENABLE_PIN     33
+
+#define Z_STEP_PIN       25
+#define Z_DIR_PIN        26
+#define Z_ENABLE_PIN     24
+
+#define E0_STEP_PIN      47
+#define E0_DIR_PIN       46
+#define E0_ENABLE_PIN    48
+
+#define E1_STEP_PIN      44
+#define E1_DIR_PIN       36
+#define E1_ENABLE_PIN    45
+
+#define E2_STEP_PIN      42
+#define E2_DIR_PIN       41
+#define E2_ENABLE_PIN    43
+
+#define E3_STEP_PIN      39
+#define E3_DIR_PIN       38
+#define E3_ENABLE_PIN    40
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN        0  // Analog Input
+#define TEMP_1_PIN        2  // Analog Input
+#define TEMP_2_PIN        3  // Analog Input
+#define TEMP_3_PIN        4  // Analog Input
+#define TEMP_BED_PIN      1  // Analog Input
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN      3
+#define HEATER_1_PIN      8
+#define HEATER_2_PIN      7
+#define HEATER_3_PIN      9
+#define HEATER_BED_PIN    2
+
+#define FAN_PIN           6
+#define FAN2_PIN          5
+
+//
+// Misc. Functions
+//
+#define SDSS             59
+#define SD_DETECT_PIN    60
+#define LED_PIN          13
+#define PS_ON_PIN        32
+
+//
+// SPI Buses
+//
+
+#define DAC0_SYNC        53 // PB14
+#define SPI_CHAN_DAC      1
+
+#define SPI_CHAN_EEPROM1 -1
+#define SPI_EEPROM1_CS   -1
+#define SPI_EEPROM2_CS   -1
+#define SPI_FLASH_CS     -1
+
+// SPI for Max6675 or Max31855 Thermocouple
+#define MAX6675_SS       65
+#define MAX31855_SS0     65
+#define MAX31855_SS1     52
+#define MAX31855_SS2     50
+#define MAX31855_SS3     51
+
+#define ENC424_SS        61
+
+//
+// LCD / Controller
+//
+
+#define BEEPER_PIN       27
+
+#if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+
+  #define LCD_PINS_RS     A8    // CS chip select / SS chip slave select
+  #define LCD_PINS_ENABLE MOSI  // SID (MOSI)
+  #define LCD_PINS_D4     SCK   // SCK (CLK) clock
+
+  #define BTN_EN1         20
+  #define BTN_EN2         21
+  #define BTN_ENC         64
+
+#endif // REPRAPWORLD_GRAPHICAL_LCD


### PR DESCRIPTION
[Cleaner Diff](8521/files?w=1)

Added board definitions for [ReprapWorld Ultratronics Pro v1.0](https://reprapworld.com/products/electronics/ultratronics/ultratronics_pro_v1_0/) board.

Fixed compiling of the Due platforms when `SERIAL_PORT` was set to `-1` (SerialUSB). I'd actually like to have @ejtagle 's input on these changes.

ReprapWorld LCD instance command changed to software SPI as the HW set up didn't seem to work for me. Might be a timing issue in U8Glib or SPI speed set to too fast but I didn't dig much deeper on that one.