### PR TITLE
[1.1.x][PlatformIO] Stop compiling after first five errors

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -772,7 +772,9 @@ void MarlinSettings::postprocess() {
     }
     else {
       float dummy = 0;
-      bool dummyb;
+      #if DISABLED(AUTO_BED_LEVELING_UBL) || DISABLED(FWRETRACT)
+        bool dummyb;
+      #endif
 
       working_crc = 0;  // Init to 0. Accumulated by EEPROM_READ
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,8 +5,10 @@
 # http://docs.platformio.org/en/latest/projectconf.html
 #
 
-# A sign `#` at the beginning of the line indicates a comment
-# Comment lines are ignored.
+#
+# By default platformio build will abort after 5 errors.
+# Remove '-fmax-errors=5' from build_flags below to see all.
+#
 
 # Automatic targets - enable auto-uploading
 # targets = upload

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,12 +25,13 @@ lib_deps =
   Adafruit NeoPixel
   https://github.com/lincomatic/LiquidTWI2.git
   https://github.com/trinamic/TMC26XStepper.git
+build_flags = -I $BUILDSRC_DIR -fmax-errors=5
 
 [env:megaatmega2560]
 platform = atmelavr
 framework = arduino
 board = megaatmega2560
-build_flags = -I $BUILDSRC_DIR
+build_flags = ${common.build_flags}
 board_f_cpu = 16000000L
 lib_deps = ${common.lib_deps}
 
@@ -38,7 +39,7 @@ lib_deps = ${common.lib_deps}
 platform = atmelavr
 framework = arduino
 board = megaatmega1280
-build_flags = -I $BUILDSRC_DIR
+build_flags = ${common.build_flags}
 board_f_cpu = 16000000L
 lib_deps = ${common.lib_deps}
 
@@ -46,7 +47,7 @@ lib_deps = ${common.lib_deps}
 platform = teensy
 framework = arduino
 board = teensy20pp
-build_flags = -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_PRINTRBOARD
+build_flags = ${common.build_flags} -D MOTHERBOARD=BOARD_PRINTRBOARD
 # Bug in arduino framework does not allow boards running at 20Mhz
 #board_f_cpu = 20000000L
 lib_deps = ${common.lib_deps}
@@ -55,21 +56,21 @@ lib_deps = ${common.lib_deps}
 platform = teensy
 framework = arduino
 board = teensy20pp
-build_flags = -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_PRINTRBOARD_REVF
+build_flags = ${common.build_flags} -D MOTHERBOARD=BOARD_PRINTRBOARD_REVF
 lib_deps = ${common.lib_deps}
 
 [env:brainwavepro]
 platform = teensy
 framework = arduino
 board = teensy20pp
-build_flags = -I $BUILDSRC_DIR -D MOTHERBOARD=BOARD_BRAINWAVE_PRO
+build_flags = ${common.build_flags} -D MOTHERBOARD=BOARD_BRAINWAVE_PRO
 lib_deps = ${common.lib_deps}
 
 [env:rambo]
 platform = atmelavr
 framework = arduino
 board = reprap_rambo
-build_flags = -I $BUILDSRC_DIR
+build_flags = ${common.build_flags}
 board_f_cpu = 16000000L
 lib_deps = ${common.lib_deps}
 
@@ -77,6 +78,7 @@ lib_deps = ${common.lib_deps}
 platform = atmelavr
 framework = arduino
 board = sanguino_atmega1284p
+build_flags = ${common.build_flags}
 upload_speed = 57600
 lib_deps = ${common.lib_deps}
 
@@ -84,4 +86,5 @@ lib_deps = ${common.lib_deps}
 platform = atmelavr
 framework = arduino
 board = sanguino_atmega644p
+build_flags = ${common.build_flags}
 lib_deps = ${common.lib_deps}


### PR DESCRIPTION
I was updating my configuration, and forgot to change `UBL_MESH_INSET` to just `MESH_INSET`, but instead of just receiving the _"UBL_MESH_INSET is now just MESH_INSET. Please update your configuration."_ error message, I was spammed with a bunch of errors due to `MESH_INSET` not being defined.

This PR addresses this issue by enabling the fatal-errors compiler flag, which tells GCC to stop compiling after the first error it detects.