### PR TITLE
[2.0.x] MKS Sbase support for RepRap Discount Full Graphic Smart Controller

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/spi_pins.h
+++ b/Marlin/src/HAL/HAL_LPC1768/spi_pins.h
@@ -23,6 +23,22 @@
 #ifndef SPI_PINS_LPC1768_H
 #define SPI_PINS_LPC1768_H
 
+#include "../../inc/MarlinConfig.h"
+
+#if MB(MKS_SBASE)
+  
+#define LPC_SOFTWARE_SPI
+
+// A custom cable is needed. See the README file in the 
+// Marlin\src\config\examples\Mks\Sbase directory
+
+#define SCK_PIN           P1_22  // J8-2 (moved from EXP2 P0.7)
+#define MISO_PIN          P1_23  // J8-3 (moved from EXP2 P0.8)  
+#define MOSI_PIN          P2_12  // J8-4 (moved from EXP2 P0.5)  
+#define SS_PIN            P0_28  
+
+#else
+
 #define LPC_SOFTWARE_SPI
 
 /** onboard SD card */
@@ -47,8 +63,9 @@
   #define SDSS              SS_PIN
 #endif
 
-#if (defined(TARGET_LPC1768) && !(defined(LPC_SOFTWARE_SPI)))   // signal LCDs that they need to use the hardware SPI
+#if defined(TARGET_LPC1768) && !defined(LPC_SOFTWARE_SPI)   // signal LCDs that they need to use the hardware SPI
   #define SHARED_SPI
 #endif
 
+#endif // MKS_SBASE
 #endif /* SPI_PINS_LPC1768_H */

--- a/Marlin/src/config/examples/Mks/Sbase/000-README_RepRap_Discount_Full_Graphic_Smart_Controller.txt
+++ b/Marlin/src/config/examples/Mks/Sbase/000-README_RepRap_Discount_Full_Graphic_Smart_Controller.txt
@@ -1,0 +1,27 @@
+The MKS products (all?) have the EXP1 & EXP2 LCD connectors rotated 180 degrees from the ones on the RepRap LCD controllers.
+
+In order to attach the RepRap Discount Full Graphic Smart Controller you'll need to do something like one of the following for both EXP1 & EXP2:
+ a. On one end only, shave the keying plug off the cables and plug the cables in backwards.
+ b. On one end only, carefully pry the housings off the board, rotate them 180 degrees and press them back onto the pins.
+ c. Make custom cables where one connector is rotated 180 degrees.
+
+     MKS:  1  2  3  4  5  6  7  8  9 10
+  RepRap: 10  9  8  7  6  5  4  3  2  1
+
+
+/////////////////////////////////////////////////////////////////////
+
+3 DEC 2017
+
+The current Marlin 2.0.x firmware cannot properly access some of the pins on the EXP2 connector.  In order to use the RepRap Discount Full Graphic Smart Controller you'll need a custom cable that gets three of the signals from a different connector. In that cable move the pin/wire that:
+
+    used to go to P0.8 to J8-3
+    "     "  "  " P0.7 to J8-2
+    "     "  "  " P0.5 to J8-4
+
+If pins different than the J8 ones above are used then the spi_pins.h file will need to be modified.
+
+An octopus cable something like the Adafruit 1199 will simply the construction of the custom cable.  Just plug the Adafruit 1199 into one of the cables that came with the LCD and the individual pins into J8 and EXP2 as needed.
+
+Adafruit 10-pin IDC Socket Rainbow Breakout Cable [1199]
+  https://www.adafruit.com/product/1199


### PR DESCRIPTION
This PR adds support for the RepRap Discount Full Graphic Smart Controller to the MKS Sbase controller.

The MKS Sbase's EXP2 connector uses the same hardware SPI pins as used for the on board SD card.  The current Marlin software can not share these pins with the on board SD card.  This (hopefully temporary workaround) gets the SPI signals from another connector which requires a custom cable.  See the README file for details.

This issue has come up on Issue #8498 .