### PR TITLE
[Bugfix-1.1.x] initial step correction

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -447,10 +447,13 @@ void Stepper::isr() {
   }
 
   // If there is no current block, attempt to pop one from the buffer
+  bool first_step = false;
   if (!current_block) {
     // Anything in the buffer?
     if ((current_block = planner.get_current_block())) {
       trapezoid_generator_reset();
+      TCNT1 = 0;  // make sure first pulse is not truncated
+      first_step = true;
 
       // Initialize Bresenham counters to 1/2 the ceiling
       counter_X = counter_Y = counter_Z = counter_E = -(current_block->step_event_count >> 1);
@@ -705,8 +708,13 @@ void Stepper::isr() {
   // Calculate new timer value
   if (step_events_completed <= (uint32_t)current_block->accelerate_until) {
 
-    MultiU24X32toH16(acc_step_rate, acceleration_time, current_block->acceleration_rate);
-    acc_step_rate += current_block->initial_rate;
+    if (first_step) {
+      acc_step_rate = current_block->initial_rate;
+    }
+    else {
+      MultiU24X32toH16(acc_step_rate, acceleration_time, current_block->acceleration_rate);
+      acc_step_rate += current_block->initial_rate;
+    }
 
     // upper limit
     NOMORE(acc_step_rate, current_block->nominal_rate);

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -710,6 +710,7 @@ void Stepper::isr() {
 
     if (first_step) {
       acc_step_rate = current_block->initial_rate;
+      acceleration_time = 0;
     }
     else {
       MultiU24X32toH16(acc_step_rate, acceleration_time, current_block->acceleration_rate);

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -359,9 +359,6 @@ class Stepper {
       OCR1A_nominal = calc_timer_interval(current_block->nominal_rate);
       // make a note of the number of step loops required at nominal speed
       step_loops_nominal = step_loops;
-      acc_step_rate = current_block->initial_rate;
-      acceleration_time = calc_timer_interval(acc_step_rate);
-      _NEXT_ISR(acceleration_time);
 
       #if ENABLED(LIN_ADVANCE)
         if (current_block->use_advance_lead) {


### PR DESCRIPTION
Issues with the current code:
1) The time between the first two steps is usually truncated.  This happens only when starting up from a standstill.  The root cause is the timer TCNT1 isn't initialized at the start so it can be any value.
2) If a new block requires acceleration, the time between the first two steps is less than called for by the jerk setting.  The root cause is the values generated by trapezoid_generator_reset() are not being used.

Solution
1) Set TCNT1 to zero when a new block is popped.
2) Move the initial accel step calculations from trapezoid_generator_reset() into  stepper.cpp.  `if (step_events_completed == 1)` could have been used to flag the first step instead of `if (first_step)` but I felt it was a little slower.

Example of a truncated first step:
![image](https://user-images.githubusercontent.com/20692583/33800505-56ea3986-dd06-11e7-9495-ff2816978e3a.png)

Example of short first acceleration step.  The spacing should be 1.250mS but measures 0.879mS.
![image](https://user-images.githubusercontent.com/20692583/33800521-b2d12f20-dd06-11e7-9f72-23ac4755252a.png)
