### PR TITLE
[1.1.x] Fix some planner bugs

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8714,12 +8714,8 @@ inline void gcode_M200() {
     // setting any extruder filament size disables volumetric on the assumption that
     // slicers either generate in extruder values as cubic mm or as as filament feeds
     // for all extruders
-    if ( (parser.volumetric_enabled = (parser.value_linear_units() != 0.0)) ) {
-      planner.filament_size[target_extruder] = parser.value_linear_units();
-      // make sure all extruders have some sane value for the filament size
-      for (uint8_t i = 0; i < COUNT(planner.filament_size); i++)
-        if (!planner.filament_size[i]) planner.filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
-    }
+    if ( (parser.volumetric_enabled = (parser.value_linear_units() != 0.0)) )
+      planner.set_filament_size(target_extruder, parser.value_linear_units());
   }
   planner.calculate_volumetric_multipliers();
 }

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -251,14 +251,22 @@ class Planner {
     // Manage fans, paste pressure, etc.
     static void check_axes_activity();
 
-    static void calculate_volumetric_multipliers();
-
     /**
      * Number of moves currently in the planner
      */
     static uint8_t movesplanned() { return BLOCK_MOD(block_buffer_head - block_buffer_tail + BLOCK_BUFFER_SIZE); }
 
     static bool is_full() { return (block_buffer_tail == BLOCK_MOD(block_buffer_head + 1)); }
+
+    // Update multipliers based on new diameter measurements
+    static void calculate_volumetric_multipliers();
+
+    FORCE_INLINE static void set_filament_size(const uint8_t e, const float &v) {
+      filament_size[e] = v;
+      // make sure all extruders have some sane value for the filament size
+      for (uint8_t i = 0; i < COUNT(filament_size); i++)
+        if (!filament_size[i]) filament_size[i] = DEFAULT_NOMINAL_FILAMENT_DIA;
+    }
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -219,10 +219,6 @@ class Planner {
       static uint32_t axis_segment_time_us[2][3];
     #endif
 
-    #if ENABLED(LIN_ADVANCE)
-      static float position_float[NUM_AXIS];
-    #endif
-
     #if ENABLED(ULTRA_LCD)
       volatile static uint32_t block_buffer_runtime_us; //Theoretical block buffer runtime in µs
     #endif


### PR DESCRIPTION
- Fix a typo that broke `ENABLE_LEVELING_FADE_HEIGHT` for ABL/MBL.
- Update `Planner::apply_leveling` and `Planner::unapply_leveling` with latest methods.
- Drop `Planner::position_float` — no longer needed for `LIN_ADVANCE`.
- Add `Planner::set_filament_size` for parity with 2.0.x

See also #8612