### PR TITLE
[2.0.x] Fix missing return values in G33_auto_tune

### DIFF
--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -254,7 +254,7 @@ static float probe_G33_points(float z_at_pt[NPP + 1], const int8_t probe_points,
       recalc_delta_settings();
 
       endstops.enable(true);
-      if (!home_delta()) return;
+      if (!home_delta()) return false;
       endstops.not_homing();
 
       SERIAL_PROTOCOLPGM("Tuning E");
@@ -286,7 +286,7 @@ static float probe_G33_points(float z_at_pt[NPP + 1], const int8_t probe_points,
       recalc_delta_settings();
 
       endstops.enable(true);
-      if (!home_delta()) return;
+      if (!home_delta()) return false;
       endstops.not_homing();
 
       SERIAL_PROTOCOLPGM("Tuning R");
@@ -312,7 +312,7 @@ static float probe_G33_points(float z_at_pt[NPP + 1], const int8_t probe_points,
       recalc_delta_settings();
 
       endstops.enable(true);
-      if (!home_delta()) return;
+      if (!home_delta()) return false;
       endstops.not_homing();
 
       SERIAL_PROTOCOLPGM("Tuning T");
@@ -346,7 +346,7 @@ static float probe_G33_points(float z_at_pt[NPP + 1], const int8_t probe_points,
     a_fac *= norm; // Normalize to 0.83 for Kossel mini
 
     endstops.enable(true);
-    if (!home_delta()) return;
+    if (!home_delta()) return false;
     endstops.not_homing();
     print_signed_float(PSTR( "H_FACTOR: "), h_fac);
     print_signed_float(PSTR(" R_FACTOR: "), r_fac);


### PR DESCRIPTION
A return type was added to `G33_auto_tune`, but not all of the return statements were modified to return a value, leading to a compilation error.