### PR TITLE
Add missing library in Makefile

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -332,7 +332,7 @@ endif
 
 ifeq ($(RELOC_WORKAROUND), 1)
 LD_PREFIX=-nodefaultlibs
-LD_SUFFIX=-lm -lgcc -lc -lgcc
+LD_SUFFIX=-lm -lgcc -lc -lgcc -L$(ARDUINO_INSTALL_DIR)/hardware/tools/avr/avr/lib/avr6 -l$(MCU)
 endif
 
 #Check for Arduino 1.0.0 or higher and use the correct source files for that version


### PR DESCRIPTION
When using RELOC_WORKAROUND library needs to be linked explicitly, otherwise
eeprom functions are not available.

Thanks to @rfjakob for finding the crucial hint to solve this issue.

This solves the following issue: when enabling EEPROM_SETTINGS make reports the following error:

```
$ make
...
  CXX   applet/Marlin.elf
/tmp/ccUqfxN6.ltrans7.ltrans.o: In function `MarlinSettings::read_data(int&, unsigned char*, unsigned int, unsigned int*)':
ccUqfxN6.ltrans7.o:(.text._ZN14MarlinSettings9read_dataERiPhjPj+0x30): undefined reference to `eeprom_read_byte'
/tmp/ccUqfxN6.ltrans7.ltrans.o: In function `MarlinSettings::write_data(int&, unsigned char const*, unsigned int, unsigned int*)':
ccUqfxN6.ltrans7.o:(.text._ZN14MarlinSettings10write_dataERiPKhjPj+0x4e): undefined reference to `eeprom_read_byte'
ccUqfxN6.ltrans7.o:(.text._ZN14MarlinSettings10write_dataERiPKhjPj+0x5a): undefined reference to `eeprom_write_byte'
ccUqfxN6.ltrans7.o:(.text._ZN14MarlinSettings10write_dataERiPKhjPj+0x60): undefined reference to `eeprom_read_byte'
collect2: error: ld returned 1 exit status
Makefile:515: recipe for target 'applet/Marlin.elf' failed
make: *** [applet/Marlin.elf] Error 1
```

Setting RELOC_WORKAROUND=0 fixes the problem, but I guess the correct fix is to include the missing library explicitly when -nodefaultlibs is used because of RELOC_WORKAROUND=1.

Branch 1.0.x is not affected.

Tested with arduino 1.8.5.