### PR TITLE
[2.0.x] Fix for #8604

### DIFF
--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -124,8 +124,8 @@
     for (uint8_t s = 0; s < strokes; s++)
       for (uint8_t i = 0; i < NOZZLE_CLEAN_CIRCLE_FN; i++)
         do_blocking_move_to_xy(
-          middle.x + sin((2.0 * M_PI / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius,
-          middle.y + cos((2.0 * M_PI / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius
+          middle.x + sin((RADIANS(360) / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius,
+          middle.y + cos((RADIANS(360) / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius
         );
 
     // Let's be safe

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -124,8 +124,8 @@
     for (uint8_t s = 0; s < strokes; s++)
       for (uint8_t i = 0; i < NOZZLE_CLEAN_CIRCLE_FN; i++)
         do_blocking_move_to_xy(
-          middle.x + sin((M_2_PI / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius,
-          middle.y + cos((M_2_PI / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius
+          middle.x + sin((2.0 * M_PI / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius,
+          middle.y + cos((2.0 * M_PI / NOZZLE_CLEAN_CIRCLE_FN) * i) * radius
         );
 
     // Let's be safe


### PR DESCRIPTION
This is a fix for issue #8604, replacing an incorrect constant M_2_PI (2/pi) with 2.0 * M_PI in nozzle.cpp. I think this multiplication should be constant-folded by the compiler, if it won't and it's a waste of cycles then it could be #defined (nozzle.h?) as a constant instead. 