### PR TITLE
[1.1.x] stepper decel when direction changes

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -235,6 +235,7 @@ void Planner::calculate_trapezoid_for_block(block_t* const block, const float &e
     block->final_rate = final_rate;
   }
   CRITICAL_SECTION_END;
+
 }
 
 // "Junction jerk" in this context is the immediate change in speed at the junction of two blocks.
@@ -326,20 +327,28 @@ void Planner::forward_pass() {
  * Recalculate the trapezoid speed profiles for all blocks in the plan
  * according to the entry_factor for each junction. Must be called by
  * recalculate() after updating the blocks.
+ *
+ * If there is a direction change then the final_rate of the current block
+ * is set to that block's jerk limited rate and the init_rate of the next
+ * block is set to that block's jerk limited rate.
  */
 void Planner::recalculate_trapezoids() {
   int8_t block_index = block_buffer_tail;
+  bool direction_change = false;
   block_t *current, *next = NULL;
-
   while (block_index != block_buffer_head) {
     current = next;
     next = &block_buffer[block_index];
     if (current) {
       // Recalculate if current block entry or exit junction speed has changed.
       if (TEST(current->flag, BLOCK_BIT_RECALCULATE) || TEST(next->flag, BLOCK_BIT_RECALCULATE)) {
+        LOOP_XYZE(axis)
+          if (current->steps[axis] && TEST(current->direction_bits ^ next->direction_bits, axis))
+            direction_change = true;
+
         // NOTE: Entry and exit factors always > 0 by all previous logic operations.
         const float nomr = 1.0 / current->nominal_speed;
-        calculate_trapezoid_for_block(current, current->entry_speed * nomr, next->entry_speed * nomr);
+        calculate_trapezoid_for_block(current, current->entry_speed * nomr, direction_change ? current->min_axis_accel_ratio : next->entry_speed * nomr);
         CBI(current->flag, BLOCK_BIT_RECALCULATE); // Reset current only to ensure next trapezoid is computed
       }
     }
@@ -348,7 +357,7 @@ void Planner::recalculate_trapezoids() {
   // Last/newest block in buffer. Exit speed is set with MINIMUM_PLANNER_SPEED. Always recalculated.
   if (next) {
     const float nomr = 1.0 / next->nominal_speed;
-    calculate_trapezoid_for_block(next, next->entry_speed * nomr, (MINIMUM_PLANNER_SPEED) * nomr);
+    calculate_trapezoid_for_block(next, direction_change ? next->min_axis_accel_ratio : next->entry_speed * nomr, (MINIMUM_PLANNER_SPEED) * nomr);
     CBI(next->flag, BLOCK_BIT_RECALCULATE);
   }
 }
@@ -1061,7 +1070,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
   float max_stepper_speed = 0, min_axis_accel_ratio = 1; // ratio < 1 means acceleration ramp needed
   LOOP_XYZE(i) {
     const float cs = FABS((current_speed[i] = delta_mm[i] * inverse_secs));
-    if (cs >  max_jerk[i]) 
+    if (cs >  max_jerk[i])
       NOMORE(min_axis_accel_ratio, max_jerk[i] / cs);
     NOLESS(max_stepper_speed, cs);
     #if ENABLED(DISTINCT_E_FACTORS)
@@ -1069,6 +1078,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     #endif
     if (cs > max_feedrate_mm_s[i]) NOMORE(speed_factor, max_feedrate_mm_s[i] / cs);
   }
+  block->min_axis_accel_ratio = min_axis_accel_ratio;
 
   // Max segment time in µs.
   #ifdef XY_FREQUENCY_LIMIT

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -107,7 +107,8 @@ typedef struct {
         entry_speed,                        // Entry speed at previous-current junction in mm/sec
         max_entry_speed,                    // Maximum allowable junction entry speed in mm/sec
         millimeters,                        // The total travel of this block in mm
-        acceleration;                       // acceleration mm/sec^2
+        acceleration,                       // acceleration mm/sec^2
+        min_axis_accel_ratio;               // ratio between nominal speed and startup speed
 
   // Settings for the trapezoid generator
   uint32_t nominal_rate,                    // The nominal step rate for this block in step_events/sec
@@ -571,7 +572,9 @@ class Planner {
      */
     static float estimate_acceleration_distance(const float &initial_rate, const float &target_rate, const float &accel) {
       if (accel == 0) return 0; // accel was 0, set acceleration distance to 0
-      return (sq(target_rate) - sq(initial_rate)) / (accel * 2);
+      return (sq(target_rate) - sq(initial_rate)) / (accel * 1.7);  // 1.7 - fudge factor to get most of stepper
+                                                                    // decel ramps to hit the final rate - overkill
+                                                                    // for accel ramps but doesn't matter
     }
 
     /**

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -744,15 +744,10 @@ void Stepper::isr() {
   }
   else if (step_events_completed > (uint32_t)current_block->decelerate_after) {
     uint16_t step_rate;
-    MultiU24X32toH16(step_rate, deceleration_time, current_block->acceleration_rate);
-
-    if (step_rate < acc_step_rate) { // Still decelerating?
-      step_rate = acc_step_rate - step_rate;
-      NOLESS(step_rate, current_block->final_rate);
-    }
-    else
-      step_rate = current_block->final_rate;
-
+    MultiU24X32toH16(step_rate, deceleration_time, current_block->acceleration_rate);  //calc decel rate
+    NOMORE(step_rate, acc_step_rate);  // make sure final step rate doesn't go negative
+    step_rate =  acc_step_rate - step_rate;  // now we have the real step rate
+    NOLESS(step_rate, current_block->final_rate);
     // step_rate to timer interval
     const uint16_t interval = calc_timer_interval(step_rate);
 


### PR DESCRIPTION
This code will decelerate all steppers to the jerk limited rate (or less) if any stepper has a direction change.

See issue #8752 for some more discussion on this topic.

This is done in the re-calculation phase of the planner within the `recalculate_trapezoids() `routine.  If  there is a direction change then the final_rate of the current block is set to that block's jerk limited rate and the init_rate of the next  block is set to that block's jerk limited rate.

The `estimate_acceleration_distance` equation was modified to give about 15% more steps.  This was done to get **MOST** of the stepper decel ramps to hit the final rate.  Looks like it is resulting in 1 or 2 more decel steps than required.  Previously it was usually 1-3 steps short of reaching the final rate.   It also results in more acel steps than needed but that doesn't hurt anything because the step rate is limited to the nominal rate. 

In stepper.cpp the deceleration code was cleaned up a little and comments were added so it's easier to see what is going on.

This is the current code.  The Y axis only gets to 0.6mS spacing before the direction change.  The jerk requirement on this axis is 1.25mS.
![image](https://user-images.githubusercontent.com/20692583/33868156-eb4cd856-dec6-11e7-9c21-fb890e764599.png)


With new code.  Same scale as above.  Th step spacings now conform to the jerk limitations.
![image](https://user-images.githubusercontent.com/20692583/33868105-a0e7de14-dec6-11e7-98a5-2b4d7851fcb8.png)


----

I did some playing around to see I could get an accurate calculation for the required number of deceleration pulses.  The only method I found was to uses the same code as in the decel section of the stepper ISR and count the number of iterations needed to complete a decel ramp.  This approach is very costly in CPU time.  Each iteration (decel pulse) costs about 30uS (hundreds of microseconds per block) while the current estimation method costs about 10uS per block.

----

No matter what there will always be at least one step used to reverse a stepper.  No attempt has been made to compensate for that lost step.  
