### PR TITLE
Serial Echo as 'mm/s(2)' for clearer understanding

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -1481,7 +1481,7 @@ void MarlinSettings::reset() {
 
     if (!forReplay) {
       CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Maximum feedrates (units/s):");
+      SERIAL_ECHOLNPGM("Maximum feedrates (mm/s):");
     }
     CONFIG_ECHO_START;
     SERIAL_ECHOPAIR("  M203 X", LINEAR_UNIT(planner.max_feedrate_mm_s[X_AXIS]));
@@ -1501,7 +1501,7 @@ void MarlinSettings::reset() {
 
     if (!forReplay) {
       CONFIG_ECHO_START;
-      SERIAL_ECHOLNPGM("Maximum Acceleration (units/s2):");
+      SERIAL_ECHOLNPGM("Maximum Acceleration (mm/s2):");
     }
     CONFIG_ECHO_START;
     SERIAL_ECHOPAIR("  M201 X", LINEAR_UNIT(planner.max_acceleration_mm_per_s2[X_AXIS]));


### PR DESCRIPTION
I compiled Marlin today for the first time, and I noticed that in Serial 'echo', it would say 'units/s'.

I thought it meant 'steps/s', but that would be too small when converted to mm/s.

So, for these cases where all the info it prints are in 'mm' unit, what about printing 'mm' . Instead of 'units' ?