### PR TITLE
[2.0.x] Fix for #8525 and other cleanup

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
@@ -55,10 +55,6 @@
   #error "Pins for this chip not defined in Arduino.h! If you have a working pins definition, please contribute!"
 #endif
 
-#ifndef _BV
-  #define _BV(bit) (1UL << (bit))
-#endif
-
 /**
  * Magic I/O routines
  *

--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.h
@@ -53,8 +53,6 @@
   #define MYSERIAL customizedSerial
 #endif
 
-#define _BV(bit) (1 << (bit))
-
 // We need the previous define before the include, or compilation bombs...
 #include "MarlinSerial_Due.h"
 

--- a/Marlin/src/HAL/HAL_LPC1768/include/arduino.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/arduino.h
@@ -38,8 +38,6 @@
 #define OUTPUT       0x01
 #define INPUT_PULLUP 0x02
 
-#define _BV(bit) (1 << (bit))
-
 #define E2END 0xFFF // EEPROM end address
 
 typedef uint8_t byte;

--- a/Marlin/src/HAL/HAL_LPC1768/pinmapping.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmapping.cpp
@@ -27,8 +27,8 @@
 #include "../../gcode/parser.h"
 
 // Get the digital pin for an analog index
-pin_t analogInputToDigitalPin(const uint8_t p) {
-  return (p < COUNT(adc_pin_table) ? adc_pin_table[p] : P_NC);
+pin_t analogInputToDigitalPin(const int8_t p) {
+  return (WITHIN(p, 0, NUM_ANALOG_INPUTS) ? adc_pin_table[p] : P_NC);
 }
 
 // Return the index of a pin number

--- a/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
@@ -239,7 +239,7 @@ constexpr pin_t pin_map[] = {
   P_NC,  P_NC,  P_NC,  P_NC,  P4_28, P4_29, P_NC,  P_NC
 };
 
-constexpr int16_t NUM_DIGITAL_PINS = COUNT(pin_map);
+constexpr int8_t NUM_DIGITAL_PINS = COUNT(pin_map);
 
 constexpr pin_t adc_pin_table[] = {
   P0_23, P0_24, P0_25, P0_26, P1_30, P1_31,
@@ -255,7 +255,7 @@ constexpr int16_t NUM_ANALOG_INPUTS = COUNT(adc_pin_table);
 #define HAL_SENSITIVE_PINS P0_06, P0_07, P0_08, P0_09, P0_29, P0_30
 
 // Get the digital pin for an analog index
-pin_t analogInputToDigitalPin(const uint8_t p);
+pin_t analogInputToDigitalPin(const int8_t p);
 
 // Return the index of a pin number
 // The pin number given here is in the form ppp:nnnnn

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.h
@@ -77,8 +77,6 @@
   #define MYSERIAL Serial3
 #endif
 
-#define _BV(bit) 	(1 << (bit))
-
 /**
  * TODO: review this to return 1 for pins that are not analog input
  */

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_Teensy.h
@@ -30,6 +30,9 @@
 // Includes
 // --------------------------------------------------------------------------
 
+// _BV is re-defined in Arduino.h
+#undef _BV
+
 #include <Arduino.h>
 
 // Redefine sq macro defined by teensy3/wiring.h

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -635,7 +635,7 @@ static_assert(1 >= 0
   , "Please enable only one probe option: PROBE_MANUALLY, FIX_MOUNTED_PROBE, BLTOUCH, SOLENOID_PROBE, Z_PROBE_ALLEN_KEY, Z_PROBE_SLED, or Z Servo."
 );
 
-#if HAS_BED_PROBE
+#if PROBE_SELECTED && DISABLED(PROBE_MANUALLY)
 
   /**
    * Z_PROBE_SLED is incompatible with DELTA

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -485,9 +485,6 @@
   #define MAX_EXTRUDERS 5
 #endif
 
-// Marlin needs to account for pins that equal -1
-#define marlinAnalogInputToDigitalPin(p) ((p) == -1 ? -1 : analogInputToDigitalPin(p))
-
 //
 // Assign auto fan pins if needed
 //
@@ -541,7 +538,7 @@
   #endif // EXTRUDERS > 2
 #endif // EXTRUDERS > 1
 
-#define _H0_PINS HEATER_0_PIN, E0_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_0_PIN),
+#define _H0_PINS HEATER_0_PIN, E0_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_0_PIN),
 #define _H1_PINS
 #define _H2_PINS
 #define _H3_PINS
@@ -549,16 +546,16 @@
 
 #if HOTENDS > 1
   #undef _H1_PINS
-  #define _H1_PINS HEATER_1_PIN, E1_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_1_PIN),
+  #define _H1_PINS HEATER_1_PIN, E1_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_1_PIN),
   #if HOTENDS > 2
     #undef _H2_PINS
-    #define _H2_PINS HEATER_2_PIN, E2_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_2_PIN),
+    #define _H2_PINS HEATER_2_PIN, E2_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_2_PIN),
     #if HOTENDS > 3
       #undef _H3_PINS
-      #define _H3_PINS HEATER_3_PIN, E3_AUTO_FAN_PIN, marlinAnalogInputToDigitalPin(TEMP_3_PIN),
+      #define _H3_PINS HEATER_3_PIN, E3_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_3_PIN),
       #if HOTENDS > 4
         #undef _H4_PINS
-        #define _H4_PINS HEATER_4_PIN, marlinAnalogInputToDigitalPin(TEMP_4_PIN),
+        #define _H4_PINS HEATER_4_PIN, analogInputToDigitalPin(TEMP_4_PIN),
       #endif // HOTENDS > 4
     #endif // HOTENDS > 3
   #endif // HOTENDS > 2
@@ -579,7 +576,7 @@
   #endif // MIXING_STEPPERS > 2
 #endif // MIXING_STEPPERS > 1
 
-#define BED_PINS HEATER_BED_PIN, marlinAnalogInputToDigitalPin(TEMP_BED_PIN),
+#define BED_PINS HEATER_BED_PIN, analogInputToDigitalPin(TEMP_BED_PIN),
 
 //
 // Assign endstop pins for boards with only 3 connectors


### PR DESCRIPTION
This PR fixes the issue found in #8525 where the sanity checks for the bed probe weren't being executed. It also fixes some other warnings that were being generated during compilation.