### PR TITLE
[2.0.x] Fix M49 so that it does not hang the terminal console

### DIFF
--- a/Marlin/src/gcode/bedlevel/ubl/M49.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/M49.cpp
@@ -34,8 +34,7 @@
 void GcodeSuite::M49() {
   g26_debug_flag ^= true;
   SERIAL_PROTOCOLPGM("G26 Debug: ");
-  serialprintPGM(g26_debug_flag ? PSTR("On") : PSTR("Off"));
-  SERIAL_EOL();
+  serialprintPGM(g26_debug_flag ? PSTR("On\n") : PSTR("Off\n"));
 }
 
 #endif // G26_MESH_VALIDATION

--- a/Marlin/src/gcode/bedlevel/ubl/M49.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/M49.cpp
@@ -33,8 +33,9 @@
 
 void GcodeSuite::M49() {
   g26_debug_flag ^= true;
-  SERIAL_PROTOCOLPGM("G26 Debug ");
-  serialprintPGM(g26_debug_flag ? PSTR("on.") : PSTR("off."));
+  SERIAL_PROTOCOLPGM("G26 Debug: ");
+  serialprintPGM(g26_debug_flag ? PSTR("On") : PSTR("Off"));
+  SERIAL_EOL();
 }
 
 #endif // G26_MESH_VALIDATION


### PR DESCRIPTION
M49 does not send an EOL so the terminal console hangs and no further commands are possible.

* Added an EOL after the on/off state output
* Tidied up the output a little