### PR TITLE
[1.1.x] Disabled Power supply prevents homing success

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4064,12 +4064,17 @@ inline void gcode_G4() {
  */
 inline void gcode_G28(const bool always_home_all) {
 
-  #if (HAS_POWER_SWITCH && ENABLED(NO_MOTION_BEFORE_HOMING))
+  #if HAS_POWER_SWITCH && ENABLED(NO_MOTION_BEFORE_HOMING)
     if (!powersupply_on) {
-      SERIAL_ECHOLNPGM(MSG_ERR_PS_OFF);
+      SERIAL_ERROR_START();
+      SERIAL_ERRORLNPGM(MSG_ERR_PS_OFF);
+      #if ENABLED(ULTIPANEL)
+        lcd_completion_feedback(false);
+      #endif
       return;
     }
   #endif
+
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOLNPGM(">>> G28");

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8613,6 +8613,7 @@ inline void gcode_M81() {
     suicide();
   #elif HAS_POWER_SWITCH
     PSU_OFF();
+    axis_homed = axis_known_position = 0;
   #endif
 
   #if ENABLED(ULTIPANEL)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4064,6 +4064,12 @@ inline void gcode_G4() {
  */
 inline void gcode_G28(const bool always_home_all) {
 
+  #if (HAS_POWER_SWITCH && ENABLED(NO_MOTION_BEFORE_HOMING))
+    if (!powersupply_on) {
+      SERIAL_ECHOLNPGM(MSG_ERR_PS_OFF);
+      return;
+    }
+  #endif
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOLNPGM(">>> G28");

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -176,6 +176,7 @@
 #define MSG_ERR_M420_FAILED                 "Failed to enable Bed Leveling"
 #define MSG_ERR_M428_TOO_FAR                "Too far from reference point"
 #define MSG_ERR_M303_DISABLED               "PIDTEMP disabled"
+#define MSG_ERR_PS_OFF                      "Command aborted. Power supply is standby - switch it on with M80."
 #define MSG_M119_REPORT                     "Reporting endstop status"
 #define MSG_ENDSTOP_HIT                     "TRIGGERED"
 #define MSG_ENDSTOP_OPEN                    "open"

--- a/Marlin/language.h
+++ b/Marlin/language.h
@@ -176,7 +176,7 @@
 #define MSG_ERR_M420_FAILED                 "Failed to enable Bed Leveling"
 #define MSG_ERR_M428_TOO_FAR                "Too far from reference point"
 #define MSG_ERR_M303_DISABLED               "PIDTEMP disabled"
-#define MSG_ERR_PS_OFF                      "Command aborted. Power supply is standby - switch it on with M80."
+#define MSG_ERR_PS_OFF                      "No Power! Command aborted."
 #define MSG_M119_REPORT                     "Reporting endstop status"
 #define MSG_ENDSTOP_HIT                     "TRIGGERED"
 #define MSG_ENDSTOP_OPEN                    "open"


### PR DESCRIPTION
Inhibits Homing when power supply is off/standby and "No movement before homing" is selected.
Without the commit, Homing succeeds, resulting in later erroneous (and possibly dangerous) behavior.

Explanation:
This change is a security improment in a scenario where RAMPS board is powered by ATX-like PSU. When PSU is standby (5V on, Atmega powered, Main power & motors off), homing can still succeed virtually even if there is no real motion. This wrong behaviour invalidates "NO_MOVEMENT_BEFORE_HOMING" option if main power is applied after "virtual homing" while power off.
The commit prevents this potentially dangerous behaviour (movements beyond axis limits) by aborting homing command if power supply is not in ON state.
Inhibition of other movement commands (G0,G1) should probably be considered if running Gcode in relative position.