### PR TITLE
[2.0.x] Comment, fix filament width sensor

### DIFF
--- a/Marlin/src/gcode/feature/filwidth/M404-M407.cpp
+++ b/Marlin/src/gcode/feature/filwidth/M404-M407.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M405() {
   }
 
   if (filwidth_delay_index[1] == -1) { // Initialize the ring buffer if not done since startup
-    const uint8_t temp_ratio = thermalManager.widthFil_to_size_ratio() - 100; // -100 to scale within a signed byte
+    const uint8_t temp_ratio = thermalManager.widthFil_to_size_ratio();
 
     for (uint8_t i = 0; i < COUNT(measurement_delay); ++i)
       measurement_delay[i] = temp_ratio;
@@ -65,11 +65,6 @@ void GcodeSuite::M405() {
   }
 
   filament_sensor = true;
-
-  //SERIAL_PROTOCOLPGM("Filament dia (measured mm):");
-  //SERIAL_PROTOCOL(filament_width_meas);
-  //SERIAL_PROTOCOLPGM("Extrusion ratio(%):");
-  //SERIAL_PROTOCOL(planner.flow_percentage[active_extruder]);
 }
 
 /**

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -660,10 +660,12 @@ static void lcd_implementation_status_screen() {
     strcpy(zstring, ftostr52sp(FIXFLOAT(LOGICAL_Z_POSITION(current_position[Z_AXIS]))));
     #if ENABLED(FILAMENT_LCD_DISPLAY)
       strcpy(wstring, ftostr12ns(filament_width_meas));
-      if (parser.volumetric_enabled)
-        strcpy(mstring, itostr3(100.0 * planner.volumetric_area_nominal / planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]));
-      else
-        strcpy_P(mstring, PSTR("---"));
+      strcpy(mstring, itostr3(100.0 * (
+          parser.volumetric_enabled
+            ? planner.volumetric_area_nominal / planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
+            : planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
+        )
+      ));
     #endif
   }
 

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -884,12 +884,13 @@ static void lcd_implementation_status_screen() {
       lcd_printPGM(PSTR("Dia "));
       lcd.print(ftostr12ns(filament_width_meas));
       lcd_printPGM(PSTR(" V"));
-      if (parser.volumetric_enabled) {
-        lcd.print(itostr3(100.0 * planner.volumetric_area_nominal / planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]));
-        lcd.write('%');
-      }
-      else
-        lcd_printPGM(PSTR("--- "));
+      lcd.print(itostr3(100.0 * (
+          parser.volumetric_enabled
+            ? planner.volumetric_area_nominal / planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
+            : planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
+        )
+      ));
+      lcd.write('%');
       return;
     }
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -561,16 +561,44 @@ void Planner::check_axes_activity() {
   #endif
 }
 
+/**
+ * Get a volumetric multiplier from a filament diameter.
+ * This is the reciprocal of the circular cross-section area.
+ * Return 1.0 with volumetric off or a diameter of 0.0.
+ */
 inline float calculate_volumetric_multiplier(const float &diameter) {
   return (parser.volumetric_enabled && diameter) ? 1.0 / CIRCLE_AREA(diameter * 0.5) : 1.0;
 }
 
+/**
+ * Convert the filament sizes into volumetric multipliers.
+ * The multiplier converts a given E value into a length.
+ */
 void Planner::calculate_volumetric_multipliers() {
   for (uint8_t i = 0; i < COUNT(filament_size); i++) {
     volumetric_multiplier[i] = calculate_volumetric_multiplier(filament_size[i]);
     refresh_e_factor(i);
   }
 }
