### PR TITLE
[2.0.x] Fix example configs and add to TravisCI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -493,9 +493,12 @@ script:
   - use_example_configs Infitary/i3-M508
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   - restore_configs
-  - use_example_configs Malyan/M200
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
-  - restore_configs
+#
+# Disabled due to compile failure on E0_AUTO_FAN_PIN PB8
+#
+#  - use_example_configs Malyan/M200
+#  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+#  - restore_configs
   - use_example_configs Micromake/C1/basic
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   - restore_configs

--- a/.travis.yml
+++ b/.travis.yml
@@ -582,13 +582,16 @@ script:
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
 
 
-  - export TEST_PLATFORM="-e STM32F1"
-  - restore_configs
-  - use_example_configs STM32F10
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
-  - restore_configs
-  - use_example_configs stm32f103ret6
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+#
+# Disabled due to numerous compile failures
+#
+#  - export TEST_PLATFORM="-e STM32F1"
+#  - restore_configs
+#  - use_example_configs STM32F10
+#  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+#  - restore_configs
+#  - use_example_configs stm32f103ret6
+#  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
 
 
   - export TEST_PLATFORM="-e DUE"

--- a/.travis.yml
+++ b/.travis.yml
@@ -577,9 +577,12 @@ script:
 
 
   - export TEST_PLATFORM="-e teensy20"
-  - restore_configs
-  - use_example_configs delta/kossel_pro
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+#
+# Disabled due to Z_MIN_PIN related compile failure
+#
+#  - restore_configs
+#  - use_example_configs delta/kossel_pro
+#  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   - restore_configs
   - use_example_configs makibox
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}

--- a/.travis.yml
+++ b/.travis.yml
@@ -600,7 +600,10 @@ script:
 #  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
 
 
-  - export TEST_PLATFORM="-e DUE"
-  - restore_configs
-  - use_example_configs UltiMachine/Archim2
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+#
+# Disabled to do pin related compile failures
+#
+#  - export TEST_PLATFORM="-e DUE"
+#  - restore_configs
+#  - use_example_configs UltiMachine/Archim2
+#  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}

