### PR TITLE
[2.0.x] Don't split first_move while homing or probing

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -426,11 +426,13 @@ void bracket_probe_move(const bool before) {
     saved_feedrate_percentage = feedrate_percentage;
     feedrate_percentage = 100;
     gcode.refresh_cmd_timeout();
+    planner.split_first_move = false;
   }
   else {
     feedrate_mm_s = saved_feedrate_mm_s;
     feedrate_percentage = saved_feedrate_percentage;
     gcode.refresh_cmd_timeout();
+    planner.split_first_move = true;
   }
 }
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -103,6 +103,8 @@ float Planner::max_feedrate_mm_s[XYZE_N], // Max speeds in mm per second
   uint8_t Planner::last_extruder = 0;     // Respond to extruder change
 #endif
 
+bool Planner::split_first_move = true;
+
 int16_t Planner::flow_percentage[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100); // Extrusion factor for each extruder
 
 float Planner::e_factor[EXTRUDERS],               // The flow percentage and volumetric multiplier combine to scale E movement
@@ -1444,8 +1446,8 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   if (DEBUGGING(DRYRUN))
     position[E_AXIS] = target[E_AXIS];
 
-  // Always split the first move into one longer and one shorter move
-  if (!blocks_queued()) {
+  // Always split the first move into two (if not homing or probing)
+  if (!blocks_queued() && split_first_move) {
     #define _BETWEEN(A) (position[A##_AXIS] + target[A##_AXIS]) >> 1
     const int32_t between[XYZE] = { _BETWEEN(X), _BETWEEN(Y), _BETWEEN(Z), _BETWEEN(E) };
     DISABLE_STEPPER_DRIVER_INTERRUPT();

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -165,6 +165,7 @@ class Planner {
                  travel_acceleration,  // Travel acceleration mm/s^2  DEFAULT ACCELERATION for all NON printing moves. M204 MXXXX
                  max_jerk[XYZE],       // The largest speed change requiring no acceleration
                  min_travel_feedrate_mm_s;
+    static bool split_first_move;
 
     #if HAS_LEVELING
       static bool leveling_active;          // Flag that bed leveling is enabled


### PR DESCRIPTION
While homing or probing it might be bad if the stop/trobe triggers during the first part and the second is still in the buffer.