### PR TITLE
[2.0.x][LPC1768][fix] Implement GET_TIMER and other GET_xxx, fixes PWM

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -85,13 +85,22 @@ bool useable_hardware_PWM(pin_t pin);
 /// set pin as input with pullup mode
 #define _PULLUP(IO, v) (pinMode(IO, (v!=LOW ? INPUT_PULLUP : INPUT)))
 
+// hg42: all pins can be input or output (I hope)
+// hg42: undefined pins create compile error (IO, is no pin)
+// hg42: currently not used, but was used by pinsDebug
+
 /// check if pin is an input
-#define _GET_INPUT(IO)
+#define _GET_INPUT(IO)        (LPC1768_PIN_PIN(IO)>=0)
+
 /// check if pin is an output
-#define _GET_OUTPUT(IO)
+#define _GET_OUTPUT(IO)       (LPC1768_PIN_PIN(IO)>=0)
+
+// hg42: GET_TIMER is used only to check if it's a PWM pin
+// hg42: we cannot use USEABLE_HARDWARE_PWM because it uses a function that cannot be used statically
+// hg42: instead use PWM bit from the #define
 
 /// check if pin is an timer
-#define _GET_TIMER(IO)
+#define _GET_TIMER(IO)        LPC1768_PIN_PWM(IO)
 
 /// Read a pin wrapper
 #define READ(IO)  _READ(IO)
@@ -111,9 +120,9 @@ bool useable_hardware_PWM(pin_t pin);
 #define SET_OUTPUT(IO)  do{ _SET_OUTPUT(IO); _WRITE(IO, LOW); }while(0)
 
 /// check if pin is an input wrapper
-#define GET_INPUT(IO)  _GET_INPUT(IO) // todo: Never used?
+#define GET_INPUT(IO)  _GET_INPUT(IO)
 /// check if pin is an output wrapper
-#define GET_OUTPUT(IO)  _GET_OUTPUT(IO) //todo: Never Used?
+#define GET_OUTPUT(IO)  _GET_OUTPUT(IO)
 
 /// check if pin is an timer wrapper
 #define GET_TIMER(IO)  _GET_TIMER(IO)

--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -100,7 +100,10 @@ bool useable_hardware_PWM(pin_t pin);
 // hg42: instead use PWM bit from the #define
 
 /// check if pin is an timer
-#define _GET_TIMER(IO)        LPC1768_PIN_PWM(IO)
+#define _GET_TIMER(IO)        TRUE  // could be LPC1768_PIN_PWM(IO), but there
+// hg42: could be this:
+// #define _GET_TIMER(IO)        LPC1768_PIN_PWM(IO)
+// but this is an incomplete check (12 pins are PWMable, but only 6 can be used at the same time)
 
 /// Read a pin wrapper
 #define READ(IO)  _READ(IO)


### PR DESCRIPTION
PWM did not work for E*_AUTO_FAN_PIN, even with a hardware PWM pin.
SanityCheck tests if the pin has a TIMER and this throws a compile error, because the macro is empty.
I first tried to use USEABLE_HARDWARE_PWM, but it's implemented by a run time function which cannot be used in a static_assert. But the pin id includes a PWM bit, so this was easy to implement.
GET_TIMER is only used for this purpose.

I think the name doesn't reflect what it does. Should be call CAN_PWN instead.

Also, E*_AUTO_FAN_PIN should not be checked for hardware PWM but for PWM.
Why not be able to use FAN_SOFT_PWM?