+
+#if ENABLED(FILAMENT_WIDTH_SENSOR)
+  /**
+   * Convert the ratio value given by the filament width sensor
+   * into a volumetric multiplier. Conversion differs when using
+   * linear extrusion vs volumetric extrusion.
+   */
+  void Planner::calculate_volumetric_for_width_sensor(const int8_t encoded_ratio) {
+    // Reconstitute the nominal/measured ratio
+    const float nom_meas_ratio = 1.0 + 0.01 * encoded_ratio,
+                ratio_2 = sq(nom_meas_ratio);
+
+    volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM] = parser.volumetric_enabled
+      ? ratio_2 / CIRCLE_AREA(filament_width_nominal * 0.5) // Volumetric uses a true volumetric multiplier
+      : ratio_2;                                            // Linear squares the ratio, which scales the volume
+
+    refresh_e_factor(FILAMENT_SENSOR_EXTRUDER_NUM);
+  }
+#endif
 
 #if PLANNER_LEVELING
   /**
@@ -1057,7 +1085,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
         // If the index has changed (must have gone forward)...
         if (filwidth_delay_index[0] != filwidth_delay_index[1]) {
           filwidth_e_count = 0; // Reset the E movement counter
-          const uint8_t meas_sample = thermalManager.widthFil_to_size_ratio() - 100; // Subtract 100 to reduce magnitude - to store in a signed char
+          const uint8_t meas_sample = thermalManager.widthFil_to_size_ratio();
           do {
             filwidth_delay_index[1] = (filwidth_delay_index[1] + 1) % MMD_CM; // The next unused slot
             measurement_delay[filwidth_delay_index[1]] = meas_sample;         // Store the measurement

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -293,6 +293,10 @@ class Planner {
     // Update multipliers based on new diameter measurements
     static void calculate_volumetric_multipliers();
 
+    #if ENABLED(FILAMENT_WIDTH_SENSOR)
+      void calculate_volumetric_for_width_sensor(const int8_t encoded_ratio);
+    #endif
+
     FORCE_INLINE static void set_filament_size(const uint8_t e, const float &v) {
       filament_size[e] = v;
       // make sure all extruders have some sane value for the filament size

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -688,7 +688,7 @@ void Stepper::isr() {
     // step_rate to timer interval
     const hal_timer_t interval = calc_timer_interval(acc_step_rate);
 
-    SPLIT(interval);  // split step into multiple ISRs if larger than  ENDSTOP_NOMINAL_OCR_VAL
+    SPLIT(interval);  // split step into multiple ISRs if larger than ENDSTOP_NOMINAL_OCR_VAL
     _NEXT_ISR(ocr_val);
 
     acceleration_time += interval;
@@ -725,7 +725,7 @@ void Stepper::isr() {
     // step_rate to timer interval
     const hal_timer_t interval = calc_timer_interval(step_rate);
 
-    SPLIT(interval);  // split step into multiple ISRs if larger than  ENDSTOP_NOMINAL_OCR_VAL
+    SPLIT(interval);  // split step into multiple ISRs if larger than ENDSTOP_NOMINAL_OCR_VAL
     _NEXT_ISR(ocr_val);
     deceleration_time += interval;
 
@@ -754,7 +754,7 @@ void Stepper::isr() {
 
     #endif
 
-    SPLIT(OCR1A_nominal);  // split step into multiple ISRs if larger than  ENDSTOP_NOMINAL_OCR_VAL
+    SPLIT(OCR1A_nominal);  // split step into multiple ISRs if larger than ENDSTOP_NOMINAL_OCR_VAL
     _NEXT_ISR(ocr_val);
     // ensure we're running at the correct step rate, even if we just came off an acceleration
     step_loops = step_loops_nominal;

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -325,10 +325,9 @@ class Temperature {
     #endif
 
     #if ENABLED(FILAMENT_WIDTH_SENSOR)
-      static float analog2widthFil(); // Convert raw Filament Width to millimeters
-      static int widthFil_to_size_ratio(); // Convert raw Filament Width to an extrusion ratio
+      static float analog2widthFil();         // Convert raw Filament Width to millimeters
+      static int8_t widthFil_to_size_ratio(); // Convert Filament Width (mm) to an extrusion ratio
     #endif
-
 
     //high level conversion routines, for use outside of temperature.cpp
     //inline so that there is no performance decrease.


### PR DESCRIPTION
The filament width sensor continues to function whether using volumetric or linear extrusion. However the older code always assumed linear extrusion would be in effect, and the newer code attempted to patch this but ended up mishandling linear extrusion.

This PR fixes the filament width sensor code so that it produces the proper `volumetric_multiplier` for the current mode. When in volumetric extrusion mode, it needs to convert volume into linear motion. When in linear extrusion mode it simply needs to increase flow.

Reference: #8590, #8767
See also #8772