### PR TITLE
Fix for issue #8629

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -898,11 +898,11 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(dummy);
         #endif
 
-        for (uint8_t q=7; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=8; q--;) EEPROM_READ(dummy);
 
       #else
 
-        for (uint8_t q=10; q--;) EEPROM_READ(dummy);
+        for (uint8_t q=11; q--;) EEPROM_READ(dummy);
 
       #endif
 


### PR DESCRIPTION
bugfix-2.0 issue for issue #8629. Mismatch between number of stored and loaded dummy items on non-delta configurations would presumably cause CRC failure on `M501`. This was the case on bugfix-1.1.x, now fixed by pull #8630. 