### PR TITLE
Added Support for RAMPS 1.4 Plus board

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -49,6 +49,11 @@
 #define BOARD_RAMPS_14_EFF      45   // RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
 #define BOARD_RAMPS_14_EEF      46   // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS_14_SF       48   // RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
+#define BOARD_RAMPS_14P_EFB     431  // RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_14P_EEB     441  // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_14P_EFF     451  // RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_14P_EEF     461  // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_14P_SF      481  // RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
 #define BOARD_GEN6              5    // Gen6
 #define BOARD_GEN6_DELUXE       51   // Gen6 deluxe
 #define BOARD_SANGUINOLOLU_11   6    // Sanguinololu < 1.2

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -71,7 +71,21 @@
 #elif MB(RAMPS_14_SF)
   #define IS_RAMPS_SF
   #include "pins_RAMPS.h"
-
+#elif MB(RAMPS_14P_EFB)
+  #define IS_RAMPS_EFB
+  #include "pins_RAMPS_14Plus.h"
+#elif MB(RAMPS_14P_EEB)
+  #define IS_RAMPS_EEB
+  #include "pins_RAMPS_14Plus.h"
+#elif MB(RAMPS_14P_EFF)
+  #define IS_RAMPS_EFF
+  #include "pins_RAMPS_14Plus.h"
+#elif MB(RAMPS_14P_EEF)
+  #define IS_RAMPS_EEF
+  #include "pins_RAMPS_14Plus.h"
+#elif MB(RAMPS_14P_SF)
+  #define IS_RAMPS_SF
+  #include "pins_RAMPS_14Plus.h"
 //
 // RAMPS Derivatives - ATmega1280, ATmega2560
 //

--- a/Marlin/pins_RAMPS_14Plus.h
+++ b/Marlin/pins_RAMPS_14Plus.h
@@ -26,7 +26,7 @@
  * Swap heater E0 with E1
  * Swap pins 8 and 10. Bed, Fan and Hotend, as labeled on the board, are on pins
  * 8,9 and 10 respectively.
- * Changed pins 16 -> 42, 17 -> 44 and 29 -> 53. Those pins are
+ * Changed pins 16 -> 42, 17 -> 44 and 29 -> 53 used for display
  *
  * Applies to the following boards:
  *
@@ -280,14 +280,14 @@
          #define DOGLCD_SCK      23
          #define DOGLCD_A0       LCD_PINS_DC
        #else
-         #define LCD_PINS_RS     16
-         #define LCD_PINS_ENABLE 17
+         #define LCD_PINS_RS     42   // 3DYMY boards pin 16 -> 42
+         #define LCD_PINS_ENABLE 44   // 3DYMY boards pin 17 -> 44
          #define LCD_PINS_D4     23
          #define LCD_PINS_D5     25
          #define LCD_PINS_D6     27
        #endif
 
-       #define LCD_PINS_D7       29
+       #define LCD_PINS_D7       53   // 3DYMY boards pin 29 -> 53
 
        #if DISABLED(NEWPANEL)
          #define BEEPER_PIN      33

