### PR TITLE
[1.1.x] SERIAL_XON_XOFF not supported on USB-native AVR devices

### DIFF
--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -88,7 +88,6 @@
 
 #ifndef USBCON
   #if ENABLED(SERIAL_XON_XOFF) && RX_BUFFER_SIZE < 1024
-    #error "XON/XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
     #error "SERIAL_XON_XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
   #endif
 

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -75,27 +75,27 @@
 #define BIN 2
 #define BYTE 0
 
-#ifndef USBCON
-  // Define constants and variables for buffering incoming serial data.  We're
-  // using a ring buffer (I think), in which rx_buffer_head is the index of the
-  // location to which to write the next incoming character and rx_buffer_tail
-  // is the index of the location from which to read.
-  // Use only powers of 2.
-  // : [0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...]
-  #ifndef RX_BUFFER_SIZE
-    #define RX_BUFFER_SIZE 128
-  #endif
-  // 256 is the max TX buffer climit due to uint8_t head and tail.
-  #ifndef TX_BUFFER_SIZE
-    #define TX_BUFFER_SIZE 32
-  #endif
+// Define constants and variables for buffering serial data.
+// Use only 0 or powers of 2 greater than 1
+// : [0, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...]
+#ifndef RX_BUFFER_SIZE
+  #define RX_BUFFER_SIZE 128
+#endif
+// 256 is the max TX buffer limit due to uint8_t head and tail.
+#ifndef TX_BUFFER_SIZE
+  #define TX_BUFFER_SIZE 32
+#endif
 
+#ifndef USBCON
   #if ENABLED(SERIAL_XON_XOFF) && RX_BUFFER_SIZE < 1024
     #error "XON/XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
+    #error "SERIAL_XON_XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
   #endif
+
   #if !IS_POWER_OF_2(RX_BUFFER_SIZE) || RX_BUFFER_SIZE < 2
     #error "RX_BUFFER_SIZE must be a power of 2 greater than 1."
   #endif
+
   #if TX_BUFFER_SIZE && (TX_BUFFER_SIZE < 2 || TX_BUFFER_SIZE > 256 || !IS_POWER_OF_2(TX_BUFFER_SIZE))
     #error "TX_BUFFER_SIZE must be 0, a power of 2 greater than 1, and no greater than 256."
   #endif

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -5,7 +5,6 @@
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
  *
- * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
@@ -248,10 +247,8 @@
 /**
  * Serial
  */
-#ifdef USBCON
-  #if ENABLED(SERIAL_XON_XOFF)
-    #error "SERIAL_XON_XOFF is not supported on USB-native AVR devices."
-  #endif
+#if defined(USBCON) && ENABLED(SERIAL_XON_XOFF)
+  #error "SERIAL_XON_XOFF is not supported on USB-native AVR devices."
 #endif
 
 /**

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -5,6 +5,7 @@
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
  *
+ * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -246,6 +246,15 @@
 #endif
 
 /**
+ * Serial
+ */
+#ifdef USBCON
+  #if ENABLED(SERIAL_XON_XOFF)
+    #error "SERIAL_XON_XOFF is not supported on USB-native AVR devices."
+  #endif
+#endif
+
+/**
  * Dual Stepper Drivers
  */
 #if ENABLED(X_DUAL_STEPPER_DRIVERS) && ENABLED(DUAL_X_CARRIAGE)


### PR DESCRIPTION
User could enable SERIAL_XON_XOFF on USB-native devices and it would not be enabled without warning, but M115 would report the capability as available.

@thinkyhead - can you please review this one as I may have made some incorrect assumptions when porting this fix from bugfix2.0.x where there were some changes in this area.  I tried relocating the sanity checks from within `MarlinSerial.h` but it would break non-USB AVR, and _vice versa_ (which is why I believe you may have left them there in the first place ?)

'Spent way too long messing with this 1.1.x port.  I tested all error conditions and confirms it works as expected, but you should take a quick once over just in case it could be done better (note the relocation of USBCON check below the setting of the default buffers sizes to pick those up for both, while USBCON is taken care of in Conditionals_adv.h in bf2).

I think this just further illustrates the need to release 2.0 + 1.1.7 and leave 1.1.7 to strict bugfix-only ;)