### PR TITLE
[1.1.x] Fix up LCD init / charset

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -13904,9 +13904,6 @@ void setup() {
 
   #if ENABLED(SHOW_BOOTSCREEN)
     lcd_bootscreen();
-    #if DISABLED(DOGLCD) && ENABLED(ULTRA_LCD) && DISABLED(SDSUPPORT)
-      lcd_init();
-    #endif
   #endif
 
   #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8414,7 +8414,7 @@ inline void gcode_M18_M84() {
     }
 
     #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  // Only needed with an LCD
-      ubl_lcd_map_control = defer_return_to_status = false;
+      ubl.lcd_map_control = defer_return_to_status = false;
     #endif
   }
 }
@@ -13483,7 +13483,7 @@ void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
       disable_e_steppers();
     #endif
     #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTRA_LCD)  // Only needed with an LCD
-      ubl_lcd_map_control = defer_return_to_status = false;
+      ubl.lcd_map_control = defer_return_to_status = false;
     #endif
   }
 

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -54,6 +54,10 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 
+#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTIPANEL)
+  #include "ubl.h"
+#endif
+
 #if HAS_DIGIPOTSS
   #include <SPI.h>
 #endif
@@ -61,10 +65,6 @@
 Stepper stepper; // Singleton
 
 // public:
-
-#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTIPANEL)
-  extern bool ubl_lcd_map_control;
-#endif
 
 block_t* Stepper::current_block = NULL;  // A pointer to the block currently being traced
 
