### PR TITLE
[2.0.x] MKS Sbase - add servo pin definitions and add directly controlled PWM

### DIFF
--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -40,6 +40,15 @@
 #define PIN_P0_28         P0_28
 */
 
+
+//
+// Servo pin
+//
+#define SERVO0_PIN         P1_23  // J8-3 (low jitter)
+#define SERVO1_PIN         P2_12  // J8-4
+#define SERVO2_PIN         P2_11  // J8-5
+#define SERVO3_PIN         P4_28  // J8-6
+
 //
 // Limit Switches
 //


### PR DESCRIPTION
The MKS Sbase does not have any dedicated servo pins and none of the free pins can presently be assigned a directly controlled PWM.

This PR does the following:
1) Adds servo pin definitions to the pins_MKS_SBASE.h file
```
      //
      // Servo pin
      //
      #define SERVO0_PIN         P1_23  // J8-3 (low jitter)
      #define SERVO1_PIN         P2_12  // J8-4
      #define SERVO2_PIN         P2_11  // J8-5
      #define SERVO3_PIN         P4_28  // J8-6
```

2) Add P1_23 to the directly controlled pins list in LPC1768_Servo.cpp when the MKS Sbase is the motherboard.  P1_23 is the only free pin on the MKS Sbase that can be directly controlled by the PWM controller.