### PR TITLE
Fix #8540

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2416,8 +2416,20 @@ static void clean_up_after_endstop_or_probe_move() {
       : !position_is_reachable_by_probe(rx, ry)
     ) return NAN;
 
-    // Move the probe to the given XY
-    do_blocking_move_to_xy(nx, ny, XY_PROBE_FEEDRATE_MM_S);
+    const float nz = 
+      #if ENABLED(DELTA)
+        // Move below clip height or xy move will be aborted by do_blocking_move_to
+        min(current_position[Z_AXIS], delta_clip_start_height)
+      #else
+        current_position[Z_AXIS]
+      #endif
+    ;
+
+    const float old_feedrate_mm_s = feedrate_mm_s;
+    feedrate_mm_s = XY_PROBE_FEEDRATE_MM_S;
+
+    // Move the probe to the starting XYZ
+    do_blocking_move_to(nx, ny, nz);
 
     float measured_z = NAN;
     if (!DEPLOY_PROBE()) {
@@ -2442,6 +2454,8 @@ static void clean_up_after_endstop_or_probe_move() {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< probe_pt");
     #endif
+
+    feedrate_mm_s = old_feedrate_mm_s;
 
     if (isnan(measured_z)) {
       LCD_MESSAGEPGM(MSG_ERR_PROBING_FAILED);


### PR DESCRIPTION
Does this fix #8540? This brings parity between 1.1.x and 2.0.x versions of `probe_pt`.

This should also fix #8549.