### PR TITLE
Fix for issue #8629

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -926,11 +926,11 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(dummy);
         #endif
 
-        for (uint8_t q=7; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=8; q--;) EEPROM_READ(dummy);
 
       #else
 
-        for (uint8_t q=10; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=11; q--;) EEPROM_READ(dummy);
 
       #endif
 


### PR DESCRIPTION
Fix for mismatch on number of dummy DELTA variables on EEPROM save/load; see Issue #8629 