### PR TITLE
[1.1.x] Add board Mini RAMBo 1.0a

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -90,10 +90,11 @@
 #define BOARD_MEGATRONICS_31    704   // Megatronics v3.1
 #define BOARD_RAMBO             301   // Rambo
 #define BOARD_MINIRAMBO         302   // Mini-Rambo
+#define BOARD_MINIRAMBO_10A     303   // Mini-Rambo 1.0a
 #define BOARD_ELEFU_3           21    // Elefu Ra Board (v3)
 #define BOARD_LEAPFROG          999   // Leapfrog
 #define BOARD_MEGACONTROLLER    310   // Mega controller
-#define BOARD_SCOOVO_X9H        303   // abee Scoovo X9H
+#define BOARD_SCOOVO_X9H        321   // abee Scoovo X9H
 #define BOARD_GT2560_REV_A      74    // Geeetech GT2560 Rev. A
 #define BOARD_GT2560_REV_A_PLUS 75    // Geeetech GT2560 Rev. A+ (with auto level probe)
 

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -156,7 +156,7 @@
   #include "pins_MEGATRONICS_3.h"     // ATmega2560
 #elif MB(RAMBO)
   #include "pins_RAMBO.h"             // ATmega2560
-#elif MB(MINIRAMBO)
+#elif MB(MINIRAMBO) || MB(MINIRAMBO_10A)
   #include "pins_MINIRAMBO.h"         // ATmega2560
 #elif MB(ELEFU_3)
   #include "pins_ELEFU_3.h"           // ATmega2560

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -152,10 +152,7 @@
   #include "pins_MEGATRONICS.h"       // ATmega2560
 #elif MB(MEGATRONICS_2)
   #include "pins_MEGATRONICS_2.h"     // ATmega2560
-#elif MB(MEGATRONICS_3)
-  #include "pins_MEGATRONICS_3.h"     // ATmega2560
-#elif MB(MEGATRONICS_31)
-  #define MEGATRONICS_31
+#elif MB(MEGATRONICS_3) || MB(MEGATRONICS_31)
   #include "pins_MEGATRONICS_3.h"     // ATmega2560
 #elif MB(RAMBO)
   #include "pins_RAMBO.h"             // ATmega2560

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -21,19 +21,17 @@
  */
 
 /**
- * MegaTronics v3.0 pin assignments
+ * MegaTronics v3.0 / v3.1 pin assignments
  */
 
 #ifndef __AVR_ATmega2560__
   #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define MEGATRONICS_31
-
-#if ENABLED(MEGATRONICS_31)
-  #define BOARD_NAME       "Megatronics v3.1"
+#if MB(MEGATRONICS_31)
+  #define BOARD_NAME "Megatronics v3.1"
 #else
-  #define BOARD_NAME       "Megatronics v3.0"
+  #define BOARD_NAME "Megatronics v3.0"
 #endif
 
 //
@@ -161,10 +159,8 @@
   #define SHIFT_OUT        34
   #define SHIFT_EN         44
 
-  #if ENABLED(MEGATRONICS_31)
+  #if MB(MEGATRONICS_31)
     #define SD_DETECT_PIN  56
-  #else
-    #define SD_DETECT_PIN  -1
   #endif
 
 #endif

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -25,10 +25,14 @@
  */
 
 #ifndef __AVR_ATmega2560__
-  #error "Oops!  Make sure you have 'Arduino Mega 2560 or Rambo' selected from the 'Tools -> Boards' menu."
+  #error "Oops!  Make sure you have 'Rambo' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define BOARD_NAME          "Mini Rambo"
+#if MB(MINIRAMBO_10A)
+  #define BOARD_NAME "Mini Rambo 1.0a"
+#else
+  #define BOARD_NAME "Mini Rambo"
+#endif
 
 //
 // Limit Switches
@@ -66,10 +70,6 @@
 #define E0_DIR_PIN         43
 #define E0_ENABLE_PIN      26
 
