### PR TITLE
fix for #8669

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -207,20 +207,19 @@ void GcodeSuite::G28(const bool always_home_all) {
 
     #endif
 
-      if (home_all || homeX || homeY) {
-        // Raise Z before homing any other axes and z is not already high enough (never lower z)
-        destination[Z_AXIS] = Z_HOMING_HEIGHT;
-        if (destination[Z_AXIS] > current_position[Z_AXIS]) {
+    if (home_all || homeX || homeY) {
+      // Raise Z before homing any other axes and z is not already high enough (never lower z)
+      destination[Z_AXIS] = Z_HOMING_HEIGHT;
+      if (destination[Z_AXIS] > current_position[Z_AXIS]) {
 
-          #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING))
-              SERIAL_ECHOLNPAIR("Raise Z (before homing) to ", destination[Z_AXIS]);
-          #endif
+        #if ENABLED(DEBUG_LEVELING_FEATURE)
+          if (DEBUGGING(LEVELING))
+            SERIAL_ECHOLNPAIR("Raise Z (before homing) to ", destination[Z_AXIS]);
+        #endif
 
-          do_blocking_move_to_z(destination[Z_AXIS]);
-        }
+        do_blocking_move_to_z(destination[Z_AXIS]);
       }
-
+    }
 
     #if ENABLED(QUICK_HOME)
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -205,7 +205,7 @@ void GcodeSuite::G28(const bool always_home_all) {
         #endif
       }
 
-    #else
+    #endif
 
       if (home_all || homeX || homeY) {
         // Raise Z before homing any other axes and z is not already high enough (never lower z)
@@ -221,7 +221,6 @@ void GcodeSuite::G28(const bool always_home_all) {
         }
       }
 
-    #endif
 
     #if ENABLED(QUICK_HOME)
 


### PR DESCRIPTION
Z_HOMING_HEIGHT has to be respected in any case, not just when homing Z to max. 

Same as PR #8677 for bugfix-2.0