--- a/.travis.yml
+++ b/.travis.yml
@@ -519,9 +519,13 @@ script:
   - restore_configs
   - use_example_configs Velleman/K8400
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
-  - restore_configs
-  - use_example_configs wt150
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+#
+# Disabled due to compile failure on https://github.com/stawel/SlowSoftI2CMaster
+#
+#  - Requires https://github.com/stawel/SlowSoftI2CMaster
+#  - restore_configs
+#  - use_example_configs wt150
+#  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
 
 
   - export TEST_PLATFORM="-e rambo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -435,3 +435,159 @@ script:
   - cp Marlin/Configuration.h Marlin/src/config/default/Configuration.h
   - cp Marlin/Configuration_adv.h Marlin/src/config/default/Configuration_adv.h
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+  #################################
+  # Build all sample configurations
+  #################################
+
+  - export TEST_PLATFORM="-e megaatmega2560"
+  - restore_configs
+  - use_example_configs adafruit/ST7565
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs BQ/Hephestos
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs BQ/Hephestos_2
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs BQ/WITBOX
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs AliExpress/CL-260
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Cartesio
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs delta/FLSUN/auto_calibrate
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs delta/FLSUN/kossel_mini
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs delta/generic
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs delta/kossel_mini
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs delta/kossel_xl
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Felix
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Felix/DUAL
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs gCreate/gMax1.5+
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Geeetech/GT2560
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Geeetech/I3_Pro_X-GT2560
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Infitary/i3-M508
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Malyan/M200
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Micromake/C1/basic
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Micromake/C1/enhanced
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs RepRapWorld/Megatronics
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs RigidBot
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs SCARA
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Velleman/K8200
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Velleman/K8400/Dual-head
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Velleman/K8400
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs wt150
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e rambo"
+  - restore_configs
+  - use_example_configs AlephObjects/TAZ4  - restore_configs
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e LPC1768"
+  - restore_configs
+  - use_example_configs FolgerTech/i3-2020
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Mks/Sbase
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Wanhao/Duplicator 6
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e anet10"
+  - restore_configs
+  - use_example_configs Anet/A6
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Anet/A8
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Creality/CR-10
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Malyan/M150
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs Sanguinololu
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs TinyBoy2
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e sanguino_atmega644p"
+  - restore_configs
+  - use_example_configs tvrrug/Round2
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e teensy20"
+  - restore_configs
+  - use_example_configs delta/kossel_pro
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs makibox
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e STM32F1"
+  - restore_configs
+  - use_example_configs STM32F10
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  - restore_configs
+  - use_example_configs stm32f103ret6
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+
+
+  - export TEST_PLATFORM="-e DUE"
+  - restore_configs
+  - use_example_configs UltiMachine/Archim2
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -287,7 +287,7 @@
  * :{ '0': "Not used", '1':"100k / 4.7k - EPCOS", '2':"200k / 4.7k - ATC Semitec 204GT-2", '3':"Mendel-parts / 4.7k", '4':"10k !! do not use for a hotend. Bad resolution at high temp. !!", '5':"100K / 4.7k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '6':"100k / 4.7k EPCOS - Not as accurate as Table 1", '7':"100k / 4.7k Honeywell 135-104LAG-J01", '8':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT", '9':"100k / 4.7k GE Sensing AL03006-58.2K-97-G1", '10':"100k / 4.7k RS 198-961", '11':"100k / 4.7k beta 3950 1%", '12':"100k / 4.7k 0603 SMD Vishay NTCS0603E3104FXT (calibrated for Makibox hot bed)", '13':"100k Hisens 3950  1% up to 300°C for hotend 'Simple ONE ' & hotend 'All In ONE'", '20':"PT100 (Ultimainboard V2.x)", '51':"100k / 1k - EPCOS", '52':"200k / 1k - ATC Semitec 204GT-2", '55':"100k / 1k - ATC Semitec 104GT-2 (Used in ParCan & J-Head)", '60':"100k Maker's Tool Works Kapton Bed Thermistor beta=3950", '66':"Dyze Design 4.7M High Temperature thermistor", '70':"the 100K thermistor found in the bq Hephestos 2", '71':"100k / 4.7k Honeywell 135-104LAF-J01", '147':"Pt100 / 4.7k", '1047':"Pt1000 / 4.7k", '110':"Pt100 / 1k (non-standard)", '1010':"Pt1000 / 1k (non standard)", '-3':"Thermocouple + MAX31855 (only for sensor 0)", '-2':"Thermocouple + MAX6675 (only for sensor 0)", '-1':"Thermocouple + AD595",'998':"Dummy 1", '999':"Dummy 2" }
  */
 #define TEMP_SENSOR_0 7
-#define TEMP_SENSOR_1 7
+#define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0
 #define TEMP_SENSOR_4 0

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
@@ -126,9 +126,6 @@
 // Displayed in the LCD "Ready" message
 #define CUSTOM_MACHINE_NAME "HEPHESTOS"
 
-// Added for BQ
-#define SOURCE_CODE_URL "http://www.bq.com/gb/downloads-prusa-i3-hephestos.html"
-
 // Define this to set a unique identifier for this printer, (Used by some programs to differentiate between machines)
 // You can use an online service to generate a random UUID. (eg http://www.uuidgenerator.net/version4)
 //#define MACHINE_UUID "00000000-0000-0000-0000-000000000000"

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -126,9 +126,6 @@
 // Displayed in the LCD "Ready" message
 #define CUSTOM_MACHINE_NAME "WITBOX"
 
-// Added for BQ
-#define SOURCE_CODE_URL "http://www.bq.com/gb/downloads-witbox.html"
-
 // Define this to set a unique identifier for this printer, (Used by some programs to differentiate between machines)
 // You can use an online service to generate a random UUID. (eg http://www.uuidgenerator.net/version4)
 //#define MACHINE_UUID "00000000-0000-0000-0000-000000000000"

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -81,8 +81,8 @@
 // build by the user have been successfully uploaded into firmware.
 #define STRING_CONFIG_H_AUTHOR "(Gunther)" // Who made the changes.
 #define SHOW_BOOTSCREEN
