### PR TITLE
[1.1.x] Discard "continued" blocks on interrupted move

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -778,7 +778,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
   block_t* block = &block_buffer[block_buffer_head];
 
   // Clear all flags, including the "busy" bit
-  block->flag = 0;
+  block->flag = 0x00;
 
   // Set direction bits
   block->direction_bits = dm;
@@ -1139,6 +1139,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
 
   float safe_speed = block->nominal_speed * min_axis_accel_ratio;
   static float previous_safe_speed;
+
   // Compute and limit the acceleration rate for the trapezoid generator.
   const float steps_per_mm = block->step_event_count * inverse_millimeters;
   uint32_t accel;
@@ -1423,7 +1424,9 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
     const int32_t between[XYZE] = { _BETWEEN(X), _BETWEEN(Y), _BETWEEN(Z), _BETWEEN(E) };
     DISABLE_STEPPER_DRIVER_INTERRUPT();
     _buffer_steps(between, fr_mm_s, extruder);
+    const uint8_t next = block_buffer_head;
     _buffer_steps(target, fr_mm_s, extruder);
+    SBI(block_buffer[next].flag, BLOCK_BIT_CONTINUED);
     ENABLE_STEPPER_DRIVER_INTERRUPT();
   }
   else

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -427,16 +427,19 @@ void Stepper::isr() {
   // When cleaning, discard the current block and run fast
   //
   if (cleaning_buffer_counter) {
-    current_block = NULL;
-    planner.discard_current_block();
-    if (cleaning_buffer_counter < 0)
-      ++cleaning_buffer_counter;            // Count up for endstop hit
+    if (cleaning_buffer_counter < 0) {          // Count up for endstop hit
+      if (current_block) planner.discard_current_block(); // Discard the active block that led to the trigger
+      if (!planner.discard_continued_block())   // Discard next CONTINUED block
+        cleaning_buffer_counter = 0;            // Keep discarding until non-CONTINUED
+    }
     else {
-      --cleaning_buffer_counter;            // Count down for abort print
+      planner.discard_current_block();
+      --cleaning_buffer_counter;                // Count down for abort print
       #ifdef SD_FINISHED_RELEASECOMMAND
         if (!cleaning_buffer_counter && (SD_FINISHED_STEPPERRELEASE)) enqueue_and_echo_commands_P(PSTR(SD_FINISHED_RELEASECOMMAND));
       #endif
     }
+    current_block = NULL;                       // Prep to get a new block after cleaning
     _NEXT_ISR(200);                             // Run at max speed - 10 KHz
     _ENABLE_ISRs();
     return;
@@ -1124,9 +1127,9 @@ void Stepper::init() {
 
 
 /**
- * Block until all buffered steps are executed
+ * Block until all buffered steps are executed / cleaned
  */
-void Stepper::synchronize() { while (planner.blocks_queued()) idle(); }
+void Stepper::synchronize() { while (planner.blocks_queued() || cleaning_buffer_counter) idle(); }
 
 /**
  * Set the stepper positions directly in steps
@@ -1250,7 +1253,7 @@ void Stepper::endstop_triggered(AxisEnum axis) {
   #endif // !COREXY && !COREXZ && !COREYZ
 
   kill_current_block();
-  cleaning_buffer_counter = -(BLOCK_BUFFER_SIZE - 1); // Ignore remaining blocks
+  cleaning_buffer_counter = -1; // Discard the rest of the move
 }
 
 void Stepper::report_positions() {


### PR DESCRIPTION
Addressing #8700, #8704
Reference: #8690

**Background:** In order to fix a planner first move stutter issue we modified `_buffer_line` to always split the first move to the planner, allowing it to be chained by the junction code. This led to an issue where the extra move would be in the buffer after an endstop/probe hit, leading to continued motion after the hit. To deal with this, we added code to throw away the rest of the planner blocks on an interrupted move. This led to a problem where pre-buffered intentional moves ended up being thrown away.

**Summary:** Homing is borked.

This PR fixes the issue by marking the second block in a split as `CONTINUED`. On any endstop hit, only blocks marked `CONTINUED` will be thrown away, and the next non-`CONTINUED` block will be executed.

Note that this flag could be applied to any segmented move that should be interruptible by endstop or probe. This would allow `G38` to work on a delta, for example. Extending this would add some overhead to the planner, so it should be limited to cases where it is needed (e.g., `G38` on delta).