### PR TITLE
[2.0.x] SERIAL_XON_XOFF not supported on USB-native AVR devices

### DIFF
--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -29,16 +29,20 @@
 #define CONDITIONALS_ADV_H
 
   #ifndef USBCON
-    // Define constants and variables for buffering incoming serial data.
-    // Use only powers of 2.
-    // : [0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...]
+    // Define constants and variables for buffering serial data.
+    // Use only 0 or powers of 2 greater than 1
+    // : [0, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...]
     #ifndef RX_BUFFER_SIZE
       #define RX_BUFFER_SIZE 128
     #endif
-    // 256 is the max TX buffer climit due to uint8_t head and tail.
+    // 256 is the max TX buffer limit due to uint8_t head and tail
+    // : [0, 4, 8, 16, 32, 64, 128, 256]
     #ifndef TX_BUFFER_SIZE
       #define TX_BUFFER_SIZE 32
     #endif
+  #else
+    // SERIAL_XON_XOFF not supported on USB-native devices
+    #undef SERIAL_XON_XOFF
   #endif
 
 #endif // CONDITIONALS_ADV_H

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -253,17 +253,18 @@
  */
 #ifndef USBCON
   #if ENABLED(SERIAL_XON_XOFF) && RX_BUFFER_SIZE < 1024
-    #error "XON/XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
+    #error "SERIAL_XON_XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
   #endif
 
   #if !IS_POWER_OF_2(RX_BUFFER_SIZE) || RX_BUFFER_SIZE < 2
     #error "RX_BUFFER_SIZE must be a power of 2 greater than 1."
   #endif
 
-  // 256 is the max limit due to uint8_t head and tail. Use only powers of 2. (...,16,32,64,128,256)
   #if TX_BUFFER_SIZE && (TX_BUFFER_SIZE < 2 || TX_BUFFER_SIZE > 256 || !IS_POWER_OF_2(TX_BUFFER_SIZE))
     #error "TX_BUFFER_SIZE must be 0, a power of 2 greater than 1, and no greater than 256."
   #endif
+#elif ENABLED(SERIAL_XON_XOFF)
+  #error "SERIAL_XON_XOFF is not supported on USB-native AVR devices."
 #endif
 
 /**


### PR DESCRIPTION
User could enable SERIAL_XON_XOFF on USB-native devices and it would not be enabled without warning, but M115 would report the capability as available.