### PR TITLE
[2.0.x] Fix #8577 - Update parser.boolval usage in M290 to current

### DIFF
--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -52,7 +52,7 @@ void GcodeSuite::M290() {
         const float offs = constrain(parser.value_axis_units((AxisEnum)a), -2, 2);
         thermalManager.babystep_axis((AxisEnum)a, offs * planner.axis_steps_per_mm[a]);
         #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-          if (a == Z_AXIS && parser.boolval('P', true)) mod_zprobe_zoffset(offs);
+          if (a == Z_AXIS && parser.boolval('P')) mod_zprobe_zoffset(offs);
         #endif
       }
   #else
@@ -60,7 +60,7 @@ void GcodeSuite::M290() {
       const float offs = constrain(parser.value_axis_units(Z_AXIS), -2, 2);
       thermalManager.babystep_axis(Z_AXIS, offs * planner.axis_steps_per_mm[Z_AXIS]);
       #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-        if (parser.boolval('P', true)) mod_zprobe_zoffset(offs);
+        if (parser.boolval('P')) mod_zprobe_zoffset(offs);
       #endif
     }
   #endif


### PR DESCRIPTION
parser.boolval() usage was changed with  #8016 & #8017,  but old method was re-introduced into M290 routines with https://github.com/MarlinFirmware/Marlin/commit/2060ba3556df97621eae8051845f1224f764cb82 (bf11) and https://github.com/MarlinFirmware/Marlin/commit/be00e421a76cc82a3e68cf801e211b0f450ea393 (bf20).

Fixes #8577