### PR TITLE
[2.0.x][LPC1768][FIX] NUM_DIGITAL_PINS was negative, fixes PWM, arduino io functions, M42, M43, M226, probably also Servo, some LCD, soft spi, SoftwareSerial, ... may be others

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
@@ -239,7 +239,7 @@ constexpr pin_t pin_map[] = {
   P_NC,  P_NC,  P_NC,  P_NC,  P4_28, P4_29, P_NC,  P_NC
 };
 
-constexpr int8_t NUM_DIGITAL_PINS = COUNT(pin_map);
+constexpr uint8_t NUM_DIGITAL_PINS = COUNT(pin_map);
 
 constexpr pin_t adc_pin_table[] = {
   P0_23, P0_24, P0_25, P0_26, P1_30, P1_31,


### PR DESCRIPTION
NUM_DIGITAL_PINS will be negative if the count of digital pins is bigger than 127.
With negative NUM_DIGITAL_PINS function PARSED_PIN_INDEX fails, because of shift and compare operations in this line:
```
  const  int16_t ind = (port < (NUM_DIGITAL_PINS >> 5) && (pin < 32))
                      ? GET_PIN_MAP_INDEX(port << 5 | pin) : -2;
```
which in turn causes M42 to fail because of these lines:
```
  const int pin_index = PARSED_PIN_INDEX('P', GET_PIN_MAP_INDEX(LED_PIN));
  if (pin_index < 0) return;
```
Additionally, M43 fails, because NUM_DIGITAL_PINS is used for enumeration.
There may be other failures because of this, I didn't check all.

uint8_t could eventually be bigger, because it's a constant. Or it could be a define...