### PR TITLE
[1.1.x] M852 skew changes position. And, position change reporting.

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -373,7 +373,7 @@ void report_current_position();
 #endif
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-  void set_z_fade_height(const float zfh);
+  void set_z_fade_height(const float zfh, const bool do_report=true);
 #endif
 
 #if ENABLED(X_DUAL_ENDSTOPS)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9914,43 +9914,60 @@ inline void gcode_M502() {
    *  K[yz_factor] - New YZ skew factor
    */
   inline void gcode_M852() {
-    const bool ijk = parser.seen('I') || parser.seen('S')
-      #if ENABLED(SKEW_CORRECTION_FOR_Z)
-        || parser.seen('J') || parser.seen('K')
-      #endif
-    ;
-    bool badval = false;
+    uint8_t ijk = 0, badval = 0, setval = 0;
 
     if (parser.seen('I') || parser.seen('S')) {
+      ++ijk;
       const float value = parser.value_linear_units();
-      if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX))
-        planner.xy_skew_factor = value;
+      if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX)) {
+        if (planner.xy_skew_factor != value) {
+          planner.xy_skew_factor = value;
+          ++setval;
+        }
+      }
       else
-        badval = true;
+        ++badval;
     }
 
     #if ENABLED(SKEW_CORRECTION_FOR_Z)
 
       if (parser.seen('J')) {
+        ++ijk;
         const float value = parser.value_linear_units();
-        if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX))
-          planner.xz_skew_factor = value;
+        if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX)) {
+          if (planner.xz_skew_factor != value) {
+            planner.xz_skew_factor = value;
+            ++setval;
+          }
+        }
         else
-          badval = true;
+          ++badval;
       }
 
       if (parser.seen('K')) {
+        ++ijk;
         const float value = parser.value_linear_units();
-        if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX))
-          planner.yz_skew_factor = value;
+        if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX)) {
+          if (planner.yz_skew_factor != value) {
+            planner.yz_skew_factor = value;
+            ++setval;
+          }
+        }
         else
-          badval = true;
+          ++badval;
       }
 
     #endif
 
     if (badval)
       SERIAL_ECHOLNPGM(MSG_SKEW_MIN " " STRINGIFY(SKEW_FACTOR_MIN) " " MSG_SKEW_MAX " " STRINGIFY(SKEW_FACTOR_MAX));
+
+    // When skew is changed the current position changes
+    if (setval) {
+      set_current_from_steppers_for_axis(ALL_AXES);
+      SYNC_PLAN_POSITION_KINEMATIC();
+      report_current_position();
+    }
 
     if (!ijk) {
       SERIAL_ECHO_START();

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2475,7 +2475,9 @@ static void clean_up_after_endstop_or_probe_move() {
 
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
-    void set_z_fade_height(const float zfh) {
+    void set_z_fade_height(const float zfh, const bool do_report/*=true*/) {
+
+      if (planner.z_fade_height == zfh) return; // do nothing if no change
 
       const bool level_active = planner.leveling_active;
 
@@ -2497,6 +2499,7 @@ static void clean_up_after_endstop_or_probe_move() {
             #endif
           );
         #endif
+        if (do_report) report_current_position();
       }
     }
 

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -67,17 +67,19 @@
   volatile int unified_bed_leveling::encoder_diff;
 
   unified_bed_leveling::unified_bed_leveling() {
-    ubl_cnt++;  // Debug counter to insure we only have one UBL object present in memory.  We can eliminate this (and all references to ubl_cnt) very soon.
+    ubl_cnt++;  // Debug counter to ensure we only have one UBL object present in memory.  We can eliminate this (and all references to ubl_cnt) very soon.
     reset();
   }
 
   void unified_bed_leveling::reset() {
+    const bool was_enabled = planner.leveling_active;
     set_bed_leveling_enabled(false);
     storage_slot = -1;
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       planner.set_z_fade_height(10.0);
     #endif
     ZERO(z_values);
+    if (was_enabled) report_current_position();
   }
 
   void unified_bed_leveling::invalidate() {


### PR DESCRIPTION
`M852` needs to update the current logical position based on changes to skew, as with leveling.

This PR also includes changes so that `M420` and other code will call `SYNC_PLAN_POSITION_KINEMATIC` and `report_current_position` when the `current_position` is likely to have changed.

See #8747 for 2.0.x