### PR TITLE
Update TEMP_BED_PIN in MIGHTYBOARD_REVE

### DIFF
--- a/Marlin/src/pins/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/pins_MIGHTYBOARD_REVE.h
@@ -124,7 +124,7 @@
 //
 // Temperature Sensors
 //
-#define TEMP_BED_PIN        69   // K7
+#define TEMP_BED_PIN        15   // K7 - 69 / ADC15 - 15 
 
 // SPI for Max6675 or Max31855 Thermocouple
 // Uses a separate SPI bus


### PR DESCRIPTION
Pin K7 number in fastio1280.h is 69, but it's also ADC15 pin. 
To get correct value from ADC reading it should be set as 15.