### PR TITLE
[1.1.x] Use custom segment length for UBL Cartesian

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -1101,21 +1101,6 @@
     #define LCD_TIMEOUT_TO_STATUS 15000
   #endif
 
-  /**
-   * DELTA_SEGMENT_MIN_LENGTH for UBL_DELTA
-   */
-  #if UBL_DELTA
-    #ifndef DELTA_SEGMENT_MIN_LENGTH
-      #if IS_SCARA
-        #define DELTA_SEGMENT_MIN_LENGTH 0.25 // SCARA minimum segment size is 0.25mm
-      #elif ENABLED(DELTA)
-        #define DELTA_SEGMENT_MIN_LENGTH 0.10 // mm (still subject to DELTA_SEGMENTS_PER_SECOND)
-      #else // CARTESIAN
-        #define DELTA_SEGMENT_MIN_LENGTH 1.00 // mm (similar to G2/G3 arc segmentation)
-      #endif
-    #endif
-  #endif
-
   // Shorthand
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -569,6 +569,7 @@ void Planner::calculate_volumetric_multipliers() {
 #if PLANNER_LEVELING
   /**
    * rx, ry, rz - Cartesian positions in mm
+   *              Leveled XYZ on completion
    */
   void Planner::apply_leveling(float &rx, float &ry, float &rz) {
 
@@ -611,7 +612,7 @@ void Planner::calculate_volumetric_multipliers() {
       #endif
 
       rz += (
-        #if ENABLED(AUTO_BED_LEVELING_UBL)
+        #if ENABLED(AUTO_BED_LEVELING_UBL) // UBL_DELTA
           ubl.get_z_correction(rx, ry) * fade_scaling_factor
         #elif ENABLED(MESH_BED_LEVELING)
           mbl.get_z(rx, ry

--- a/Marlin/ubl_motion.cpp
+++ b/Marlin/ubl_motion.cpp
@@ -497,6 +497,17 @@
       #endif
     }
 
+    #if IS_SCARA
+      #define DELTA_SEGMENT_MIN_LENGTH 0.25 // SCARA minimum segment size is 0.25mm
+    #elif ENABLED(DELTA)
+      #define DELTA_SEGMENT_MIN_LENGTH 0.10 // mm (still subject to DELTA_SEGMENTS_PER_SECOND)
+    #else // CARTESIAN
+      #ifdef LEVELED_SEGMENT_LENGTH
+        #define DELTA_SEGMENT_MIN_LENGTH LEVELED_SEGMENT_LENGTH
+      #else
+        #define DELTA_SEGMENT_MIN_LENGTH 1.00 // mm (similar to G2/G3 arc segmentation)
+      #endif
+    #endif
 
     /**
      * Prepare a segmented linear move for DELTA/SCARA/CARTESIAN with UBL and FADE semantics.


### PR DESCRIPTION
Use the shared setting `LEVELED_SEGMENT_LENGTH` to override UBL segment length, if UBL is running in cartesian segmented mode (as is the new default).