### PR TITLE
[bugfix-1.1.x] COREXY stutter moves (planner.cpp changes) 

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1083,7 +1083,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
   float max_stepper_speed = 0, min_axis_accel_ratio = 1; // ratio < 1 means acceleration ramp needed
   LOOP_XYZE(i) {
     const float cs = FABS((current_speed[i] = delta_mm[i] * inverse_secs));
-    NOMORE(min_axis_accel_ratio, max_jerk[i]/cs);
+    NOMORE(min_axis_accel_ratio, max_jerk[i] / cs);
     NOLESS(max_stepper_speed, cs);
     #if ENABLED(DISTINCT_E_FACTORS)
       if (i == E_AXIS) i += extruder;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1044,9 +1044,6 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     CRITICAL_SECTION_END
   #endif
 
-  block->nominal_speed = block->millimeters * inverse_secs;           //   (mm/sec) Always > 0
-  block->nominal_rate = CEIL(block->step_event_count * inverse_secs); // (step/sec) Always > 0
-
   #if ENABLED(FILAMENT_WIDTH_SENSOR)
     static float filwidth_e_count = 0, filwidth_delay_dist = 0;
 
@@ -1081,10 +1078,13 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     }
   #endif
 
-  // Calculate and limit speed in mm/sec for each axis
+  // Calculate and limit speed in mm/sec for each axis, calculate minimum acceleration ratio
   float current_speed[NUM_AXIS], speed_factor = 1.0; // factor <1 decreases speed
+  float max_stepper_speed = 0, min_axis_accel_ratio = 1; // ratio < 1 means accelation ramp needed
   LOOP_XYZE(i) {
     const float cs = FABS((current_speed[i] = delta_mm[i] * inverse_secs));
+    NOMORE(min_axis_accel_ratio, max_jerk[i]/cs);
+    NOLESS(max_stepper_speed, cs);
     #if ENABLED(DISTINCT_E_FACTORS)
       if (i == E_AXIS) i += extruder;
     #endif
@@ -1129,6 +1129,9 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     }
   #endif // XY_FREQUENCY_LIMIT
 
+  block->nominal_speed = max_stepper_speed; // (mm/sec) Always > 0
+  block->nominal_rate = CEIL(block->step_event_count * inverse_secs); // (step/sec) Always > 0
+
   // Correct the speed
   if (speed_factor < 1.0) {
     LOOP_XYZE(i) current_speed[i] *= speed_factor;
@@ -1136,6 +1139,8 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     block->nominal_rate *= speed_factor;
   }
 
+  float safe_speed = block->nominal_speed * min_axis_accel_ratio;
+  static float previous_safe_speed;
   // Compute and limit the acceleration rate for the trapezoid generator.
   const float steps_per_mm = block->step_event_count * inverse_millimeters;
   uint32_t accel;
@@ -1237,32 +1242,6 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     }
   #endif
 
-  /**
-   * Adapted from Průša MKS firmware
-   * https://github.com/prusa3d/Prusa-Firmware
-   *
-   * Start with a safe speed (from which the machine may halt to stop immediately).
-   */
-
-  // Exit speed limited by a jerk to full halt of a previous last segment
-  static float previous_safe_speed;
-
-  float safe_speed = block->nominal_speed;
-  uint8_t limited = 0;
-  LOOP_XYZE(i) {
-    const float jerk = FABS(current_speed[i]), maxj = max_jerk[i];
-    if (jerk > maxj) {
-      if (limited) {
-        const float mjerk = maxj * block->nominal_speed;
-        if (jerk * safe_speed > mjerk) safe_speed = mjerk / jerk;
-      }
-      else {
-        ++limited;
-        safe_speed = maxj;
-      }
-    }
-  }
-
   if (moves_queued && !UNEAR_ZERO(previous_nominal_speed)) {
     // Estimate a maximum velocity allowed at a joint of two successive segments.
     // If this maximum velocity allowed is lower than the minimum of the entry / exit safe velocities,
@@ -1274,7 +1253,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
 
     // Factor to multiply the previous / current nominal velocities to get componentwise limited velocities.
     float v_factor = 1;
-    limited = 0;
+    uint8_t limited = 0;
 
     // Now limit the jerk in all axes.
     const float smaller_speed_factor = vmax_junction / previous_nominal_speed;

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1080,7 +1080,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
 
   // Calculate and limit speed in mm/sec for each axis, calculate minimum acceleration ratio
   float current_speed[NUM_AXIS], speed_factor = 1.0; // factor <1 decreases speed
-  float max_stepper_speed = 0, min_axis_accel_ratio = 1; // ratio < 1 means accelation ramp needed
+  float max_stepper_speed = 0, min_axis_accel_ratio = 1; // ratio < 1 means acceleration ramp needed
   LOOP_XYZE(i) {
     const float cs = FABS((current_speed[i] = delta_mm[i] * inverse_secs));
     NOMORE(min_axis_accel_ratio, max_jerk[i]/cs);


### PR DESCRIPTION
This is from Issue #8573 

In a band of feed rates the CORE machines will have short (10mS – 30mS) pauses.

The root cause is the current code doesn’t apply jerk until the head movement rate exceeds the jerk setting.  On a CORE machine one of the steppers is always moving faster than the head.  The result is a band of feed rates where the stepper needs jerk but the head rate isn’t yet calling for it.

In that band of feed rates, negative values for **block->accelerate_until** are fed to the stepper routine.  These negative values result in the short pauses of about 10mS - 30mS spaced about 275mS apart..
 
This update calculates the jerk requirements on a per stepper basis.  It also applies the worst case rather than just the one with the maximum configured jerk.

`nominal_speed` is now based on maximum stepper speed and `start_speed` is based on the worst case jerk.

----

CPU loading is not affected by the code change.  Execution times for `_buffer_steps()` are similar.

Execution times are in milliseconds.  

```
current  1.499  2.008  2.258  2.326  2.212  2.143
         1.533  1.977  2.258  2.326  2.212  2.125
         1.546  1.973  2.258  2.319  2.392  2.010
         1.505  2.002  2.211  2.380  2.206  2.136

update   1.616  1.900  2.271  2.321  2.254  2.126
         1.627  1.905  2.271  2.321  2.312  2.033
         1.627  1.901  2.251  2.321  2.102  2.207
         1.632  1.905  2.288  2.321  2.324  2.033
```

The above uses the following gcode program
```
  g1 x100 y100 f1000
  g1 x50  y200 f1000
  g1 x0   y0   f1000
  g1 x275 y25  f1000
  g1 x100 y100 f100
```

----

Build sizes and RAM usage are the same or a little less.
```
         text       data     bss 
current  51642       192    2406
update   51776       192    2406  
```

----

Here's an example of the stuttering when the feed rate is in problem band.
![image](https://user-images.githubusercontent.com/20692583/33699068-6ef8f7f6-dad6-11e7-9c58-d7da5c2bbec9.png)

Here are logic analyzer captures of the step pulses.  They include new & old software, COREXY & Cartesian and various feedrates.  The gcode program is given above.  X jerk was set to 20 and Y was set to 10 so that it is possible to see what happens when axis need different accelerations.

The very bottom trace is the time spend in the `_buffer_steps()` routine.

You'll need the [Saleae software](https://www.saleae.com/downloads) to view them.

[stepper captures.zip](https://github.com/MarlinFirmware/Marlin/files/1537848/stepper.captures.zip)
