### PR TITLE
Fix #8561. Fix #8562

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - export PATH=${TRAVIS_BUILD_DIR}/buildroot/bin/:${PATH}
 
 install:
+  - pip install backports.functools_lru_cache
   - pip install -U platformio
 
 before_script:


### PR DESCRIPTION
Fix #8561. Fix #8562.

Do a manual install of `backports.functools_lru_cache` to work around a problem with pip.