### PR TITLE
Fix the G26 out of scope identifiers in the v2.0.0 branch

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -41,7 +41,7 @@
   #endif
 #endif
 
-#if G26_MESH_VALIDATION
+#if ENABLED(G26_MESH_VALIDATION)
   bool g26_debug_flag; // = false
 #endif
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -146,6 +146,8 @@ float g26_extrusion_multiplier,
       g26_layer_height,
       g26_prime_length;
 
+float g26_x_pos=0, g26_y_pos=0;
+
 int16_t g26_bed_temp,
         g26_hotend_temp;
 
@@ -403,7 +405,10 @@ inline bool look_for_lines_to_connect() {
                   SERIAL_ECHOPAIR(", ey=", ey);
                   SERIAL_CHAR(')');
                   SERIAL_EOL();
-                  debug_current_and_destination(PSTR("Connecting vertical line."));
+                  #if ENABLED(AUTO_BED_LEVELING_UBL)
+                    void debug_current_and_destination(const char *title);
+                    debug_current_and_destination(PSTR("Connecting vertical line."));
+                  #endif
                 }
                 print_line_from_here_to_there(sx, sy, g26_layer_height, ex, ey, g26_layer_height);
               }
@@ -675,8 +680,9 @@ void GcodeSuite::G26() {
     return G26_ERR;
   }
 
-  float g26_x_pos = parser.seenval('X') ? RAW_X_POSITION(parser.value_linear_units()) : current_position[X_AXIS],
-        g26_y_pos = parser.seenval('Y') ? RAW_Y_POSITION(parser.value_linear_units()) : current_position[Y_AXIS];
+  g26_x_pos = parser.seenval('X') ? RAW_X_POSITION(parser.value_linear_units()) : current_position[X_AXIS],
+  g26_y_pos = parser.seenval('Y') ? RAW_Y_POSITION(parser.value_linear_units()) : current_position[Y_AXIS];
+
   if (!position_is_reachable(g26_x_pos, g26_y_pos)) {
     SERIAL_PROTOCOLLNPGM("?Specified X,Y coordinate out of bounds.");
     return G26_ERR;


### PR DESCRIPTION
These changes may need to be warmed over.  I tried to fix things with
the least amount of disruption.   I just wanted to get the bugfix_v2.0.0
branch working for people again.