### PR TITLE
[1.1.x] Revert #8735 "Initial step correction"

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -447,13 +447,10 @@ void Stepper::isr() {
   }
 
   // If there is no current block, attempt to pop one from the buffer
-  bool first_step = false;
   if (!current_block) {
     // Anything in the buffer?
     if ((current_block = planner.get_current_block())) {
       trapezoid_generator_reset();
-      TCNT1 = 0;  // make sure first pulse is not truncated
-      first_step = true;
 
       // Initialize Bresenham counters to 1/2 the ceiling
       counter_X = counter_Y = counter_Z = counter_E = -(current_block->step_event_count >> 1);
@@ -708,14 +705,8 @@ void Stepper::isr() {
   // Calculate new timer value
   if (step_events_completed <= (uint32_t)current_block->accelerate_until) {
 
-    if (first_step) {
-      acc_step_rate = current_block->initial_rate;
-      acceleration_time = 0;
-    }
-    else {
-      MultiU24X32toH16(acc_step_rate, acceleration_time, current_block->acceleration_rate);
-      acc_step_rate += current_block->initial_rate;
-    }
+    MultiU24X32toH16(acc_step_rate, acceleration_time, current_block->acceleration_rate);
+    acc_step_rate += current_block->initial_rate;
 
     // upper limit
     NOMORE(acc_step_rate, current_block->nominal_rate);

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -359,6 +359,9 @@ class Stepper {
       OCR1A_nominal = calc_timer_interval(current_block->nominal_rate);
       // make a note of the number of step loops required at nominal speed
       step_loops_nominal = step_loops;
+      acc_step_rate = current_block->initial_rate;
+      acceleration_time = calc_timer_interval(acc_step_rate);
+      _NEXT_ISR(acceleration_time);
 
       #if ENABLED(LIN_ADVANCE)
         if (current_block->use_advance_lead) {


### PR DESCRIPTION
This reverts commit ec028bf747ff7fe99c4fac29f0df62491db2528c from #8735.

This change seems to fix #8808 and fix #8585.

@Bob-the-Kuhn — We'll need to look at the unwanted side-effects of the original change and see what needs tweaking.

See also #8819