@@ -1224,7 +1224,7 @@ void Stepper::finish_and_disable() {
 
 void Stepper::quick_stop() {
   #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTIPANEL)
-    if (!ubl_lcd_map_control)
+    if (!ubl.lcd_map_control)
       cleaning_buffer_counter = 5000;
   #else
     cleaning_buffer_counter = 5000;

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -73,6 +73,10 @@
   bool unified_bed_leveling::g26_debug_flag = false,
        unified_bed_leveling::has_control_of_lcd_panel = false;
 
+  #if ENABLED(ULTIPANEL)
+    bool unified_bed_leveling::lcd_map_control = false;
+  #endif
+
   volatile int unified_bed_leveling::encoder_diff;
 
   unified_bed_leveling::unified_bed_leveling() {

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -46,9 +46,9 @@
 
   // ubl.cpp
 
-void bit_clear(uint16_t bits[16], const uint8_t x, const uint8_t y);
-void bit_set(uint16_t bits[16], const uint8_t x, const uint8_t y);
-bool is_bit_set(uint16_t bits[16], const uint8_t x, const uint8_t y);
+  void bit_clear(uint16_t bits[16], const uint8_t x, const uint8_t y);
+  void bit_set(uint16_t bits[16], const uint8_t x, const uint8_t y);
+  bool is_bit_set(uint16_t bits[16], const uint8_t x, const uint8_t y);
 
   // ubl_motion.cpp
 
@@ -190,6 +190,10 @@ bool is_bit_set(uint16_t bits[16], const uint8_t x, const uint8_t y);
                               };
 
       static bool g26_debug_flag, has_control_of_lcd_panel;
+
+      #if ENABLED(ULTIPANEL)
+        static bool lcd_map_control;
+      #endif
 
       static volatile int encoder_diff; // Volatile because it's changed at interrupt time.
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1526,7 +1526,7 @@
           idle();
         } while (!ubl_lcd_clicked());
 
-        if (!ubl_lcd_map_control) lcd_return_to_status();
+        if (!lcd_map_control) lcd_return_to_status();
 
         // The technique used here generates a race condition for the encoder click.
         // It could get detected in lcd_mesh_edit (actually _lcd_mesh_fine_tune) or here.
@@ -1571,7 +1571,7 @@
       LCD_MESSAGEPGM(MSG_UBL_DONE_EDITING_MESH);
       SERIAL_ECHOLNPGM("Done Editing Mesh");
 
-      if (ubl_lcd_map_control)
+      if (lcd_map_control)
         lcd_goto_screen(_lcd_ubl_output_map_lcd);
       else
         lcd_return_to_status();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -50,7 +50,6 @@
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "ubl.h"
-  bool ubl_lcd_map_control = false;
 #elif HAS_ABL
   #include "planner.h"
 #elif ENABLED(MESH_BED_LEVELING) && ENABLED(LCD_BED_LEVELING)
@@ -514,14 +513,14 @@ uint16_t max_display_update_time = 0;
       if (screen == lcd_status_screen) {
         defer_return_to_status = false;
         #if ENABLED(AUTO_BED_LEVELING_UBL)
-          ubl_lcd_map_control = false;
+          ubl.lcd_map_control = false;
         #endif
         screen_history_depth = 0;
       }
       lcd_implementation_clear();
       // Re-initialize custom characters that may be re-used
       #if DISABLED(DOGLCD) && ENABLED(AUTO_BED_LEVELING_UBL)
-        if (!ubl_lcd_map_control) {
+        if (!ubl.lcd_map_control) {
           lcd_set_custom_characters(
             #if ENABLED(LCD_PROGRESS_BAR)
               screen == lcd_status_screen ? CHARSET_INFO : CHARSET_MENU
@@ -2358,7 +2357,7 @@ void kill_screen(const char* lcd_msg) {
 
     void _lcd_ubl_map_homing() {
       defer_return_to_status = true;
-      ubl_lcd_map_control = true; // Return to the map screen
+      ubl.lcd_map_control = true; // Return to the map screen
       if (lcdDrawUpdate) lcd_implementation_drawmenu_static(LCD_HEIGHT < 3 ? 0 : (LCD_HEIGHT > 4 ? 2 : 1), PSTR(MSG_LEVEL_BED_HOMING));
       lcdDrawUpdate = LCDVIEW_CALL_NO_REDRAW;
       if (axis_homed[X_AXIS] && axis_homed[Y_AXIS] && axis_homed[Z_AXIS])

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -521,13 +521,15 @@ uint16_t max_display_update_time = 0;
       lcd_implementation_clear();
       // Re-initialize custom characters that may be re-used
       #if DISABLED(DOGLCD) && ENABLED(AUTO_BED_LEVELING_UBL)
-        if (!ubl_lcd_map_control) lcd_set_custom_characters(
-          #if ENABLED(LCD_PROGRESS_BAR)
-            screen == lcd_status_screen
-          #endif
-        );
+        if (!ubl_lcd_map_control) {
+          lcd_set_custom_characters(
+            #if ENABLED(LCD_PROGRESS_BAR)
+              screen == lcd_status_screen ? CHARSET_INFO : CHARSET_MENU
+            #endif
+          );
+        }
       #elif ENABLED(LCD_PROGRESS_BAR)
-        lcd_set_custom_characters(screen == lcd_status_screen);
+        lcd_set_custom_characters(screen == lcd_status_screen ? CHARSET_INFO : CHARSET_MENU);
       #endif
       lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;
       screen_changed = true;
@@ -669,7 +671,7 @@ void lcd_status_screen() {
       #endif
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
         #if ENABLED(LCD_PROGRESS_BAR)
-          false
+          CHARSET_MENU
         #endif
       );
       lcd_goto_screen(lcd_main_menu);
@@ -850,7 +852,7 @@ void kill_screen(const char* lcd_msg) {
       static int8_t bar_percent = 0;
       if (lcd_clicked) {
         lcd_goto_previous_menu();
-        lcd_set_custom_characters(false);
+        lcd_set_custom_characters(CHARSET_MENU);
         return;
       }
       bar_percent += (int8_t)encoderPosition;
@@ -4469,11 +4471,7 @@ void kill_screen(const char* lcd_msg) {
 
 void lcd_init() {
 
-  lcd_implementation_init(
-    #if ENABLED(LCD_PROGRESS_BAR)
-      true
-    #endif
-  );
+  lcd_implementation_init();
 
   #if ENABLED(NEWPANEL)
     #if BUTTON_EXISTS(EN1)
@@ -4642,7 +4640,7 @@ void lcd_update() {
       lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
       lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
         #if ENABLED(LCD_PROGRESS_BAR)
-          currentScreen == lcd_status_screen
+          currentScreen == lcd_status_screen ? CHARSET_INFO : CHARSET_MENU
         #endif
       );
     }

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -193,7 +193,6 @@
 void lcd_reset_status();
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
-  extern bool ubl_lcd_map_control;
   void lcd_mesh_edit_setup(float initial);
   float lcd_mesh_edit();
   void lcd_z_offset_edit_setup(float);

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -218,11 +218,57 @@ static void createChar_P(const char c, const byte * const ptr) {
   lcd.createChar(c, temp);
 }
 
+#define CHARSET_MENU 0
+#define CHARSET_INFO 1
+#define CHARSET_BOOT 2
+
 static void lcd_set_custom_characters(
-  #if ENABLED(LCD_PROGRESS_BAR)
-    const bool info_screen_charset = true
+  #if ENABLED(LCD_PROGRESS_BAR) || ENABLED(SHOW_BOOTSCREEN)
+    const uint8_t screen_charset=CHARSET_INFO
   #endif
 ) {
+  // CHARSET_BOOT
+  #if ENABLED(SHOW_BOOTSCREEN)
+    const static PROGMEM byte corner[4][8] = { {
+      B00000,
+      B00000,
+      B00000,
+      B00000,
+      B00001,
+      B00010,
+      B00100,
+      B00100
+    }, {
+      B00000,
+      B00000,
+      B00000,
+      B11100,
+      B11100,
+      B01100,
+      B00100,
+      B00100
+    }, {
+      B00100,
+      B00010,
+      B00001,
+      B00000,
+      B00000,
+      B00000,
+      B00000,
+      B00000
+    }, {
+      B00100,
+      B01000,
+      B10000,
+      B00000,
+      B00000,
+      B00000,
+      B00000,
+      B00000
+    } };
+  #endif // SHOW_BOOTSCREEN
+
+  // CHARSET_INFO
   const static PROGMEM byte bedTemp[8] = {
     B00000,
     B11111,
@@ -290,6 +336,8 @@ static void lcd_set_custom_characters(
   };
 
   #if ENABLED(SDSUPPORT)
+
+    // CHARSET_MENU
     const static PROGMEM byte refresh[8] = {
       B00000,
       B00110,
@@ -312,6 +360,8 @@ static void lcd_set_custom_characters(
     };
 
     #if ENABLED(LCD_PROGRESS_BAR)
+
+      // CHARSET_INFO
       const static PROGMEM byte progress[3][8] = { {
         B00000,
         B10000,
@@ -340,43 +390,61 @@ static void lcd_set_custom_characters(
         B10101,
         B00000
       } };
-    #endif
-  #endif
 
-  createChar_P(LCD_BEDTEMP_CHAR, bedTemp);
-  createChar_P(LCD_DEGREE_CHAR, degree);
-  createChar_P(LCD_STR_THERMOMETER[0], thermometer);
-  createChar_P(LCD_FEEDRATE_CHAR, feedrate);
-  createChar_P(LCD_CLOCK_CHAR, clock);
+    #endif // LCD_PROGRESS_BAR
 
-  #if ENABLED(SDSUPPORT)
-    #if ENABLED(LCD_PROGRESS_BAR)
-      static bool char_mode = false;
-      if (info_screen_charset != char_mode) {
-        char_mode = info_screen_charset;
-        if (info_screen_charset) { // Progress bar characters for info screen
-          for (int16_t i = 3; i--;) createChar_P(LCD_STR_PROGRESS[i], progress[i]);
-        }
-        else { // Custom characters for submenus
-          createChar_P(LCD_UPLEVEL_CHAR, uplevel);
-          createChar_P(LCD_STR_REFRESH[0], refresh);
-          createChar_P(LCD_STR_FOLDER[0], folder);
-        }
-      }
-    #else
-      createChar_P(LCD_UPLEVEL_CHAR, uplevel);
-      createChar_P(LCD_STR_REFRESH[0], refresh);
-      createChar_P(LCD_STR_FOLDER[0], folder);
-    #endif
+  #endif // SDSUPPORT
 
+  #if ENABLED(SHOW_BOOTSCREEN) || ENABLED(LCD_PROGRESS_BAR)
+    static uint8_t char_mode = 0;
+    #define CHAR_COND (screen_charset != char_mode)
   #else
-    createChar_P(LCD_UPLEVEL_CHAR, uplevel);
+    #define CHAR_COND true
   #endif
+
+  if (CHAR_COND) {
+    #if ENABLED(SHOW_BOOTSCREEN) || ENABLED(LCD_PROGRESS_BAR)
+      char_mode = screen_charset;
+      #if ENABLED(SHOW_BOOTSCREEN)
+        // Set boot screen corner characters
+        if (screen_charset == CHARSET_BOOT) {
+          for (uint8_t i = 4; i--;)
+            createChar_P(i, corner[i]);
+        }
+        else
+      #endif
+    #endif
+        { // Info Screen uses 5 special characters
+          createChar_P(LCD_BEDTEMP_CHAR, bedTemp);
+          createChar_P(LCD_DEGREE_CHAR, degree);
+          createChar_P(LCD_STR_THERMOMETER[0], thermometer);
+          createChar_P(LCD_FEEDRATE_CHAR, feedrate);
+          createChar_P(LCD_CLOCK_CHAR, clock);
+
+          #if ENABLED(SDSUPPORT)
+            #if ENABLED(LCD_PROGRESS_BAR)
+              if (screen_charset == CHARSET_INFO) { // 3 Progress bar characters for info screen
+                for (int16_t i = 3; i--;)
+                  createChar_P(LCD_STR_PROGRESS[i], progress[i]);
+              }
+              else
+            #endif
+              { // SD Card sub-menu special characters
+                createChar_P(LCD_UPLEVEL_CHAR, uplevel);
+                createChar_P(LCD_STR_REFRESH[0], refresh);
+                createChar_P(LCD_STR_FOLDER[0], folder);
+              }
+          #else
+            // With no SD support, only need the uplevel character
+            createChar_P(LCD_UPLEVEL_CHAR, uplevel);
+          #endif
+        }
+  }
 }
 
 static void lcd_implementation_init(
   #if ENABLED(LCD_PROGRESS_BAR)
-    const bool info_screen_charset = true
+    const uint8_t screen_charset=CHARSET_INFO
   #endif
 ) {
 
@@ -406,7 +474,7 @@ static void lcd_implementation_init(
 
   lcd_set_custom_characters(
     #if ENABLED(LCD_PROGRESS_BAR)
-      info_screen_charset
+      screen_charset
     #endif
   );
 
@@ -458,46 +526,7 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
   }
 
   void lcd_bootscreen() {
-    const static PROGMEM byte corner[4][8] = { {
-      B00000,
-      B00000,
-      B00000,
-      B00000,
-      B00001,
-      B00010,
-      B00100,
-      B00100
-    }, {
-      B00000,
-      B00000,
-      B00000,
-      B11100,
-      B11100,
-      B01100,
-      B00100,
-      B00100
-    }, {
-      B00100,
-      B00010,
-      B00001,
-      B00000,
-      B00000,
-      B00000,
-      B00000,
-      B00000
-    }, {
-      B00100,
-      B01000,
-      B10000,
-      B00000,
-      B00000,
-      B00000,
-      B00000,
-      B00000
-    } };
-    for (uint8_t i = 0; i < 4; i++)
-      createChar_P(i, corner[i]);
-
+    lcd_set_custom_characters(CHARSET_BOOT);
     lcd.clear();
 
     #define LCD_EXTRA_SPACE (LCD_WIDTH-8)
@@ -568,11 +597,7 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
 
     safe_delay(100);
 
-    lcd_set_custom_characters(
-      #if ENABLED(LCD_PROGRESS_BAR)
-        false
-      #endif
-    );
+    lcd_set_custom_characters();
   }
 
 #endif // SHOW_BOOTSCREEN


### PR DESCRIPTION
Addressing #8509

No need to call `lcd_init` after boot-screen if the `lcd_bootscreen` manages resetting the custom characters.