-//#define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
-//#define STRING_SPLASH_LINE2 WEBSITE_URL         // will be shown during bootup in line 2
+#define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
+#define STRING_SPLASH_LINE2 WEBSITE_URL         // will be shown during bootup in line 2
 
 //
 // *** VENDORS PLEASE READ *****************************************************

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -484,7 +484,7 @@
 // extra connectors. Leave undefined any used for non-endstop and non-probe purposes.
 #define USE_XMIN_PLUG
 #define USE_YMIN_PLUG
-//#define USE_ZMIN_PLUG
+#define USE_ZMIN_PLUG
 //#define USE_XMAX_PLUG
 //#define USE_YMAX_PLUG
 #define USE_ZMAX_PLUG

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -781,14 +781,14 @@
 
 // The size of the print bed
 #define X_BED_SIZE 200
-#define Y_BED_SIZE 200
+#define Y_BED_SIZE 180
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
 #define Y_MIN_POS 20
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
-#define Y_MAX_POS Y_BED_SIZE
+#define Y_MAX_POS ((Y_BED_SIZE) + (Y_MIN_POS))
 #define Z_MAX_POS 190
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -781,14 +781,14 @@
 
 // The size of the print bed
 #define X_BED_SIZE 200
-#define Y_BED_SIZE 200
+#define Y_BED_SIZE 180
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
 #define Y_MIN_POS 20
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
-#define Y_MAX_POS Y_BED_SIZE
+#define Y_MAX_POS ((Y_BED_SIZE) + (Y_MIN_POS))
 #define Z_MAX_POS 190
 
 /**

--- a/Marlin/src/pins/pins_MAKEBOARD_MINI.h
+++ b/Marlin/src/pins/pins_MAKEBOARD_MINI.h
@@ -1,0 +1,39 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "pins_RAMPS.h"
+
+#undef BOARD_NAME
+#define BOARD_NAME "MAKEBOARD_MINI"
+
+//
+// Only 3 Limit Switch plugs on Micromake C1
+//
+#undef X_MIN_PIN
+#undef Y_MIN_PIN
+#undef Z_MIN_PIN
+#undef X_MAX_PIN
+#undef Y_MAX_PIN
+#undef Z_MAX_PIN
+#define X_STOP_PIN          2
+#define Y_STOP_PIN         15
+#define Z_STOP_PIN         19

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -181,6 +181,11 @@
 #define ENET_TXD0          P1_00  // J12-11
 #define ENET_TXD1          P1_01  // J12-12
 
+//
+// Misc. Functions
+//
+#define SDSS               P0_06
+
 /**
  *  PWMs
  *

--- a/Marlin/src/pins/pins_RAMBO.h
+++ b/Marlin/src/pins/pins_RAMBO.h
@@ -108,6 +108,9 @@
 
 #define DIGIPOTSS_PIN      38
 #define DIGIPOT_CHANNELS {4,5,3,0,1} // X Y Z E0 E1 digipot channels to stepper driver mapping
+#ifndef DIGIPOT_MOTOR_CURRENT
+  #define DIGIPOT_MOTOR_CURRENT { 135,135,135,135,135 }   // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
+#endif
 
 //
 // Temperature Sensors


### PR DESCRIPTION
I didn't think to comment on which printer I was making the fix for each commit, and included still-present errors in the commit comments which unfortunately get consolidated in a somewhat confusing way when squashed.   Because of this, I'm submitting 2 identical PRs for this: this unsquashed one that retains all comment details, and #8784 (the squashed version which literally squashes the info together with less context).   Reject whichever you don't want.

Travis cycle only seemed to bump up an additional 7-12 min or so (depending on Travis load) and certainly found a lot of issues, so I would say please allow adding these CI tests.  It's better to have a slow Travis cycle spur someone into action to parallelize the tests vs. continuing to allow regressions to creep in (IMHO).  And I may tackle parallelization of the tests if I get the urge.

I fixed all that I could - the handful of still-failing ones are now disabled from CI. Once merged, I will submit issues for each of the failing targets just so they can be tracked, and hopefully someone with the specific printer might jump in to fix.

Thanks,

-=dave

EDIT- I pulled in #8780 on this one so dependant on it to pass travis tests.  Also, I just realized that I did coding on a new Sublime install and forgot to set trailing whitespace autoremoval.  Sorry if a few may have got through !