### PR TITLE
[1.1.x] Fix #8577 - Update parser.boolval usage to current

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9346,7 +9346,7 @@ inline void gcode_M226() {
           const float offs = constrain(parser.value_axis_units((AxisEnum)a), -2, 2);
           thermalManager.babystep_axis((AxisEnum)a, offs * planner.axis_steps_per_mm[a]);
           #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-            if (a == Z_AXIS && parser.boolval('P', true)) mod_zprobe_zoffset(offs);
+            if (a == Z_AXIS && parser.boolval('P')) mod_zprobe_zoffset(offs);
           #endif
         }
     #else
@@ -9354,7 +9354,7 @@ inline void gcode_M226() {
         const float offs = constrain(parser.value_axis_units(Z_AXIS), -2, 2);
         thermalManager.babystep_axis(Z_AXIS, offs * planner.axis_steps_per_mm[Z_AXIS]);
         #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-          if (parser.boolval('P', true)) mod_zprobe_zoffset(offs);
+          if (parser.boolval('P')) mod_zprobe_zoffset(offs);
         #endif
       }
     #endif


### PR DESCRIPTION
parser.boolval() usage was changed with  #8016 & #8017,  but old method was re-introduced into M290 routines with https://github.com/MarlinFirmware/Marlin/commit/2060ba3556df97621eae8051845f1224f764cb82 (bf11) and https://github.com/MarlinFirmware/Marlin/commit/be00e421a76cc82a3e68cf801e211b0f450ea393 (bf20).