### PR TITLE
[2.0.x] Purge blocks on endstop/probe hit

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -426,13 +426,11 @@ void bracket_probe_move(const bool before) {
     saved_feedrate_percentage = feedrate_percentage;
     feedrate_percentage = 100;
     gcode.refresh_cmd_timeout();
-    planner.split_first_move = false;
   }
   else {
     feedrate_mm_s = saved_feedrate_mm_s;
     feedrate_percentage = saved_feedrate_percentage;
     gcode.refresh_cmd_timeout();
-    planner.split_first_move = true;
   }
 }
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -103,8 +103,6 @@ float Planner::max_feedrate_mm_s[XYZE_N], // Max speeds in mm per second
   uint8_t Planner::last_extruder = 0;     // Respond to extruder change
 #endif
 
-bool Planner::split_first_move = true;
-
 int16_t Planner::flow_percentage[EXTRUDERS] = ARRAY_BY_EXTRUDERS1(100); // Extrusion factor for each extruder
 
 float Planner::e_factor[EXTRUDERS],               // The flow percentage and volumetric multiplier combine to scale E movement
@@ -1452,7 +1450,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
     position[E_AXIS] = target[E_AXIS];
 
   // Always split the first move into two (if not homing or probing)
-  if (!blocks_queued() && split_first_move) {
+  if (!blocks_queued()) {
     #define _BETWEEN(A) (position[A##_AXIS] + target[A##_AXIS]) >> 1
     const int32_t between[XYZE] = { _BETWEEN(X), _BETWEEN(Y), _BETWEEN(Z), _BETWEEN(E) };
     DISABLE_STEPPER_DRIVER_INTERRUPT();

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -165,7 +165,6 @@ class Planner {
                  travel_acceleration,  // Travel acceleration mm/s^2  DEFAULT ACCELERATION for all NON printing moves. M204 MXXXX
                  max_jerk[XYZE],       // The largest speed change requiring no acceleration
                  min_travel_feedrate_mm_s;
-    static bool split_first_move;
 
     #if HAS_LEVELING
       static bool leveling_active;          // Flag that bed leveling is enabled

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1219,12 +1219,7 @@ void Stepper::finish_and_disable() {
 }
 
 void Stepper::quick_stop() {
-
-  #if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTIPANEL)
-    if (!ubl.lcd_map_control)
-  #endif
-      cleaning_buffer_counter = 5000;
-
+  cleaning_buffer_counter = 5000;
   DISABLE_STEPPER_DRIVER_INTERRUPT();
   while (planner.blocks_queued()) planner.discard_current_block();
   current_block = NULL;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1250,6 +1250,7 @@ void Stepper::endstop_triggered(AxisEnum axis) {
   #endif // !COREXY && !COREXZ && !COREYZ
 
   kill_current_block();
+  cleaning_buffer_counter = -(BLOCK_BUFFER_SIZE - 1); // Ignore remaining blocks
 }
 
 void Stepper::report_positions() {

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -77,10 +77,11 @@ class Stepper {
       static uint32_t motor_current_setting[3];
     #endif
 
+    static int16_t cleaning_buffer_counter;
+
   private:
 
     static uint8_t last_direction_bits;        // The next stepping-bits to be output
-    static int16_t cleaning_buffer_counter;
 
     #if ENABLED(X_DUAL_ENDSTOPS)
       static bool locked_x_motor, locked_x2_motor;


### PR DESCRIPTION
As an alternative to #8687 / #8688

Rather than rely on code that plans to trigger endstops clearing a flag (`planner.split_first_move`) to prevent the first move being split, simply make sure to purge the rest of the blocks in the buffer when an endstop or probe move leads to a trigger.

The stepper code should be doing this for safety anyway. Although the high-level code is careful to only do single un-segmented moves when endstops or the probe are enabled, and the G-code parser is blocked during operations like `G28` and `G29`, there are some cases where there could be more than one move in the planner.

When using commands like `G38.2` on a Delta or SCARA, a sideways probe will be a segmented move. Likewise, when using the `ABORT_ON_ENDSTOP_HIT` feature during an SD print, it is entirely possible for extra moves to be in the planner when the abort occurs.

The `cleaning_buffer_counter` has only been used by `quick_stop` so far, so this PR modifies it slightly so it can differentiate between an endstop hit and a `quick_stop`.

---
The opening code of `Stepper::isr` differs somewhat between the 1.1.x and 2.0.x branches.

https://github.com/MarlinFirmware/Marlin/commit/1beaef04521e60533cf39df67bf34c333c67839a#diff-a7c736c674fcde8ddf7bf0e86181e4c0R355

I'd like to resolve which differences are important and get these back in sync asap.