### PR TITLE
avoid some MK2_MULTIPLEXER pitfalls

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1492,4 +1492,38 @@
                                          // tweaks made to the configuration are affecting the printer in real-time.
 #endif
 
+
+// some MK2_MUXER requirements
+#if ENABLED(MK2_MULTIPLEXER)
+
+  #undef DISABLE_INACTIVE_EXTRUDER
+  #define DISABLE_INACTIVE_EXTRUDER false // Keep only the active extruder enabled. MK2_MULTIPLEXER won't work otherwise.
+
+  // all extruders use E0 stepper
+  #undef E1_STEP_PIN                  
+  #undef E1_DIR_PIN
+  #undef E1_ENABLE_PIN
+
+  #undef E2_STEP_PIN                  
+  #undef E2_DIR_PIN
+  #undef E2_ENABLE_PIN
+
+  #undef E3_STEP_PIN                  
+  #undef E3_DIR_PIN
+  #undef E3_ENABLE_PIN
+
+  #define E1_STEP_PIN     E0_STEP_PIN
+  #define E1_DIR_PIN      E0_DIR_PIN
+  #define E1_ENABLE_PIN   E0_ENABLE_PIN
+
+  #define E2_STEP_PIN     E0_STEP_PIN
+  #define E2_DIR_PIN      E0_DIR_PIN
+  #define E2_ENABLE_PIN   E0_ENABLE_PIN
+
+  #define E3_STEP_PIN     E0_STEP_PIN
+  #define E3_DIR_PIN      E0_DIR_PIN
+  #define E3_ENABLE_PIN   E0_ENABLE_PIN
+  
+#endif
+
 #endif // CONFIGURATION_ADV_H

--- a/Marlin/src/pins/pins_RAMPS.h
+++ b/Marlin/src/pins/pins_RAMPS.h
@@ -114,10 +114,13 @@
 #define E0_ENABLE_PIN      24
 #define E0_CS_PIN          42
 
-#define E1_STEP_PIN        36
-#define E1_DIR_PIN         34
-#define E1_ENABLE_PIN      30
-#define E1_CS_PIN          44
+#if DISABLED(MK2_MULTIPLEXER)
+ // MK2_MUXER does not use E1 stepper
+  #define E1_STEP_PIN        36
+  #define E1_DIR_PIN         34
+  #define E1_ENABLE_PIN      30
+  #define E1_CS_PIN          44
+#endif
 
 //
 // Temperature Sensors


### PR DESCRIPTION
The MK2_MULTIPLEXER feature requires a set of other configuration options to have the correct values. Some are checked by SanityCheck.h but others are not. To avoid some pitfalls for other users I added a block in Configuration_adv.h to set some requirements for MK2_MULTIPLEXER.

I also had to disable the E1_*_PIN defines in pins_RAMPS.h to get the 2nd extruder working. The corresponding undefs in Configuration_adv.h seem to have no effect on this behalf.