### PR TITLE
[1.1.x] Purge blocks on endstop/probe hit

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -166,24 +166,15 @@
   #if ENABLED(NEWPANEL)
 
     /**
-     * Detect is_lcd_clicked, debounce it, and return true for cancel
+     * If the LCD is clicked, cancel, wait for release, return true
      */
     bool user_canceled() {
       if (!is_lcd_clicked()) return false; // Return if the button isn't pressed
-
-      #if ENABLED(ULTRA_LCD)
-        lcd_setstatusPGM(PSTR("Mesh Validation Stopped."), 99);
+      lcd_setstatusPGM(PSTR("Mesh Validation Stopped."), 99);
+      #if ENABLED(ULTIPANEL)
         lcd_quick_feedback();
       #endif
-
-      safe_delay(10);                      // Wait for click to settle
-      while (!is_lcd_clicked()) idle();    // Wait for button press again?
-
-      // If the button is suddenly pressed again,
-      // ask the user to resolve the issue
-      lcd_setstatusPGM(PSTR("Release button"), 99); // will never appear...
       wait_for_release();
-      lcd_reset_status();
       return true;
     }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1719,7 +1719,6 @@ static void setup_for_endstop_or_probe_move() {
   saved_feedrate_percentage = feedrate_percentage;
   feedrate_percentage = 100;
   refresh_cmd_timeout();
-  planner.split_first_move = false; 
 }
 
 static void clean_up_after_endstop_or_probe_move() {
@@ -1729,7 +1728,6 @@ static void clean_up_after_endstop_or_probe_move() {
   feedrate_mm_s = saved_feedrate_mm_s;
   feedrate_percentage = saved_feedrate_percentage;
   refresh_cmd_timeout();
-  planner.split_first_move = true; 
 }
 
 #if HAS_BED_PROBE

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -92,8 +92,6 @@ float Planner::max_feedrate_mm_s[XYZE_N], // Max speeds in mm per second
   uint8_t Planner::last_extruder = 0;     // Respond to extruder change
 #endif
 
-bool Planner::split_first_move = true;
-
 int16_t Planner::flow_percentage[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100); // Extrusion factor for each extruder
 
 float Planner::e_factor[EXTRUDERS],               // The flow percentage and volumetric multiplier combine to scale E movement
@@ -1441,7 +1439,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
     position[E_AXIS] = target[E_AXIS];
 
   // Always split the first move into two (if not homing or probing)
-  if (!blocks_queued() && split_first_move) {
+  if (!blocks_queued()) {
     #define _BETWEEN(A) (position[A##_AXIS] + target[A##_AXIS]) >> 1
     const int32_t between[XYZE] = { _BETWEEN(X), _BETWEEN(Y), _BETWEEN(Z), _BETWEEN(E) };
     DISABLE_STEPPER_DRIVER_INTERRUPT();

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -161,7 +161,6 @@ class Planner {
                  travel_acceleration,  // Travel acceleration mm/s^2  DEFAULT ACCELERATION for all NON printing moves. M204 MXXXX
                  max_jerk[XYZE],       // The largest speed change requiring no acceleration
                  min_travel_feedrate_mm_s;
-    static bool split_first_move;
 
     #if HAS_LEVELING
       static bool leveling_active;          // Flag that bed leveling is enabled

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1255,6 +1255,7 @@ void Stepper::endstop_triggered(AxisEnum axis) {
   #endif // !COREXY && !COREXZ && !COREYZ
 
   kill_current_block();
+  cleaning_buffer_counter = -(BLOCK_BUFFER_SIZE - 1); // Ignore remaining blocks
 }
 
 void Stepper::report_positions() {

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -1224,12 +1224,7 @@ void Stepper::finish_and_disable() {
 }
 
 void Stepper::quick_stop() {
-  #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTIPANEL)
-    if (!ubl.lcd_map_control)
-      cleaning_buffer_counter = 5000;
-  #else
-    cleaning_buffer_counter = 5000;
-  #endif
+  cleaning_buffer_counter = 5000;
   DISABLE_STEPPER_DRIVER_INTERRUPT();
   while (planner.blocks_queued()) planner.discard_current_block();
   current_block = NULL;

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -101,10 +101,11 @@ class Stepper {
       static uint32_t motor_current_setting[3];
     #endif
 
+    static int16_t cleaning_buffer_counter;
+
   private:
 
     static uint8_t last_direction_bits;        // The next stepping-bits to be output
-    static int16_t cleaning_buffer_counter;
 
     #if ENABLED(X_DUAL_ENDSTOPS)
       static bool locked_x_motor, locked_x2_motor;

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -311,8 +311,7 @@
   void unified_bed_leveling::G29() {
 
     if (!settings.calc_num_meshes()) {
-      SERIAL_PROTOCOLLNPGM("?You need to enable your EEPROM and initialize it");
-      SERIAL_PROTOCOLLNPGM("with M502, M500, M501 in that order.\n");
+      SERIAL_PROTOCOLLNPGM("?Enable EEPROM and init with M502, M500.\n");
       return;
     }
 


### PR DESCRIPTION
As an alternative to #8687 / #8688

Rather than rely on code that plans to trigger endstops clearing a flag (`planner.split_first_move`) to prevent the first move being split, simply make sure to purge the rest of the blocks in the buffer when an endstop or probe move leads to a trigger.

The stepper code should be doing this for safety anyway. Although the high-level code is careful to only do single un-segmented moves when endstops or the probe are enabled, and the G-code parser is blocked during operations like `G28` and `G29`, there are some cases where there could be more than one move in the planner.

When using commands like `G38.2` on a Delta or SCARA, a sideways probe will be a segmented move. Likewise, when using the `ABORT_ON_ENDSTOP_HIT` feature during an SD print, it is entirely possible for extra moves to be in the planner when the abort occurs.

The `cleaning_buffer_counter` has only been used by `quick_stop` so far, so this PR modifies it slightly so it can differentiate between an endstop hit and a `quick_stop`.

---
The opening code of `Stepper::isr` differs somewhat between the 1.1.x and 2.0.x branches.

https://github.com/MarlinFirmware/Marlin/commit/1beaef04521e60533cf39df67bf34c333c67839a#diff-a7c736c674fcde8ddf7bf0e86181e4c0R355

I'd like to resolve which differences are important and get these back in sync asap.