--- a/Marlin/pins_RAMPS_14Plus.h
+++ b/Marlin/pins_RAMPS_14Plus.h
@@ -1,0 +1,471 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Arduino Mega with RAMPS v1.4Plus, also known as 3DYMY version, pin assignments
+ * The difference to the RAMPS v1.4 are
+ * Swap heater E0 with E1
+ * Swap pins 8 and 10. Bed, Fan and Hotend, as labeled on the board, are on pins
+ * 8,9 and 10 respectively.
+ * Changed pins 16 -> 42, 17 -> 44 and 29 -> 53. Those pins are
+ *
+ * Applies to the following boards:
+ *
+ *  RAMPS_14P_EFB (Extruder, Fan, Bed)
+ *  RAMPS_14P_EEB (Extruder, Extruder, Bed)
+ *  RAMPS_14P_EFF (Extruder, Fan, Fan)
+ *  RAMPS_14P_EEF (Extruder, Extruder, Fan)
+ *  RAMPS_14P_SF  (Spindle, Controller Fan)
+ *
+ */
+
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
+ #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
+#endif
+
+#ifndef BOARD_NAME
+ #define BOARD_NAME "RAMPS 1.4 Plus"
+#endif
+
+#define LARGE_FLASH true
+
+//
+// Servos
+//
+#define SERVO0_PIN        11
+#define SERVO1_PIN        6
+#define SERVO2_PIN        5
+#define SERVO3_PIN        4
+
+ //
+ // Limit Switches
+ //
+#define X_MIN_PIN         3
+#define X_MAX_PIN         2
+#define Y_MIN_PIN         14
+#define Y_MAX_PIN         15
+#define Z_MIN_PIN         18
+#define Z_MAX_PIN         19
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+ #define Z_MIN_PROBE_PIN  32
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN         54
+#define X_DIR_PIN          55
+#define X_ENABLE_PIN       38
+#define X_CS_PIN           -1    // not used
+
+#define Y_STEP_PIN         60
+#define Y_DIR_PIN          61
+#define Y_ENABLE_PIN       56
+#define Y_CS_PIN           -1    // not used
+
+#define Z_STEP_PIN         46
+#define Z_DIR_PIN          48
+#define Z_ENABLE_PIN       62
+#define Z_CS_PIN           -1    // not used
+
+#define E0_STEP_PIN        36   // 3DYMY boards 26 -> 36
+#define E0_DIR_PIN         34   // 3DYMY boards 28 -> 34
+#define E0_ENABLE_PIN      30   // 3DYMY boards 24 -> 30
+#define E0_CS_PIN          -1   // 3DYMY boards 42 -> not used
+
+#define E1_STEP_PIN        26   // 3DYMY boards 36 -> 26
+#define E1_DIR_PIN         28   // 3DYMY boards 34 -> 28
+#define E1_ENABLE_PIN      24   // 3DYMY boards 30 -> 24
+#define E1_CS_PIN          -1   // 3DYMY boards 44 -> not used
+
+ //
+ // Temperature Sensors
+ //
+ #define TEMP_0_PIN         13   // Analog Input
+ #define TEMP_1_PIN         15   // Analog Input
+ #define TEMP_BED_PIN       14   // Analog Input
+
+ // SPI for Max6675 or Max31855 Thermocouple
+ #if DISABLED(SDSUPPORT)
+   #define MAX6675_SS       66 // Do not use pin 53 if there is even the remote possibility of using Display/SD card
+ #else
+   #define MAX6675_SS       66 // Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
+ #endif
+
+ //
+ // Augmentation for auto-assigning RAMPS plugs
+ //
+ #if DISABLED(IS_RAMPS_EEB) && DISABLED(IS_RAMPS_EEF) && DISABLED(IS_RAMPS_EFB) && DISABLED(IS_RAMPS_EFF) && DISABLED(IS_RAMPS_SF) && !PIN_EXISTS(MOSFET_D)
+   #if HOTENDS > 1
+     #if TEMP_SENSOR_BED
+       #define IS_RAMPS_EEB
+     #else
+       #define IS_RAMPS_EEF
+     #endif
+   #elif TEMP_SENSOR_BED
+     #define IS_RAMPS_EFB
+   #else
+     #define IS_RAMPS_EFF
+   #endif
+ #endif
+
+ //
+ // Heaters / Fans
+ //
+ #ifndef MOSFET_D_PIN
+   #define MOSFET_D_PIN  -1
+ #endif
+ #ifndef RAMPS_D8_PIN
+   #define RAMPS_D8_PIN   8
+ #endif
+ #ifndef RAMPS_D9_PIN
+   #define RAMPS_D9_PIN   9
+ #endif
+ #ifndef RAMPS_D10_PIN
+   #define RAMPS_D10_PIN 10
+ #endif
+
+ #define HEATER_0_PIN     RAMPS_D8_PIN          // 3DYMY boards heater 0 10 -> 8
+
+ #if ENABLED(IS_RAMPS_EFB)                      // Hotend, Fan, Bed
+   #define FAN_PIN        RAMPS_D9_PIN
+   #define HEATER_BED_PIN RAMPS_D10_PIN         // 3DYMY boards swapped 8 -> 10
+ #elif ENABLED(IS_RAMPS_EEF)                    // Hotend, Hotend, Fan
+   #define HEATER_1_PIN   RAMPS_D9_PIN
+   #define FAN_PIN        RAMPS_D10_PIN         // 3DYMY boards swapped 8 -> 10
+ #elif ENABLED(IS_RAMPS_EEB)                    // Hotend, Hotend, Bed
+   #define HEATER_1_PIN   RAMPS_D9_PIN
+   #define HEATER_BED_PIN RAMPS_D10_PIN         // 3DYMY boards swapped 8 -> 10
+ #elif ENABLED(IS_RAMPS_EFF)                    // Hotend, Fan, Fan
+   #define FAN_PIN        RAMPS_D9_PIN
+   #define FAN1_PIN       RAMPS_D10_PIN
+ #elif ENABLED(IS_RAMPS_SF)                     // Spindle, Fan
+   #define FAN_PIN        RAMPS_D9_PIN
+ #else                                          // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
+   #define FAN_PIN        RAMPS_D9_PIN
+   #define HEATER_BED_PIN RAMPS_D10_PIN
+   #if HOTENDS == 1
+     #define FAN1_PIN     MOSFET_D_PIN
+   #else
+     #define HEATER_1_PIN MOSFET_D_PIN
+   #endif
+ #endif
+
+ #ifndef FAN_PIN
+   #define FAN_PIN 4      // IO pin. Buffer needed
+ #endif
+
+ //
+ // Misc. Functions
+ //
+ #define SDSS               53
+ #define LED_PIN            13
+
+ #ifndef FILWIDTH_PIN
+   #define FILWIDTH_PIN      5   // Analog Input on AUX2
+ #endif
+
+ // define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
+ #define FIL_RUNOUT_PIN      4
+
+ #ifndef PS_ON_PIN
+   #define PS_ON_PIN        12
+ #endif
+
+ #if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT) && !defined(SPINDLE_LASER_ENABLE_PIN)
+   #if !defined(NUM_SERVOS) || NUM_SERVOS == 0 // try to use servo connector first
+     #define CASE_LIGHT_PIN   6      // MUST BE HARDWARE PWM
+   #elif !(ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL) \
+       && (ENABLED(PANEL_ONE) || ENABLED(VIKI2) || ENABLED(miniVIKI) || ENABLED(MINIPANEL) || ENABLED(REPRAPWORLD_KEYPAD)))  // try to use AUX 2
+     #define CASE_LIGHT_PIN   44     // MUST BE HARDWARE PWM
+   #endif
+ #endif
+
+ //
+ // M3/M4/M5 - Spindle/Laser Control
+ //
+ #if ENABLED(SPINDLE_LASER_ENABLE) && !PIN_EXISTS(SPINDLE_LASER_ENABLE)
+   #if !defined(NUM_SERVOS) || NUM_SERVOS == 0 // try to use servo connector first
+     #define SPINDLE_LASER_ENABLE_PIN  4  // Pin should have a pullup/pulldown!
+     #define SPINDLE_LASER_PWM_PIN     6  // MUST BE HARDWARE PWM
+     #define SPINDLE_DIR_PIN           5
+   #elif !(ENABLED(ULTRA_LCD) && ENABLED(NEWPANEL) \
+       && (ENABLED(PANEL_ONE) || ENABLED(VIKI2) || ENABLED(miniVIKI) || ENABLED(MINIPANEL) || ENABLED(REPRAPWORLD_KEYPAD)))  // try to use AUX 2
+     #define SPINDLE_LASER_ENABLE_PIN 40  // Pin should have a pullup/pulldown!
+     #define SPINDLE_LASER_PWM_PIN    44  // MUST BE HARDWARE PWM
+     #define SPINDLE_DIR_PIN          65
+   #endif
+ #endif
+
+ //
+ // Průša i3 MK2 Multiplexer Support
+ //
+ #ifndef E_MUX0_PIN
+   #define E_MUX0_PIN 40   // Z_CS_PIN
+ #endif
+ #ifndef E_MUX1_PIN
+   #define E_MUX1_PIN 42   // E0_CS_PIN
+ #endif
+ #ifndef E_MUX2_PIN
+   #define E_MUX2_PIN 44   // E1_CS_PIN
+ #endif
+
+ //////////////////////////
+ // LCDs and Controllers //
+ //////////////////////////
+
+ #if ENABLED(ULTRA_LCD)
+
+   //
+   // LCD Display output pins
+   //
+   #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+
+     #define LCD_PINS_RS         49 // CS chip select /SS chip slave select
+     #define LCD_PINS_ENABLE     51 // SID (MOSI)
+     #define LCD_PINS_D4         52 // SCK (CLK) clock
+
+   #elif ENABLED(NEWPANEL) && ENABLED(PANEL_ONE)
+
+     #define LCD_PINS_RS         40
+     #define LCD_PINS_ENABLE     42
+     #define LCD_PINS_D4         65
+     #define LCD_PINS_D5         66
+     #define LCD_PINS_D6         44
+     #define LCD_PINS_D7         64
+
+   #else
+
+     #if ENABLED(CR10_STOCKDISPLAY)
+
+       #define LCD_PINS_RS       27
+       #define LCD_PINS_ENABLE   29
+       #define LCD_PINS_D4       25
+
+       #if DISABLED(NEWPANEL)
+         #define BEEPER_PIN      37
+       #endif
+
+     #else
+
+       #if ENABLED(MKS_12864OLED)
+         #define LCD_PINS_DC     25 // Set as output on init
+         #define LCD_PINS_RS     27 // Pull low for 1s to init
+         // DOGM SPI LCD Support
+         #define DOGLCD_CS       16
+         #define DOGLCD_MOSI     17
+         #define DOGLCD_SCK      23
+         #define DOGLCD_A0       LCD_PINS_DC
+       #else
+         #define LCD_PINS_RS     16
+         #define LCD_PINS_ENABLE 17
+         #define LCD_PINS_D4     23
+         #define LCD_PINS_D5     25
+         #define LCD_PINS_D6     27
+       #endif
+
+       #define LCD_PINS_D7       29
+
+       #if DISABLED(NEWPANEL)
+         #define BEEPER_PIN      33
+       #endif
+
+     #endif
+
+     #if DISABLED(NEWPANEL)
+       // Buttons are attached to a shift register
+       // Not wired yet
+       //#define SHIFT_CLK       38
+       //#define SHIFT_LD        42
+       //#define SHIFT_OUT       40
+       //#define SHIFT_EN        17
+     #endif
+
+   #endif
+
+   //
+   // LCD Display input pins
+   //
+   #if ENABLED(NEWPANEL)
+
+     #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
+
+       #define BEEPER_PIN        37
+
+       #if ENABLED(CR10_STOCKDISPLAY)
+         #define BTN_EN1         17
+         #define BTN_EN2         23
+       #else
+         #define BTN_EN1         31
+         #define BTN_EN2         33
+       #endif
+
+       #define BTN_ENC           35
+       #define SD_DETECT_PIN     49
+       #define KILL_PIN          41
+
+       #if ENABLED(BQ_LCD_SMART_CONTROLLER)
+         #define LCD_BACKLIGHT_PIN 39
+       #endif
+
+     #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+
+       #define BTN_EN1           64
+       #define BTN_EN2           59
+       #define BTN_ENC           63
+       #define SD_DETECT_PIN     42
+
+     #elif ENABLED(LCD_I2C_PANELOLU2)
+
+       #define BTN_EN1           47
+       #define BTN_EN2           43
+       #define BTN_ENC           32
+       #define LCD_SDSS          53
+       #define KILL_PIN          41
+
+     #elif ENABLED(LCD_I2C_VIKI)
+
+       #define BTN_EN1           22 // http://files.panucatt.com/datasheets/viki_wiring_diagram.pdf explains 40/42.
+       #define BTN_EN2            7 // 22/7 are unused on RAMPS_14. 22 is unused and 7 the SERVO0_PIN on RAMPS_13.
+       #define BTN_ENC           -1
+
+       #define LCD_SDSS          53
+       #define SD_DETECT_PIN     49
+
+     #elif ENABLED(VIKI2) || ENABLED(miniVIKI)
+
+       #define DOGLCD_CS         45
+       #define DOGLCD_A0         44
+       #define LCD_SCREEN_ROT_180
+
+       #define BEEPER_PIN        33
+       #define STAT_LED_RED_PIN  32
+       #define STAT_LED_BLUE_PIN 35
+
+       #define BTN_EN1           22
+       #define BTN_EN2            7
+       #define BTN_ENC           39
+
+       #define SDSS              53
+       #define SD_DETECT_PIN     -1 // Pin 49 for display sd interface, 72 for easy adapter board
+       #define KILL_PIN          31
+
+     #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
+
+       #define DOGLCD_CS         29
+       #define DOGLCD_A0         27
+
+       #define BEEPER_PIN        23
+       #define LCD_BACKLIGHT_PIN 33
+
+       #define BTN_EN1           35
+       #define BTN_EN2           37
+       #define BTN_ENC           31
+
+       #define LCD_SDSS          53
+       #define SD_DETECT_PIN     49
+       #define KILL_PIN          41
+
+     #elif ENABLED(MKS_MINI_12864)  // Added in Marlin 1.1.6
+
+       #define DOGLCD_A0         27
+       #define DOGLCD_CS         25
+
+       // GLCD features
+       //#define LCD_CONTRAST   190
+       // Uncomment screen orientation
+       //#define LCD_SCREEN_ROT_90
+       //#define LCD_SCREEN_ROT_180
+       //#define LCD_SCREEN_ROT_270
+
+       #define BEEPER_PIN        37
+       // not connected to a pin
+       #define LCD_BACKLIGHT_PIN 65 // backlight LED on A11/D65
+
+       #define BTN_EN1           31
+       #define BTN_EN2           33
+       #define BTN_ENC           35
+
+       #define SDSS              53
+       #define SD_DETECT_PIN     49
+       #define KILL_PIN          64
+
+     #elif ENABLED(MINIPANEL)
+
+       #define BEEPER_PIN        42
+       // not connected to a pin
+       #define LCD_BACKLIGHT_PIN 65 // backlight LED on A11/D65
+
+       #define DOGLCD_A0         44
+       #define DOGLCD_CS         66
+
+       // GLCD features
+       //#define LCD_CONTRAST   190
+       // Uncomment screen orientation
+       //#define LCD_SCREEN_ROT_90
+       //#define LCD_SCREEN_ROT_180
+       //#define LCD_SCREEN_ROT_270
+
+       #define BTN_EN1           40
+       #define BTN_EN2           63
+       #define BTN_ENC           59
+
+       #define SDSS              53
+       #define SD_DETECT_PIN     49
+       #define KILL_PIN          64
+
+     #else
+
+       // Beeper on AUX-4
+       #define BEEPER_PIN        33
+
+       // Buttons are directly attached using AUX-2
+       #if ENABLED(REPRAPWORLD_KEYPAD)
+         #define SHIFT_OUT       40
+         #define SHIFT_CLK       44
+         #define SHIFT_LD        42
+         #define BTN_EN1         64
+         #define BTN_EN2         59
+         #define BTN_ENC         63
+       #elif ENABLED(PANEL_ONE)
+         #define BTN_EN1         59 // AUX2 PIN 3
+         #define BTN_EN2         63 // AUX2 PIN 4
+         #define BTN_ENC         49 // AUX3 PIN 7
+       #else
+         #define BTN_EN1         37
+         #define BTN_EN2         35
+         #define BTN_ENC         31
+       #endif
+
+       #if ENABLED(G3D_PANEL)
+         #define SD_DETECT_PIN   49
+         #define KILL_PIN        41
+       #endif
+
+     #endif
+   #endif // NEWPANEL
+
+ #endif // ULTRA_LCD


### PR DESCRIPTION
Based on the information I found in the internet, pull-request #5332 and the information provided by the supplier of my printer I added support for RAMPS 1.4 Plus board.

The board differs from the original RAMPS 1.4 board in the following ways:
- Pins for  heater E0 with E1 are swapped
- Pins 8 and 10, which control fan and hotbed are swapped
- Pins that control the display are changed in the following way 16 -> 42, 17 -> 44 and 29 -> 53

Instead of adding the changes to pins_RAMPS.h I decided to copy the file and adding the changes to a separate file. This way
1. I do not break anything
2. The file would have been quite complicated to read with several layers of #ifdef in it

I tested it on my printer using BOARD_RAMPS_14P_EFB and REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER and can confirm that it's working