### PR TITLE
[1.1.x] Fix WDTO during long delta moves

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12746,6 +12746,14 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
 
     // Calculate and execute the segments
     for (uint16_t s = segments + 1; --s;) {
+
+      static millis_t next_idle_ms = millis() + 200UL;
+      thermalManager.manage_heater();  // This returns immediately if not really needed.
+      if (ELAPSED(millis(), next_idle_ms)) {
+        next_idle_ms = millis() + 200UL;
+        idle();
+      }
+
       LOOP_XYZE(i) raw[i] += segment_distance[i];
       #if ENABLED(DELTA)
         DELTA_RAW_IK(); // Delta can inline its kinematics


### PR DESCRIPTION
During long lasting moves of a delta machine neither the temperatures are maintained nor buttons checked nor ... .
The fix is to call 'manage_heater()' and 'idle()' every now and then in the loop where the move is segmented. 
The code is about the same as in G2_G3 where we had the same problem with too large circles lasting too long.
Fixing #7510 
Details about the failing mechanism in https://github.com/MarlinFirmware/Marlin/issues/7510#issuecomment-347353641