-#define E1_STEP_PIN        -1
-#define E1_DIR_PIN         -1
-#define E1_ENABLE_PIN      -1
-
 // Microstepping pins - Mapping not from fastio.h (?)
 #define X_MS1_PIN          40
 #define X_MS2_PIN          41
@@ -101,7 +101,9 @@
 //
 #define HEATER_0_PIN        3
 #define HEATER_1_PIN        7
-#define HEATER_2_PIN        6
+#if !MB(MINIRAMBO_10A)
+  #define HEATER_2_PIN      6
+#endif
 #define HEATER_BED_PIN      4
 
 #define FAN_PIN             8
@@ -112,7 +114,9 @@
 //
 #define SDSS               53
 #define LED_PIN            13
-#define CASE_LIGHT_PIN      9
+#if !MB(MINIRAMBO_10A)
+  #define CASE_LIGHT_PIN    9
+#endif
 
 //
 // M3/M4/M5 - Spindle/Laser Control
@@ -127,33 +131,59 @@
 //
 #define E_MUX0_PIN         17
 #define E_MUX1_PIN         16
-#define E_MUX2_PIN         78 // 84 in MK2 Firmware, with BEEPER as 78
+#if !MB(MINIRAMBO_10A)
+  #define E_MUX2_PIN       78   // 84 in MK2 Firmware, with BEEPER as 78
+#endif
 
 //
 // LCD / Controller
 //
 #if ENABLED(ULTRA_LCD)
 
-  #define KILL_PIN         32
+  #if !MB(MINIRAMBO_10A)
+    #define KILL_PIN       32
+  #endif
 
   #if ENABLED(NEWPANEL)
 
-    // Beeper on AUX-4
-    #define BEEPER_PIN     84
+    #if MB(MINIRAMBO_10A)
 
-    #define LCD_PINS_RS    82
-    #define LCD_PINS_ENABLE 18
-    #define LCD_PINS_D4    19
-    #define LCD_PINS_D5    70
-    #define LCD_PINS_D6    85
-    #define LCD_PINS_D7    71
+      #define BEEPER_PIN   78
 
-    // buttons are directly attached using AUX-2
-    #define BTN_EN1        14
-    #define BTN_EN2        72
-    #define BTN_ENC         9  // the click
+      #define BTN_EN1      80
+      #define BTN_EN2      73
+      #define BTN_ENC      21
 
-    #define SD_DETECT_PIN  15
+      #define LCD_PINS_RS  38
+      #define LCD_PINS_ENABLE 5
+      #define LCD_PINS_D4  14
+      #define LCD_PINS_D5  15
+      #define LCD_PINS_D6  32
+      #define LCD_PINS_D7  31
+
+      #define SD_DETECT_PIN  72
+
+    #else // !MINIRAMBO_10A
+
+      // AUX-4
+      #define BEEPER_PIN   84
+
+      // AUX-2
+      #define BTN_EN1      14
+      #define BTN_EN2      72
+      #define BTN_ENC       9
+
+      #define LCD_PINS_RS  82
+      #define LCD_PINS_ENABLE 18
+      #define LCD_PINS_D4  19
+      #define LCD_PINS_D5  70
+      #define LCD_PINS_D6  85
+      #define LCD_PINS_D7  71
+
+      #define SD_DETECT_PIN  15
+
+    #endif // !MINIRAMBO_10A
 
   #endif // NEWPANEL
+
 #endif // ULTRA_LCD


### PR DESCRIPTION
Hi again,
the board definitions for older version of MINIRAMBo ( see PR #8619 )
I've reworked the patch to be just an addition to the original pins_MINIRAMBO.h file.

These are Board definitions for the MiniRAMBo 1.0a board from Ultimachine. This board was used in the very first Prusa i3 Printers. But since then seems to be forgotten. I own such a machine and tried to install the vanilla Marlin Firmware and not the PrusaFW. Then i wondered why some things (like the LCD display didn't work as expected. This should fix it for owners of the older board.
Prusa used 101 as Board-ID ans so did i. The Name is BOARD_MINIRAMBO_10a.


