### PR TITLE
Added Support for RAMPS 1.4 Plus board 

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -30,16 +30,24 @@
 //
 
 #define BOARD_RAMPS_OLD         3     // MEGA/RAMPS up to 1.2
+
 #define BOARD_RAMPS_13_EFB      33    // RAMPS 1.3 (Power outputs: Hotend, Fan, Bed)
 #define BOARD_RAMPS_13_EEB      34    // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Bed)
 #define BOARD_RAMPS_13_EFF      35    // RAMPS 1.3 (Power outputs: Hotend, Fan0, Fan1)
 #define BOARD_RAMPS_13_EEF      36    // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS_13_SF       38    // RAMPS 1.3 (Power outputs: Spindle, Controller Fan)
+
 #define BOARD_RAMPS_14_EFB      43    // RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
 #define BOARD_RAMPS_14_EEB      44    // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
 #define BOARD_RAMPS_14_EFF      45    // RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
 #define BOARD_RAMPS_14_EEF      46    // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
 #define BOARD_RAMPS_14_SF       48    // RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
+
+#define BOARD_RAMPS_PLUS_EFB   143    // RAMPS Plus 3DYMY (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_PLUS_EEB   144    // RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_PLUS_EFF   145    // RAMPS Plus 3DYMY (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_PLUS_EEF   146    // RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_PLUS_SF    148    // RAMPS Plus 3DYMY (Power outputs: Spindle, Controller Fan)
 
 //
 // RAMPS Derivatives - ATmega1280, ATmega2560

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -71,6 +71,21 @@
 #elif MB(RAMPS_14_SF)
   #define IS_RAMPS_SF
   #include "pins_RAMPS.h"
+#elif MB(RAMPS_PLUS_EFB)
+  #define IS_RAMPS_EFB
+  #include "pins_RAMPS_PLUS.h"
+#elif MB(RAMPS_PLUS_EEB)
+  #define IS_RAMPS_EEB
+  #include "pins_RAMPS_PLUS.h"
+#elif MB(RAMPS_PLUS_EFF)
+  #define IS_RAMPS_EFF
+  #include "pins_RAMPS_PLUS.h"
+#elif MB(RAMPS_PLUS_EEF)
+  #define IS_RAMPS_EEF
+  #include "pins_RAMPS_PLUS.h"
+#elif MB(RAMPS_PLUS_SF)
+  #define IS_RAMPS_SF
+  #include "pins_RAMPS_PLUS.h"
 
 //
 // RAMPS Derivatives - ATmega1280, ATmega2560

--- a/Marlin/pins_RAMPS_PLUS.h
+++ b/Marlin/pins_RAMPS_PLUS.h
@@ -1,0 +1,87 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Arduino Mega with RAMPS v1.4Plus, also known as 3DYMY version, pin assignments
+ * The differences to the RAMPS v1.4 are:
+ *  - Swap heater E0 with E1
+ *  - Swap pins 8 and 10. Bed/Fan/Hotend as labeled on the board are on pins 8/9/10.
+ *  - Change pins 16->42, 17->44 and 29->53 used for display.
+ *
+ * Applies to the following boards:
+ *
+ *  RAMPS_PLUS_EFB (Extruder, Fan, Bed)
+ *  RAMPS_PLUS_EEB (Extruder, Extruder, Bed)
+ *  RAMPS_PLUS_EFF (Extruder, Fan, Fan)
+ *  RAMPS_PLUS_EEF (Extruder, Extruder, Fan)
+ *  RAMPS_PLUS_SF  (Spindle, Controller Fan)
+ *
+ */
+
+#if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
+ #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
+#endif
+
+#ifndef BOARD_NAME
+ #define BOARD_NAME "RAMPS 1.4 Plus"
+#endif
+
+#define RAMPS_D8_PIN  10
+#define RAMPS_D10_PIN  8
+
+#include "pins_RAMPS.h"
+
+//
+// Steppers - Swap E0 / E1 on 3DYMY
+//
+#undef E0_STEP_PIN
+#undef E0_DIR_PIN
+#undef E0_ENABLE_PIN
+
+#undef E1_STEP_PIN
+#undef E1_DIR_PIN
+#undef E1_ENABLE_PIN
+
+#define E0_STEP_PIN        36
+#define E0_DIR_PIN         34
+#define E0_ENABLE_PIN      30
+
+#define E1_STEP_PIN        26
+#define E1_DIR_PIN         28
+#define E1_ENABLE_PIN      24
+
+#undef X_CS_PIN
+#undef Y_CS_PIN
+#undef Z_CS_PIN
+#undef E0_CS_PIN
+#undef E1_CS_PIN
+
+#if ENABLED(ULTRA_LCD) && DISABLED(REPRAPWORLD_GRAPHICAL_LCD) && (DISABLED(NEWPANEL) || DISABLED(PANEL_ONE)) && DISABLED(CR10_STOCKDISPLAY)
+  #if DISABLED(MKS_12864OLED)
+    #undef LCD_PINS_RS
+    #define LCD_PINS_RS     42   // 3DYMY boards pin 16 -> 42
+    #undef LCD_PINS_ENABLE
+    #define LCD_PINS_ENABLE 44   // 3DYMY boards pin 17 -> 44
+  #endif
+  #undef LCD_PINS_D7
+  #define LCD_PINS_D7       53   // 3DYMY boards pin 29 -> 53
+#endif


### PR DESCRIPTION
Based on the information I found in the internet, pull-request #5332 and the information provided by the supplier of my printer I added support for RAMPS 1.4 Plus board.

The board differs from the original RAMPS 1.4 board in the following ways:

- Pins for heater E0 with E1 are swapped
- Pins 8 and 10, which control fan and hotbed are swapped
- Pins that control the display are changed in the following way 16 -> 42, 17 -> 44 and 29 -> 53

Instead of adding the changes to pins_RAMPS.h I decided to copy the file and adding the changes to a separate file. This way

1. I do not break anything
2. The file won't get too complicated to read with several layers of #ifdef in it

I tested it on my printer using BOARD_RAMPS_14P_EFB and REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER and can confirm that it's working