### PR TITLE
[2.0.x] Implement NANODLP_Z_SYNC for 2.0.x

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1492,4 +1492,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1492,4 +1492,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -1493,4 +1493,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1488,4 +1488,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1494,4 +1494,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1501,4 +1501,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1485,4 +1485,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1495,4 +1495,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1513,4 +1513,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1480,4 +1480,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1492,4 +1492,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1499,4 +1499,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1492,4 +1492,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1493,4 +1493,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1493,4 +1493,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1493,4 +1493,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1493,4 +1493,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -1498,4 +1498,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1493,4 +1493,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1492,4 +1492,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1491,4 +1491,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1492,4 +1492,14 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+/**
+ * NanoDLP Synch support
+ *
+ * Add support for Synchronized Z moves when using with NanoDLP. G0/G1 axis moves will output "Z_move_comp" 
+ * string to enable synchronization with DLP projector exposure. This change will allow to use
+ * [[WaitForDoneMessage]] instead of populating your gcode with M400 commands
+ *
+ */
+ //#define NANODLP_Z_SYNC
+ 
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -145,6 +145,7 @@
 #define MSG_BUSY_PROCESSING                 "busy: processing"
 #define MSG_BUSY_PAUSED_FOR_USER            "busy: paused for user"
 #define MSG_BUSY_PAUSED_FOR_INPUT           "busy: paused for input"
+#define MSG_Z_MOVE_COMP                     "Z_move_comp"
 #define MSG_RESEND                          "Resend: "
 #define MSG_UNKNOWN_COMMAND                 "Unknown command: \""
 #define MSG_ACTIVE_EXTRUDER                 "Active Extruder: "

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -72,5 +72,13 @@ void GcodeSuite::G0_G1(
     #else
       prepare_move_to_destination();
     #endif
+
+    #if ENABLED(NANODLP_Z_SYNC)
+      // If G0/G1 command include Z-axis, wait for move and output sync text.
+      if (parser.seenval('Z')) {
+        stepper.synchronize();
+        SERIAL_ECHOLNPGM(MSG_Z_MOVE_COMP);
+      }
+    #endif
   }
 }

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -429,6 +429,10 @@
     #define NORM_E_DIR() { switch (current_block->active_extruder) { case 0: E0_DIR_WRITE(!INVERT_E0_DIR); break; case 1: E0_DIR_WRITE(INVERT_E0_DIR); break; case 2: E1_DIR_WRITE(!INVERT_E1_DIR); break; case 3: E1_DIR_WRITE(INVERT_E1_DIR); } }
     #define REV_E_DIR() { switch (current_block->active_extruder) { case 0: E0_DIR_WRITE(INVERT_E0_DIR); break; case 1: E0_DIR_WRITE(!INVERT_E0_DIR); break; case 2: E1_DIR_WRITE(INVERT_E1_DIR); break; case 3: E1_DIR_WRITE(!INVERT_E1_DIR); } }
   #endif
+#elif ENABLED(MK2_MULTIPLEXER) // Even-numbered steppers are reversed
+  #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
+  #define NORM_E_DIR() E0_DIR_WRITE(TEST(current_block->active_extruder, 0) ? !INVERT_E0_DIR: INVERT_E0_DIR)
+  #define REV_E_DIR() E0_DIR_WRITE(TEST(current_block->active_extruder, 0) ? INVERT_E0_DIR: !INVERT_E0_DIR)
 #elif EXTRUDERS > 4
   #define E_STEP_WRITE(v) { switch (current_block->active_extruder) { case 0: E0_STEP_WRITE(v); break; case 1: E1_STEP_WRITE(v); break; case 2: E2_STEP_WRITE(v); break; case 3: E3_STEP_WRITE(v); break; case 4: E4_STEP_WRITE(v); } }
   #define NORM_E_DIR() { switch (current_block->active_extruder) { case 0: E0_DIR_WRITE(!INVERT_E0_DIR); break; case 1: E1_DIR_WRITE(!INVERT_E1_DIR); break; case 2: E2_DIR_WRITE(!INVERT_E2_DIR); break; case 3: E3_DIR_WRITE(!INVERT_E3_DIR); break; case 4: E4_DIR_WRITE(!INVERT_E4_DIR); } }
@@ -472,14 +476,8 @@
   #endif
 #else
   #define E_STEP_WRITE(v) E0_STEP_WRITE(v)
-  #if ENABLED(MK2_MULTIPLEXER)
-    // Even-numbered steppers are reversed
-    #define NORM_E_DIR() E0_DIR_WRITE(TEST(current_block->active_extruder, 0) ? !INVERT_E0_DIR: INVERT_E0_DIR)
-    #define REV_E_DIR() E0_DIR_WRITE(TEST(current_block->active_extruder, 0) ? INVERT_E0_DIR: !INVERT_E0_DIR)
-  #else
-    #define NORM_E_DIR() E0_DIR_WRITE(!INVERT_E0_DIR)
-    #define REV_E_DIR() E0_DIR_WRITE(INVERT_E0_DIR)
-  #endif
+  #define NORM_E_DIR() E0_DIR_WRITE(!INVERT_E0_DIR)
+  #define REV_E_DIR() E0_DIR_WRITE(INVERT_E0_DIR)
 #endif
 
 #endif // STEPPER_INDIRECTION_H


### PR DESCRIPTION
Based on #8337 by @robpower

---
Implemented synchronization message output for NanoDLP printers (nanodlp.com).
If optional feature is enabled in "configuration_adv.h", Marlin will ouput "Z_move_comp" string to serial after completing any G0/G1 Z-axis movements. This feature is used by NanoDLP to synchronize Z-axis movement with projector exposure in DLP stereolithography printers.
It was already patched on some forks from previous versions (https://github.com/mUVe3D/Marlin-mUVe1DLP-Running, https://github.com/WheresWaldo/Marlin_KLD-LCD) but never contributed back to the original code and implemented as optional configuration option.