### PR TITLE
USB Mass Storage Implementation / CDC with HW flow control and misc fixes and improvements for Arduino DUE/RE-ARM based boards

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.h
@@ -40,15 +40,13 @@
 //
 // Defines
 //
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL SerialUSB
-#elif SERIAL_PORT >= 0 && SERIAL_PORT <= 4
+#if SERIAL_PORT >= -1 && SERIAL_PORT <= 4
   #define MYSERIAL customizedSerial
 #endif
 
 // We need the previous define before the include, or compilation bombs...
 #include "MarlinSerial_Due.h"
+#include "MarlinSerialUSB_Due.h"
 
 #ifndef analogInputToDigitalPin
   #define analogInputToDigitalPin(p) ((p < 12u) ? (p) + 54u : -1)
@@ -152,5 +150,17 @@ void HAL_enable_AdcFreerun(void);
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
+
+// Enable hooks into idle and setup for USB stack
+#define HAL_IDLETASK 1
+#define HAL_INIT 1
+#ifdef __cplusplus
+extern "C" {
+#endif
+void HAL_idletask(void);
+void HAL_init(void);
+#ifdef __cplusplus
+}
+#endif
 
 #endif // _HAL_DUE_H

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerialUSB_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerialUSB_Due.cpp
@@ -1,0 +1,254 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MarlinSerial_Due.cpp - Hardware serial library for Arduino DUE
+ * Copyright (c) 2017 Eduardo José Tagle. All right reserved
+ * Based on MarlinSerial for AVR, copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+ */
+#ifdef ARDUINO_ARCH_SAM
+
+#include "../../inc/MarlinConfig.h"
+
+#if SERIAL_PORT == -1
+
+#include "MarlinSerialUSB_Due.h"
+
+// Imports from Atmel USB Stack/CDC implementation
+extern "C" {
+  bool usb_task_cdc_isenabled(void);
+  bool udi_cdc_is_rx_ready(void);
+  int udi_cdc_getc(void);
+  bool udi_cdc_is_tx_ready(void);
+  int udi_cdc_putc(int value);
+};
+
+// Pending character
+static int pending_char = -1;
+
+// Public Methods
+void MarlinSerialUSB::begin(const long baud_setting) {
+}
+
+void MarlinSerialUSB::end() {
+}
+
+int MarlinSerialUSB::peek(void) {
+  if (pending_char >= 0)
+    return pending_char;
+
+  if (!usb_task_cdc_isenabled())
+    return -1;
+
+  if (!udi_cdc_is_rx_ready())
+    return -1;
+
+  pending_char = udi_cdc_getc();
+  return pending_char;
+}
+
+int MarlinSerialUSB::read(void) {
+  if (pending_char >= 0) {
+    int ret = pending_char;
+    pending_char = -1;
+    return ret;
+  }
+
+  if (!usb_task_cdc_isenabled())
+    return -1;
+
+  if (!udi_cdc_is_rx_ready())
+    return -1;
+
+  return udi_cdc_getc();
+}
+
+bool MarlinSerialUSB::available(void) {
+  return pending_char >= 0 ||
+      (usb_task_cdc_isenabled() && udi_cdc_is_rx_ready());
+}
+
+void MarlinSerialUSB::flush(void) {
+}
+
+void MarlinSerialUSB::write(const uint8_t c) {
+
+  while (usb_task_cdc_isenabled() &&
+        !udi_cdc_is_tx_ready()) {
+  };
+
+  if (!usb_task_cdc_isenabled())
+    return;
+
+  // Fifo full
+  //  udi_cdc_signal_overrun();
+  udi_cdc_putc(c);
+}
+
+/**
+* Imports from print.h
+*/
+
+void MarlinSerialUSB::print(char c, int base) {
+  print((long)c, base);
+}
+
+void MarlinSerialUSB::print(unsigned char b, int base) {
+  print((unsigned long)b, base);
+}
+
+void MarlinSerialUSB::print(int n, int base) {
+  print((long)n, base);
+}
+
+void MarlinSerialUSB::print(unsigned int n, int base) {
+  print((unsigned long)n, base);
+}
+
+void MarlinSerialUSB::print(long n, int base) {
+  if (base == 0)
+    write(n);
+  else if (base == 10) {
+    if (n < 0) {
+      print('-');
+      n = -n;
+    }
+    printNumber(n, 10);
+  }
+  else
+    printNumber(n, base);
+}
+
+void MarlinSerialUSB::print(unsigned long n, int base) {
+  if (base == 0) write(n);
+  else printNumber(n, base);
+}
+
+void MarlinSerialUSB::print(double n, int digits) {
+  printFloat(n, digits);
+}
+
+void MarlinSerialUSB::println(void) {
+  print('\r');
+  print('\n');
+}
+
+void MarlinSerialUSB::println(const String& s) {
+  print(s);
+  println();
+}
+
+void MarlinSerialUSB::println(const char c[]) {
+  print(c);
+  println();
+}
+
+void MarlinSerialUSB::println(char c, int base) {
+  print(c, base);
+  println();
+}
+
+void MarlinSerialUSB::println(unsigned char b, int base) {
+  print(b, base);
+  println();
+}
+
+void MarlinSerialUSB::println(int n, int base) {
+  print(n, base);
+  println();
+}
+
+void MarlinSerialUSB::println(unsigned int n, int base) {
+  print(n, base);
+  println();
+}
+
+void MarlinSerialUSB::println(long n, int base) {
+  print(n, base);
+  println();
+}
+
+void MarlinSerialUSB::println(unsigned long n, int base) {
+  print(n, base);
+  println();
+}
+
+void MarlinSerialUSB::println(double n, int digits) {
+  print(n, digits);
+  println();
+}
+
+// Private Methods
+
+void MarlinSerialUSB::printNumber(unsigned long n, uint8_t base) {
+  if (n) {
+    unsigned char buf[8 * sizeof(long)]; // Enough space for base 2
+    int8_t i = 0;
+    while (n) {
+      buf[i++] = n % base;
+      n /= base;
+    }
+    while (i--)
+      print((char)(buf[i] + (buf[i] < 10 ? '0' : 'A' - 10)));
+  }
+  else
+    print('0');
+}
+
+void MarlinSerialUSB::printFloat(double number, uint8_t digits) {
+  // Handle negative numbers
+  if (number < 0.0) {
+    print('-');
+    number = -number;
+  }
+
+  // Round correctly so that print(1.999, 2) prints as "2.00"
+  double rounding = 0.5;
+  for (uint8_t i = 0; i < digits; ++i)
+    rounding *= 0.1;
+
+  number += rounding;
+
+  // Extract the integer part of the number and print it
+  unsigned long int_part = (unsigned long)number;
+  double remainder = number - (double)int_part;
+  print(int_part);
+
+  // Print the decimal point, but only if there are digits beyond
+  if (digits) {
+    print('.');
+    // Extract digits from the remainder one at a time
+    while (digits--) {
+      remainder *= 10.0;
+      int toPrint = int(remainder);
+      print(toPrint);
+      remainder -= toPrint;
+    }
+  }
+}
+
+// Preinstantiate
+MarlinSerialUSB customizedSerial;
+
+#endif // SERIAL_PORT == -1
+
+#endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerialUSB_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerialUSB_Due.h
@@ -1,0 +1,96 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MarlinSerialUSB_Due.h - Hardware Serial over USB (CDC) library for Arduino DUE
+ * Copyright (c) 2017 Eduardo José Tagle. All right reserved
+ */
+
+#ifndef MARLINSERIALUSB_DUE_H
+#define MARLINSERIALUSB_DUE_H
+
+#include "../../inc/MarlinConfig.h"
+
+#if SERIAL_PORT == -1
+
+#include <WString.h>
+
+#define DEC 10
+#define HEX 16
+#define OCT 8
+#define BIN 2
+#define BYTE 0
+
+class MarlinSerialUSB {
+
+public:
+  MarlinSerialUSB() {};
+  static void begin(const long);
+  static void end();
+  static int peek(void);
+  static int read(void);
+  static void flush(void);
+  static bool available(void);
+  static void write(const uint8_t c);
+
+  #if ENABLED(SERIAL_STATS_DROPPED_RX)
+  FORCE_INLINE static uint32_t dropped() { return 0; }
+  #endif
+
+  #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
+  FORCE_INLINE static int rxMaxEnqueued() { return 0; }
+  #endif
+
+  static FORCE_INLINE void write(const char* str) { while (*str) write(*str++); }
+  static FORCE_INLINE void write(const uint8_t* buffer, size_t size) { while (size--) write(*buffer++); }
+  static FORCE_INLINE void print(const String& s) { for (int i = 0; i < (int)s.length(); i++) write(s[i]); }
+  static FORCE_INLINE void print(const char* str) { write(str); }
+
+  static void print(char, int = BYTE);
+  static void print(unsigned char, int = BYTE);
+  static void print(int, int = DEC);
+  static void print(unsigned int, int = DEC);
+  static void print(long, int = DEC);
+  static void print(unsigned long, int = DEC);
+  static void print(double, int = 2);
+
+  static void println(const String& s);
+  static void println(const char[]);
+  static void println(char, int = BYTE);
+  static void println(unsigned char, int = BYTE);
+  static void println(int, int = DEC);
+  static void println(unsigned int, int = DEC);
+  static void println(long, int = DEC);
+  static void println(unsigned long, int = DEC);
+  static void println(double, int = 2);
+  static void println(void);
+  operator bool() { return true; }
+
+private:
+  static void printNumber(unsigned long, const uint8_t);
+  static void printFloat(double, uint8_t);
+};
+
+extern MarlinSerialUSB customizedSerial;
+
+#endif // SERIAL_PORT == -1
+#endif // MARLINSERIAL_DUE_H

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
@@ -31,11 +31,9 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#include <WString.h>
+#if SERIAL_PORT >= 0
 
-#ifndef SERIAL_PORT
-  #define SERIAL_PORT 0
-#endif
+#include <WString.h>
 
 #define DEC 10
 #define HEX 16
@@ -134,5 +132,7 @@ private:
 };
 
 extern MarlinSerial customizedSerial;
+
+#endif // SERIAL_PORT >= 0
 
 #endif // MARLINSERIAL_DUE_H

--- a/Marlin/src/HAL/HAL_DUE/usb/arduino_due_x.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/arduino_due_x.h
@@ -1,0 +1,103 @@
+/**
+ * \file
+ *
+ * \brief Arduino Due/X Board Definition.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef ARDUINO_DUE_X_H_INCLUDED
+#define ARDUINO_DUE_X_H_INCLUDED
+
+/* ------------------------------------------------------------------------ */
+
+/**
+ *  \page arduino_due_x_opfreq "Arduino Due/X - Operating frequencies"
+ *  This page lists several definition related to the board operating frequency
+ *
+ *  \section Definitions
+ *  - \ref BOARD_FREQ_*
+ *  - \ref BOARD_MCK
+ */
+
+/*! Board oscillator settings */
+#define BOARD_FREQ_SLCK_XTAL            (32768U)
+#define BOARD_FREQ_SLCK_BYPASS          (32768U)
+#define BOARD_FREQ_MAINCK_XTAL          (12000000U)
+#define BOARD_FREQ_MAINCK_BYPASS        (12000000U)
+
+/*! Master clock frequency */
+#define BOARD_MCK                       CHIP_FREQ_CPU_MAX
+#define BOARD_NO_32K_XTAL
+
+/** board main clock xtal startup time */
+#define BOARD_OSC_STARTUP_US   15625
+
+/* ------------------------------------------------------------------------ */
+
+/**
+ * \page arduino_due_x_board_info "Arduino Due/X - Board informations"
+ * This page lists several definition related to the board description.
+ *
+ */
+
+/* ------------------------------------------------------------------------ */
+/* USB                                                                      */
+/* ------------------------------------------------------------------------ */
+/*! USB OTG VBus On/Off: Bus Power Control Port. */
+#define PIN_UOTGHS_VBOF  { PIO_PB10, PIOB, ID_PIOB, PIO_PERIPH_A, PIO_PULLUP }
+/*! USB OTG Identification: Mini Connector Identification Port. */
+#define PIN_UOTGHS_ID    { PIO_PB11, PIOB, ID_PIOB, PIO_PERIPH_A, PIO_PULLUP }
+
+/*! Multiplexed pin used for USB_ID: */
+#define USB_ID                      PIO_PB11_IDX
+#define USB_ID_GPIO                 (PIO_PB11_IDX)
+#define USB_ID_FLAGS                (PIO_PERIPH_A | PIO_DEFAULT)
+/*! Multiplexed pin used for USB_VBOF: */
+#define USB_VBOF                    PIO_PB10_IDX
+#define USB_VBOF_GPIO               (PIO_PB10_IDX)
+#define USB_VBOF_FLAGS              (PIO_PERIPH_A | PIO_DEFAULT)
+/*! Active level of the USB_VBOF output pin. */
+#define USB_VBOF_ACTIVE_LEVEL       LOW
+/* ------------------------------------------------------------------------ */
+
+
+#endif /* ARDUINO_DUE_X_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/compiler.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/compiler.h
@@ -1,0 +1,1224 @@
+/**
+ * \file
+ *
+ * \brief Commonly used includes, types and macros.
+ *
+ * Copyright (c) 2010-2016 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef UTILS_COMPILER_H
+#define UTILS_COMPILER_H
+
+#include <sam.h>
+#include <chip.h>
+#include "arduino_due_x.h"
+#include "conf_clock.h"
+#ifdef SAM3XA_SERIES
+#define SAM3XA 1
+#endif
+#define UDD_NO_SLEEP_MGR 1
+#define pmc_is_wakeup_clocks_restored() true
+
+#undef udd_get_endpoint_size_max
+#define UDD_USB_INT_FUN USBD_ISR
+
+/**
+ * \defgroup group_sam_utils Compiler abstraction layer and code utilities
+ *
+ * Compiler abstraction layer and code utilities for AT91SAM.
+ * This module provides various abstraction layers and utilities to make code compatible between different compilers.
+ *
+ * \{
+ */
+#include <stddef.h>
+
+#if (defined __ICCARM__)
+#  include <intrinsics.h>
+#endif
+
+#include <sam.h>
+#include "preprocessor.h"
+
+//_____ D E C L A R A T I O N S ____________________________________________
+
+#ifndef __ASSEMBLY__ // Not defined for assembling.
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#ifdef __ICCARM__
+/*! \name Compiler Keywords
+ *
+ * Port of some keywords from GCC to IAR Embedded Workbench.
+ */
+//! @{
+#define __asm__             asm
+#define __inline__          inline
+#define __volatile__
+//! @}
+
+#endif
+
+#define FUNC_PTR                            void *
+/**
+ * \def UNUSED
+ * \brief Marking \a v as a unused parameter or value.
+ */
+#ifndef UNUSED
+#define UNUSED(v)          (void)(v)
+#endif
+
+/**
+ * \def unused
+ * \brief Marking \a v as a unused parameter or value.
+ */
+#define unused(v)          do { (void)(v); } while(0)
+
+/**
+ * \def barrier
+ * \brief Memory barrier
+ */
+#define barrier()          __DMB()
+
+/**
+ * \brief Emit the compiler pragma \a arg.
+ *
+ * \param arg The pragma directive as it would appear after \e \#pragma
+ * (i.e. not stringified).
+ */
+#define COMPILER_PRAGMA(arg)            _Pragma(#arg)
+
+/**
+ * \def COMPILER_PACK_SET(alignment)
+ * \brief Set maximum alignment for subsequent struct and union
+ * definitions to \a alignment.
+ */
+#define COMPILER_PACK_SET(alignment)   COMPILER_PRAGMA(pack(alignment))
+
+/**
+ * \def COMPILER_PACK_RESET()
+ * \brief Set default alignment for subsequent struct and union
+ * definitions.
+ */
+#define COMPILER_PACK_RESET()          COMPILER_PRAGMA(pack())
+
+
+/**
+ * \brief Set aligned boundary.
+ */
+#if (defined __GNUC__) || (defined __CC_ARM)
+#   define COMPILER_ALIGNED(a)    __attribute__((__aligned__(a)))
+#elif (defined __ICCARM__)
+#   define COMPILER_ALIGNED(a)    COMPILER_PRAGMA(data_alignment = a)
+#endif
+
+/**
+ * \brief Set word-aligned boundary.
+ */
+#if (defined __GNUC__) || defined(__CC_ARM)
+#define COMPILER_WORD_ALIGNED    __attribute__((__aligned__(4)))
+#elif (defined __ICCARM__)
+#define COMPILER_WORD_ALIGNED    COMPILER_PRAGMA(data_alignment = 4)
+#endif
+
+/**
+ * \def __always_inline
+ * \brief The function should always be inlined.
+ *
+ * This annotation instructs the compiler to ignore its inlining
+ * heuristics and inline the function no matter how big it thinks it
+ * becomes.
+ */
+#if defined(__CC_ARM)
+#   define __always_inline   __forceinline
+#elif (defined __GNUC__)
+#ifdef __always_inline
+#	undef __always_inline
+#endif
+#	define __always_inline   inline __attribute__((__always_inline__))
+#elif (defined __ICCARM__)
+#	define __always_inline   _Pragma("inline=forced")
+#endif
+
+/**
+ * \def __no_inline
+ * \brief The function should not be inlined.
+ *
+ * This annotation instructs the compiler to ignore its inlining
+ * heuristics and not inline the function.
+ */
+#if defined(__CC_ARM)
+#   define __no_inline   __attribute__((noinline))
+#elif (defined __GNUC__)
+#	define __no_inline   __attribute__((__noinline__))
+#elif (defined __ICCARM__)
+#	define __no_inline   _Pragma("inline=never")
+#endif
+
+/*! \brief This macro is used to test fatal errors.
+ *
+ * The macro tests if the expression is false. If it is, a fatal error is
+ * detected and the application hangs up. If TEST_SUITE_DEFINE_ASSERT_MACRO
+ * is defined, a unit test version of the macro is used, to allow execution
+ * of further tests after a false expression.
+ *
+ * \param expr  Expression to evaluate and supposed to be nonzero.
+ */
+#if defined(_ASSERT_ENABLE_)
+#  if defined(TEST_SUITE_DEFINE_ASSERT_MACRO)
+     // Assert() is defined in unit_test/suite.h
+#    include "unit_test/suite.h"
+#  else
+#undef TEST_SUITE_DEFINE_ASSERT_MACRO
+#    define Assert(expr) \
+	{\
+		if (!(expr)) while (true);\
+	}
+#  endif
+#else
+#  define Assert(expr) ((void) 0)
+#endif
+
+/* Define WEAK attribute */
+#if defined   ( __CC_ARM   ) /* Keil µVision 4 */
+#   define WEAK __attribute__ ((weak))
+#elif defined ( __ICCARM__ ) /* IAR Ewarm 5.41+ */
+#   define WEAK __weak
+#elif defined (  __GNUC__  ) /* GCC CS3 2009q3-68 */
+#   define WEAK __attribute__ ((weak))
+#endif
+
+/* Define NO_INIT attribute */
+#if 0 //ndef NO_INIT
+#if defined   ( __CC_ARM   )
+#   define NO_INIT __attribute__((zero_init))
+#elif defined ( __ICCARM__ )
+#   define NO_INIT __no_init
+#elif defined (  __GNUC__  )
+#   define NO_INIT __attribute__((section(".no_init")))
+#endif
+#endif
+
+/* Define RAMFUNC attribute */
+#if defined   ( __CC_ARM   ) /* Keil µVision 4 */
+#   define RAMFUNC __attribute__ ((section(".ramfunc")))
+#elif defined ( __ICCARM__ ) /* IAR Ewarm 5.41+ */
+#   define RAMFUNC __ramfunc
+#elif defined (  __GNUC__  ) /* GCC CS3 2009q3-68 */
+#   define RAMFUNC __attribute__ ((section(".ramfunc")))
+#endif
+
+/* Define OPTIMIZE_HIGH attribute */
+#if defined   ( __CC_ARM   ) /* Keil µVision 4 */
+#   define OPTIMIZE_HIGH _Pragma("O3") 
+#elif defined ( __ICCARM__ ) /* IAR Ewarm 5.41+ */
+#   define OPTIMIZE_HIGH _Pragma("optimize=high")
+#elif defined (  __GNUC__  ) /* GCC CS3 2009q3-68 */
+#   define OPTIMIZE_HIGH __attribute__((optimize("s")))
+#endif
+
+/*! \name Usual Types
+ */
+//! @{
+typedef unsigned char           Bool; //!< Boolean.
+#ifndef __cplusplus
+#if !defined(__bool_true_false_are_defined)
+typedef unsigned char           bool; //!< Boolean.
+#endif
+#endif
+typedef int8_t                  S8 ;  //!< 8-bit signed integer.
+typedef uint8_t                 U8 ;  //!< 8-bit unsigned integer.
+typedef int16_t                 S16;  //!< 16-bit signed integer.
+typedef uint16_t                U16;  //!< 16-bit unsigned integer.
+typedef uint16_t                le16_t;
+typedef uint16_t                be16_t;
+typedef int32_t                 S32;  //!< 32-bit signed integer.
+typedef uint32_t                U32;  //!< 32-bit unsigned integer.
+typedef uint32_t                le32_t;
+typedef uint32_t                be32_t;
+typedef int64_t                 S64;  //!< 64-bit signed integer.
+typedef uint64_t                U64;  //!< 64-bit unsigned integer.
+typedef float                   F32;  //!< 32-bit floating-point number.
+typedef double                  F64;  //!< 64-bit floating-point number.
+typedef uint32_t                iram_size_t;
+//! @}
+
+
+/*! \name Status Types
+ */
+//! @{
+typedef bool                Status_bool_t;  //!< Boolean status.
+typedef U8                  Status_t;       //!< 8-bit-coded status.
+//! @}
+
+
+/*! \name Aliasing Aggregate Types
+ */
+//! @{
+
+//! 16-bit union.
+typedef union
+{
+  S16 s16   ;
+  U16 u16   ;
+  S8  s8 [2];
+  U8  u8 [2];
+} Union16;
+
+//! 32-bit union.
+typedef union
+{
+  S32 s32   ;
+  U32 u32   ;
+  S16 s16[2];
+  U16 u16[2];
+  S8  s8 [4];
+  U8  u8 [4];
+} Union32;
+
+//! 64-bit union.
+typedef union
+{
+  S64 s64   ;
+  U64 u64   ;
+  S32 s32[2];
+  U32 u32[2];
+  S16 s16[4];
+  U16 u16[4];
+  S8  s8 [8];
+  U8  u8 [8];
+} Union64;
+
+//! Union of pointers to 64-, 32-, 16- and 8-bit unsigned integers.
+typedef union
+{
+  S64 *s64ptr;
+  U64 *u64ptr;
+  S32 *s32ptr;
+  U32 *u32ptr;
+  S16 *s16ptr;
+  U16 *u16ptr;
+  S8  *s8ptr ;
+  U8  *u8ptr ;
+} UnionPtr;
+
+//! Union of pointers to volatile 64-, 32-, 16- and 8-bit unsigned integers.
+typedef union
+{
+  volatile S64 *s64ptr;
+  volatile U64 *u64ptr;
+  volatile S32 *s32ptr;
+  volatile U32 *u32ptr;
+  volatile S16 *s16ptr;
+  volatile U16 *u16ptr;
+  volatile S8  *s8ptr ;
+  volatile U8  *u8ptr ;
+} UnionVPtr;
+
+//! Union of pointers to constant 64-, 32-, 16- and 8-bit unsigned integers.
+typedef union
+{
+  const S64 *s64ptr;
+  const U64 *u64ptr;
+  const S32 *s32ptr;
+  const U32 *u32ptr;
+  const S16 *s16ptr;
+  const U16 *u16ptr;
+  const S8  *s8ptr ;
+  const U8  *u8ptr ;
+} UnionCPtr;
+
+//! Union of pointers to constant volatile 64-, 32-, 16- and 8-bit unsigned integers.
+typedef union
+{
+  const volatile S64 *s64ptr;
+  const volatile U64 *u64ptr;
+  const volatile S32 *s32ptr;
+  const volatile U32 *u32ptr;
+  const volatile S16 *s16ptr;
+  const volatile U16 *u16ptr;
+  const volatile S8  *s8ptr ;
+  const volatile U8  *u8ptr ;
+} UnionCVPtr;
+
+//! Structure of pointers to 64-, 32-, 16- and 8-bit unsigned integers.
+typedef struct
+{
+  S64 *s64ptr;
+  U64 *u64ptr;
+  S32 *s32ptr;
+  U32 *u32ptr;
+  S16 *s16ptr;
+  U16 *u16ptr;
+  S8  *s8ptr ;
+  U8  *u8ptr ;
+} StructPtr;
+
+//! Structure of pointers to volatile 64-, 32-, 16- and 8-bit unsigned integers.
+typedef struct
+{
+  volatile S64 *s64ptr;
+  volatile U64 *u64ptr;
+  volatile S32 *s32ptr;
+  volatile U32 *u32ptr;
+  volatile S16 *s16ptr;
+  volatile U16 *u16ptr;
+  volatile S8  *s8ptr ;
+  volatile U8  *u8ptr ;
+} StructVPtr;
+
+//! Structure of pointers to constant 64-, 32-, 16- and 8-bit unsigned integers.
+typedef struct
+{
+  const S64 *s64ptr;
+  const U64 *u64ptr;
+  const S32 *s32ptr;
+  const U32 *u32ptr;
+  const S16 *s16ptr;
+  const U16 *u16ptr;
+  const S8  *s8ptr ;
+  const U8  *u8ptr ;
+} StructCPtr;
+
+//! Structure of pointers to constant volatile 64-, 32-, 16- and 8-bit unsigned integers.
+typedef struct
+{
+  const volatile S64 *s64ptr;
+  const volatile U64 *u64ptr;
+  const volatile S32 *s32ptr;
+  const volatile U32 *u32ptr;
+  const volatile S16 *s16ptr;
+  const volatile U16 *u16ptr;
+  const volatile S8  *s8ptr ;
+  const volatile U8  *u8ptr ;
+} StructCVPtr;
+
+//! @}
+
+#endif  // #ifndef __ASSEMBLY__
+
+/*! \name Usual Constants
+ */
+//! @{
+#define DISABLE   0
+#define ENABLE    1
+#ifndef __cplusplus
+#if !defined(__bool_true_false_are_defined)
+#define false     0
+#define true      1
+#endif
+#endif
+#ifndef PASS
+#define PASS      0
+#endif
+#ifndef FAIL
+#define FAIL      1
+#endif
+#ifndef LOW
+#define LOW       0
+#endif
+#ifndef HIGH
+#define HIGH      1
+#endif
+//! @}
+
+
+#ifndef __ASSEMBLY__ // not for assembling.
+
+//! \name Optimization Control
+//@{
+
+/**
+ * \def likely(exp)
+ * \brief The expression \a exp is likely to be true
+ */
+#ifndef likely
+#   define likely(exp)    (exp)
+#endif
+
+/**
+ * \def unlikely(exp)
+ * \brief The expression \a exp is unlikely to be true
+ */
+#ifndef unlikely
+#   define unlikely(exp)  (exp)
+#endif
+
+/**
+ * \def is_constant(exp)
+ * \brief Determine if an expression evaluates to a constant value.
+ *
+ * \param exp Any expression
+ *
+ * \return true if \a exp is constant, false otherwise.
+ */
+#if (defined __GNUC__) || (defined __CC_ARM)
+#   define is_constant(exp)       __builtin_constant_p(exp)
+#else
+#   define is_constant(exp)       (0)
+#endif
+
+//! @}
+
+/*! \name Bit-Field Handling
+ */
+//! @{
+
+/*! \brief Reads the bits of a value specified by a given bit-mask.
+ *
+ * \param value Value to read bits from.
+ * \param mask  Bit-mask indicating bits to read.
+ *
+ * \return Read bits.
+ */
+#define Rd_bits( value, mask)        ((value) & (mask))
+
+/*! \brief Writes the bits of a C lvalue specified by a given bit-mask.
+ *
+ * \param lvalue  C lvalue to write bits to.
+ * \param mask    Bit-mask indicating bits to write.
+ * \param bits    Bits to write.
+ *
+ * \return Resulting value with written bits.
+ */
+#define Wr_bits(lvalue, mask, bits)  ((lvalue) = ((lvalue) & ~(mask)) |\
+                                                 ((bits  ) &  (mask)))
+
+/*! \brief Tests the bits of a value specified by a given bit-mask.
+ *
+ * \param value Value of which to test bits.
+ * \param mask  Bit-mask indicating bits to test.
+ *
+ * \return \c 1 if at least one of the tested bits is set, else \c 0.
+ */
+#define Tst_bits( value, mask)  (Rd_bits(value, mask) != 0)
+
+/*! \brief Clears the bits of a C lvalue specified by a given bit-mask.
+ *
+ * \param lvalue  C lvalue of which to clear bits.
+ * \param mask    Bit-mask indicating bits to clear.
+ *
+ * \return Resulting value with cleared bits.
+ */
+#define Clr_bits(lvalue, mask)  ((lvalue) &= ~(mask))
+
+/*! \brief Sets the bits of a C lvalue specified by a given bit-mask.
+ *
+ * \param lvalue  C lvalue of which to set bits.
+ * \param mask    Bit-mask indicating bits to set.
+ *
+ * \return Resulting value with set bits.
+ */
+#define Set_bits(lvalue, mask)  ((lvalue) |=  (mask))
+
+/*! \brief Toggles the bits of a C lvalue specified by a given bit-mask.
+ *
+ * \param lvalue  C lvalue of which to toggle bits.
+ * \param mask    Bit-mask indicating bits to toggle.
+ *
+ * \return Resulting value with toggled bits.
+ */
+#define Tgl_bits(lvalue, mask)  ((lvalue) ^=  (mask))
+
+/*! \brief Reads the bit-field of a value specified by a given bit-mask.
+ *
+ * \param value Value to read a bit-field from.
+ * \param mask  Bit-mask indicating the bit-field to read.
+ *
+ * \return Read bit-field.
+ */
+#define Rd_bitfield( value, mask)           (Rd_bits( value, mask) >> ctz(mask))
+
+/*! \brief Writes the bit-field of a C lvalue specified by a given bit-mask.
+ *
+ * \param lvalue    C lvalue to write a bit-field to.
+ * \param mask      Bit-mask indicating the bit-field to write.
+ * \param bitfield  Bit-field to write.
+ *
+ * \return Resulting value with written bit-field.
+ */
+#define Wr_bitfield(lvalue, mask, bitfield) (Wr_bits(lvalue, mask, (U32)(bitfield) << ctz(mask)))
+
+//! @}
+
+
+/*! \name Zero-Bit Counting
+ *
+ * Under GCC, __builtin_clz and __builtin_ctz behave like macros when
+ * applied to constant expressions (values known at compile time), so they are
+ * more optimized than the use of the corresponding assembly instructions and
+ * they can be used as constant expressions e.g. to initialize objects having
+ * static storage duration, and like the corresponding assembly instructions
+ * when applied to non-constant expressions (values unknown at compile time), so
+ * they are more optimized than an assembly periphrasis. Hence, clz and ctz
+ * ensure a possible and optimized behavior for both constant and non-constant
+ * expressions.
+ */
+//! @{
+
+/*! \brief Counts the leading zero bits of the given value considered as a 32-bit integer.
+ *
+ * \param u Value of which to count the leading zero bits.
+ *
+ * \return The count of leading zero bits in \a u.
+ */
+#ifndef clz
+#if (defined __GNUC__) || (defined __CC_ARM)
+#   define clz(u)              ((u) ? __builtin_clz(u) : 32)
+#elif (defined __ICCARM__)
+#   define clz(u)              ((u) ? __CLZ(u) : 32)
+#else
+#   define clz(u)              (((u) == 0)          ? 32 : \
+                                ((u) & (1ul << 31)) ?  0 : \
+                                ((u) & (1ul << 30)) ?  1 : \
+                                ((u) & (1ul << 29)) ?  2 : \
+                                ((u) & (1ul << 28)) ?  3 : \
+                                ((u) & (1ul << 27)) ?  4 : \
+                                ((u) & (1ul << 26)) ?  5 : \
+                                ((u) & (1ul << 25)) ?  6 : \
+                                ((u) & (1ul << 24)) ?  7 : \
+                                ((u) & (1ul << 23)) ?  8 : \
+                                ((u) & (1ul << 22)) ?  9 : \
+                                ((u) & (1ul << 21)) ? 10 : \
+                                ((u) & (1ul << 20)) ? 11 : \
+                                ((u) & (1ul << 19)) ? 12 : \
+                                ((u) & (1ul << 18)) ? 13 : \
+                                ((u) & (1ul << 17)) ? 14 : \
+                                ((u) & (1ul << 16)) ? 15 : \
+                                ((u) & (1ul << 15)) ? 16 : \
+                                ((u) & (1ul << 14)) ? 17 : \
+                                ((u) & (1ul << 13)) ? 18 : \
+                                ((u) & (1ul << 12)) ? 19 : \
+                                ((u) & (1ul << 11)) ? 20 : \
+                                ((u) & (1ul << 10)) ? 21 : \
+                                ((u) & (1ul <<  9)) ? 22 : \
+                                ((u) & (1ul <<  8)) ? 23 : \
+                                ((u) & (1ul <<  7)) ? 24 : \
+                                ((u) & (1ul <<  6)) ? 25 : \
+                                ((u) & (1ul <<  5)) ? 26 : \
+                                ((u) & (1ul <<  4)) ? 27 : \
+                                ((u) & (1ul <<  3)) ? 28 : \
+                                ((u) & (1ul <<  2)) ? 29 : \
+                                ((u) & (1ul <<  1)) ? 30 : \
+                                31)
+#endif
+#endif
+
+/*! \brief Counts the trailing zero bits of the given value considered as a 32-bit integer.
+ *
+ * \param u Value of which to count the trailing zero bits.
+ *
+ * \return The count of trailing zero bits in \a u.
+ */
+#ifndef ctz
+#if (defined __GNUC__) || (defined __CC_ARM)
+#   define ctz(u)              ((u) ? __builtin_ctz(u) : 32)
+#else
+#   define ctz(u)              ((u) & (1ul <<  0) ?  0 : \
+                                (u) & (1ul <<  1) ?  1 : \
+                                (u) & (1ul <<  2) ?  2 : \
+                                (u) & (1ul <<  3) ?  3 : \
+                                (u) & (1ul <<  4) ?  4 : \
+                                (u) & (1ul <<  5) ?  5 : \
+                                (u) & (1ul <<  6) ?  6 : \
+                                (u) & (1ul <<  7) ?  7 : \
+                                (u) & (1ul <<  8) ?  8 : \
+                                (u) & (1ul <<  9) ?  9 : \
+                                (u) & (1ul << 10) ? 10 : \
+                                (u) & (1ul << 11) ? 11 : \
+                                (u) & (1ul << 12) ? 12 : \
+                                (u) & (1ul << 13) ? 13 : \
+                                (u) & (1ul << 14) ? 14 : \
+                                (u) & (1ul << 15) ? 15 : \
+                                (u) & (1ul << 16) ? 16 : \
+                                (u) & (1ul << 17) ? 17 : \
+                                (u) & (1ul << 18) ? 18 : \
+                                (u) & (1ul << 19) ? 19 : \
+                                (u) & (1ul << 20) ? 20 : \
+                                (u) & (1ul << 21) ? 21 : \
+                                (u) & (1ul << 22) ? 22 : \
+                                (u) & (1ul << 23) ? 23 : \
+                                (u) & (1ul << 24) ? 24 : \
+                                (u) & (1ul << 25) ? 25 : \
+                                (u) & (1ul << 26) ? 26 : \
+                                (u) & (1ul << 27) ? 27 : \
+                                (u) & (1ul << 28) ? 28 : \
+                                (u) & (1ul << 29) ? 29 : \
+                                (u) & (1ul << 30) ? 30 : \
+                                (u) & (1ul << 31) ? 31 : \
+                                32)
+#endif
+#endif
+
+//! @}
+
+
+/*! \name Bit Reversing
+ */
+//! @{
+
+/*! \brief Reverses the bits of \a u8.
+ *
+ * \param u8  U8 of which to reverse the bits.
+ *
+ * \return Value resulting from \a u8 with reversed bits.
+ */
+#define bit_reverse8(u8)    ((U8)(bit_reverse32((U8)(u8)) >> 24))
+
+/*! \brief Reverses the bits of \a u16.
+ *
+ * \param u16 U16 of which to reverse the bits.
+ *
+ * \return Value resulting from \a u16 with reversed bits.
+ */
+#define bit_reverse16(u16)  ((U16)(bit_reverse32((U16)(u16)) >> 16))
+
+/*! \brief Reverses the bits of \a u32.
+ *
+ * \param u32 U32 of which to reverse the bits.
+ *
+ * \return Value resulting from \a u32 with reversed bits.
+ */
+#define bit_reverse32(u32)   __RBIT(u32)
+
+/*! \brief Reverses the bits of \a u64.
+ *
+ * \param u64 U64 of which to reverse the bits.
+ *
+ * \return Value resulting from \a u64 with reversed bits.
+ */
+#define bit_reverse64(u64)  ((U64)(((U64)bit_reverse32((U64)(u64) >> 32)) |\
+                                   ((U64)bit_reverse32((U64)(u64)) << 32)))
+
+//! @}
+
+
+/*! \name Alignment
+ */
+//! @{
+
+/*! \brief Tests alignment of the number \a val with the \a n boundary.
+ *
+ * \param val Input value.
+ * \param n   Boundary.
+ *
+ * \return \c 1 if the number \a val is aligned with the \a n boundary, else \c 0.
+ */
+#define Test_align(val, n     ) (!Tst_bits( val, (n) - 1     )   )
+
+/*! \brief Gets alignment of the number \a val with respect to the \a n boundary.
+ *
+ * \param val Input value.
+ * \param n   Boundary.
+ *
+ * \return Alignment of the number \a val with respect to the \a n boundary.
+ */
+#define Get_align( val, n     ) (  Rd_bits( val, (n) - 1     )   )
+
+/*! \brief Sets alignment of the lvalue number \a lval to \a alg with respect to the \a n boundary.
+ *
+ * \param lval  Input/output lvalue.
+ * \param n     Boundary.
+ * \param alg   Alignment.
+ *
+ * \return New value of \a lval resulting from its alignment set to \a alg with respect to the \a n boundary.
+ */
+#define Set_align(lval, n, alg) (  Wr_bits(lval, (n) - 1, alg)   )
+
+/*! \brief Aligns the number \a val with the upper \a n boundary.
+ *
+ * \param val Input value.
+ * \param n   Boundary.
+ *
+ * \return Value resulting from the number \a val aligned with the upper \a n boundary.
+ */
+#define Align_up(  val, n     ) (((val) + ((n) - 1)) & ~((n) - 1))
+
+/*! \brief Aligns the number \a val with the lower \a n boundary.
+ *
+ * \param val Input value.
+ * \param n   Boundary.
+ *
+ * \return Value resulting from the number \a val aligned with the lower \a n boundary.
+ */
+#define Align_down(val, n     ) ( (val)              & ~((n) - 1))
+
+//! @}
+
+
+/*! \name Mathematics
+ *
+ * The same considerations as for clz and ctz apply here but GCC does not
+ * provide built-in functions to access the assembly instructions abs, min and
+ * max and it does not produce them by itself in most cases, so two sets of
+ * macros are defined here:
+ *   - Abs, Min and Max to apply to constant expressions (values known at
+ *     compile time);
+ *   - abs, min and max to apply to non-constant expressions (values unknown at
+ *     compile time), abs is found in stdlib.h.
+ */
+//! @{
+
+/*! \brief Takes the absolute value of \a a.
+ *
+ * \param a Input value.
+ *
+ * \return Absolute value of \a a.
+ *
+ * \note More optimized if only used with values known at compile time.
+ */
+#define Abs(a)              (((a) <  0 ) ? -(a) : (a))
+
+/*! \brief Takes the minimal value of \a a and \a b.
+ *
+ * \param a Input value.
+ * \param b Input value.
+ *
+ * \return Minimal value of \a a and \a b.
+ *
+ * \note More optimized if only used with values known at compile time.
+ */
+#define Min(a, b)           (((a) < (b)) ?  (a) : (b))
+
+/*! \brief Takes the maximal value of \a a and \a b.
+ *
+ * \param a Input value.
+ * \param b Input value.
+ *
+ * \return Maximal value of \a a and \a b.
+ *
+ * \note More optimized if only used with values known at compile time.
+ */
+#define Max(a, b)           (((a) > (b)) ?  (a) : (b))
+
+// abs() is already defined by stdlib.h
+
+/*! \brief Takes the minimal value of \a a and \a b.
+ *
+ * \param a Input value.
+ * \param b Input value.
+ *
+ * \return Minimal value of \a a and \a b.
+ *
+ * \note More optimized if only used with values unknown at compile time.
+ */
+#define min(a, b)   Min(a, b)
+
+/*! \brief Takes the maximal value of \a a and \a b.
+ *
+ * \param a Input value.
+ * \param b Input value.
+ *
+ * \return Maximal value of \a a and \a b.
+ *
+ * \note More optimized if only used with values unknown at compile time.
+ */
+#define max(a, b)   Max(a, b)
+
+//! @}
+
+
+/*! \brief Calls the routine at address \a addr.
+ *
+ * It generates a long call opcode.
+ *
+ * For example, `Long_call(0x80000000)' generates a software reset on a UC3 if
+ * it is invoked from the CPU supervisor mode.
+ *
+ * \param addr  Address of the routine to call.
+ *
+ * \note It may be used as a long jump opcode in some special cases.
+ */
+#define Long_call(addr)                   ((*(void (*)(void))(addr))())
+
+
+/*! \name MCU Endianism Handling
+ * ARM is MCU little endianism.
+ */
+//! @{
+#define  MSB(u16)       (((U8  *)&(u16))[1]) //!< Most significant byte of \a u16.
+#define  LSB(u16)       (((U8  *)&(u16))[0]) //!< Least significant byte of \a u16.
+
+#define  MSH(u32)       (((U16 *)&(u32))[1]) //!< Most significant half-word of \a u32.
+#define  LSH(u32)       (((U16 *)&(u32))[0]) //!< Least significant half-word of \a u32.
+#define  MSB0W(u32)     (((U8  *)&(u32))[3]) //!< Most significant byte of 1st rank of \a u32.
+#define  MSB1W(u32)     (((U8  *)&(u32))[2]) //!< Most significant byte of 2nd rank of \a u32.
+#define  MSB2W(u32)     (((U8  *)&(u32))[1]) //!< Most significant byte of 3rd rank of \a u32.
+#define  MSB3W(u32)     (((U8  *)&(u32))[0]) //!< Most significant byte of 4th rank of \a u32.
+#define  LSB3W(u32)     MSB0W(u32)           //!< Least significant byte of 4th rank of \a u32.
+#define  LSB2W(u32)     MSB1W(u32)           //!< Least significant byte of 3rd rank of \a u32.
+#define  LSB1W(u32)     MSB2W(u32)           //!< Least significant byte of 2nd rank of \a u32.
+#define  LSB0W(u32)     MSB3W(u32)           //!< Least significant byte of 1st rank of \a u32.
+        
+#define  MSW(u64)       (((U32 *)&(u64))[1]) //!< Most significant word of \a u64.
+#define  LSW(u64)       (((U32 *)&(u64))[0]) //!< Least significant word of \a u64.
+#define  MSH0(u64)      (((U16 *)&(u64))[3]) //!< Most significant half-word of 1st rank of \a u64.
+#define  MSH1(u64)      (((U16 *)&(u64))[2]) //!< Most significant half-word of 2nd rank of \a u64.
+#define  MSH2(u64)      (((U16 *)&(u64))[1]) //!< Most significant half-word of 3rd rank of \a u64.
+#define  MSH3(u64)      (((U16 *)&(u64))[0]) //!< Most significant half-word of 4th rank of \a u64.
+#define  LSH3(u64)      MSH0(u64)            //!< Least significant half-word of 4th rank of \a u64.
+#define  LSH2(u64)      MSH1(u64)            //!< Least significant half-word of 3rd rank of \a u64.
+#define  LSH1(u64)      MSH2(u64)            //!< Least significant half-word of 2nd rank of \a u64.
+#define  LSH0(u64)      MSH3(u64)            //!< Least significant half-word of 1st rank of \a u64.
+#define  MSB0D(u64)     (((U8  *)&(u64))[7]) //!< Most significant byte of 1st rank of \a u64.
+#define  MSB1D(u64)     (((U8  *)&(u64))[6]) //!< Most significant byte of 2nd rank of \a u64.
+#define  MSB2D(u64)     (((U8  *)&(u64))[5]) //!< Most significant byte of 3rd rank of \a u64.
+#define  MSB3D(u64)     (((U8  *)&(u64))[4]) //!< Most significant byte of 4th rank of \a u64.
+#define  MSB4D(u64)     (((U8  *)&(u64))[3]) //!< Most significant byte of 5th rank of \a u64.
+#define  MSB5D(u64)     (((U8  *)&(u64))[2]) //!< Most significant byte of 6th rank of \a u64.
+#define  MSB6D(u64)     (((U8  *)&(u64))[1]) //!< Most significant byte of 7th rank of \a u64.
+#define  MSB7D(u64)     (((U8  *)&(u64))[0]) //!< Most significant byte of 8th rank of \a u64.
+#define  LSB7D(u64)     MSB0D(u64)           //!< Least significant byte of 8th rank of \a u64.
+#define  LSB6D(u64)     MSB1D(u64)           //!< Least significant byte of 7th rank of \a u64.
+#define  LSB5D(u64)     MSB2D(u64)           //!< Least significant byte of 6th rank of \a u64.
+#define  LSB4D(u64)     MSB3D(u64)           //!< Least significant byte of 5th rank of \a u64.
+#define  LSB3D(u64)     MSB4D(u64)           //!< Least significant byte of 4th rank of \a u64.
+#define  LSB2D(u64)     MSB5D(u64)           //!< Least significant byte of 3rd rank of \a u64.
+#define  LSB1D(u64)     MSB6D(u64)           //!< Least significant byte of 2nd rank of \a u64.
+#define  LSB0D(u64)     MSB7D(u64)           //!< Least significant byte of 1st rank of \a u64.
+
+#define  BE16(x)        swap16(x)
+#define  LE16(x)        (x)
+
+#define  le16_to_cpu(x) (x)
+#define  cpu_to_le16(x) (x)
+#define  LE16_TO_CPU(x) (x)
+#define  CPU_TO_LE16(x) (x)
+
+#define  be16_to_cpu(x) swap16(x)
+#define  cpu_to_be16(x) swap16(x)
+#define  BE16_TO_CPU(x) swap16(x)
+#define  CPU_TO_BE16(x) swap16(x)
+
+#define  le32_to_cpu(x) (x)
+#define  cpu_to_le32(x) (x)
+#define  LE32_TO_CPU(x) (x)
+#define  CPU_TO_LE32(x) (x)
+
+#define  be32_to_cpu(x) swap32(x)
+#define  cpu_to_be32(x) swap32(x)
+#define  BE32_TO_CPU(x) swap32(x)
+#define  CPU_TO_BE32(x) swap32(x)
+//! @}
+
+
+/*! \name Endianism Conversion
+ *
+ * The same considerations as for clz and ctz apply here but GCC's
+ * __builtin_bswap_32 and __builtin_bswap_64 do not behave like macros when
+ * applied to constant expressions, so two sets of macros are defined here:
+ *   - Swap16, Swap32 and Swap64 to apply to constant expressions (values known
+ *     at compile time);
+ *   - swap16, swap32 and swap64 to apply to non-constant expressions (values
+ *     unknown at compile time).
+ */
+//! @{
+
+/*! \brief Toggles the endianism of \a u16 (by swapping its bytes).
+ *
+ * \param u16 U16 of which to toggle the endianism.
+ *
+ * \return Value resulting from \a u16 with toggled endianism.
+ *
+ * \note More optimized if only used with values known at compile time.
+ */
+#define Swap16(u16) ((U16)(((U16)(u16) >> 8) |\
+                           ((U16)(u16) << 8)))
+
+/*! \brief Toggles the endianism of \a u32 (by swapping its bytes).
+ *
+ * \param u32 U32 of which to toggle the endianism.
+ *
+ * \return Value resulting from \a u32 with toggled endianism.
+ *
+ * \note More optimized if only used with values known at compile time.
+ */
+#define Swap32(u32) ((U32)(((U32)Swap16((U32)(u32) >> 16)) |\
+                           ((U32)Swap16((U32)(u32)) << 16)))
+
+/*! \brief Toggles the endianism of \a u64 (by swapping its bytes).
+ *
+ * \param u64 U64 of which to toggle the endianism.
+ *
+ * \return Value resulting from \a u64 with toggled endianism.
+ *
+ * \note More optimized if only used with values known at compile time.
+ */
+#define Swap64(u64) ((U64)(((U64)Swap32((U64)(u64) >> 32)) |\
+                           ((U64)Swap32((U64)(u64)) << 32)))
+
+/*! \brief Toggles the endianism of \a u16 (by swapping its bytes).
+ *
+ * \param u16 U16 of which to toggle the endianism.
+ *
+ * \return Value resulting from \a u16 with toggled endianism.
+ *
+ * \note More optimized if only used with values unknown at compile time.
+ */
+#define swap16(u16) Swap16(u16)
+
+/*! \brief Toggles the endianism of \a u32 (by swapping its bytes).
+ *
+ * \param u32 U32 of which to toggle the endianism.
+ *
+ * \return Value resulting from \a u32 with toggled endianism.
+ *
+ * \note More optimized if only used with values unknown at compile time.
+ */
+#if (defined __GNUC__)
+#   define swap32(u32) ((U32)__builtin_bswap32((U32)(u32)))
+#else
+#   define swap32(u32) Swap32(u32)
+#endif
+
+/*! \brief Toggles the endianism of \a u64 (by swapping its bytes).
+ *
+ * \param u64 U64 of which to toggle the endianism.
+ *
+ * \return Value resulting from \a u64 with toggled endianism.
+ *
+ * \note More optimized if only used with values unknown at compile time.
+ */
+#if (defined __GNUC__)
+#   define swap64(u64) ((U64)__builtin_bswap64((U64)(u64)))
+#else
+#   define swap64(u64) ((U64)(((U64)swap32((U64)(u64) >> 32)) |\
+                           ((U64)swap32((U64)(u64)) << 32)))
+#endif
+
+//! @}
+
+
+/*! \name Target Abstraction
+ */
+//! @{
+
+#define _GLOBEXT_           extern      //!< extern storage-class specifier.
+#define _CONST_TYPE_        const       //!< const type qualifier.
+#define _MEM_TYPE_SLOW_                 //!< Slow memory type.
+#define _MEM_TYPE_MEDFAST_              //!< Fairly fast memory type.
+#define _MEM_TYPE_FAST_                 //!< Fast memory type.
+
+typedef U8                  Byte;       //!< 8-bit unsigned integer.
+
+#define memcmp_ram2ram      memcmp      //!< Target-specific memcmp of RAM to RAM.
+#define memcmp_code2ram     memcmp      //!< Target-specific memcmp of RAM to NVRAM.
+#define memcpy_ram2ram      memcpy      //!< Target-specific memcpy from RAM to RAM.
+#define memcpy_code2ram     memcpy      //!< Target-specific memcpy from NVRAM to RAM.
+
+#define LSB0(u32)           LSB0W(u32)  //!< Least significant byte of 1st rank of \a u32.
+#define LSB1(u32)           LSB1W(u32)  //!< Least significant byte of 2nd rank of \a u32.
+#define LSB2(u32)           LSB2W(u32)  //!< Least significant byte of 3rd rank of \a u32.
+#define LSB3(u32)           LSB3W(u32)  //!< Least significant byte of 4th rank of \a u32.
+#define MSB3(u32)           MSB3W(u32)  //!< Most significant byte of 4th rank of \a u32.
+#define MSB2(u32)           MSB2W(u32)  //!< Most significant byte of 3rd rank of \a u32.
+#define MSB1(u32)           MSB1W(u32)  //!< Most significant byte of 2nd rank of \a u32.
+#define MSB0(u32)           MSB0W(u32)  //!< Most significant byte of 1st rank of \a u32.
+
+//! @}
+
+/**
+ * \brief Calculate \f$ \left\lceil \frac{a}{b} \right\rceil \f$ using
+ * integer arithmetic.
+ *
+ * \param a An integer
+ * \param b Another integer
+ *
+ * \return (\a a / \a b) rounded up to the nearest integer.
+ */
+#define div_ceil(a, b)      (((a) + (b) - 1) / (b))
+
+#endif  // #ifndef __ASSEMBLY__
+
+
+#if defined(__ICCARM__)
+#define SHORTENUM           __packed
+#elif defined(__GNUC__)
+#define SHORTENUM           __attribute__((packed))
+#endif
+
+/* No operation */
+#if defined(__ICCARM__)
+#define nop()               __no_operation()
+#elif defined(__GNUC__)
+#define nop()               (__NOP())
+#endif
+
+#define FLASH_DECLARE(x)  const x
+#define FLASH_EXTERN(x) extern const x
+#define PGM_READ_BYTE(x) *(x)
+#define PGM_READ_WORD(x) *(x)
+#define PGM_READ_DWORD(x) *(x)
+#define MEMCPY_ENDIAN memcpy
+#define PGM_READ_BLOCK(dst, src, len) memcpy((dst), (src), (len))
+
+/*Defines the Flash Storage for the request and response of MAC*/
+#define CMD_ID_OCTET    (0)
+
+/* Converting of values from CPU endian to little endian. */
+#define CPU_ENDIAN_TO_LE16(x)   (x)
+#define CPU_ENDIAN_TO_LE32(x)   (x)
+#define CPU_ENDIAN_TO_LE64(x)   (x)
+
+/* Converting of values from little endian to CPU endian. */
+#define LE16_TO_CPU_ENDIAN(x)   (x)
+#define LE32_TO_CPU_ENDIAN(x)   (x)
+#define LE64_TO_CPU_ENDIAN(x)   (x)
+
+/* Converting of constants from little endian to CPU endian. */
+#define CLE16_TO_CPU_ENDIAN(x)  (x)
+#define CLE32_TO_CPU_ENDIAN(x)  (x)
+#define CLE64_TO_CPU_ENDIAN(x)  (x)
+
+/* Converting of constants from CPU endian to little endian. */
+#define CCPU_ENDIAN_TO_LE16(x)  (x)
+#define CCPU_ENDIAN_TO_LE32(x)  (x)
+#define CCPU_ENDIAN_TO_LE64(x)  (x)
+
+#define ADDR_COPY_DST_SRC_16(dst, src)  ((dst) = (src))
+#define ADDR_COPY_DST_SRC_64(dst, src)  ((dst) = (src))
+
+/**
+ * @brief Converts a 64-Bit value into  a 8 Byte array
+ *
+ * @param[in] value 64-Bit value
+ * @param[out] data Pointer to the 8 Byte array to be updated with 64-Bit value
+ * @ingroup apiPalApi
+ */
+static inline void convert_64_bit_to_byte_array(uint64_t value, uint8_t *data)
+{
+    uint8_t val_index = 0;
+
+    while (val_index < 8)
+    {
+        data[val_index++] = value & 0xFF;
+        value = value >> 8;
+    }
+}
+
+/**
+ * @brief Converts a 16-Bit value into  a 2 Byte array
+ *
+ * @param[in] value 16-Bit value
+ * @param[out] data Pointer to the 2 Byte array to be updated with 16-Bit value
+ * @ingroup apiPalApi
+ */
+static inline void convert_16_bit_to_byte_array(uint16_t value, uint8_t *data)
+{
+    data[0] = value & 0xFF;
+    data[1] = (value >> 8) & 0xFF;
+}
+
+/* Converts a 16-Bit value into a 2 Byte array */
+static inline void convert_spec_16_bit_to_byte_array(uint16_t value, uint8_t *data)
+{
+    data[0] = value & 0xFF;
+    data[1] = (value >> 8) & 0xFF;
+}
+
+/* Converts a 16-Bit value into a 2 Byte array */
+static inline void convert_16_bit_to_byte_address(uint16_t value, uint8_t *data)
+{
+    data[0] = value & 0xFF;
+    data[1] = (value >> 8) & 0xFF;
+}
+
+/*
+ * @brief Converts a 2 Byte array into a 16-Bit value
+ *
+ * @param data Specifies the pointer to the 2 Byte array
+ *
+ * @return 16-Bit value
+ * @ingroup apiPalApi
+ */
+static inline uint16_t convert_byte_array_to_16_bit(uint8_t *data)
+{
+    return (data[0] | ((uint16_t)data[1] << 8));
+}
+
+/* Converts a 8 Byte array into a 32-Bit value */
+static inline uint32_t convert_byte_array_to_32_bit(uint8_t *data)
+{
+	union
+	{
+		uint32_t u32;
+		uint8_t u8[8];
+	}long_addr;
+	uint8_t index;
+	for (index = 0; index < 4; index++)
+	{
+		long_addr.u8[index] = *data++;
+	}
+	return long_addr.u32;
+}
+
+/**
+ * @brief Converts a 8 Byte array into a 64-Bit value
+ *
+ * @param data Specifies the pointer to the 8 Byte array
+ *
+ * @return 64-Bit value
+ * @ingroup apiPalApi
+ */
+static inline uint64_t convert_byte_array_to_64_bit(uint8_t *data)
+{
+    union
+    {
+        uint64_t u64;
+        uint8_t u8[8];
+    } long_addr;
+
+    uint8_t val_index;
+
+    for (val_index = 0; val_index < 8; val_index++)
+    {
+        long_addr.u8[val_index] = *data++;
+    }
+
+    return long_addr.u64;
+}
+/**
+ * \}
+ */
+
+#endif /* UTILS_COMPILER_H */

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
@@ -1,0 +1,115 @@
+/**
+ * \file
+ *
+ * \brief Memory access control configuration file.
+ *
+ * Copyright (c) 2012-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _CONF_ACCESS_H_
+#define _CONF_ACCESS_H_
+
+#include "compiler.h"
+
+
+/*! \name Activation of Logical Unit Numbers
+ */
+//! @{
+#define LUN_0                ENABLE    //!< SD/MMC Card over MCI Slot 0.
+#define LUN_1                DISABLE   
+#define LUN_2                DISABLE   
+#define LUN_3                DISABLE   
+#define LUN_4                DISABLE
+#define LUN_5                DISABLE
+#define LUN_6                DISABLE
+#define LUN_7                DISABLE
+#define LUN_USB              DISABLE   
+//! @}
+
+/*! \name LUN 0 Definitions
+ */
+//! @{
+#define SD_MMC_SPI_MEM                          LUN_0
+#define LUN_ID_SD_MMC_SPI_MEM                   LUN_ID_0
+#define LUN_0_INCLUDE                           "sd_mmc_spi_mem.h"
+#define Lun_0_test_unit_ready                   sd_mmc_spi_test_unit_ready
+#define Lun_0_read_capacity                     sd_mmc_spi_read_capacity
+#define Lun_0_unload                            sd_mmc_spi_unload
+#define Lun_0_wr_protect                        sd_mmc_spi_wr_protect
+#define Lun_0_removal                           sd_mmc_spi_removal
+#define Lun_0_usb_read_10                       sd_mmc_spi_usb_read_10
+#define Lun_0_usb_write_10                      sd_mmc_spi_usb_write_10
+#define LUN_0_NAME                              "\"SD/MMC Card\""
+//! @}
+
+
+/*! \name Actions Associated with Memory Accesses
+ *
+ * Write here the action to associate with each memory access.
+ *
+ * \warning Be careful not to waste time in order not to disturb the functions.
+ */
+//! @{
+#define memory_start_read_action(nb_sectors)    
+#define memory_stop_read_action()               
+#define memory_start_write_action(nb_sectors)   
+#define memory_stop_write_action()              
+//! @}
+
+/*! \name Activation of Interface Features
+ */
+//! @{
+#define ACCESS_USB           true    //!< MEM <-> USB interface.
+#define ACCESS_MEM_TO_RAM    false   //!< MEM <-> RAM interface.
+#define ACCESS_STREAM        false   //!< Streaming MEM <-> MEM interface.
+#define ACCESS_STREAM_RECORD false   //!< Streaming MEM <-> MEM interface in record mode.
+#define ACCESS_MEM_TO_MEM    false   //!< MEM <-> MEM interface.
+#define ACCESS_CODEC         false   //!< Codec interface.
+//! @}
+
+/*! \name Specific Options for Access Control
+ */
+//! @{
+#define GLOBAL_WR_PROTECT    false   //!< Management of a global write protection.
+//! @}
+
+
+#endif // _CONF_ACCESS_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_clock.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_clock.h
@@ -1,0 +1,100 @@
+/**
+ * \file
+ *
+ * \brief SAM3X clock configuration.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef CONF_CLOCK_H_INCLUDED
+#define CONF_CLOCK_H_INCLUDED
+
+// ===== System Clock (MCK) Source Options
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_SLCK_RC
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_SLCK_XTAL
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_SLCK_BYPASS
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_MAINCK_4M_RC
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_MAINCK_8M_RC
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_MAINCK_12M_RC
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_MAINCK_XTAL
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_MAINCK_BYPASS
+#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_PLLACK
+//#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_UPLLCK
+
+// ===== System Clock (MCK) Prescaler Options   (Fmck = Fsys / (SYSCLK_PRES))
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_1
+#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_2
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_4
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_8
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_16
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_32
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_64
+//#define CONFIG_SYSCLK_PRES          SYSCLK_PRES_3
+
+// ===== PLL0 (A) Options   (Fpll = (Fclk * PLL_mul) / PLL_div)
+// Use mul and div effective values here.
+#define CONFIG_PLL0_SOURCE          PLL_SRC_MAINCK_XTAL
+#define CONFIG_PLL0_MUL             14
+#define CONFIG_PLL0_DIV             1
+
+// ===== UPLL (UTMI) Hardware fixed at 480MHz.
+
+// ===== USB Clock Source Options   (Fusb = FpllX / USB_div)
+// Use div effective value here.
+//#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_PLL0
+#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_UPLL
+#define CONFIG_USBCLK_DIV           1
+
+// ===== Target frequency (System clock)
+// - XTAL frequency: 12MHz
+// - System clock source: PLLA
+// - System clock prescaler: 2 (divided by 2)
+// - PLLA source: XTAL
+// - PLLA output: XTAL * 14 / 1
+// - System clock is: 12 * 14 / 1 /2 = 84MHz
+// ===== Target frequency (USB Clock)
+// - USB clock source: UPLL
+// - USB clock divider: 1 (not divided)
+// - UPLL frequency: 480MHz
+// - USB clock: 480 / 1 = 480MHz
+
+
+#endif /* CONF_CLOCK_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_usb.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_usb.h
@@ -1,0 +1,287 @@
+/**
+ * \file
+ *
+ * \brief USB configuration file
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _CONF_USB_H_
+#define _CONF_USB_H_
+
+#include "compiler.h"
+
+/**
+ * USB Device Configuration
+ * @{
+ */
+
+//! Device definition (mandatory)
+#define  USB_DEVICE_VENDOR_ID             0x03EB /* ATMEL VID */
+#define  USB_DEVICE_PRODUCT_ID            0x2424 /* MSC / CDC */
+#define  USB_DEVICE_MAJOR_VERSION         1
+#define  USB_DEVICE_MINOR_VERSION         0
+#define  USB_DEVICE_POWER                 100 // Consumption on Vbus line (mA)
+#define  USB_DEVICE_ATTR                  \
+	(USB_CONFIG_ATTR_SELF_POWERED)
+// (USB_CONFIG_ATTR_BUS_POWERED)
+//	(USB_CONFIG_ATTR_REMOTE_WAKEUP|USB_CONFIG_ATTR_SELF_POWERED)
+//	(USB_CONFIG_ATTR_REMOTE_WAKEUP|USB_CONFIG_ATTR_BUS_POWERED)
+
+//! USB Device string definitions (Optional)
+#define  USB_DEVICE_MANUFACTURE_NAME      "MARLIN 3D"
+#define  USB_DEVICE_PRODUCT_NAME          "CDC and MSC"
+#define  USB_DEVICE_SERIAL_NAME           "123985739853" // Disk SN for MSC
+
+/**
+ * Device speeds support
+ * Low speed not supported by CDC and MSC
+ * @{
+ */
+
+//! To define a Low speed device
+//#define  USB_DEVICE_LOW_SPEED
+
+//! To authorize the High speed
+#if (UC3A3||UC3A4)
+#  define  USB_DEVICE_HS_SUPPORT
+#elif (SAM3XA||SAM3U)
+#  define  USB_DEVICE_HS_SUPPORT
+#endif
+//@}
+
+
+/**
+ * USB Device Callbacks definitions (Optional)
+ * @{
+ */
+#define  UDC_VBUS_EVENT(b_vbus_high)
+#define  UDC_SOF_EVENT()                  
+#define  UDC_SUSPEND_EVENT()              
+#define  UDC_RESUME_EVENT()               
+#define  UDC_GET_EXTRA_STRING()           usb_task_extra_string()
+//@}
+
+/**
+ * USB Device low level configuration
+ * When only one interface is used, these configurations are defined by the class module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Control endpoint size
+#define  USB_DEVICE_EP_CTRL_SIZE       64
+
+//! Two interfaces for this device (CDC COM + CDC DATA + MSC)
+#define  USB_DEVICE_NB_INTERFACE       3
+
+//! 5 endpoints used by CDC and MSC interfaces
+#if SAM3U
+// (3 | USB_EP_DIR_IN)  // CDC Notify endpoint
+// (6 | USB_EP_DIR_IN)  // CDC TX
+// (5 | USB_EP_DIR_OUT) // CDC RX
+// (1 | USB_EP_DIR_IN)  // MSC IN
+// (2 | USB_EP_DIR_OUT) // MSC OUT
+#  define  USB_DEVICE_MAX_EP           6
+#  if defined(USB_DEVICE_HS_SUPPORT)
+// In HS mode, size of bulk endpoints are 512
+// If CDC and MSC endpoints all uses 2 banks, DPRAM is not enough: 4 bulk
+// endpoints requires 4K bytes. So reduce the number of banks of CDC bulk
+// endpoints to use less DPRAM. Keep MSC setting to keep MSC performance.
+#     define  UDD_BULK_NB_BANK(ep) ((ep == 5 || ep== 6) ? 1 : 2)
+#endif
+#else
+// (3 | USB_EP_DIR_IN)  // CDC Notify endpoint
+// (4 | USB_EP_DIR_IN)  // CDC TX
+// (5 | USB_EP_DIR_OUT) // CDC RX
+// (1 | USB_EP_DIR_IN)  // MSC IN
+// (2 | USB_EP_DIR_OUT) // MSC OUT
+#  define  USB_DEVICE_MAX_EP           5
+#  if SAM3XA && defined(USB_DEVICE_HS_SUPPORT)
+// In HS mode, size of bulk endpoints are 512
+// If CDC and MSC endpoints all uses 2 banks, DPRAM is not enough: 4 bulk
+// endpoints requires 4K bytes. So reduce the number of banks of CDC bulk
+// endpoints to use less DPRAM. Keep MSC setting to keep MSC performance.
+#     define  UDD_BULK_NB_BANK(ep) ((ep == 4 || ep== 5) ? 1 : 2)
+#  endif
+#endif
+//@}
+
+//@}
+
+
+/**
+ * USB Interface Configuration
+ * @{
+ */
+/**
+ * Configuration of CDC interface
+ * @{
+ */
+
+//! Define one USB communication ports
+#define  UDI_CDC_PORT_NB 1
+
+//! Interface callback definition
+#define  UDI_CDC_ENABLE_EXT(port)         usb_task_cdc_enable(port)
+#define  UDI_CDC_DISABLE_EXT(port)        usb_task_cdc_disable(port)
+#define  UDI_CDC_RX_NOTIFY(port)          usb_task_cdc_rx_notify(port)
+#define  UDI_CDC_TX_EMPTY_NOTIFY(port)
+#define  UDI_CDC_SET_CODING_EXT(port,cfg) usb_task_cdc_config(port,cfg)
+#define  UDI_CDC_SET_DTR_EXT(port,set)    usb_task_cdc_set_dtr(port,set)
+#define  UDI_CDC_SET_RTS_EXT(port,set)
+
+//! Define it when the transfer CDC Device to Host is a low rate (<512000 bauds)
+//! to reduce CDC buffers size
+//#define  UDI_CDC_LOW_RATE
+
+//! Default configuration of communication port
+#define  UDI_CDC_DEFAULT_RATE             115200
+#define  UDI_CDC_DEFAULT_STOPBITS         CDC_STOP_BITS_1
+#define  UDI_CDC_DEFAULT_PARITY           CDC_PAR_NONE
+#define  UDI_CDC_DEFAULT_DATABITS         8
+
+//! Enable id string of interface to add an extra USB string
+#define  UDI_CDC_IAD_STRING_ID            4
+
+/**
+ * USB CDC low level configuration
+ * In standalone these configurations are defined by the CDC module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Endpoint numbers definition
+#if SAM3U
+#  define  UDI_CDC_COMM_EP_0             (3 | USB_EP_DIR_IN) // Notify endpoint
+#  define  UDI_CDC_DATA_EP_IN_0          (6 | USB_EP_DIR_IN) // TX
+#  define  UDI_CDC_DATA_EP_OUT_0         (5 | USB_EP_DIR_OUT)// RX
+#else
+#  define  UDI_CDC_COMM_EP_0             (3 | USB_EP_DIR_IN) // Notify endpoint
+#  define  UDI_CDC_DATA_EP_IN_0          (4 | USB_EP_DIR_IN) // TX
+#  define  UDI_CDC_DATA_EP_OUT_0         (5 | USB_EP_DIR_OUT)// RX
+#endif
+
+//! Interface numbers
+#define  UDI_CDC_COMM_IFACE_NUMBER_0   0
+#define  UDI_CDC_DATA_IFACE_NUMBER_0   1
+//@}
+//@}
+
+
+/**
+ * Configuration of MSC interface
+ * @{
+ */
+//! Vendor name and Product version of MSC interface
+#define UDI_MSC_GLOBAL_VENDOR_ID            \
+   'M', 'A', 'R', 'L', 'I', 'N', '3', 'D'
+#define UDI_MSC_GLOBAL_PRODUCT_VERSION            \
+   '1', '.', '0', '0'
+
+//! Interface callback definition
+#define  UDI_MSC_ENABLE_EXT()          usb_task_msc_enable()
+#define  UDI_MSC_DISABLE_EXT()         usb_task_msc_disable()
+
+//! Enable id string of interface to add an extra USB string
+#define  UDI_MSC_STRING_ID                5
+
+/**
+ * USB MSC low level configuration
+ * In standalone these configurations are defined by the MSC module.
+ * For composite device, these configuration must be defined here
+ * @{
+ */
+//! Endpoint numbers definition
+#define  UDI_MSC_EP_IN                 (1 | USB_EP_DIR_IN)
+#define  UDI_MSC_EP_OUT                (2 | USB_EP_DIR_OUT)
+
+//! Interface number
+#define  UDI_MSC_IFACE_NUMBER          2
+//@}
+//@}
+
+//@}
+
+
+/**
+ * Description of Composite Device
+ * @{
+ */
+//! USB Interfaces descriptor structure
+#define UDI_COMPOSITE_DESC_T \
+	usb_iad_desc_t       udi_cdc_iad; \
+	udi_cdc_comm_desc_t  udi_cdc_comm; \
+	udi_cdc_data_desc_t  udi_cdc_data; \
+	udi_msc_desc_t       udi_msc
+
+//! USB Interfaces descriptor value for Full Speed
+#define UDI_COMPOSITE_DESC_FS \
+	.udi_cdc_iad   = UDI_CDC_IAD_DESC_0, \
+	.udi_cdc_comm  = UDI_CDC_COMM_DESC_0, \
+	.udi_cdc_data  = UDI_CDC_DATA_DESC_0_FS, \
+	.udi_msc       = UDI_MSC_DESC_FS
+
+//! USB Interfaces descriptor value for High Speed
+#define UDI_COMPOSITE_DESC_HS \
+	.udi_cdc_iad   = UDI_CDC_IAD_DESC_0, \
+	.udi_cdc_comm  = UDI_CDC_COMM_DESC_0, \
+	.udi_cdc_data  = UDI_CDC_DATA_DESC_0_HS, \
+	.udi_msc       = UDI_MSC_DESC_HS
+
+//! USB Interface APIs
+#define UDI_COMPOSITE_API \
+	&udi_api_cdc_comm, \
+	&udi_api_cdc_data, \
+	&udi_api_msc
+//@}
+
+
+/**
+ * USB Device Driver Configuration
+ * @{
+ */
+//@}
+
+//! The includes of classes and other headers must be done at the end of this file to avoid compile error
+#include "udi_cdc.h"
+#include "udi_msc.h"
+#include "usb_task.h"
+
+#endif // _CONF_USB_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.c
@@ -1,0 +1,646 @@
+/*****************************************************************************
+ *
+ * \file
+ *
+ * \brief Abstraction layer for memory interfaces.
+ *
+ * This module contains the interfaces:
+ *   - MEM <-> USB;
+ *   - MEM <-> RAM;
+ *   - MEM <-> MEM.
+ *
+ * This module may be configured and expanded to support the following features:
+ *   - write-protected globals;
+ *   - password-protected data;
+ *   - specific features;
+ *   - etc.
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ ******************************************************************************/
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+
+//_____ I N C L U D E S ____________________________________________________
+
+#include "compiler.h"
+#include "preprocessor.h"
+#ifdef FREERTOS_USED
+#include "FreeRTOS.h"
+#include "semphr.h"
+#endif
+#include "ctrl_access.h"
+
+
+//_____ D E F I N I T I O N S ______________________________________________
+
+#ifdef FREERTOS_USED
+
+/*! \name LUN Access Protection Macros
+ */
+//! @{
+
+/*! \brief Locks accesses to LUNs.
+ *
+ * \return \c true if the access was successfully locked, else \c false.
+ */
+#define Ctrl_access_lock()    ctrl_access_lock()
+
+/*! \brief Unlocks accesses to LUNs.
+ */
+#define Ctrl_access_unlock()  xSemaphoreGive(ctrl_access_semphr)
+
+//! @}
+
+//! Handle to the semaphore protecting accesses to LUNs.
+static xSemaphoreHandle ctrl_access_semphr = NULL;
+
+#else
+
+/*! \name LUN Access Protection Macros
+ */
+//! @{
+
+/*! \brief Locks accesses to LUNs.
+ *
+ * \return \c true if the access was successfully locked, else \c false.
+ */
+#define Ctrl_access_lock()    true
+
+/*! \brief Unlocks accesses to LUNs.
+ */
+#define Ctrl_access_unlock()
+
+//! @}
+
+#endif  // FREERTOS_USED
+
+
+#if MAX_LUN
+
+/*! \brief Initializes an entry of the LUN descriptor table.
+ *
+ * \param lun Logical Unit Number.
+ *
+ * \return LUN descriptor table entry initializer.
+ */
+#if ACCESS_USB == true && ACCESS_MEM_TO_RAM == true
+#define Lun_desc_entry(lun) \
+  {\
+    TPASTE3(Lun_, lun, _test_unit_ready),\
+    TPASTE3(Lun_, lun, _read_capacity),\
+    TPASTE3(Lun_, lun, _unload),\
+    TPASTE3(Lun_, lun, _wr_protect),\
+    TPASTE3(Lun_, lun, _removal),\
+    TPASTE3(Lun_, lun, _usb_read_10),\
+    TPASTE3(Lun_, lun, _usb_write_10),\
+    TPASTE3(Lun_, lun, _mem_2_ram),\
+    TPASTE3(Lun_, lun, _ram_2_mem),\
+    TPASTE3(LUN_, lun, _NAME)\
+  }
+#elif ACCESS_USB == true
+#define Lun_desc_entry(lun) \
+  {\
+    TPASTE3(Lun_, lun, _test_unit_ready),\
+    TPASTE3(Lun_, lun, _read_capacity),\
+    TPASTE3(Lun_, lun, _unload),\
+    TPASTE3(Lun_, lun, _wr_protect),\
+    TPASTE3(Lun_, lun, _removal),\
+    TPASTE3(Lun_, lun, _usb_read_10),\
+    TPASTE3(Lun_, lun, _usb_write_10),\
+    TPASTE3(LUN_, lun, _NAME)\
+  }
+#elif ACCESS_MEM_TO_RAM == true
+#define Lun_desc_entry(lun) \
+  {\
+    TPASTE3(Lun_, lun, _test_unit_ready),\
+    TPASTE3(Lun_, lun, _read_capacity),\
+    TPASTE3(Lun_, lun, _unload),\
+    TPASTE3(Lun_, lun, _wr_protect),\
+    TPASTE3(Lun_, lun, _removal),\
+    TPASTE3(Lun_, lun, _mem_2_ram),\
+    TPASTE3(Lun_, lun, _ram_2_mem),\
+    TPASTE3(LUN_, lun, _NAME)\
+  }
+#else
+#define Lun_desc_entry(lun) \
+  {\
+    TPASTE3(Lun_, lun, _test_unit_ready),\
+    TPASTE3(Lun_, lun, _read_capacity),\
+    TPASTE3(Lun_, lun, _unload),\
+    TPASTE3(Lun_, lun, _wr_protect),\
+    TPASTE3(Lun_, lun, _removal),\
+    TPASTE3(LUN_, lun, _NAME)\
+  }
+#endif
+
+//! LUN descriptor table.
+static const struct
+{
+  Ctrl_status (*test_unit_ready)(void);
+  Ctrl_status (*read_capacity)(U32 *);
+  bool (*unload)(bool);
+  bool (*wr_protect)(void);
+  bool (*removal)(void);
+#if ACCESS_USB == true
+  Ctrl_status (*usb_read_10)(U32, U16);
+  Ctrl_status (*usb_write_10)(U32, U16);
+#endif
+#if ACCESS_MEM_TO_RAM == true
+  Ctrl_status (*mem_2_ram)(U32, void *);
+  Ctrl_status (*ram_2_mem)(U32, const void *);
+#endif
+  const char *name;
+} lun_desc[MAX_LUN] =
+{
+#if LUN_0 == ENABLE
+# ifndef Lun_0_unload
+#  define Lun_0_unload NULL
+# endif
+  Lun_desc_entry(0),
+#endif
+#if LUN_1 == ENABLE
+# ifndef Lun_1_unload
+#  define Lun_1_unload NULL
+# endif
+  Lun_desc_entry(1),
+#endif
+#if LUN_2 == ENABLE
+# ifndef Lun_2_unload
+#  define Lun_2_unload NULL
+# endif
+  Lun_desc_entry(2),
+#endif
+#if LUN_3 == ENABLE
+# ifndef Lun_3_unload
+#  define Lun_3_unload NULL
+# endif
+  Lun_desc_entry(3),
+#endif
+#if LUN_4 == ENABLE
+# ifndef Lun_4_unload
+#  define Lun_4_unload NULL
+# endif
+  Lun_desc_entry(4),
+#endif
+#if LUN_5 == ENABLE
+# ifndef Lun_5_unload
+#  define Lun_5_unload NULL
+# endif
+  Lun_desc_entry(5),
+#endif
+#if LUN_6 == ENABLE
+# ifndef Lun_6_unload
+#  define Lun_6_unload NULL
+# endif
+  Lun_desc_entry(6),
+#endif
+#if LUN_7 == ENABLE
+# ifndef Lun_7_unload
+#  define Lun_7_unload NULL
+# endif
+  Lun_desc_entry(7)
+#endif
+};
+
+#endif
+
+
+#if GLOBAL_WR_PROTECT == true
+bool g_wr_protect;
+#endif
+
+
+/*! \name Control Interface
+ */
+//! @{
+
+
+#ifdef FREERTOS_USED
+
+bool ctrl_access_init(void)
+{
+  // If the handle to the protecting semaphore is not valid,
+  if (!ctrl_access_semphr)
+  {
+    // try to create the semaphore.
+    vSemaphoreCreateBinary(ctrl_access_semphr);
+
+    // If the semaphore could not be created, there is no backup solution.
+    if (!ctrl_access_semphr) return false;
+  }
+
+  return true;
+}
+
+
+/*! \brief Locks accesses to LUNs.
+ *
+ * \return \c true if the access was successfully locked, else \c false.
+ */
+static bool ctrl_access_lock(void)
+{
+  // If the semaphore could not be created, there is no backup solution.
+  if (!ctrl_access_semphr) return false;
+
+  // Wait for the semaphore.
+  while (!xSemaphoreTake(ctrl_access_semphr, portMAX_DELAY));
+
+  return true;
+}
+
+#endif  // FREERTOS_USED
+
+
+U8 get_nb_lun(void)
+{
+#if MEM_USB == ENABLE
+#  ifndef Lun_usb_get_lun
+#    define Lun_usb_get_lun()  host_get_lun()
+#  endif
+  U8 nb_lun;
+
+  if (!Ctrl_access_lock()) return MAX_LUN;
+
+  nb_lun = MAX_LUN + Lun_usb_get_lun();
+
+  Ctrl_access_unlock();
+
+  return nb_lun;
+#else
+  return MAX_LUN;
+#endif
+}
+
+
+U8 get_cur_lun(void)
+{
+  return LUN_ID_0;
+}
+
+
+Ctrl_status mem_test_unit_ready(U8 lun)
+{
+  Ctrl_status status;
+
+  if (!Ctrl_access_lock()) return CTRL_FAIL;
+
+  status =
+#if MAX_LUN
+         (lun < MAX_LUN) ? lun_desc[lun].test_unit_ready() :
+#endif
+#if LUN_USB == ENABLE
+                             Lun_usb_test_unit_ready(lun - LUN_ID_USB);
+#else
+                             CTRL_FAIL;
+#endif
+
+  Ctrl_access_unlock();
+
+  return status;
+}
+
+
+Ctrl_status mem_read_capacity(U8 lun, U32 *u32_nb_sector)
+{
+  Ctrl_status status;
+
+  if (!Ctrl_access_lock()) return CTRL_FAIL;
+
+  status =
+#if MAX_LUN
+         (lun < MAX_LUN) ? lun_desc[lun].read_capacity(u32_nb_sector) :
+#endif
+#if LUN_USB == ENABLE
+                             Lun_usb_read_capacity(lun - LUN_ID_USB, u32_nb_sector);
+#else
+                             CTRL_FAIL;
+#endif
+
+  Ctrl_access_unlock();
+
+  return status;
+}
+
+
+U8 mem_sector_size(U8 lun)
+{
+  U8 sector_size;
+
+  if (!Ctrl_access_lock()) return 0;
+
+  sector_size =
+#if MAX_LUN
+              (lun < MAX_LUN) ? 1 :
+#endif
+#if LUN_USB == ENABLE
+                                  Lun_usb_read_sector_size(lun - LUN_ID_USB);
+#else
+                                  0;
+#endif
+
+  Ctrl_access_unlock();
+
+  return sector_size;
+}
+
+
+bool mem_unload(U8 lun, bool unload)
+{
+  bool unloaded;
+#if !MAX_LUN || !defined(Lun_usb_unload)
+  UNUSED(lun);
+#endif
+
+  if (!Ctrl_access_lock()) return false;
+
+  unloaded =
+#if MAX_LUN
+          (lun < MAX_LUN) ?
+              (lun_desc[lun].unload ?
+                  lun_desc[lun].unload(unload) : !unload) :
+#endif
+#if LUN_USB == ENABLE
+# if defined(Lun_usb_unload)
+              Lun_usb_unload(lun - LUN_ID_USB, unload);
+# else
+              !unload; /* Can not unload: load success, unload fail */
+# endif
+#else
+              false; /* No mem, unload/load fail */
+#endif
+
+  Ctrl_access_unlock();
+
+  return unloaded;
+}
+
+bool mem_wr_protect(U8 lun)
+{
+  bool wr_protect;
+
+  if (!Ctrl_access_lock()) return true;
+
+  wr_protect =
+#if MAX_LUN
+             (lun < MAX_LUN) ? lun_desc[lun].wr_protect() :
+#endif
+#if LUN_USB == ENABLE
+                                 Lun_usb_wr_protect(lun - LUN_ID_USB);
+#else
+                                 true;
+#endif
+
+  Ctrl_access_unlock();
+
+  return wr_protect;
+}
+
+
+bool mem_removal(U8 lun)
+{
+  bool removal;
+#if MAX_LUN==0
+  UNUSED(lun);
+#endif
+
+  if (!Ctrl_access_lock()) return true;
+
+  removal =
+#if MAX_LUN
+          (lun < MAX_LUN) ? lun_desc[lun].removal() :
+#endif
+#if LUN_USB == ENABLE
+                              Lun_usb_removal();
+#else
+                              true;
+#endif
+
+  Ctrl_access_unlock();
+
+  return removal;
+}
+
+
+const char *mem_name(U8 lun)
+{
+#if MAX_LUN==0
+  UNUSED(lun);
+#endif
+  return
+#if MAX_LUN
+       (lun < MAX_LUN) ? lun_desc[lun].name :
+#endif
+#if LUN_USB == ENABLE
+                           LUN_USB_NAME;
+#else
+                           NULL;
+#endif
+}
+
+
+//! @}
+
+
+#if ACCESS_USB == true
+
+/*! \name MEM <-> USB Interface
+ */
+//! @{
+
+
+Ctrl_status memory_2_usb(U8 lun, U32 addr, U16 nb_sector)
+{
+  Ctrl_status status;
+
+  if (!Ctrl_access_lock()) return CTRL_FAIL;
+
+  memory_start_read_action(nb_sector);
+  status =
+#if MAX_LUN
+           (lun < MAX_LUN) ? lun_desc[lun].usb_read_10(addr, nb_sector) :
+#endif
+                             CTRL_FAIL;
+  memory_stop_read_action();
+
+  Ctrl_access_unlock();
+
+  return status;
+}
+
+
+Ctrl_status usb_2_memory(U8 lun, U32 addr, U16 nb_sector)
+{
+  Ctrl_status status;
+
+  if (!Ctrl_access_lock()) return CTRL_FAIL;
+
+  memory_start_write_action(nb_sector);
+  status =
+#if MAX_LUN
+           (lun < MAX_LUN) ? lun_desc[lun].usb_write_10(addr, nb_sector) :
+#endif
+                             CTRL_FAIL;
+  memory_stop_write_action();
+
+  Ctrl_access_unlock();
+
+  return status;
+}
+
+
+//! @}
+
+#endif  // ACCESS_USB == true
+
+
+#if ACCESS_MEM_TO_RAM == true
+
+/*! \name MEM <-> RAM Interface
+ */
+//! @{
+
+
+Ctrl_status memory_2_ram(U8 lun, U32 addr, void *ram)
+{
+  Ctrl_status status;
+#if MAX_LUN==0
+  UNUSED(lun);
+#endif
+
+  if (!Ctrl_access_lock()) return CTRL_FAIL;
+
+  memory_start_read_action(1);
+  status =
+#if MAX_LUN
+           (lun < MAX_LUN) ? lun_desc[lun].mem_2_ram(addr, ram) :
+#endif
+#if LUN_USB == ENABLE
+                             Lun_usb_mem_2_ram(addr, ram);
+#else
+                             CTRL_FAIL;
+#endif
+  memory_stop_read_action();
+
+  Ctrl_access_unlock();
+
+  return status;
+}
+
+
+Ctrl_status ram_2_memory(U8 lun, U32 addr, const void *ram)
+{
+  Ctrl_status status;
+#if MAX_LUN==0
+  UNUSED(lun);
+#endif
+
+  if (!Ctrl_access_lock()) return CTRL_FAIL;
+
+  memory_start_write_action(1);
+  status =
+#if MAX_LUN
+           (lun < MAX_LUN) ? lun_desc[lun].ram_2_mem(addr, ram) :
+#endif
+#if LUN_USB == ENABLE
+                             Lun_usb_ram_2_mem(addr, ram);
+#else
+                             CTRL_FAIL;
+#endif
+  memory_stop_write_action();
+
+  Ctrl_access_unlock();
+
+  return status;
+}
+
+
+//! @}
+
+#endif  // ACCESS_MEM_TO_RAM == true
+
+
+#if ACCESS_STREAM == true
+
+/*! \name Streaming MEM <-> MEM Interface
+ */
+//! @{
+
+
+  #if ACCESS_MEM_TO_MEM == true
+
+#include "fat.h"
+
+Ctrl_status stream_mem_to_mem(U8 src_lun, U32 src_addr, U8 dest_lun, U32 dest_addr, U16 nb_sector)
+{
+  COMPILER_ALIGNED(4)
+  static U8 sector_buf[FS_512B];
+  Ctrl_status status = CTRL_GOOD;
+
+  while (nb_sector--)
+  {
+    if ((status = memory_2_ram(src_lun, src_addr++, sector_buf)) != CTRL_GOOD) break;
+    if ((status = ram_2_memory(dest_lun, dest_addr++, sector_buf)) != CTRL_GOOD) break;
+  }
+
+  return status;
+}
+
+  #endif  // ACCESS_MEM_TO_MEM == true
+
+
+Ctrl_status stream_state(U8 id)
+{
+  UNUSED(id);
+  return CTRL_GOOD;
+}
+
+
+U16 stream_stop(U8 id)
+{
+  UNUSED(id);
+  return 0;
+}
+
+
+//! @}
+
+#endif  // ACCESS_STREAM == true
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.h
@@ -1,0 +1,402 @@
+/*****************************************************************************
+ *
+ * \file
+ *
+ * \brief Abstraction layer for memory interfaces.
+ *
+ * This module contains the interfaces:
+ *   - MEM <-> USB;
+ *   - MEM <-> RAM;
+ *   - MEM <-> MEM.
+ *
+ * This module may be configured and expanded to support the following features:
+ *   - write-protected globals;
+ *   - password-protected data;
+ *   - specific features;
+ *   - etc.
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ ******************************************************************************/
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+
+#ifndef _CTRL_ACCESS_H_
+#define _CTRL_ACCESS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \defgroup group_common_services_storage_ctrl_access Memory Control Access
+ *
+ * Common abstraction layer for memory interfaces. It provides interfaces between:
+ * Memory and USB, Memory and RAM, Memory and Memory. Common API for XMEGA and UC3.
+ *
+ * \{
+ */
+
+#include "compiler.h"
+#include "conf_access.h"
+
+#ifndef SECTOR_SIZE
+#define SECTOR_SIZE  512
+#endif
+
+//! Status returned by CTRL_ACCESS interfaces.
+typedef enum
+{
+  CTRL_GOOD       = PASS,     //!< Success, memory ready.
+  CTRL_FAIL       = FAIL,     //!< An error occurred.
+  CTRL_NO_PRESENT = FAIL + 1, //!< Memory unplugged.
+  CTRL_BUSY       = FAIL + 2  //!< Memory not initialized or changed.
+} Ctrl_status;
+
+
+// FYI: Each Logical Unit Number (LUN) corresponds to a memory.
+
+// Check LUN defines.
+#ifndef LUN_0
+  #error LUN_0 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_1
+  #error LUN_1 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_2
+  #error LUN_2 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_3
+  #error LUN_3 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_4
+  #error LUN_4 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_5
+  #error LUN_5 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_6
+  #error LUN_6 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_7
+  #error LUN_7 must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+#ifndef LUN_USB
+  #error LUN_USB must be defined as ENABLE or DISABLE in conf_access.h
+#endif
+
+/*! \name LUN IDs
+ */
+//! @{
+#define LUN_ID_0        (0)                 //!< First static LUN.
+#define LUN_ID_1        (LUN_ID_0 + LUN_0)
+#define LUN_ID_2        (LUN_ID_1 + LUN_1)
+#define LUN_ID_3        (LUN_ID_2 + LUN_2)
+#define LUN_ID_4        (LUN_ID_3 + LUN_3)
+#define LUN_ID_5        (LUN_ID_4 + LUN_4)
+#define LUN_ID_6        (LUN_ID_5 + LUN_5)
+#define LUN_ID_7        (LUN_ID_6 + LUN_6)
+#define MAX_LUN         (LUN_ID_7 + LUN_7)  //!< Number of static LUNs.
+#define LUN_ID_USB      (MAX_LUN)           //!< First dynamic LUN (USB host mass storage).
+//! @}
+
+
+// Include LUN header files.
+#if LUN_0 == ENABLE
+  #include LUN_0_INCLUDE
+#endif
+#if LUN_1 == ENABLE
+  #include LUN_1_INCLUDE
+#endif
+#if LUN_2 == ENABLE
+  #include LUN_2_INCLUDE
+#endif
+#if LUN_3 == ENABLE
+  #include LUN_3_INCLUDE
+#endif
+#if LUN_4 == ENABLE
+  #include LUN_4_INCLUDE
+#endif
+#if LUN_5 == ENABLE
+  #include LUN_5_INCLUDE
+#endif
+#if LUN_6 == ENABLE
+  #include LUN_6_INCLUDE
+#endif
+#if LUN_7 == ENABLE
+  #include LUN_7_INCLUDE
+#endif
+#if LUN_USB == ENABLE
+  #include LUN_USB_INCLUDE
+#endif
+
+
+// Check the configuration of write protection in conf_access.h.
+#ifndef GLOBAL_WR_PROTECT
+  #error GLOBAL_WR_PROTECT must be defined as true or false in conf_access.h
+#endif
+
+
+#if GLOBAL_WR_PROTECT == true
+
+//! Write protect.
+extern bool g_wr_protect;
+
+#endif
+
+
+/*! \name Control Interface
+ */
+//! @{
+
+#ifdef FREERTOS_USED
+
+/*! \brief Initializes the LUN access locker.
+ *
+ * \return \c true if the locker was successfully initialized, else \c false.
+ */
+extern bool ctrl_access_init(void);
+
+#endif  // FREERTOS_USED
+
+/*! \brief Returns the number of LUNs.
+ *
+ * \return Number of LUNs in the system.
+ */
+extern U8 get_nb_lun(void);
+
+/*! \brief Returns the current LUN.
+ *
+ * \return Current LUN.
+ *
+ * \todo Implement.
+ */
+extern U8 get_cur_lun(void);
+
+/*! \brief Tests the memory state and initializes the memory if required.
+ *
+ * The TEST UNIT READY SCSI primary command allows an application client to poll
+ * a LUN until it is ready without having to allocate memory for returned data.
+ *
+ * This command may be used to check the media status of LUNs with removable
+ * media.
+ *
+ * \param lun Logical Unit Number.
+ *
+ * \return Status.
+ */
+extern Ctrl_status mem_test_unit_ready(U8 lun);
+
+/*! \brief Returns the address of the last valid sector (512 bytes) in the
+ *         memory.
+ *
+ * \param lun           Logical Unit Number.
+ * \param u32_nb_sector Pointer to the address of the last valid sector.
+ *
+ * \return Status.
+ */
+extern Ctrl_status mem_read_capacity(U8 lun, U32 *u32_nb_sector);
+
+/*! \brief Returns the size of the physical sector.
+ *
+ * \param lun Logical Unit Number.
+ *
+ * \return Sector size (unit: 512 bytes).
+ */
+extern U8 mem_sector_size(U8 lun);
+
+/*! \brief Unload/load the medium.
+ *
+ * \param lun Logical Unit Number.
+ * \param unload \c true to unload the medium, \c false to load the medium.
+ *
+ * \return \c true if unload/load success, else \c false.
+ */
+extern bool mem_unload(U8 lun, bool unload);
+
+/*! \brief Returns the write-protection state of the memory.
+ *
+ * \param lun Logical Unit Number.
+ *
+ * \return \c true if the memory is write-protected, else \c false.
+ *
+ * \note Only used by removable memories with hardware-specific write
+ *       protection.
+ */
+extern bool mem_wr_protect(U8 lun);
+
+/*! \brief Tells whether the memory is removable.
+ *
+ * \param lun Logical Unit Number.
+ *
+ * \return \c true if the memory is removable, else \c false.
+ */
+extern bool mem_removal(U8 lun);
+
+/*! \brief Returns a pointer to the LUN name.
+ *
+ * \param lun Logical Unit Number.
+ *
+ * \return Pointer to the LUN name string.
+ */
+extern const char *mem_name(U8 lun);
+
+//! @}
+
+
+#if ACCESS_USB == true
+
+/*! \name MEM <-> USB Interface
+ */
+//! @{
+
+/*! \brief Transfers data from the memory to USB.
+ *
+ * \param lun       Logical Unit Number.
+ * \param addr      Address of first memory sector to read.
+ * \param nb_sector Number of sectors to transfer.
+ *
+ * \return Status.
+ */
+extern Ctrl_status memory_2_usb(U8 lun, U32 addr, U16 nb_sector);
+
+/*! \brief Transfers data from USB to the memory.
+ *
+ * \param lun       Logical Unit Number.
+ * \param addr      Address of first memory sector to write.
+ * \param nb_sector Number of sectors to transfer.
+ *
+ * \return Status.
+ */
+extern Ctrl_status usb_2_memory(U8 lun, U32 addr, U16 nb_sector);
+
+//! @}
+
+#endif  // ACCESS_USB == true
+
+
+#if ACCESS_MEM_TO_RAM == true
+
+/*! \name MEM <-> RAM Interface
+ */
+//! @{
+
+/*! \brief Copies 1 data sector from the memory to RAM.
+ *
+ * \param lun   Logical Unit Number.
+ * \param addr  Address of first memory sector to read.
+ * \param ram   Pointer to RAM buffer to write.
+ *
+ * \return Status.
+ */
+extern Ctrl_status memory_2_ram(U8 lun, U32 addr, void *ram);
+
+/*! \brief Copies 1 data sector from RAM to the memory.
+ *
+ * \param lun   Logical Unit Number.
+ * \param addr  Address of first memory sector to write.
+ * \param ram   Pointer to RAM buffer to read.
+ *
+ * \return Status.
+ */
+extern Ctrl_status ram_2_memory(U8 lun, U32 addr, const void *ram);
+
+//! @}
+
+#endif  // ACCESS_MEM_TO_RAM == true
+
+
+#if ACCESS_STREAM == true
+
+/*! \name Streaming MEM <-> MEM Interface
+ */
+//! @{
+
+//! Erroneous streaming data transfer ID.
+#define ID_STREAM_ERR         0xFF
+
+  #if ACCESS_MEM_TO_MEM == true
+
+/*! \brief Copies data from one memory to another.
+ *
+ * \param src_lun   Source Logical Unit Number.
+ * \param src_addr  Source address of first memory sector to read.
+ * \param dest_lun  Destination Logical Unit Number.
+ * \param dest_addr Destination address of first memory sector to write.
+ * \param nb_sector Number of sectors to copy.
+ *
+ * \return Status.
+ */
+extern Ctrl_status stream_mem_to_mem(U8 src_lun, U32 src_addr, U8 dest_lun, U32 dest_addr, U16 nb_sector);
+
+  #endif  // ACCESS_MEM_TO_MEM == true
+
+/*! \brief Returns the state of a streaming data transfer.
+ *
+ * \param id  Transfer ID.
+ *
+ * \return Status.
+ *
+ * \todo Implement.
+ */
+extern Ctrl_status stream_state(U8 id);
+
+/*! \brief Stops a streaming data transfer.
+ *
+ * \param id  Transfer ID.
+ *
+ * \return Number of remaining sectors.
+ *
+ * \todo Implement.
+ */
+extern U16 stream_stop(U8 id);
+
+//! @}
+
+#endif  // ACCESS_STREAM == true
+
+/**
+ * \}
+ */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _CTRL_ACCESS_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/genclk.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/genclk.h
@@ -1,0 +1,278 @@
+/**
+ * \file
+ *
+ * \brief Chip-specific generic clock management.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef CHIP_GENCLK_H_INCLUDED
+#define CHIP_GENCLK_H_INCLUDED
+
+#include <osc.h>
+#include <pll.h>
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+/**
+ * \weakgroup genclk_group
+ * @{
+ */
+
+//! \name Programmable Clock Identifiers (PCK)
+//@{
+#define GENCLK_PCK_0      0 //!< PCK0 ID
+#define GENCLK_PCK_1      1 //!< PCK1 ID
+#define GENCLK_PCK_2      2 //!< PCK2 ID
+//@}
+
+//! \name Programmable Clock Sources (PCK)
+//@{
+
+enum genclk_source {
+	GENCLK_PCK_SRC_SLCK_RC       = 0, //!< Internal 32kHz RC oscillator as PCK source clock
+	GENCLK_PCK_SRC_SLCK_XTAL     = 1, //!< External 32kHz crystal oscillator as PCK source clock
+	GENCLK_PCK_SRC_SLCK_BYPASS   = 2, //!< External 32kHz bypass oscillator as PCK source clock
+	GENCLK_PCK_SRC_MAINCK_4M_RC  = 3, //!< Internal 4MHz RC oscillator as PCK source clock
+	GENCLK_PCK_SRC_MAINCK_8M_RC  = 4, //!< Internal 8MHz RC oscillator as PCK source clock
+	GENCLK_PCK_SRC_MAINCK_12M_RC = 5, //!< Internal 12MHz RC oscillator as PCK source clock
+	GENCLK_PCK_SRC_MAINCK_XTAL   = 6, //!< External crystal oscillator as PCK source clock
+	GENCLK_PCK_SRC_MAINCK_BYPASS = 7, //!< External bypass oscillator as PCK source clock
+	GENCLK_PCK_SRC_PLLACK        = 8, //!< Use PLLACK as PCK source clock
+	GENCLK_PCK_SRC_PLLBCK        = 9, //!< Use PLLBCK as PCK source clock
+	GENCLK_PCK_SRC_MCK           = 10, //!< Use Master Clk as PCK source clock
+};
+
+//@}
+
+//! \name Programmable Clock Prescalers (PCK)
+//@{
+
+enum genclk_divider {
+	GENCLK_PCK_PRES_1  = PMC_PCK_PRES_CLK_1, //!< Set PCK clock prescaler to 1
+	GENCLK_PCK_PRES_2  = PMC_PCK_PRES_CLK_2, //!< Set PCK clock prescaler to 2
+	GENCLK_PCK_PRES_4  = PMC_PCK_PRES_CLK_4, //!< Set PCK clock prescaler to 4
+	GENCLK_PCK_PRES_8  = PMC_PCK_PRES_CLK_8, //!< Set PCK clock prescaler to 8
+	GENCLK_PCK_PRES_16 = PMC_PCK_PRES_CLK_16, //!< Set PCK clock prescaler to 16
+	GENCLK_PCK_PRES_32 = PMC_PCK_PRES_CLK_32, //!< Set PCK clock prescaler to 32
+	GENCLK_PCK_PRES_64 = PMC_PCK_PRES_CLK_64, //!< Set PCK clock prescaler to 64
+};
+
+//@}
+
+struct genclk_config {
+	uint32_t ctrl;
+};
+
+static inline void genclk_config_defaults(struct genclk_config *p_cfg,
+		uint32_t ul_id)
+{
+	ul_id = ul_id;
+	p_cfg->ctrl = 0;
+}
+
+static inline void genclk_config_read(struct genclk_config *p_cfg,
+		uint32_t ul_id)
+{
+	p_cfg->ctrl = PMC->PMC_PCK[ul_id];
+}
+
+static inline void genclk_config_write(const struct genclk_config *p_cfg,
+		uint32_t ul_id)
+{
+	PMC->PMC_PCK[ul_id] = p_cfg->ctrl;
+}
+
+//! \name Programmable Clock Source and Prescaler configuration
+//@{
+
+static inline void genclk_config_set_source(struct genclk_config *p_cfg,
+		enum genclk_source e_src)
+{
+	p_cfg->ctrl &= (~PMC_PCK_CSS_Msk);
+
+	switch (e_src) {
+	case GENCLK_PCK_SRC_SLCK_RC:
+	case GENCLK_PCK_SRC_SLCK_XTAL:
+	case GENCLK_PCK_SRC_SLCK_BYPASS:
+		p_cfg->ctrl |= (PMC_PCK_CSS_SLOW_CLK);
+		break;
+
+	case GENCLK_PCK_SRC_MAINCK_4M_RC:
+	case GENCLK_PCK_SRC_MAINCK_8M_RC:
+	case GENCLK_PCK_SRC_MAINCK_12M_RC:
+	case GENCLK_PCK_SRC_MAINCK_XTAL:
+	case GENCLK_PCK_SRC_MAINCK_BYPASS:
+		p_cfg->ctrl |= (PMC_PCK_CSS_MAIN_CLK);
+		break;
+
+	case GENCLK_PCK_SRC_PLLACK:
+		p_cfg->ctrl |= (PMC_PCK_CSS_PLLA_CLK);
+		break;
+
+	case GENCLK_PCK_SRC_PLLBCK:
+		p_cfg->ctrl |= (PMC_PCK_CSS_UPLL_CLK);
+		break;
+
+	case GENCLK_PCK_SRC_MCK:
+		p_cfg->ctrl |= (PMC_PCK_CSS_MCK);
+		break;
+	}
+}
+
+static inline void genclk_config_set_divider(struct genclk_config *p_cfg,
+		uint32_t e_divider)
+{
+	p_cfg->ctrl &= ~PMC_PCK_PRES_Msk;
+	p_cfg->ctrl |= e_divider;
+}
+
+//@}
+
+static inline void genclk_enable(const struct genclk_config *p_cfg,
+		uint32_t ul_id)
+{
+	PMC->PMC_PCK[ul_id] = p_cfg->ctrl;
+	pmc_enable_pck(ul_id);
+}
+
+static inline void genclk_disable(uint32_t ul_id)
+{
+	pmc_disable_pck(ul_id);
+}
+
+static inline void genclk_enable_source(enum genclk_source e_src)
+{
+	switch (e_src) {
+	case GENCLK_PCK_SRC_SLCK_RC:
+		if (!osc_is_ready(OSC_SLCK_32K_RC)) {
+			osc_enable(OSC_SLCK_32K_RC);
+			osc_wait_ready(OSC_SLCK_32K_RC);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_SLCK_XTAL:
+		if (!osc_is_ready(OSC_SLCK_32K_XTAL)) {
+			osc_enable(OSC_SLCK_32K_XTAL);
+			osc_wait_ready(OSC_SLCK_32K_XTAL);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_SLCK_BYPASS:
+		if (!osc_is_ready(OSC_SLCK_32K_BYPASS)) {
+			osc_enable(OSC_SLCK_32K_BYPASS);
+			osc_wait_ready(OSC_SLCK_32K_BYPASS);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_MAINCK_4M_RC:
+		if (!osc_is_ready(OSC_MAINCK_4M_RC)) {
+			osc_enable(OSC_MAINCK_4M_RC);
+			osc_wait_ready(OSC_MAINCK_4M_RC);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_MAINCK_8M_RC:
+		if (!osc_is_ready(OSC_MAINCK_8M_RC)) {
+			osc_enable(OSC_MAINCK_8M_RC);
+			osc_wait_ready(OSC_MAINCK_8M_RC);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_MAINCK_12M_RC:
+		if (!osc_is_ready(OSC_MAINCK_12M_RC)) {
+			osc_enable(OSC_MAINCK_12M_RC);
+			osc_wait_ready(OSC_MAINCK_12M_RC);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_MAINCK_XTAL:
+		if (!osc_is_ready(OSC_MAINCK_XTAL)) {
+			osc_enable(OSC_MAINCK_XTAL);
+			osc_wait_ready(OSC_MAINCK_XTAL);
+		}
+		break;
+
+	case GENCLK_PCK_SRC_MAINCK_BYPASS:
+		if (!osc_is_ready(OSC_MAINCK_BYPASS)) {
+			osc_enable(OSC_MAINCK_BYPASS);
+			osc_wait_ready(OSC_MAINCK_BYPASS);
+		}
+		break;
+
+#ifdef CONFIG_PLL0_SOURCE
+	case GENCLK_PCK_SRC_PLLACK:
+		pll_enable_config_defaults(0);
+		break;
+#endif
+
+#ifdef CONFIG_PLL1_SOURCE
+	case GENCLK_PCK_SRC_PLLBCK:
+		pll_enable_config_defaults(1);
+		break;
+#endif
+
+	case GENCLK_PCK_SRC_MCK:
+		break;
+
+	default:
+		Assert(false);
+		break;
+	}
+}
+
+//! @}
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+}
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+#endif /* CHIP_GENCLK_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/mrepeat.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/mrepeat.h
@@ -1,0 +1,339 @@
+/**
+ * \file
+ *
+ * \brief Preprocessor macro repeating utils.
+ *
+ * Copyright (c) 2010-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _MREPEAT_H_
+#define _MREPEAT_H_
+
+/**
+ * \defgroup group_sam_utils_mrepeat Preprocessor - Macro Repeat
+ *
+ * \ingroup group_sam_utils
+ *
+ * \{
+ */
+
+#include "preprocessor.h"
+
+
+//! Maximal number of repetitions supported by MREPEAT.
+#define MREPEAT_LIMIT   256
+
+/*! \brief Macro repeat.
+ *
+ * This macro represents a horizontal repetition construct.
+ *
+ * \param count  The number of repetitious calls to macro. Valid values range from 0 to MREPEAT_LIMIT.
+ * \param macro  A binary operation of the form macro(n, data). This macro is expanded by MREPEAT with
+ *               the current repetition number and the auxiliary data argument.
+ * \param data   Auxiliary data passed to macro.
+ *
+ * \return       <tt>macro(0, data) macro(1, data) ... macro(count - 1, data)</tt>
+ */
+#define MREPEAT(count, macro, data)         TPASTE2(MREPEAT, count)(macro, data)
+
+#define MREPEAT0(  macro, data)
+#define MREPEAT1(  macro, data)       MREPEAT0(  macro, data)   macro(  0, data)
+#define MREPEAT2(  macro, data)       MREPEAT1(  macro, data)   macro(  1, data)
+#define MREPEAT3(  macro, data)       MREPEAT2(  macro, data)   macro(  2, data)
+#define MREPEAT4(  macro, data)       MREPEAT3(  macro, data)   macro(  3, data)
+#define MREPEAT5(  macro, data)       MREPEAT4(  macro, data)   macro(  4, data)
+#define MREPEAT6(  macro, data)       MREPEAT5(  macro, data)   macro(  5, data)
+#define MREPEAT7(  macro, data)       MREPEAT6(  macro, data)   macro(  6, data)
+#define MREPEAT8(  macro, data)       MREPEAT7(  macro, data)   macro(  7, data)
+#define MREPEAT9(  macro, data)       MREPEAT8(  macro, data)   macro(  8, data)
+#define MREPEAT10( macro, data)       MREPEAT9(  macro, data)   macro(  9, data)
+#define MREPEAT11( macro, data)       MREPEAT10( macro, data)   macro( 10, data)
+#define MREPEAT12( macro, data)       MREPEAT11( macro, data)   macro( 11, data)
+#define MREPEAT13( macro, data)       MREPEAT12( macro, data)   macro( 12, data)
+#define MREPEAT14( macro, data)       MREPEAT13( macro, data)   macro( 13, data)
+#define MREPEAT15( macro, data)       MREPEAT14( macro, data)   macro( 14, data)
+#define MREPEAT16( macro, data)       MREPEAT15( macro, data)   macro( 15, data)
+#define MREPEAT17( macro, data)       MREPEAT16( macro, data)   macro( 16, data)
+#define MREPEAT18( macro, data)       MREPEAT17( macro, data)   macro( 17, data)
+#define MREPEAT19( macro, data)       MREPEAT18( macro, data)   macro( 18, data)
+#define MREPEAT20( macro, data)       MREPEAT19( macro, data)   macro( 19, data)
+#define MREPEAT21( macro, data)       MREPEAT20( macro, data)   macro( 20, data)
+#define MREPEAT22( macro, data)       MREPEAT21( macro, data)   macro( 21, data)
+#define MREPEAT23( macro, data)       MREPEAT22( macro, data)   macro( 22, data)
+#define MREPEAT24( macro, data)       MREPEAT23( macro, data)   macro( 23, data)
+#define MREPEAT25( macro, data)       MREPEAT24( macro, data)   macro( 24, data)
+#define MREPEAT26( macro, data)       MREPEAT25( macro, data)   macro( 25, data)
+#define MREPEAT27( macro, data)       MREPEAT26( macro, data)   macro( 26, data)
+#define MREPEAT28( macro, data)       MREPEAT27( macro, data)   macro( 27, data)
+#define MREPEAT29( macro, data)       MREPEAT28( macro, data)   macro( 28, data)
+#define MREPEAT30( macro, data)       MREPEAT29( macro, data)   macro( 29, data)
+#define MREPEAT31( macro, data)       MREPEAT30( macro, data)   macro( 30, data)
+#define MREPEAT32( macro, data)       MREPEAT31( macro, data)   macro( 31, data)
+#define MREPEAT33( macro, data)       MREPEAT32( macro, data)   macro( 32, data)
+#define MREPEAT34( macro, data)       MREPEAT33( macro, data)   macro( 33, data)
+#define MREPEAT35( macro, data)       MREPEAT34( macro, data)   macro( 34, data)
+#define MREPEAT36( macro, data)       MREPEAT35( macro, data)   macro( 35, data)
+#define MREPEAT37( macro, data)       MREPEAT36( macro, data)   macro( 36, data)
+#define MREPEAT38( macro, data)       MREPEAT37( macro, data)   macro( 37, data)
+#define MREPEAT39( macro, data)       MREPEAT38( macro, data)   macro( 38, data)
+#define MREPEAT40( macro, data)       MREPEAT39( macro, data)   macro( 39, data)
+#define MREPEAT41( macro, data)       MREPEAT40( macro, data)   macro( 40, data)
+#define MREPEAT42( macro, data)       MREPEAT41( macro, data)   macro( 41, data)
+#define MREPEAT43( macro, data)       MREPEAT42( macro, data)   macro( 42, data)
+#define MREPEAT44( macro, data)       MREPEAT43( macro, data)   macro( 43, data)
+#define MREPEAT45( macro, data)       MREPEAT44( macro, data)   macro( 44, data)
+#define MREPEAT46( macro, data)       MREPEAT45( macro, data)   macro( 45, data)
+#define MREPEAT47( macro, data)       MREPEAT46( macro, data)   macro( 46, data)
+#define MREPEAT48( macro, data)       MREPEAT47( macro, data)   macro( 47, data)
+#define MREPEAT49( macro, data)       MREPEAT48( macro, data)   macro( 48, data)
+#define MREPEAT50( macro, data)       MREPEAT49( macro, data)   macro( 49, data)
+#define MREPEAT51( macro, data)       MREPEAT50( macro, data)   macro( 50, data)
+#define MREPEAT52( macro, data)       MREPEAT51( macro, data)   macro( 51, data)
+#define MREPEAT53( macro, data)       MREPEAT52( macro, data)   macro( 52, data)
+#define MREPEAT54( macro, data)       MREPEAT53( macro, data)   macro( 53, data)
+#define MREPEAT55( macro, data)       MREPEAT54( macro, data)   macro( 54, data)
+#define MREPEAT56( macro, data)       MREPEAT55( macro, data)   macro( 55, data)
+#define MREPEAT57( macro, data)       MREPEAT56( macro, data)   macro( 56, data)
+#define MREPEAT58( macro, data)       MREPEAT57( macro, data)   macro( 57, data)
+#define MREPEAT59( macro, data)       MREPEAT58( macro, data)   macro( 58, data)
+#define MREPEAT60( macro, data)       MREPEAT59( macro, data)   macro( 59, data)
+#define MREPEAT61( macro, data)       MREPEAT60( macro, data)   macro( 60, data)
+#define MREPEAT62( macro, data)       MREPEAT61( macro, data)   macro( 61, data)
+#define MREPEAT63( macro, data)       MREPEAT62( macro, data)   macro( 62, data)
+#define MREPEAT64( macro, data)       MREPEAT63( macro, data)   macro( 63, data)
+#define MREPEAT65( macro, data)       MREPEAT64( macro, data)   macro( 64, data)
+#define MREPEAT66( macro, data)       MREPEAT65( macro, data)   macro( 65, data)
+#define MREPEAT67( macro, data)       MREPEAT66( macro, data)   macro( 66, data)
+#define MREPEAT68( macro, data)       MREPEAT67( macro, data)   macro( 67, data)
+#define MREPEAT69( macro, data)       MREPEAT68( macro, data)   macro( 68, data)
+#define MREPEAT70( macro, data)       MREPEAT69( macro, data)   macro( 69, data)
+#define MREPEAT71( macro, data)       MREPEAT70( macro, data)   macro( 70, data)
+#define MREPEAT72( macro, data)       MREPEAT71( macro, data)   macro( 71, data)
+#define MREPEAT73( macro, data)       MREPEAT72( macro, data)   macro( 72, data)
+#define MREPEAT74( macro, data)       MREPEAT73( macro, data)   macro( 73, data)
+#define MREPEAT75( macro, data)       MREPEAT74( macro, data)   macro( 74, data)
+#define MREPEAT76( macro, data)       MREPEAT75( macro, data)   macro( 75, data)
+#define MREPEAT77( macro, data)       MREPEAT76( macro, data)   macro( 76, data)
+#define MREPEAT78( macro, data)       MREPEAT77( macro, data)   macro( 77, data)
+#define MREPEAT79( macro, data)       MREPEAT78( macro, data)   macro( 78, data)
+#define MREPEAT80( macro, data)       MREPEAT79( macro, data)   macro( 79, data)
+#define MREPEAT81( macro, data)       MREPEAT80( macro, data)   macro( 80, data)
+#define MREPEAT82( macro, data)       MREPEAT81( macro, data)   macro( 81, data)
+#define MREPEAT83( macro, data)       MREPEAT82( macro, data)   macro( 82, data)
+#define MREPEAT84( macro, data)       MREPEAT83( macro, data)   macro( 83, data)
+#define MREPEAT85( macro, data)       MREPEAT84( macro, data)   macro( 84, data)
+#define MREPEAT86( macro, data)       MREPEAT85( macro, data)   macro( 85, data)
+#define MREPEAT87( macro, data)       MREPEAT86( macro, data)   macro( 86, data)
+#define MREPEAT88( macro, data)       MREPEAT87( macro, data)   macro( 87, data)
+#define MREPEAT89( macro, data)       MREPEAT88( macro, data)   macro( 88, data)
+#define MREPEAT90( macro, data)       MREPEAT89( macro, data)   macro( 89, data)
+#define MREPEAT91( macro, data)       MREPEAT90( macro, data)   macro( 90, data)
+#define MREPEAT92( macro, data)       MREPEAT91( macro, data)   macro( 91, data)
+#define MREPEAT93( macro, data)       MREPEAT92( macro, data)   macro( 92, data)
+#define MREPEAT94( macro, data)       MREPEAT93( macro, data)   macro( 93, data)
+#define MREPEAT95( macro, data)       MREPEAT94( macro, data)   macro( 94, data)
+#define MREPEAT96( macro, data)       MREPEAT95( macro, data)   macro( 95, data)
+#define MREPEAT97( macro, data)       MREPEAT96( macro, data)   macro( 96, data)
+#define MREPEAT98( macro, data)       MREPEAT97( macro, data)   macro( 97, data)
+#define MREPEAT99( macro, data)       MREPEAT98( macro, data)   macro( 98, data)
+#define MREPEAT100(macro, data)       MREPEAT99( macro, data)   macro( 99, data)
+#define MREPEAT101(macro, data)       MREPEAT100(macro, data)   macro(100, data)
+#define MREPEAT102(macro, data)       MREPEAT101(macro, data)   macro(101, data)
+#define MREPEAT103(macro, data)       MREPEAT102(macro, data)   macro(102, data)
+#define MREPEAT104(macro, data)       MREPEAT103(macro, data)   macro(103, data)
+#define MREPEAT105(macro, data)       MREPEAT104(macro, data)   macro(104, data)
+#define MREPEAT106(macro, data)       MREPEAT105(macro, data)   macro(105, data)
+#define MREPEAT107(macro, data)       MREPEAT106(macro, data)   macro(106, data)
+#define MREPEAT108(macro, data)       MREPEAT107(macro, data)   macro(107, data)
+#define MREPEAT109(macro, data)       MREPEAT108(macro, data)   macro(108, data)
+#define MREPEAT110(macro, data)       MREPEAT109(macro, data)   macro(109, data)
+#define MREPEAT111(macro, data)       MREPEAT110(macro, data)   macro(110, data)
+#define MREPEAT112(macro, data)       MREPEAT111(macro, data)   macro(111, data)
+#define MREPEAT113(macro, data)       MREPEAT112(macro, data)   macro(112, data)
+#define MREPEAT114(macro, data)       MREPEAT113(macro, data)   macro(113, data)
+#define MREPEAT115(macro, data)       MREPEAT114(macro, data)   macro(114, data)
+#define MREPEAT116(macro, data)       MREPEAT115(macro, data)   macro(115, data)
+#define MREPEAT117(macro, data)       MREPEAT116(macro, data)   macro(116, data)
+#define MREPEAT118(macro, data)       MREPEAT117(macro, data)   macro(117, data)
+#define MREPEAT119(macro, data)       MREPEAT118(macro, data)   macro(118, data)
+#define MREPEAT120(macro, data)       MREPEAT119(macro, data)   macro(119, data)
+#define MREPEAT121(macro, data)       MREPEAT120(macro, data)   macro(120, data)
+#define MREPEAT122(macro, data)       MREPEAT121(macro, data)   macro(121, data)
+#define MREPEAT123(macro, data)       MREPEAT122(macro, data)   macro(122, data)
+#define MREPEAT124(macro, data)       MREPEAT123(macro, data)   macro(123, data)
+#define MREPEAT125(macro, data)       MREPEAT124(macro, data)   macro(124, data)
+#define MREPEAT126(macro, data)       MREPEAT125(macro, data)   macro(125, data)
+#define MREPEAT127(macro, data)       MREPEAT126(macro, data)   macro(126, data)
+#define MREPEAT128(macro, data)       MREPEAT127(macro, data)   macro(127, data)
+#define MREPEAT129(macro, data)       MREPEAT128(macro, data)   macro(128, data)
+#define MREPEAT130(macro, data)       MREPEAT129(macro, data)   macro(129, data)
+#define MREPEAT131(macro, data)       MREPEAT130(macro, data)   macro(130, data)
+#define MREPEAT132(macro, data)       MREPEAT131(macro, data)   macro(131, data)
+#define MREPEAT133(macro, data)       MREPEAT132(macro, data)   macro(132, data)
+#define MREPEAT134(macro, data)       MREPEAT133(macro, data)   macro(133, data)
+#define MREPEAT135(macro, data)       MREPEAT134(macro, data)   macro(134, data)
+#define MREPEAT136(macro, data)       MREPEAT135(macro, data)   macro(135, data)
+#define MREPEAT137(macro, data)       MREPEAT136(macro, data)   macro(136, data)
+#define MREPEAT138(macro, data)       MREPEAT137(macro, data)   macro(137, data)
+#define MREPEAT139(macro, data)       MREPEAT138(macro, data)   macro(138, data)
+#define MREPEAT140(macro, data)       MREPEAT139(macro, data)   macro(139, data)
+#define MREPEAT141(macro, data)       MREPEAT140(macro, data)   macro(140, data)
+#define MREPEAT142(macro, data)       MREPEAT141(macro, data)   macro(141, data)
+#define MREPEAT143(macro, data)       MREPEAT142(macro, data)   macro(142, data)
+#define MREPEAT144(macro, data)       MREPEAT143(macro, data)   macro(143, data)
+#define MREPEAT145(macro, data)       MREPEAT144(macro, data)   macro(144, data)
+#define MREPEAT146(macro, data)       MREPEAT145(macro, data)   macro(145, data)
+#define MREPEAT147(macro, data)       MREPEAT146(macro, data)   macro(146, data)
+#define MREPEAT148(macro, data)       MREPEAT147(macro, data)   macro(147, data)
+#define MREPEAT149(macro, data)       MREPEAT148(macro, data)   macro(148, data)
+#define MREPEAT150(macro, data)       MREPEAT149(macro, data)   macro(149, data)
+#define MREPEAT151(macro, data)       MREPEAT150(macro, data)   macro(150, data)
+#define MREPEAT152(macro, data)       MREPEAT151(macro, data)   macro(151, data)
+#define MREPEAT153(macro, data)       MREPEAT152(macro, data)   macro(152, data)
+#define MREPEAT154(macro, data)       MREPEAT153(macro, data)   macro(153, data)
+#define MREPEAT155(macro, data)       MREPEAT154(macro, data)   macro(154, data)
+#define MREPEAT156(macro, data)       MREPEAT155(macro, data)   macro(155, data)
+#define MREPEAT157(macro, data)       MREPEAT156(macro, data)   macro(156, data)
+#define MREPEAT158(macro, data)       MREPEAT157(macro, data)   macro(157, data)
+#define MREPEAT159(macro, data)       MREPEAT158(macro, data)   macro(158, data)
+#define MREPEAT160(macro, data)       MREPEAT159(macro, data)   macro(159, data)
+#define MREPEAT161(macro, data)       MREPEAT160(macro, data)   macro(160, data)
+#define MREPEAT162(macro, data)       MREPEAT161(macro, data)   macro(161, data)
+#define MREPEAT163(macro, data)       MREPEAT162(macro, data)   macro(162, data)
+#define MREPEAT164(macro, data)       MREPEAT163(macro, data)   macro(163, data)
+#define MREPEAT165(macro, data)       MREPEAT164(macro, data)   macro(164, data)
+#define MREPEAT166(macro, data)       MREPEAT165(macro, data)   macro(165, data)
+#define MREPEAT167(macro, data)       MREPEAT166(macro, data)   macro(166, data)
+#define MREPEAT168(macro, data)       MREPEAT167(macro, data)   macro(167, data)
+#define MREPEAT169(macro, data)       MREPEAT168(macro, data)   macro(168, data)
+#define MREPEAT170(macro, data)       MREPEAT169(macro, data)   macro(169, data)
+#define MREPEAT171(macro, data)       MREPEAT170(macro, data)   macro(170, data)
+#define MREPEAT172(macro, data)       MREPEAT171(macro, data)   macro(171, data)
+#define MREPEAT173(macro, data)       MREPEAT172(macro, data)   macro(172, data)
+#define MREPEAT174(macro, data)       MREPEAT173(macro, data)   macro(173, data)
+#define MREPEAT175(macro, data)       MREPEAT174(macro, data)   macro(174, data)
+#define MREPEAT176(macro, data)       MREPEAT175(macro, data)   macro(175, data)
+#define MREPEAT177(macro, data)       MREPEAT176(macro, data)   macro(176, data)
+#define MREPEAT178(macro, data)       MREPEAT177(macro, data)   macro(177, data)
+#define MREPEAT179(macro, data)       MREPEAT178(macro, data)   macro(178, data)
+#define MREPEAT180(macro, data)       MREPEAT179(macro, data)   macro(179, data)
+#define MREPEAT181(macro, data)       MREPEAT180(macro, data)   macro(180, data)
+#define MREPEAT182(macro, data)       MREPEAT181(macro, data)   macro(181, data)
+#define MREPEAT183(macro, data)       MREPEAT182(macro, data)   macro(182, data)
+#define MREPEAT184(macro, data)       MREPEAT183(macro, data)   macro(183, data)
+#define MREPEAT185(macro, data)       MREPEAT184(macro, data)   macro(184, data)
+#define MREPEAT186(macro, data)       MREPEAT185(macro, data)   macro(185, data)
+#define MREPEAT187(macro, data)       MREPEAT186(macro, data)   macro(186, data)
+#define MREPEAT188(macro, data)       MREPEAT187(macro, data)   macro(187, data)
+#define MREPEAT189(macro, data)       MREPEAT188(macro, data)   macro(188, data)
+#define MREPEAT190(macro, data)       MREPEAT189(macro, data)   macro(189, data)
+#define MREPEAT191(macro, data)       MREPEAT190(macro, data)   macro(190, data)
+#define MREPEAT192(macro, data)       MREPEAT191(macro, data)   macro(191, data)
+#define MREPEAT193(macro, data)       MREPEAT192(macro, data)   macro(192, data)
+#define MREPEAT194(macro, data)       MREPEAT193(macro, data)   macro(193, data)
+#define MREPEAT195(macro, data)       MREPEAT194(macro, data)   macro(194, data)
+#define MREPEAT196(macro, data)       MREPEAT195(macro, data)   macro(195, data)
+#define MREPEAT197(macro, data)       MREPEAT196(macro, data)   macro(196, data)
+#define MREPEAT198(macro, data)       MREPEAT197(macro, data)   macro(197, data)
+#define MREPEAT199(macro, data)       MREPEAT198(macro, data)   macro(198, data)
+#define MREPEAT200(macro, data)       MREPEAT199(macro, data)   macro(199, data)
+#define MREPEAT201(macro, data)       MREPEAT200(macro, data)   macro(200, data)
+#define MREPEAT202(macro, data)       MREPEAT201(macro, data)   macro(201, data)
+#define MREPEAT203(macro, data)       MREPEAT202(macro, data)   macro(202, data)
+#define MREPEAT204(macro, data)       MREPEAT203(macro, data)   macro(203, data)
+#define MREPEAT205(macro, data)       MREPEAT204(macro, data)   macro(204, data)
+#define MREPEAT206(macro, data)       MREPEAT205(macro, data)   macro(205, data)
+#define MREPEAT207(macro, data)       MREPEAT206(macro, data)   macro(206, data)
+#define MREPEAT208(macro, data)       MREPEAT207(macro, data)   macro(207, data)
+#define MREPEAT209(macro, data)       MREPEAT208(macro, data)   macro(208, data)
+#define MREPEAT210(macro, data)       MREPEAT209(macro, data)   macro(209, data)
+#define MREPEAT211(macro, data)       MREPEAT210(macro, data)   macro(210, data)
+#define MREPEAT212(macro, data)       MREPEAT211(macro, data)   macro(211, data)
+#define MREPEAT213(macro, data)       MREPEAT212(macro, data)   macro(212, data)
+#define MREPEAT214(macro, data)       MREPEAT213(macro, data)   macro(213, data)
+#define MREPEAT215(macro, data)       MREPEAT214(macro, data)   macro(214, data)
+#define MREPEAT216(macro, data)       MREPEAT215(macro, data)   macro(215, data)
+#define MREPEAT217(macro, data)       MREPEAT216(macro, data)   macro(216, data)
+#define MREPEAT218(macro, data)       MREPEAT217(macro, data)   macro(217, data)
+#define MREPEAT219(macro, data)       MREPEAT218(macro, data)   macro(218, data)
+#define MREPEAT220(macro, data)       MREPEAT219(macro, data)   macro(219, data)
+#define MREPEAT221(macro, data)       MREPEAT220(macro, data)   macro(220, data)
+#define MREPEAT222(macro, data)       MREPEAT221(macro, data)   macro(221, data)
+#define MREPEAT223(macro, data)       MREPEAT222(macro, data)   macro(222, data)
+#define MREPEAT224(macro, data)       MREPEAT223(macro, data)   macro(223, data)
+#define MREPEAT225(macro, data)       MREPEAT224(macro, data)   macro(224, data)
+#define MREPEAT226(macro, data)       MREPEAT225(macro, data)   macro(225, data)
+#define MREPEAT227(macro, data)       MREPEAT226(macro, data)   macro(226, data)
+#define MREPEAT228(macro, data)       MREPEAT227(macro, data)   macro(227, data)
+#define MREPEAT229(macro, data)       MREPEAT228(macro, data)   macro(228, data)
+#define MREPEAT230(macro, data)       MREPEAT229(macro, data)   macro(229, data)
+#define MREPEAT231(macro, data)       MREPEAT230(macro, data)   macro(230, data)
+#define MREPEAT232(macro, data)       MREPEAT231(macro, data)   macro(231, data)
+#define MREPEAT233(macro, data)       MREPEAT232(macro, data)   macro(232, data)
+#define MREPEAT234(macro, data)       MREPEAT233(macro, data)   macro(233, data)
+#define MREPEAT235(macro, data)       MREPEAT234(macro, data)   macro(234, data)
+#define MREPEAT236(macro, data)       MREPEAT235(macro, data)   macro(235, data)
+#define MREPEAT237(macro, data)       MREPEAT236(macro, data)   macro(236, data)
+#define MREPEAT238(macro, data)       MREPEAT237(macro, data)   macro(237, data)
+#define MREPEAT239(macro, data)       MREPEAT238(macro, data)   macro(238, data)
+#define MREPEAT240(macro, data)       MREPEAT239(macro, data)   macro(239, data)
+#define MREPEAT241(macro, data)       MREPEAT240(macro, data)   macro(240, data)
+#define MREPEAT242(macro, data)       MREPEAT241(macro, data)   macro(241, data)
+#define MREPEAT243(macro, data)       MREPEAT242(macro, data)   macro(242, data)
+#define MREPEAT244(macro, data)       MREPEAT243(macro, data)   macro(243, data)
+#define MREPEAT245(macro, data)       MREPEAT244(macro, data)   macro(244, data)
+#define MREPEAT246(macro, data)       MREPEAT245(macro, data)   macro(245, data)
+#define MREPEAT247(macro, data)       MREPEAT246(macro, data)   macro(246, data)
+#define MREPEAT248(macro, data)       MREPEAT247(macro, data)   macro(247, data)
+#define MREPEAT249(macro, data)       MREPEAT248(macro, data)   macro(248, data)
+#define MREPEAT250(macro, data)       MREPEAT249(macro, data)   macro(249, data)
+#define MREPEAT251(macro, data)       MREPEAT250(macro, data)   macro(250, data)
+#define MREPEAT252(macro, data)       MREPEAT251(macro, data)   macro(251, data)
+#define MREPEAT253(macro, data)       MREPEAT252(macro, data)   macro(252, data)
+#define MREPEAT254(macro, data)       MREPEAT253(macro, data)   macro(253, data)
+#define MREPEAT255(macro, data)       MREPEAT254(macro, data)   macro(254, data)
+#define MREPEAT256(macro, data)       MREPEAT255(macro, data)   macro(255, data)
+
+/**
+ * \}
+ */
+
+#endif  // _MREPEAT_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/osc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/osc.h
@@ -1,0 +1,261 @@
+/**
+ * \file
+ *
+ * \brief Chip-specific oscillator management functions.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef CHIP_OSC_H_INCLUDED
+#define CHIP_OSC_H_INCLUDED
+
+#include "compiler.h"
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+/*
+ * Below BOARD_XXX macros are related to the specific board, and
+ * should be defined by the board code, otherwise default value are used.
+ */
+#if !defined(BOARD_FREQ_SLCK_XTAL)
+#  warning The board slow clock xtal frequency has not been defined.
+#  define BOARD_FREQ_SLCK_XTAL      (32768UL)
+#endif
+
+#if !defined(BOARD_FREQ_SLCK_BYPASS)
+#  warning The board slow clock bypass frequency has not been defined.
+#  define BOARD_FREQ_SLCK_BYPASS    (32768UL)
+#endif
+
+#if !defined(BOARD_FREQ_MAINCK_XTAL)
+#  warning The board main clock xtal frequency has not been defined.
+#  define BOARD_FREQ_MAINCK_XTAL    (12000000UL)
+#endif
+
+#if !defined(BOARD_FREQ_MAINCK_BYPASS)
+#  warning The board main clock bypass frequency has not been defined.
+#  define BOARD_FREQ_MAINCK_BYPASS  (12000000UL)
+#endif
+
+#if !defined(BOARD_OSC_STARTUP_US)
+#  warning The board main clock xtal startup time has not been defined.
+#  define BOARD_OSC_STARTUP_US      (15625UL)
+#endif
+
+/**
+ * \weakgroup osc_group
+ * @{
+ */
+
+//! \name Oscillator identifiers
+//@{
+#define OSC_SLCK_32K_RC             0    //!< Internal 32kHz RC oscillator.
+#define OSC_SLCK_32K_XTAL           1    //!< External 32kHz crystal oscillator.
+#define OSC_SLCK_32K_BYPASS         2    //!< External 32kHz bypass oscillator.
+#define OSC_MAINCK_4M_RC            3    //!< Internal 4MHz RC oscillator.
+#define OSC_MAINCK_8M_RC            4    //!< Internal 8MHz RC oscillator.
+#define OSC_MAINCK_12M_RC           5    //!< Internal 12MHz RC oscillator.
+#define OSC_MAINCK_XTAL             6    //!< External crystal oscillator.
+#define OSC_MAINCK_BYPASS           7    //!< External bypass oscillator.
+//@}
+
+//! \name Oscillator clock speed in hertz
+//@{
+#define OSC_SLCK_32K_RC_HZ          CHIP_FREQ_SLCK_RC               //!< Internal 32kHz RC oscillator.
+#define OSC_SLCK_32K_XTAL_HZ        BOARD_FREQ_SLCK_XTAL            //!< External 32kHz crystal oscillator.
+#define OSC_SLCK_32K_BYPASS_HZ      BOARD_FREQ_SLCK_BYPASS          //!< External 32kHz bypass oscillator.
+#define OSC_MAINCK_4M_RC_HZ         CHIP_FREQ_MAINCK_RC_4MHZ        //!< Internal 4MHz RC oscillator.
+#define OSC_MAINCK_8M_RC_HZ         CHIP_FREQ_MAINCK_RC_8MHZ        //!< Internal 8MHz RC oscillator.
+#define OSC_MAINCK_12M_RC_HZ        CHIP_FREQ_MAINCK_RC_12MHZ       //!< Internal 12MHz RC oscillator.
+#define OSC_MAINCK_XTAL_HZ          BOARD_FREQ_MAINCK_XTAL          //!< External crystal oscillator.
+#define OSC_MAINCK_BYPASS_HZ        BOARD_FREQ_MAINCK_BYPASS        //!< External bypass oscillator.
+//@}
+
+static inline void osc_enable(uint32_t ul_id)
+{
+	switch (ul_id) {
+	case OSC_SLCK_32K_RC:
+		break;
+
+	case OSC_SLCK_32K_XTAL:
+		pmc_switch_sclk_to_32kxtal(PMC_OSC_XTAL);
+		break;
+
+	case OSC_SLCK_32K_BYPASS:
+		pmc_switch_sclk_to_32kxtal(PMC_OSC_BYPASS);
+		break;
+
+
+	case OSC_MAINCK_4M_RC:
+		pmc_switch_mainck_to_fastrc(CKGR_MOR_MOSCRCF_4_MHz);
+		break;
+
+	case OSC_MAINCK_8M_RC:
+		pmc_switch_mainck_to_fastrc(CKGR_MOR_MOSCRCF_8_MHz);
+		break;
+
+	case OSC_MAINCK_12M_RC:
+		pmc_switch_mainck_to_fastrc(CKGR_MOR_MOSCRCF_12_MHz);
+		break;
+
+
+	case OSC_MAINCK_XTAL:
+		pmc_switch_mainck_to_xtal(PMC_OSC_XTAL/*,
+			pmc_us_to_moscxtst(BOARD_OSC_STARTUP_US,
+				OSC_SLCK_32K_RC_HZ)*/);
+		break;
+
+	case OSC_MAINCK_BYPASS:
+		pmc_switch_mainck_to_xtal(PMC_OSC_BYPASS/*,
+			pmc_us_to_moscxtst(BOARD_OSC_STARTUP_US,
+				OSC_SLCK_32K_RC_HZ)*/);
+		break;
+	}
+}
+
+static inline void osc_disable(uint32_t ul_id)
+{
+	switch (ul_id) {
+	case OSC_SLCK_32K_RC:
+	case OSC_SLCK_32K_XTAL:
+	case OSC_SLCK_32K_BYPASS:
+		break;
+
+	case OSC_MAINCK_4M_RC:
+	case OSC_MAINCK_8M_RC:
+	case OSC_MAINCK_12M_RC:
+		pmc_osc_disable_fastrc();
+		break;
+
+	case OSC_MAINCK_XTAL:
+		pmc_osc_disable_xtal(PMC_OSC_XTAL);
+		break;
+
+	case OSC_MAINCK_BYPASS:
+		pmc_osc_disable_xtal(PMC_OSC_BYPASS);
+		break;
+	}
+}
+
+static inline bool osc_is_ready(uint32_t ul_id)
+{
+	switch (ul_id) {
+	case OSC_SLCK_32K_RC:
+		return 1;
+
+	case OSC_SLCK_32K_XTAL:
+	case OSC_SLCK_32K_BYPASS:
+		return pmc_osc_is_ready_32kxtal();
+
+	case OSC_MAINCK_4M_RC:
+	case OSC_MAINCK_8M_RC:
+	case OSC_MAINCK_12M_RC:
+	case OSC_MAINCK_XTAL:
+	case OSC_MAINCK_BYPASS:
+		return pmc_osc_is_ready_mainck();
+	}
+
+	return 0;
+}
+
+static inline uint32_t osc_get_rate(uint32_t ul_id)
+{
+	switch (ul_id) {
+	case OSC_SLCK_32K_RC:
+		return OSC_SLCK_32K_RC_HZ;
+
+	case OSC_SLCK_32K_XTAL:
+		return BOARD_FREQ_SLCK_XTAL;
+
+	case OSC_SLCK_32K_BYPASS:
+		return BOARD_FREQ_SLCK_BYPASS;
+
+	case OSC_MAINCK_4M_RC:
+		return OSC_MAINCK_4M_RC_HZ;
+
+	case OSC_MAINCK_8M_RC:
+		return OSC_MAINCK_8M_RC_HZ;
+
+	case OSC_MAINCK_12M_RC:
+		return OSC_MAINCK_12M_RC_HZ;
+
+	case OSC_MAINCK_XTAL:
+		return BOARD_FREQ_MAINCK_XTAL;
+
+	case OSC_MAINCK_BYPASS:
+		return BOARD_FREQ_MAINCK_BYPASS;
+	}
+
+	return 0;
+}
+
+/**
+ * \brief Wait until the oscillator identified by \a id is ready
+ *
+ * This function will busy-wait for the oscillator identified by \a id
+ * to become stable and ready to use as a clock source.
+ *
+ * \param id A number identifying the oscillator to wait for.
+ */
+static inline void osc_wait_ready(uint8_t id)
+{
+	while (!osc_is_ready(id)) {
+		/* Do nothing */
+	}
+} 
+
+//! @}
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+}
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+#endif /* CHIP_OSC_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/pll.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/pll.h
@@ -1,0 +1,288 @@
+/**
+ * \file
+ *
+ * \brief Chip-specific PLL definitions.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef CHIP_PLL_H_INCLUDED
+#define CHIP_PLL_H_INCLUDED
+
+#include "osc.h"
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+/**
+ * \weakgroup pll_group
+ * @{
+ */
+
+#define PLL_OUTPUT_MIN_HZ   84000000
+#define PLL_OUTPUT_MAX_HZ   192000000
+
+#define PLL_INPUT_MIN_HZ    8000000
+#define PLL_INPUT_MAX_HZ    16000000
+
+#define NR_PLLS             2
+#define PLLA_ID             0
+#define UPLL_ID             1   //!< USB UTMI PLL.
+
+#define PLL_UPLL_HZ     480000000
+
+#define PLL_COUNT           0x3fU
+
+enum pll_source {
+	PLL_SRC_MAINCK_4M_RC        = OSC_MAINCK_4M_RC,     //!< Internal 4MHz RC oscillator.
+	PLL_SRC_MAINCK_8M_RC        = OSC_MAINCK_8M_RC,     //!< Internal 8MHz RC oscillator.
+	PLL_SRC_MAINCK_12M_RC       = OSC_MAINCK_12M_RC,    //!< Internal 12MHz RC oscillator.
+	PLL_SRC_MAINCK_XTAL         = OSC_MAINCK_XTAL,      //!< External crystal oscillator.
+	PLL_SRC_MAINCK_BYPASS       = OSC_MAINCK_BYPASS,    //!< External bypass oscillator.
+	PLL_NR_SOURCES,                                     //!< Number of PLL sources.
+};
+
+struct pll_config {
+	uint32_t ctrl;
+};
+
+#define pll_get_default_rate(pll_id)                                       \
+	((osc_get_rate(CONFIG_PLL##pll_id##_SOURCE)                            \
+			* CONFIG_PLL##pll_id##_MUL)                                    \
+			/ CONFIG_PLL##pll_id##_DIV)
+
+/* Force UTMI PLL parameters (Hardware defined) */
+#ifdef CONFIG_PLL1_SOURCE
+# undef CONFIG_PLL1_SOURCE
+#endif
+#ifdef CONFIG_PLL1_MUL
+# undef CONFIG_PLL1_MUL
+#endif
+#ifdef CONFIG_PLL1_DIV
+# undef CONFIG_PLL1_DIV
+#endif
+#define CONFIG_PLL1_SOURCE  PLL_SRC_MAINCK_XTAL
+#define CONFIG_PLL1_MUL     0
+#define CONFIG_PLL1_DIV     0
+
+/**
+ * \note The SAM3X PLL hardware interprets mul as mul+1. For readability the hardware mul+1
+ * is hidden in this implementation. Use mul as mul effective value.
+ */
+static inline void pll_config_init(struct pll_config *p_cfg,
+		enum pll_source e_src, uint32_t ul_div, uint32_t ul_mul)
+{
+	uint32_t vco_hz;
+
+	Assert(e_src < PLL_NR_SOURCES);
+
+	if (ul_div == 0 && ul_mul == 0) { /* Must only be true for UTMI PLL */
+		p_cfg->ctrl = CKGR_UCKR_UPLLCOUNT(PLL_COUNT);
+	} else { /* PLLA */
+		/* Calculate internal VCO frequency */
+		vco_hz = osc_get_rate(e_src) / ul_div;
+		Assert(vco_hz >= PLL_INPUT_MIN_HZ);
+		Assert(vco_hz <= PLL_INPUT_MAX_HZ);
+
+		vco_hz *= ul_mul;
+		Assert(vco_hz >= PLL_OUTPUT_MIN_HZ);
+		Assert(vco_hz <= PLL_OUTPUT_MAX_HZ);
+
+		/* PMC hardware will automatically make it mul+1 */
+		p_cfg->ctrl = CKGR_PLLAR_MULA(ul_mul - 1) | CKGR_PLLAR_DIVA(ul_div) | CKGR_PLLAR_PLLACOUNT(PLL_COUNT);
+	}
+}
+
+#define pll_config_defaults(cfg, pll_id)                                   \
+	pll_config_init(cfg,                                                   \
+			CONFIG_PLL##pll_id##_SOURCE,                                   \
+			CONFIG_PLL##pll_id##_DIV,                                      \
+			CONFIG_PLL##pll_id##_MUL)
+
+static inline void pll_config_read(struct pll_config *p_cfg, uint32_t ul_pll_id)
+{
+	Assert(ul_pll_id < NR_PLLS);
+
+	if (ul_pll_id == PLLA_ID) {
+		p_cfg->ctrl = PMC->CKGR_PLLAR;
+	} else {
+		p_cfg->ctrl = PMC->CKGR_UCKR;
+	}
+}
+
+static inline void pll_config_write(const struct pll_config *p_cfg, uint32_t ul_pll_id)
+{
+	Assert(ul_pll_id < NR_PLLS);
+
+	if (ul_pll_id == PLLA_ID) {
+		pmc_disable_pllack(); // Always stop PLL first!
+		PMC->CKGR_PLLAR = CKGR_PLLAR_ONE | p_cfg->ctrl;
+	} else {
+		PMC->CKGR_UCKR = p_cfg->ctrl;
+	}
+}
+
+static inline void pll_enable(const struct pll_config *p_cfg, uint32_t ul_pll_id)
+{
+	Assert(ul_pll_id < NR_PLLS);
+
+	if (ul_pll_id == PLLA_ID) {
+		pmc_disable_pllack(); // Always stop PLL first!
+		PMC->CKGR_PLLAR = CKGR_PLLAR_ONE | p_cfg->ctrl;
+	} else {
+		PMC->CKGR_UCKR = p_cfg->ctrl | CKGR_UCKR_UPLLEN;
+	}
+}
+
+/**
+ * \note This will only disable the selected PLL, not the underlying oscillator (mainck).
+ */
+static inline void pll_disable(uint32_t ul_pll_id)
+{
+	Assert(ul_pll_id < NR_PLLS);
+
+	if (ul_pll_id == PLLA_ID) {
+		pmc_disable_pllack();
+	} else {
+		PMC->CKGR_UCKR &= ~CKGR_UCKR_UPLLEN;
+	}
+}
+
+static inline uint32_t pll_is_locked(uint32_t ul_pll_id)
+{
+	Assert(ul_pll_id < NR_PLLS);
+
+	if (ul_pll_id == PLLA_ID) {
+		return pmc_is_locked_pllack();
+	} else {
+		return pmc_is_locked_upll();
+	}
+}
+
+static inline void pll_enable_source(enum pll_source e_src)
+{
+	switch (e_src) {
+	case PLL_SRC_MAINCK_4M_RC:
+	case PLL_SRC_MAINCK_8M_RC:
+	case PLL_SRC_MAINCK_12M_RC:
+	case PLL_SRC_MAINCK_XTAL:
+	case PLL_SRC_MAINCK_BYPASS:
+		osc_enable(e_src);
+		osc_wait_ready(e_src);
+		break;
+
+	default:
+		Assert(false);
+		break;
+	}
+}
+
+static inline void pll_enable_config_defaults(unsigned int ul_pll_id)
+{
+	struct pll_config pllcfg;
+
+	if (pll_is_locked(ul_pll_id)) {
+		return; // Pll already running
+	}
+	switch (ul_pll_id) {
+#ifdef CONFIG_PLL0_SOURCE
+	case 0:
+		pll_enable_source(CONFIG_PLL0_SOURCE);
+		pll_config_init(&pllcfg,
+				CONFIG_PLL0_SOURCE,
+				CONFIG_PLL0_DIV,
+				CONFIG_PLL0_MUL);
+		break;
+#endif
+#ifdef CONFIG_PLL1_SOURCE
+	case 1:
+		pll_enable_source(CONFIG_PLL1_SOURCE);
+		pll_config_init(&pllcfg,
+				CONFIG_PLL1_SOURCE,
+				CONFIG_PLL1_DIV,
+				CONFIG_PLL1_MUL);
+		break;
+#endif
+	default:
+		Assert(false);
+		break;
+	}
+	pll_enable(&pllcfg, ul_pll_id);
+	while (!pll_is_locked(ul_pll_id));
+}
+
+/**
+ * \brief Wait for PLL \a pll_id to become locked
+ *
+ * \todo Use a timeout to avoid waiting forever and hanging the system
+ *
+ * \param pll_id The ID of the PLL to wait for.
+ *
+ * \retval STATUS_OK The PLL is now locked.
+ * \retval ERR_TIMEOUT Timed out waiting for PLL to become locked.
+ */
+static inline int pll_wait_for_lock(unsigned int pll_id)
+{
+	Assert(pll_id < NR_PLLS);
+
+	while (!pll_is_locked(pll_id)) {
+		/* Do nothing */
+	}
+
+	return 0;
+} 
+ 
+//! @}
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+}
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+#endif /* CHIP_PLL_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/preprocessor.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/preprocessor.h
@@ -1,0 +1,55 @@
+/**
+ * \file
+ *
+ * \brief Preprocessor utils.
+ *
+ * Copyright (c) 2010-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _PREPROCESSOR_H_
+#define _PREPROCESSOR_H_
+
+#include "tpaste.h"
+#include "stringz.h"
+#include "mrepeat.h"
+
+
+#endif  // _PREPROCESSOR_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/sbc_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sbc_protocol.h
@@ -1,0 +1,173 @@
+/**
+ * \file
+ *
+ * \brief SCSI Block Commands
+ *
+ * This file contains definitions of some of the commands found in the
+ * SCSI SBC-2 standard.
+ *
+ * Note that the SBC specification depends on several commands defined
+ * by the SCSI Primary Commands (SPC) standard. Each version of the SBC
+ * standard is meant to be used in conjunction with a specific version
+ * of the SPC standard, as follows:
+ *   - SBC   depends on SPC
+ *   - SBC-2 depends on SPC-3
+ *   - SBC-3 depends on SPC-4
+ *
+ * Copyright (c) 2014-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+#ifndef _SBC_PROTOCOL_H_
+#define _SBC_PROTOCOL_H_
+
+
+/**
+ * \ingroup usb_msc_protocol
+ * \defgroup usb_sbc_protocol SCSI Block Commands protocol definitions
+ *
+ * @{
+ */
+
+//! \name SCSI commands defined by SBC-2
+//@{
+#define  SBC_FORMAT_UNIT         0x04
+#define  SBC_READ6               0x08
+#define  SBC_WRITE6              0x0A
+#define  SBC_START_STOP_UNIT     0x1B
+#define  SBC_READ_CAPACITY10     0x25
+#define  SBC_READ10              0x28
+#define  SBC_WRITE10             0x2A
+#define  SBC_VERIFY10            0x2F
+//@}
+
+//! \name SBC-2 Mode page definitions
+//@{
+
+enum scsi_sbc_mode {
+	SCSI_MS_MODE_RW_ERR_RECOV = 0x01,	//!< Read-Write Error Recovery mode page
+	SCSI_MS_MODE_FORMAT_DEVICE = 0x03,	//!< Format Device mode page
+	SCSI_MS_MODE_FLEXIBLE_DISK = 0x05,	//!< Flexible Disk mode page
+	SCSI_MS_MODE_CACHING = 0x08,	//!< Caching mode page
+};
+
+
+//! \name SBC-2 Device-Specific Parameter
+//@{
+#define SCSI_MS_SBC_WP              0x80	//!< Write Protected
+#define SCSI_MS_SBC_DPOFUA          0x10	//!< DPO and FUA supported
+//@}
+
+/**
+ * \brief SBC-2 Short LBA mode parameter block descriptor
+ */
+struct sbc_slba_block_desc {
+	be32_t nr_blocks;	//!< Number of Blocks
+	be32_t block_len;	//!< Block Length
+#define SBC_SLBA_BLOCK_LEN_MASK   0x00FFFFFFU	//!< Mask reserved bits
+};
+
+/**
+ * \brief SBC-2 Caching mode page
+ */
+struct sbc_caching_mode_page {
+	uint8_t page_code;
+	uint8_t page_length;
+	uint8_t flags2;
+#define  SBC_MP_CACHE_IC      (1 << 7)	//!< Initiator Control
+#define  SBC_MP_CACHE_ABPF    (1 << 6)	//!< Abort Pre-Fetch
+#define  SBC_MP_CACHE_CAP     (1 << 5)	//!< Catching Analysis Permitted
+#define  SBC_MP_CACHE_DISC    (1 << 4)	//!< Discontinuity
+#define  SBC_MP_CACHE_SIZE    (1 << 3)	//!< Size enable
+#define  SBC_MP_CACHE_WCE     (1 << 2)	//!< Write back Cache Enable
+#define  SBC_MP_CACHE_MF      (1 << 1)	//!< Multiplication Factor
+#define  SBC_MP_CACHE_RCD     (1 << 0)	//!< Read Cache Disable
+	uint8_t retention;
+	be16_t dis_pf_transfer_len;
+	be16_t min_prefetch;
+	be16_t max_prefetch;
+	be16_t max_prefetch_ceil;
+	uint8_t flags12;
+#define  SBC_MP_CACHE_FSW     (1 << 7)	//!< Force Sequential Write
+#define  SBC_MP_CACHE_LBCSS   (1 << 6)	//!< Logical Blk Cache Seg Sz
+#define  SBC_MP_CACHE_DRA     (1 << 5)	//!< Disable Read-Ahead
+#define  SBC_MP_CACHE_NV_DIS  (1 << 0)	//!< Non-Volatile Cache Disable
+	uint8_t nr_cache_segments;
+	be16_t cache_segment_size;
+	uint8_t reserved[4];
+};
+
+/**
+ * \brief SBC-2 Read-Write Error Recovery mode page
+ */
+struct sbc_rdwr_error_recovery_mode_page {
+	uint8_t page_code;
+	uint8_t page_length;
+#define  SPC_MP_RW_ERR_RECOV_PAGE_LENGTH    0x0A
+	uint8_t flags1;
+#define  SBC_MP_RW_ERR_RECOV_AWRE   (1 << 7)
+#define  SBC_MP_RW_ERR_RECOV_ARRE   (1 << 6)
+#define  SBC_MP_RW_ERR_RECOV_TB     (1 << 5)
+#define  SBC_MP_RW_ERR_RECOV_RC     (1 << 4)
+#define  SBC_MP_RW_ERR_RECOV_ERR    (1 << 3)
+#define  SBC_MP_RW_ERR_RECOV_PER    (1 << 2)
+#define  SBC_MP_RW_ERR_RECOV_DTE    (1 << 1)
+#define  SBC_MP_RW_ERR_RECOV_DCR    (1 << 0)
+	uint8_t read_retry_count;
+	uint8_t correction_span;
+	uint8_t head_offset_count;
+	uint8_t data_strobe_offset_count;
+	uint8_t flags2;
+	uint8_t write_retry_count;
+	uint8_t flags3;
+	be16_t recovery_time_limit;
+};
+//@}
+
+/**
+ * \brief SBC-2 READ CAPACITY (10) parameter data
+ */
+struct sbc_read_capacity10_data {
+	be32_t max_lba;	//!< LBA of last logical block
+	be32_t block_len;	//!< Number of bytes in the last logical block
+};
+
+//@}
+
+#endif // _SBC_PROTOCOL_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -1,0 +1,135 @@
+/**
+ * Interface from Atmel USB MSD to Marlin SD card
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+
+#include "../../../inc/MarlinConfig.h"
+#include "../../../sd/cardreader.h"
+extern "C" {
+#include "sd_mmc_spi_mem.h"
+}
+
+#define SD_MMC_BLOCK_SIZE 512
+
+void sd_mmc_spi_mem_init(void)
+{
+}
+
+Ctrl_status sd_mmc_spi_test_unit_ready(void)
+{
+  if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
+    return CTRL_NO_PRESENT;
+  return CTRL_GOOD;
+}
+
+Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector)
+{
+  if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
+    return CTRL_NO_PRESENT;
+  *nb_sector = card.getSd2Card().cardSize();
+  return CTRL_GOOD;
+}
+
+bool sd_mmc_spi_unload(bool unload)
+{
+  return true;
+}
+
+bool sd_mmc_spi_wr_protect(void)
+{
+  return false;
+}
+
+bool sd_mmc_spi_removal(void)
+{
+  if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
+    return true;
+  return false;
+}
+
+#if ACCESS_USB == true
+/**
+ * \name MEM <-> USB Interface
+ * @{
+ */
+
+#include "udi_msc.h"
+
+COMPILER_WORD_ALIGNED
+uint8_t sector_buf[SD_MMC_BLOCK_SIZE];
+
+// #define DEBUG_MMC
+
+Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector)
+{
+  if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
+    return CTRL_NO_PRESENT;
+
+#ifdef DEBUG_MMC
+  char buffer[80];
+  sprintf(buffer, "SDRD: %d @ 0x%08x\n", nb_sector, addr);
+  MYSERIAL.print(buffer);
+#endif
+
+  // Start reading
+  if (!card.getSd2Card().readStart(addr))
+    return CTRL_FAIL;
+
+  // For each specified sector
+  while (nb_sector--) {
+
+    // Read a sector
+    card.getSd2Card().readData(sector_buf);
+
+    // RAM -> USB
+    if (!udi_msc_trans_block(true, sector_buf, SD_MMC_BLOCK_SIZE, NULL)) {
+      card.getSd2Card().readStop();
+      return CTRL_FAIL;
+    }
+  }
+
+  // Stop reading
+  card.getSd2Card().readStop();
+
+  // Done
+  return CTRL_GOOD;
+}
+
+Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector)
+{
+  if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
+    return CTRL_NO_PRESENT;
+
+#ifdef DEBUG_MMC
+  char buffer[80];
+  sprintf(buffer, "SDWR: %d @ 0x%08x\n", nb_sector, addr);
+  MYSERIAL.print(buffer);
+#endif
+
+  if (!card.getSd2Card().writeStart(addr, nb_sector))
+    return CTRL_FAIL;
+
+  // For each specified sector
+  while (nb_sector--) {
+
+    // USB -> RAM
+    if (!udi_msc_trans_block(false, sector_buf, SD_MMC_BLOCK_SIZE, NULL)) {
+      card.getSd2Card().writeStop();
+      return CTRL_FAIL;
+    }
+
+    // Write a sector
+    card.getSd2Card().writeData(sector_buf);
+  }
+
+  // Stop writing
+  card.getSd2Card().writeStop();
+
+  // Done
+  return CTRL_GOOD;
+}
+
+#endif // ACCESS_USB == true
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.h
@@ -1,0 +1,177 @@
+/*****************************************************************************
+ *
+ * \file
+ *
+ * \brief CTRL_ACCESS interface for SD/MMC card.
+ *
+ * Copyright (c) 2014-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ ******************************************************************************/
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+
+#ifndef _SD_MMC_SPI_MEM_H_
+#define _SD_MMC_SPI_MEM_H_
+
+/**
+ * \defgroup group_avr32_components_memory_sd_mmc_sd_mmc_spi_mem SD/MMC SPI Memory
+ *
+ * \ingroup group_avr32_components_memory_sd_mmc_sd_mmc_spi
+ *
+ * \{
+ */
+
+#include "conf_access.h"
+
+#if SD_MMC_SPI_MEM == DISABLE
+  #error sd_mmc_spi_mem.h is #included although SD_MMC_SPI_MEM is disabled
+#endif
+
+
+#include "ctrl_access.h"
+
+
+//_____ D E F I N I T I O N S ______________________________________________
+
+#define   SD_MMC_REMOVED       0
+#define   SD_MMC_INSERTED      1
+#define   SD_MMC_REMOVING      2
+
+
+//---- CONTROL FONCTIONS ----
+//!
+//! @brief This function initializes the hw/sw resources required to drive the SD_MMC_SPI.
+//!/
+extern void           sd_mmc_spi_mem_init(void);
+
+//!
+//! @brief This function tests the state of the SD_MMC memory and sends it to the Host.
+//!        For a PC, this device is seen as a removable media
+//!        Before indicating any modification of the status of the media (GOOD->NO_PRESENT or vice-versa),
+//!         the function must return the BUSY data to make the PC accepting the change
+//!
+//! @return                Ctrl_status
+//!   Media is ready       ->    CTRL_GOOD
+//!   Media not present    ->    CTRL_NO_PRESENT
+//!   Media has changed    ->    CTRL_BUSY
+//!/
+extern Ctrl_status    sd_mmc_spi_test_unit_ready(void);
+
+//!
+//! @brief This function gives the address of the last valid sector.
+//!
+//! @param *nb_sector  number of sector (sector = 512B). OUT
+//!
+//! @return                Ctrl_status
+//!   Media ready          ->  CTRL_GOOD
+//!   Media not present    ->  CTRL_NO_PRESENT
+//!/
+extern Ctrl_status    sd_mmc_spi_read_capacity(uint32_t *nb_sector);
+
+/*! \brief Unload/Load the SD/MMC card selected
+ *
+ * The START STOP UNIT SCSI optional command allows an application client to
+ * eject the removable medium on a LUN.
+ *
+ * \param unload \c true to unload the medium, \c false to load the medium.
+ *
+ * \return \c true if unload/load done success.
+ */
+extern bool sd_mmc_spi_unload(bool unload); 
+
+//!
+//! @brief This function returns the write protected status of the memory.
+//!
+//! Only used by memory removal with a HARDWARE SPECIFIC write protected detection
+//! ! The user must unplug the memory to change this write protected status,
+//! which cannot be for a SD_MMC.
+//!
+//! @return false  -> the memory is not write-protected (always)
+//!/
+extern bool           sd_mmc_spi_wr_protect(void);
+
+//!
+//! @brief This function tells if the memory has been removed or not.
+//!
+//! @return false  -> The memory isn't removed
+//!
+extern bool           sd_mmc_spi_removal(void);
+
+
+//---- ACCESS DATA FONCTIONS ----
+
+#if ACCESS_USB == true
+// Standard functions for open in read/write mode the device
+
+//!
+//! @brief This function performs a read operation of n sectors from a given address on.
+//! (sector = 512B)
+//!
+//!         DATA FLOW is: SD_MMC => USB
+//!
+//! @param addr         Sector address to start the read from
+//! @param nb_sector    Number of sectors to transfer
+//!
+//! @return                Ctrl_status
+//!   It is ready    ->    CTRL_GOOD
+//!   A error occur  ->    CTRL_FAIL
+//!
+extern Ctrl_status    sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector);
+
+//! This function initializes the SD/MMC memory for a write operation
+//!
+//!         DATA FLOW is: USB => SD_MMC
+//!
+//! (sector = 512B)
+//! @param addr         Sector address to start write
+//! @param nb_sector    Number of sectors to transfer
+//!
+//! @return                Ctrl_status
+//!   It is ready    ->    CTRL_GOOD
+//!   An error occurs  ->    CTRL_FAIL
+//!
+extern Ctrl_status    sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector);
+
+#endif // #if ACCESS_USB == true
+
+/**
+ * \}
+ */
+
+#endif  // _SD_MMC_SPI_MEM_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/spc_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/spc_protocol.h
@@ -1,0 +1,337 @@
+/**
+ * \file
+ *
+ * \brief SCSI Primary Commands
+ *
+ * This file contains definitions of some of the commands found in the
+ * SPC-2 standard.
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+#ifndef  _SPC_PROTOCOL_H_
+#define  _SPC_PROTOCOL_H_
+
+
+/**
+ * \ingroup usb_msc_protocol
+ * \defgroup usb_spc_protocol SCSI Primary Commands protocol definitions
+ *
+ * @{
+ */
+
+//! \name SCSI commands defined by SPC-2
+//@{
+#define  SPC_TEST_UNIT_READY              0x00
+#define  SPC_REQUEST_SENSE                0x03
+#define  SPC_INQUIRY                      0x12
+#define  SPC_MODE_SELECT6                 0x15
+#define  SPC_MODE_SENSE6                  0x1A
+#define  SPC_SEND_DIAGNOSTIC              0x1D
+#define  SPC_PREVENT_ALLOW_MEDIUM_REMOVAL 0x1E
+#define  SPC_MODE_SENSE10                 0x5A
+#define  SPC_REPORT_LUNS                  0xA0
+//@}
+
+//! \brief May be set in byte 0 of the INQUIRY CDB
+//@{
+//! Enable Vital Product Data
+#define  SCSI_INQ_REQ_EVPD    0x01
+//! Command Support Data specified by the PAGE OR OPERATION CODE field
+#define  SCSI_INQ_REQ_CMDT    0x02
+//@}
+
+COMPILER_PACK_SET(1)
+
+/**
+ * \brief SCSI Standard Inquiry data structure
+ */
+struct scsi_inquiry_data {
+	uint8_t pq_pdt; //!< Peripheral Qual / Peripheral Dev Type
+#define  SCSI_INQ_PQ_CONNECTED   0x00   //!< Peripheral connected
+#define  SCSI_INQ_PQ_NOT_CONN    0x20   //!< Peripheral not connected
+#define  SCSI_INQ_PQ_NOT_SUPP    0x60   //!< Peripheral not supported
+#define  SCSI_INQ_DT_DIR_ACCESS  0x00   //!< Direct Access (SBC)
+#define  SCSI_INQ_DT_SEQ_ACCESS  0x01   //!< Sequential Access
+#define  SCSI_INQ_DT_PRINTER     0x02   //!< Printer
+#define  SCSI_INQ_DT_PROCESSOR   0x03   //!< Processor device
+#define  SCSI_INQ_DT_WRITE_ONCE  0x04   //!< Write-once device
+#define  SCSI_INQ_DT_CD_DVD      0x05   //!< CD/DVD device
+#define  SCSI_INQ_DT_OPTICAL     0x07   //!< Optical Memory
+#define  SCSI_INQ_DT_MC          0x08   //!< Medium Changer
+#define  SCSI_INQ_DT_ARRAY       0x0c   //!< Storage Array Controller
+#define  SCSI_INQ_DT_ENCLOSURE   0x0d   //!< Enclosure Services
+#define  SCSI_INQ_DT_RBC         0x0e   //!< Simplified Direct Access
+#define  SCSI_INQ_DT_OCRW        0x0f   //!< Optical card reader/writer
+#define  SCSI_INQ_DT_BCC         0x10   //!< Bridge Controller Commands
+#define  SCSI_INQ_DT_OSD         0x11   //!< Object-based Storage
+#define  SCSI_INQ_DT_NONE        0x1f   //!< No Peripheral
+	uint8_t flags1; //!< Flags (byte 1)
+#define  SCSI_INQ_RMB            0x80   //!< Removable Medium
+	uint8_t version; //!< Version
+#define  SCSI_INQ_VER_NONE       0x00   //!< No standards conformance
+#define  SCSI_INQ_VER_SPC        0x03   //!< SCSI Primary Commands     (link to SBC)
+#define  SCSI_INQ_VER_SPC2       0x04   //!< SCSI Primary Commands - 2 (link to SBC-2)
+#define  SCSI_INQ_VER_SPC3       0x05   //!< SCSI Primary Commands - 3 (link to SBC-2)
+#define  SCSI_INQ_VER_SPC4       0x06   //!< SCSI Primary Commands - 4 (link to SBC-3)
+	uint8_t flags3; //!< Flags (byte 3)
+#define  SCSI_INQ_NORMACA        0x20   //!< Normal ACA Supported
+#define  SCSI_INQ_HISUP          0x10   //!< Hierarchal LUN addressing
+#define  SCSI_INQ_RSP_SPC2       0x02   //!< SPC-2 / SPC-3 response format
+	uint8_t addl_len; //!< Additional Length (n-4)
+#define  SCSI_INQ_ADDL_LEN(tot)  ((tot)-5) //!< Total length is \a tot
+	uint8_t flags5; //!< Flags (byte 5)
+#define  SCSI_INQ_SCCS           0x80
+	uint8_t flags6; //!< Flags (byte 6)
+#define  SCSI_INQ_BQUE           0x80
+#define  SCSI_INQ_ENCSERV        0x40
+#define  SCSI_INQ_MULTIP         0x10
+#define  SCSI_INQ_MCHGR          0x08
+#define  SCSI_INQ_ADDR16         0x01
+	uint8_t flags7; //!< Flags (byte 7)
+#define  SCSI_INQ_WBUS16         0x20
+#define  SCSI_INQ_SYNC           0x10
+#define  SCSI_INQ_LINKED         0x08
+#define  SCSI_INQ_CMDQUE         0x02
+	uint8_t vendor_id[8];   //!< T10 Vendor Identification
+	uint8_t product_id[16]; //!< Product Identification
+	uint8_t product_rev[4]; //!< Product Revision Level
+};
+
+/**
+ * \brief SCSI Standard Request sense data structure
+ */
+struct scsi_request_sense_data {
+	/* 1st byte: REQUEST SENSE response flags*/
+	uint8_t valid_reponse_code;
+#define  SCSI_SENSE_VALID              0x80 //!< Indicates the INFORMATION field contains valid information
+#define  SCSI_SENSE_RESPONSE_CODE_MASK 0x7F
+#define  SCSI_SENSE_CURRENT            0x70 //!< Response code 70h (current errors)
+#define  SCSI_SENSE_DEFERRED           0x71
+
+	/* 2nd byte */
+	uint8_t obsolete;
+
+	/* 3rd byte */
+	uint8_t sense_flag_key;
+#define  SCSI_SENSE_FILEMARK        0x80 //!< Indicates that the current command has read a filemark or setmark.
+#define  SCSI_SENSE_EOM             0x40 //!< Indicates that an end-of-medium condition exists.
+#define  SCSI_SENSE_ILI             0x20 //!< Indicates that the requested logical block length did not match the logical block length of the data on the medium.
+#define  SCSI_SENSE_RESERVED        0x10 //!< Reserved
+#define  SCSI_SENSE_KEY(x)          (x&0x0F) //!< Sense Key
+
+	/* 4th to 7th bytes - INFORMATION field */
+	uint8_t information[4];
+
+	/* 8th byte  - ADDITIONAL SENSE LENGTH field */
+	uint8_t AddSenseLen;
+#define  SCSI_SENSE_ADDL_LEN(total_len)   ((total_len) - 8)
+
+	/* 9th to 12th byte  - COMMAND-SPECIFIC INFORMATION field */
+	uint8_t CmdSpecINFO[4];
+
+	/* 13th byte  - ADDITIONAL SENSE CODE field */
+	uint8_t AddSenseCode;
+
+	/* 14th byte  - ADDITIONAL SENSE CODE QUALIFIER field */
+	uint8_t AddSnsCodeQlfr;
+
+	/* 15th byte  - FIELD REPLACEABLE UNIT CODE field */
+	uint8_t FldReplUnitCode;
+
+	/* 16th byte */
+	uint8_t SenseKeySpec[3];
+#define  SCSI_SENSE_SKSV            0x80 //!< Indicates the SENSE-KEY SPECIFIC field contains valid information
+};
+
+COMPILER_PACK_RESET()
+
+/* Vital Product Data page codes */
+enum scsi_vpd_page_code {
+	SCSI_VPD_SUPPORTED_PAGES = 0x00,
+	SCSI_VPD_UNIT_SERIAL_NUMBER = 0x80,
+	SCSI_VPD_DEVICE_IDENTIFICATION = 0x83,
+};
+#define  SCSI_VPD_HEADER_SIZE       4
+
+/* Constants associated with the Device Identification VPD page */
+#define  SCSI_VPD_ID_HEADER_SIZE    4
+
+#define  SCSI_VPD_CODE_SET_BINARY   1
+#define  SCSI_VPD_CODE_SET_ASCII    2
+#define  SCSI_VPD_CODE_SET_UTF8     3
+
+#define  SCSI_VPD_ID_TYPE_T10       1
+
+
+/* Sense keys */
+enum scsi_sense_key {
+	SCSI_SK_NO_SENSE = 0x0,
+	SCSI_SK_RECOVERED_ERROR = 0x1,
+	SCSI_SK_NOT_READY = 0x2,
+	SCSI_SK_MEDIUM_ERROR = 0x3,
+	SCSI_SK_HARDWARE_ERROR = 0x4,
+	SCSI_SK_ILLEGAL_REQUEST = 0x5,
+	SCSI_SK_UNIT_ATTENTION = 0x6,
+	SCSI_SK_DATA_PROTECT = 0x7,
+	SCSI_SK_BLANK_CHECK = 0x8,
+	SCSI_SK_VENDOR_SPECIFIC = 0x9,
+	SCSI_SK_COPY_ABORTED = 0xa,
+	SCSI_SK_ABORTED_COMMAND = 0xb,
+	SCSI_SK_VOLUME_OVERFLOW = 0xd,
+	SCSI_SK_MISCOMPARE = 0xe,
+};
+
+/* Additional Sense Code / Additional Sense Code Qualifier pairs */
+enum scsi_asc_ascq {
+	SCSI_ASC_NO_ADDITIONAL_SENSE_INFO = 0x0000,
+	SCSI_ASC_LU_NOT_READY_REBUILD_IN_PROGRESS = 0x0405,
+	SCSI_ASC_WRITE_ERROR = 0x0c00,
+	SCSI_ASC_UNRECOVERED_READ_ERROR = 0x1100,
+	SCSI_ASC_INVALID_COMMAND_OPERATION_CODE = 0x2000,
+	SCSI_ASC_INVALID_FIELD_IN_CDB = 0x2400,
+	SCSI_ASC_WRITE_PROTECTED = 0x2700,
+	SCSI_ASC_NOT_READY_TO_READY_CHANGE = 0x2800,
+	SCSI_ASC_MEDIUM_NOT_PRESENT = 0x3A00,
+	SCSI_ASC_INTERNAL_TARGET_FAILURE = 0x4400,
+};
+
+/**
+ * \brief SPC-2 Mode parameter
+ * This subclause describes the block descriptors and the pages
+ * used with MODE SELECT and MODE SENSE commands
+ * that are applicable to all SCSI devices.
+ */
+enum scsi_spc_mode {
+	SCSI_MS_MODE_VENDOR_SPEC = 0x00,
+	SCSI_MS_MODE_INFEXP = 0x1C,    // Informational exceptions control page
+	SCSI_MS_MODE_ALL = 0x3f,
+};
+
+/**
+ * \brief SPC-2 Informational exceptions control page
+ * See chapter 8.3.8
+ */
+struct spc_control_page_info_execpt {
+	uint8_t page_code;
+	uint8_t page_length;
+#define  SPC_MP_INFEXP_PAGE_LENGTH     0x0A
+	uint8_t flags1;
+#define  SPC_MP_INFEXP_PERF            (1<<7)   //!< Initiator Control
+#define  SPC_MP_INFEXP_EBF             (1<<5)   //!< Caching Analysis Permitted
+#define  SPC_MP_INFEXP_EWASC           (1<<4)   //!< Discontinuity
+#define  SPC_MP_INFEXP_DEXCPT          (1<<3)   //!< Size enable
+#define  SPC_MP_INFEXP_TEST            (1<<2)   //!< Writeback Cache Enable
+#define  SPC_MP_INFEXP_LOGERR          (1<<0)   //!< Log errors bit
+	uint8_t mrie;
+#define  SPC_MP_INFEXP_MRIE_NO_REPORT           0x00
+#define  SPC_MP_INFEXP_MRIE_ASYNC_EVENT         0x01
+#define  SPC_MP_INFEXP_MRIE_GEN_UNIT            0x02
+#define  SPC_MP_INFEXP_MRIE_COND_RECOV_ERROR    0x03
+#define  SPC_MP_INFEXP_MRIE_UNCOND_RECOV_ERROR  0x04
+#define  SPC_MP_INFEXP_MRIE_NO_SENSE            0x05
+#define  SPC_MP_INFEXP_MRIE_ONLY_REPORT         0x06
+	be32_t interval_timer;
+	be32_t report_count;
+};
+
+
+enum scsi_spc_mode_sense_pc {
+	SCSI_MS_SENSE_PC_CURRENT = 0,
+	SCSI_MS_SENSE_PC_CHANGEABLE = 1,
+	SCSI_MS_SENSE_PC_DEFAULT = 2,
+	SCSI_MS_SENSE_PC_SAVED = 3,
+};
+
+
+
+static inline bool scsi_mode_sense_dbd_is_set(const uint8_t * cdb)
+{
+	return (cdb[1] >> 3) & 1;
+}
+
+static inline uint8_t scsi_mode_sense_get_page_code(const uint8_t * cdb)
+{
+	return cdb[2] & 0x3f;
+}
+
+static inline uint8_t scsi_mode_sense_get_pc(const uint8_t * cdb)
+{
+	return cdb[2] >> 6;
+}
+
+/**
+ * \brief SCSI Mode Parameter Header used by MODE SELECT(6) and MODE
+ * SENSE(6)
+ */
+struct scsi_mode_param_header6 {
+	uint8_t mode_data_length;	//!< Number of bytes after this
+	uint8_t medium_type;	//!< Medium Type
+	uint8_t device_specific_parameter;	//!< Defined by command set
+	uint8_t block_descriptor_length;	//!< Length of block descriptors
+};
+
+/**
+ * \brief SCSI Mode Parameter Header used by MODE SELECT(10) and MODE
+ * SENSE(10)
+ */
+struct scsi_mode_param_header10 {
+	be16_t mode_data_length;	//!< Number of bytes after this
+	uint8_t medium_type;	//!< Medium Type
+	uint8_t device_specific_parameter;	//!< Defined by command set
+	uint8_t flags4;	//!< LONGLBA in bit 0
+	uint8_t reserved;
+	be16_t block_descriptor_length;	//!< Length of block descriptors
+};
+
+/**
+ * \brief SCSI Page_0 Mode Page header (SPF not set)
+ */
+struct scsi_mode_page_0_header {
+	uint8_t page_code;
+#define  SCSI_PAGE_CODE_PS          (1 << 7)	//!< Parameters Saveable
+#define  SCSI_PAGE_CODE_SPF         (1 << 6)	//!< SubPage Format
+	uint8_t page_length;	//!< Number of bytes after this
+#define  SCSI_MS_PAGE_LEN(total)   ((total) - 2)
+};
+
+//@}
+
+#endif // SPC_PROTOCOL_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/stringz.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/stringz.h
@@ -1,0 +1,85 @@
+/**
+ * \file
+ *
+ * \brief Preprocessor stringizing utils.
+ *
+ * Copyright (c) 2010-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _STRINGZ_H_
+#define _STRINGZ_H_
+
+/**
+ * \defgroup group_sam_utils_stringz Preprocessor - Stringize
+ *
+ * \ingroup group_sam_utils
+ *
+ * \{
+ */
+
+/*! \brief Stringize.
+ *
+ * Stringize a preprocessing token, this token being allowed to be \#defined.
+ *
+ * May be used only within macros with the token passed as an argument if the token is \#defined.
+ *
+ * For example, writing STRINGZ(PIN) within a macro \#defined by PIN_NAME(PIN)
+ * and invoked as PIN_NAME(PIN0) with PIN0 \#defined as A0 is equivalent to
+ * writing "A0".
+ */
+#define STRINGZ(x)                                #x
+
+/*! \brief Absolute stringize.
+ *
+ * Stringize a preprocessing token, this token being allowed to be \#defined.
+ *
+ * No restriction of use if the token is \#defined.
+ *
+ * For example, writing ASTRINGZ(PIN0) anywhere with PIN0 \#defined as A0 is
+ * equivalent to writing "A0".
+ */
+#define ASTRINGZ(x)                               STRINGZ(x)
+
+/**
+ * \}
+ */
+
+#endif  // _STRINGZ_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/sysclk.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/sysclk.c
@@ -1,0 +1,122 @@
+/**
+ * \file
+ *
+ * \brief Chip-specific system clock management functions.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+ 
+#include "sysclk.h"
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+/**
+ * \weakgroup sysclk_group
+ * @{
+ */
+
+#if defined(CONFIG_USBCLK_SOURCE) || defined(__DOXYGEN__)
+/**
+ * \brief Enable full speed USB clock.
+ *
+ * \note The SAM3X PMC hardware interprets div as div+1. For readability the hardware div+1
+ * is hidden in this implementation. Use div as div effective value.
+ *
+ * \param pll_id Source of the USB clock.
+ * \param div Actual clock divisor. Must be superior to 0.
+ */
+void sysclk_enable_usb(void)
+{
+	Assert(CONFIG_USBCLK_DIV > 0);
+
+#ifdef CONFIG_PLL0_SOURCE
+	if (CONFIG_USBCLK_SOURCE == USBCLK_SRC_PLL0) {
+		struct pll_config pllcfg;
+
+		pll_enable_source(CONFIG_PLL0_SOURCE);
+		pll_config_defaults(&pllcfg, 0);
+		pll_enable(&pllcfg, 0);
+		pll_wait_for_lock(0);
+		pmc_switch_udpck_to_pllack(CONFIG_USBCLK_DIV - 1);
+		pmc_enable_udpck();
+		return;
+	}
+#endif
+
+	if (CONFIG_USBCLK_SOURCE == USBCLK_SRC_UPLL) {
+
+		pmc_enable_upll_clock();
+		pmc_switch_udpck_to_upllck(CONFIG_USBCLK_DIV - 1);
+		pmc_enable_udpck();
+		return;
+	}
+}
+
+/**
+ * \brief Disable full speed USB clock.
+ *
+ * \note This implementation does not switch off the PLL, it just turns off the USB clock.
+ */
+void sysclk_disable_usb(void)
+{
+	pmc_disable_udpck();
+}
+#endif // CONFIG_USBCLK_SOURCE
+
+//! @}
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+}
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/sysclk.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sysclk.h
@@ -1,0 +1,229 @@
+/**
+ * \file
+ *
+ * \brief Chip-specific system clock management functions.
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef CHIP_SYSCLK_H_INCLUDED
+#define CHIP_SYSCLK_H_INCLUDED
+
+#include "osc.h"
+#include "pll.h"
+
+/**
+ * \page sysclk_quickstart Quick Start Guide for the System Clock Management service (SAM3A)
+ *
+ * This is the quick start guide for the \ref sysclk_group "System Clock Management"
+ * service, with step-by-step instructions on how to configure and use the service for
+ * specific use cases.
+ *
+ * \section sysclk_quickstart_usecases System Clock Management use cases
+ * - \ref sysclk_quickstart_basic
+ *
+ * \section sysclk_quickstart_basic Basic usage of the System Clock Management service
+ * This section will present a basic use case for the System Clock Management service.
+ * This use case will configure the main system clock to 84MHz, using an internal PLL
+ * module to multiply the frequency of a crystal attached to the microcontroller.
+ *
+ * \subsection sysclk_quickstart_use_case_1_prereq Prerequisites
+ *  - None
+ *
+ * \subsection sysclk_quickstart_use_case_1_setup_steps Initialization code
+ * Add to the application initialization code:
+ * \code
+	sysclk_init();
+\endcode
+ *
+ * \subsection sysclk_quickstart_use_case_1_setup_steps_workflow Workflow
+ * -# Configure the system clocks according to the settings in conf_clock.h:
+ *    \code sysclk_init(); \endcode
+ *
+ * \subsection sysclk_quickstart_use_case_1_example_code Example code
+ *   Add or uncomment the following in your conf_clock.h header file, commenting out all other
+ *   definitions of the same symbol(s):
+ *   \code
+	   #define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_PLLACK
+
+	   // Fpll0 = (Fclk * PLL_mul) / PLL_div
+	   #define CONFIG_PLL0_SOURCE          PLL_SRC_MAINCK_XTAL
+	   #define CONFIG_PLL0_MUL             (84000000UL / BOARD_FREQ_MAINCK_XTAL)
+	   #define CONFIG_PLL0_DIV             1
+
+	   // Fbus = Fsys / BUS_div
+	   #define CONFIG_SYSCLK_PRES          SYSCLK_PRES_1
+\endcode
+ *
+ * \subsection sysclk_quickstart_use_case_1_example_workflow Workflow
+ *  -# Configure the main system clock to use the output of the PLL module as its source:
+ *   \code #define CONFIG_SYSCLK_SOURCE          SYSCLK_SRC_PLLACK \endcode
+ *  -# Configure the PLL module to use the fast external fast crystal oscillator as its source:
+ *   \code #define CONFIG_PLL0_SOURCE            PLL_SRC_MAINCK_XTAL \endcode
+ *  -# Configure the PLL module to multiply the external fast crystal oscillator frequency up to 84MHz:
+ *   \code
+	#define CONFIG_PLL0_MUL             (84000000UL / BOARD_FREQ_MAINCK_XTAL)
+	#define CONFIG_PLL0_DIV             1
+\endcode
+ *   \note For user boards, \c BOARD_FREQ_MAINCK_XTAL should be defined in the board \c conf_board.h configuration
+ *         file as the frequency of the fast crystal attached to the microcontroller.
+ *  -# Configure the main clock to run at the full 84MHz, disable scaling of the main system clock speed:
+ *    \code
+	#define CONFIG_SYSCLK_PRES         SYSCLK_PRES_1
+\endcode
+ *    \note Some dividers are powers of two, while others are integer division factors. Refer to the
+ *          formulas in the conf_clock.h template commented above each division define.
+ */
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+/**
+ * \weakgroup sysclk_group
+ * @{
+ */
+
+//! \name Configuration Symbols
+//@{
+/**
+ * \def CONFIG_SYSCLK_SOURCE
+ * \brief Initial/static main system clock source
+ *
+ * The main system clock will be configured to use this clock during
+ * initialization.
+ */
+#ifndef CONFIG_SYSCLK_SOURCE
+# define CONFIG_SYSCLK_SOURCE   SYSCLK_SRC_MAINCK_4M_RC
+#endif
+/**
+ * \def CONFIG_SYSCLK_PRES
+ * \brief Initial CPU clock divider (mck)
+ *
+ * The MCK will run at
+ * \f[
+ *   f_{MCK} = \frac{f_{sys}}{\mathrm{CONFIG\_SYSCLK\_PRES}}\,\mbox{Hz}
+ * \f]
+ * after initialization.
+ */
+#ifndef CONFIG_SYSCLK_PRES
+# define CONFIG_SYSCLK_PRES  0
+#endif
+
+//@}
+
+//! \name Master Clock Sources (MCK)
+//@{
+#define SYSCLK_SRC_SLCK_RC              0       //!< Internal 32kHz RC oscillator as master source clock
+#define SYSCLK_SRC_SLCK_XTAL            1       //!< External 32kHz crystal oscillator as master source clock
+#define SYSCLK_SRC_SLCK_BYPASS          2       //!< External 32kHz bypass oscillator as master source clock
+#define SYSCLK_SRC_MAINCK_4M_RC         3       //!< Internal 4MHz RC oscillator as master source clock
+#define SYSCLK_SRC_MAINCK_8M_RC         4       //!< Internal 8MHz RC oscillator as master source clock
+#define SYSCLK_SRC_MAINCK_12M_RC        5       //!< Internal 12MHz RC oscillator as master source clock
+#define SYSCLK_SRC_MAINCK_XTAL          6       //!< External crystal oscillator as master source clock
+#define SYSCLK_SRC_MAINCK_BYPASS        7       //!< External bypass oscillator as master source clock
+#define SYSCLK_SRC_PLLACK               8       //!< Use PLLACK as master source clock
+#define SYSCLK_SRC_UPLLCK               9       //!< Use UPLLCK as master source clock
+//@}
+
+//! \name Master Clock Prescalers (MCK)
+//@{
+#define SYSCLK_PRES_1           PMC_MCKR_PRES_CLK_1     //!< Set master clock prescaler to 1
+#define SYSCLK_PRES_2           PMC_MCKR_PRES_CLK_2     //!< Set master clock prescaler to 2
+#define SYSCLK_PRES_4           PMC_MCKR_PRES_CLK_4     //!< Set master clock prescaler to 4
+#define SYSCLK_PRES_8           PMC_MCKR_PRES_CLK_8     //!< Set master clock prescaler to 8
+#define SYSCLK_PRES_16          PMC_MCKR_PRES_CLK_16    //!< Set master clock prescaler to 16
+#define SYSCLK_PRES_32          PMC_MCKR_PRES_CLK_32    //!< Set master clock prescaler to 32
+#define SYSCLK_PRES_64          PMC_MCKR_PRES_CLK_64    //!< Set master clock prescaler to 64
+#define SYSCLK_PRES_3           PMC_MCKR_PRES_CLK_3     //!< Set master clock prescaler to 3
+//@}
+
+//! \name USB Clock Sources
+//@{
+#define USBCLK_SRC_PLL0       0     //!< Use PLLA
+#define USBCLK_SRC_UPLL       1     //!< Use UPLL
+//@}
+
+/**
+ * \def CONFIG_USBCLK_SOURCE
+ * \brief Configuration symbol for the USB generic clock source
+ *
+ * Sets the clock source to use for the USB. The source must also be properly
+ * configured.
+ *
+ * Define this to one of the \c USBCLK_SRC_xxx settings. Leave it undefined if
+ * USB is not required.
+ */
+#ifdef __DOXYGEN__
+# define CONFIG_USBCLK_SOURCE
+#endif
+
+/**
+ * \def CONFIG_USBCLK_DIV
+ * \brief Configuration symbol for the USB generic clock divider setting
+ *
+ * Sets the clock division for the USB generic clock. If a USB clock source is
+ * selected with CONFIG_USBCLK_SOURCE, this configuration symbol must also be
+ * defined.
+ */
+#ifdef __DOXYGEN__
+# define CONFIG_USBCLK_DIV
+#endif
+
+
+extern void sysclk_enable_usb(void);
+extern void sysclk_disable_usb(void);
+
+//! @}
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+}
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+#endif /* CHIP_SYSCLK_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/tpaste.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/tpaste.h
@@ -1,0 +1,105 @@
+/**
+ * \file
+ *
+ * \brief Preprocessor token pasting utils.
+ *
+ * Copyright (c) 2010-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _TPASTE_H_
+#define _TPASTE_H_
+
+/**
+ * \defgroup group_sam_utils_tpaste Preprocessor - Token Paste
+ *
+ * \ingroup group_sam_utils
+ *
+ * \{
+ */
+
+/*! \name Token Paste
+ *
+ * Paste N preprocessing tokens together, these tokens being allowed to be \#defined.
+ *
+ * May be used only within macros with the tokens passed as arguments if the tokens are \#defined.
+ *
+ * For example, writing TPASTE2(U, WIDTH) within a macro \#defined by
+ * UTYPE(WIDTH) and invoked as UTYPE(UL_WIDTH) with UL_WIDTH \#defined as 32 is
+ * equivalent to writing U32.
+ */
+//! @{
+#define TPASTE2( a, b)                            a##b
+#define TPASTE3( a, b, c)                         a##b##c
+#define TPASTE4( a, b, c, d)                      a##b##c##d
+#define TPASTE5( a, b, c, d, e)                   a##b##c##d##e
+#define TPASTE6( a, b, c, d, e, f)                a##b##c##d##e##f
+#define TPASTE7( a, b, c, d, e, f, g)             a##b##c##d##e##f##g
+#define TPASTE8( a, b, c, d, e, f, g, h)          a##b##c##d##e##f##g##h
+#define TPASTE9( a, b, c, d, e, f, g, h, i)       a##b##c##d##e##f##g##h##i
+#define TPASTE10(a, b, c, d, e, f, g, h, i, j)    a##b##c##d##e##f##g##h##i##j
+//! @}
+
+/*! \name Absolute Token Paste
+ *
+ * Paste N preprocessing tokens together, these tokens being allowed to be \#defined.
+ *
+ * No restriction of use if the tokens are \#defined.
+ *
+ * For example, writing ATPASTE2(U, UL_WIDTH) anywhere with UL_WIDTH \#defined
+ * as 32 is equivalent to writing U32.
+ */
+//! @{
+#define ATPASTE2( a, b)                           TPASTE2( a, b)
+#define ATPASTE3( a, b, c)                        TPASTE3( a, b, c)
+#define ATPASTE4( a, b, c, d)                     TPASTE4( a, b, c, d)
+#define ATPASTE5( a, b, c, d, e)                  TPASTE5( a, b, c, d, e)
+#define ATPASTE6( a, b, c, d, e, f)               TPASTE6( a, b, c, d, e, f)
+#define ATPASTE7( a, b, c, d, e, f, g)            TPASTE7( a, b, c, d, e, f, g)
+#define ATPASTE8( a, b, c, d, e, f, g, h)         TPASTE8( a, b, c, d, e, f, g, h)
+#define ATPASTE9( a, b, c, d, e, f, g, h, i)      TPASTE9( a, b, c, d, e, f, g, h, i)
+#define ATPASTE10(a, b, c, d, e, f, g, h, i, j)   TPASTE10(a, b, c, d, e, f, g, h, i, j)
+//! @}
+
+/**
+ * \}
+ */
+
+#endif  // _TPASTE_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/udc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udc.c
@@ -1,0 +1,1149 @@
+/**
+ * \file
+ *
+ * \brief USB Device Controller (UDC)
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+ 
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "udd.h"
+#include "udc_desc.h"
+#include "udi.h"
+#include "udc.h"
+
+/**
+ * \ingroup udc_group
+ * \defgroup udc_group_interne Implementation of UDC
+ *
+ * Internal implementation
+ * @{
+ */
+
+//! \name Internal variables to manage the USB device
+//! @{
+
+//! Device status state (see enum usb_device_status in usb_protocol.h)
+static le16_t udc_device_status;
+
+COMPILER_WORD_ALIGNED
+//! Device interface setting value
+static uint8_t udc_iface_setting = 0;
+
+//! Device Configuration number selected by the USB host
+COMPILER_WORD_ALIGNED
+static uint8_t udc_num_configuration = 0;
+
+//! Pointer on the selected speed device configuration
+static udc_config_speed_t UDC_DESC_STORAGE *udc_ptr_conf;
+
+//! Pointer on interface descriptor used by SETUP request.
+static usb_iface_desc_t UDC_DESC_STORAGE *udc_ptr_iface;
+
+//! @}
+
+
+//! \name Internal structure to store the USB device main strings
+//! @{
+
+/**
+ * \brief Language ID of USB device (US ID by default)
+ */
+COMPILER_WORD_ALIGNED
+static UDC_DESC_STORAGE usb_str_lgid_desc_t udc_string_desc_languageid = {
+	.desc.bLength = sizeof(usb_str_lgid_desc_t),
+	.desc.bDescriptorType = USB_DT_STRING,
+	.string = {LE16(USB_LANGID_EN_US)}
+};
+
+/**
+ * \brief USB device manufacture name storage
+ * String is allocated only if USB_DEVICE_MANUFACTURE_NAME is declared
+ * by usb application configuration
+ */
+#ifdef USB_DEVICE_MANUFACTURE_NAME
+static uint8_t udc_string_manufacturer_name[] = USB_DEVICE_MANUFACTURE_NAME;
+#  define USB_DEVICE_MANUFACTURE_NAME_SIZE  \
+	(sizeof(udc_string_manufacturer_name)-1)
+#else
+#  define USB_DEVICE_MANUFACTURE_NAME_SIZE  0
+#endif
+
+/**
+ * \brief USB device product name storage
+ * String is allocated only if USB_DEVICE_PRODUCT_NAME is declared
+ * by usb application configuration
+ */
+#ifdef USB_DEVICE_PRODUCT_NAME
+static uint8_t udc_string_product_name[] = USB_DEVICE_PRODUCT_NAME;
+#  define USB_DEVICE_PRODUCT_NAME_SIZE  (sizeof(udc_string_product_name)-1)
+#else
+#  define USB_DEVICE_PRODUCT_NAME_SIZE  0
+#endif
+
+/**
+ * \brief Get USB device serial number
+ *
+ * Use the define USB_DEVICE_SERIAL_NAME to set static serial number.
+ *
+ * For dynamic serial number set the define USB_DEVICE_GET_SERIAL_NAME_POINTER
+ * to a suitable pointer. This will also require the serial number length
+ * define USB_DEVICE_GET_SERIAL_NAME_LENGTH.
+ */
+#if defined USB_DEVICE_GET_SERIAL_NAME_POINTER
+	static const uint8_t *udc_get_string_serial_name(void)
+	{
+		return (const uint8_t *)USB_DEVICE_GET_SERIAL_NAME_POINTER;
+	}
+#  define USB_DEVICE_SERIAL_NAME_SIZE \
+	USB_DEVICE_GET_SERIAL_NAME_LENGTH
+#elif defined USB_DEVICE_SERIAL_NAME
+	static const uint8_t *udc_get_string_serial_name(void)
+	{
+		return (const uint8_t *)USB_DEVICE_SERIAL_NAME;
+	}
+#  define USB_DEVICE_SERIAL_NAME_SIZE \
+	(sizeof(USB_DEVICE_SERIAL_NAME)-1)
+#else
+#  define USB_DEVICE_SERIAL_NAME_SIZE  0
+#endif
+
+/**
+ * \brief USB device string descriptor
+ * Structure used to transfer ASCII strings to USB String descriptor structure.
+ */
+struct udc_string_desc_t {
+	usb_str_desc_t header;
+	le16_t string[Max(Max(USB_DEVICE_MANUFACTURE_NAME_SIZE, \
+			USB_DEVICE_PRODUCT_NAME_SIZE), USB_DEVICE_SERIAL_NAME_SIZE)];
+};
+COMPILER_WORD_ALIGNED
+static UDC_DESC_STORAGE struct udc_string_desc_t udc_string_desc = {
+	.header.bDescriptorType = USB_DT_STRING
+};
+//! @}
+
+usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc(void)
+{
+	return udc_ptr_iface;
+}
+
+/**
+ * \brief Returns a value to check the end of USB Configuration descriptor
+ *
+ * \return address after the last byte of USB Configuration descriptor
+ */
+static usb_conf_desc_t UDC_DESC_STORAGE *udc_get_eof_conf(void)
+{
+	return (UDC_DESC_STORAGE usb_conf_desc_t *) ((uint8_t *)
+			udc_ptr_conf->desc +
+			le16_to_cpu(udc_ptr_conf->desc->wTotalLength));
+}
+
+#if (0!=USB_DEVICE_MAX_EP)
+/**
+ * \brief Search specific descriptor in global interface descriptor
+ *
+ * \param desc       Address of interface descriptor
+ *                   or previous specific descriptor found
+ * \param desc_id    Descriptor ID to search
+ *
+ * \return address of specific descriptor found
+ * \return NULL if it is the end of global interface descriptor
+ */
+static usb_conf_desc_t UDC_DESC_STORAGE *udc_next_desc_in_iface(usb_conf_desc_t
+		UDC_DESC_STORAGE * desc, uint8_t desc_id)
+{
+	usb_conf_desc_t UDC_DESC_STORAGE *ptr_eof_desc;
+
+	ptr_eof_desc = udc_get_eof_conf();
+	// Go to next descriptor
+	desc = (UDC_DESC_STORAGE usb_conf_desc_t *) ((uint8_t *) desc +
+			desc->bLength);
+	// Check the end of configuration descriptor
+	while (ptr_eof_desc > desc) {
+		// If new interface descriptor is found,
+		// then it is the end of the current global interface descriptor
+		if (USB_DT_INTERFACE == desc->bDescriptorType) {
+			break; // End of global interface descriptor
+		}
+		if (desc_id == desc->bDescriptorType) {
+			return desc; // Specific descriptor found
+		}
+		// Go to next descriptor
+		desc = (UDC_DESC_STORAGE usb_conf_desc_t *) ((uint8_t *) desc +
+				desc->bLength);
+	}
+	return NULL; // No specific descriptor found
+}
+#endif
+
+/**
+ * \brief Search an interface descriptor
+ * This routine updates the internal pointer udc_ptr_iface.
+ *
+ * \param iface_num     Interface number to find in Configuration Descriptor
+ * \param setting_num   Setting number of interface to find
+ *
+ * \return 1 if found or 0 if not found
+ */
+static bool udc_update_iface_desc(uint8_t iface_num, uint8_t setting_num)
+{
+	usb_conf_desc_t UDC_DESC_STORAGE *ptr_end_desc;
+
+	if (0 == udc_num_configuration) {
+		return false;
+	}
+
+	if (iface_num >= udc_ptr_conf->desc->bNumInterfaces) {
+		return false;
+	}
+
+	// Start at the beginning of configuration descriptor
+	udc_ptr_iface = (UDC_DESC_STORAGE usb_iface_desc_t *)
+			udc_ptr_conf->desc;
+
+	// Check the end of configuration descriptor
+	ptr_end_desc = udc_get_eof_conf();
+	while (ptr_end_desc >
+			(UDC_DESC_STORAGE usb_conf_desc_t *) udc_ptr_iface) {
+		if (USB_DT_INTERFACE == udc_ptr_iface->bDescriptorType) {
+			// A interface descriptor is found
+			// Check interface and alternate setting number
+			if ((iface_num == udc_ptr_iface->bInterfaceNumber) &&
+					(setting_num ==
+					udc_ptr_iface->bAlternateSetting)) {
+				return true; // Interface found
+			}
+		}
+		// Go to next descriptor
+		udc_ptr_iface = (UDC_DESC_STORAGE usb_iface_desc_t *) (
+				(uint8_t *) udc_ptr_iface +
+				udc_ptr_iface->bLength);
+	}
+	return false; // Interface not found
+}
+
+/**
+ * \brief Disables an usb device interface (UDI)
+ * This routine call the UDI corresponding to interface number
+ *
+ * \param iface_num     Interface number to disable
+ *
+ * \return 1 if it is done or 0 if interface is not found
+ */
+static bool udc_iface_disable(uint8_t iface_num)
+{
+	udi_api_t UDC_DESC_STORAGE *udi_api;
+
+	// Select first alternate setting of the interface
+	// to update udc_ptr_iface before call iface->getsetting()
+	if (!udc_update_iface_desc(iface_num, 0)) {
+		return false;
+	}
+
+	// Select the interface with the current alternate setting
+	udi_api = udc_ptr_conf->udi_apis[iface_num];
+
+#if (0!=USB_DEVICE_MAX_EP)
+	if (!udc_update_iface_desc(iface_num, udi_api->getsetting())) {
+		return false;
+	}
+
+	// Start at the beginning of interface descriptor
+	{
+		usb_ep_desc_t UDC_DESC_STORAGE *ep_desc;
+		ep_desc = (UDC_DESC_STORAGE usb_ep_desc_t *) udc_ptr_iface;
+		while (1) {
+			// Search Endpoint descriptor included in global interface descriptor
+			ep_desc = (UDC_DESC_STORAGE usb_ep_desc_t *)
+					udc_next_desc_in_iface((UDC_DESC_STORAGE
+					usb_conf_desc_t *)
+					ep_desc, USB_DT_ENDPOINT);
+			if (NULL == ep_desc) {
+				break;
+			}
+			// Free the endpoint used by the interface
+			udd_ep_free(ep_desc->bEndpointAddress);
+		}
+	}
+#endif
+
+	// Disable interface
+	udi_api->disable();
+	return true;
+}
+
+/**
+ * \brief Enables an usb device interface (UDI)
+ * This routine calls the UDI corresponding
+ * to the interface and setting number.
+ *
+ * \param iface_num     Interface number to enable
+ * \param setting_num   Setting number to enable
+ *
+ * \return 1 if it is done or 0 if interface is not found
+ */
+static bool udc_iface_enable(uint8_t iface_num, uint8_t setting_num)
+{
+	// Select the interface descriptor
+	if (!udc_update_iface_desc(iface_num, setting_num)) {
+		return false;
+	}
+
+#if (0!=USB_DEVICE_MAX_EP)
+	usb_ep_desc_t UDC_DESC_STORAGE *ep_desc;
+
+	// Start at the beginning of the global interface descriptor
+	ep_desc = (UDC_DESC_STORAGE usb_ep_desc_t *) udc_ptr_iface;
+	while (1) {
+		// Search Endpoint descriptor included in the global interface descriptor
+		ep_desc = (UDC_DESC_STORAGE usb_ep_desc_t *)
+				udc_next_desc_in_iface((UDC_DESC_STORAGE
+						usb_conf_desc_t *) ep_desc,
+				USB_DT_ENDPOINT);
+		if (NULL == ep_desc)
+			break;
+		// Alloc the endpoint used by the interface
+		if (!udd_ep_alloc(ep_desc->bEndpointAddress,
+				ep_desc->bmAttributes,
+				le16_to_cpu
+				(ep_desc->wMaxPacketSize))) {
+			return false;
+		}
+	}
+#endif
+	// Enable the interface
+	return udc_ptr_conf->udi_apis[iface_num]->enable();
+}
+
+/*! \brief Start the USB Device stack
+ */
+void udc_start(void)
+{
+	udd_enable();
+}
+
+/*! \brief Stop the USB Device stack
+ */
+void udc_stop(void)
+{
+	udd_disable();
+	udc_reset();
+}
+
+/**
+ * \brief Reset the current configuration of the USB device,
+ * This routines can be called by UDD when a RESET on the USB line occurs.
+ */
+void udc_reset(void)
+{
+	uint8_t iface_num;
+
+	if (udc_num_configuration) {
+		for (iface_num = 0;
+				iface_num < udc_ptr_conf->desc->bNumInterfaces;
+				iface_num++) {
+			udc_iface_disable(iface_num);
+		}
+	}
+	udc_num_configuration = 0;
+#if (USB_CONFIG_ATTR_REMOTE_WAKEUP \
+	== (USB_DEVICE_ATTR & USB_CONFIG_ATTR_REMOTE_WAKEUP))
+	if (CPU_TO_LE16(USB_DEV_STATUS_REMOTEWAKEUP) & udc_device_status) {
+		// Remote wakeup is enabled then disable it
+		UDC_REMOTEWAKEUP_DISABLE();
+	}
+#endif
+	udc_device_status =
+#if (USB_DEVICE_ATTR & USB_CONFIG_ATTR_SELF_POWERED)
+			CPU_TO_LE16(USB_DEV_STATUS_SELF_POWERED);
+#else
+			CPU_TO_LE16(USB_DEV_STATUS_BUS_POWERED);
+#endif
+}
+
+void udc_sof_notify(void)
+{
+	uint8_t iface_num;
+
+	if (udc_num_configuration) {
+		for (iface_num = 0;
+				iface_num < udc_ptr_conf->desc->bNumInterfaces;
+				iface_num++) {
+			if (udc_ptr_conf->udi_apis[iface_num]->sof_notify != NULL) {
+				udc_ptr_conf->udi_apis[iface_num]->sof_notify();
+			}
+		}
+	}
+}
+
+/**
+ * \brief Standard device request to get device status
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_get_status(void)
+{
+	if (udd_g_ctrlreq.req.wLength != sizeof(udc_device_status)) {
+		return false;
+	}
+
+	udd_set_setup_payload( (uint8_t *) & udc_device_status,
+			sizeof(udc_device_status));
+	return true;
+}
+
+#if (0!=USB_DEVICE_MAX_EP)
+/**
+ * \brief Standard endpoint request to get endpoint status
+ *
+ * \return true if success
+ */
+static bool udc_req_std_ep_get_status(void)
+{
+	static le16_t udc_ep_status;
+
+	if (udd_g_ctrlreq.req.wLength != sizeof(udc_ep_status)) {
+		return false;
+	}
+
+	udc_ep_status = udd_ep_is_halted(udd_g_ctrlreq.req.
+			wIndex & 0xFF) ? CPU_TO_LE16(USB_EP_STATUS_HALTED) : 0;
+
+	udd_set_setup_payload( (uint8_t *) & udc_ep_status,
+			sizeof(udc_ep_status));
+	return true;
+}
+#endif
+
+/**
+ * \brief Standard device request to change device status
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_clear_feature(void)
+{
+	if (udd_g_ctrlreq.req.wLength) {
+		return false;
+	}
+
+	if (udd_g_ctrlreq.req.wValue == USB_DEV_FEATURE_REMOTE_WAKEUP) {
+		udc_device_status &= CPU_TO_LE16(~(uint32_t)USB_DEV_STATUS_REMOTEWAKEUP);
+#if (USB_CONFIG_ATTR_REMOTE_WAKEUP \
+	== (USB_DEVICE_ATTR & USB_CONFIG_ATTR_REMOTE_WAKEUP))
+		UDC_REMOTEWAKEUP_DISABLE();
+#endif
+		return true;
+	}
+	return false;
+}
+
+#if (0!=USB_DEVICE_MAX_EP)
+/**
+ * \brief Standard endpoint request to clear endpoint feature
+ *
+ * \return true if success
+ */
+static bool udc_req_std_ep_clear_feature(void)
+{
+	if (udd_g_ctrlreq.req.wLength) {
+		return false;
+	}
+
+	if (udd_g_ctrlreq.req.wValue == USB_EP_FEATURE_HALT) {
+		return udd_ep_clear_halt(udd_g_ctrlreq.req.wIndex & 0xFF);
+	}
+	return false;
+}
+#endif
+
+/**
+ * \brief Standard device request to set a feature
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_set_feature(void)
+{
+	if (udd_g_ctrlreq.req.wLength) {
+		return false;
+	}
+
+	switch (udd_g_ctrlreq.req.wValue) {
+
+	case USB_DEV_FEATURE_REMOTE_WAKEUP:
+#if (USB_CONFIG_ATTR_REMOTE_WAKEUP \
+	== (USB_DEVICE_ATTR & USB_CONFIG_ATTR_REMOTE_WAKEUP))
+		udc_device_status |= CPU_TO_LE16(USB_DEV_STATUS_REMOTEWAKEUP);
+		UDC_REMOTEWAKEUP_ENABLE();
+		return true;
+#else
+		return false;
+#endif
+
+#ifdef USB_DEVICE_HS_SUPPORT
+	case USB_DEV_FEATURE_TEST_MODE:
+		if (!udd_is_high_speed()) {
+			break;
+		}
+		if (udd_g_ctrlreq.req.wIndex & 0xff) {
+			break;
+		}
+		// Unconfigure the device, terminating all ongoing requests
+		udc_reset();
+		switch ((udd_g_ctrlreq.req.wIndex >> 8) & 0xFF) {
+		case USB_DEV_TEST_MODE_J:
+			udd_g_ctrlreq.callback = udd_test_mode_j;
+			return true;
+
+		case USB_DEV_TEST_MODE_K:
+			udd_g_ctrlreq.callback = udd_test_mode_k;
+			return true;
+
+		case USB_DEV_TEST_MODE_SE0_NAK:
+			udd_g_ctrlreq.callback = udd_test_mode_se0_nak;
+			return true;
+
+		case USB_DEV_TEST_MODE_PACKET:
+			udd_g_ctrlreq.callback = udd_test_mode_packet;
+			return true;
+
+		case USB_DEV_TEST_MODE_FORCE_ENABLE: // Only for downstream facing hub ports
+		default:
+			break;
+		}
+		break;
+#endif
+	default:
+		break;
+	}
+	return false;
+}
+
+/**
+ * \brief Standard endpoint request to halt an endpoint
+ *
+ * \return true if success
+ */
+#if (0!=USB_DEVICE_MAX_EP)
+static bool udc_req_std_ep_set_feature(void)
+{
+	if (udd_g_ctrlreq.req.wLength) {
+		return false;
+	}
+	if (udd_g_ctrlreq.req.wValue == USB_EP_FEATURE_HALT) {
+		udd_ep_abort(udd_g_ctrlreq.req.wIndex & 0xFF);
+		return udd_ep_set_halt(udd_g_ctrlreq.req.wIndex & 0xFF);
+	}
+	return false;
+}
+#endif
+
+/**
+ * \brief Change the address of device
+ * Callback called at the end of request set address
+ */
+static void udc_valid_address(void)
+{
+	udd_set_address(udd_g_ctrlreq.req.wValue & 0x7F);
+}
+
+/**
+ * \brief Standard device request to set device address
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_set_address(void)
+{
+	if (udd_g_ctrlreq.req.wLength) {
+		return false;
+	}
+
+	// The address must be changed at the end of setup request after the handshake
+	// then we use a callback to change address
+	udd_g_ctrlreq.callback = udc_valid_address;
+	return true;
+}
+
+/**
+ * \brief Standard device request to get device string descriptor
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_get_str_desc(void)
+{
+	uint8_t i;
+	const uint8_t *str;
+	uint8_t str_length = 0;
+
+	// Link payload pointer to the string corresponding at request
+	switch (udd_g_ctrlreq.req.wValue & 0xff) {
+	case 0:
+		udd_set_setup_payload((uint8_t *) &udc_string_desc_languageid,
+				sizeof(udc_string_desc_languageid));
+		break;
+
+#ifdef USB_DEVICE_MANUFACTURE_NAME
+	case 1:
+		str_length = USB_DEVICE_MANUFACTURE_NAME_SIZE;
+		str = udc_string_manufacturer_name;
+		break;
+#endif
+#ifdef USB_DEVICE_PRODUCT_NAME
+	case 2:
+		str_length = USB_DEVICE_PRODUCT_NAME_SIZE;
+		str = udc_string_product_name;
+		break;
+#endif
+#if defined USB_DEVICE_SERIAL_NAME || defined USB_DEVICE_GET_SERIAL_NAME_POINTER
+	case 3:
+		str_length = USB_DEVICE_SERIAL_NAME_SIZE;
+		str = udc_get_string_serial_name();
+		break;
+#endif
+	default:
+#ifdef UDC_GET_EXTRA_STRING
+		if (UDC_GET_EXTRA_STRING()) {
+			break;
+		}
+#endif
+		return false;
+	}
+
+	if (str_length) {
+		for(i = 0; i < str_length; i++) {
+			udc_string_desc.string[i] = cpu_to_le16((le16_t)str[i]);
+		}
+
+		udc_string_desc.header.bLength = 2 + (str_length) * 2;
+		udd_set_setup_payload(
+			(uint8_t *) &udc_string_desc,
+			udc_string_desc.header.bLength);
+	}
+
+	return true;
+}
+
+/**
+ * \brief Standard device request to get descriptors about USB device
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_get_descriptor(void)
+{
+	uint8_t conf_num;
+
+	conf_num = udd_g_ctrlreq.req.wValue & 0xff;
+
+	// Check descriptor ID
+	switch ((uint8_t) (udd_g_ctrlreq.req.wValue >> 8)) {
+	case USB_DT_DEVICE:
+		// Device descriptor requested
+#ifdef USB_DEVICE_HS_SUPPORT
+		if (!udd_is_high_speed()) {
+			udd_set_setup_payload(
+				(uint8_t *) udc_config.confdev_hs,
+				udc_config.confdev_hs->bLength);
+		} else
+#endif
+		{
+			udd_set_setup_payload(
+				(uint8_t *) udc_config.confdev_lsfs,
+				udc_config.confdev_lsfs->bLength);
+		}
+		break;
+
+	case USB_DT_CONFIGURATION:
+		// Configuration descriptor requested
+#ifdef USB_DEVICE_HS_SUPPORT
+		if (udd_is_high_speed()) {
+			// HS descriptor
+			if (conf_num >= udc_config.confdev_hs->
+					bNumConfigurations) {
+				return false;
+			}
+			udd_set_setup_payload(
+				(uint8_t *)udc_config.conf_hs[conf_num].desc,
+				le16_to_cpu(udc_config.conf_hs[conf_num].desc->wTotalLength));
+		} else
+#endif
+		{
+			// FS descriptor
+			if (conf_num >= udc_config.confdev_lsfs->
+					bNumConfigurations) {
+				return false;
+			}
+			udd_set_setup_payload(
+				(uint8_t *)udc_config.conf_lsfs[conf_num].desc,
+				le16_to_cpu(udc_config.conf_lsfs[conf_num].desc->wTotalLength));
+		}
+		((usb_conf_desc_t *) udd_g_ctrlreq.payload)->bDescriptorType =
+				USB_DT_CONFIGURATION;
+		break;
+
+#ifdef USB_DEVICE_HS_SUPPORT
+	case USB_DT_DEVICE_QUALIFIER:
+		// Device qualifier descriptor requested
+		udd_set_setup_payload( (uint8_t *) udc_config.qualifier,
+				udc_config.qualifier->bLength);
+		break;
+
+	case USB_DT_OTHER_SPEED_CONFIGURATION:
+		// Other configuration descriptor requested
+		if (!udd_is_high_speed()) {
+			// HS descriptor
+			if (conf_num >= udc_config.confdev_hs->
+					bNumConfigurations) {
+				return false;
+			}
+			udd_set_setup_payload(
+				(uint8_t *)udc_config.conf_hs[conf_num].desc,
+				le16_to_cpu(udc_config.conf_hs[conf_num].desc->wTotalLength));
+		} else {
+			// FS descriptor
+			if (conf_num >= udc_config.confdev_lsfs->
+					bNumConfigurations) {
+				return false;
+			}
+			udd_set_setup_payload(
+				(uint8_t *)udc_config.conf_lsfs[conf_num].desc,
+				le16_to_cpu(udc_config.conf_lsfs[conf_num].desc->wTotalLength));
+		}
+		((usb_conf_desc_t *) udd_g_ctrlreq.payload)->bDescriptorType =
+				USB_DT_OTHER_SPEED_CONFIGURATION;
+		break;
+#endif
+
+	case USB_DT_BOS:
+		// Device BOS descriptor requested
+		if (udc_config.conf_bos == NULL) {
+			return false;
+		}
+		udd_set_setup_payload( (uint8_t *) udc_config.conf_bos,
+				udc_config.conf_bos->wTotalLength);
+		break;
+
+	case USB_DT_STRING:
+		// String descriptor requested
+		if (!udc_req_std_dev_get_str_desc()) {
+			return false;
+		}
+		break;
+
+	default:
+		// Unknown descriptor requested
+		return false;
+	}
+	// if the descriptor is larger than length requested, then reduce it
+	if (udd_g_ctrlreq.req.wLength < udd_g_ctrlreq.payload_size) {
+		udd_g_ctrlreq.payload_size = udd_g_ctrlreq.req.wLength;
+	}
+	return true;
+}
+
+/**
+ * \brief Standard device request to get configuration number
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_get_configuration(void)
+{
+	if (udd_g_ctrlreq.req.wLength != 1) {
+		return false;
+	}
+
+	udd_set_setup_payload(&udc_num_configuration,1);
+	return true;
+}
+
+/**
+ * \brief Standard device request to enable a configuration
+ *
+ * \return true if success
+ */
+static bool udc_req_std_dev_set_configuration(void)
+{
+	uint8_t iface_num;
+
+	// Check request length
+	if (udd_g_ctrlreq.req.wLength) {
+		return false;
+	}
+	// Authorize configuration only if the address is valid
+	if (!udd_getaddress()) {
+		return false;
+	}
+	// Check the configuration number requested
+#ifdef USB_DEVICE_HS_SUPPORT
+	if (udd_is_high_speed()) {
+		// HS descriptor
+		if ((udd_g_ctrlreq.req.wValue & 0xFF) >
+				udc_config.confdev_hs->bNumConfigurations) {
+			return false;
+		}
+	} else
+#endif
+	{
+		// FS descriptor
+		if ((udd_g_ctrlreq.req.wValue & 0xFF) >
+				udc_config.confdev_lsfs->bNumConfigurations) {
+			return false;
+		}
+	}
+
+	// Reset current configuration
+	udc_reset();
+
+	// Enable new configuration
+	udc_num_configuration = udd_g_ctrlreq.req.wValue & 0xFF;
+	if (udc_num_configuration == 0) {
+		return true; // Default empty configuration requested
+	}
+	// Update pointer of the configuration descriptor
+#ifdef USB_DEVICE_HS_SUPPORT
+	if (udd_is_high_speed()) {
+		// HS descriptor
+		udc_ptr_conf = &udc_config.conf_hs[udc_num_configuration - 1];
+	} else
+#endif
+	{
+		// FS descriptor
+		udc_ptr_conf = &udc_config.conf_lsfs[udc_num_configuration - 1];
+	}
+	// Enable all interfaces of the selected configuration
+	for (iface_num = 0; iface_num < udc_ptr_conf->desc->bNumInterfaces;
+			iface_num++) {
+		if (!udc_iface_enable(iface_num, 0)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+/**
+ * \brief Standard interface request
+ * to get the alternate setting number of an interface
+ *
+ * \return true if success
+ */
+static bool udc_req_std_iface_get_setting(void)
+{
+	uint8_t iface_num;
+	udi_api_t UDC_DESC_STORAGE *udi_api;
+
+	if (udd_g_ctrlreq.req.wLength != 1) {
+		return false; // Error in request
+	}
+	if (!udc_num_configuration) {
+		return false; // The device is not is configured state yet
+	}
+
+	// Check the interface number included in the request
+	iface_num = udd_g_ctrlreq.req.wIndex & 0xFF;
+	if (iface_num >= udc_ptr_conf->desc->bNumInterfaces) {
+		return false;
+	}
+
+	// Select first alternate setting of the interface to update udc_ptr_iface
+	// before call iface->getsetting()
+	if (!udc_update_iface_desc(iface_num, 0)) {
+		return false;
+	}
+	// Get alternate setting from UDI
+	udi_api = udc_ptr_conf->udi_apis[iface_num];
+	udc_iface_setting = udi_api->getsetting();
+
+	// Link value to payload pointer of request
+	udd_set_setup_payload(&udc_iface_setting,1);
+	return true;
+}
+
+/**
+ * \brief Standard interface request
+ * to set an alternate setting of an interface
+ *
+ * \return true if success
+ */
+static bool udc_req_std_iface_set_setting(void)
+{
+	uint8_t iface_num, setting_num;
+
+	if (udd_g_ctrlreq.req.wLength) {
+		return false; // Error in request
+	}
+	if (!udc_num_configuration) {
+		return false; // The device is not is configured state yet
+	}
+
+	iface_num = udd_g_ctrlreq.req.wIndex & 0xFF;
+	setting_num = udd_g_ctrlreq.req.wValue & 0xFF;
+
+	// Disable current setting
+	if (!udc_iface_disable(iface_num)) {
+		return false;
+	}
+
+	// Enable new setting
+	return udc_iface_enable(iface_num, setting_num);
+}
+
+/**
+ * \brief Main routine to manage the standard USB SETUP request
+ *
+ * \return true if the request is supported
+ */
+static bool udc_reqstd(void)
+{
+	if (Udd_setup_is_in()) {
+		// GET Standard Requests
+		if (udd_g_ctrlreq.req.wLength == 0) {
+			return false; // Error for USB host
+		}
+
+		if (USB_REQ_RECIP_DEVICE == Udd_setup_recipient()) {
+			// Standard Get Device request
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_GET_STATUS:
+				return udc_req_std_dev_get_status();
+			case USB_REQ_GET_DESCRIPTOR:
+				return udc_req_std_dev_get_descriptor();
+			case USB_REQ_GET_CONFIGURATION:
+				return udc_req_std_dev_get_configuration();
+			default:
+				break;
+			}
+		}
+
+		if (USB_REQ_RECIP_INTERFACE == Udd_setup_recipient()) {
+			// Standard Get Interface request
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_GET_INTERFACE:
+				return udc_req_std_iface_get_setting();
+			default:
+				break;
+			}
+		}
+#if (0!=USB_DEVICE_MAX_EP)
+		if (USB_REQ_RECIP_ENDPOINT == Udd_setup_recipient()) {
+			// Standard Get Endpoint request
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_GET_STATUS:
+				return udc_req_std_ep_get_status();
+			default:
+				break;
+			}
+		}
+#endif
+	} else {
+		// SET Standard Requests
+		if (USB_REQ_RECIP_DEVICE == Udd_setup_recipient()) {
+			// Standard Set Device request
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_SET_ADDRESS:
+				return udc_req_std_dev_set_address();
+			case USB_REQ_CLEAR_FEATURE:
+				return udc_req_std_dev_clear_feature();
+			case USB_REQ_SET_FEATURE:
+				return udc_req_std_dev_set_feature();
+			case USB_REQ_SET_CONFIGURATION:
+				return udc_req_std_dev_set_configuration();
+			case USB_REQ_SET_DESCRIPTOR:
+				/* Not supported (defined as optional by the USB 2.0 spec) */
+				break;
+			default:
+				break;
+			}
+		}
+
+		if (USB_REQ_RECIP_INTERFACE == Udd_setup_recipient()) {
+			// Standard Set Interface request
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_SET_INTERFACE:
+				return udc_req_std_iface_set_setting();
+			default:
+				break;
+			}
+		}
+#if (0!=USB_DEVICE_MAX_EP)
+		if (USB_REQ_RECIP_ENDPOINT == Udd_setup_recipient()) {
+			// Standard Set Endpoint request
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_CLEAR_FEATURE:
+				return udc_req_std_ep_clear_feature();
+			case USB_REQ_SET_FEATURE:
+				return udc_req_std_ep_set_feature();
+			default:
+				break;
+			}
+		}
+#endif
+	}
+	return false;
+}
+
+/**
+ * \brief Send the SETUP interface request to UDI
+ *
+ * \return true if the request is supported
+ */
+static bool udc_req_iface(void)
+{
+	uint8_t iface_num;
+	udi_api_t UDC_DESC_STORAGE *udi_api;
+
+	if (0 == udc_num_configuration) {
+		return false; // The device is not is configured state yet
+	}
+	// Check interface number
+	iface_num = udd_g_ctrlreq.req.wIndex & 0xFF;
+	if (iface_num >= udc_ptr_conf->desc->bNumInterfaces) {
+		return false;
+	}
+
+	//* To update udc_ptr_iface with the selected interface in request
+	// Select first alternate setting of interface to update udc_ptr_iface
+	// before calling udi_api->getsetting()
+	if (!udc_update_iface_desc(iface_num, 0)) {
+		return false;
+	}
+	// Select the interface with the current alternate setting
+	udi_api = udc_ptr_conf->udi_apis[iface_num];
+	if (!udc_update_iface_desc(iface_num, udi_api->getsetting())) {
+		return false;
+	}
+
+	// Send the SETUP request to the UDI corresponding to the interface number
+	return udi_api->setup();
+}
+
+/**
+ * \brief Send the SETUP interface request to UDI
+ *
+ * \return true if the request is supported
+ */
+static bool udc_req_ep(void)
+{
+	uint8_t iface_num;
+	udi_api_t UDC_DESC_STORAGE *udi_api;
+
+	if (0 == udc_num_configuration) {
+		return false; // The device is not is configured state yet
+	}
+	// Send this request on all enabled interfaces
+	iface_num = udd_g_ctrlreq.req.wIndex & 0xFF;
+	for (iface_num = 0; iface_num < udc_ptr_conf->desc->bNumInterfaces;
+			iface_num++) {
+		// Select the interface with the current alternate setting
+		udi_api = udc_ptr_conf->udi_apis[iface_num];
+		if (!udc_update_iface_desc(iface_num, udi_api->getsetting())) {
+			return false;
+		}
+
+		// Send the SETUP request to the UDI
+		if (udi_api->setup()) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * \brief Main routine to manage the USB SETUP request.
+ *
+ * This function parses a USB SETUP request and submits an appropriate
+ * response back to the host or, in the case of SETUP OUT requests
+ * with data, sets up a buffer for receiving the data payload.
+ *
+ * The main standard requests defined by the USB 2.0 standard are handled
+ * internally. The interface requests are sent to UDI, and the specific request
+ * sent to a specific application callback.
+ *
+ * \return true if the request is supported, else the request is stalled by UDD
+ */
+bool udc_process_setup(void)
+{
+	// By default no data (receive/send) and no callbacks registered
+	udd_g_ctrlreq.payload_size = 0;
+	udd_g_ctrlreq.callback = NULL;
+	udd_g_ctrlreq.over_under_run = NULL;
+
+	if (Udd_setup_is_in()) {
+		if (udd_g_ctrlreq.req.wLength == 0) {
+			return false; // Error from USB host
+		}
+	}
+
+	// If standard request then try to decode it in UDC
+	if (Udd_setup_type() == USB_REQ_TYPE_STANDARD) {
+		if (udc_reqstd()) {
+			return true;
+		}
+	}
+
+	// If interface request then try to decode it in UDI
+	if (Udd_setup_recipient() == USB_REQ_RECIP_INTERFACE) {
+		if (udc_req_iface()) {
+			return true;
+		}
+	}
+
+	// If endpoint request then try to decode it in UDI
+	if (Udd_setup_recipient() == USB_REQ_RECIP_ENDPOINT) {
+		if (udc_req_ep()) {
+			return true;
+		}
+	}
+
+	// Here SETUP request unknown by UDC and UDIs
+#ifdef USB_DEVICE_SPECIFIC_REQUEST
+	// Try to decode it in specific callback
+	return USB_DEVICE_SPECIFIC_REQUEST(); // Ex: Vendor request,...
+#else
+	return false;
+#endif
+}
+
+//! @}
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/udc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udc.h
@@ -1,0 +1,697 @@
+/**
+ * \file
+ *
+ * \brief Interface of the USB Device Controller (UDC)
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _UDC_H_
+#define _UDC_H_
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "udc_desc.h"
+#include "udd.h"
+
+#if USB_DEVICE_VENDOR_ID == 0
+#   error USB_DEVICE_VENDOR_ID cannot be equal to 0
+#endif
+
+#if USB_DEVICE_PRODUCT_ID == 0
+#   error USB_DEVICE_PRODUCT_ID cannot be equal to 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \ingroup usb_device_group
+ * \defgroup udc_group USB Device Controller (UDC)
+ *
+ * The UDC provides a high-level abstraction of the usb device.
+ * You can use these functions to control the main device state
+ * (start/attach/wakeup).
+ *
+ * \section USB_DEVICE_CONF USB Device Custom configuration
+ * The following USB Device configuration must be included in the conf_usb.h
+ * file of the application.
+ *
+ * USB_DEVICE_VENDOR_ID (Word)<br>
+ * Vendor ID provided by USB org (ATMEL 0x03EB).
+ *
+ * USB_DEVICE_PRODUCT_ID (Word)<br>
+ * Product ID (Referenced in usb_atmel.h).
+ *
+ * USB_DEVICE_MAJOR_VERSION (Byte)<br>
+ * Major version of the device
+ *
+ * USB_DEVICE_MINOR_VERSION (Byte)<br>
+ * Minor version of the device
+ *
+ * USB_DEVICE_MANUFACTURE_NAME (string)<br>
+ * ASCII name for the manufacture
+ *
+ * USB_DEVICE_PRODUCT_NAME (string)<br>
+ * ASCII name for the product
+ *
+ * USB_DEVICE_SERIAL_NAME (string)<br>
+ * ASCII name to enable and set a serial number
+ *
+ * USB_DEVICE_POWER (Numeric)<br>
+ * (unit mA) Maximum device power
+ *
+ * USB_DEVICE_ATTR (Byte)<br>
+ * USB attributes available:
+ *  - USB_CONFIG_ATTR_SELF_POWERED
+ *  - USB_CONFIG_ATTR_REMOTE_WAKEUP
+ *  Note: if remote wake enabled then defines remotewakeup callbacks,
+ * see Table 5-2. External API from UDC - Callback
+ *
+ * USB_DEVICE_LOW_SPEED (Only defined)<br>
+ * Force the USB Device to run in low speed
+ *
+ * USB_DEVICE_HS_SUPPORT (Only defined)<br>
+ * Authorize the USB Device to run in high speed
+ *
+ * USB_DEVICE_MAX_EP (Byte)<br>
+ * Define the maximum endpoint number used by the USB Device.<br>
+ * This one is already defined in UDI default configuration.
+ * Ex:
+ * - When endpoint control 0x00, endpoint 0x01 and
+ *   endpoint 0x82 is used then USB_DEVICE_MAX_EP=2
+ * - When only endpoint control 0x00 is used then USB_DEVICE_MAX_EP=0
+ * - When endpoint 0x01 and endpoint 0x81 is used then USB_DEVICE_MAX_EP=1<br>
+ *   (configuration not possible on USBB interface)
+ * @{
+ */
+
+/**
+ * \brief Authorizes the VBUS event
+ *
+ * \return true, if the VBUS monitoring is possible.
+ *
+ * \section udc_vbus_monitoring VBus monitoring used cases
+ *
+ * The VBus monitoring is used only for USB SELF Power application.
+ *
+ * - By default the USB device is automatically attached when Vbus is high
+ * or when USB is start for devices without internal Vbus monitoring.
+ * conf_usb.h file does not contains define USB_DEVICE_ATTACH_AUTO_DISABLE.
+ * \code //#define USB_DEVICE_ATTACH_AUTO_DISABLE \endcode
+ *
+ * - Add custom VBUS monitoring. conf_usb.h file contains define
+ * USB_DEVICE_ATTACH_AUTO_DISABLE:
+ * \code #define USB_DEVICE_ATTACH_AUTO_DISABLE \endcode
+ * User C file contains:
+ * \code  
+	// Authorize VBUS monitoring
+	if (!udc_include_vbus_monitoring()) {
+	  // Implement custom VBUS monitoring via GPIO or other
+	}
+	Event_VBUS_present() // VBUS interrupt or GPIO interrupt or other
+	{
+	  // Attach USB Device
+	  udc_attach();
+	}
+\endcode
+ *
+ * - Case of battery charging. conf_usb.h file contains define
+ * USB_DEVICE_ATTACH_AUTO_DISABLE:
+ * \code #define USB_DEVICE_ATTACH_AUTO_DISABLE \endcode
+ * User C file contains:
+ * \code  
+	Event VBUS present() // VBUS interrupt or GPIO interrupt or ..
+	{
+	  // Authorize battery charging, but wait key press to start USB.
+	}
+	Event Key press()
+	{
+	  // Stop batteries charging
+	  // Start USB
+	  udc_attach();
+	}
+\endcode
+ */
+static inline bool udc_include_vbus_monitoring(void)
+{
+	return udd_include_vbus_monitoring();
+}
+
+/*! \brief Start the USB Device stack
+ */
+void udc_start(void);
+
+/*! \brief Stop the USB Device stack
+ */
+void udc_stop(void);
+
+/**
+ * \brief Attach device to the bus when possible
+ *
+ * \warning If a VBus control is included in driver,
+ * then it will attach device when an acceptable Vbus
+ * level from the host is detected.
+ */
+static inline void udc_attach(void)
+{
+	udd_attach();
+}
+
+
+/**
+ * \brief Detaches the device from the bus
+ *
+ * The driver must remove pull-up on USB line D- or D+.
+ */
+static inline void udc_detach(void)
+{
+	udd_detach();
+}
+
+
+/*! \brief The USB driver sends a resume signal called \e "Upstream Resume"
+ * This is authorized only when the remote wakeup feature is enabled by host.
+ */
+static inline void udc_remotewakeup(void)
+{
+	udd_send_remotewakeup();
+}
+
+
+/**
+ * \brief Returns a pointer on the current interface descriptor
+ *
+ * \return pointer on the current interface descriptor.
+ */
+usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc(void);
+
+//@}
+
+/**
+ * \ingroup usb_group
+ * \defgroup usb_device_group USB Stack Device
+ *
+ * This module includes USB Stack Device implementation.
+ * The stack is divided in three parts:
+ * - USB Device Controller (UDC) provides USB chapter 9 compliance
+ * - USB Device Interface (UDI) provides USB Class compliance
+ * - USB Device Driver (UDD) provides USB Driver for each Atmel MCU
+
+ * Many USB Device applications can be implemented on Atmel MCU.
+ * Atmel provides many application notes for different applications:
+ * - AVR4900, provides general information about Device Stack
+ * - AVR4901, explains how to create a new class
+ * - AVR4902, explains how to create a composite device
+ * - AVR49xx, all device classes provided in ASF have an application note
+ *
+ * A basic USB knowledge is required to understand the USB Device
+ * Class application notes (HID,MS,CDC,PHDC,...).
+ * Then, to create an USB device with
+ * only one class provided by ASF, refer directly to the application note
+ * corresponding to this USB class. The USB Device application note for
+ * New Class and Composite is dedicated to advanced USB users.
+ *
+ * @{
+ */
+
+//! @}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * \ingroup udc_group
+ * \defgroup udc_basic_use_case_setup_prereq USB Device Controller (UDC) - Prerequisites
+ * Common prerequisites for all USB devices.
+ *
+ * This module is based on USB device stack full interrupt driven, and supporting
+ * \ref sleepmgr_group sleepmgr. For AVR and SAM3/4 devices the \ref clk_group clock services
+ * is supported. For SAMD devices the \ref asfdoc_sam0_system_clock_group clock driver is supported.
+ *
+ * The following procedure must be executed to setup the project correctly:
+ * - Specify the clock configuration:
+ *   - XMEGA USB devices need 48MHz clock input.\n
+ *     XMEGA USB devices need CPU frequency higher than 12MHz.\n
+ *     You can use either an internal RC48MHz auto calibrated by Start of Frames
+ *     or an external OSC.
+ *   - UC3 and SAM3/4 devices without USB high speed support need 48MHz clock input.\n
+ *     You must use a PLL and an external OSC.
+ *   - UC3 and SAM3/4 devices with USB high speed support need 12MHz clock input.\n
+ *     You must use an external OSC.
+ *   - UC3 devices with USBC hardware need CPU frequency higher than 25MHz.
+ *   - SAMD devices without USB high speed support need 48MHz clock input.\n
+ *     You should use DFLL with USBCRM.
+ * - In conf_board.h, the define CONF_BOARD_USB_PORT must be added to enable USB lines.
+ * (Not mandatory for all boards)
+ * - Enable interrupts
+ * - Initialize the clock service
+ *
+ * The usage of \ref sleepmgr_group sleepmgr service is optional, but recommended to reduce power
+ * consumption:
+ * - Initialize the sleep manager service
+ * - Activate sleep mode when the application is in IDLE state
+ *
+ * \subpage udc_conf_clock.
+ *
+ * for AVR and SAM3/4 devices, add to the initialization code:
+ * \code
+	sysclk_init();
+	irq_initialize_vectors();
+	cpu_irq_enable();
+	board_init();
+	sleepmgr_init(); // Optional
+\endcode
+ *
+ * For SAMD devices, add to the initialization code:
+ * \code
+	system_init();
+	irq_initialize_vectors();
+	cpu_irq_enable();
+	sleepmgr_init(); // Optional
+\endcode
+ * Add to the main IDLE loop:
+ * \code
+	sleepmgr_enter_sleep(); // Optional
+\endcode
+ *
+ */
+
+/**
+ * \ingroup udc_group
+ * \defgroup udc_basic_use_case_setup_code USB Device Controller (UDC) - Example code
+ * Common example code for all USB devices.
+ *
+ * Content of conf_usb.h:
+ * \code
+	#define USB_DEVICE_VENDOR_ID 0x03EB
+	#define USB_DEVICE_PRODUCT_ID 0xXXXX
+	#define USB_DEVICE_MAJOR_VERSION 1
+	#define USB_DEVICE_MINOR_VERSION 0
+	#define USB_DEVICE_POWER 100
+	#define USB_DEVICE_ATTR USB_CONFIG_ATTR_BUS_POWERED
+\endcode
+ *
+ * Add to application C-file:
+ * \code
+	void usb_init(void)
+	{
+	  udc_start();
+	}
+\endcode
+ */
+
+/**
+ * \ingroup udc_group
+ * \defgroup udc_basic_use_case_setup_flow USB Device Controller (UDC) - Workflow
+ * Common workflow for all USB devices.
+ *
+ * -# Ensure that conf_usb.h is available and contains the following configuration
+ * which is the main USB device configuration:
+ *   - \code // Vendor ID provided by USB org (ATMEL 0x03EB)
+	#define USB_DEVICE_VENDOR_ID 0x03EB // Type Word
+	// Product ID (Atmel PID referenced in usb_atmel.h)
+	#define USB_DEVICE_PRODUCT_ID 0xXXXX // Type Word
+	// Major version of the device
+	#define USB_DEVICE_MAJOR_VERSION 1 // Type Byte
+	// Minor version of the device
+	#define USB_DEVICE_MINOR_VERSION 0 // Type Byte
+	// Maximum device power (mA)
+	#define USB_DEVICE_POWER 100 // Type 9-bits
+	// USB attributes to enable features
+	#define USB_DEVICE_ATTR USB_CONFIG_ATTR_BUS_POWERED // Flags \endcode
+ * -# Call the USB device stack start function to enable stack and start USB:
+ *   - \code udc_start(); \endcode
+ *     \note In case of USB dual roles (Device and Host) managed through USB OTG connector
+ * (USB ID pin), the call of udc_start() must be removed and replaced by uhc_start().
+ * SeRefer to "AVR4950 section 6.1 Dual roles" for further information about dual roles.
+ */
+
+/**
+ * \page udc_conf_clock conf_clock.h examples with USB support
+ *
+ * Content of XMEGA conf_clock.h:
+ * \code
+	// Configuration based on internal RC:
+	// USB clock need of 48Mhz
+	#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_RCOSC
+	#define CONFIG_OSC_RC32_CAL         48000000UL
+	#define CONFIG_OSC_AUTOCAL_RC32MHZ_REF_OSC  OSC_ID_USBSOF
+	// CPU clock need of clock > 12MHz to run with USB (Here 24MHz)
+	#define CONFIG_SYSCLK_SOURCE     SYSCLK_SRC_RC32MHZ
+	#define CONFIG_SYSCLK_PSADIV     SYSCLK_PSADIV_2
+	#define CONFIG_SYSCLK_PSBCDIV    SYSCLK_PSBCDIV_1_1
+\endcode
+ *
+ * Content of conf_clock.h for AT32UC3A0, AT32UC3A1, AT32UC3B devices (USBB):
+ * \code
+	// Configuration based on 12MHz external OSC:
+	#define CONFIG_PLL1_SOURCE          PLL_SRC_OSC0
+	#define CONFIG_PLL1_MUL             8
+	#define CONFIG_PLL1_DIV             2
+	#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_PLL1
+	#define CONFIG_USBCLK_DIV           1 // Fusb = Fsys/(2 ^ USB_div)
+\endcode
+ *
+ * Content of conf_clock.h for AT32UC3A3, AT32UC3A4 devices (USBB with high speed support):
+ * \code
+	// Configuration based on 12MHz external OSC:
+	#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_OSC0
+	#define CONFIG_USBCLK_DIV           1 // Fusb = Fsys/(2 ^ USB_div)
+\endcode
+ *
+ * Content of conf_clock.h for AT32UC3C, ATUCXXD, ATUCXXL3U, ATUCXXL4U devices (USBC):
+ * \code
+	// Configuration based on 12MHz external OSC:
+	#define CONFIG_PLL1_SOURCE          PLL_SRC_OSC0
+	#define CONFIG_PLL1_MUL             8
+	#define CONFIG_PLL1_DIV             2
+	#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_PLL1
+	#define CONFIG_USBCLK_DIV           1 // Fusb = Fsys/(2 ^ USB_div)
+	// CPU clock need of clock > 25MHz to run with USBC
+	#define CONFIG_SYSCLK_SOURCE        SYSCLK_SRC_PLL1
+\endcode
+ *
+ * Content of conf_clock.h for SAM3S, SAM3SD, SAM4S devices (UPD: USB Peripheral Device):
+ * \code
+	// PLL1 (B) Options   (Fpll = (Fclk * PLL_mul) / PLL_div)
+	#define CONFIG_PLL1_SOURCE          PLL_SRC_MAINCK_XTAL
+	#define CONFIG_PLL1_MUL             16
+	#define CONFIG_PLL1_DIV             2
+	// USB Clock Source Options   (Fusb = FpllX / USB_div)
+	#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_PLL1
+	#define CONFIG_USBCLK_DIV           2
+\endcode
+ *
+ * Content of conf_clock.h for SAM3U device (UPDHS: USB Peripheral Device High Speed):
+ * \code
+	// USB Clock Source fixed at UPLL.
+\endcode
+ *
+ * Content of conf_clock.h for SAM3X, SAM3A devices (UOTGHS: USB OTG High Speed):
+ * \code
+	// USB Clock Source fixed at UPLL.
+	#define CONFIG_USBCLK_SOURCE        USBCLK_SRC_UPLL
+	#define CONFIG_USBCLK_DIV           1
+\endcode
+ *
+ * Content of conf_clocks.h for SAMD devices (USB):
+ * \code
+	// System clock bus configuration
+	#  define CONF_CLOCK_FLASH_WAIT_STATES            2
+
+	// USB Clock Source fixed at DFLL.
+	// SYSTEM_CLOCK_SOURCE_DFLL configuration - Digital Frequency Locked Loop
+	#  define CONF_CLOCK_DFLL_ENABLE                  true
+	#  define CONF_CLOCK_DFLL_LOOP_MODE               SYSTEM_CLOCK_DFLL_LOOP_MODE_USB_RECOVERY
+	#  define CONF_CLOCK_DFLL_ON_DEMAND               true
+
+	// Set this to true to configure the GCLK when running clocks_init. 
+	// If set to false, none of the GCLK generators will be configured in clocks_init().
+	#  define CONF_CLOCK_CONFIGURE_GCLK               true
+
+	// Configure GCLK generator 0 (Main Clock)
+	#  define CONF_CLOCK_GCLK_0_ENABLE                true
+	#  define CONF_CLOCK_GCLK_0_RUN_IN_STANDBY        true
+	#  define CONF_CLOCK_GCLK_0_CLOCK_SOURCE          SYSTEM_CLOCK_SOURCE_DFLL
+	#  define CONF_CLOCK_GCLK_0_PRESCALER             1
+	#  define CONF_CLOCK_GCLK_0_OUTPUT_ENABLE         false
+\endcode
+ */
+
+/**
+ * \page udc_use_case_1 Change USB speed
+ *
+ * In this use case, the USB device is used with different USB speeds.
+ *
+ * \section udc_use_case_1_setup Setup steps
+ *
+ * Prior to implement this use case, be sure to have already
+ * apply the UDI module "basic use case".
+ *
+ * \section udc_use_case_1_usage Usage steps
+ *
+ * \subsection udc_use_case_1_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	 #if // Low speed
+	 #define USB_DEVICE_LOW_SPEED
+	 // #define USB_DEVICE_HS_SUPPORT
+
+	 #elif // Full speed
+	 // #define USB_DEVICE_LOW_SPEED
+	 // #define USB_DEVICE_HS_SUPPORT
+
+	 #elif // High speed
+	 // #define USB_DEVICE_LOW_SPEED
+	 #define USB_DEVICE_HS_SUPPORT
+
+	 #endif
+\endcode
+ *
+ * \subsection udc_use_case_1_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters
+ * required for a USB device low speed (1.5Mbit/s):
+ *   - \code #define USB_DEVICE_LOW_SPEED
+	 //#define  USB_DEVICE_HS_SUPPORT \endcode
+ * -# Ensure that conf_usb.h contains the following parameters
+ * required for a USB device full speed (12Mbit/s):
+ *   - \code //#define USB_DEVICE_LOW_SPEED
+	 //#define  USB_DEVICE_HS_SUPPORT \endcode
+ * -# Ensure that conf_usb.h contains the following parameters
+ * required for a USB device high speed (480Mbit/s):
+ *   - \code //#define USB_DEVICE_LOW_SPEED
+	 #define  USB_DEVICE_HS_SUPPORT \endcode
+ */
+
+/**
+ * \page udc_use_case_2 Use USB strings
+ *
+ * In this use case, the usual USB strings is added in the USB device.
+ *
+ * \section udc_use_case_2_setup Setup steps
+ * Prior to implement this use case, be sure to have already
+ * apply the UDI module "basic use case".
+ *
+ * \section udc_use_case_2_usage Usage steps
+ *
+ * \subsection udc_use_case_2_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	#define  USB_DEVICE_MANUFACTURE_NAME      "Manufacture name"
+	#define  USB_DEVICE_PRODUCT_NAME          "Product name"
+	#define  USB_DEVICE_SERIAL_NAME           "12...EF"
+\endcode
+ *
+ * \subsection udc_use_case_2_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters
+ * required to enable different USB strings:
+ *   - \code // Static ASCII name for the manufacture
+	#define  USB_DEVICE_MANUFACTURE_NAME "Manufacture name" \endcode
+ *   - \code // Static ASCII name for the product
+	#define  USB_DEVICE_PRODUCT_NAME "Product name" \endcode
+ *   - \code // Static ASCII name to enable and set a serial number
+	#define  USB_DEVICE_SERIAL_NAME "12...EF" \endcode
+ */
+
+/**
+ * \page udc_use_case_3 Use USB remote wakeup feature
+ *
+ * In this use case, the USB remote wakeup feature is enabled.
+ *
+ * \section udc_use_case_3_setup Setup steps
+ * Prior to implement this use case, be sure to have already
+ * apply the UDI module "basic use case".
+ *
+ * \section udc_use_case_3_usage Usage steps
+ *
+ * \subsection udc_use_case_3_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	#define  USB_DEVICE_ATTR \
+	  (USB_CONFIG_ATTR_REMOTE_WAKEUP | USB_CONFIG_ATTR_..._POWERED)
+	#define UDC_REMOTEWAKEUP_ENABLE() my_callback_remotewakeup_enable()
+	extern void my_callback_remotewakeup_enable(void);
+	#define UDC_REMOTEWAKEUP_DISABLE() my_callback_remotewakeup_disable()
+	extern void my_callback_remotewakeup_disable(void);
+\endcode
+ *
+ * Add to application C-file:
+ * \code
+	 void my_callback_remotewakeup_enable(void)
+	 {
+	    // Enable application wakeup events (e.g. enable GPIO interrupt)
+	 }
+	 void my_callback_remotewakeup_disable(void)
+	 {
+	    // Disable application wakeup events (e.g. disable GPIO interrupt)
+	 }
+
+	 void my_interrupt_event(void)
+	 {
+	    udc_remotewakeup();
+	 }
+\endcode
+ *
+ * \subsection udc_use_case_3_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters
+ * required to enable remote wakeup feature:
+ *   - \code // Authorizes the remote wakeup feature
+	     #define  USB_DEVICE_ATTR (USB_CONFIG_ATTR_REMOTE_WAKEUP | USB_CONFIG_ATTR_..._POWERED) \endcode
+ *   - \code // Define callback called when the host enables the remotewakeup feature
+	#define UDC_REMOTEWAKEUP_ENABLE() my_callback_remotewakeup_enable()
+	extern void my_callback_remotewakeup_enable(void); \endcode
+ *   - \code // Define callback called when the host disables the remotewakeup feature
+	#define UDC_REMOTEWAKEUP_DISABLE() my_callback_remotewakeup_disable()
+	extern void my_callback_remotewakeup_disable(void); \endcode
+ * -# Send a remote wakeup (USB upstream):
+ *   - \code udc_remotewakeup(); \endcode
+ */
+
+/**
+ * \page udc_use_case_5 Bus power application recommendations
+ *
+ * In this use case, the USB device BUS power feature is enabled.
+ * This feature requires a correct power consumption management.
+ *
+ * \section udc_use_case_5_setup Setup steps
+ * Prior to implement this use case, be sure to have already
+ * apply the UDI module "basic use case".
+ *
+ * \section udc_use_case_5_usage Usage steps
+ *
+ * \subsection udc_use_case_5_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	#define  USB_DEVICE_ATTR (USB_CONFIG_ATTR_BUS_POWERED)
+	#define  UDC_SUSPEND_EVENT()         user_callback_suspend_action()
+	extern void user_callback_suspend_action(void)
+	#define  UDC_RESUME_EVENT()          user_callback_resume_action()
+	extern void user_callback_resume_action(void)
+\endcode
+ *
+ * Add to application C-file:
+ * \code
+	void user_callback_suspend_action(void)
+	{
+	   // Disable hardware component to reduce power consumption
+	}
+	void user_callback_resume_action(void)
+	{
+	   // Re-enable hardware component
+	}
+\endcode
+ *
+ * \subsection udc_use_case_5_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters:
+ *   - \code // Authorizes the BUS power feature
+	#define  USB_DEVICE_ATTR (USB_CONFIG_ATTR_BUS_POWERED) \endcode
+ *   - \code // Define callback called when the host suspend the USB line
+	#define UDC_SUSPEND_EVENT() user_callback_suspend_action()
+	extern void user_callback_suspend_action(void); \endcode
+ *   - \code // Define callback called when the host or device resume the USB line
+	#define UDC_RESUME_EVENT() user_callback_resume_action()
+	extern void user_callback_resume_action(void); \endcode
+ * -# Reduce power consumption in suspend mode (max. 2.5mA on Vbus):
+ *   - \code void user_callback_suspend_action(void)
+	{
+	turn_off_components();
+	} \endcode
+ */
+
+/**
+ * \page udc_use_case_6 USB dynamic serial number
+ *
+ * In this use case, the USB serial strings is dynamic.
+ * For a static serial string refer to \ref udc_use_case_2.
+ *
+ * \section udc_use_case_6_setup Setup steps
+ * Prior to implement this use case, be sure to have already
+ * apply the UDI module "basic use case".
+ *
+ * \section udc_use_case_6_usage Usage steps
+ *
+ * \subsection udc_use_case_6_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	#define  USB_DEVICE_SERIAL_NAME
+	#define  USB_DEVICE_GET_SERIAL_NAME_POINTER serial_number
+	#define  USB_DEVICE_GET_SERIAL_NAME_LENGTH  12
+	extern uint8_t serial_number[];
+\endcode
+ *
+ * Add to application C-file:
+ * \code
+	 uint8_t serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH];
+
+	 void init_build_usb_serial_number(void)
+	 {
+	 serial_number[0] = 'A';
+	 serial_number[1] = 'B';
+	 ...
+	 serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH-1] = 'C';
+	 } \endcode
+ *
+ * \subsection udc_use_case_6_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters
+ * required to enable a USB serial number strings dynamically:
+ *   - \code #define  USB_DEVICE_SERIAL_NAME // Define this empty
+	#define  USB_DEVICE_GET_SERIAL_NAME_POINTER serial_number // Give serial array pointer
+	#define  USB_DEVICE_GET_SERIAL_NAME_LENGTH  12 // Give size of serial array
+	extern uint8_t serial_number[]; // Declare external serial array \endcode
+ * -# Before start USB stack, initialize the serial array
+ *   - \code
+	 uint8_t serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH];
+
+	 void init_build_usb_serial_number(void)
+	 {
+	 serial_number[0] = 'A';
+	 serial_number[1] = 'B';
+	 ...
+	 serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH-1] = 'C';
+	 } \endcode
+ */
+
+
+
+#endif // _UDC_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/udc_desc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udc_desc.h
@@ -1,0 +1,135 @@
+/**
+ * \file
+ *
+ * \brief Common API for USB Device Interface
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _UDC_DESC_H_
+#define _UDC_DESC_H_
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "udi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \ingroup udc_group
+ * \defgroup udc_desc_group USB Device Descriptor
+ *
+ * @{
+ */
+
+/**
+ * \brief Defines the memory's location of USB descriptors
+ *
+ * By default the Descriptor is stored in RAM
+ * (UDC_DESC_STORAGE is defined empty).
+ *
+ * If you have need to free RAM space,
+ * it is possible to put descriptor in flash in following case:
+ * - USB driver authorize flash transfer (USBB on UC3 and USB on Mega)
+ * - USB Device is not high speed (UDC no need to change USB descriptors)
+ *
+ * For UC3 application used "const".
+ *
+ * For Mega application used "code".
+ */
+#define  UDC_DESC_STORAGE
+	// Descriptor storage in internal RAM
+#if (defined UDC_DATA_USE_HRAM_SUPPORT)
+#	if defined(__GNUC__)
+#		define UDC_DATA(x)              COMPILER_WORD_ALIGNED __attribute__((__section__(".data_hram0")))
+#		define UDC_BSS(x)               COMPILER_ALIGNED(x)   __attribute__((__section__(".bss_hram0")))
+#	elif defined(__ICCAVR32__)
+#		define UDC_DATA(x)              COMPILER_ALIGNED(x)   __data32
+#		define UDC_BSS(x)               COMPILER_ALIGNED(x)   __data32
+#	endif
+#else
+#	define UDC_DATA(x)              COMPILER_ALIGNED(x)
+#	define UDC_BSS(x)               COMPILER_ALIGNED(x)
+#endif
+
+
+
+/**
+ * \brief Configuration descriptor and UDI link for one USB speed
+ */
+typedef struct {
+	//! USB configuration descriptor
+	usb_conf_desc_t UDC_DESC_STORAGE *desc;
+	//! Array of UDI API pointer
+	udi_api_t UDC_DESC_STORAGE *UDC_DESC_STORAGE * udi_apis;
+} udc_config_speed_t;
+
+
+/**
+ * \brief All information about the USB Device
+ */
+typedef struct {
+	//! USB device descriptor for low or full speed
+	usb_dev_desc_t UDC_DESC_STORAGE *confdev_lsfs;
+	//! USB configuration descriptor and UDI API pointers for low or full speed
+	udc_config_speed_t UDC_DESC_STORAGE *conf_lsfs;
+#ifdef USB_DEVICE_HS_SUPPORT
+	//! USB device descriptor for high speed
+	usb_dev_desc_t UDC_DESC_STORAGE *confdev_hs;
+	//! USB device qualifier, only use in high speed mode
+	usb_dev_qual_desc_t UDC_DESC_STORAGE *qualifier;
+	//! USB configuration descriptor and UDI API pointers for high speed
+	udc_config_speed_t UDC_DESC_STORAGE *conf_hs;
+#endif
+	usb_dev_bos_desc_t UDC_DESC_STORAGE *conf_bos;
+} udc_config_t;
+
+//! Global variables of USB Device Descriptor and UDI links
+extern UDC_DESC_STORAGE udc_config_t udc_config;
+
+//@}
+
+#ifdef __cplusplus
+}
+#endif
+#endif // _UDC_DESC_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/udd.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udd.h
@@ -1,0 +1,396 @@
+/**
+ * \file
+ *
+ * \brief Common API for USB Device Drivers (UDD)
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _UDD_H_
+#define _UDD_H_
+
+#include "usb_protocol.h"
+#include "udc_desc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \ingroup usb_device_group
+ * \defgroup udd_group USB Device Driver (UDD)
+ *
+ * The UDD driver provides a low-level abstraction of the device
+ * controller hardware. Most events coming from the hardware such as
+ * interrupts, which may cause the UDD to call into the UDC and UDI.
+ *
+ * @{
+ */
+
+//! \brief Endpoint identifier
+typedef uint8_t udd_ep_id_t;
+
+//! \brief Endpoint transfer status
+//! Returned in parameters of callback register via udd_ep_run routine.
+typedef enum {
+	UDD_EP_TRANSFER_OK = 0,
+	UDD_EP_TRANSFER_ABORT = 1,
+} udd_ep_status_t;
+
+/**
+ * \brief Global variable to give and record information of the setup request management
+ *
+ * This global variable allows to decode and response a setup request.
+ * It can be updated by udc_process_setup() from UDC or *setup() from UDIs.
+ */
+typedef struct {
+	//! Data received in USB SETUP packet
+	//! Note: The swap of "req.wValues" from uin16_t to le16_t is done by UDD.
+	usb_setup_req_t req;
+
+	//! Point to buffer to send or fill with data following SETUP packet
+	//! This buffer must be word align for DATA IN phase (use prefix COMPILER_WORD_ALIGNED for buffer)
+	uint8_t *payload;
+
+	//! Size of buffer to send or fill, and content the number of byte transfered
+	uint16_t payload_size;
+
+	//! Callback called after reception of ZLP from setup request
+	void (*callback) (void);
+
+	//! Callback called when the buffer given (.payload) is full or empty.
+	//! This one return false to abort data transfer, or true with a new buffer in .payload.
+	bool(*over_under_run) (void);
+} udd_ctrl_request_t;
+extern udd_ctrl_request_t udd_g_ctrlreq;
+
+//! Return true if the setup request \a udd_g_ctrlreq indicates IN data transfer
+#define  Udd_setup_is_in()       \
+      (USB_REQ_DIR_IN == (udd_g_ctrlreq.req.bmRequestType & USB_REQ_DIR_MASK))
+
+//! Return true if the setup request \a udd_g_ctrlreq indicates OUT data transfer
+#define  Udd_setup_is_out()      \
+      (USB_REQ_DIR_OUT == (udd_g_ctrlreq.req.bmRequestType & USB_REQ_DIR_MASK))
+
+//! Return the type of the SETUP request \a udd_g_ctrlreq. \see usb_reqtype.
+#define  Udd_setup_type()        \
+      (udd_g_ctrlreq.req.bmRequestType & USB_REQ_TYPE_MASK)
+
+//! Return the recipient of the SETUP request \a udd_g_ctrlreq. \see usb_recipient
+#define  Udd_setup_recipient()   \
+      (udd_g_ctrlreq.req.bmRequestType & USB_REQ_RECIP_MASK)
+
+/**
+ * \brief End of halt callback function type.
+ * Registered by routine udd_ep_wait_stall_clear()
+ * Callback called when endpoint stall is cleared.
+ */
+typedef void (*udd_callback_halt_cleared_t) (void);
+
+/**
+ * \brief End of transfer callback function type.
+ * Registered by routine udd_ep_run()
+ * Callback called by USB interrupt after data transfer or abort (reset,...).
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer is complete
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer is aborted
+ * \param n          number of data transfered
+ */
+typedef void (*udd_callback_trans_t) (udd_ep_status_t status,
+		iram_size_t nb_transfered, udd_ep_id_t ep);
+
+/**
+ * \brief Authorizes the VBUS event
+ *
+ * \return true, if the VBUS monitoring is possible.
+ */
+bool udd_include_vbus_monitoring(void);
+
+/**
+ * \brief Enables the USB Device mode
+ */
+void udd_enable(void);
+
+/**
+ * \brief Disables the USB Device mode
+ */
+void udd_disable(void);
+
+/**
+ * \brief Attach device to the bus when possible
+ *
+ * \warning If a VBus control is included in driver,
+ * then it will attach device when an acceptable Vbus
+ * level from the host is detected.
+ */
+void udd_attach(void);
+
+/**
+ * \brief Detaches the device from the bus
+ *
+ * The driver must remove pull-up on USB line D- or D+.
+ */
+void udd_detach(void);
+
+/**
+ * \brief Test whether the USB Device Controller is running at high
+ * speed or not.
+ *
+ * \return \c true if the Device is running at high speed mode, otherwise \c false.
+ */
+bool udd_is_high_speed(void);
+
+/**
+ * \brief Changes the USB address of device
+ *
+ * \param address    New USB address
+ */
+void udd_set_address(uint8_t address);
+
+/**
+ * \brief Returns the USB address of device
+ *
+ * \return USB address
+ */
+uint8_t udd_getaddress(void);
+
+/**
+ * \brief Returns the current start of frame number
+ *
+ * \return current start of frame number.
+ */
+uint16_t udd_get_frame_number(void);
+
+/**
+ * \brief Returns the current micro start of frame number
+ *
+ * \return current micro start of frame number required in high speed mode.
+ */
+uint16_t udd_get_micro_frame_number(void);
+
+/*! \brief The USB driver sends a resume signal called Upstream Resume
+ */
+void udd_send_remotewakeup(void);
+
+/**
+ * \brief Load setup payload
+ *
+ * \param payload       Pointer on payload
+ * \param payload_size  Size of payload
+ */
+void udd_set_setup_payload( uint8_t *payload, uint16_t payload_size );
+
+
+/**
+ * \name Endpoint Management
+ *
+ * The following functions allow drivers to create and remove
+ * endpoints, as well as set, clear and query their "halted" and
+ * "wedged" states.
+ */
+//@{
+
+#if (USB_DEVICE_MAX_EP != 0)
+
+/**
+ * \brief Configures and enables an endpoint
+ *
+ * \param ep               Endpoint number including direction (USB_EP_DIR_IN/USB_EP_DIR_OUT).
+ * \param bmAttributes     Attributes of endpoint declared in the descriptor.
+ * \param MaxEndpointSize  Endpoint maximum size
+ *
+ * \return \c 1 if the endpoint is enabled, otherwise \c 0.
+ */
+bool udd_ep_alloc(udd_ep_id_t ep, uint8_t bmAttributes,
+		uint16_t MaxEndpointSize);
+
+/**
+ * \brief Disables an endpoint
+ *
+ * \param ep               Endpoint number including direction (USB_EP_DIR_IN/USB_EP_DIR_OUT).
+ */
+void udd_ep_free(udd_ep_id_t ep);
+
+/**
+ * \brief Check if the endpoint \a ep is halted.
+ *
+ * \param ep The ID of the endpoint to check.
+ *
+ * \return \c 1 if \a ep is halted, otherwise \c 0.
+ */
+bool udd_ep_is_halted(udd_ep_id_t ep);
+
+/**
+ * \brief Set the halted state of the endpoint \a ep
+ *
+ * After calling this function, any transaction on \a ep will result
+ * in a STALL handshake being sent. Any pending transactions will be
+ * performed first, however.
+ *
+ * \param ep The ID of the endpoint to be halted
+ *
+ * \return \c 1 if \a ep is halted, otherwise \c 0.
+ */
+bool udd_ep_set_halt(udd_ep_id_t ep);
+
+/**
+ * \brief Clear the halted state of the endpoint \a ep
+ *
+ * After calling this function, any transaction on \a ep will
+ * be handled normally, i.e. a STALL handshake will not be sent, and
+ * the data toggle sequence will start at DATA0.
+ *
+ * \param ep The ID of the endpoint to be un-halted
+ *
+ * \return \c 1 if function was successfully done, otherwise \c 0.
+ */
+bool udd_ep_clear_halt(udd_ep_id_t ep);
+
+/**
+ * \brief Registers a callback to call when endpoint halt is cleared
+ *
+ * \param ep            The ID of the endpoint to use
+ * \param callback      NULL or function to call when endpoint halt is cleared
+ *
+ * \warning if the endpoint is not halted then the \a callback is called immediately.
+ *
+ * \return \c 1 if the register is accepted, otherwise \c 0.
+ */
+bool udd_ep_wait_stall_clear(udd_ep_id_t ep,
+		udd_callback_halt_cleared_t callback);
+
+/**
+ * \brief Allows to receive or send data on an endpoint
+ *
+ * The driver uses a specific DMA USB to transfer data
+ * from internal RAM to endpoint, if this one is available.
+ * When the transfer is finished or aborted (stall, reset, ...), the \a callback is called.
+ * The \a callback returns the transfer status and eventually the number of byte transfered.
+ * Note: The control endpoint is not authorized.
+ *
+ * \param ep            The ID of the endpoint to use
+ * \param b_shortpacket Enabled automatic short packet
+ * \param buf           Buffer on Internal RAM to send or fill.
+ *                      It must be align, then use COMPILER_WORD_ALIGNED.
+ * \param buf_size      Buffer size to send or fill
+ * \param callback      NULL or function to call at the end of transfer
+ *
+ * \warning About \a b_shortpacket, for IN endpoint it means that a short packet
+ * (or a Zero Length Packet) will be sent to the USB line to properly close the usb
+ * transfer at the end of the data transfer.
+ * For Bulk and Interrupt OUT endpoint, it will automatically stop the transfer
+ * at the end of the data transfer (received short packet).
+ *
+ * \return \c 1 if function was successfully done, otherwise \c 0.
+ */
+bool udd_ep_run(udd_ep_id_t ep, bool b_shortpacket,
+		uint8_t * buf, iram_size_t buf_size,
+		udd_callback_trans_t callback);
+/**
+ * \brief Aborts transfer on going on endpoint
+ *
+ * If a transfer is on going, then it is stopped and
+ * the callback registered is called to signal the end of transfer.
+ * Note: The control endpoint is not authorized.
+ *
+ * \param ep            Endpoint to abort
+ */
+void udd_ep_abort(udd_ep_id_t ep);
+
+#endif
+
+//@}
+
+
+/**
+ * \name High speed test mode management
+ *
+ * The following functions allow the device to jump to a specific test mode required in high speed mode.
+ */
+//@{
+void udd_test_mode_j(void);
+void udd_test_mode_k(void);
+void udd_test_mode_se0_nak(void);
+void udd_test_mode_packet(void);
+//@}
+
+
+/**
+ * \name UDC callbacks to provide for UDD
+ *
+ * The following callbacks are used by UDD.
+ */
+//@{
+
+/**
+ * \brief Decodes and manages a setup request
+ *
+ * The driver call it when a SETUP packet is received.
+ * The \c udd_g_ctrlreq contains the data of SETUP packet.
+ * If this callback accepts the setup request then it must
+ * return \c 1 and eventually update \c udd_g_ctrlreq to send or receive data.
+ *
+ * \return \c 1 if the request is accepted, otherwise \c 0.
+ */
+extern bool udc_process_setup(void);
+
+/**
+ * \brief Reset the UDC
+ *
+ * The UDC must reset all configuration.
+ */
+extern void udc_reset(void);
+
+/**
+ * \brief To signal that a SOF is occurred
+ *
+ * The UDC must send the signal to all UDIs enabled
+ */
+extern void udc_sof_notify(void);
+
+//@}
+
+//@}
+
+#ifdef __cplusplus
+}
+#endif
+#endif // _UDD_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/udi.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi.h
@@ -1,0 +1,133 @@
+/**
+ * \file
+ *
+ * \brief Common API for USB Device Interface
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _UDI_H_
+#define _UDI_H_
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \ingroup usb_device_group
+ * \defgroup udi_group USB Device Interface (UDI)
+ * The UDI provides a common API for all classes,
+ * and this is used by UDC for the main control of USB Device interface.
+ * @{
+ */
+
+/**
+ * \brief UDI API.
+ *
+ * The callbacks within this structure are called only by
+ * USB Device Controller (UDC)
+ *
+ * The udc_get_interface_desc() can be use by UDI to know the interface descriptor
+ * selected by UDC.
+ */
+typedef struct {
+	/**
+	 * \brief Enable the interface.
+	 *
+	 * This function is called when the host selects a configuration
+	 * to which this interface belongs through a Set Configuration
+	 * request, and when the host selects an alternate setting of
+	 * this interface through a Set Interface request.
+	 *
+	 * \return \c 1 if function was successfully done, otherwise \c 0.
+	 */
+	bool(*enable) (void);
+
+	/**
+	 * \brief Disable the interface.
+	 *
+	 * This function is called when this interface is currently
+	 * active, and
+	 * - the host selects any configuration through a Set
+	 *   Configuration request, or
+	 * - the host issues a USB reset, or
+	 * - the device is detached from the host (i.e. Vbus is no
+	 *   longer present)
+	 */
+	void (*disable) (void);
+
+	/**
+	 * \brief Handle a control request directed at an interface.
+	 *
+	 * This function is called when this interface is currently
+	 * active and the host sends a SETUP request
+	 * with this interface as the recipient.
+	 *
+	 * Use udd_g_ctrlreq to decode and response to SETUP request.
+	 *
+	 * \return \c 1 if this interface supports the SETUP request, otherwise \c 0.
+	 */
+	bool(*setup) (void);
+
+	/**
+	 * \brief Returns the current setting of the selected interface.
+	 *
+	 * This function is called when UDC when know alternate setting of selected interface.
+	 *
+	 * \return alternate setting of selected interface
+	 */
+	uint8_t(*getsetting) (void);
+
+	/**
+	 * \brief To signal that a SOF is occurred
+	 */
+	void(*sof_notify) (void);
+} udi_api_t;
+
+//@}
+
+#ifdef __cplusplus
+}
+#endif
+#endif // _UDI_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.c
@@ -1,0 +1,1155 @@
+/**
+ * \file
+ *
+ * \brief USB Device Communication Device Class (CDC) interface.
+ *
+ * Copyright (c) 2009-2016 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "usb_protocol_cdc.h"
+#include "udd.h"
+#include "udc.h"
+#include "udi_cdc.h"
+#include <string.h>
+
+#ifdef UDI_CDC_LOW_RATE
+#  ifdef USB_DEVICE_HS_SUPPORT
+#    define UDI_CDC_TX_BUFFERS     (UDI_CDC_DATA_EPS_HS_SIZE)
+#    define UDI_CDC_RX_BUFFERS     (UDI_CDC_DATA_EPS_HS_SIZE)
+#  else
+#    define UDI_CDC_TX_BUFFERS     (UDI_CDC_DATA_EPS_FS_SIZE)
+#    define UDI_CDC_RX_BUFFERS     (UDI_CDC_DATA_EPS_FS_SIZE)
+#  endif
+#else
+#  ifdef USB_DEVICE_HS_SUPPORT
+#    define UDI_CDC_TX_BUFFERS     (UDI_CDC_DATA_EPS_HS_SIZE)
+#    define UDI_CDC_RX_BUFFERS     (UDI_CDC_DATA_EPS_HS_SIZE)
+#  else
+#    define UDI_CDC_TX_BUFFERS     (5*UDI_CDC_DATA_EPS_FS_SIZE)
+#    define UDI_CDC_RX_BUFFERS     (5*UDI_CDC_DATA_EPS_FS_SIZE)
+#  endif
+#endif
+
+#ifndef UDI_CDC_TX_EMPTY_NOTIFY
+#  define UDI_CDC_TX_EMPTY_NOTIFY(port)
+#endif
+
+/**
+ * \ingroup udi_cdc_group
+ * \defgroup udi_cdc_group_udc Interface with USB Device Core (UDC)
+ *
+ * Structures and functions required by UDC.
+ *
+ * @{
+ */
+bool udi_cdc_comm_enable(void);
+void udi_cdc_comm_disable(void);
+bool udi_cdc_comm_setup(void);
+bool udi_cdc_data_enable(void);
+void udi_cdc_data_disable(void);
+bool udi_cdc_data_setup(void);
+uint8_t udi_cdc_getsetting(void);
+void udi_cdc_data_sof_notify(void);
+UDC_DESC_STORAGE udi_api_t udi_api_cdc_comm = {
+	.enable = udi_cdc_comm_enable,
+	.disable = udi_cdc_comm_disable,
+	.setup = udi_cdc_comm_setup,
+	.getsetting = udi_cdc_getsetting,
+};
+UDC_DESC_STORAGE udi_api_t udi_api_cdc_data = {
+	.enable = udi_cdc_data_enable,
+	.disable = udi_cdc_data_disable,
+	.setup = udi_cdc_data_setup,
+	.getsetting = udi_cdc_getsetting,
+	.sof_notify = udi_cdc_data_sof_notify,
+};
+//@}
+
+/**
+ * \ingroup udi_cdc_group
+ * \defgroup udi_cdc_group_internal Implementation of UDI CDC
+ *
+ * Class internal implementation
+ * @{
+ */
+
+/**
+ * \name Internal routines
+ */
+//@{
+
+/**
+ * \name Routines to control serial line
+ */
+//@{
+
+/**
+ * \brief Returns the port number corresponding at current setup request
+ *
+ * \return port number
+ */
+static uint8_t udi_cdc_setup_to_port(void);
+
+/**
+ * \brief Sends line coding to application
+ *
+ * Called after SETUP request when line coding data is received.
+ */
+static void udi_cdc_line_coding_received(void);
+
+/**
+ * \brief Records new state
+ *
+ * \param port       Communication port number to manage
+ * \param b_set      State is enabled if true, else disabled
+ * \param bit_mask   Field to process (see CDC_SERIAL_STATE_ defines)
+ */
+static void udi_cdc_ctrl_state_change(uint8_t port, bool b_set, le16_t bit_mask);
+
+/**
+ * \brief Check and eventually notify the USB host of new state
+ *
+ * \param port       Communication port number to manage
+ * \param ep         Port communication endpoint
+ */
+static void udi_cdc_ctrl_state_notify(uint8_t port, udd_ep_id_t ep);
+
+/**
+ * \brief Ack sent of serial state message
+ * Callback called after serial state message sent
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer finished
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
+ * \param n          number of data transfered
+ */
+static void udi_cdc_serial_state_msg_sent(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep);
+
+//@}
+
+/**
+ * \name Routines to process data transfer
+ */
+//@{
+
+/**
+ * \brief Enable the reception of data from the USB host
+ *
+ * The value udi_cdc_rx_trans_sel indicate the RX buffer to fill.
+ *
+ * \param port       Communication port number to manage
+ *
+ * \return \c 1 if function was successfully done, otherwise \c 0.
+ */
+static bool udi_cdc_rx_start(uint8_t port);
+
+/**
+ * \brief Update rx buffer management with a new data
+ * Callback called after data reception on USB line
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer finish
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
+ * \param n          number of data received
+ */
+static void udi_cdc_data_received(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep);
+
+/**
+ * \brief Ack sent of tx buffer
+ * Callback called after data transfer on USB line
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer finished
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
+ * \param n          number of data transfered
+ */
+static void udi_cdc_data_sent(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep);
+
+/**
+ * \brief Send buffer on line or wait a SOF event
+ *
+ * \param port       Communication port number to manage
+ */
+static void udi_cdc_tx_send(uint8_t port);
+
+//@}
+
+//@}
+
+/**
+ * \name Information about configuration of communication line
+ */
+//@{
+COMPILER_WORD_ALIGNED
+		static usb_cdc_line_coding_t udi_cdc_line_coding[UDI_CDC_PORT_NB];
+static bool udi_cdc_serial_state_msg_ongoing[UDI_CDC_PORT_NB];
+static volatile le16_t udi_cdc_state[UDI_CDC_PORT_NB];
+COMPILER_WORD_ALIGNED static usb_cdc_notify_serial_state_t uid_cdc_state_msg[UDI_CDC_PORT_NB];
+
+//! Status of CDC COMM interfaces
+static volatile uint8_t udi_cdc_nb_comm_enabled = 0;
+//@}
+
+/**
+ * \name Variables to manage RX/TX transfer requests
+ * Two buffers for each sense are used to optimize the speed.
+ */
+//@{
+
+//! Status of CDC DATA interfaces
+static volatile uint8_t udi_cdc_nb_data_enabled = 0;
+static volatile bool udi_cdc_data_running = false;
+//! Buffer to receive data
+COMPILER_WORD_ALIGNED static uint8_t udi_cdc_rx_buf[UDI_CDC_PORT_NB][2][UDI_CDC_RX_BUFFERS];
+//! Data available in RX buffers
+static volatile uint16_t udi_cdc_rx_buf_nb[UDI_CDC_PORT_NB][2];
+//! Give the current RX buffer used (rx0 if 0, rx1 if 1)
+static volatile uint8_t udi_cdc_rx_buf_sel[UDI_CDC_PORT_NB];
+//! Read position in current RX buffer
+static volatile uint16_t udi_cdc_rx_pos[UDI_CDC_PORT_NB];
+//! Signal a transfer on-going
+static volatile bool udi_cdc_rx_trans_ongoing[UDI_CDC_PORT_NB];
+
+//! Define a transfer halted
+#define  UDI_CDC_TRANS_HALTED    2
+
+//! Buffer to send data
+COMPILER_WORD_ALIGNED static uint8_t udi_cdc_tx_buf[UDI_CDC_PORT_NB][2][UDI_CDC_TX_BUFFERS];
+//! Data available in TX buffers
+static uint16_t udi_cdc_tx_buf_nb[UDI_CDC_PORT_NB][2];
+//! Give current TX buffer used (tx0 if 0, tx1 if 1)
+static volatile uint8_t udi_cdc_tx_buf_sel[UDI_CDC_PORT_NB];
+//! Value of SOF during last TX transfer
+static uint16_t udi_cdc_tx_sof_num[UDI_CDC_PORT_NB];
+//! Signal a transfer on-going
+static volatile bool udi_cdc_tx_trans_ongoing[UDI_CDC_PORT_NB];
+//! Signal that both buffer content data to send
+static volatile bool udi_cdc_tx_both_buf_to_send[UDI_CDC_PORT_NB];
+
+//@}
+
+bool udi_cdc_comm_enable(void)
+{
+	uint8_t port;
+	uint8_t iface_comm_num;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+	udi_cdc_nb_comm_enabled = 0;
+#else
+	if (udi_cdc_nb_comm_enabled > UDI_CDC_PORT_NB) {
+		udi_cdc_nb_comm_enabled = 0;
+	}
+	port = udi_cdc_nb_comm_enabled;
+#endif
+
+	// Initialize control signal management
+	udi_cdc_state[port] = CPU_TO_LE16(0);
+
+	uid_cdc_state_msg[port].header.bmRequestType =
+			USB_REQ_DIR_IN | USB_REQ_TYPE_CLASS |
+			USB_REQ_RECIP_INTERFACE;
+	uid_cdc_state_msg[port].header.bNotification = USB_REQ_CDC_NOTIFY_SERIAL_STATE;
+	uid_cdc_state_msg[port].header.wValue = LE16(0);
+
+	switch (port) {
+#define UDI_CDC_PORT_TO_IFACE_COMM(index, unused) \
+	case index: \
+		iface_comm_num = UDI_CDC_COMM_IFACE_NUMBER_##index; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_PORT_TO_IFACE_COMM, ~)
+#undef UDI_CDC_PORT_TO_IFACE_COMM
+	default:
+		iface_comm_num = UDI_CDC_COMM_IFACE_NUMBER_0;
+		break;
+	}
+
+	uid_cdc_state_msg[port].header.wIndex = LE16(iface_comm_num);
+	uid_cdc_state_msg[port].header.wLength = LE16(2);
+	uid_cdc_state_msg[port].value = CPU_TO_LE16(0);
+
+	udi_cdc_line_coding[port].dwDTERate = CPU_TO_LE32(UDI_CDC_DEFAULT_RATE);
+	udi_cdc_line_coding[port].bCharFormat = UDI_CDC_DEFAULT_STOPBITS;
+	udi_cdc_line_coding[port].bParityType = UDI_CDC_DEFAULT_PARITY;
+	udi_cdc_line_coding[port].bDataBits = UDI_CDC_DEFAULT_DATABITS;
+	// Call application callback
+	// to initialize memories or indicate that interface is enabled
+	UDI_CDC_SET_CODING_EXT(port,(&udi_cdc_line_coding[port]));
+	if (!UDI_CDC_ENABLE_EXT(port)) {
+		return false;
+	}
+	udi_cdc_nb_comm_enabled++;
+	return true;
+}
+
+bool udi_cdc_data_enable(void)
+{
+	uint8_t port;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+	udi_cdc_nb_data_enabled = 0;
+#else
+	if (udi_cdc_nb_data_enabled > UDI_CDC_PORT_NB) {
+		udi_cdc_nb_data_enabled = 0;
+	}
+	port = udi_cdc_nb_data_enabled;
+#endif
+
+	// Initialize TX management
+	udi_cdc_tx_trans_ongoing[port] = false;
+	udi_cdc_tx_both_buf_to_send[port] = false;
+	udi_cdc_tx_buf_sel[port] = 0;
+	udi_cdc_tx_buf_nb[port][0] = 0;
+	udi_cdc_tx_buf_nb[port][1] = 0;
+	udi_cdc_tx_sof_num[port] = 0;
+	udi_cdc_tx_send(port);
+
+	// Initialize RX management
+	udi_cdc_rx_trans_ongoing[port] = false;
+	udi_cdc_rx_buf_sel[port] = 0;
+	udi_cdc_rx_buf_nb[port][0] = 0;
+	udi_cdc_rx_buf_nb[port][1] = 0;
+	udi_cdc_rx_pos[port] = 0;
+	if (!udi_cdc_rx_start(port)) {
+		return false;
+	}
+	udi_cdc_nb_data_enabled++;
+	if (udi_cdc_nb_data_enabled == UDI_CDC_PORT_NB) {
+		udi_cdc_data_running = true;
+	}
+	return true;
+}
+
+void udi_cdc_comm_disable(void)
+{
+	Assert(udi_cdc_nb_comm_enabled != 0);
+	udi_cdc_nb_comm_enabled--;
+}
+
+void udi_cdc_data_disable(void)
+{
+	uint8_t port;
+
+	Assert(udi_cdc_nb_data_enabled != 0);
+	udi_cdc_nb_data_enabled--;
+	port = udi_cdc_nb_data_enabled;
+	UDI_CDC_DISABLE_EXT(port);
+	udi_cdc_data_running = false;
+}
+
+bool udi_cdc_comm_setup(void)
+{
+	uint8_t port = udi_cdc_setup_to_port();
+
+	if (Udd_setup_is_in()) {
+		// GET Interface Requests
+		if (Udd_setup_type() == USB_REQ_TYPE_CLASS) {
+			// Requests Class Interface Get
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_CDC_GET_LINE_CODING:
+				// Get configuration of CDC line
+				if (sizeof(usb_cdc_line_coding_t) !=
+						udd_g_ctrlreq.req.wLength)
+					return false; // Error for USB host
+				udd_g_ctrlreq.payload =
+						(uint8_t *) &
+						udi_cdc_line_coding[port];
+				udd_g_ctrlreq.payload_size =
+						sizeof(usb_cdc_line_coding_t);
+				return true;
+			}
+		}
+	}
+	if (Udd_setup_is_out()) {
+		// SET Interface Requests
+		if (Udd_setup_type() == USB_REQ_TYPE_CLASS) {
+			// Requests Class Interface Set
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_CDC_SET_LINE_CODING:
+				// Change configuration of CDC line
+				if (sizeof(usb_cdc_line_coding_t) !=
+						udd_g_ctrlreq.req.wLength)
+					return false; // Error for USB host
+				udd_g_ctrlreq.callback =
+						udi_cdc_line_coding_received;
+				udd_g_ctrlreq.payload =
+						(uint8_t *) &
+						udi_cdc_line_coding[port];
+				udd_g_ctrlreq.payload_size =
+						sizeof(usb_cdc_line_coding_t);
+				return true;
+			case USB_REQ_CDC_SET_CONTROL_LINE_STATE:
+				// According cdc spec 1.1 chapter 6.2.14
+				UDI_CDC_SET_DTR_EXT(port, (0 !=
+						(udd_g_ctrlreq.req.wValue
+						 & CDC_CTRL_SIGNAL_DTE_PRESENT)));
+				UDI_CDC_SET_RTS_EXT(port, (0 !=
+						(udd_g_ctrlreq.req.wValue
+						 & CDC_CTRL_SIGNAL_ACTIVATE_CARRIER)));
+				return true;
+			}
+		}
+	}
+	return false;  // request Not supported
+}
+
+bool udi_cdc_data_setup(void)
+{
+	return false;  // request Not supported
+}
+
+uint8_t udi_cdc_getsetting(void)
+{
+	return 0;      // CDC don't have multiple alternate setting
+}
+
+void udi_cdc_data_sof_notify(void)
+{
+	static uint8_t port_notify = 0;
+
+	// A call of udi_cdc_data_sof_notify() is done for each port
+	udi_cdc_tx_send(port_notify);
+#if UDI_CDC_PORT_NB != 1 // To optimize code
+	port_notify++;
+	if (port_notify >= UDI_CDC_PORT_NB) {
+		port_notify = 0;
+	}
+#endif
+}
+
+
+//-------------------------------------------------
+//------- Internal routines to control serial line
+
+static uint8_t udi_cdc_setup_to_port(void)
+{
+	uint8_t port;
+
+	switch (udd_g_ctrlreq.req.wIndex & 0xFF) {
+#define UDI_CDC_IFACE_COMM_TO_PORT(iface, unused) \
+	case UDI_CDC_COMM_IFACE_NUMBER_##iface: \
+		port = iface; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_IFACE_COMM_TO_PORT, ~)
+#undef UDI_CDC_IFACE_COMM_TO_PORT
+	default:
+		port = 0;
+		break;
+	}
+	return port;
+}
+
+static void udi_cdc_line_coding_received(void)
+{
+	uint8_t port = udi_cdc_setup_to_port();
+	UNUSED(port);
+
+	UDI_CDC_SET_CODING_EXT(port, (&udi_cdc_line_coding[port]));
+}
+
+static void udi_cdc_ctrl_state_change(uint8_t port, bool b_set, le16_t bit_mask)
+{
+	irqflags_t flags;
+	udd_ep_id_t ep_comm;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	// Update state
+	flags = cpu_irq_save(); // Protect udi_cdc_state
+	if (b_set) {
+		udi_cdc_state[port] |= bit_mask;
+	} else {
+		udi_cdc_state[port] &= ~(unsigned)bit_mask;
+	}
+	cpu_irq_restore(flags);
+
+	// Send it if possible and state changed
+	switch (port) {
+#define UDI_CDC_PORT_TO_COMM_EP(index, unused) \
+	case index: \
+		ep_comm = UDI_CDC_COMM_EP_##index; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_PORT_TO_COMM_EP, ~)
+#undef UDI_CDC_PORT_TO_COMM_EP
+	default:
+		ep_comm = UDI_CDC_COMM_EP_0;
+		break;
+	}
+	udi_cdc_ctrl_state_notify(port, ep_comm);
+}
+
+
+static void udi_cdc_ctrl_state_notify(uint8_t port, udd_ep_id_t ep)
+{
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	// Send it if possible and state changed
+	if ((!udi_cdc_serial_state_msg_ongoing[port])
+			&& (udi_cdc_state[port] != uid_cdc_state_msg[port].value)) {
+		// Fill notification message
+		uid_cdc_state_msg[port].value = udi_cdc_state[port];
+		// Send notification message
+		udi_cdc_serial_state_msg_ongoing[port] =
+				udd_ep_run(ep,
+				false,
+				(uint8_t *) & uid_cdc_state_msg[port],
+				sizeof(uid_cdc_state_msg[0]),
+				udi_cdc_serial_state_msg_sent);
+	}
+}
+
+
+static void udi_cdc_serial_state_msg_sent(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep)
+{
+	uint8_t port;
+	UNUSED(n);
+	UNUSED(status);
+
+	switch (ep) {
+#define UDI_CDC_GET_PORT_FROM_COMM_EP(iface, unused) \
+	case UDI_CDC_COMM_EP_##iface: \
+		port = iface; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_GET_PORT_FROM_COMM_EP, ~)
+#undef UDI_CDC_GET_PORT_FROM_COMM_EP
+	default:
+		port = 0;
+		break;
+	}
+
+	udi_cdc_serial_state_msg_ongoing[port] = false;
+
+	// For the irregular signals like break, the incoming ring signal,
+	// or the overrun error state, this will reset their values to zero
+	// and again will not send another notification until their state changes.
+	udi_cdc_state[port] &= ~(CDC_SERIAL_STATE_BREAK |
+			CDC_SERIAL_STATE_RING |
+			CDC_SERIAL_STATE_FRAMING |
+			CDC_SERIAL_STATE_PARITY | CDC_SERIAL_STATE_OVERRUN);
+	uid_cdc_state_msg[port].value &= ~(CDC_SERIAL_STATE_BREAK |
+			CDC_SERIAL_STATE_RING |
+			CDC_SERIAL_STATE_FRAMING |
+			CDC_SERIAL_STATE_PARITY | CDC_SERIAL_STATE_OVERRUN);
+	// Send it if possible and state changed
+	udi_cdc_ctrl_state_notify(port, ep);
+}
+
+
+//-------------------------------------------------
+//------- Internal routines to process data transfer
+
+
+static bool udi_cdc_rx_start(uint8_t port)
+{
+	irqflags_t flags;
+	uint8_t buf_sel_trans;
+	udd_ep_id_t ep;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	flags = cpu_irq_save();
+	buf_sel_trans = udi_cdc_rx_buf_sel[port];
+	if (udi_cdc_rx_trans_ongoing[port] ||
+		(udi_cdc_rx_pos[port] < udi_cdc_rx_buf_nb[port][buf_sel_trans])) {
+		// Transfer already on-going or current buffer no empty
+		cpu_irq_restore(flags);
+		return false;
+	}
+
+	// Change current buffer
+	udi_cdc_rx_pos[port] = 0;
+	udi_cdc_rx_buf_sel[port] = (buf_sel_trans==0)?1:0;
+
+	// Start transfer on RX
+	udi_cdc_rx_trans_ongoing[port] = true;
+	cpu_irq_restore(flags);
+
+	if (udi_cdc_multi_is_rx_ready(port)) {
+		UDI_CDC_RX_NOTIFY(port);
+	}
+	// Send the buffer with enable of short packet
+	switch (port) {
+#define UDI_CDC_PORT_TO_DATA_EP_OUT(index, unused) \
+	case index: \
+		ep = UDI_CDC_DATA_EP_OUT_##index; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_PORT_TO_DATA_EP_OUT, ~)
+#undef UDI_CDC_PORT_TO_DATA_EP_OUT
+	default:
+		ep = UDI_CDC_DATA_EP_OUT_0;
+		break;
+	}
+	return udd_ep_run(ep,
+			true,
+			udi_cdc_rx_buf[port][buf_sel_trans],
+			UDI_CDC_RX_BUFFERS,
+			udi_cdc_data_received);
+}
+
+
+static void udi_cdc_data_received(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep)
+{
+	uint8_t buf_sel_trans;
+	uint8_t port;
+
+	switch (ep) {
+#define UDI_CDC_DATA_EP_OUT_TO_PORT(index, unused) \
+	case UDI_CDC_DATA_EP_OUT_##index: \
+		port = index; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_DATA_EP_OUT_TO_PORT, ~)
+#undef UDI_CDC_DATA_EP_OUT_TO_PORT
+	default:
+		port = 0;
+		break;
+	}
+
+	if (UDD_EP_TRANSFER_OK != status) {
+		// Abort reception
+		return;
+	}
+	buf_sel_trans = (udi_cdc_rx_buf_sel[port]==0)?1:0;
+	if (!n) {
+		udd_ep_run( ep,
+				true,
+				udi_cdc_rx_buf[port][buf_sel_trans],
+				UDI_CDC_RX_BUFFERS,
+				udi_cdc_data_received);
+		return;
+	}
+	udi_cdc_rx_buf_nb[port][buf_sel_trans] = n;
+	udi_cdc_rx_trans_ongoing[port] = false;
+	udi_cdc_rx_start(port);
+}
+
+
+static void udi_cdc_data_sent(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep)
+{
+	uint8_t port;
+	UNUSED(n);
+
+	switch (ep) {
+#define UDI_CDC_DATA_EP_IN_TO_PORT(index, unused) \
+	case UDI_CDC_DATA_EP_IN_##index: \
+		port = index; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_DATA_EP_IN_TO_PORT, ~)
+#undef UDI_CDC_DATA_EP_IN_TO_PORT
+	default:
+		port = 0;
+		break;
+	}
+
+	if (UDD_EP_TRANSFER_OK != status) {
+		// Abort transfer
+		return;
+	}
+	udi_cdc_tx_buf_nb[port][(udi_cdc_tx_buf_sel[port]==0)?1:0] = 0;
+	udi_cdc_tx_both_buf_to_send[port] = false;
+	udi_cdc_tx_trans_ongoing[port] = false;
+
+	if (n != 0) {
+		UDI_CDC_TX_EMPTY_NOTIFY(port);
+	}
+	udi_cdc_tx_send(port);
+}
+
+
+static void udi_cdc_tx_send(uint8_t port)
+{
+	irqflags_t flags;
+	uint8_t buf_sel_trans;
+	bool b_short_packet;
+	udd_ep_id_t ep;
+	static uint16_t sof_zlp_counter = 0;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	if (udi_cdc_tx_trans_ongoing[port]) {
+		return; // Already on going or wait next SOF to send next data
+	}
+	if (udd_is_high_speed()) {
+		if (udi_cdc_tx_sof_num[port] == udd_get_micro_frame_number()) {
+			return; // Wait next SOF to send next data
+		}
+	}else{
+		if (udi_cdc_tx_sof_num[port] == udd_get_frame_number()) {
+			return; // Wait next SOF to send next data
+		}
+	}
+
+	flags = cpu_irq_save(); // to protect udi_cdc_tx_buf_sel
+	buf_sel_trans = udi_cdc_tx_buf_sel[port];
+	if (udi_cdc_tx_buf_nb[port][buf_sel_trans] == 0) {
+		sof_zlp_counter++;
+		if (((!udd_is_high_speed()) && (sof_zlp_counter < 100))
+				|| (udd_is_high_speed() && (sof_zlp_counter < 800))) {
+			cpu_irq_restore(flags);
+			return;
+		}
+	}
+	sof_zlp_counter = 0;
+
+	if (!udi_cdc_tx_both_buf_to_send[port]) {
+		// Send current Buffer
+		// and switch the current buffer
+		udi_cdc_tx_buf_sel[port] = (buf_sel_trans==0)?1:0;
+	}else{
+		// Send the other Buffer
+		// and no switch the current buffer
+		buf_sel_trans = (buf_sel_trans==0)?1:0;
+	}
+	udi_cdc_tx_trans_ongoing[port] = true;
+	cpu_irq_restore(flags);
+
+	b_short_packet = (udi_cdc_tx_buf_nb[port][buf_sel_trans] != UDI_CDC_TX_BUFFERS);
+	if (b_short_packet) {
+		if (udd_is_high_speed()) {
+			udi_cdc_tx_sof_num[port] = udd_get_micro_frame_number();
+		}else{
+			udi_cdc_tx_sof_num[port] = udd_get_frame_number();
+		}
+	}else{
+		udi_cdc_tx_sof_num[port] = 0; // Force next transfer without wait SOF
+	}
+
+	// Send the buffer with enable of short packet
+	switch (port) {
+#define UDI_CDC_PORT_TO_DATA_EP_IN(index, unused) \
+	case index: \
+		ep = UDI_CDC_DATA_EP_IN_##index; \
+		break;
+	MREPEAT(UDI_CDC_PORT_NB, UDI_CDC_PORT_TO_DATA_EP_IN, ~)
+#undef UDI_CDC_PORT_TO_DATA_EP_IN
+	default:
+		ep = UDI_CDC_DATA_EP_IN_0;
+		break;
+	}
+	udd_ep_run( ep,
+			b_short_packet,
+			udi_cdc_tx_buf[port][buf_sel_trans],
+			udi_cdc_tx_buf_nb[port][buf_sel_trans],
+			udi_cdc_data_sent);
+}
+
+
+//---------------------------------------------
+//------- Application interface
+
+
+//------- Application interface
+
+void udi_cdc_ctrl_signal_dcd(bool b_set)
+{
+	udi_cdc_ctrl_state_change(0, b_set, CDC_SERIAL_STATE_DCD);
+}
+
+void udi_cdc_ctrl_signal_dsr(bool b_set)
+{
+	udi_cdc_ctrl_state_change(0, b_set, CDC_SERIAL_STATE_DSR);
+}
+
+void udi_cdc_signal_framing_error(void)
+{
+	udi_cdc_ctrl_state_change(0, true, CDC_SERIAL_STATE_FRAMING);
+}
+
+void udi_cdc_signal_parity_error(void)
+{
+	udi_cdc_ctrl_state_change(0, true, CDC_SERIAL_STATE_PARITY);
+}
+
+void udi_cdc_signal_overrun(void)
+{
+	udi_cdc_ctrl_state_change(0, true, CDC_SERIAL_STATE_OVERRUN);
+}
+
+void udi_cdc_multi_ctrl_signal_dcd(uint8_t port, bool b_set)
+{
+	udi_cdc_ctrl_state_change(port, b_set, CDC_SERIAL_STATE_DCD);
+}
+
+void udi_cdc_multi_ctrl_signal_dsr(uint8_t port, bool b_set)
+{
+	udi_cdc_ctrl_state_change(port, b_set, CDC_SERIAL_STATE_DSR);
+}
+
+void udi_cdc_multi_signal_framing_error(uint8_t port)
+{
+	udi_cdc_ctrl_state_change(port, true, CDC_SERIAL_STATE_FRAMING);
+}
+
+void udi_cdc_multi_signal_parity_error(uint8_t port)
+{
+	udi_cdc_ctrl_state_change(port, true, CDC_SERIAL_STATE_PARITY);
+}
+
+void udi_cdc_multi_signal_overrun(uint8_t port)
+{
+	udi_cdc_ctrl_state_change(port, true, CDC_SERIAL_STATE_OVERRUN);
+}
+
+iram_size_t udi_cdc_multi_get_nb_received_data(uint8_t port)
+{
+	irqflags_t flags;
+	uint16_t pos;
+	iram_size_t nb_received;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+	flags = cpu_irq_save();
+	pos = udi_cdc_rx_pos[port];
+	nb_received = udi_cdc_rx_buf_nb[port][udi_cdc_rx_buf_sel[port]] - pos;
+	cpu_irq_restore(flags);
+	return nb_received;
+}
+
+iram_size_t udi_cdc_get_nb_received_data(void)
+{
+	return udi_cdc_multi_get_nb_received_data(0);
+}
+
+bool udi_cdc_multi_is_rx_ready(uint8_t port)
+{
+	return (udi_cdc_multi_get_nb_received_data(port) > 0);
+}
+
+bool udi_cdc_is_rx_ready(void)
+{
+	return udi_cdc_multi_is_rx_ready(0);
+}
+
+int udi_cdc_multi_getc(uint8_t port)
+{
+	irqflags_t flags;
+	int rx_data = 0;
+	bool b_databit_9;
+	uint16_t pos;
+	uint8_t buf_sel;
+	bool again;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	b_databit_9 = (9 == udi_cdc_line_coding[port].bDataBits);
+
+udi_cdc_getc_process_one_byte:
+	// Check available data
+	flags = cpu_irq_save();
+	pos = udi_cdc_rx_pos[port];
+	buf_sel = udi_cdc_rx_buf_sel[port];
+	again = pos >= udi_cdc_rx_buf_nb[port][buf_sel];
+	cpu_irq_restore(flags);
+	while (again) {
+		if (!udi_cdc_data_running) {
+			return 0;
+		}
+		goto udi_cdc_getc_process_one_byte;
+	}
+
+	// Read data
+	rx_data |= udi_cdc_rx_buf[port][buf_sel][pos];
+	udi_cdc_rx_pos[port] = pos+1;
+
+	udi_cdc_rx_start(port);
+
+	if (b_databit_9) {
+		// Receive MSB
+		b_databit_9 = false;
+		rx_data = rx_data << 8;
+		goto udi_cdc_getc_process_one_byte;
+	}
+	return rx_data;
+}
+
+int udi_cdc_getc(void)
+{
+	return udi_cdc_multi_getc(0);
+}
+
+iram_size_t udi_cdc_multi_read_buf(uint8_t port, void* buf, iram_size_t size)
+{
+	irqflags_t flags;
+	uint8_t *ptr_buf = (uint8_t *)buf;
+	iram_size_t copy_nb;
+	uint16_t pos;
+	uint8_t buf_sel;
+	bool again;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+udi_cdc_read_buf_loop_wait:
+	// Check available data
+	flags = cpu_irq_save();
+	pos = udi_cdc_rx_pos[port];
+	buf_sel = udi_cdc_rx_buf_sel[port];
+	again = pos >= udi_cdc_rx_buf_nb[port][buf_sel];
+	cpu_irq_restore(flags);
+	while (again) {
+		if (!udi_cdc_data_running) {
+			return size;
+		}
+		goto udi_cdc_read_buf_loop_wait;
+	}
+
+	// Read data
+	copy_nb = udi_cdc_rx_buf_nb[port][buf_sel] - pos;
+	if (copy_nb>size) {
+		copy_nb = size;
+	}
+	memcpy(ptr_buf, &udi_cdc_rx_buf[port][buf_sel][pos], copy_nb);
+	udi_cdc_rx_pos[port] += copy_nb;
+	ptr_buf += copy_nb;
+	size -= copy_nb;
+	udi_cdc_rx_start(port);
+
+	if (size) {
+		goto udi_cdc_read_buf_loop_wait;
+	}
+	return 0;
+}
+
+static iram_size_t udi_cdc_multi_read_no_polling(uint8_t port, void* buf, iram_size_t size)
+{
+	uint8_t *ptr_buf = (uint8_t *)buf;
+	iram_size_t nb_avail_data;
+	uint16_t pos;
+	uint8_t buf_sel;
+	irqflags_t flags;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	//Data interface not started... exit
+	if (!udi_cdc_data_running) {
+		return 0;
+	}
+	
+	//Get number of available data
+	// Check available data
+	flags = cpu_irq_save(); // to protect udi_cdc_rx_pos & udi_cdc_rx_buf_sel
+	pos = udi_cdc_rx_pos[port];
+	buf_sel = udi_cdc_rx_buf_sel[port];
+	nb_avail_data = udi_cdc_rx_buf_nb[port][buf_sel] - pos;
+	cpu_irq_restore(flags);
+	//If the buffer contains less than the requested number of data,
+	//adjust read size
+	if(nb_avail_data<size) {
+		size = nb_avail_data;
+	}
+	if(size>0) {
+		memcpy(ptr_buf, &udi_cdc_rx_buf[port][buf_sel][pos], size);
+		flags = cpu_irq_save(); // to protect udi_cdc_rx_pos
+		udi_cdc_rx_pos[port] += size;
+		cpu_irq_restore(flags);
+		
+		ptr_buf += size;
+		udi_cdc_rx_start(port);
+	}
+	return(nb_avail_data);
+}
+
+iram_size_t udi_cdc_read_no_polling(void* buf, iram_size_t size)
+{
+	return udi_cdc_multi_read_no_polling(0, buf, size);
+}
+
+iram_size_t udi_cdc_read_buf(void* buf, iram_size_t size)
+{
+	return udi_cdc_multi_read_buf(0, buf, size);
+}
+
+iram_size_t udi_cdc_multi_get_free_tx_buffer(uint8_t port)
+{
+	irqflags_t flags;
+	iram_size_t buf_sel_nb, retval;
+	uint8_t buf_sel;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	flags = cpu_irq_save();
+	buf_sel = udi_cdc_tx_buf_sel[port];
+	buf_sel_nb = udi_cdc_tx_buf_nb[port][buf_sel];
+	if (buf_sel_nb == UDI_CDC_TX_BUFFERS) {
+		if ((!udi_cdc_tx_trans_ongoing[port])
+			&& (!udi_cdc_tx_both_buf_to_send[port])) {
+			/* One buffer is full, but the other buffer is not used.
+			 * (not used = transfer on-going)
+			 * then move to the other buffer to store data */
+			udi_cdc_tx_both_buf_to_send[port] = true;
+			udi_cdc_tx_buf_sel[port] = (buf_sel == 0)? 1 : 0;
+			buf_sel_nb = 0;
+		}
+	}
+	retval = UDI_CDC_TX_BUFFERS - buf_sel_nb;  
+	cpu_irq_restore(flags);
+	return retval;
+}
+
+iram_size_t udi_cdc_get_free_tx_buffer(void)
+{
+	return udi_cdc_multi_get_free_tx_buffer(0);
+}
+
+bool udi_cdc_multi_is_tx_ready(uint8_t port)
+{
+	return (udi_cdc_multi_get_free_tx_buffer(port) != 0);
+}
+
+bool udi_cdc_is_tx_ready(void)
+{
+	return udi_cdc_multi_is_tx_ready(0);
+}
+
+int udi_cdc_multi_putc(uint8_t port, int value)
+{
+	irqflags_t flags;
+	bool b_databit_9;
+	uint8_t buf_sel;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	b_databit_9 = (9 == udi_cdc_line_coding[port].bDataBits);
+
+udi_cdc_putc_process_one_byte:
+	// Check available space
+	if (!udi_cdc_multi_is_tx_ready(port)) {
+		if (!udi_cdc_data_running) {
+			return false;
+		}
+		goto udi_cdc_putc_process_one_byte;
+	}
+
+	// Write value
+	flags = cpu_irq_save();
+	buf_sel = udi_cdc_tx_buf_sel[port];
+	udi_cdc_tx_buf[port][buf_sel][udi_cdc_tx_buf_nb[port][buf_sel]++] = value;
+	cpu_irq_restore(flags);
+
+	if (b_databit_9) {
+		// Send MSB
+		b_databit_9 = false;
+		value = value >> 8;
+		goto udi_cdc_putc_process_one_byte;
+	}
+	return true;
+}
+
+int udi_cdc_putc(int value)
+{
+	return udi_cdc_multi_putc(0, value);
+}
+
+iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t size)
+{
+	irqflags_t flags;
+	uint8_t buf_sel;
+	uint16_t buf_nb;
+	iram_size_t copy_nb;
+	uint8_t *ptr_buf = (uint8_t *)buf;
+
+#if UDI_CDC_PORT_NB == 1 // To optimize code
+	port = 0;
+#endif
+
+	if (9 == udi_cdc_line_coding[port].bDataBits) {
+		size *=2;
+	}
+
+udi_cdc_write_buf_loop_wait:
+	// Check available space
+	if (!udi_cdc_multi_is_tx_ready(port)) {
+		if (!udi_cdc_data_running) {
+			return size;
+		}
+		goto udi_cdc_write_buf_loop_wait;
+	}
+
+	// Write values
+	flags = cpu_irq_save();
+	buf_sel = udi_cdc_tx_buf_sel[port];
+	buf_nb = udi_cdc_tx_buf_nb[port][buf_sel];
+	copy_nb = UDI_CDC_TX_BUFFERS - buf_nb;
+	if (copy_nb > size) {
+		copy_nb = size;
+	}
+	memcpy(&udi_cdc_tx_buf[port][buf_sel][buf_nb], ptr_buf, copy_nb);
+	udi_cdc_tx_buf_nb[port][buf_sel] = buf_nb + copy_nb;
+	cpu_irq_restore(flags);
+
+	// Update buffer pointer
+	ptr_buf = ptr_buf + copy_nb;
+	size -= copy_nb;
+
+	if (size) {
+		goto udi_cdc_write_buf_loop_wait;
+	}
+
+	return 0;
+}
+
+iram_size_t udi_cdc_write_buf(const void* buf, iram_size_t size)
+{
+	return udi_cdc_multi_write_buf(0, buf, size);
+}
+
+//@}
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.h
@@ -1,0 +1,810 @@
+/**
+ * \file
+ *
+ * \brief USB Device Communication Device Class (CDC) interface definitions.
+ *
+ * Copyright (c) 2009-2016 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _UDI_CDC_H_
+#define _UDI_CDC_H_
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "usb_protocol_cdc.h"
+#include "udd.h"
+#include "udc_desc.h"
+#include "udi.h"
+
+// Check the number of port
+#ifndef  UDI_CDC_PORT_NB
+# define  UDI_CDC_PORT_NB 1
+#endif
+#if (UDI_CDC_PORT_NB < 1) || (UDI_CDC_PORT_NB > 7)
+# error UDI_CDC_PORT_NB must be between 1 and 7
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup udi_cdc_group_udc
+ * @{
+ */
+
+//! Global structure which contains standard UDI API for UDC
+extern UDC_DESC_STORAGE udi_api_t udi_api_cdc_comm;
+extern UDC_DESC_STORAGE udi_api_t udi_api_cdc_data;
+//@}
+
+/**
+ * \ingroup udi_cdc_group
+ * \defgroup udi_cdc_group_desc USB interface descriptors
+ *
+ * The following structures provide predefined USB interface descriptors.
+ * It must be used to define the final USB descriptors.
+ */
+//@{
+
+/**
+ * \brief Communication Class interface descriptor
+ *
+ * Interface descriptor with associated functional and endpoint
+ * descriptors for the CDC Communication Class interface.
+ */
+typedef struct {
+	//! Standard interface descriptor
+	usb_iface_desc_t iface;
+	//! CDC Header functional descriptor
+	usb_cdc_hdr_desc_t header;
+	//! CDC Abstract Control Model functional descriptor
+	usb_cdc_acm_desc_t acm;
+	//! CDC Union functional descriptor
+	usb_cdc_union_desc_t union_desc;
+	//! CDC Call Management functional descriptor
+	usb_cdc_call_mgmt_desc_t call_mgmt;
+	//! Notification endpoint descriptor
+	usb_ep_desc_t ep_notify;
+} udi_cdc_comm_desc_t;
+
+
+/**
+ * \brief Data Class interface descriptor
+ *
+ * Interface descriptor with associated endpoint descriptors for the
+ * CDC Data Class interface.
+ */
+typedef struct {
+	//! Standard interface descriptor
+	usb_iface_desc_t iface;
+	//! Data IN/OUT endpoint descriptors
+	usb_ep_desc_t ep_in;
+	usb_ep_desc_t ep_out;
+} udi_cdc_data_desc_t;
+
+
+//! CDC communication endpoints size for all speeds
+#define UDI_CDC_COMM_EP_SIZE        64
+//! CDC data endpoints size for FS speed (8B, 16B, 32B, 64B)
+#define UDI_CDC_DATA_EPS_FS_SIZE    64
+//! CDC data endpoints size for HS speed (512B only)
+#define UDI_CDC_DATA_EPS_HS_SIZE    512
+
+/**
+ * \name Content of interface descriptors
+ * Up to 7 CDC interfaces can be implemented on a USB device.
+ */
+//@{
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_0
+#define UDI_CDC_IAD_STRING_ID_0   0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_0
+#define UDI_CDC_COMM_STRING_ID_0   0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_0
+#define UDI_CDC_DATA_STRING_ID_0   0
+#endif
+#define UDI_CDC_IAD_DESC_0      UDI_CDC_IAD_DESC(0)
+#define UDI_CDC_COMM_DESC_0     UDI_CDC_COMM_DESC(0)
+#define UDI_CDC_DATA_DESC_0_FS  UDI_CDC_DATA_DESC_FS(0)
+#define UDI_CDC_DATA_DESC_0_HS  UDI_CDC_DATA_DESC_HS(0)
+
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_1
+#define UDI_CDC_IAD_STRING_ID_1  0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_1
+#define UDI_CDC_COMM_STRING_ID_1 0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_1
+#define UDI_CDC_DATA_STRING_ID_1 0
+#endif
+#define UDI_CDC_IAD_DESC_1      UDI_CDC_IAD_DESC(1)
+#define UDI_CDC_COMM_DESC_1     UDI_CDC_COMM_DESC(1)
+#define UDI_CDC_DATA_DESC_1_FS  UDI_CDC_DATA_DESC_FS(1)
+#define UDI_CDC_DATA_DESC_1_HS  UDI_CDC_DATA_DESC_HS(1)
+
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_2
+#define UDI_CDC_IAD_STRING_ID_2   0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_2
+#define UDI_CDC_COMM_STRING_ID_2   0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_2
+#define UDI_CDC_DATA_STRING_ID_2   0
+#endif
+#define UDI_CDC_IAD_DESC_2      UDI_CDC_IAD_DESC(2)
+#define UDI_CDC_COMM_DESC_2     UDI_CDC_COMM_DESC(2)
+#define UDI_CDC_DATA_DESC_2_FS  UDI_CDC_DATA_DESC_FS(2)
+#define UDI_CDC_DATA_DESC_2_HS  UDI_CDC_DATA_DESC_HS(2)
+
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_3
+#define UDI_CDC_IAD_STRING_ID_3   0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_3
+#define UDI_CDC_COMM_STRING_ID_3   0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_3
+#define UDI_CDC_DATA_STRING_ID_3   0
+#endif
+#define UDI_CDC_IAD_DESC_3      UDI_CDC_IAD_DESC(3)
+#define UDI_CDC_COMM_DESC_3     UDI_CDC_COMM_DESC(3)
+#define UDI_CDC_DATA_DESC_3_FS  UDI_CDC_DATA_DESC_FS(3)
+#define UDI_CDC_DATA_DESC_3_HS  UDI_CDC_DATA_DESC_HS(3)
+
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_4
+#define UDI_CDC_IAD_STRING_ID_4   0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_4
+#define UDI_CDC_COMM_STRING_ID_4   0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_4
+#define UDI_CDC_DATA_STRING_ID_4   0
+#endif
+#define UDI_CDC_IAD_DESC_4      UDI_CDC_IAD_DESC(4)
+#define UDI_CDC_COMM_DESC_4     UDI_CDC_COMM_DESC(4)
+#define UDI_CDC_DATA_DESC_4_FS  UDI_CDC_DATA_DESC_FS(4)
+#define UDI_CDC_DATA_DESC_4_HS  UDI_CDC_DATA_DESC_HS(4)
+
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_5
+#define UDI_CDC_IAD_STRING_ID_5   0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_5
+#define UDI_CDC_COMM_STRING_ID_5   0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_5
+#define UDI_CDC_DATA_STRING_ID_5   0
+#endif
+#define UDI_CDC_IAD_DESC_5      UDI_CDC_IAD_DESC(5)
+#define UDI_CDC_COMM_DESC_5     UDI_CDC_COMM_DESC(5)
+#define UDI_CDC_DATA_DESC_5_FS  UDI_CDC_DATA_DESC_FS(5)
+#define UDI_CDC_DATA_DESC_5_HS  UDI_CDC_DATA_DESC_HS(5)
+
+//! By default no string associated to these interfaces
+#ifndef UDI_CDC_IAD_STRING_ID_6
+#define UDI_CDC_IAD_STRING_ID_6   0
+#endif
+#ifndef UDI_CDC_COMM_STRING_ID_6
+#define UDI_CDC_COMM_STRING_ID_6   0
+#endif
+#ifndef UDI_CDC_DATA_STRING_ID_6
+#define UDI_CDC_DATA_STRING_ID_6   0
+#endif
+#define UDI_CDC_IAD_DESC_6      UDI_CDC_IAD_DESC(6)
+#define UDI_CDC_COMM_DESC_6     UDI_CDC_COMM_DESC(6)
+#define UDI_CDC_DATA_DESC_6_FS  UDI_CDC_DATA_DESC_FS(6)
+#define UDI_CDC_DATA_DESC_6_HS  UDI_CDC_DATA_DESC_HS(6)
+//@}
+
+
+//! Content of CDC IAD interface descriptor for all speeds
+#define UDI_CDC_IAD_DESC(port) { \
+   .bLength                      = sizeof(usb_iad_desc_t),\
+   .bDescriptorType              = USB_DT_IAD,\
+   .bInterfaceCount              = 2,\
+   .bFunctionClass               = CDC_CLASS_COMM,\
+   .bFunctionSubClass            = CDC_SUBCLASS_ACM,\
+   .bFunctionProtocol            = CDC_PROTOCOL_V25TER,\
+   .bFirstInterface              = UDI_CDC_COMM_IFACE_NUMBER_##port,\
+   .iFunction                    = UDI_CDC_IAD_STRING_ID_##port,\
+   }
+
+//! Content of CDC COMM interface descriptor for all speeds
+#define UDI_CDC_COMM_DESC(port) { \
+   .iface.bLength                = sizeof(usb_iface_desc_t),\
+   .iface.bDescriptorType        = USB_DT_INTERFACE,\
+   .iface.bAlternateSetting      = 0,\
+   .iface.bNumEndpoints          = 1,\
+   .iface.bInterfaceClass        = CDC_CLASS_COMM,\
+   .iface.bInterfaceSubClass     = CDC_SUBCLASS_ACM,\
+   .iface.bInterfaceProtocol     = CDC_PROTOCOL_V25TER,\
+   .header.bFunctionLength       = sizeof(usb_cdc_hdr_desc_t),\
+   .header.bDescriptorType       = CDC_CS_INTERFACE,\
+   .header.bDescriptorSubtype    = CDC_SCS_HEADER,\
+   .header.bcdCDC                = LE16(0x0110),\
+   .call_mgmt.bFunctionLength    = sizeof(usb_cdc_call_mgmt_desc_t),\
+   .call_mgmt.bDescriptorType    = CDC_CS_INTERFACE,\
+   .call_mgmt.bDescriptorSubtype = CDC_SCS_CALL_MGMT,\
+   .call_mgmt.bmCapabilities     = \
+			CDC_CALL_MGMT_SUPPORTED | CDC_CALL_MGMT_OVER_DCI,\
+   .acm.bFunctionLength          = sizeof(usb_cdc_acm_desc_t),\
+   .acm.bDescriptorType          = CDC_CS_INTERFACE,\
+   .acm.bDescriptorSubtype       = CDC_SCS_ACM,\
+   .acm.bmCapabilities           = CDC_ACM_SUPPORT_LINE_REQUESTS,\
+   .union_desc.bFunctionLength   = sizeof(usb_cdc_union_desc_t),\
+   .union_desc.bDescriptorType   = CDC_CS_INTERFACE,\
+   .union_desc.bDescriptorSubtype= CDC_SCS_UNION,\
+   .ep_notify.bLength            = sizeof(usb_ep_desc_t),\
+   .ep_notify.bDescriptorType    = USB_DT_ENDPOINT,\
+   .ep_notify.bmAttributes       = USB_EP_TYPE_INTERRUPT,\
+   .ep_notify.wMaxPacketSize     = LE16(UDI_CDC_COMM_EP_SIZE),\
+   .ep_notify.bInterval          = 0x10,\
+   .ep_notify.bEndpointAddress   = UDI_CDC_COMM_EP_##port,\
+   .iface.bInterfaceNumber       = UDI_CDC_COMM_IFACE_NUMBER_##port,\
+   .call_mgmt.bDataInterface     = UDI_CDC_DATA_IFACE_NUMBER_##port,\
+   .union_desc.bMasterInterface  = UDI_CDC_COMM_IFACE_NUMBER_##port,\
+   .union_desc.bSlaveInterface0  = UDI_CDC_DATA_IFACE_NUMBER_##port,\
+   .iface.iInterface             = UDI_CDC_COMM_STRING_ID_##port,\
+   }
+
+//! Content of CDC DATA interface descriptors
+#define UDI_CDC_DATA_DESC_COMMON \
+   .iface.bLength                = sizeof(usb_iface_desc_t),\
+   .iface.bDescriptorType        = USB_DT_INTERFACE,\
+   .iface.bAlternateSetting      = 0,\
+   .iface.bNumEndpoints          = 2,\
+   .iface.bInterfaceClass        = CDC_CLASS_DATA,\
+   .iface.bInterfaceSubClass     = 0,\
+   .iface.bInterfaceProtocol     = 0,\
+   .ep_in.bLength                = sizeof(usb_ep_desc_t),\
+   .ep_in.bDescriptorType        = USB_DT_ENDPOINT,\
+   .ep_in.bmAttributes           = USB_EP_TYPE_BULK,\
+   .ep_in.bInterval              = 0,\
+   .ep_out.bLength               = sizeof(usb_ep_desc_t),\
+   .ep_out.bDescriptorType       = USB_DT_ENDPOINT,\
+   .ep_out.bmAttributes          = USB_EP_TYPE_BULK,\
+   .ep_out.bInterval             = 0,
+
+#define UDI_CDC_DATA_DESC_FS(port) { \
+   UDI_CDC_DATA_DESC_COMMON \
+   .ep_in.wMaxPacketSize         = LE16(UDI_CDC_DATA_EPS_FS_SIZE),\
+   .ep_out.wMaxPacketSize        = LE16(UDI_CDC_DATA_EPS_FS_SIZE),\
+   .ep_in.bEndpointAddress       = UDI_CDC_DATA_EP_IN_##port,\
+   .ep_out.bEndpointAddress      = UDI_CDC_DATA_EP_OUT_##port,\
+   .iface.bInterfaceNumber       = UDI_CDC_DATA_IFACE_NUMBER_##port,\
+   .iface.iInterface             = UDI_CDC_DATA_STRING_ID_##port,\
+   }
+
+#define UDI_CDC_DATA_DESC_HS(port) { \
+   UDI_CDC_DATA_DESC_COMMON \
+   .ep_in.wMaxPacketSize         = LE16(UDI_CDC_DATA_EPS_HS_SIZE),\
+   .ep_out.wMaxPacketSize        = LE16(UDI_CDC_DATA_EPS_HS_SIZE),\
+   .ep_in.bEndpointAddress       = UDI_CDC_DATA_EP_IN_##port,\
+   .ep_out.bEndpointAddress      = UDI_CDC_DATA_EP_OUT_##port,\
+   .iface.bInterfaceNumber       = UDI_CDC_DATA_IFACE_NUMBER_##port,\
+   .iface.iInterface             = UDI_CDC_DATA_STRING_ID_##port,\
+   }
+
+//@}
+
+/**
+ * \ingroup udi_group
+ * \defgroup udi_cdc_group USB Device Interface (UDI) for Communication Class Device (CDC)
+ *
+ * Common APIs used by high level application to use this USB class.
+ *
+ * These routines are used to transfer and control data
+ * to/from USB CDC endpoint.
+ *
+ * See \ref udi_cdc_quickstart.
+ * @{
+ */
+
+/**
+ * \name Interface for application with single CDC interface support
+ */
+//@{
+
+/**
+ * \brief Notify a state change of DCD signal
+ *
+ * \param b_set      DCD is enabled if true, else disabled
+ */
+void udi_cdc_ctrl_signal_dcd(bool b_set);
+
+/**
+ * \brief Notify a state change of DSR signal
+ *
+ * \param b_set      DSR is enabled if true, else disabled
+ */
+void udi_cdc_ctrl_signal_dsr(bool b_set);
+
+/**
+ * \brief Notify a framing error
+ */
+void udi_cdc_signal_framing_error(void);
+
+/**
+ * \brief Notify a parity error
+ */
+void udi_cdc_signal_parity_error(void);
+
+/**
+ * \brief Notify a overrun
+ */
+void udi_cdc_signal_overrun(void);
+
+/**
+ * \brief Gets the number of byte received
+ *
+ * \return the number of data available
+ */
+iram_size_t udi_cdc_get_nb_received_data(void);
+
+/**
+ * \brief This function checks if a character has been received on the CDC line
+ *
+ * \return \c 1 if a byte is ready to be read.
+ */
+bool udi_cdc_is_rx_ready(void);
+
+/**
+ * \brief Waits and gets a value on CDC line
+ *
+ * \return value read on CDC line
+ */
+int udi_cdc_getc(void);
+
+/**
+ * \brief Reads a RAM buffer on CDC line
+ *
+ * \param buf       Values read
+ * \param size      Number of value read
+ *
+ * \return the number of data remaining
+ */
+iram_size_t udi_cdc_read_buf(void* buf, iram_size_t size);
+
+/**
+ * \brief Non polling reads of a up to 'size' data from CDC line
+ *
+ * \param port      Communication port number to manage
+ * \param buf       Buffer where to store read data
+ * \param size      Maximum number of data to read (size of buffer)
+ *
+ * \return the number of data effectively read
+ */
+iram_size_t udi_cdc_read_no_polling(void* buf, iram_size_t size);
+
+/**
+ * \brief Gets the number of free byte in TX buffer
+ *
+ * \return the number of free byte in TX buffer
+ */
+iram_size_t udi_cdc_get_free_tx_buffer(void);
+
+/**
+ * \brief This function checks if a new character sent is possible
+ * The type int is used to support scanf redirection from compiler LIB.
+ *
+ * \return \c 1 if a new character can be sent
+ */
+bool udi_cdc_is_tx_ready(void);
+
+/**
+ * \brief Puts a byte on CDC line
+ * The type int is used to support printf redirection from compiler LIB.
+ *
+ * \param value      Value to put
+ *
+ * \return \c 1 if function was successfully done, otherwise \c 0.
+ */
+int udi_cdc_putc(int value);
+
+/**
+ * \brief Writes a RAM buffer on CDC line
+ *
+ * \param buf       Values to write
+ * \param size      Number of value to write
+ *
+ * \return the number of data remaining
+ */
+iram_size_t udi_cdc_write_buf(const void* buf, iram_size_t size);
+//@}
+
+/**
+ * \name Interface for application with multi CDC interfaces support
+ */
+//@{
+
+/**
+ * \brief Notify a state change of DCD signal
+ *
+ * \param port       Communication port number to manage
+ * \param b_set      DCD is enabled if true, else disabled
+ */
+void udi_cdc_multi_ctrl_signal_dcd(uint8_t port, bool b_set);
+
+/**
+ * \brief Notify a state change of DSR signal
+ *
+ * \param port       Communication port number to manage
+ * \param b_set      DSR is enabled if true, else disabled
+ */
+void udi_cdc_multi_ctrl_signal_dsr(uint8_t port, bool b_set);
+
+/**
+ * \brief Notify a framing error
+ *
+ * \param port       Communication port number to manage
+ */
+void udi_cdc_multi_signal_framing_error(uint8_t port);
+
+/**
+ * \brief Notify a parity error
+ *
+ * \param port       Communication port number to manage
+ */
+void udi_cdc_multi_signal_parity_error(uint8_t port);
+
+/**
+ * \brief Notify a overrun
+ *
+ * \param port       Communication port number to manage
+ */
+void udi_cdc_multi_signal_overrun(uint8_t port);
+
+/**
+ * \brief Gets the number of byte received
+ *
+ * \param port       Communication port number to manage
+ *
+ * \return the number of data available
+ */
+iram_size_t udi_cdc_multi_get_nb_received_data(uint8_t port);
+
+/**
+ * \brief This function checks if a character has been received on the CDC line
+ *
+ * \param port       Communication port number to manage
+ *
+ * \return \c 1 if a byte is ready to be read.
+ */
+bool udi_cdc_multi_is_rx_ready(uint8_t port);
+
+/**
+ * \brief Waits and gets a value on CDC line
+ *
+ * \param port       Communication port number to manage
+ *
+ * \return value read on CDC line
+ */
+int udi_cdc_multi_getc(uint8_t port);
+
+/**
+ * \brief Reads a RAM buffer on CDC line
+ *
+ * \param port       Communication port number to manage
+ * \param buf       Values read
+ * \param size      Number of values read
+ *
+ * \return the number of data remaining
+ */
+iram_size_t udi_cdc_multi_read_buf(uint8_t port, void* buf, iram_size_t size);
+
+/**
+ * \brief Gets the number of free byte in TX buffer
+ *
+ * \param port       Communication port number to manage
+ *
+ * \return the number of free byte in TX buffer
+ */
+iram_size_t udi_cdc_multi_get_free_tx_buffer(uint8_t port);
+
+/**
+ * \brief This function checks if a new character sent is possible
+ * The type int is used to support scanf redirection from compiler LIB.
+ *
+ * \param port       Communication port number to manage
+ *
+ * \return \c 1 if a new character can be sent
+ */
+bool udi_cdc_multi_is_tx_ready(uint8_t port);
+
+/**
+ * \brief Puts a byte on CDC line
+ * The type int is used to support printf redirection from compiler LIB.
+ *
+ * \param port       Communication port number to manage
+ * \param value      Value to put
+ *
+ * \return \c 1 if function was successfully done, otherwise \c 0.
+ */
+int udi_cdc_multi_putc(uint8_t port, int value);
+
+/**
+ * \brief Writes a RAM buffer on CDC line
+ *
+ * \param port       Communication port number to manage
+ * \param buf       Values to write
+ * \param size      Number of value to write
+ *
+ * \return the number of data remaining
+ */
+iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t size);
+//@}
+
+//@}
+
+/**
+ * \page udi_cdc_quickstart Quick start guide for USB device Communication Class Device module (UDI CDC)
+ *
+ * This is the quick start guide for the \ref udi_cdc_group
+ * "USB device interface CDC module (UDI CDC)" with step-by-step instructions on
+ * how to configure and use the modules in a selection of use cases.
+ *
+ * The use cases contain several code fragments. The code fragments in the
+ * steps for setup can be copied into a custom initialization function, while
+ * the steps for usage can be copied into, e.g., the main application function.
+ *
+ * \section udi_cdc_basic_use_case Basic use case
+ * In this basic use case, the "USB CDC (Single Interface Device)" module is used
+ * with only one communication port.
+ * The "USB CDC (Composite Device)" module usage is described in \ref udi_cdc_use_cases
+ * "Advanced use cases".
+ *
+ * \section udi_cdc_basic_use_case_setup Setup steps
+ * \subsection udi_cdc_basic_use_case_setup_prereq Prerequisites
+ * \copydetails udc_basic_use_case_setup_prereq
+ * \subsection udi_cdc_basic_use_case_setup_code Example code
+ * \copydetails udc_basic_use_case_setup_code
+ * \subsection udi_cdc_basic_use_case_setup_flow Workflow
+ * \copydetails udc_basic_use_case_setup_flow
+ *
+ * \section udi_cdc_basic_use_case_usage Usage steps
+ *
+ * \subsection udi_cdc_basic_use_case_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	 #define UDI_CDC_ENABLE_EXT(port) my_callback_cdc_enable()
+	 extern bool my_callback_cdc_enable(void);
+	 #define UDI_CDC_DISABLE_EXT(port) my_callback_cdc_disable()
+	 extern void my_callback_cdc_disable(void);
+	 #define  UDI_CDC_LOW_RATE
+
+	 #define  UDI_CDC_DEFAULT_RATE             115200
+	 #define  UDI_CDC_DEFAULT_STOPBITS         CDC_STOP_BITS_1
+	 #define  UDI_CDC_DEFAULT_PARITY           CDC_PAR_NONE
+	 #define  UDI_CDC_DEFAULT_DATABITS         8
+
+	 #include "udi_cdc_conf.h" // At the end of conf_usb.h file
+\endcode
+ *
+ * Add to application C-file:
+ * \code
+	 static bool my_flag_autorize_cdc_transfert = false;
+	 bool my_callback_cdc_enable(void)
+	 {
+	    my_flag_autorize_cdc_transfert = true;
+	    return true;
+	 }
+	 void my_callback_cdc_disable(void)
+	 {
+	    my_flag_autorize_cdc_transfert = false;
+	 }
+
+	 void task(void)
+	 {
+	    if (my_flag_autorize_cdc_transfert) {
+	        udi_cdc_putc('A');
+	        udi_cdc_getc();
+	    }
+	 }
+\endcode
+ *
+ * \subsection udi_cdc_basic_use_case_setup_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following configuration,
+ * which is the USB device CDC configuration:
+ *   - \code #define USB_DEVICE_SERIAL_NAME  "12...EF" // Disk SN for CDC \endcode
+ *     \note The USB serial number is mandatory when a CDC interface is used.
+ *   - \code #define UDI_CDC_ENABLE_EXT(port) my_callback_cdc_enable()
+	 extern bool my_callback_cdc_enable(void); \endcode
+ *     \note After the device enumeration (detecting and identifying USB devices),
+ *     the USB host starts the device configuration. When the USB CDC interface
+ *     from the device is accepted by the host, the USB host enables this interface and the
+ *     UDI_CDC_ENABLE_EXT() callback function is called and return true.
+ *     Thus, when this event is received, the data transfer on CDC interface are authorized.
+ *   - \code #define UDI_CDC_DISABLE_EXT(port) my_callback_cdc_disable()
+	 extern void my_callback_cdc_disable(void); \endcode
+ *     \note When the USB device is unplugged or is reset by the USB host, the USB
+ *     interface is disabled and the UDI_CDC_DISABLE_EXT() callback function
+ *     is called. Thus, the data transfer must be stopped on CDC interface.
+ *   - \code #define  UDI_CDC_LOW_RATE \endcode
+ *     \note  Define it when the transfer CDC Device to Host is a low rate
+ *     (<512000 bauds) to reduce CDC buffers size.
+ *   - \code #define  UDI_CDC_DEFAULT_RATE             115200
+	#define  UDI_CDC_DEFAULT_STOPBITS         CDC_STOP_BITS_1
+	#define  UDI_CDC_DEFAULT_PARITY           CDC_PAR_NONE
+	#define  UDI_CDC_DEFAULT_DATABITS         8 \endcode
+ *     \note Default configuration of communication port at startup.
+ * -# Send or wait data on CDC line:
+ *   - \code // Waits and gets a value on CDC line
+	int udi_cdc_getc(void);
+	// Reads a RAM buffer on CDC line
+	iram_size_t udi_cdc_read_buf(int* buf, iram_size_t size);
+	// Puts a byte on CDC line
+	int udi_cdc_putc(int value);
+	// Writes a RAM buffer on CDC line
+	iram_size_t udi_cdc_write_buf(const int* buf, iram_size_t size); \endcode
+ *
+ * \section udi_cdc_use_cases Advanced use cases
+ * For more advanced use of the UDI CDC module, see the following use cases:
+ * - \subpage udi_cdc_use_case_composite
+ * - \subpage udc_use_case_1
+ * - \subpage udc_use_case_2
+ * - \subpage udc_use_case_3
+ * - \subpage udc_use_case_4
+ * - \subpage udc_use_case_5
+ * - \subpage udc_use_case_6
+ */
+
+/**
+ * \page udi_cdc_use_case_composite CDC in a composite device
+ *
+ * A USB Composite Device is a USB Device which uses more than one USB class.
+ * In this use case, the "USB CDC (Composite Device)" module is used to
+ * create a USB composite device. Thus, this USB module can be associated with
+ * another "Composite Device" module, like "USB HID Mouse (Composite Device)".
+ *
+ * Also, you can refer to application note
+ * <A href="http://www.atmel.com/dyn/resources/prod_documents/doc8445.pdf">
+ * AVR4902 ASF - USB Composite Device</A>.
+ *
+ * \section udi_cdc_use_case_composite_setup Setup steps
+ * For the setup code of this use case to work, the
+ * \ref udi_cdc_basic_use_case "basic use case" must be followed.
+ *
+ * \section udi_cdc_use_case_composite_usage Usage steps
+ *
+ * \subsection udi_cdc_use_case_composite_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	 #define USB_DEVICE_EP_CTRL_SIZE  64
+	 #define USB_DEVICE_NB_INTERFACE (X+2)
+	 #define USB_DEVICE_MAX_EP (X+3)
+
+	 #define  UDI_CDC_DATA_EP_IN_0          (1 | USB_EP_DIR_IN)  // TX
+	 #define  UDI_CDC_DATA_EP_OUT_0         (2 | USB_EP_DIR_OUT) // RX
+	 #define  UDI_CDC_COMM_EP_0             (3 | USB_EP_DIR_IN)  // Notify endpoint
+	 #define  UDI_CDC_COMM_IFACE_NUMBER_0   X+0
+	 #define  UDI_CDC_DATA_IFACE_NUMBER_0   X+1
+
+	 #define UDI_COMPOSITE_DESC_T \
+	    usb_iad_desc_t udi_cdc_iad; \
+	    udi_cdc_comm_desc_t udi_cdc_comm; \
+	    udi_cdc_data_desc_t udi_cdc_data; \
+	    ...
+	 #define UDI_COMPOSITE_DESC_FS \
+	    .udi_cdc_iad               = UDI_CDC_IAD_DESC_0, \
+	    .udi_cdc_comm              = UDI_CDC_COMM_DESC_0, \
+	    .udi_cdc_data              = UDI_CDC_DATA_DESC_0_FS, \
+	    ...
+	 #define UDI_COMPOSITE_DESC_HS \
+	    .udi_cdc_iad               = UDI_CDC_IAD_DESC_0, \
+	    .udi_cdc_comm              = UDI_CDC_COMM_DESC_0, \
+	    .udi_cdc_data              = UDI_CDC_DATA_DESC_0_HS, \
+	    ...
+	 #define UDI_COMPOSITE_API \
+	    &udi_api_cdc_comm,       \
+	    &udi_api_cdc_data,       \
+	    ...
+\endcode
+ *
+ * \subsection udi_cdc_use_case_composite_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters
+ * required for a USB composite device configuration:
+ *   - \code // Endpoint control size, This must be:
+	// - 8, 16, 32 or 64 for full speed device (8 is recommended to save RAM)
+	// - 64 for a high speed device
+	#define USB_DEVICE_EP_CTRL_SIZE  64
+	// Total Number of interfaces on this USB device.
+	// Add 2 for CDC.
+	#define USB_DEVICE_NB_INTERFACE (X+2)
+	// Total number of endpoints on this USB device.
+	// This must include each endpoint for each interface.
+	// Add 3 for CDC.
+	#define USB_DEVICE_MAX_EP (X+3) \endcode
+ * -# Ensure that conf_usb.h contains the description of
+ * composite device:
+ *   - \code // The endpoint numbers chosen by you for the CDC.
+	// The endpoint numbers starting from 1.
+	#define  UDI_CDC_DATA_EP_IN_0            (1 | USB_EP_DIR_IN)  // TX
+	#define  UDI_CDC_DATA_EP_OUT_0           (2 | USB_EP_DIR_OUT) // RX
+	#define  UDI_CDC_COMM_EP_0               (3 | USB_EP_DIR_IN)  // Notify endpoint
+	// The interface index of an interface starting from 0
+	#define  UDI_CDC_COMM_IFACE_NUMBER_0     X+0
+	#define  UDI_CDC_DATA_IFACE_NUMBER_0     X+1 \endcode
+ * -# Ensure that conf_usb.h contains the following parameters
+ * required for a USB composite device configuration:
+ *   - \code // USB Interfaces descriptor structure
+	#define UDI_COMPOSITE_DESC_T \
+	   ...
+	   usb_iad_desc_t udi_cdc_iad; \
+	   udi_cdc_comm_desc_t udi_cdc_comm; \
+	   udi_cdc_data_desc_t udi_cdc_data; \
+	   ...
+	// USB Interfaces descriptor value for Full Speed
+	#define UDI_COMPOSITE_DESC_FS \
+	   ...
+	   .udi_cdc_iad               = UDI_CDC_IAD_DESC_0, \
+	   .udi_cdc_comm              = UDI_CDC_COMM_DESC_0, \
+	   .udi_cdc_data              = UDI_CDC_DATA_DESC_0_FS, \
+	   ...
+	// USB Interfaces descriptor value for High Speed
+	#define UDI_COMPOSITE_DESC_HS \
+	   ...
+	   .udi_cdc_iad               = UDI_CDC_IAD_DESC_0, \
+	   .udi_cdc_comm              = UDI_CDC_COMM_DESC_0, \
+	   .udi_cdc_data              = UDI_CDC_DATA_DESC_0_HS, \
+	   ...
+	// USB Interface APIs
+	#define UDI_COMPOSITE_API \
+	   ...
+	   &udi_api_cdc_comm,       \
+	   &udi_api_cdc_data,       \
+	   ... \endcode
+ *   - \note The descriptors order given in the four lists above must be the
+ *     same as the order defined by all interface indexes. The interface index
+ *     orders are defined through UDI_X_IFACE_NUMBER defines.\n
+ *     Also, the CDC requires a USB Interface Association Descriptor (IAD) for
+ *     composite device.
+ */
+
+#ifdef __cplusplus
+}
+#endif
+#endif // _UDI_CDC_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_composite_desc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_composite_desc.c
@@ -1,0 +1,188 @@
+/**
+ * \file
+ *
+ * \brief Descriptors for an USB Composite Device
+ *
+ * Copyright (c) 2009-2016 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+ 
+#ifdef ARDUINO_ARCH_SAM 
+
+#include "conf_usb.h"
+#include "udd.h"
+#include "udc_desc.h"
+
+/**
+ * \defgroup udi_group_desc Descriptors for a USB Device
+ * composite
+ *
+ * @{
+ */
+
+/**INDENT-OFF**/
+
+//! USB Device Descriptor
+COMPILER_WORD_ALIGNED
+UDC_DESC_STORAGE usb_dev_desc_t udc_device_desc = {
+	.bLength                   = sizeof(usb_dev_desc_t),
+	.bDescriptorType           = USB_DT_DEVICE,
+	.bcdUSB                    = LE16(USB_V2_0),
+	.bDeviceClass              = 0,
+	.bDeviceSubClass           = 0,
+	.bDeviceProtocol           = 0,
+	.bMaxPacketSize0           = USB_DEVICE_EP_CTRL_SIZE,
+	.idVendor                  = LE16(USB_DEVICE_VENDOR_ID),
+	.idProduct                 = LE16(USB_DEVICE_PRODUCT_ID),
+	.bcdDevice                 = LE16((USB_DEVICE_MAJOR_VERSION << 8)
+		| USB_DEVICE_MINOR_VERSION),
+#ifdef USB_DEVICE_MANUFACTURE_NAME
+	.iManufacturer             = 1,
+#else
+	.iManufacturer             = 0,  // No manufacture string
+#endif
+#ifdef USB_DEVICE_PRODUCT_NAME
+	.iProduct                  = 2,
+#else
+	.iProduct                  = 0,  // No product string
+#endif
+#if (defined USB_DEVICE_SERIAL_NAME || defined USB_DEVICE_GET_SERIAL_NAME_POINTER)
+	.iSerialNumber             = 3,
+#else
+	.iSerialNumber             = 0,  // No serial string
+#endif
+	.bNumConfigurations        = 1
+};
+
+
+#ifdef USB_DEVICE_HS_SUPPORT
+//! USB Device Qualifier Descriptor for HS
+COMPILER_WORD_ALIGNED
+UDC_DESC_STORAGE usb_dev_qual_desc_t udc_device_qual = {
+	.bLength                   = sizeof(usb_dev_qual_desc_t),
+	.bDescriptorType           = USB_DT_DEVICE_QUALIFIER,
+	.bcdUSB                    = LE16(USB_V2_0),
+	.bDeviceClass              = 0,
+	.bDeviceSubClass           = 0,
+	.bDeviceProtocol           = 0,
+	.bMaxPacketSize0           = USB_DEVICE_EP_CTRL_SIZE,
+	.bNumConfigurations        = 1
+};
+#endif
+
+//! Structure for USB Device Configuration Descriptor
+COMPILER_PACK_SET(1)
+typedef struct {
+	usb_conf_desc_t conf;
+	UDI_COMPOSITE_DESC_T;
+} udc_desc_t;
+COMPILER_PACK_RESET()
+
+//! USB Device Configuration Descriptor filled for FS
+COMPILER_WORD_ALIGNED
+UDC_DESC_STORAGE udc_desc_t udc_desc_fs = {
+	.conf.bLength              = sizeof(usb_conf_desc_t),
+	.conf.bDescriptorType      = USB_DT_CONFIGURATION,
+	.conf.wTotalLength         = LE16(sizeof(udc_desc_t)),
+	.conf.bNumInterfaces       = USB_DEVICE_NB_INTERFACE,
+	.conf.bConfigurationValue  = 1,
+	.conf.iConfiguration       = 0,
+	.conf.bmAttributes         = USB_CONFIG_ATTR_MUST_SET | USB_DEVICE_ATTR,
+	.conf.bMaxPower            = USB_CONFIG_MAX_POWER(USB_DEVICE_POWER),
+	UDI_COMPOSITE_DESC_FS
+};
+
+#ifdef USB_DEVICE_HS_SUPPORT
+//! USB Device Configuration Descriptor filled for HS
+COMPILER_WORD_ALIGNED
+UDC_DESC_STORAGE udc_desc_t udc_desc_hs = {
+	.conf.bLength              = sizeof(usb_conf_desc_t),
+	.conf.bDescriptorType      = USB_DT_CONFIGURATION,
+	.conf.wTotalLength         = LE16(sizeof(udc_desc_t)),
+	.conf.bNumInterfaces       = USB_DEVICE_NB_INTERFACE,
+	.conf.bConfigurationValue  = 1,
+	.conf.iConfiguration       = 0,
+	.conf.bmAttributes         = USB_CONFIG_ATTR_MUST_SET | USB_DEVICE_ATTR,
+	.conf.bMaxPower            = USB_CONFIG_MAX_POWER(USB_DEVICE_POWER),
+	UDI_COMPOSITE_DESC_HS
+};
+#endif
+
+
+/**
+ * \name UDC structures which contains all USB Device definitions
+ */
+//@{
+
+//! Associate an UDI for each USB interface
+UDC_DESC_STORAGE udi_api_t *udi_apis[USB_DEVICE_NB_INTERFACE] = {
+	UDI_COMPOSITE_API
+};
+
+//! Add UDI with USB Descriptors FS
+UDC_DESC_STORAGE udc_config_speed_t   udc_config_lsfs[1] = {{
+	.desc          = (usb_conf_desc_t UDC_DESC_STORAGE*)&udc_desc_fs,
+	.udi_apis      = udi_apis,
+}};
+
+#ifdef USB_DEVICE_HS_SUPPORT
+//! Add UDI with USB Descriptors HS
+UDC_DESC_STORAGE udc_config_speed_t   udc_config_hs[1] = {{
+	.desc          = (usb_conf_desc_t UDC_DESC_STORAGE*)&udc_desc_hs,
+	.udi_apis      = udi_apis,
+}};
+#endif
+
+//! Add all information about USB Device in global structure for UDC
+UDC_DESC_STORAGE udc_config_t udc_config = {
+	.confdev_lsfs = &udc_device_desc,
+	.conf_lsfs = udc_config_lsfs,
+#ifdef USB_DEVICE_HS_SUPPORT
+	.confdev_hs = &udc_device_desc,
+	.qualifier = &udc_device_qual,
+	.conf_hs = udc_config_hs,
+#endif
+};
+
+//@}
+/**INDENT-ON**/
+//@}
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_msc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_msc.c
@@ -1,0 +1,1128 @@
+/**
+ * \file
+ *
+ * \brief USB Device Mass Storage Class (MSC) interface.
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+ 
+#ifdef ARDUINO_ARCH_SAM 
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "usb_protocol_msc.h"
+#include "spc_protocol.h"
+#include "sbc_protocol.h"
+#include "udd.h"
+#include "udc.h"
+#include "udi_msc.h"
+#include "ctrl_access.h"
+#include <string.h>
+
+#ifndef UDI_MSC_NOTIFY_TRANS_EXT
+#  define UDI_MSC_NOTIFY_TRANS_EXT()
+#endif
+
+/**
+ * \ingroup udi_msc_group
+ * \defgroup udi_msc_group_udc Interface with USB Device Core (UDC)
+ *
+ * Structures and functions required by UDC.
+ *
+ * @{
+ */
+bool udi_msc_enable(void);
+void udi_msc_disable(void);
+bool udi_msc_setup(void);
+uint8_t udi_msc_getsetting(void);
+
+//! Global structure which contains standard UDI API for UDC
+UDC_DESC_STORAGE udi_api_t udi_api_msc = {
+	.enable = udi_msc_enable,
+	.disable = udi_msc_disable,
+	.setup = udi_msc_setup,
+	.getsetting = udi_msc_getsetting,
+	.sof_notify = NULL,
+};
+//@}
+
+
+/**
+ * \ingroup udi_msc_group
+ * \defgroup udi_msc_group_internal Implementation of UDI MSC
+ *
+ * Class internal implementation
+ * @{
+ */
+
+//! Static block size for all memories
+#define  UDI_MSC_BLOCK_SIZE   512L
+
+/**
+ * \name Variables to manage SCSI requests
+ */
+//@{
+
+//! Structure to receive a CBW packet
+UDC_BSS(4) static struct usb_msc_cbw udi_msc_cbw;
+//! Structure to send a CSW packet
+UDC_DATA(4) static struct usb_msc_csw udi_msc_csw =
+		{.dCSWSignature = CPU_TO_BE32(USB_CSW_SIGNATURE) };
+//! Number of lun
+UDC_DATA(4) static uint8_t udi_msc_nb_lun = 0;
+//! Structure with current SCSI sense data
+UDC_BSS(4) static struct scsi_request_sense_data udi_msc_sense;
+
+/**
+ * \name Variables to manage the background read/write SCSI commands
+ */
+//@{
+//! True if an invalid CBW command has been detected
+static bool udi_msc_b_cbw_invalid = false;
+//! True if a transfer command must be processed
+static bool udi_msc_b_trans_req = false;
+//! True if it is a read command, else write command
+static bool udi_msc_b_read;
+//! Memory address to execute the command
+static uint32_t udi_msc_addr;
+//! Number of block to transfer
+static uint16_t udi_msc_nb_block;
+//! Signal end of transfer, if true
+volatile bool udi_msc_b_ack_trans = true;
+//! Status of transfer, aborted if true
+volatile bool udi_msc_b_abort_trans;
+//! Signal (re)init of transfer, if true (by reset/reconnect)
+volatile bool udi_msc_b_reset_trans = true;
+//@}
+
+//@}
+
+
+/**
+ * \name Internal routines
+ */
+//@{
+
+/**
+ * \name Routines to process CBW packet
+ */
+//@{
+
+/**
+ * \brief Stall CBW request
+ */
+static void udi_msc_cbw_invalid(void);
+
+/**
+ * \brief Stall CSW request
+ */
+static void udi_msc_csw_invalid(void);
+
+/**
+ * \brief Links a callback and buffer on endpoint OUT reception
+ *
+ * Called by:
+ * - enable interface
+ * - at the end of previous command after sending the CSW
+ */
+static void udi_msc_cbw_wait(void);
+
+/**
+ * \brief Callback called after CBW reception
+ * Called by UDD when a transfer is finished or aborted
+ *
+ * \param status       UDD_EP_TRANSFER_OK, if transfer is finished
+ * \param status       UDD_EP_TRANSFER_ABORT, if transfer is aborted
+ * \param nb_received  number of data transfered
+ */
+static void udi_msc_cbw_received(udd_ep_status_t status,
+		iram_size_t nb_received, udd_ep_id_t ep);
+
+/**
+ * \brief Function to check the CBW length and direction
+ * Call it after SCSI command decode to check integrity of command
+ *
+ * \param alloc_len  number of bytes that device want transfer
+ * \param dir_flag   Direction of transfer (USB_CBW_DIRECTION_IN/OUT)
+ *
+ * \retval true if the command can be processed
+ */
+static bool udi_msc_cbw_validate(uint32_t alloc_len, uint8_t dir_flag);
+//@}
+
+
+/**
+ * \name Routines to process small data packet
+ */
+//@{
+
+/**
+ * \brief Sends data on MSC IN endpoint
+ * Called by SCSI command which must send a data to host followed by a CSW
+ *
+ * \param buffer        Internal RAM buffer to send
+ * \param buf_size   Size of buffer to send
+ */
+static void udi_msc_data_send(uint8_t * buffer, uint8_t buf_size);
+
+/**
+ * \brief Callback called after data sent
+ * It start CSW packet process
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer finish
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
+ * \param nb_sent    number of data transfered
+ */
+static void udi_msc_data_sent(udd_ep_status_t status, iram_size_t nb_sent,
+		udd_ep_id_t ep);
+//@}
+
+
+/**
+ * \name Routines to process CSW packet
+ */
+//@{
+
+/**
+ * \brief Build CSW packet and send it
+ *
+ * Called at the end of SCSI command
+ */
+static void udi_msc_csw_process(void);
+
+/**
+ * \brief Sends CSW
+ *
+ * Called by #udi_msc_csw_process()
+ * or UDD callback when endpoint halt is cleared
+ */
+void udi_msc_csw_send(void);
+
+/**
+ * \brief Callback called after CSW sent
+ * It restart CBW reception.
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer is finished
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer is aborted
+ * \param nb_sent    number of data transfered
+ */
+static void udi_msc_csw_sent(udd_ep_status_t status, iram_size_t nb_sent,
+		udd_ep_id_t ep);
+//@}
+
+
+/**
+ * \name Routines manage sense data
+ */
+//@{
+
+/**
+ * \brief Reinitialize sense data.
+ */
+static void udi_msc_clear_sense(void);
+
+/**
+ * \brief Update sense data with new value to signal a fail
+ *
+ * \param sense_key     Sense key
+ * \param add_sense     Additional Sense Code
+ * \param lba           LBA corresponding at error
+ */
+static void udi_msc_sense_fail(uint8_t sense_key, uint16_t add_sense,
+		uint32_t lba);
+
+/**
+ * \brief Update sense data with new value to signal success
+ */
+static void udi_msc_sense_pass(void);
+
+/**
+ * \brief Update sense data to signal that memory is not present
+ */
+static void udi_msc_sense_fail_not_present(void);
+
+/**
+ * \brief Update sense data to signal that memory is busy
+ */
+static void udi_msc_sense_fail_busy_or_change(void);
+
+/**
+ * \brief Update sense data to signal a hardware error on memory
+ */
+static void udi_msc_sense_fail_hardware(void);
+
+/**
+ * \brief Update sense data to signal that memory is protected
+ */
+static void udi_msc_sense_fail_protected(void);
+
+/**
+ * \brief Update sense data to signal that CDB fields are not valid
+ */
+static void udi_msc_sense_fail_cdb_invalid(void);
+
+/**
+ * \brief Update sense data to signal that command is not supported
+ */
+static void udi_msc_sense_command_invalid(void);
+//@}
+
+
+/**
+ * \name Routines manage SCSI Commands
+ */
+//@{
+
+/**
+ * \brief Process SPC Request Sense command
+ * Returns error information about last command
+ */
+static void udi_msc_spc_requestsense(void);
+
+/**
+ * \brief Process SPC Inquiry command
+ * Returns information (name,version) about disk
+ */
+static void udi_msc_spc_inquiry(void);
+
+/**
+ * \brief Checks state of disk
+ *
+ * \retval true if disk is ready, otherwise false and updates sense data
+ */
+static bool udi_msc_spc_testunitready_global(void);
+
+/**
+ * \brief Process test unit ready command
+ * Returns state of logical unit
+ */
+static void udi_msc_spc_testunitready(void);
+
+/**
+ * \brief Process prevent allow medium removal command
+ */
+static void udi_msc_spc_prevent_allow_medium_removal(void);
+
+/**
+ * \brief Process mode sense command
+ *
+ * \param b_sense10     Sense10 SCSI command, if true
+ * \param b_sense10     Sense6  SCSI command, if false
+ */
+static void udi_msc_spc_mode_sense(bool b_sense10);
+
+/**
+ * \brief Process start stop command
+ */
+static void udi_msc_sbc_start_stop(void);
+
+/**
+ * \brief Process read capacity command
+ */
+static void udi_msc_sbc_read_capacity(void);
+
+/**
+ * \brief Process read10 or write10 command
+ *
+ * \param b_read     Read transfer, if true,
+ * \param b_read     Write transfer, if false
+ */
+static void udi_msc_sbc_trans(bool b_read);
+//@}
+
+//@}
+
+
+bool udi_msc_enable(void)
+{
+	uint8_t lun;
+	udi_msc_b_trans_req = false;
+	udi_msc_b_cbw_invalid = false;
+	udi_msc_b_ack_trans = true;
+	udi_msc_b_reset_trans = true;
+	udi_msc_nb_lun = get_nb_lun();
+	if (0 == udi_msc_nb_lun)
+		return false; // No lun available, then not authorize to enable interface
+	udi_msc_nb_lun--;
+	// Call application callback
+	// to initialize memories or signal that interface is enabled
+	if (!UDI_MSC_ENABLE_EXT())
+		return false;
+	// Load the medium on each LUN
+	for (lun = 0; lun <= udi_msc_nb_lun; lun ++) {
+		mem_unload(lun, false);
+	}
+	// Start MSC process by CBW reception
+	udi_msc_cbw_wait();
+	return true;
+}
+
+
+void udi_msc_disable(void)
+{
+	udi_msc_b_trans_req = false;
+	udi_msc_b_ack_trans = true;
+	udi_msc_b_reset_trans = true;
+	UDI_MSC_DISABLE_EXT();
+}
+
+
+bool udi_msc_setup(void)
+{
+	if (Udd_setup_is_in()) {
+		// Requests Interface GET
+		if (Udd_setup_type() == USB_REQ_TYPE_CLASS) {
+			// Requests Class Interface Get
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_MSC_GET_MAX_LUN:
+				// Give the number of memories available
+				if (1 != udd_g_ctrlreq.req.wLength)
+					return false;	// Error for USB host
+				if (0 != udd_g_ctrlreq.req.wValue)
+					return false;
+				udd_g_ctrlreq.payload = &udi_msc_nb_lun;
+				udd_g_ctrlreq.payload_size = 1;
+				return true;
+			}
+		}
+	}
+	if (Udd_setup_is_out()) {
+		// Requests Interface SET
+		if (Udd_setup_type() == USB_REQ_TYPE_CLASS) {
+			// Requests Class Interface Set
+			switch (udd_g_ctrlreq.req.bRequest) {
+			case USB_REQ_MSC_BULK_RESET:
+				// Reset MSC interface
+				if (0 != udd_g_ctrlreq.req.wLength)
+					return false;
+				if (0 != udd_g_ctrlreq.req.wValue)
+					return false;
+				udi_msc_b_cbw_invalid = false;
+				udi_msc_b_trans_req = false;
+				// Abort all tasks (transfer or clear stall wait) on endpoints
+				udd_ep_abort(UDI_MSC_EP_OUT);
+				udd_ep_abort(UDI_MSC_EP_IN);
+				// Restart by CBW wait
+				udi_msc_cbw_wait();
+				return true;
+			}
+		}
+	}
+	return false;	// Not supported request
+}
+
+uint8_t udi_msc_getsetting(void)
+{
+	return 0;	// MSC don't have multiple alternate setting
+}
+
+
+//---------------------------------------------
+//------- Routines to process CBW packet
+
+static void udi_msc_cbw_invalid(void)
+{
+	if (!udi_msc_b_cbw_invalid)
+		return;	// Don't re-stall endpoint if error reseted by setup
+	udd_ep_set_halt(UDI_MSC_EP_OUT);
+	// If stall cleared then re-stall it. Only Setup MSC Reset can clear it
+	udd_ep_wait_stall_clear(UDI_MSC_EP_OUT, udi_msc_cbw_invalid);
+}
+
+static void udi_msc_csw_invalid(void)
+{
+	if (!udi_msc_b_cbw_invalid)
+		return;	// Don't re-stall endpoint if error reseted by setup
+	udd_ep_set_halt(UDI_MSC_EP_IN);
+	// If stall cleared then re-stall it. Only Setup MSC Reset can clear it
+	udd_ep_wait_stall_clear(UDI_MSC_EP_IN, udi_msc_csw_invalid);
+}
+
+static void udi_msc_cbw_wait(void)
+{
+	// Register buffer and callback on OUT endpoint
+	if (!udd_ep_run(UDI_MSC_EP_OUT, true,
+					(uint8_t *) & udi_msc_cbw,
+					sizeof(udi_msc_cbw),
+					udi_msc_cbw_received)) {
+		// OUT endpoint not available (halted), then wait a clear of halt.
+		udd_ep_wait_stall_clear(UDI_MSC_EP_OUT, udi_msc_cbw_wait);
+	}
+}
+
+
+static void udi_msc_cbw_received(udd_ep_status_t status,
+		iram_size_t nb_received, udd_ep_id_t ep)
+{
+	UNUSED(ep);
+	// Check status of transfer
+	if (UDD_EP_TRANSFER_OK != status) {
+		// Transfer aborted
+		// Now wait MSC setup reset to relaunch CBW reception
+		return;
+	}
+	// Check CBW integrity:
+	// transfer status/CBW length/CBW signature
+	if ((sizeof(udi_msc_cbw) != nb_received)
+			|| (udi_msc_cbw.dCBWSignature !=
+					CPU_TO_BE32(USB_CBW_SIGNATURE))) {
+		// (5.2.1) Devices receiving a CBW with an invalid signature should stall
+		// further traffic on the Bulk In pipe, and either stall further traffic
+		// or accept and discard further traffic on the Bulk Out pipe, until
+		// reset recovery.
+		udi_msc_b_cbw_invalid = true;
+		udi_msc_cbw_invalid();
+		udi_msc_csw_invalid();
+		return;
+	}
+	// Check LUN asked
+	udi_msc_cbw.bCBWLUN &= USB_CBW_LUN_MASK;
+	if (udi_msc_cbw.bCBWLUN > udi_msc_nb_lun) {
+		// Bad LUN, then stop command process
+		udi_msc_sense_fail_cdb_invalid();
+		udi_msc_csw_process();
+		return;
+	}
+	// Prepare CSW residue field with the size requested
+	udi_msc_csw.dCSWDataResidue =
+			le32_to_cpu(udi_msc_cbw.dCBWDataTransferLength);
+
+	// Decode opcode
+	switch (udi_msc_cbw.CDB[0]) {
+	case SPC_REQUEST_SENSE:
+		udi_msc_spc_requestsense();
+		break;
+
+	case SPC_INQUIRY:
+		udi_msc_spc_inquiry();
+		break;
+
+	case SPC_MODE_SENSE6:
+		udi_msc_spc_mode_sense(false);
+		break;
+	case SPC_MODE_SENSE10:
+		udi_msc_spc_mode_sense(true);
+		break;
+
+	case SPC_TEST_UNIT_READY:
+		udi_msc_spc_testunitready();
+		break;
+
+	case SBC_READ_CAPACITY10:
+		udi_msc_sbc_read_capacity();
+		break;
+
+	case SBC_START_STOP_UNIT:
+		udi_msc_sbc_start_stop();
+		break;
+
+		// Accepts request to support plug/plug in case of card reader
+	case SPC_PREVENT_ALLOW_MEDIUM_REMOVAL:
+		udi_msc_spc_prevent_allow_medium_removal();
+		break;
+
+		// Accepts request to support full format from Windows
+	case SBC_VERIFY10:
+		udi_msc_sense_pass();
+		udi_msc_csw_process();
+		break;
+
+	case SBC_READ10:
+		udi_msc_sbc_trans(true);
+		break;
+
+	case SBC_WRITE10:
+		udi_msc_sbc_trans(false);
+		break;
+
+	default:
+		udi_msc_sense_command_invalid();
+		udi_msc_csw_process();
+		break;
+	}
+}
+
+
+static bool udi_msc_cbw_validate(uint32_t alloc_len, uint8_t dir_flag)
+{
+	/*
+	 * The following cases should result in a phase error:
+	 *  - Case  2: Hn < Di
+	 *  - Case  3: Hn < Do
+	 *  - Case  7: Hi < Di
+	 *  - Case  8: Hi <> Do
+	 *  - Case 10: Ho <> Di
+	 *  - Case 13: Ho < Do
+	 */
+	if (((udi_msc_cbw.bmCBWFlags ^ dir_flag) & USB_CBW_DIRECTION_IN)
+			|| (udi_msc_csw.dCSWDataResidue < alloc_len)) {
+		udi_msc_sense_fail_cdb_invalid();
+		udi_msc_csw_process();
+		return false;
+	}
+
+	/*
+	 * The following cases should result in a stall and nonzero
+	 * residue:
+	 *  - Case  4: Hi > Dn
+	 *  - Case  5: Hi > Di
+	 *  - Case  9: Ho > Dn
+	 *  - Case 11: Ho > Do
+	 */
+	return true;
+}
+
+
+//---------------------------------------------
+//------- Routines to process small data packet
+
+static void udi_msc_data_send(uint8_t * buffer, uint8_t buf_size)
+{
+	// Sends data on IN endpoint
+	if (!udd_ep_run(UDI_MSC_EP_IN, true,
+					buffer, buf_size, udi_msc_data_sent)) {
+		// If endpoint not available, then exit process command
+		udi_msc_sense_fail_hardware();
+		udi_msc_csw_process();
+	}
+}
+
+
+static void udi_msc_data_sent(udd_ep_status_t status, iram_size_t nb_sent,
+		udd_ep_id_t ep)
+{
+	UNUSED(ep);
+	if (UDD_EP_TRANSFER_OK != status) {
+		// Error protocol
+		// Now wait MSC setup reset to relaunch CBW reception
+		return;
+	}
+	// Update sense data
+	udi_msc_sense_pass();
+	// Update CSW
+	udi_msc_csw.dCSWDataResidue -= nb_sent;
+	udi_msc_csw_process();
+}
+
+
+//---------------------------------------------
+//------- Routines to process CSW packet
+
+static void udi_msc_csw_process(void)
+{
+	if (0 != udi_msc_csw.dCSWDataResidue) {
+		// Residue not NULL
+		// then STALL next request from USB host on corresponding endpoint
+		if (udi_msc_cbw.bmCBWFlags & USB_CBW_DIRECTION_IN)
+			udd_ep_set_halt(UDI_MSC_EP_IN);
+		else
+			udd_ep_set_halt(UDI_MSC_EP_OUT);
+	}
+	// Prepare and send CSW
+	udi_msc_csw.dCSWTag = udi_msc_cbw.dCBWTag;
+	udi_msc_csw.dCSWDataResidue = cpu_to_le32(udi_msc_csw.dCSWDataResidue);
+	udi_msc_csw_send();
+}
+
+
+void udi_msc_csw_send(void)
+{
+	// Sends CSW on IN endpoint
+	if (!udd_ep_run(UDI_MSC_EP_IN, false,
+					(uint8_t *) & udi_msc_csw,
+					sizeof(udi_msc_csw),
+					udi_msc_csw_sent)) {
+		// Endpoint not available
+		// then restart CSW sent when endpoint IN STALL will be cleared
+		udd_ep_wait_stall_clear(UDI_MSC_EP_IN, udi_msc_csw_send);
+	}
+}
+
+
+static void udi_msc_csw_sent(udd_ep_status_t status, iram_size_t nb_sent,
+		udd_ep_id_t ep)
+{
+	UNUSED(ep);
+	UNUSED(status);
+	UNUSED(nb_sent);
+	// CSW is sent or not
+	// In all case, restart process and wait CBW
+	udi_msc_cbw_wait();
+}
+
+
+//---------------------------------------------
+//------- Routines manage sense data
+
+static void udi_msc_clear_sense(void)
+{
+	memset((uint8_t*)&udi_msc_sense, 0, sizeof(struct scsi_request_sense_data));
+	udi_msc_sense.valid_reponse_code = SCSI_SENSE_VALID | SCSI_SENSE_CURRENT;
+	udi_msc_sense.AddSenseLen = SCSI_SENSE_ADDL_LEN(sizeof(udi_msc_sense));
+}
+
+static void udi_msc_sense_fail(uint8_t sense_key, uint16_t add_sense,
+		uint32_t lba)
+{
+	udi_msc_clear_sense();
+	udi_msc_csw.bCSWStatus = USB_CSW_STATUS_FAIL;
+	udi_msc_sense.sense_flag_key = sense_key;
+	udi_msc_sense.information[0] = lba >> 24;
+	udi_msc_sense.information[1] = lba >> 16;
+	udi_msc_sense.information[2] = lba >> 8;
+	udi_msc_sense.information[3] = lba;
+	udi_msc_sense.AddSenseCode = add_sense >> 8;
+	udi_msc_sense.AddSnsCodeQlfr = add_sense;
+}
+
+static void udi_msc_sense_pass(void)
+{
+	udi_msc_clear_sense();
+	udi_msc_csw.bCSWStatus = USB_CSW_STATUS_PASS;
+}
+
+
+static void udi_msc_sense_fail_not_present(void)
+{
+	udi_msc_sense_fail(SCSI_SK_NOT_READY, SCSI_ASC_MEDIUM_NOT_PRESENT, 0);
+}
+
+static void udi_msc_sense_fail_busy_or_change(void)
+{
+	udi_msc_sense_fail(SCSI_SK_UNIT_ATTENTION,
+			SCSI_ASC_NOT_READY_TO_READY_CHANGE, 0);
+}
+
+static void udi_msc_sense_fail_hardware(void)
+{
+	udi_msc_sense_fail(SCSI_SK_HARDWARE_ERROR,
+			SCSI_ASC_NO_ADDITIONAL_SENSE_INFO, 0);
+}
+
+static void udi_msc_sense_fail_protected(void)
+{
+	udi_msc_sense_fail(SCSI_SK_DATA_PROTECT, SCSI_ASC_WRITE_PROTECTED, 0);
+}
+
+static void udi_msc_sense_fail_cdb_invalid(void)
+{
+	udi_msc_sense_fail(SCSI_SK_ILLEGAL_REQUEST,
+			SCSI_ASC_INVALID_FIELD_IN_CDB, 0);
+}
+
+static void udi_msc_sense_command_invalid(void)
+{
+	udi_msc_sense_fail(SCSI_SK_ILLEGAL_REQUEST,
+			SCSI_ASC_INVALID_COMMAND_OPERATION_CODE, 0);
+}
+
+
+//---------------------------------------------
+//------- Routines manage SCSI Commands
+
+static void udi_msc_spc_requestsense(void)
+{
+	uint8_t length = udi_msc_cbw.CDB[4];
+
+	// Can't send more than sense data length
+	if (length > sizeof(udi_msc_sense))
+		length = sizeof(udi_msc_sense);
+
+	if (!udi_msc_cbw_validate(length, USB_CBW_DIRECTION_IN))
+		return;
+	// Send sense data
+	udi_msc_data_send((uint8_t*)&udi_msc_sense, length);
+}
+
+
+static void udi_msc_spc_inquiry(void)
+{
+	uint8_t length, i;
+	UDC_DATA(4)
+	// Constant inquiry data for all LUNs
+	static struct scsi_inquiry_data udi_msc_inquiry_data = {
+		.pq_pdt = SCSI_INQ_PQ_CONNECTED | SCSI_INQ_DT_DIR_ACCESS,
+		.version = SCSI_INQ_VER_SPC,
+		.flags3 = SCSI_INQ_RSP_SPC2,
+		.addl_len = SCSI_INQ_ADDL_LEN(sizeof(struct scsi_inquiry_data)),
+		.vendor_id = {UDI_MSC_GLOBAL_VENDOR_ID},
+		.product_rev = {UDI_MSC_GLOBAL_PRODUCT_VERSION},
+	};
+
+	length = udi_msc_cbw.CDB[4];
+
+	// Can't send more than inquiry data length
+	if (length > sizeof(udi_msc_inquiry_data))
+		length = sizeof(udi_msc_inquiry_data);
+
+	if (!udi_msc_cbw_validate(length, USB_CBW_DIRECTION_IN))
+		return;
+	if ((0 != (udi_msc_cbw.CDB[1] & (SCSI_INQ_REQ_EVPD | SCSI_INQ_REQ_CMDT)))
+			|| (0 != udi_msc_cbw.CDB[2])) {
+		// CMDT and EPVD bits are not at 0
+		// PAGE or OPERATION CODE fields are not empty
+		//  = No standard inquiry asked
+		udi_msc_sense_fail_cdb_invalid(); // Command is unsupported
+		udi_msc_csw_process();
+		return;
+	}
+
+	udi_msc_inquiry_data.flags1 = mem_removal(udi_msc_cbw.bCBWLUN) ?
+			SCSI_INQ_RMB : 0;
+
+	//* Fill product ID field
+	// Copy name in product id field
+	memcpy(udi_msc_inquiry_data.product_id,
+			mem_name(udi_msc_cbw.bCBWLUN)+1, // To remove first '"'
+			sizeof(udi_msc_inquiry_data.product_id));
+
+	// Search end of name '/0' or '"'
+	i = 0;
+	while (sizeof(udi_msc_inquiry_data.product_id) != i) {
+		if ((0 == udi_msc_inquiry_data.product_id[i])
+				|| ('"' == udi_msc_inquiry_data.product_id[i])) {
+			break;
+		}
+		i++;
+	}
+	// Padding with space char
+	while (sizeof(udi_msc_inquiry_data.product_id) != i) {
+		udi_msc_inquiry_data.product_id[i] = ' ';
+		i++;
+	}
+
+	// Send inquiry data
+	udi_msc_data_send((uint8_t *) & udi_msc_inquiry_data, length);
+}
+
+
+static bool udi_msc_spc_testunitready_global(void)
+{
+	switch (mem_test_unit_ready(udi_msc_cbw.bCBWLUN)) {
+	case CTRL_GOOD:
+		return true;	// Don't change sense data
+	case CTRL_BUSY:
+		udi_msc_sense_fail_busy_or_change();
+		break;
+	case CTRL_NO_PRESENT:
+		udi_msc_sense_fail_not_present();
+		break;
+	case CTRL_FAIL:
+	default:
+		udi_msc_sense_fail_hardware();
+		break;
+	}
+	return false;
+}
+
+
+static void udi_msc_spc_testunitready(void)
+{
+	if (udi_msc_spc_testunitready_global()) {
+		// LUN ready, then update sense data with status pass
+		udi_msc_sense_pass();
+	}
+	// Send status in CSW packet
+	udi_msc_csw_process();
+}
+
+
+static void udi_msc_spc_mode_sense(bool b_sense10)
+{
+	// Union of all mode sense structures
+	union sense_6_10 {
+		struct {
+			struct scsi_mode_param_header6 header;
+			struct spc_control_page_info_execpt sense_data;
+		} s6;
+		struct {
+			struct scsi_mode_param_header10 header;
+			struct spc_control_page_info_execpt sense_data;
+		} s10;
+	};
+
+	uint8_t data_sense_lgt;
+	uint8_t mode;
+	uint8_t request_lgt;
+	uint8_t wp;
+	struct spc_control_page_info_execpt *ptr_mode;
+	UDC_BSS(4)  static union sense_6_10 sense;
+
+	// Clear all fields
+	memset(&sense, 0, sizeof(sense));
+
+	// Initialize process
+	if (b_sense10) {
+		request_lgt = udi_msc_cbw.CDB[8];
+		ptr_mode = &sense.s10.sense_data;
+		data_sense_lgt = sizeof(struct scsi_mode_param_header10);
+	} else {
+		request_lgt = udi_msc_cbw.CDB[4];
+		ptr_mode = &sense.s6.sense_data;
+		data_sense_lgt = sizeof(struct scsi_mode_param_header6);
+	}
+
+	// No Block descriptor
+
+	// Fill page(s)
+	mode = udi_msc_cbw.CDB[2] & SCSI_MS_MODE_ALL;
+	if ((SCSI_MS_MODE_INFEXP == mode)
+			|| (SCSI_MS_MODE_ALL == mode)) {
+		// Informational exceptions control page (from SPC)
+		ptr_mode->page_code =
+				SCSI_MS_MODE_INFEXP;
+		ptr_mode->page_length =
+				SPC_MP_INFEXP_PAGE_LENGTH;
+		ptr_mode->mrie =
+				SPC_MP_INFEXP_MRIE_NO_SENSE;
+		data_sense_lgt += sizeof(struct spc_control_page_info_execpt);
+	}
+	// Can't send more than mode sense data length
+	if (request_lgt > data_sense_lgt)
+		request_lgt = data_sense_lgt;
+	if (!udi_msc_cbw_validate(request_lgt, USB_CBW_DIRECTION_IN))
+		return;
+
+	// Fill mode parameter header length
+	wp = (mem_wr_protect(udi_msc_cbw.bCBWLUN)) ? SCSI_MS_SBC_WP : 0;
+
+	if (b_sense10) {
+		sense.s10.header.mode_data_length =
+				cpu_to_be16((data_sense_lgt - 2));
+		//sense.s10.header.medium_type                 = 0;
+		sense.s10.header.device_specific_parameter = wp;
+		//sense.s10.header.block_descriptor_length     = 0;
+	} else {
+		sense.s6.header.mode_data_length = data_sense_lgt - 1;
+		//sense.s6.header.medium_type                  = 0;
+		sense.s6.header.device_specific_parameter = wp;
+		//sense.s6.header.block_descriptor_length      = 0;
+	}
+
+	// Send mode sense data
+	udi_msc_data_send((uint8_t *) & sense, request_lgt);
+}
+
+
+static void udi_msc_spc_prevent_allow_medium_removal(void)
+{
+	uint8_t prevent = udi_msc_cbw.CDB[4];
+	if (0 == prevent) {
+		udi_msc_sense_pass();
+	} else {
+		udi_msc_sense_fail_cdb_invalid(); // Command is unsupported
+	}
+	udi_msc_csw_process();
+}
+
+
+static void udi_msc_sbc_start_stop(void)
+{
+	bool start = 0x1 & udi_msc_cbw.CDB[4];
+	bool loej = 0x2 & udi_msc_cbw.CDB[4];
+	if (loej) {
+		mem_unload(udi_msc_cbw.bCBWLUN, !start);
+	}
+	udi_msc_sense_pass();
+	udi_msc_csw_process();
+}
+
+
+static void udi_msc_sbc_read_capacity(void)
+{
+	UDC_BSS(4) static struct sbc_read_capacity10_data udi_msc_capacity;
+
+	if (!udi_msc_cbw_validate(sizeof(udi_msc_capacity),
+					USB_CBW_DIRECTION_IN))
+		return;
+
+	// Get capacity of LUN
+	switch (mem_read_capacity(udi_msc_cbw.bCBWLUN,
+					&udi_msc_capacity.max_lba)) {
+	case CTRL_GOOD:
+		break;
+	case CTRL_BUSY:
+		udi_msc_sense_fail_busy_or_change();
+		udi_msc_csw_process();
+		return;
+	case CTRL_NO_PRESENT:
+		udi_msc_sense_fail_not_present();
+		udi_msc_csw_process();
+		return;
+	default:
+		udi_msc_sense_fail_hardware();
+		udi_msc_csw_process();
+		return;
+	}
+
+	// Format capacity data
+	udi_msc_capacity.block_len = CPU_TO_BE32(UDI_MSC_BLOCK_SIZE);
+	udi_msc_capacity.max_lba = cpu_to_be32(udi_msc_capacity.max_lba);
+	// Send the corresponding sense data
+	udi_msc_data_send((uint8_t *) & udi_msc_capacity,
+			sizeof(udi_msc_capacity));
+}
+
+
+static void udi_msc_sbc_trans(bool b_read)
+{
+	uint32_t trans_size;
+
+	if (!b_read) {
+		// Write operation then check Write Protect
+		if (mem_wr_protect(udi_msc_cbw.bCBWLUN)) {
+			// Write not authorized
+			udi_msc_sense_fail_protected();
+			udi_msc_csw_process();
+			return;
+		}
+	}
+	// Read/Write command fields (address and number of block)
+	MSB0(udi_msc_addr) = udi_msc_cbw.CDB[2];
+	MSB1(udi_msc_addr) = udi_msc_cbw.CDB[3];
+	MSB2(udi_msc_addr) = udi_msc_cbw.CDB[4];
+	MSB3(udi_msc_addr) = udi_msc_cbw.CDB[5];
+	MSB(udi_msc_nb_block) = udi_msc_cbw.CDB[7];
+	LSB(udi_msc_nb_block) = udi_msc_cbw.CDB[8];
+
+	// Compute number of byte to transfer and valid it
+	trans_size = (uint32_t) udi_msc_nb_block *UDI_MSC_BLOCK_SIZE;
+	if (!udi_msc_cbw_validate(trans_size,
+					(b_read) ? USB_CBW_DIRECTION_IN :
+					USB_CBW_DIRECTION_OUT))
+		return;
+
+	// Record transfer request to do it in a task and not under interrupt
+	udi_msc_b_read = b_read;
+	udi_msc_b_trans_req = true;
+	UDI_MSC_NOTIFY_TRANS_EXT();
+}
+
+
+bool udi_msc_process_trans(void)
+{
+	Ctrl_status status;
+
+	if (!udi_msc_b_trans_req)
+		return false;	// No Transfer request to do
+	udi_msc_b_trans_req = false;
+	udi_msc_b_reset_trans = false;
+
+	// Start transfer
+	if (udi_msc_b_read) {
+		status = memory_2_usb(udi_msc_cbw.bCBWLUN, udi_msc_addr,
+				udi_msc_nb_block);
+	} else {
+		status = usb_2_memory(udi_msc_cbw.bCBWLUN, udi_msc_addr,
+				udi_msc_nb_block);
+	}
+
+	// Check if transfer is aborted by reset
+	if (udi_msc_b_reset_trans) {
+		udi_msc_b_reset_trans = false;
+		return true;
+	}
+
+	// Check status of transfer
+	switch (status) {
+	case CTRL_GOOD:
+		udi_msc_sense_pass();
+		break;
+	case CTRL_BUSY:
+		udi_msc_sense_fail_busy_or_change();
+		break;
+	case CTRL_NO_PRESENT:
+		udi_msc_sense_fail_not_present();
+		break;
+	default:
+	case CTRL_FAIL:
+		udi_msc_sense_fail_hardware();
+		break;
+	}
+	// Send status of transfer in CSW packet
+	udi_msc_csw_process();
+	return true;
+}
+
+
+static void udi_msc_trans_ack(udd_ep_status_t status, iram_size_t n,
+		udd_ep_id_t ep)
+{
+	UNUSED(ep);
+	UNUSED(n);
+	// Update variable to signal the end of transfer
+	udi_msc_b_abort_trans = (UDD_EP_TRANSFER_OK != status) ? true : false;
+	udi_msc_b_ack_trans = true;
+}
+
+
+bool udi_msc_trans_block(bool b_read, uint8_t * block, iram_size_t block_size,
+		void (*callback) (udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep))
+{
+	if (!udi_msc_b_ack_trans)
+		return false;	// No possible, transfer on going
+
+	// Start transfer Internal RAM<->USB line
+	udi_msc_b_ack_trans = false;
+	if (!udd_ep_run((b_read) ? UDI_MSC_EP_IN : UDI_MSC_EP_OUT,
+					false,
+					block,
+					block_size,
+					(NULL == callback) ? udi_msc_trans_ack :
+					callback)) {
+		udi_msc_b_ack_trans = true;
+		return false;
+	}
+	if (NULL == callback) {
+		while (!udi_msc_b_ack_trans);
+		if (udi_msc_b_abort_trans) {
+			return false;
+		}
+		udi_msc_csw.dCSWDataResidue -= block_size;
+		return (!udi_msc_b_abort_trans);
+	}
+	udi_msc_csw.dCSWDataResidue -= block_size;
+	return true;
+}
+
+//@}
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_msc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_msc.h
@@ -1,0 +1,376 @@
+/**
+ * \file
+ *
+ * \brief USB Device Mass Storage Class (MSC) interface definitions.
+ *
+ * Copyright (c) 2009-2016 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _UDI_MSC_H_
+#define _UDI_MSC_H_
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "usb_protocol_msc.h"
+#include "udd.h"
+#include "udc_desc.h"
+#include "udi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \addtogroup udi_msc_group_udc
+ * @{
+ */
+//! Global structure which contains standard UDI interface for UDC
+extern UDC_DESC_STORAGE udi_api_t udi_api_msc;
+//@}
+
+/**
+ * \ingroup udi_msc_group
+ * \defgroup udi_msc_group USB interface descriptors
+ *
+ * The following structures provide predefined USB interface descriptors.
+ * It must be used to define the final USB descriptors.
+ */
+//@{
+
+//! Interface descriptor structure for MSC
+typedef struct {
+	usb_iface_desc_t iface;
+	usb_ep_desc_t ep_in;
+	usb_ep_desc_t ep_out;
+} udi_msc_desc_t;
+
+//! By default no string associated to this interface
+#ifndef UDI_MSC_STRING_ID
+#define UDI_MSC_STRING_ID     0
+#endif
+
+//! MSC endpoints size for full speed
+#define UDI_MSC_EPS_SIZE_FS   64
+//! MSC endpoints size for high speed
+#define UDI_MSC_EPS_SIZE_HS   512
+
+//! Content of MSC interface descriptor for all speeds
+#define UDI_MSC_DESC      \
+   .iface.bLength             = sizeof(usb_iface_desc_t),\
+   .iface.bDescriptorType     = USB_DT_INTERFACE,\
+   .iface.bInterfaceNumber    = UDI_MSC_IFACE_NUMBER,\
+   .iface.bAlternateSetting   = 0,\
+   .iface.bNumEndpoints       = 2,\
+   .iface.bInterfaceClass     = MSC_CLASS,\
+   .iface.bInterfaceSubClass  = MSC_SUBCLASS_TRANSPARENT,\
+   .iface.bInterfaceProtocol  = MSC_PROTOCOL_BULK,\
+   .iface.iInterface          = UDI_MSC_STRING_ID,\
+   .ep_in.bLength             = sizeof(usb_ep_desc_t),\
+   .ep_in.bDescriptorType     = USB_DT_ENDPOINT,\
+   .ep_in.bEndpointAddress    = UDI_MSC_EP_IN,\
+   .ep_in.bmAttributes        = USB_EP_TYPE_BULK,\
+   .ep_in.bInterval           = 0,\
+   .ep_out.bLength            = sizeof(usb_ep_desc_t),\
+   .ep_out.bDescriptorType    = USB_DT_ENDPOINT,\
+   .ep_out.bEndpointAddress   = UDI_MSC_EP_OUT,\
+   .ep_out.bmAttributes       = USB_EP_TYPE_BULK,\
+   .ep_out.bInterval          = 0,
+
+//! Content of MSC interface descriptor for full speed only
+#define UDI_MSC_DESC_FS   {\
+   UDI_MSC_DESC \
+   .ep_in.wMaxPacketSize      = LE16(UDI_MSC_EPS_SIZE_FS),\
+   .ep_out.wMaxPacketSize     = LE16(UDI_MSC_EPS_SIZE_FS),\
+   }
+
+//! Content of MSC interface descriptor for high speed only
+#define UDI_MSC_DESC_HS   {\
+   UDI_MSC_DESC \
+   .ep_in.wMaxPacketSize      = LE16(UDI_MSC_EPS_SIZE_HS),\
+   .ep_out.wMaxPacketSize     = LE16(UDI_MSC_EPS_SIZE_HS),\
+   }
+//@}
+
+
+/**
+ * \ingroup udi_group
+ * \defgroup udi_msc_group USB Device Interface (UDI) for Mass Storage Class (MSC)
+ *
+ * Common APIs used by high level application to use this USB class.
+ *
+ * These routines are used by memory to transfer its data
+ * to/from USB MSC endpoints.
+ *
+ * See \ref udi_msc_quickstart.
+ * @{
+ */
+
+/**
+ * \brief Process the background read/write commands
+ *
+ * Routine called by the main loop
+ */
+bool udi_msc_process_trans(void);
+
+/**
+ * \brief Transfers data to/from USB MSC endpoints
+ *
+ *
+ * \param b_read        Memory to USB, if true
+ * \param block         Buffer on Internal RAM to send or fill
+ * \param block_size    Buffer size to send or fill
+ * \param callback      Function to call at the end of transfer.
+ *                      If NULL then the routine exit when transfer is finish.
+ *
+ * \return \c 1 if function was successfully done, otherwise \c 0.
+ */
+bool udi_msc_trans_block(bool b_read, uint8_t * block, iram_size_t block_size,
+		void (*callback) (udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep));
+//@}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+/**
+ * \page udi_msc_quickstart Quick start guide for USB device Mass Storage module (UDI MSC)
+ *
+ * This is the quick start guide for the \ref udi_msc_group 
+ * "USB device interface MSC module (UDI MSC)" with step-by-step instructions on 
+ * how to configure and use the modules in a selection of use cases.
+ *
+ * The use cases contain several code fragments. The code fragments in the
+ * steps for setup can be copied into a custom initialization function, while
+ * the steps for usage can be copied into, e.g., the main application function.
+ * 
+ * \section udi_msc_basic_use_case Basic use case
+ * In this basic use case, the "USB MSC (Single Interface Device)" module is used.
+ * The "USB MSC (Composite Device)" module usage is described in \ref udi_msc_use_cases
+ * "Advanced use cases".
+ *
+ * \section udi_msc_basic_use_case_setup Setup steps
+ * \subsection udi_msc_basic_use_case_setup_prereq Prerequisites
+ * \copydetails udc_basic_use_case_setup_prereq
+ * \subsection udi_msc_basic_use_case_setup_code Example code
+ * \copydetails udc_basic_use_case_setup_code
+ * \subsection udi_msc_basic_use_case_setup_flow Workflow
+ * \copydetails udc_basic_use_case_setup_flow
+ *
+ * \section udi_msc_basic_use_case_usage Usage steps
+ *
+ * \subsection udi_msc_basic_use_case_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	#define  USB_DEVICE_SERIAL_NAME  "12...EF" // Disk SN for MSC
+	#define UDI_MSC_GLOBAL_VENDOR_ID \
+	   'A', 'T', 'M', 'E', 'L', ' ', ' ', ' '
+	#define UDI_MSC_GLOBAL_PRODUCT_VERSION \
+	   '1', '.', '0', '0'
+	#define UDI_MSC_ENABLE_EXT() my_callback_msc_enable()
+	extern bool my_callback_msc_enable(void);
+	#define UDI_MSC_DISABLE_EXT() my_callback_msc_disable()
+	extern void my_callback_msc_disable(void);
+	#include "udi_msc_conf.h" // At the end of conf_usb.h file
+\endcode
+ *
+ * Add to application C-file:
+ * \code
+	 static bool my_flag_autorize_msc_transfert = false;
+	 bool my_callback_msc_enable(void)
+	 {
+	    my_flag_autorize_msc_transfert = true;
+	    return true;
+	 }
+	 void my_callback_msc_disable(void)
+	 {
+	    my_flag_autorize_msc_transfert = false;
+	 }
+
+	 void task(void)
+	 {
+	    udi_msc_process_trans();
+	 }
+\endcode
+ *
+ * \subsection udi_msc_basic_use_case_setup_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following configuration,
+ * which is the USB device MSC configuration:
+ *   - \code #define USB_DEVICE_SERIAL_NAME  "12...EF" // Disk SN for MSC \endcode
+ *     \note The USB serial number is mandatory when a MSC interface is used.
+ *   - \code //! Vendor name and Product version of MSC interface
+	#define UDI_MSC_GLOBAL_VENDOR_ID \
+	   'A', 'T', 'M', 'E', 'L', ' ', ' ', ' '
+	#define UDI_MSC_GLOBAL_PRODUCT_VERSION \
+	   '1', '.', '0', '0' \endcode
+ *     \note The USB MSC interface requires a vendor ID (8 ASCII characters)
+ *     and a product version (4 ASCII characters).
+ *   - \code #define UDI_MSC_ENABLE_EXT() my_callback_msc_enable()
+	extern bool my_callback_msc_enable(void); \endcode
+ *     \note After the device enumeration (detecting and identifying USB devices),
+ *     the USB host starts the device configuration. When the USB MSC interface 
+ *     from the device is accepted by the host, the USB host enables this interface and the
+ *     UDI_MSC_ENABLE_EXT() callback function is called and return true.
+ *     Thus, when this event is received, the tasks which call
+ *     udi_msc_process_trans() must be enabled.
+ *   - \code #define UDI_MSC_DISABLE_EXT() my_callback_msc_disable()
+	extern void my_callback_msc_disable(void); \endcode
+ *     \note When the USB device is unplugged or is reset by the USB host, the USB
+ *     interface is disabled and the UDI_MSC_DISABLE_EXT() callback function
+ *     is called. Thus, it is recommended to disable the task which is called udi_msc_process_trans().
+ * -# The MSC is automatically linked with memory control access component 
+ * which provides the memories interfaces. However, the memory data transfers
+ * must be done outside USB interrupt routine. This is done in the MSC process
+ * ("udi_msc_process_trans()") called by main loop:
+ *   - \code  * void task(void) {
+	udi_msc_process_trans();
+	} \endcode
+ * -# The MSC speed depends on task periodicity. To get the best speed
+ * the notification callback "UDI_MSC_NOTIFY_TRANS_EXT" can be used to wakeup
+ * this task (Example, through a mutex):
+ *   - \code #define  UDI_MSC_NOTIFY_TRANS_EXT()    msc_notify_trans()
+	void msc_notify_trans(void) {
+	wakeup_my_task();
+	} \endcode
+ *
+ * \section udi_msc_use_cases Advanced use cases
+ * For more advanced use of the UDI MSC module, see the following use cases:
+ * - \subpage udi_msc_use_case_composite
+ * - \subpage udc_use_case_1
+ * - \subpage udc_use_case_2
+ * - \subpage udc_use_case_3
+ * - \subpage udc_use_case_5
+ * - \subpage udc_use_case_6
+ */
+
+/**
+ * \page udi_msc_use_case_composite MSC in a composite device
+ *
+ * A USB Composite Device is a USB Device which uses more than one USB class.
+ * In this use case, the "USB MSC (Composite Device)" module is used to
+ * create a USB composite device. Thus, this USB module can be associated with
+ * another "Composite Device" module, like "USB HID Mouse (Composite Device)".
+ * 
+ * Also, you can refer to application note
+ * <A href="http://www.atmel.com/dyn/resources/prod_documents/doc8445.pdf">
+ * AVR4902 ASF - USB Composite Device</A>.
+ *
+ * \section udi_msc_use_case_composite_setup Setup steps
+ * For the setup code of this use case to work, the
+ * \ref udi_msc_basic_use_case "basic use case" must be followed.
+ *
+ * \section udi_msc_use_case_composite_usage Usage steps
+ *
+ * \subsection udi_msc_use_case_composite_usage_code Example code
+ * Content of conf_usb.h:
+ * \code
+	 #define USB_DEVICE_EP_CTRL_SIZE  64
+	 #define USB_DEVICE_NB_INTERFACE (X+1)
+	 #define USB_DEVICE_MAX_EP (X+2)
+
+	 #define UDI_MSC_EP_IN  (X | USB_EP_DIR_IN)
+	 #define UDI_MSC_EP_OUT (Y | USB_EP_DIR_OUT)
+	 #define UDI_MSC_IFACE_NUMBER  X
+
+	 #define UDI_COMPOSITE_DESC_T \
+	    udi_msc_desc_t udi_msc; \
+	    ...
+	 #define UDI_COMPOSITE_DESC_FS \
+	    .udi_msc = UDI_MSC_DESC, \
+	    ...
+	 #define UDI_COMPOSITE_DESC_HS \
+	    .udi_msc = UDI_MSC_DESC, \
+	    ...
+	 #define UDI_COMPOSITE_API \
+	    &udi_api_msc, \
+	    ...
+\endcode
+ *
+ * \subsection udi_msc_use_case_composite_usage_flow Workflow
+ * -# Ensure that conf_usb.h is available and contains the following parameters
+ * required for a USB composite device configuration:
+ *   - \code // Endpoint control size, This must be:
+	// - 8, 16, 32 or 64 for full speed device (8 is recommended to save RAM)
+	// - 64 for a high speed device
+	#define USB_DEVICE_EP_CTRL_SIZE  64
+	// Total Number of interfaces on this USB device.
+	// Add 1 for MSC.
+	#define USB_DEVICE_NB_INTERFACE (X+1)
+	// Total number of endpoints on this USB device.
+	// This must include each endpoint for each interface.
+	// Add 2 for MSC.
+	#define USB_DEVICE_MAX_EP (X+2) \endcode
+ * -# Ensure that conf_usb.h contains the description of
+ * composite device:
+ *   - \code // The endpoint numbers chosen by you for the MSC.
+	// The endpoint numbers starting from 1.
+	#define UDI_MSC_EP_IN  (X | USB_EP_DIR_IN)
+	#define UDI_MSC_EP_OUT (Y | USB_EP_DIR_OUT)
+	// The interface index of an interface starting from 0
+	#define UDI_MSC_IFACE_NUMBER  X \endcode
+ * -# Ensure that conf_usb.h contains the following parameters
+ * required for a USB composite device configuration:
+ *   - \code // USB Interfaces descriptor structure
+	#define UDI_COMPOSITE_DESC_T \
+	   ...
+	   udi_msc_desc_t udi_msc; \
+	   ...
+	// USB Interfaces descriptor value for Full Speed
+	#define UDI_COMPOSITE_DESC_FS \
+	   ...
+	   .udi_msc = UDI_MSC_DESC_FS, \
+	   ...
+	// USB Interfaces descriptor value for High Speed
+	#define UDI_COMPOSITE_DESC_HS \
+	   ...
+	   .udi_msc = UDI_MSC_DESC_HS, \
+	   ...
+	// USB Interface APIs
+	#define UDI_COMPOSITE_API \
+	   ...
+	   &udi_api_msc, \
+	   ... \endcode
+ *   - \note The descriptors order given in the four lists above must be the
+ *     same as the order defined by all interface indexes. The interface index
+ *     orders are defined through UDI_X_IFACE_NUMBER defines.
+ */
+
+#endif // _UDI_MSC_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/uotghs_device_due.c
@@ -1,0 +1,2073 @@
+/**
+ * \file
+ *
+ * \brief USB Device Driver for UOTGHS. Compliant with common UDD driver.
+ *
+ * Copyright (c) 2012-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+ 
+#ifdef ARDUINO_ARCH_SAM
+
+#include "compiler.h"
+#include "uotghs_device_due.h"
+
+#include "conf_usb.h"
+#include "sysclk.h"
+#include "udd.h"
+#include "uotghs_otg.h"
+#include <string.h>
+
+#ifndef UDD_NO_SLEEP_MGR
+# include "sleep.h"
+# include "sleepmgr.h"
+#endif
+
+#if !(SAM3XA)
+# error The current UOTGHS Device Driver supports only SAM3X and SAM3A.
+#endif
+#ifndef UDD_USB_INT_FUN
+# define UDD_USB_INT_FUN UOTGHS_Handler
+#endif
+
+#ifndef UDD_USB_INT_LEVEL
+# define UDD_USB_INT_LEVEL 5 // By default USB interrupt have low priority
+#endif
+
+#define UDD_EP_USED(ep)      (USB_DEVICE_MAX_EP >= ep)
+
+#if (     (UDD_EP_USED( 1) && Is_udd_endpoint_dma_supported( 1)) \
+	||(UDD_EP_USED( 2) && Is_udd_endpoint_dma_supported( 2)) \
+	||(UDD_EP_USED( 3) && Is_udd_endpoint_dma_supported( 3)) \
+	||(UDD_EP_USED( 4) && Is_udd_endpoint_dma_supported( 4)) \
+	||(UDD_EP_USED( 5) && Is_udd_endpoint_dma_supported( 5)) \
+	||(UDD_EP_USED( 6) && Is_udd_endpoint_dma_supported( 6)) \
+	||(UDD_EP_USED( 7) && Is_udd_endpoint_dma_supported( 7)) \
+	||(UDD_EP_USED( 8) && Is_udd_endpoint_dma_supported( 8)) \
+	||(UDD_EP_USED( 9) && Is_udd_endpoint_dma_supported( 9)) \
+	||(UDD_EP_USED(10) && Is_udd_endpoint_dma_supported(10)) \
+	||(UDD_EP_USED(11) && Is_udd_endpoint_dma_supported(11)) \
+	||(UDD_EP_USED(12) && Is_udd_endpoint_dma_supported(12)) \
+	||(UDD_EP_USED(13) && Is_udd_endpoint_dma_supported(13)) \
+	||(UDD_EP_USED(14) && Is_udd_endpoint_dma_supported(14)) \
+	||(UDD_EP_USED(15) && Is_udd_endpoint_dma_supported(15)) \
+	)
+# define UDD_EP_DMA_SUPPORTED
+#endif
+
+#if (     (UDD_EP_USED( 1) && !Is_udd_endpoint_dma_supported( 1)) \
+	||(UDD_EP_USED( 2) && !Is_udd_endpoint_dma_supported( 2)) \
+	||(UDD_EP_USED( 3) && !Is_udd_endpoint_dma_supported( 3)) \
+	||(UDD_EP_USED( 4) && !Is_udd_endpoint_dma_supported( 4)) \
+	||(UDD_EP_USED( 5) && !Is_udd_endpoint_dma_supported( 5)) \
+	||(UDD_EP_USED( 6) && !Is_udd_endpoint_dma_supported( 6)) \
+	||(UDD_EP_USED( 7) && !Is_udd_endpoint_dma_supported( 7)) \
+	||(UDD_EP_USED( 8) && !Is_udd_endpoint_dma_supported( 8)) \
+	||(UDD_EP_USED( 9) && !Is_udd_endpoint_dma_supported( 9)) \
+	||(UDD_EP_USED(10) && !Is_udd_endpoint_dma_supported(10)) \
+	||(UDD_EP_USED(11) && !Is_udd_endpoint_dma_supported(11)) \
+	||(UDD_EP_USED(12) && !Is_udd_endpoint_dma_supported(12)) \
+	||(UDD_EP_USED(13) && !Is_udd_endpoint_dma_supported(13)) \
+	||(UDD_EP_USED(14) && !Is_udd_endpoint_dma_supported(14)) \
+	||(UDD_EP_USED(15) && !Is_udd_endpoint_dma_supported(15)) \
+	)
+# define UDD_EP_FIFO_SUPPORTED
+#endif
+
+// for debug text
+//#define dbg_print printf
+#define dbg_print(...)
+
+/**
+ * \ingroup udd_group
+ * \defgroup udd_udphs_group USB On-The-Go High-Speed Port for device mode (UOTGHS)
+ *
+ * \section UOTGHS_CONF UOTGHS Custom configuration
+ * The following UOTGHS driver configuration must be included in the conf_usb.h
+ * file of the application.
+ *
+ * UDD_USB_INT_LEVEL<br>
+ * Option to change the interrupt priority (0 to 15) by default 5 (recommended).
+ *
+ * UDD_USB_INT_FUN<br>
+ * Option to fit interrupt function to what defined in exception table.
+ *
+ * UDD_ISOCHRONOUS_NB_BANK(ep)<br>
+ * Feature to reduce or increase isochronous endpoints buffering (1 to 3).
+ * Default value 2.
+ *
+ * UDD_BULK_NB_BANK(ep)<br>
+ * Feature to reduce or increase bulk endpoints buffering (1 to 2).
+ * Default value 2.
+ *
+ * UDD_INTERRUPT_NB_BANK(ep)<br>
+ * Feature to reduce or increase interrupt endpoints buffering (1 to 2).
+ * Default value 1.
+ *
+ * \section Callbacks management
+ * The USB driver is fully managed by interrupt and does not request periodique
+ * task. Thereby, the USB events use callbacks to transfer the information.
+ * The callbacks are declared in static during compilation or in variable during
+ * code execution.
+ *
+ * Static declarations defined in conf_usb.h:
+ * - UDC_VBUS_EVENT(bool b_present)<br>
+ *   To signal Vbus level change
+ * - UDC_SUSPEND_EVENT()<br>
+ *   Called when USB bus enter in suspend mode
+ * - UDC_RESUME_EVENT()<br>
+ *   Called when USB bus is wakeup
+ * - UDC_SOF_EVENT()<br>
+ *   Called for each received SOF, Note: Each 1ms in HS/FS mode only.
+ *
+ * Dynamic callbacks, called "endpoint job" , are registered
+ * in udd_ep_job_t structure via the following functions:
+ * - udd_ep_run()<br>
+ *   To call it when a transfer is finish
+ * - udd_ep_wait_stall_clear()<br>
+ *   To call it when a endpoint halt is disabled
+ *
+ * \section Power mode management
+ * The Sleep modes authorized :
+ * - in USB IDLE state, the UOTGHS needs of USB clock and authorizes up to sleep mode WFI.
+ * - in USB SUSPEND state, the UOTGHS no needs USB clock and authorizes up to sleep mode WAIT.
+ * @{
+ */
+
+// Check USB Device configuration
+#ifndef USB_DEVICE_EP_CTRL_SIZE
+# error USB_DEVICE_EP_CTRL_SIZE not defined
+#endif
+#ifndef USB_DEVICE_MAX_EP
+# error USB_DEVICE_MAX_EP not defined
+#endif
+
+// Note: USB_DEVICE_MAX_EP does not include control endpoint
+#if USB_DEVICE_MAX_EP > (UDD_MAX_PEP_NB-1)
+#  error USB_DEVICE_MAX_EP is too high and not supported by this part
+#endif
+
+#define UDD_EP_ISO_NBANK_ERROR(ep)            \
+	( (UDD_ISOCHRONOUS_NB_BANK(ep) < 1)   \
+		|| (UDD_ISOCHRONOUS_NB_BANK(ep) > 3) )
+#define UDD_EP_BULK_NBANK_ERROR(ep)           \
+	( (UDD_BULK_NB_BANK(ep) < 1) || (UDD_BULK_NB_BANK(ep) > 2) )
+#define UDD_EP_INT_NBANK_ERROR(ep)            \
+	( (UDD_INTERRUPT_NB_BANK(ep) < 1) || (UDD_INTERRUPT_NB_BANK(ep) > 2) )
+
+#define UDD_EP_ISO_NB_BANK_ERROR(ep)          \
+	(UDD_EP_USED(ep) && UDD_EP_ISO_NBANK_ERROR(ep))
+#define UDD_EP_BULK_NB_BANK_ERROR(ep)         \
+	(UDD_EP_USED(ep) && UDD_EP_ISO_NBANK_ERROR(ep))
+#define UDD_EP_INT_NB_BANK_ERROR(ep)          \
+	(UDD_EP_USED(ep) && UDD_EP_ISO_NBANK_ERROR(ep))
+
+#define UDD_EP_NB_BANK_ERROR(ep, type)        \
+	(ATPASTE3(UDD_EP_, type, _NB_BANK_ERROR(ep)))
+
+#define UDD_ISO_NB_BANK_ERROR \
+	(          UDD_EP_NB_BANK_ERROR( 1, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 2, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 3, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 4, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 5, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 6, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 7, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 8, ISO) \
+		|| UDD_EP_NB_BANK_ERROR( 9, ISO) \
+		|| UDD_EP_NB_BANK_ERROR(10, ISO) \
+		|| UDD_EP_NB_BANK_ERROR(11, ISO) \
+		|| UDD_EP_NB_BANK_ERROR(12, ISO) \
+		|| UDD_EP_NB_BANK_ERROR(13, ISO) \
+		|| UDD_EP_NB_BANK_ERROR(14, ISO) \
+		|| UDD_EP_NB_BANK_ERROR(15, ISO) )
+#define UDD_BULK_NB_BANK_ERROR \
+	(          UDD_EP_NB_BANK_ERROR( 1, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 2, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 3, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 4, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 5, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 6, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 7, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 8, BULK) \
+		|| UDD_EP_NB_BANK_ERROR( 9, BULK) \
+		|| UDD_EP_NB_BANK_ERROR(10, BULK) \
+		|| UDD_EP_NB_BANK_ERROR(11, BULK) \
+		|| UDD_EP_NB_BANK_ERROR(12, BULK) \
+		|| UDD_EP_NB_BANK_ERROR(13, BULK) \
+		|| UDD_EP_NB_BANK_ERROR(14, BULK) \
+		|| UDD_EP_NB_BANK_ERROR(15, BULK) )
+#define UDD_INTERRUPT_NB_BANK_ERROR \
+	(          UDD_EP_NB_BANK_ERROR( 1, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 2, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 3, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 4, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 5, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 6, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 7, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 8, INT) \
+		|| UDD_EP_NB_BANK_ERROR( 9, INT) \
+		|| UDD_EP_NB_BANK_ERROR(10, INT) \
+		|| UDD_EP_NB_BANK_ERROR(11, INT) \
+		|| UDD_EP_NB_BANK_ERROR(12, INT) \
+		|| UDD_EP_NB_BANK_ERROR(13, INT) \
+		|| UDD_EP_NB_BANK_ERROR(14, INT) \
+		|| UDD_EP_NB_BANK_ERROR(15, INT) )
+
+#ifndef UDD_ISOCHRONOUS_NB_BANK
+# define UDD_ISOCHRONOUS_NB_BANK(ep) 2
+#else
+# if UDD_ISO_NB_BANK_ERROR
+#  error UDD_ISOCHRONOUS_NB_BANK(ep) must be define within 1 to 3.
+# endif
+#endif
+
+#ifndef UDD_BULK_NB_BANK
+# define UDD_BULK_NB_BANK(ep) 2
+#else
+# if UDD_BULK_NB_BANK_ERROR
+#  error UDD_BULK_NB_BANK must be define with 1 or 2.
+# endif
+#endif
+
+#ifndef UDD_INTERRUPT_NB_BANK
+# define UDD_INTERRUPT_NB_BANK(ep) 1
+#else
+# if UDD_INTERRUPT_NB_BANK_ERROR
+#  error UDD_INTERRUPT_NB_BANK must be define with 1 or 2.
+# endif
+#endif
+
+
+/**
+ * \name Power management routine.
+ */
+//@{
+
+#ifndef UDD_NO_SLEEP_MGR
+
+//! Definition of sleep levels
+#define UOTGHS_SLEEP_MODE_USB_SUSPEND  SLEEPMGR_WAIT_FAST
+#define UOTGHS_SLEEP_MODE_USB_IDLE     SLEEPMGR_SLEEP_WFI
+
+//! State of USB line
+static bool udd_b_idle;
+//! State of sleep manager
+static bool udd_b_sleep_initialized = false;
+
+
+/*! \brief Authorize or not the CPU powerdown mode
+ *
+ * \param b_enable true to authorize idle mode
+ */
+static void udd_sleep_mode(bool b_idle)
+{
+	if (!b_idle && udd_b_idle) {
+		dbg_print("_S ");
+		sleepmgr_unlock_mode(UOTGHS_SLEEP_MODE_USB_IDLE);
+	}
+	if (b_idle && !udd_b_idle) {
+		dbg_print("_W ");
+		sleepmgr_lock_mode(UOTGHS_SLEEP_MODE_USB_IDLE);
+	}
+	udd_b_idle = b_idle;
+}
+#else
+
+static void udd_sleep_mode(bool b_idle)
+{
+	b_idle = b_idle;
+}
+
+#endif // UDD_NO_SLEEP_MGR
+
+//@}
+
+
+/**
+ * \name Control endpoint low level management routine.
+ *
+ * This function performs control endpoint mangement.
+ * It handle the SETUP/DATA/HANDSHAKE phases of a control transaction.
+ */
+//@{
+
+//! Global variable to give and record information about setup request management
+COMPILER_WORD_ALIGNED udd_ctrl_request_t udd_g_ctrlreq;
+
+//! Bit definitions about endpoint control state machine for udd_ep_control_state
+typedef enum {
+	UDD_EPCTRL_SETUP                  = 0, //!< Wait a SETUP packet
+	UDD_EPCTRL_DATA_OUT               = 1, //!< Wait a OUT data packet
+	UDD_EPCTRL_DATA_IN                = 2, //!< Wait a IN data packet
+	UDD_EPCTRL_HANDSHAKE_WAIT_IN_ZLP  = 3, //!< Wait a IN ZLP packet
+	UDD_EPCTRL_HANDSHAKE_WAIT_OUT_ZLP = 4, //!< Wait a OUT ZLP packet
+	UDD_EPCTRL_STALL_REQ              = 5, //!< STALL enabled on IN & OUT packet
+} udd_ctrl_ep_state_t;
+
+//! State of the endpoint control management
+static udd_ctrl_ep_state_t udd_ep_control_state;
+
+//! Total number of data received/sent during data packet phase with previous payload buffers
+static uint16_t udd_ctrl_prev_payload_buf_cnt;
+
+//! Number of data received/sent to/from udd_g_ctrlreq.payload buffer
+static uint16_t udd_ctrl_payload_buf_cnt;
+
+/**
+ * \brief Reset control endpoint
+ *
+ * Called after a USB line reset or when UDD is enabled
+ */
+static void udd_reset_ep_ctrl(void);
+
+/**
+ * \brief Reset control endpoint management
+ *
+ * Called after a USB line reset or at the end of SETUP request (after ZLP)
+ */
+static void udd_ctrl_init(void);
+
+//! \brief Managed reception of SETUP packet on control endpoint
+static void udd_ctrl_setup_received(void);
+
+//! \brief Managed reception of IN packet on control endpoint
+static void udd_ctrl_in_sent(void);
+
+//! \brief Managed reception of OUT packet on control endpoint
+static void udd_ctrl_out_received(void);
+
+//! \brief Managed underflow event of IN packet on control endpoint
+static void udd_ctrl_underflow(void);
+
+//! \brief Managed overflow event of OUT packet on control endpoint
+static void udd_ctrl_overflow(void);
+
+//! \brief Managed stall event of IN/OUT packet on control endpoint
+static void udd_ctrl_stall_data(void);
+
+//! \brief Send a ZLP IN on control endpoint
+static void udd_ctrl_send_zlp_in(void);
+
+//! \brief Send a ZLP OUT on control endpoint
+static void udd_ctrl_send_zlp_out(void);
+
+//! \brief Call callback associated to setup request
+static void udd_ctrl_endofrequest(void);
+
+
+/**
+ * \brief Main interrupt routine for control endpoint
+ *
+ * This switchs control endpoint events to correct sub function.
+ *
+ * \return \c 1 if an event about control endpoint is occured, otherwise \c 0.
+ */
+static bool udd_ctrl_interrupt(void);
+
+//@}
+
+
+/**
+ * \name Management of bulk/interrupt/isochronous endpoints
+ *
+ * The UDD manages the data transfer on endpoints:
+ * - Start data tranfer on endpoint with USB Device DMA
+ * - Send a ZLP packet if requested
+ * - Call callback registered to signal end of transfer
+ * The transfer abort and stall feature are supported.
+ */
+//@{
+#if (0!=USB_DEVICE_MAX_EP)
+
+//! Structure definition about job registered on an endpoint
+typedef struct {
+	union {
+		//! Callback to call at the end of transfer
+		udd_callback_trans_t call_trans;
+
+		//! Callback to call when the endpoint halt is cleared
+		udd_callback_halt_cleared_t call_nohalt;
+	};
+	//! Buffer located in internal RAM to send or fill during job
+	uint8_t *buf;
+	//! Size of buffer to send or fill
+	iram_size_t buf_size;
+	//!< Size of data transfered
+	iram_size_t buf_cnt;
+	//!< Size of data loaded (or prepared for DMA) last time
+	iram_size_t buf_load;
+	//! A job is registered on this endpoint
+	uint8_t busy:1;
+	//! A short packet is requested for this job on endpoint IN
+	uint8_t b_shortpacket:1;
+	//! A stall has been requested but not executed
+	uint8_t stall_requested:1;
+} udd_ep_job_t;
+
+
+//! Array to register a job on bulk/interrupt/isochronous endpoint
+static udd_ep_job_t udd_ep_job[USB_DEVICE_MAX_EP];
+
+//! \brief Reset all job table
+static void udd_ep_job_table_reset(void);
+
+//! \brief Abort all endpoint jobs on going
+static void udd_ep_job_table_kill(void);
+
+#ifdef UDD_EP_FIFO_SUPPORTED
+	/**
+	 * \brief Fill banks and send them
+	 *
+	 * \param ep endpoint number of job to abort
+	 */
+	static void udd_ep_in_sent(udd_ep_id_t ep);
+
+	/**
+	 * \brief Store received banks
+	 *
+	 * \param ep endpoint number of job to abort
+	 */
+	static void udd_ep_out_received(udd_ep_id_t ep);
+#endif
+
+/**
+ * \brief Abort endpoint job on going
+ *
+ * \param ep endpoint number of job to abort
+ */
+static void udd_ep_abort_job(udd_ep_id_t ep);
+
+/**
+ * \brief Call the callback associated to the job which is finished
+ *
+ * \param ptr_job job to complete
+ * \param b_abort if true then the job has been aborted
+ */
+static void udd_ep_finish_job(udd_ep_job_t * ptr_job, bool b_abort, uint8_t ep_num);
+
+#ifdef UDD_EP_DMA_SUPPORTED
+	/**
+	 * \brief Start the next transfer if necessary or complet the job associated.
+	 *
+	 * \param ep endpoint number without direction flag
+	 */
+	static void udd_ep_trans_done(udd_ep_id_t ep);
+#endif
+
+/**
+ * \brief Main interrupt routine for bulk/interrupt/isochronous endpoints
+ *
+ * This switchs endpoint events to correct sub function.
+ *
+ * \return \c 1 if an event about bulk/interrupt/isochronous endpoints has occured, otherwise \c 0.
+ */
+static bool udd_ep_interrupt(void);
+
+#endif // (0!=USB_DEVICE_MAX_EP)
+//@}
+
+
+//--------------------------------------------------------
+//--- INTERNAL ROUTINES TO MANAGED GLOBAL EVENTS
+
+/**
+ * \internal
+ * \brief Function called by UOTGHS interrupt to manage USB Device interrupts
+ *
+ * USB Device interrupt events are splited in three parts:
+ * - USB line events (SOF, reset, suspend, resume, wakeup)
+ * - control endpoint events (setup reception, end of data transfer, underflow, overflow, stall)
+ * - bulk/interrupt/isochronous endpoints events (end of data transfer)
+ *
+ * Note:
+ * Here, the global interrupt mask is not clear when an USB interrupt is enabled
+ * because this one can not be occured during the USB ISR (=during INTX is masked).
+ * See Technical reference $3.8.3 Masking interrupt requests in peripheral modules.
+ */
+#ifdef UHD_ENABLE
+void udd_interrupt(void);
+void udd_interrupt(void)
+#else
+ISR(UDD_USB_INT_FUN)
+#endif
+{
+	/* For fast wakeup clocks restore
+	 * In WAIT mode, clocks are switched to FASTRC.
+	 * After wakeup clocks should be restored, before that ISR should not
+	 * be served.
+	 */
+	if (!pmc_is_wakeup_clocks_restored() && !Is_udd_suspend()) {
+		cpu_irq_disable();
+		return;
+	}
+
+	if (Is_udd_sof()) {
+		udd_ack_sof();
+		if (Is_udd_full_speed_mode()) {
+			udc_sof_notify();
+		}
+#ifdef UDC_SOF_EVENT
+		UDC_SOF_EVENT();
+#endif
+		goto udd_interrupt_sof_end;
+	}
+
+	if (Is_udd_msof()) {
+		udd_ack_msof();
+		udc_sof_notify();
+		goto udd_interrupt_sof_end;
+	}
+
+	dbg_print("%c ", udd_is_high_speed() ? 'H' : 'F');
+
+	if (udd_ctrl_interrupt()) {
+		goto udd_interrupt_end; // Interrupt acked by control endpoint managed
+	}
+
+#if (0 != USB_DEVICE_MAX_EP)
+	if (udd_ep_interrupt()) {
+		goto udd_interrupt_end; // Interrupt acked by bulk/interrupt/isochronous endpoint managed
+	}
+#endif
+
+	// USB bus reset detection
+	if (Is_udd_reset()) {
+		udd_ack_reset();
+		dbg_print("RST ");
+		// Abort all jobs on-going
+#if (USB_DEVICE_MAX_EP != 0)
+		udd_ep_job_table_kill();
+#endif
+		// Reset USB Device Stack Core
+		udc_reset();
+		// Reset endpoint control
+		udd_reset_ep_ctrl();
+		// Reset endpoint control management
+		udd_ctrl_init();
+		goto udd_interrupt_end;
+	}
+
+	if (Is_udd_suspend_interrupt_enabled() && Is_udd_suspend()) {
+		otg_unfreeze_clock();
+		// The suspend interrupt is automatic acked when a wakeup occur
+		udd_disable_suspend_interrupt();
+		udd_enable_wake_up_interrupt();
+		otg_freeze_clock(); // Mandatory to exit of sleep mode after a wakeup event
+		udd_sleep_mode(false);  // Enter in SUSPEND mode
+#ifdef UDC_SUSPEND_EVENT
+		UDC_SUSPEND_EVENT();
+#endif
+		goto udd_interrupt_end;
+	}
+
+	if (Is_udd_wake_up_interrupt_enabled() && Is_udd_wake_up()) {
+		// Ack wakeup interrupt and enable suspend interrupt
+		otg_unfreeze_clock();
+		// Check USB clock ready after suspend and eventually sleep USB clock
+		while (!Is_otg_clock_usable()) {
+			if (Is_udd_suspend()) {
+				break; // In case of USB state change in HS
+			}
+		};
+		// The wakeup interrupt is automatic acked when a suspend occur
+		udd_disable_wake_up_interrupt();
+		udd_enable_suspend_interrupt();
+		udd_sleep_mode(true); // Enter in IDLE mode
+#ifdef UDC_RESUME_EVENT
+		UDC_RESUME_EVENT();
+#endif
+		goto udd_interrupt_end;
+	}
+
+	if (Is_otg_vbus_transition()) {
+		dbg_print("VBus ");
+		// Ack Vbus transition and send status to high level
+		otg_unfreeze_clock();
+		otg_ack_vbus_transition();
+		otg_freeze_clock();
+#ifndef USB_DEVICE_ATTACH_AUTO_DISABLE
+		if (Is_otg_vbus_high()) {
+			udd_attach();
+		} else {
+			udd_detach();
+		}
+#endif
+#ifdef UDC_VBUS_EVENT
+		UDC_VBUS_EVENT(Is_otg_vbus_high());
+#endif
+		goto udd_interrupt_end;
+	}
+udd_interrupt_end:
+	dbg_print("\n\r");
+udd_interrupt_sof_end:
+	return;
+}
+
+
+bool udd_include_vbus_monitoring(void)
+{
+	return true;
+}
+
+
+void udd_enable(void)
+{
+	irqflags_t flags;
+
+	flags = cpu_irq_save();
+
+#ifdef UHD_ENABLE
+	// DUAL ROLE INITIALIZATION
+	if (otg_dual_enable()) {
+		// The current mode has been started by otg_dual_enable()
+		cpu_irq_restore(flags);
+		return;
+	}
+#else
+	// SINGLE DEVICE MODE INITIALIZATION
+	pmc_enable_periph_clk(ID_UOTGHS);
+	sysclk_enable_usb();
+
+	// Here, only the device mode is possible, then link UOTGHS interrupt to UDD interrupt
+	NVIC_SetPriority((IRQn_Type) ID_UOTGHS, UDD_USB_INT_LEVEL);
+	NVIC_EnableIRQ((IRQn_Type) ID_UOTGHS);
+
+	// Always authorize asynchrone USB interrupts to exit of sleep mode
+	// For SAM USB wake up device except BACKUP mode
+	pmc_set_fast_startup_input(PMC_FSMR_USBAL);
+#endif
+
+#if (defined USB_ID_GPIO) && (defined UHD_ENABLE)
+	// Check that the device mode is selected by ID pin
+	if (!Is_otg_id_device()) {
+		cpu_irq_restore(flags);
+		return; // Device is not the current mode
+	}
+#else
+	// ID pin not used then force device mode
+	otg_disable_id_pin();
+	otg_force_device_mode();
+#endif
+	// Enable USB hardware
+	otg_enable_pad();
+	otg_enable();
+
+	// Set the USB speed requested by configuration file
+#ifdef USB_DEVICE_LOW_SPEED
+	udd_low_speed_enable();
+#else
+	udd_low_speed_disable();
+# ifdef USB_DEVICE_HS_SUPPORT
+	udd_high_speed_enable();
+# else
+	udd_high_speed_disable();
+# endif
+#endif // USB_DEVICE_LOW_SPEED
+
+	// Check USB clock
+	otg_unfreeze_clock();
+	while (!Is_otg_clock_usable());
+
+	// Reset internal variables
+#if (0!=USB_DEVICE_MAX_EP)
+	udd_ep_job_table_reset();
+#endif
+
+	otg_ack_vbus_transition();
+	// Force Vbus interrupt in case of Vbus always with a high level
+	// This is possible with a short timing between a Host mode stop/start.
+	if (Is_otg_vbus_high()) {
+		otg_raise_vbus_transition();
+	}
+	otg_enable_vbus_interrupt();
+	otg_freeze_clock();
+
+#ifndef UDD_NO_SLEEP_MGR
+	if (!udd_b_sleep_initialized) {
+		udd_b_sleep_initialized = true;
+		// Initialize the sleep mode authorized for the USB suspend mode
+		udd_b_idle = false;
+		sleepmgr_lock_mode(UOTGHS_SLEEP_MODE_USB_SUSPEND);
+	} else {
+		udd_sleep_mode(false); // Enter idle mode
+	}
+#endif
+
+	cpu_irq_restore(flags);
+}
+
+
+void udd_disable(void)
+{
+	irqflags_t flags;
+
+#ifdef UHD_ENABLE
+# ifdef USB_ID_GPIO
+	if (Is_otg_id_host()) {
+		// Freeze clock to switch mode
+		otg_freeze_clock();
+		udd_detach();
+		otg_disable();
+		return; // Host mode running, ignore UDD disable
+	}
+# else
+	if (Is_otg_host_mode_forced()) {
+		return; // Host mode running, ignore UDD disable
+	}
+# endif
+#endif
+
+	flags = cpu_irq_save();
+	otg_unfreeze_clock();
+	udd_detach();
+#ifndef UDD_NO_SLEEP_MGR
+	if (udd_b_sleep_initialized) {
+		udd_b_sleep_initialized = false;
+		sleepmgr_unlock_mode(UOTGHS_SLEEP_MODE_USB_SUSPEND);
+	}
+#endif
+
+#ifndef UHD_ENABLE
+	otg_disable();
+	otg_disable_pad();
+	sysclk_disable_usb();
+	pmc_disable_periph_clk(ID_UOTGHS);
+	// Else the USB clock disable is done by UHC which manage USB dual role
+#endif
+	cpu_irq_restore(flags);
+}
+
+
+void udd_attach(void)
+{
+	irqflags_t flags;
+	flags = cpu_irq_save();
+
+	// At startup the USB bus state is unknown,
+	// therefore the state is considered IDLE to not miss any USB event
+	udd_sleep_mode(true);
+	otg_unfreeze_clock();
+
+	// This section of clock check can be improved with a chek of
+	// USB clock source via sysclk()
+	// Check USB clock because the source can be a PLL
+	while (!Is_otg_clock_usable());
+
+	// Authorize attach if Vbus is present
+	udd_attach_device();
+
+	// Enable USB line events
+	udd_enable_reset_interrupt();
+	udd_enable_suspend_interrupt();
+	udd_enable_wake_up_interrupt();
+	udd_enable_sof_interrupt();
+#ifdef USB_DEVICE_HS_SUPPORT
+	udd_enable_msof_interrupt();
+#endif
+	// Reset following interupts flag
+	udd_ack_reset();
+	udd_ack_sof();
+	udd_ack_msof();
+
+	// The first suspend interrupt must be forced
+	// The first suspend interrupt is not detected else raise it
+	udd_raise_suspend();
+
+	udd_ack_wake_up();
+	otg_freeze_clock();
+	cpu_irq_restore(flags);
+}
+
+
+void udd_detach(void)
+{
+	otg_unfreeze_clock();
+
+	// Detach device from the bus
+	udd_detach_device();
+	otg_freeze_clock();
+	udd_sleep_mode(false);
+}
+
+
+bool udd_is_high_speed(void)
+{
+#ifdef USB_DEVICE_HS_SUPPORT
+	return !Is_udd_full_speed_mode();
+#else
+	return false;
+#endif
+}
+
+
+void udd_set_address(uint8_t address)
+{
+	udd_disable_address();
+	udd_configure_address(address);
+	udd_enable_address();
+}
+
+
+uint8_t udd_getaddress(void)
+{
+	return udd_get_configured_address();
+}
+
+
+uint16_t udd_get_frame_number(void)
+{
+	return udd_frame_number();
+}
+
+uint16_t udd_get_micro_frame_number(void)
+{
+	return udd_micro_frame_number();
+}
+
+void udd_send_remotewakeup(void)
+{
+#ifndef UDD_NO_SLEEP_MGR
+	if (!udd_b_idle)
+#endif
+	{
+		udd_sleep_mode(true); // Enter in IDLE mode
+		otg_unfreeze_clock();
+		udd_initiate_remote_wake_up();
+	}
+}
+
+
+void udd_set_setup_payload(uint8_t *payload, uint16_t payload_size)
+{
+	udd_g_ctrlreq.payload = payload;
+	udd_g_ctrlreq.payload_size = payload_size;
+}
+
+
+#if (0 != USB_DEVICE_MAX_EP)
+bool udd_ep_alloc(udd_ep_id_t ep, uint8_t bmAttributes,
+		uint16_t MaxEndpointSize)
+{
+	bool b_dir_in;
+	uint16_t ep_allocated;
+	uint8_t nb_bank, bank, i;
+
+	b_dir_in = ep & USB_EP_DIR_IN;
+	ep = ep & USB_EP_ADDR_MASK;
+
+	if (ep > USB_DEVICE_MAX_EP) {
+		return false;
+	}
+	if (Is_udd_endpoint_enabled(ep)) {
+		return false;
+	}
+	dbg_print("alloc(%x, %d) ", ep, MaxEndpointSize);
+
+	// Bank choise
+	switch (bmAttributes & USB_EP_TYPE_MASK) {
+	case USB_EP_TYPE_ISOCHRONOUS:
+		nb_bank = UDD_ISOCHRONOUS_NB_BANK(ep);
+		break;
+	case USB_EP_TYPE_INTERRUPT:
+		nb_bank = UDD_INTERRUPT_NB_BANK(ep);
+		break;
+	case USB_EP_TYPE_BULK:
+		nb_bank = UDD_BULK_NB_BANK(ep);
+		break;
+	default:
+		Assert(false);
+		return false;
+	}
+	switch (nb_bank) {
+	case 1:
+		bank = UOTGHS_DEVEPTCFG_EPBK_1_BANK >>
+				UOTGHS_DEVEPTCFG_EPBK_Pos;
+		break;
+	case 2:
+		bank = UOTGHS_DEVEPTCFG_EPBK_2_BANK >>
+				UOTGHS_DEVEPTCFG_EPBK_Pos;
+		break;
+	case 3:
+		bank = UOTGHS_DEVEPTCFG_EPBK_3_BANK >>
+				UOTGHS_DEVEPTCFG_EPBK_Pos;
+		break;
+	default:
+		Assert(false);
+		return false;
+	}
+
+	// Check if endpoint size is 8,16,32,64,128,256,512 or 1023
+	Assert(MaxEndpointSize < 1024);
+	Assert((MaxEndpointSize == 1023)
+		|| !(MaxEndpointSize & (MaxEndpointSize - 1)));
+	Assert(MaxEndpointSize >= 8);
+
+	// Set configuration of new endpoint
+	udd_configure_endpoint(ep, bmAttributes, (b_dir_in ? 1 : 0),
+			MaxEndpointSize, bank);
+	ep_allocated = 1 << ep;
+
+	// Unalloc endpoints superior
+	for (i = USB_DEVICE_MAX_EP; i > ep; i--) {
+		if (Is_udd_endpoint_enabled(i)) {
+			ep_allocated |= 1 << i;
+			udd_disable_endpoint(i);
+			udd_unallocate_memory(i);
+		}
+	}
+
+	// Realloc/Enable endpoints
+	for (i = ep; i <= USB_DEVICE_MAX_EP; i++) {
+		if (ep_allocated & (1 << i)) {
+			udd_ep_job_t *ptr_job = &udd_ep_job[i - 1];
+			bool b_restart = ptr_job->busy;
+			// Restart running job because
+			// memory window slides up and its data is lost
+			ptr_job->busy = false;
+			// Re-allocate memory
+			udd_allocate_memory(i);
+			udd_enable_endpoint(i);
+			if (!Is_udd_endpoint_configured(i)) {
+				dbg_print("ErrRealloc%d ", i);
+				if (NULL == ptr_job->call_trans) {
+					return false;
+				}
+				if (Is_udd_endpoint_in(i)) {
+					i |= USB_EP_DIR_IN;
+				}
+				ptr_job->call_trans(UDD_EP_TRANSFER_ABORT,
+						ptr_job->buf_cnt, i);
+				return false;
+			}
+			udd_enable_endpoint_bank_autoswitch(i);
+			if (b_restart) {
+				// Re-run the job remaining part
+#  ifdef UDD_EP_FIFO_SUPPORTED
+				if (!Is_udd_endpoint_dma_supported(i)
+					&& !Is_udd_endpoint_in(i)) {
+					ptr_job->buf_cnt -= ptr_job->buf_load;
+				}
+#  else
+				ptr_job->buf_cnt -= ptr_job->buf_load;
+#  endif
+				b_restart = udd_ep_run(Is_udd_endpoint_in(i) ?
+							(i | USB_EP_DIR_IN) : i,
+						ptr_job->b_shortpacket,
+						&ptr_job->buf[ptr_job->buf_cnt],
+						ptr_job->buf_size
+							- ptr_job->buf_cnt,
+						ptr_job->call_trans);
+				if (!b_restart) {
+					dbg_print("ErrReRun%d ", i);
+					return false;
+				}
+			}
+		}
+	}
+	return true;
+}
+
+
+void udd_ep_free(udd_ep_id_t ep)
+{
+	uint8_t ep_index = ep & USB_EP_ADDR_MASK;
+	if (USB_DEVICE_MAX_EP < ep_index) {
+		return;
+	}
+	udd_disable_endpoint(ep_index);
+	udd_unallocate_memory(ep_index);
+	udd_ep_abort_job(ep);
+	udd_ep_job[ep_index - 1].stall_requested = false;
+}
+
+
+bool udd_ep_is_halted(udd_ep_id_t ep)
+{
+	uint8_t ep_index = ep & USB_EP_ADDR_MASK;
+	return Is_udd_endpoint_stall_requested(ep_index);
+}
+
+
+bool udd_ep_set_halt(udd_ep_id_t ep)
+{
+	uint8_t ep_index = ep & USB_EP_ADDR_MASK;
+	udd_ep_job_t *ptr_job = &udd_ep_job[ep_index - 1];
+	irqflags_t flags;
+
+	if (USB_DEVICE_MAX_EP < ep_index) {
+		return false;
+	}
+
+	if (Is_udd_endpoint_stall_requested(ep_index) // Endpoint stalled
+			|| ptr_job->stall_requested) { // Endpoint stall is requested
+		return true; // Already STALL
+	}
+
+	if (ptr_job->busy == true) {
+		return false; // Job on going, stall impossible
+	}
+
+	flags = cpu_irq_save();
+	if ((ep & USB_EP_DIR_IN) && (0 != udd_nb_busy_bank(ep_index))) {
+		// Delay the stall after the end of IN transfer on USB line
+		ptr_job->stall_requested = true;
+#ifdef UDD_EP_FIFO_SUPPORTED
+		udd_disable_in_send_interrupt(ep_index);
+		udd_enable_endpoint_bank_autoswitch(ep_index);
+#endif
+		udd_enable_bank_interrupt(ep_index);
+		udd_enable_endpoint_interrupt(ep_index);
+		cpu_irq_restore(flags);
+		return true;
+	}
+	// Stall endpoint immediately
+	udd_disable_endpoint_bank_autoswitch(ep_index);
+	udd_ack_stall(ep_index);
+	udd_enable_stall_handshake(ep_index);
+	cpu_irq_restore(flags);
+	return true;
+}
+
+
+bool udd_ep_clear_halt(udd_ep_id_t ep)
+{
+	uint8_t ep_index = ep & USB_EP_ADDR_MASK;
+	udd_ep_job_t *ptr_job = &udd_ep_job[ep_index - 1];
+	bool b_stall_cleared = false;
+
+	if (USB_DEVICE_MAX_EP < ep_index)
+		return false;
+
+	if (ptr_job->stall_requested) {
+		// Endpoint stall has been requested but not done
+		// Remove stall request
+		ptr_job->stall_requested = false;
+		udd_disable_bank_interrupt(ep_index);
+		udd_disable_endpoint_interrupt(ep_index);
+		b_stall_cleared = true;
+	}
+	if (Is_udd_endpoint_stall_requested(ep_index)) {
+		if (Is_udd_stall(ep_index)) {
+			udd_ack_stall(ep_index);
+			// A packet has been stalled
+			// then reset datatoggle
+			udd_reset_data_toggle(ep_index);
+		}
+		// Disable stall
+		udd_disable_stall_handshake(ep_index);
+		udd_enable_endpoint_bank_autoswitch(ep_index);
+		b_stall_cleared = true;
+	}
+	if (b_stall_cleared) {
+		// If a job is register on clear halt action
+		// then execute callback
+		if (ptr_job->busy == true) {
+			ptr_job->busy = false;
+			ptr_job->call_nohalt();
+		}
+	}
+	return true;
+}
+
+
+bool udd_ep_run(udd_ep_id_t ep, bool b_shortpacket,
+		uint8_t * buf, iram_size_t buf_size,
+		udd_callback_trans_t callback)
+{
+#ifdef UDD_EP_FIFO_SUPPORTED
+	bool b_dir_in = Is_udd_endpoint_in(ep & USB_EP_ADDR_MASK);
+#endif
+	udd_ep_job_t *ptr_job;
+	irqflags_t flags;
+
+	ep &= USB_EP_ADDR_MASK;
+	if (USB_DEVICE_MAX_EP < ep) {
+		return false;
+	}
+
+	// Get job about endpoint
+	ptr_job = &udd_ep_job[ep - 1];
+
+	if ((!Is_udd_endpoint_enabled(ep))
+			|| Is_udd_endpoint_stall_requested(ep)
+			|| ptr_job->stall_requested) {
+		return false; // Endpoint is halted
+	}
+
+	flags = cpu_irq_save();
+	if (ptr_job->busy == true) {
+		cpu_irq_restore(flags);
+		return false; // Job already on going
+	}
+	ptr_job->busy = true;
+	cpu_irq_restore(flags);
+
+	// No job running. Let's setup a new one.
+	ptr_job->buf = buf;
+	ptr_job->buf_size = buf_size;
+	ptr_job->buf_cnt = 0;
+	ptr_job->buf_load = 0;
+	ptr_job->call_trans = callback;
+	ptr_job->b_shortpacket = b_shortpacket || (buf_size == 0);
+
+#ifdef UDD_EP_FIFO_SUPPORTED
+	// No DMA support
+	if (!Is_udd_endpoint_dma_supported(ep)) {
+		dbg_print("ex%x.%c%d\n\r", ep, b_dir_in ? 'i':'o', buf_size);
+		flags = cpu_irq_save();
+		udd_enable_endpoint_interrupt(ep);
+		if (b_dir_in) {
+			udd_disable_endpoint_bank_autoswitch(ep);
+			udd_enable_in_send_interrupt(ep);
+		} else {
+			udd_disable_endpoint_bank_autoswitch(ep);
+			udd_enable_out_received_interrupt(ep);
+		}
+		cpu_irq_restore(flags);
+		return true;
+	}
+#endif // UDD_EP_FIFO_SUPPORTED
+
+#ifdef UDD_EP_DMA_SUPPORTED
+	// Request first DMA transfer
+	dbg_print("(exDMA%x) ", ep);
+	udd_ep_trans_done(ep);
+	return true;
+#endif
+}
+
+
+void udd_ep_abort(udd_ep_id_t ep)
+{
+	uint8_t ep_index = ep & USB_EP_ADDR_MASK;
+
+#ifdef UDD_EP_FIFO_SUPPORTED
+	if (!Is_udd_endpoint_dma_supported(ep_index)) {
+		// Disable interrupts
+		udd_disable_endpoint_interrupt(ep_index);
+		udd_disable_out_received_interrupt(ep_index);
+		udd_disable_in_send_interrupt(ep_index);
+	} else
+#endif
+	{
+		// Stop DMA transfer
+		udd_disable_endpoint_dma_interrupt(ep_index);
+		udd_endpoint_dma_set_control(ep_index, 0);
+	}
+	udd_disable_endpoint_interrupt(ep_index);
+	// Kill IN banks
+	if (ep & USB_EP_DIR_IN) {
+		while(udd_nb_busy_bank(ep_index)) {
+			udd_kill_last_in_bank(ep_index);
+			while(Is_udd_kill_last(ep_index));
+		}
+	}
+	udd_ep_abort_job(ep);
+}
+
+
+bool udd_ep_wait_stall_clear(udd_ep_id_t ep,
+		udd_callback_halt_cleared_t callback)
+{
+	udd_ep_job_t *ptr_job;
+
+	ep &= USB_EP_ADDR_MASK;
+	if (USB_DEVICE_MAX_EP < ep) {
+		return false;
+	}
+
+	ptr_job = &udd_ep_job[ep - 1];
+
+	if (!Is_udd_endpoint_enabled(ep)) {
+		return false; // Endpoint not enabled
+	}
+
+	// Wait clear halt endpoint
+	if (ptr_job->busy == true) {
+		return false; // Job already on going
+	}
+
+	if (Is_udd_endpoint_stall_requested(ep)
+			|| ptr_job->stall_requested) {
+		// Endpoint halted then registes the callback
+		ptr_job->busy = true;
+		ptr_job->call_nohalt = callback;
+	} else {
+		// endpoint not halted then call directly callback
+		callback();
+	}
+	return true;
+}
+#endif // (0 != USB_DEVICE_MAX_EP)
+
+
+#ifdef USB_DEVICE_HS_SUPPORT
+
+void udd_test_mode_j(void)
+{
+	udd_enable_hs_test_mode();
+	udd_enable_hs_test_mode_j();
+}
+
+
+void udd_test_mode_k(void)
+{
+	udd_enable_hs_test_mode();
+	udd_enable_hs_test_mode_k();
+}
+
+
+void udd_test_mode_se0_nak(void)
+{
+	udd_enable_hs_test_mode();
+}
+
+
+void udd_test_mode_packet(void)
+{
+	uint8_t i;
+	uint8_t *ptr_dest;
+	const uint8_t *ptr_src;
+
+	const uint8_t test_packet[] = {
+		// 00000000 * 9
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// 01010101 * 8
+		0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA,
+		// 01110111 * 8
+		0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE, 0xEE,
+		// 0, {111111S * 15}, 111111
+		0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+				0xFF, 0xFF,
+		// S, 111111S, {0111111S * 7}
+		0x7F, 0xBF, 0xDF, 0xEF, 0xF7, 0xFB, 0xFD,
+		// 00111111, {S0111111 * 9}, S0
+		0xFC, 0x7E, 0xBF, 0xDF, 0xEF, 0xF7, 0xFB, 0xFD, 0x7E
+	};
+
+	// Reconfigure control endpoint to bulk IN endpoint
+	udd_disable_endpoint(0);
+	udd_configure_endpoint(0, USB_EP_TYPE_BULK, 1,
+			64, UOTGHS_DEVEPTCFG_EPBK_1_BANK);
+	udd_allocate_memory(0);
+	udd_enable_endpoint(0);
+
+	udd_enable_hs_test_mode();
+	udd_enable_hs_test_mode_packet();
+
+	// Send packet on endpoint 0
+	ptr_dest = (uint8_t *) & udd_get_endpoint_fifo_access(0, 8);
+	ptr_src = test_packet;
+
+	for (i = 0; i < sizeof(test_packet); i++) {
+		*ptr_dest++ = *ptr_src++;
+	}
+	udd_ack_fifocon(0);
+}
+#endif // USB_DEVICE_HS_SUPPORT
+
+
+
+//--------------------------------------------------------
+//--- INTERNAL ROUTINES TO MANAGED THE CONTROL ENDPOINT
+
+static void udd_reset_ep_ctrl(void)
+{
+	irqflags_t flags;
+
+	// Reset USB address to 0
+	udd_configure_address(0);
+	udd_enable_address();
+
+	// Alloc and configure control endpoint
+	udd_configure_endpoint(0,
+		USB_EP_TYPE_CONTROL,
+		0,
+		USB_DEVICE_EP_CTRL_SIZE,
+		UOTGHS_DEVEPTCFG_EPBK_1_BANK);
+
+	udd_allocate_memory(0);
+	udd_enable_endpoint(0);
+	flags = cpu_irq_save();
+	udd_enable_setup_received_interrupt(0);
+	udd_enable_out_received_interrupt(0);
+	udd_enable_endpoint_interrupt(0);
+	cpu_irq_restore(flags);
+}
+
+static void udd_ctrl_init(void)
+{
+	irqflags_t flags;
+	flags = cpu_irq_save();
+
+	// In case of abort of IN Data Phase:
+	// No need to abort IN transfer (rise TXINI),
+	// because it is automatically done by hardware when a Setup packet is received.
+	// But the interrupt must be disabled to don't generate interrupt TXINI
+	// after SETUP reception.
+	udd_disable_in_send_interrupt(0);
+	cpu_irq_restore(flags);
+
+	// In case of OUT ZLP event is no processed before Setup event occurs
+	udd_ack_out_received(0);
+
+	udd_g_ctrlreq.callback = NULL;
+	udd_g_ctrlreq.over_under_run = NULL;
+	udd_g_ctrlreq.payload_size = 0;
+	udd_ep_control_state = UDD_EPCTRL_SETUP;
+}
+
+
+static void udd_ctrl_setup_received(void)
+{
+	irqflags_t flags;
+	uint8_t i;
+
+	if (UDD_EPCTRL_SETUP != udd_ep_control_state) {
+		// May be a hidden DATA or ZLP phase or protocol abort
+		udd_ctrl_endofrequest();
+
+		// Reinitializes control endpoint management
+		udd_ctrl_init();
+	}
+	// Fill setup request structure
+	if (8 != udd_byte_count(0)) {
+		udd_ctrl_stall_data();
+		udd_ack_setup_received(0);
+		return; // Error data number doesn't correspond to SETUP packet
+	}
+	uint8_t *ptr = (uint8_t *) & udd_get_endpoint_fifo_access(0,8);
+	for (i = 0; i < 8; i++) {
+		((uint8_t*) &udd_g_ctrlreq.req)[i] = *ptr++;
+	}
+	// Manage LSB/MSB to fit with CPU usage
+	udd_g_ctrlreq.req.wValue = le16_to_cpu(udd_g_ctrlreq.req.wValue);
+	udd_g_ctrlreq.req.wIndex = le16_to_cpu(udd_g_ctrlreq.req.wIndex);
+	udd_g_ctrlreq.req.wLength = le16_to_cpu(udd_g_ctrlreq.req.wLength);
+
+	// Decode setup request
+	if (udc_process_setup() == false) {
+		// Setup request unknow then stall it
+		udd_ctrl_stall_data();
+		udd_ack_setup_received(0);
+		return;
+	}
+	udd_ack_setup_received(0);
+
+	if (Udd_setup_is_in()) {
+		// IN data phase requested
+		udd_ctrl_prev_payload_buf_cnt = 0;
+		udd_ctrl_payload_buf_cnt = 0;
+		udd_ep_control_state = UDD_EPCTRL_DATA_IN;
+		udd_ctrl_in_sent(); // Send first data transfer
+	} else {
+		if (0 == udd_g_ctrlreq.req.wLength) {
+			// No data phase requested
+			// Send IN ZLP to ACK setup request
+			udd_ctrl_send_zlp_in();
+			return;
+		}
+		// OUT data phase requested
+		udd_ctrl_prev_payload_buf_cnt = 0;
+		udd_ctrl_payload_buf_cnt = 0;
+		udd_ep_control_state = UDD_EPCTRL_DATA_OUT;
+		// To detect a protocol error, enable nak interrupt on data IN phase
+		udd_ack_nak_in(0);
+		flags = cpu_irq_save();
+		udd_enable_nak_in_interrupt(0);
+		cpu_irq_restore(flags);
+	}
+}
+
+
+static void udd_ctrl_in_sent(void)
+{
+	static bool b_shortpacket = false;
+	uint16_t nb_remain;
+	uint8_t i;
+	uint8_t *ptr_dest, *ptr_src;
+	irqflags_t flags;
+
+	flags = cpu_irq_save();
+	udd_disable_in_send_interrupt(0);
+	cpu_irq_restore(flags);
+
+	if (UDD_EPCTRL_HANDSHAKE_WAIT_IN_ZLP == udd_ep_control_state) {
+		// ZLP on IN is sent, then valid end of setup request
+		udd_ctrl_endofrequest();
+		// Reinitializes control endpoint management
+		udd_ctrl_init();
+		return;
+	}
+	Assert(udd_ep_control_state == UDD_EPCTRL_DATA_IN);
+
+	nb_remain = udd_g_ctrlreq.payload_size - udd_ctrl_payload_buf_cnt;
+	if (0 == nb_remain) {
+		// All content of current buffer payload are sent
+		// Update number of total data sending by previous playlaod buffer
+		udd_ctrl_prev_payload_buf_cnt += udd_ctrl_payload_buf_cnt;
+		if ((udd_g_ctrlreq.req.wLength == udd_ctrl_prev_payload_buf_cnt)
+					|| b_shortpacket) {
+			// All data requested are transfered or a short packet has been sent
+			// then it is the end of data phase.
+			// Generate an OUT ZLP for handshake phase.
+			udd_ctrl_send_zlp_out();
+			return;
+		}
+		// Need of new buffer because the data phase is not complete
+		if ((!udd_g_ctrlreq.over_under_run)
+				|| (!udd_g_ctrlreq.over_under_run())) {
+			// Underrun then send zlp on IN
+			// Here nb_remain=0 and allows to send a IN ZLP
+		} else {
+			// A new payload buffer is given
+			udd_ctrl_payload_buf_cnt = 0;
+			nb_remain = udd_g_ctrlreq.payload_size;
+		}
+	}
+	// Continue transfer and send next data
+	if (nb_remain >= USB_DEVICE_EP_CTRL_SIZE) {
+		nb_remain = USB_DEVICE_EP_CTRL_SIZE;
+		b_shortpacket = false;
+	} else {
+		b_shortpacket = true;
+	}
+	// Fill buffer of endpoint control
+	ptr_dest = (uint8_t *) & udd_get_endpoint_fifo_access(0, 8);
+	ptr_src = udd_g_ctrlreq.payload + udd_ctrl_payload_buf_cnt;
+	// Critical section
+	// Only in case of DATA IN phase abort without USB Reset signal after.
+	// The IN data don't must be written in endpoint 0 DPRAM during
+	// a next setup reception in same endpoint 0 DPRAM.
+	// Thereby, an OUT ZLP reception must check before IN data write
+	// and if no OUT ZLP is recevied the data must be written quickly (800us)
+	// before an eventually ZLP OUT and SETUP reception
+	flags = cpu_irq_save();
+	if (Is_udd_out_received(0)) {
+		// IN DATA phase aborted by OUT ZLP
+		cpu_irq_restore(flags);
+		udd_ep_control_state = UDD_EPCTRL_HANDSHAKE_WAIT_OUT_ZLP;
+		return; // Exit of IN DATA phase
+	}
+	// Write quickly the IN data
+	for (i = 0; i < nb_remain; i++) {
+		*ptr_dest++ = *ptr_src++;
+	}
+	udd_ctrl_payload_buf_cnt += nb_remain;
+
+	// Validate and send the data available in the control endpoint buffer
+	udd_ack_in_send(0);
+	udd_enable_in_send_interrupt(0);
+	// In case of abort of DATA IN phase, no need to enable nak OUT interrupt
+	// because OUT endpoint is already free and ZLP OUT accepted.
+	cpu_irq_restore(flags);
+}
+
+
+static void udd_ctrl_out_received(void)
+{
+	irqflags_t flags;
+	uint8_t i;
+	uint16_t nb_data;
+
+	if (UDD_EPCTRL_DATA_OUT != udd_ep_control_state) {
+		if ((UDD_EPCTRL_DATA_IN == udd_ep_control_state)
+				|| (UDD_EPCTRL_HANDSHAKE_WAIT_OUT_ZLP ==
+						udd_ep_control_state)) {
+			// End of SETUP request:
+			// - Data IN Phase aborted,
+			// - or last Data IN Phase hidden by ZLP OUT sending quiclky,
+			// - or ZLP OUT received normaly.
+			udd_ctrl_endofrequest();
+		} else {
+			// Protocol error during SETUP request
+			udd_ctrl_stall_data();
+		}
+		// Reinitializes control endpoint management
+		udd_ctrl_init();
+		return;
+	}
+	// Read data received during OUT phase
+	nb_data = udd_byte_count(0);
+	if (udd_g_ctrlreq.payload_size < (udd_ctrl_payload_buf_cnt + nb_data)) {
+		// Payload buffer too small
+		nb_data = udd_g_ctrlreq.payload_size - udd_ctrl_payload_buf_cnt;
+	}
+	uint8_t *ptr_src = (uint8_t *) & udd_get_endpoint_fifo_access(0, 8);
+	uint8_t *ptr_dest = udd_g_ctrlreq.payload + udd_ctrl_payload_buf_cnt;
+	for (i = 0; i < nb_data; i++) {
+		*ptr_dest++ = *ptr_src++;
+	}
+	udd_ctrl_payload_buf_cnt += nb_data;
+
+	if ((USB_DEVICE_EP_CTRL_SIZE != nb_data)
+			|| (udd_g_ctrlreq.req.wLength <=
+					(udd_ctrl_prev_payload_buf_cnt +
+							udd_ctrl_payload_buf_cnt))) {
+		// End of reception because it is a short packet
+		// Before send ZLP, call intermediat calback
+		// in case of data receiv generate a stall
+		udd_g_ctrlreq.payload_size = udd_ctrl_payload_buf_cnt;
+		if (NULL != udd_g_ctrlreq.over_under_run) {
+			if (!udd_g_ctrlreq.over_under_run()) {
+				// Stall ZLP
+				udd_ctrl_stall_data();
+				// Ack reception of OUT to replace NAK by a STALL
+				udd_ack_out_received(0);
+				return;
+			}
+		}
+		// Send IN ZLP to ACK setup request
+		udd_ack_out_received(0);
+		udd_ctrl_send_zlp_in();
+		return;
+	}
+
+	if (udd_g_ctrlreq.payload_size == udd_ctrl_payload_buf_cnt) {
+		// Overrun then request a new payload buffer
+		if (!udd_g_ctrlreq.over_under_run) {
+			// No callback availabled to request a new payload buffer
+			udd_ctrl_stall_data();
+			// Ack reception of OUT to replace NAK by a STALL
+			udd_ack_out_received(0);
+			return;
+		}
+		if (!udd_g_ctrlreq.over_under_run()) {
+			// No new payload buffer delivered
+			udd_ctrl_stall_data();
+			// Ack reception of OUT to replace NAK by a STALL
+			udd_ack_out_received(0);
+			return;
+		}
+		// New payload buffer available
+		// Update number of total data received
+		udd_ctrl_prev_payload_buf_cnt += udd_ctrl_payload_buf_cnt;
+		// Reinit reception on payload buffer
+		udd_ctrl_payload_buf_cnt = 0;
+	}
+	// Free buffer of control endpoint to authorize next reception
+	udd_ack_out_received(0);
+	// To detect a protocol error, enable nak interrupt on data IN phase
+	udd_ack_nak_in(0);
+	flags = cpu_irq_save();
+	udd_enable_nak_in_interrupt(0);
+	cpu_irq_restore(flags);
+}
+
+
+static void udd_ctrl_underflow(void)
+{
+	if (Is_udd_out_received(0))
+		return; // Underflow ignored if OUT data is received
+
+	if (UDD_EPCTRL_DATA_OUT == udd_ep_control_state) {
+		// Host want to stop OUT transaction
+		// then stop to wait OUT data phase and wait IN ZLP handshake
+		udd_ctrl_send_zlp_in();
+	} else if (UDD_EPCTRL_HANDSHAKE_WAIT_OUT_ZLP == udd_ep_control_state) {
+		// A OUT handshake is waiting by device,
+		// but host want extra IN data then stall extra IN data
+		udd_enable_stall_handshake(0);
+	}
+}
+
+
+static void udd_ctrl_overflow(void)
+{
+	if (Is_udd_in_send(0))
+		return; // Overflow ignored if IN data is received
+
+	// The case of UDD_EPCTRL_DATA_IN is not managed
+	// because the OUT endpoint is already free and OUT ZLP accepted
+
+	if (UDD_EPCTRL_HANDSHAKE_WAIT_IN_ZLP == udd_ep_control_state) {
+		// A IN handshake is waiting by device,
+		// but host want extra OUT data then stall extra OUT data
+		udd_enable_stall_handshake(0);
+	}
+}
+
+
+static void udd_ctrl_stall_data(void)
+{
+	// Stall all packets on IN & OUT control endpoint
+	udd_ep_control_state = UDD_EPCTRL_STALL_REQ;
+	udd_enable_stall_handshake(0);
+}
+
+
+static void udd_ctrl_send_zlp_in(void)
+{
+	irqflags_t flags;
+
+	udd_ep_control_state = UDD_EPCTRL_HANDSHAKE_WAIT_IN_ZLP;
+
+	// Validate and send empty IN packet on control endpoint
+	flags = cpu_irq_save();
+	// Send ZLP on IN endpoint
+	udd_ack_in_send(0);
+	udd_enable_in_send_interrupt(0);
+	// To detect a protocol error, enable nak interrupt on data OUT phase
+	udd_ack_nak_out(0);
+	udd_enable_nak_out_interrupt(0);
+	cpu_irq_restore(flags);
+}
+
+
+static void udd_ctrl_send_zlp_out(void)
+{
+	irqflags_t flags;
+
+	udd_ep_control_state = UDD_EPCTRL_HANDSHAKE_WAIT_OUT_ZLP;
+	// No action is necessary to accept OUT ZLP
+	// because the buffer of control endpoint is already free
+
+	// To detect a protocol error, enable nak interrupt on data IN phase
+	flags = cpu_irq_save();
+	udd_ack_nak_in(0);
+	udd_enable_nak_in_interrupt(0);
+	cpu_irq_restore(flags);
+}
+
+
+static void udd_ctrl_endofrequest(void)
+{
+	// If a callback is registered then call it
+	if (udd_g_ctrlreq.callback) {
+		udd_g_ctrlreq.callback();
+	}
+}
+
+
+static bool udd_ctrl_interrupt(void)
+{
+
+	if (!Is_udd_endpoint_interrupt(0)) {
+		return false; // No interrupt events on control endpoint
+	}
+
+	dbg_print("0: ");
+
+	// By default disable overflow and underflow interrupt
+	udd_disable_nak_in_interrupt(0);
+	udd_disable_nak_out_interrupt(0);
+
+	// Search event on control endpoint
+	if (Is_udd_setup_received(0)) {
+		dbg_print("stup ");
+		// SETUP packet received
+		udd_ctrl_setup_received();
+		return true;
+	}
+	if (Is_udd_in_send(0) && Is_udd_in_send_interrupt_enabled(0)) {
+		dbg_print("in ");
+		// IN packet sent
+		udd_ctrl_in_sent();
+		return true;
+	}
+	if (Is_udd_out_received(0)) {
+		dbg_print("out ");
+		// OUT packet received
+		udd_ctrl_out_received();
+		return true;
+	}
+	if (Is_udd_nak_out(0)) {
+		dbg_print("nako ");
+		// Overflow on OUT packet
+		udd_ack_nak_out(0);
+		udd_ctrl_overflow();
+		return true;
+	}
+	if (Is_udd_nak_in(0)) {
+		dbg_print("naki ");
+		// Underflow on IN packet
+		udd_ack_nak_in(0);
+		udd_ctrl_underflow();
+		return true;
+	}
+	dbg_print("n%x ", UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], 0));
+	return false;
+}
+
+
+//--------------------------------------------------------
+//--- INTERNAL ROUTINES TO MANAGED THE BULK/INTERRUPT/ISOCHRONOUS ENDPOINTS
+
+#if (0 != USB_DEVICE_MAX_EP)
+
+static void udd_ep_job_table_reset(void)
+{
+	uint8_t i;
+	for (i = 0; i < USB_DEVICE_MAX_EP; i++) {
+		udd_ep_job[i].busy = false;
+		udd_ep_job[i].stall_requested = false;
+	}
+}
+
+
+static void udd_ep_job_table_kill(void)
+{
+	uint8_t i;
+
+	// For each endpoint, kill job
+	for (i = 0; i < USB_DEVICE_MAX_EP; i++) {
+		udd_ep_finish_job(&udd_ep_job[i], true, i + 1);
+	}
+}
+
+
+static void udd_ep_abort_job(udd_ep_id_t ep)
+{
+	ep &= USB_EP_ADDR_MASK;
+
+	// Abort job on endpoint
+	udd_ep_finish_job(&udd_ep_job[ep - 1], true, ep);
+}
+
+
+static void udd_ep_finish_job(udd_ep_job_t * ptr_job, bool b_abort, uint8_t ep_num)
+{
+	if (ptr_job->busy == false) {
+		return; // No on-going job
+	}
+	dbg_print("(JobE%x:%d) ", (ptr_job-udd_ep_job)+1, b_abort);
+	ptr_job->busy = false;
+	if (NULL == ptr_job->call_trans) {
+		return; // No callback linked to job
+	}
+	if (Is_udd_endpoint_in(ep_num)) {
+		ep_num |= USB_EP_DIR_IN;
+	}
+	ptr_job->call_trans((b_abort) ? UDD_EP_TRANSFER_ABORT :
+			UDD_EP_TRANSFER_OK, ptr_job->buf_size, ep_num);
+}
+
+#ifdef UDD_EP_DMA_SUPPORTED
+static void udd_ep_trans_done(udd_ep_id_t ep)
+{
+	uint32_t udd_dma_ctrl = 0;
+	udd_ep_job_t *ptr_job;
+	iram_size_t next_trans;
+	irqflags_t flags;
+
+	// Get job corresponding at endpoint
+	ptr_job = &udd_ep_job[ep - 1];
+
+	if (!ptr_job->busy) {
+		return; // No job is running, then ignore it (system error)
+	}
+
+	if (ptr_job->buf_cnt != ptr_job->buf_size) {
+		// Need to send or receiv other data
+		next_trans = ptr_job->buf_size - ptr_job->buf_cnt;
+
+		if (UDD_ENDPOINT_MAX_TRANS < next_trans) {
+			// The USB hardware support a maximum
+			// transfer size of UDD_ENDPOINT_MAX_TRANS Bytes
+			next_trans = UDD_ENDPOINT_MAX_TRANS;
+
+			// Set 0 to tranfer the maximum
+			udd_dma_ctrl = UOTGHS_DEVDMACONTROL_BUFF_LENGTH(0);
+		} else {
+			udd_dma_ctrl = UOTGHS_DEVDMACONTROL_BUFF_LENGTH(next_trans);
+		}
+		if (Is_udd_endpoint_in(ep)) {
+			if (0 != (next_trans % udd_get_endpoint_size(ep))) {
+				// Enable short packet option
+				// else the DMA transfer is accepted
+				// and interrupt DMA valid but nothing is sent.
+				udd_dma_ctrl |= UOTGHS_DEVDMACONTROL_END_B_EN;
+				// No need to request another ZLP
+				ptr_job->b_shortpacket = false;
+			}
+		} else {
+			if ((USB_EP_TYPE_ISOCHRONOUS != udd_get_endpoint_type(ep))
+					|| (next_trans <= (iram_size_t) udd_get_endpoint_size(ep))) {
+
+				// Enable short packet reception
+				udd_dma_ctrl |= UOTGHS_DEVDMACONTROL_END_TR_IT
+						| UOTGHS_DEVDMACONTROL_END_TR_EN;
+			}
+		}
+
+		// Start USB DMA to fill or read fifo of the selected endpoint
+		udd_endpoint_dma_set_addr(ep, (uint32_t) & ptr_job->buf[ptr_job->buf_cnt]);
+		udd_dma_ctrl |= UOTGHS_DEVDMACONTROL_END_BUFFIT |
+				UOTGHS_DEVDMACONTROL_CHANN_ENB;
+
+
+		// Disable IRQs to have a short sequence
+		// between read of EOT_STA and DMA enable
+		flags = cpu_irq_save();
+		if (!(udd_endpoint_dma_get_status(ep)
+				& UOTGHS_DEVDMASTATUS_END_TR_ST)) {
+			dbg_print("dmaS%x ", ep);
+			udd_endpoint_dma_set_control(ep, udd_dma_ctrl);
+			ptr_job->buf_cnt += next_trans;
+			ptr_job->buf_load = next_trans;
+			udd_enable_endpoint_dma_interrupt(ep);
+			cpu_irq_restore(flags);
+			return;
+		}
+		cpu_irq_restore(flags);
+
+		// Here a ZLP has been recieved
+		// and the DMA transfer must be not started.
+		// It is the end of transfer
+		ptr_job->buf_size = ptr_job->buf_cnt;
+	}
+	if (Is_udd_endpoint_in(ep)) {
+		if (ptr_job->b_shortpacket) {
+			dbg_print("zlpS%x ", ep);
+			// Need to send a ZLP (No possible with USB DMA)
+			// enable interrupt to wait a free bank to sent ZLP
+			udd_ack_in_send(ep);
+			if (Is_udd_write_enabled(ep)) {
+				// Force interrupt in case of ep already free
+				udd_raise_in_send(ep);
+			}
+			udd_enable_in_send_interrupt(ep);
+			udd_enable_endpoint_interrupt(ep);
+			return;
+		}
+	}
+	dbg_print("dmaE ");
+	// Call callback to signal end of transfer
+	udd_ep_finish_job(ptr_job, false, ep);
+}
+#endif
+
+#ifdef UDD_EP_FIFO_SUPPORTED
+static void udd_ep_in_sent(udd_ep_id_t ep)
+{
+	udd_ep_job_t *ptr_job = &udd_ep_job[ep - 1];
+	uint8_t *ptr_src = &ptr_job->buf[ptr_job->buf_cnt];
+	uint8_t *ptr_dst = (uint8_t *) & udd_get_endpoint_fifo_access(ep, 8);
+	uint32_t pkt_size = udd_get_endpoint_size(ep);
+	uint32_t nb_data = 0, i;
+	uint32_t nb_remain;
+	irqflags_t flags;
+
+	// All transfer done, including ZLP, Finish Job
+	if (ptr_job->buf_cnt >= ptr_job->buf_size && !ptr_job->b_shortpacket) {
+		flags = cpu_irq_save();
+		udd_disable_in_send_interrupt(ep);
+		udd_disable_endpoint_interrupt(ep);
+		cpu_irq_restore(flags);
+
+		ptr_job->buf_size = ptr_job->buf_cnt; // buf_size is passed to callback as XFR count
+		udd_ep_finish_job(ptr_job, false, ep);
+		return;
+	} else {
+		// ACK TXINI
+		udd_ack_in_send(ep);
+		// Fill FIFO
+		ptr_dst = (uint8_t *) & udd_get_endpoint_fifo_access(ep, 8);
+		ptr_src = &ptr_job->buf[ptr_job->buf_cnt];
+		nb_remain = ptr_job->buf_size - ptr_job->buf_cnt;
+		// Fill a bank even if no data (ZLP)
+		nb_data = min(nb_remain, pkt_size);
+		// Modify job information
+		ptr_job->buf_cnt += nb_data;
+		ptr_job->buf_load = nb_data;
+
+		// Copy buffer to FIFO
+		for (i = 0; i < nb_data; i++) {
+			*ptr_dst++ = *ptr_src++;
+		}
+		// Switch to next bank
+		udd_ack_fifocon(ep);
+		// ZLP?
+		if (nb_data < pkt_size) {
+			ptr_job->b_shortpacket = false;
+		}
+	}
+}
+
+static void udd_ep_out_received(udd_ep_id_t ep)
+{
+	udd_ep_job_t *ptr_job = &udd_ep_job[ep - 1];
+	uint32_t nb_data = 0, i;
+	uint32_t nb_remain = ptr_job->buf_size - ptr_job->buf_cnt;
+	uint32_t pkt_size = udd_get_endpoint_size(ep);
+	uint8_t *ptr_src = (uint8_t *) & udd_get_endpoint_fifo_access(ep, 8);
+	uint8_t *ptr_dst = &ptr_job->buf[ptr_job->buf_cnt];
+	bool b_full = false, b_short = false;
+
+	// Clear RX OUT
+	udd_ack_out_received(ep);
+
+	// Read byte count
+	nb_data = udd_byte_count(ep);
+	if (nb_data < pkt_size) {
+		b_short = true;
+	}
+	//dbg_print("o%d ", ep);
+	//dbg_print("%d ", nb_data);
+	// Copy data if there is
+	if (nb_data > 0) {
+		if (nb_data >= nb_remain) {
+			nb_data = nb_remain;
+			b_full = true;
+		}
+		// Modify job information
+		ptr_job->buf_cnt += nb_data;
+		ptr_job->buf_load = nb_data;
+		// Copy FIFO to buffer
+		for (i = 0; i < nb_data; i++) {
+			*ptr_dst++ = *ptr_src++;
+		}
+	}
+	// Clear FIFO Status
+	udd_ack_fifocon(ep);
+	// Finish job on error or short packet
+	if (b_full || b_short) {
+		//dbg_print("EoO%d\n\r", ep);
+		udd_disable_out_received_interrupt(ep);
+		udd_disable_endpoint_interrupt(ep);
+		ptr_job->buf_size = ptr_job->buf_cnt; // buf_size is passed to callback as XFR count
+		udd_ep_finish_job(ptr_job, false, ep);
+	}
+}
+#endif // #ifdef UDD_EP_FIFO_SUPPORTED
+
+static bool udd_ep_interrupt(void)
+{
+	udd_ep_id_t ep;
+	udd_ep_job_t *ptr_job;
+
+	// For each endpoint different of control endpoint (0)
+	for (ep = 1; ep <= USB_DEVICE_MAX_EP; ep++) {
+		// Get job corresponding at endpoint
+		ptr_job = &udd_ep_job[ep - 1];
+
+#ifdef UDD_EP_DMA_SUPPORTED
+		// Check DMA event
+		if (Is_udd_endpoint_dma_interrupt_enabled(ep)
+				&& Is_udd_endpoint_dma_interrupt(ep)) {
+			uint32_t nb_remaining;
+			if (udd_endpoint_dma_get_status(ep)
+					& UOTGHS_DEVDMASTATUS_CHANN_ENB) {
+				return true; // Ignore EOT_STA interrupt
+			}
+			dbg_print("dma%x: ", ep);
+			udd_disable_endpoint_dma_interrupt(ep);
+			// Save number of data no transfered
+			nb_remaining = (udd_endpoint_dma_get_status(ep) &
+					UOTGHS_DEVDMASTATUS_BUFF_COUNT_Msk)
+					>> UOTGHS_DEVDMASTATUS_BUFF_COUNT_Pos;
+			if (nb_remaining) {
+				// Transfer no complete (short packet or ZLP) then:
+				// Update number of data transfered
+				ptr_job->buf_cnt -= nb_remaining;
+				// Set transfer complete to stop the transfer
+				ptr_job->buf_size = ptr_job->buf_cnt;
+			}
+			udd_ep_trans_done(ep);
+			return true;
+		}
+#endif
+#ifdef UDD_EP_FIFO_SUPPORTED
+		// Check RXRDY and TXEMPTY event for none DMA endpoints
+		if (!Is_udd_endpoint_dma_supported(ep)
+				&& Is_udd_endpoint_interrupt_enabled(ep)) {
+			dbg_print("ep%x: ", ep);
+			// RXOUT: Full packet received
+			if (Is_udd_out_received(ep)
+				&& Is_udd_out_received_interrupt_enabled(ep)) {
+				dbg_print("Out ");
+				udd_ep_out_received(ep);
+				return true;
+			}
+			// TXIN: packet sent
+			if (Is_udd_in_send(ep)
+					&& Is_udd_in_send_interrupt_enabled(ep)) {
+				dbg_print("In ");
+				udd_ep_in_sent(ep);
+				return true;
+			}
+			// Errors: Abort?
+			if (Is_udd_overflow(ep)
+					|| Is_udd_underflow(ep)
+					|| Is_udd_crc_error(ep)) {
+				dbg_print("Err ");
+				udd_ep_abort(ep);
+				return true;
+			}
+		}
+#endif // UDD_EP_FIFO_SUPPORTED
+		// Check empty bank interrupt event
+		if (Is_udd_endpoint_interrupt_enabled(ep)) {
+			dbg_print("bg%x: ", ep);
+			if (Is_udd_in_send_interrupt_enabled(ep)
+					&& Is_udd_in_send(ep)) {
+				dbg_print("I ");
+				udd_disable_in_send_interrupt(ep);
+				// One bank is free then send a ZLP
+				udd_ack_in_send(ep);
+				udd_ack_fifocon(ep);
+				udd_ep_finish_job(ptr_job, false, ep);
+				return true;
+			}
+			if (Is_udd_bank_interrupt_enabled(ep)
+					&& (0 == udd_nb_busy_bank(ep))) {
+				dbg_print("EoT ");
+				// End of background transfer on IN endpoint
+				udd_disable_bank_interrupt(ep);
+				udd_disable_endpoint_interrupt(ep);
+
+				Assert(ptr_job->stall_requested);
+				// A stall has been requested during backgound transfer
+				ptr_job->stall_requested = false;
+				udd_disable_endpoint_bank_autoswitch(ep);
+				udd_enable_stall_handshake(ep);
+				udd_reset_data_toggle(ep);
+				return true;
+			}
+		}
+	}
+	return false;
+}
+#endif // (0 != USB_DEVICE_MAX_EP)
+
+//@}
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/uotghs_device_due.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/uotghs_device_due.h
@@ -1,0 +1,663 @@
+/**
+ * \file
+ *
+ * \brief USB Device Driver for UOTGHS. Compliant with common UDD driver.
+ *
+ * Copyright (c) 2014-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef UOTGHS_DEVICE_DUE_H_INCLUDED
+#define UOTGHS_DEVICE_DUE_H_INCLUDED
+
+//#include "compiler.h"
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+extern "C" {
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+//! \ingroup udd_group
+//! \defgroup udd_udphs_group USB On-The-Go High-Speed Port for device mode (UOTGHS)
+//! UOTGHS low-level driver for USB device mode
+//!
+//! @{
+
+#ifndef UOTGHS_DEVEPTCFG_EPDIR_Pos
+// Bit pos is not defined in SAM header file but we need it.
+# define UOTGHS_DEVEPTCFG_EPDIR_Pos 8
+#endif
+
+//! @name UOTGHS Device IP properties
+//! These macros give access to IP properties
+//! @{
+  //! Get maximal number of endpoints
+#define udd_get_endpoint_max_nbr()             (9)
+#define UDD_MAX_PEP_NB                         (udd_get_endpoint_max_nbr() + 1)
+  //! Get maximal number of banks of endpoints
+#define udd_get_endpoint_bank_max_nbr(ep)      ((ep == 0) ? 1 : (( ep <= 2) ? 3 : 2))
+  //! Get maximal size of endpoint (3X, 1024/64)
+#define udd_get_endpoint_size_max(ep)          (((ep) == 0) ? 64 : 1024)
+  //! Get DMA support of endpoints
+#define Is_udd_endpoint_dma_supported(ep)      ((((ep) >= 1) && ((ep) <= 6)) ? true : false)
+  //! Get High Band Width support of endpoints
+#define Is_udd_endpoint_high_bw_supported(ep)  (((ep) >= 2) ? true : false)
+//! @}
+
+//! @name UOTGHS Device speeds management
+//! @{
+  //! Enable/disable device low-speed mode
+#define udd_low_speed_enable()               (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_LS))
+#define udd_low_speed_disable()              (Clr_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_LS))
+  //! Test if device low-speed mode is forced
+#define Is_udd_low_speed_enable()            (Tst_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_LS))
+
+#ifdef UOTGHS_DEVCTRL_SPDCONF_HIGH_SPEED
+  //! Enable high speed mode
+# define udd_high_speed_enable()          (Wr_bitfield(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_SPDCONF_Msk, 0))
+  //! Disable high speed mode
+# define udd_high_speed_disable()         (Wr_bitfield(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_SPDCONF_Msk, 3))
+  //! Test if controller is in full speed mode
+# define Is_udd_full_speed_mode()         (Rd_bitfield(UOTGHS->UOTGHS_SR, UOTGHS_SR_SPEED_Msk) == UOTGHS_SR_SPEED_FULL_SPEED)
+#else
+# define udd_high_speed_enable()          do { } while (0)
+# define udd_high_speed_disable()         do { } while (0)
+# define Is_udd_full_speed_mode()         true
+#endif
+//! @}
+
+//! @name UOTGHS Device HS test mode management
+//! @{
+#ifdef UOTGHS_DEVCTRL_SPDCONF_HIGH_SPEED
+  //! Enable high speed test mode
+# define udd_enable_hs_test_mode()        (Wr_bitfield(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_SPDCONF_Msk, 2))
+# define udd_enable_hs_test_mode_j()      (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_TSTJ))
+# define udd_enable_hs_test_mode_k()      (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_TSTK))
+# define udd_enable_hs_test_mode_packet() (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_TSTPCKT))
+#endif
+//! @}
+
+//! @name UOTGHS Device vbus management
+//! @{
+#define udd_enable_vbus_interrupt()       (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_VBUSTE))
+#define udd_disable_vbus_interrupt()      (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_VBUSTE))
+#define Is_udd_vbus_interrupt_enabled()   (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_VBUSTE))
+#define Is_udd_vbus_high()                (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_VBUS))
+#define Is_udd_vbus_low()                 (!Is_udd_vbus_high())
+#define udd_ack_vbus_transition()         (UOTGHS->UOTGHS_SCR = UOTGHS_SCR_VBUSTIC)
+#define udd_raise_vbus_transition()       (UOTGHS->UOTGHS_SFR = UOTGHS_SFR_VBUSTIS)
+#define Is_udd_vbus_transition()          (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_VBUSTI))
+//! @}
+
+
+//! @name UOTGHS device attach control
+//! These macros manage the UOTGHS Device attach.
+//! @{
+  //! Detaches from USB bus
+#define udd_detach_device()               (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_DETACH))
+  //! Attaches to USB bus
+#define udd_attach_device()               (Clr_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_DETACH))
+  //! Test if the device is detached
+#define Is_udd_detached()                 (Tst_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_DETACH))
+//! @}
+
+
+//! @name UOTGHS device bus events control
+//! These macros manage the UOTGHS Device bus events.
+//! @{
+
+//! Initiates a remote wake-up event
+//! @{
+#define udd_initiate_remote_wake_up()     (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_RMWKUP))
+#define Is_udd_pending_remote_wake_up()   (Tst_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_RMWKUP))
+//! @}
+
+//! Manage upstream resume event (=remote wakeup)
+//! The USB driver sends a resume signal called "Upstream Resume"
+//! @{
+#define udd_enable_remote_wake_up_interrupt()     (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_UPRSMES)
+#define udd_disable_remote_wake_up_interrupt()    (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_UPRSMEC)
+#define Is_udd_remote_wake_up_interrupt_enabled() (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_UPRSME))
+#define udd_ack_remote_wake_up_start()            (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVICR_UPRSMC)
+#define udd_raise_remote_wake_up_start()          (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_UPRSMS)
+#define Is_udd_remote_wake_up_start()             (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_UPRSM))
+//! @}
+
+//! Manage downstream resume event (=remote wakeup from host)
+//! The USB controller detects a valid "End of Resume" signal initiated by the host
+//! @{
+#define udd_enable_resume_interrupt()             (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_EORSMES)
+#define udd_disable_resume_interrupt()            (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_EORSMEC)
+#define Is_udd_resume_interrupt_enabled()         (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_EORSME))
+#define udd_ack_resume()                          (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVICR_EORSMC)
+#define udd_raise_resume()                        (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_EORSMS)
+#define Is_udd_resume()                           (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_EORSM))
+//! @}
+
+//! Manage wake-up event (=usb line activity)
+//! The USB controller is reactivated by a filtered non-idle signal from the lines
+//! @{
+#define udd_enable_wake_up_interrupt()            (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_WAKEUPES)
+#define udd_disable_wake_up_interrupt()           (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_WAKEUPEC)
+#define Is_udd_wake_up_interrupt_enabled()        (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_WAKEUPE))
+#define udd_ack_wake_up()                         (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVICR_WAKEUPC)
+#define udd_raise_wake_up()                       (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_WAKEUPS)
+#define Is_udd_wake_up()                          (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_WAKEUP))
+//! @}
+
+//! Manage reset event
+//! Set when a USB "End of Reset" has been detected
+//! @{
+#define udd_enable_reset_interrupt()              (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_EORSTES)
+#define udd_disable_reset_interrupt()             (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_EORSTEC)
+#define Is_udd_reset_interrupt_enabled()          (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_EORSTE))
+#define udd_ack_reset()                           (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVICR_EORSTC)
+#define udd_raise_reset()                         (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_EORSTS)
+#define Is_udd_reset()                            (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_EORST))
+//! @}
+
+//! Manage start of frame event
+//! @{
+#define udd_enable_sof_interrupt()                (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_SOFES)
+#define udd_disable_sof_interrupt()               (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_SOFEC)
+#define Is_udd_sof_interrupt_enabled()            (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_SOFE))
+#define udd_ack_sof()                             (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVICR_SOFC)
+#define udd_raise_sof()                           (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_SOFS)
+#define Is_udd_sof()                              (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_SOF))
+#define udd_frame_number()                        (Rd_bitfield(UOTGHS->UOTGHS_DEVFNUM, UOTGHS_DEVFNUM_FNUM_Msk))
+#define Is_udd_frame_number_crc_error()           (Tst_bits(UOTGHS->UOTGHS_DEVFNUM, UOTGHS_DEVFNUM_FNCERR))
+//! @}
+
+//! Manage Micro start of frame event (High Speed Only)
+//! @{
+#define udd_enable_msof_interrupt()               (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_MSOFES)
+#define udd_disable_msof_interrupt()              (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_MSOFEC)
+#define Is_udd_msof_interrupt_enabled()           (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_MSOFE))
+#define udd_ack_msof()                            (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVIMR_MSOFE)
+#define udd_raise_msof()                          (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_MSOFS)
+#define Is_udd_msof()                             (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_MSOF))
+#define udd_micro_frame_number()                  \
+	(Rd_bitfield(UOTGHS->UOTGHS_DEVFNUM, (UOTGHS_DEVFNUM_FNUM_Msk|UOTGHS_DEVFNUM_MFNUM_Msk)))
+//! @}
+
+//! Manage suspend event
+//! @{
+#define udd_enable_suspend_interrupt()            (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_SUSPES)
+#define udd_disable_suspend_interrupt()           (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_SUSPEC)
+#define Is_udd_suspend_interrupt_enabled()        (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_SUSPE))
+#define udd_ack_suspend()                         (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVICR_SUSPC)
+#define udd_raise_suspend()                       (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_SUSPS)
+#define Is_udd_suspend()                          (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_SUSP))
+//! @}
+
+//! @}
+
+//! @name UOTGHS device address control
+//! These macros manage the UOTGHS Device address.
+//! @{
+  //! enables USB device address
+#define udd_enable_address()                      (Set_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_ADDEN))
+  //! disables USB device address
+#define udd_disable_address()                     (Clr_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_ADDEN))
+#define Is_udd_address_enabled()                  (Tst_bits(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_ADDEN))
+  //! configures the USB device address
+#define udd_configure_address(addr)               (Wr_bitfield(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_UADD_Msk, addr))
+  //! gets the currently configured USB device address
+#define udd_get_configured_address()              (Rd_bitfield(UOTGHS->UOTGHS_DEVCTRL, UOTGHS_DEVCTRL_UADD_Msk))
+//! @}
+
+
+//! @name UOTGHS Device endpoint drivers
+//! These macros manage the common features of the endpoints.
+//! @{
+
+//! Generic macro for UOTGHS registers that can be arrayed
+//! @{
+#define UOTGHS_ARRAY(reg,index)                   ((&(UOTGHS->reg))[(index)])
+//! @}
+
+//! @name UOTGHS Device endpoint configuration
+//! @{
+  //! enables the selected endpoint
+#define udd_enable_endpoint(ep)                   (Set_bits(UOTGHS->UOTGHS_DEVEPT, UOTGHS_DEVEPT_EPEN0 << (ep)))
+  //! disables the selected endpoint
+#define udd_disable_endpoint(ep)                  (Clr_bits(UOTGHS->UOTGHS_DEVEPT, UOTGHS_DEVEPT_EPEN0 << (ep)))
+  //! tests if the selected endpoint is enabled
+#define Is_udd_endpoint_enabled(ep)               (Tst_bits(UOTGHS->UOTGHS_DEVEPT, UOTGHS_DEVEPT_EPEN0 << (ep)))
+  //! resets the selected endpoint
+#define udd_reset_endpoint(ep)                                         \
+	do {                                                               \
+		Set_bits(UOTGHS->UOTGHS_DEVEPT, UOTGHS_DEVEPT_EPRST0 << (ep)); \
+		Clr_bits(UOTGHS->UOTGHS_DEVEPT, UOTGHS_DEVEPT_EPRST0 << (ep)); \
+	} while (0)
+  //! Tests if the selected endpoint is being reset
+#define Is_udd_resetting_endpoint(ep)             (Tst_bits(UOTGHS->UOTGHS_DEVEPT, UOTGHS_DEVEPT_EPRST0 << (ep)))
+
+  //! Configures the selected endpoint type
+#define udd_configure_endpoint_type(ep, type)     (Wr_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPTYPE_Msk, type))
+  //! Gets the configured selected endpoint type
+#define udd_get_endpoint_type(ep)                 (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPTYPE_Msk))
+  //! Enables the bank autoswitch for the selected endpoint
+#define udd_enable_endpoint_bank_autoswitch(ep)   (Set_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_AUTOSW))
+  //! Disables the bank autoswitch for the selected endpoint
+#define udd_disable_endpoint_bank_autoswitch(ep)    (Clr_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_AUTOSW))
+#define Is_udd_endpoint_bank_autoswitch_enabled(ep) (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_AUTOSW))
+  //! Configures the selected endpoint direction
+#define udd_configure_endpoint_direction(ep, dir) (Wr_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPDIR, dir))
+  //! Gets the configured selected endpoint direction
+#define udd_get_endpoint_direction(ep)            (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPDIR))
+#define Is_udd_endpoint_in(ep)                    (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPDIR))
+  //! Bounds given integer size to allowed range and rounds it up to the nearest
+  //! available greater size, then applies register format of UOTGHS controller
+  //! for endpoint size bit-field.
+#define udd_format_endpoint_size(size)            (32 - clz(((uint32_t)min(max(size, 8), 1024) << 1) - 1) - 1 - 3)
+  //! Configures the selected endpoint size
+#define udd_configure_endpoint_size(ep, size)     (Wr_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPSIZE_Msk, udd_format_endpoint_size(size)))
+  //! Gets the configured selected endpoint size
+#define udd_get_endpoint_size(ep)                 (8 << Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPSIZE_Msk))
+  //! Configures the selected endpoint number of banks
+#define udd_configure_endpoint_bank(ep, bank)     (Wr_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPBK_Msk, bank))
+  //! Gets the configured selected endpoint number of banks
+#define udd_get_endpoint_bank(ep)                 (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPBK_Msk)+1)
+  //! Allocates the configuration selected endpoint in DPRAM memory
+#define udd_allocate_memory(ep)                   (Set_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_ALLOC))
+  //! un-allocates the configuration selected endpoint in DPRAM memory
+#define udd_unallocate_memory(ep)                 (Clr_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_ALLOC))
+#define Is_udd_memory_allocated(ep)               (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_ALLOC))
+
+  //! Configures selected endpoint in one step
+#define udd_configure_endpoint(ep, type, dir, size, bank) (\
+	Wr_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTCFG[0], ep), UOTGHS_DEVEPTCFG_EPTYPE_Msk |\
+			UOTGHS_DEVEPTCFG_EPDIR  |\
+			UOTGHS_DEVEPTCFG_EPSIZE_Msk |\
+			UOTGHS_DEVEPTCFG_EPBK_Msk ,   \
+			(((uint32_t)(type) << UOTGHS_DEVEPTCFG_EPTYPE_Pos) & UOTGHS_DEVEPTCFG_EPTYPE_Msk) |\
+			(((uint32_t)(dir ) << UOTGHS_DEVEPTCFG_EPDIR_Pos ) & UOTGHS_DEVEPTCFG_EPDIR) |\
+			( (uint32_t)udd_format_endpoint_size(size) << UOTGHS_DEVEPTCFG_EPSIZE_Pos) |\
+			(((uint32_t)(bank) << UOTGHS_DEVEPTCFG_EPBK_Pos) & UOTGHS_DEVEPTCFG_EPBK_Msk))\
+)
+  //! Tests if current endpoint is configured
+#define Is_udd_endpoint_configured(ep)            (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_CFGOK))
+  //! Returns the control direction
+#define udd_control_direction()                   (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], EP_CONTROL), UOTGHS_DEVEPTISR_CTRLDIR))
+
+  //! Resets the data toggle sequence
+#define udd_reset_data_toggle(ep)                 (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_RSTDTS)
+  //! Tests if the data toggle sequence is being reset
+#define Is_udd_data_toggle_reset(ep)              (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_RSTDT))
+  //! Returns data toggle
+#define udd_data_toggle(ep)                       (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_DTSEQ_Msk))
+//! @}
+
+
+//! @name UOTGHS Device control endpoint
+//! These macros control the endpoints.
+//! @{
+
+//! @name UOTGHS Device control endpoint interrupts
+//! These macros control the endpoints interrupts.
+//! @{
+  //! Enables the selected endpoint interrupt
+#define udd_enable_endpoint_interrupt(ep)         (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_PEP_0 << (ep))
+  //! Disables the selected endpoint interrupt
+#define udd_disable_endpoint_interrupt(ep)        (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_PEP_0 << (ep))
+  //! Tests if the selected endpoint interrupt is enabled
+#define Is_udd_endpoint_interrupt_enabled(ep)     (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_PEP_0 << (ep)))
+  //! Tests if an interrupt is triggered by the selected endpoint
+#define Is_udd_endpoint_interrupt(ep)             (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_PEP_0 << (ep)))
+  //! Returns the lowest endpoint number generating an endpoint interrupt or MAX_PEP_NB if none
+#define udd_get_interrupt_endpoint_number()       (ctz(((UOTGHS->UOTGHS_DEVISR >> UOTGHS_DEVISR_PEP_Pos) & \
+                                                   (UOTGHS->UOTGHS_DEVIMR >> UOTGHS_DEVIMR_PEP_Pos)) |     \
+                                                   (1 << MAX_PEP_NB)))
+#define UOTGHS_DEVISR_PEP_Pos   12
+#define UOTGHS_DEVIMR_PEP_Pos   12
+//! @}
+
+//! @name UOTGHS Device control endpoint errors
+//! These macros control the endpoint errors.
+//! @{
+  //! Enables the STALL handshake
+#define udd_enable_stall_handshake(ep)            (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_STALLRQS)
+  //! Disables the STALL handshake
+#define udd_disable_stall_handshake(ep)           (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_STALLRQC)
+  //! Tests if STALL handshake request is running
+#define Is_udd_endpoint_stall_requested(ep)       (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_STALLRQ))
+  //! Tests if STALL sent
+#define Is_udd_stall(ep)                          (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_STALLEDI))
+  //! ACKs STALL sent
+#define udd_ack_stall(ep)                         (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_STALLEDIC)
+  //! Raises STALL sent
+#define udd_raise_stall(ep)                       (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_STALLEDIS)
+  //! Enables STALL sent interrupt
+#define udd_enable_stall_interrupt(ep)            (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_STALLEDES)
+  //! Disables STALL sent interrupt
+#define udd_disable_stall_interrupt(ep)           (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_STALLEDEC)
+  //! Tests if STALL sent interrupt is enabled
+#define Is_udd_stall_interrupt_enabled(ep)        (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_STALLEDE))
+
+  //! Tests if NAK OUT received
+#define Is_udd_nak_out(ep)                        (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_NAKOUTI))
+  //! ACKs NAK OUT received
+#define udd_ack_nak_out(ep)                       (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_NAKOUTIC)
+  //! Raises NAK OUT received
+#define udd_raise_nak_out(ep)                     (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_NAKOUTIS)
+  //! Enables NAK OUT interrupt
+#define udd_enable_nak_out_interrupt(ep)          (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_NAKOUTES)
+  //! Disables NAK OUT interrupt
+#define udd_disable_nak_out_interrupt(ep)         (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_NAKOUTEC)
+  //! Tests if NAK OUT interrupt is enabled
+#define Is_udd_nak_out_interrupt_enabled(ep)      (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_NAKOUTE))
+
+  //! Tests if NAK IN received
+#define Is_udd_nak_in(ep)                         (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_NAKINI))
+  //! ACKs NAK IN received
+#define udd_ack_nak_in(ep)                        (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_NAKINIC)
+  //! Raises NAK IN received
+#define udd_raise_nak_in(ep)                      (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_NAKINIS)
+  //! Enables NAK IN interrupt
+#define udd_enable_nak_in_interrupt(ep)           (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_NAKINES)
+  //! Disables NAK IN interrupt
+#define udd_disable_nak_in_interrupt(ep)          (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_NAKINEC)
+  //! Tests if NAK IN interrupt is enabled
+#define Is_udd_nak_in_interrupt_enabled(ep)       (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_NAKINE))
+
+  //! ACKs endpoint isochronous overflow interrupt
+#define udd_ack_overflow_interrupt(ep)            (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_OVERFIC)
+  //! Raises endpoint isochronous overflow interrupt
+#define udd_raise_overflow_interrupt(ep)          (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_OVERFIS)
+  //! Tests if an overflow occurs
+#define Is_udd_overflow(ep)                       (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_OVERFI))
+  //! Enables overflow interrupt
+#define udd_enable_overflow_interrupt(ep)         (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_OVERFES)
+  //! Disables overflow interrupt
+#define udd_disable_overflow_interrupt(ep)        (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_OVERFEC)
+  //! Tests if overflow interrupt is enabled
+#define Is_udd_overflow_interrupt_enabled(ep)     (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_OVERFE))
+
+  //! ACKs endpoint isochronous underflow interrupt
+#define udd_ack_underflow_interrupt(ep)           (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_UNDERFIC)
+  //! Raises endpoint isochronous underflow interrupt
+#define udd_raise_underflow_interrupt(ep)         (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_UNDERFIS)
+  //! Tests if an underflow occurs
+#define Is_udd_underflow(ep)                      (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_UNDERFI))
+  //! Enables underflow interrupt
+#define udd_enable_underflow_interrupt(ep)        (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_UNDERFES)
+  //! Disables underflow interrupt
+#define udd_disable_underflow_interrupt(ep)       (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_UNDERFEC)
+  //! Tests if underflow interrupt is enabled
+#define Is_udd_underflow_interrupt_enabled(ep)    (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_UNDERFE))
+
+  //! Tests if CRC ERROR ISO OUT detected
+#define Is_udd_crc_error(ep)                      (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_CRCERRI))
+  //! ACKs CRC ERROR ISO OUT detected
+#define udd_ack_crc_error(ep)                     (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_CRCERRIC)
+  //! Raises CRC ERROR ISO OUT detected
+#define udd_raise_crc_error(ep)                   (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_CRCERRIS)
+  //! Enables CRC ERROR ISO OUT detected interrupt
+#define udd_enable_crc_error_interrupt(ep)        (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_CRCERRES)
+  //! Disables CRC ERROR ISO OUT detected interrupt
+#define udd_disable_crc_error_interrupt(ep)       (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_CRCERREC)
+  //! Tests if CRC ERROR ISO OUT detected interrupt is enabled
+#define Is_udd_crc_error_interrupt_enabled(ep)    (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_CRCERRE))
+//! @}
+
+//! @name UOTGHS Device control endpoint transfer
+//! These macros control the endpoint transfer.
+//! @{
+
+  //! Tests if endpoint read allowed
+#define Is_udd_read_enabled(ep)                   (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_RWALL))
+  //! Tests if endpoint write allowed
+#define Is_udd_write_enabled(ep)                  (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_RWALL))
+
+  //! Returns the byte count
+#define udd_byte_count(ep)                        (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_BYCT_Msk))
+  //! Clears FIFOCON bit
+#define udd_ack_fifocon(ep)                       (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_FIFOCONC)
+  //! Tests if FIFOCON bit set
+#define Is_udd_fifocon(ep)                        (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_FIFOCON))
+
+  //! Returns the number of busy banks
+#define udd_nb_busy_bank(ep)                      (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_NBUSYBK_Msk))
+  //! Returns the number of the current bank
+#define udd_current_bank(ep)                      (Rd_bitfield(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_CURRBK_Msk))
+  //! Kills last bank
+#define udd_kill_last_in_bank(ep)                 (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_KILLBKS)
+#define Is_udd_kill_last(ep)                      (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_KILLBK))
+  //! Tests if last bank killed
+#define Is_udd_last_in_bank_killed(ep)            (!Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_KILLBK))
+  //! Forces all banks full (OUT) or free (IN) interrupt
+#define udd_force_bank_interrupt(ep)              (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_NBUSYBKS)
+  //! Unforces all banks full (OUT) or free (IN) interrupt
+#define udd_unforce_bank_interrupt(ep)            (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_NBUSYBKS)
+  //! Enables all banks full (OUT) or free (IN) interrupt
+#define udd_enable_bank_interrupt(ep)             (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_NBUSYBKES)
+  //! Disables all banks full (OUT) or free (IN) interrupt
+#define udd_disable_bank_interrupt(ep)            (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_NBUSYBKEC)
+  //! Tests if all banks full (OUT) or free (IN) interrupt enabled
+#define Is_udd_bank_interrupt_enabled(ep)         (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_NBUSYBKE))
+
+  //! Tests if SHORT PACKET received
+#define Is_udd_short_packet(ep)                   (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_SHORTPACKET))
+  //! ACKs SHORT PACKET received
+#define udd_ack_short_packet(ep)                  (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_SHORTPACKETC)
+  //! Raises SHORT PACKET received
+#define udd_raise_short_packet(ep)                (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_SHORTPACKETS)
+  //! Enables SHORT PACKET received interrupt
+#define udd_enable_short_packet_interrupt(ep)     (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_SHORTPACKETES)
+  //! Disables SHORT PACKET received interrupt
+#define udd_disable_short_packet_interrupt(ep)    (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_SHORTPACKETEC)
+  //! Tests if SHORT PACKET received interrupt is enabled
+#define Is_udd_short_packet_interrupt_enabled(ep) (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_SHORTPACKETE))
+
+  //! Tests if SETUP received
+#define Is_udd_setup_received(ep)                    (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_RXSTPI))
+  //! ACKs SETUP received
+#define udd_ack_setup_received(ep)                   (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_RXSTPIC)
+  //! Raises SETUP received
+#define udd_raise_setup_received(ep)                 (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_RXSTPIS)
+  //! Enables SETUP received interrupt
+#define udd_enable_setup_received_interrupt(ep)      (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_RXSTPES)
+  //! Disables SETUP received interrupt
+#define udd_disable_setup_received_interrupt(ep)     (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_RXSTPEC)
+  //! Tests if SETUP received interrupt is enabled
+#define Is_udd_setup_received_interrupt_enabled(ep)  (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_RXSTPE))
+
+  //! Tests if OUT received
+#define Is_udd_out_received(ep)                   (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_RXOUTI))
+  //! ACKs OUT received
+#define udd_ack_out_received(ep)                  (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_RXOUTIC)
+  //! Raises OUT received
+#define udd_raise_out_received(ep)                (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_RXOUTIS)
+  //! Enables OUT received interrupt
+#define udd_enable_out_received_interrupt(ep)     (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_RXOUTES)
+  //! Disables OUT received interrupt
+#define udd_disable_out_received_interrupt(ep)    (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_RXOUTEC)
+  //! Tests if OUT received interrupt is enabled
+#define Is_udd_out_received_interrupt_enabled(ep) (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_RXOUTE))
+
+  //! Tests if IN sending
+#define Is_udd_in_send(ep)                        (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTISR[0], ep), UOTGHS_DEVEPTISR_TXINI))
+  //! ACKs IN sending
+#define udd_ack_in_send(ep)                       (UOTGHS_ARRAY(UOTGHS_DEVEPTICR[0], ep) = UOTGHS_DEVEPTICR_TXINIC)
+  //! Raises IN sending
+#define udd_raise_in_send(ep)                     (UOTGHS_ARRAY(UOTGHS_DEVEPTIFR[0], ep) = UOTGHS_DEVEPTIFR_TXINIS)
+  //! Enables IN sending interrupt
+#define udd_enable_in_send_interrupt(ep)          (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0], ep) = UOTGHS_DEVEPTIER_TXINES)
+  //! Disables IN sending interrupt
+#define udd_disable_in_send_interrupt(ep)         (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0], ep) = UOTGHS_DEVEPTIDR_TXINEC)
+  //! Tests if IN sending interrupt is enabled
+#define Is_udd_in_send_interrupt_enabled(ep)      (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0], ep), UOTGHS_DEVEPTIMR_TXINE))
+
+
+  //! Get 64-, 32-, 16- or 8-bit access to FIFO data register of selected endpoint.
+  //! @param ep Endpoint of which to access FIFO data register
+  //! @param scale Data scale in bits: 64, 32, 16 or 8
+  //! @return Volatile 64-, 32-, 16- or 8-bit data pointer to FIFO data register
+  //! @warning It is up to the user of this macro to make sure that all accesses
+  //! are aligned with their natural boundaries except 64-bit accesses which
+  //! require only 32-bit alignment.
+  //! @warning It is up to the user of this macro to make sure that used HSB
+  //! addresses are identical to the DPRAM internal pointer modulo 32 bits.
+#define udd_get_endpoint_fifo_access(ep, scale) \
+		(((volatile TPASTE2(U, scale) (*)[0x8000 / ((scale) / 8)])UOTGHS_RAM_ADDR)[(ep)])
+
+//! @name UOTGHS endpoint DMA drivers
+//! These macros manage the common features of the endpoint DMA channels.
+//! @{
+
+  //! Maximum transfer size on USB DMA
+#define UDD_ENDPOINT_MAX_TRANS 0x10000
+  //! Enables the disabling of HDMA requests by endpoint interrupts
+#define udd_enable_endpoint_int_dis_hdma_req(ep)     (UOTGHS_ARRAY(UOTGHS_DEVEPTIER[0](ep) = UOTGHS_DEVEPTIER_EPDISHDMAS)
+  //! Disables the disabling of HDMA requests by endpoint interrupts
+#define udd_disable_endpoint_int_dis_hdma_req(ep)    (UOTGHS_ARRAY(UOTGHS_DEVEPTIDR[0](ep) = UOTGHS_DEVEPTIDR_EPDISHDMAC)
+  //! Tests if the disabling of HDMA requests by endpoint interrupts is enabled
+#define Is_udd_endpoint_int_dis_hdma_req_enabled(ep) (Tst_bits(UOTGHS_ARRAY(UOTGHS_DEVEPTIMR[0](ep), UOTGHS_DEVEPTIMR_EPDISHDMA))
+
+  //! Raises the selected endpoint DMA channel interrupt
+#define udd_raise_endpoint_dma_interrupt(ep)         (UOTGHS->UOTGHS_DEVIFR = UOTGHS_DEVIFR_DMA_1 << ((ep) - 1))
+  //! Raises the selected endpoint DMA channel interrupt
+#define udd_clear_endpoint_dma_interrupt(ep)         (UOTGHS->UOTGHS_DEVICR = UOTGHS_DEVISR_DMA_1 << ((ep) - 1))
+  //! Tests if an interrupt is triggered by the selected endpoint DMA channel
+#define Is_udd_endpoint_dma_interrupt(ep)            (Tst_bits(UOTGHS->UOTGHS_DEVISR, UOTGHS_DEVISR_DMA_1 << ((ep) - 1)))
+  //! Enables the selected endpoint DMA channel interrupt
+#define udd_enable_endpoint_dma_interrupt(ep)        (UOTGHS->UOTGHS_DEVIER = UOTGHS_DEVIER_DMA_1 << ((ep) - 1))
+  //! Disables the selected endpoint DMA channel interrupt
+#define udd_disable_endpoint_dma_interrupt(ep)       (UOTGHS->UOTGHS_DEVIDR = UOTGHS_DEVIDR_DMA_1 << ((ep) - 1))
+  //! Tests if the selected endpoint DMA channel interrupt is enabled
+#define Is_udd_endpoint_dma_interrupt_enabled(ep)    (Tst_bits(UOTGHS->UOTGHS_DEVIMR, UOTGHS_DEVIMR_DMA_1 << ((ep) - 1)))
+
+  //! Access points to the UOTGHS device DMA memory map with arrayed registers
+  //! @{
+      //! Structure for DMA next descriptor register
+typedef struct {
+	uint32_t *NXT_DSC_ADD;
+} uotghs_dma_nextdesc_t;
+      //! Structure for DMA control register
+typedef struct {
+	uint32_t CHANN_ENB:1,
+		LDNXT_DSC:1,
+		END_TR_EN:1,
+		END_B_EN:1,
+		END_TR_IT:1,
+		END_BUFFIT:1,
+		DESC_LD_IT:1,
+		BUST_LCK:1,
+		reserved:8,
+		BUFF_LENGTH:16;
+} uotghs_dma_control_t;
+      //! Structure for DMA status register
+typedef struct {
+	uint32_t CHANN_ENB:1,
+		CHANN_ACT:1,
+		reserved0:2,
+		END_TR_ST:1,
+		END_BF_ST:1,
+		DESC_LDST:1,
+		reserved1:9,
+		BUFF_COUNT:16;
+} uotghs_dma_status_t;
+      //! Structure for DMA descriptor
+typedef struct {
+	union {
+		uint32_t nextdesc;
+		uotghs_dma_nextdesc_t NEXTDESC;
+	};
+	uint32_t addr;
+	union {
+		uint32_t control;
+		uotghs_dma_control_t CONTROL;
+	};
+	uint32_t reserved;
+} sam_uotghs_dmadesc_t, uotghs_dmadesc_t;
+      //! Structure for DMA registers in a channel
+typedef struct {
+	union {
+		uint32_t nextdesc;
+		uotghs_dma_nextdesc_t NEXTDESC;
+	};
+	uint32_t addr;
+	union {
+		uint32_t control;
+		uotghs_dma_control_t CONTROL;
+	};
+	union {
+		unsigned long status;
+		uotghs_dma_status_t STATUS;
+	};
+} sam_uotghs_dmach_t, uotghs_dmach_t;
+      //! DMA channel control command
+#define UDD_ENDPOINT_DMA_STOP_NOW                 (0)
+#define UDD_ENDPOINT_DMA_RUN_AND_STOP             (UOTGHS_DEVDMACONTROL_CHANN_ENB)
+#define UDD_ENDPOINT_DMA_LOAD_NEXT_DESC           (UOTGHS_DEVDMACONTROL_LDNXT_DSC)
+#define UDD_ENDPOINT_DMA_RUN_AND_LINK             (UOTGHS_DEVDMACONTROL_CHANN_ENB|UOTGHS_DEVDMACONTROL_LDNXT_DSC)
+      //! Structure for DMA registers
+#define UOTGHS_UDDMA_ARRAY(ep)                    (((volatile uotghs_dmach_t *)UOTGHS->UOTGHS_DEVDMA)[(ep) - 1])
+
+      //! Set control desc to selected endpoint DMA channel
+#define udd_endpoint_dma_set_control(ep,desc)     (UOTGHS_UDDMA_ARRAY(ep).control = desc)
+      //! Get control desc to selected endpoint DMA channel
+#define udd_endpoint_dma_get_control(ep)          (UOTGHS_UDDMA_ARRAY(ep).control)
+      //! Set RAM address to selected endpoint DMA channel
+#define udd_endpoint_dma_set_addr(ep,add)         (UOTGHS_UDDMA_ARRAY(ep).addr = add)
+      //! Get status to selected endpoint DMA channel
+#define udd_endpoint_dma_get_status(ep)           (UOTGHS_UDDMA_ARRAY(ep).status)
+   //! @}
+//! @}
+
+//! @}
+//! @}
+//! @}
+//! @}
+
+
+/// @cond 0
+/**INDENT-OFF**/
+#ifdef __cplusplus
+}
+#endif
+/**INDENT-ON**/
+/// @endcond
+
+#endif /* UOTGHS_DEVICE_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/uotghs_otg.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/uotghs_otg.h
@@ -1,0 +1,242 @@
+/**
+ * \file
+ *
+ * \brief USB OTG Driver for UOTGHS.
+ *
+ * Copyright (c) 2012-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef UOTGHS_OTG_H_INCLUDED
+#define UOTGHS_OTG_H_INCLUDED
+
+#include "compiler.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+//! \ingroup usb_group
+//! \defgroup otg_group UOTGHS OTG Driver
+//! UOTGHS low-level driver for OTG features
+//!
+//! @{
+
+/**
+ * \brief Initialize the dual role
+ * This function is implemented in uotghs_host.c file.
+ *
+ * \return \c true if the ID pin management has been started, otherwise \c false.
+ */
+bool otg_dual_enable(void);
+
+/**
+ * \brief Uninitialize the dual role
+ * This function is implemented in uotghs_host.c file.
+ */
+void otg_dual_disable(void);
+
+
+//! @name UOTGHS OTG ID pin management
+//! The ID pin come from the USB OTG connector (A and B receptable) and
+//! allows to select the USB mode host or device.
+//! The UOTGHS hardware can manage it automatically. This feature is optional.
+//! When USB_ID_GPIO is defined (in board.h), this feature is enabled.
+//!
+//! @{
+   //! Enable external OTG_ID pin (listened to by USB)
+#define otg_enable_id_pin()                 (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIDE))
+   //! Disable external OTG_ID pin (ignored by USB)
+#define otg_disable_id_pin()                (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIDE))
+   //! Test if external OTG_ID pin enabled (listened to by USB)
+#define Is_otg_id_pin_enabled()             (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIDE))
+   //! Disable external OTG_ID pin and force device mode
+#define otg_force_device_mode()             (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIMOD), otg_disable_id_pin())
+   //! Test if device mode is forced
+#define Is_otg_device_mode_forced()         (!Is_otg_id_pin_enabled() && Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIMOD))
+   //! Disable external OTG_ID pin and force host mode
+#define otg_force_host_mode()               (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIMOD), otg_disable_id_pin())
+   //! Test if host mode is forced
+#define Is_otg_host_mode_forced()           (!Is_otg_id_pin_enabled() && !Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UIMOD))
+
+//! @name UOTGHS OTG ID pin interrupt management
+//! These macros manage the ID pin interrupt
+//! @{
+#define otg_enable_id_interrupt()           (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_IDTE))
+#define otg_disable_id_interrupt()          (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_IDTE))
+#define Is_otg_id_interrupt_enabled()       (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_IDTE))
+#define Is_otg_id_device()                  (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_ID))
+#define Is_otg_id_host()                    (!Is_otg_id_device())
+#define otg_ack_id_transition()             (UOTGHS->UOTGHS_SCR = UOTGHS_SCR_IDTIC)
+#define otg_raise_id_transition()           (UOTGHS->UOTGHS_SFR = UOTGHS_SFR_IDTIS)
+#define Is_otg_id_transition()              (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_IDTI))
+//! @}
+//! @}
+
+//! @name OTG Vbus management
+//! @{
+#define otg_enable_vbus_interrupt()         (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_VBUSTE))
+#define otg_disable_vbus_interrupt()        (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_VBUSTE))
+#define Is_otg_vbus_interrupt_enabled()     (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_VBUSTE))
+#define Is_otg_vbus_high()                  (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_VBUS))
+#define Is_otg_vbus_low()                   (!Is_otg_vbus_high())
+#define otg_ack_vbus_transition()           (UOTGHS->UOTGHS_SCR = UOTGHS_SCR_VBUSTIC)
+#define otg_raise_vbus_transition()         (UOTGHS->UOTGHS_SFR = UOTGHS_SFR_VBUSTIS)
+#define Is_otg_vbus_transition()            (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_VBUSTI))
+//! @}
+
+//! @name UOTGHS OTG main management
+//! These macros allows to enable/disable pad and UOTGHS hardware
+//! @{
+  //! Reset USB macro
+#define otg_reset()                         \
+	do {                                    \
+		UOTGHS->UOTGHS_CTRL = 0;            \
+		while( UOTGHS->UOTGHS_SR & 0x3FFF) {\
+			UOTGHS->UOTGHS_SCR = 0xFFFFFFFF;\
+		}                                   \
+	} while (0)
+  //! Enable USB macro
+#define otg_enable()                        (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_USBE))
+  //! Disable USB macro                     
+#define otg_disable()                       (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_USBE))
+#define Is_otg_enabled()                    (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_USBE))
+
+  //! Enable OTG pad                        
+#define otg_enable_pad()                    (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_OTGPADE))
+  //! Disable OTG pad                       
+#define otg_disable_pad()                   (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_OTGPADE))
+#define Is_otg_pad_enabled()                (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_OTGPADE))
+
+  //! Check Clock Usable               
+  //! For parts with HS feature, this one corresponding at UTMI clock
+#define Is_otg_clock_usable()               (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_CLKUSABLE))
+
+  //! Stop (freeze) internal USB clock
+#define otg_freeze_clock()                  (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK))
+#define otg_unfreeze_clock()                (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK))
+#define Is_otg_clock_frozen()               (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_FRZCLK))
+
+  //! Configure time-out of specified OTG timer
+#define otg_configure_timeout(timer, timeout) (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UNLOCK),\
+		Wr_bitfield(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_TIMPAGE_Msk, timer),\
+		Wr_bitfield(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_TIMVALUE_Msk, timeout),\
+		Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UNLOCK))
+  //! Get configured time-out of specified OTG timer
+#define otg_get_timeout(timer)              (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UNLOCK),\
+		Wr_bitfield(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_TIMPAGE_Msk, timer),\
+		Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_UNLOCK),\
+		Rd_bitfield(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_TIMVALUE_Msk))
+
+
+  //! Get the dual-role device state of the internal USB finite state machine of the UOTGHS controller
+#define otg_get_fsm_drd_state()             (Rd_bitfield(UOTGHS->UOTGHS_FSM, UOTGHS_FSM_DRDSTATE_Msk))
+#define Is_otg_a_suspend()                  (4==otg_get_fsm_drd_state())
+#define Is_otg_a_wait_vrise()               (1==otg_get_fsm_drd_state())
+//! @}
+
+//! @name UOTGHS OTG hardware protocol
+//! These macros manages the hardware OTG protocol
+//! @{
+  //! Initiates a Host negotiation Protocol
+#define otg_device_initiate_hnp()             (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPREQ))
+  //! Accepts a Host negotiation Protocol
+#define otg_host_accept_hnp()                 (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPREQ))
+  //! Rejects a Host negotiation Protocol
+#define otg_host_reject_hnp()                 (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPREQ))
+  //! initiates a Session Request Protocol
+#define otg_device_initiate_srp()             (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPREQ))
+  //! Selects VBus as SRP method
+#define otg_select_vbus_srp_method()          (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPSEL))
+#define Is_otg_vbus_srp_method_selected()     (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPSEL))
+  //! Selects data line as SRP method
+#define otg_select_data_srp_method()          (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPSEL))
+#define Is_otg_data_srp_method_selected()     (!Is_otg_vbus_srp_method_selected())
+  //! Tests if a HNP occurs
+#define Is_otg_hnp()                          (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPREQ))
+  //! Tests if a SRP from device occurs
+#define Is_otg_device_srp()                   (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPREQ))
+
+  //! Enables HNP error interrupt
+#define otg_enable_hnp_error_interrupt()      (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPERRE))
+  //! Disables HNP error interrupt
+#define otg_disable_hnp_error_interrupt()     (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPERRE))
+#define Is_otg_hnp_error_interrupt_enabled()  (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_HNPERRE))
+  //! ACKs HNP error interrupt
+#define otg_ack_hnp_error_interrupt()         (UOTGHS->UOTGHS_SCR = UOTGHS_SCR_HNPERRIC)
+  //! Raises HNP error interrupt
+#define otg_raise_hnp_error_interrupt()       (UOTGHS->UOTGHS_SFR = UOTGHS_SFR_HNPERRIS)
+  //! Tests if a HNP error occurs
+#define Is_otg_hnp_error_interrupt()          (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_HNPERRI))
+
+  //! Enables role exchange interrupt
+#define otg_enable_role_exchange_interrupt()      (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_ROLEEXE))
+  //! Disables role exchange interrupt
+#define otg_disable_role_exchange_interrupt()     (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_ROLEEXE))
+#define Is_otg_role_exchange_interrupt_enabled()  (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_ROLEEXE))
+  //! ACKs role exchange interrupt
+#define otg_ack_role_exchange_interrupt()         (UOTGHS->UOTGHS_SCR = UOTGHS_SCR_ROLEEXIC)
+  //! Raises role exchange interrupt
+#define otg_raise_role_exchange_interrupt()       (UOTGHS->UOTGHS_SFR = UOTGHS_SFR_ROLEEXIS)
+  //! Tests if a role exchange occurs
+#define Is_otg_role_exchange_interrupt()          (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_ROLEEXI))
+
+  //! Enables SRP interrupt
+#define otg_enable_srp_interrupt()          (Set_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPE))
+  //! Disables SRP interrupt
+#define otg_disable_srp_interrupt()         (Clr_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPE))
+#define Is_otg_srp_interrupt_enabled()      (Tst_bits(UOTGHS->UOTGHS_CTRL, UOTGHS_CTRL_SRPE))
+  //! ACKs SRP interrupt
+#define otg_ack_srp_interrupt()             (UOTGHS->UOTGHS_SCR = UOTGHS_SCR_SRPIC)
+  //! Raises SRP interrupt
+#define otg_raise_srp_interrupt()           (UOTGHS->UOTGHS_SFR = UOTGHS_SFR_SRPIS)
+  //! Tests if a SRP occurs
+#define Is_otg_srp_interrupt()              (Tst_bits(UOTGHS->UOTGHS_SR, UOTGHS_SR_SRPI))
+//! @}
+
+//! @}
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* UOTGHS_OTG_H_INCLUDED */

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol.h
@@ -1,0 +1,496 @@
+/**
+ * \file
+ *
+ * \brief USB protocol definitions.
+ *
+ * This file contains the USB definitions and data structures provided by the
+ * USB 2.0 specification.
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _USB_PROTOCOL_H_
+#define _USB_PROTOCOL_H_
+
+/**
+ * \ingroup usb_group
+ * \defgroup usb_protocol_group USB Protocol Definitions
+ *
+ * This module defines constants and data structures provided by the USB
+ * 2.0 specification.
+ *
+ * @{
+ */
+
+//! Value for field bcdUSB
+#define  USB_V2_0    0x0200 //!< USB Specification version 2.00
+#define  USB_V2_1    0x0201 //!< USB Specification version 2.01
+
+/*! \name Generic definitions (Class, subclass and protocol)
+ */
+//! @{
+#define  NO_CLASS                0x00
+#define  CLASS_VENDOR_SPECIFIC   0xFF
+#define  NO_SUBCLASS             0x00
+#define  NO_PROTOCOL             0x00
+//! @}
+
+//! \name IAD (Interface Association Descriptor) constants
+//! @{
+#define  CLASS_IAD               0xEF
+#define  SUB_CLASS_IAD           0x02
+#define  PROTOCOL_IAD            0x01
+//! @}
+
+/**
+ * \brief USB request data transfer direction (bmRequestType)
+ */
+#define  USB_REQ_DIR_OUT         (0<<7) //!< Host to device
+#define  USB_REQ_DIR_IN          (1<<7) //!< Device to host
+#define  USB_REQ_DIR_MASK        (1<<7) //!< Mask
+
+/**
+ * \brief USB request types (bmRequestType)
+ */
+#define  USB_REQ_TYPE_STANDARD   (0<<5) //!< Standard request
+#define  USB_REQ_TYPE_CLASS      (1<<5) //!< Class-specific request
+#define  USB_REQ_TYPE_VENDOR     (2<<5) //!< Vendor-specific request
+#define  USB_REQ_TYPE_MASK       (3<<5) //!< Mask
+
+/**
+ * \brief USB recipient codes (bmRequestType)
+ */
+#define  USB_REQ_RECIP_DEVICE    (0<<0) //!< Recipient device
+#define  USB_REQ_RECIP_INTERFACE (1<<0) //!< Recipient interface
+#define  USB_REQ_RECIP_ENDPOINT  (2<<0) //!< Recipient endpoint
+#define  USB_REQ_RECIP_OTHER     (3<<0) //!< Recipient other
+#define  USB_REQ_RECIP_MASK      (0x1F) //!< Mask
+
+/**
+ * \brief Standard USB requests (bRequest)
+ */
+enum usb_reqid {
+	USB_REQ_GET_STATUS = 0,
+	USB_REQ_CLEAR_FEATURE = 1,
+	USB_REQ_SET_FEATURE = 3,
+	USB_REQ_SET_ADDRESS = 5,
+	USB_REQ_GET_DESCRIPTOR = 6,
+	USB_REQ_SET_DESCRIPTOR = 7,
+	USB_REQ_GET_CONFIGURATION = 8,
+	USB_REQ_SET_CONFIGURATION = 9,
+	USB_REQ_GET_INTERFACE = 10,
+	USB_REQ_SET_INTERFACE = 11,
+	USB_REQ_SYNCH_FRAME = 12,
+};
+
+/**
+ * \brief Standard USB device status flags
+ *
+ */
+enum usb_device_status {
+	USB_DEV_STATUS_BUS_POWERED = 0,
+	USB_DEV_STATUS_SELF_POWERED = 1,
+	USB_DEV_STATUS_REMOTEWAKEUP = 2
+};
+
+/**
+ * \brief Standard USB Interface status flags
+ *
+ */
+enum usb_interface_status {
+	USB_IFACE_STATUS_RESERVED = 0
+};
+
+/**
+ * \brief Standard USB endpoint status flags
+ *
+ */
+enum usb_endpoint_status {
+	USB_EP_STATUS_HALTED = 1,
+};
+
+/**
+ * \brief Standard USB device feature flags
+ *
+ * \note valid for SetFeature request.
+ */
+enum usb_device_feature {
+	USB_DEV_FEATURE_REMOTE_WAKEUP = 1, //!< Remote wakeup enabled
+	USB_DEV_FEATURE_TEST_MODE = 2,     //!< USB test mode
+	USB_DEV_FEATURE_OTG_B_HNP_ENABLE = 3,
+	USB_DEV_FEATURE_OTG_A_HNP_SUPPORT = 4,
+	USB_DEV_FEATURE_OTG_A_ALT_HNP_SUPPORT = 5
+};
+
+/**
+ * \brief Test Mode possible on HS USB device
+ *
+ * \note valid for USB_DEV_FEATURE_TEST_MODE request.
+ */
+enum usb_device_hs_test_mode {
+	USB_DEV_TEST_MODE_J = 1,
+	USB_DEV_TEST_MODE_K = 2,
+	USB_DEV_TEST_MODE_SE0_NAK = 3,
+	USB_DEV_TEST_MODE_PACKET = 4,
+	USB_DEV_TEST_MODE_FORCE_ENABLE = 5,
+};
+
+/**
+ * \brief Standard USB endpoint feature/status flags
+ */
+enum usb_endpoint_feature {
+	USB_EP_FEATURE_HALT = 0,
+};
+
+/**
+ * \brief Standard USB Test Mode Selectors
+ */
+enum usb_test_mode_selector {
+	USB_TEST_J = 0x01,
+	USB_TEST_K = 0x02,
+	USB_TEST_SE0_NAK = 0x03,
+	USB_TEST_PACKET = 0x04,
+	USB_TEST_FORCE_ENABLE = 0x05,
+};
+
+/**
+ * \brief Standard USB descriptor types
+ */
+enum usb_descriptor_type {
+	USB_DT_DEVICE = 1,
+	USB_DT_CONFIGURATION = 2,
+	USB_DT_STRING = 3,
+	USB_DT_INTERFACE = 4,
+	USB_DT_ENDPOINT = 5,
+	USB_DT_DEVICE_QUALIFIER = 6,
+	USB_DT_OTHER_SPEED_CONFIGURATION = 7,
+	USB_DT_INTERFACE_POWER = 8,
+	USB_DT_OTG = 9,
+	USB_DT_IAD = 0x0B,
+	USB_DT_BOS = 0x0F,
+	USB_DT_DEVICE_CAPABILITY = 0x10,
+};
+
+/**
+ * \brief USB Device Capability types
+ */
+enum usb_capability_type {
+	USB_DC_USB20_EXTENSION = 0x02,
+};
+
+/**
+ * \brief USB Device Capability - USB 2.0 Extension
+ * To fill bmAttributes field of usb_capa_ext_desc_t structure.
+ */
+enum usb_capability_extension_attr {
+	USB_DC_EXT_LPM  = 0x00000002,
+};
+
+#define HIRD_50_US    0
+#define HIRD_125_US   1
+#define HIRD_200_US   2
+#define HIRD_275_US   3
+#define HIRD_350_US   4
+#define HIRD_425_US   5
+#define HIRD_500_US   6
+#define HIRD_575_US  7
+#define HIRD_650_US  8
+#define HIRD_725_US  9
+#define HIRD_800_US  10
+#define HIRD_875_US  11
+#define HIRD_950_US  12
+#define HIRD_1025_US  13
+#define HIRD_1100_US  14
+#define HIRD_1175_US  15
+
+/** Fields definition from a LPM TOKEN  */
+#define  USB_LPM_ATTRIBUT_BLINKSTATE_MASK      (0xF << 0)
+#define  USB_LPM_ATTRIBUT_FIRD_MASK            (0xF << 4)
+#define  USB_LPM_ATTRIBUT_REMOTEWAKE_MASK      (1 << 8)
+#define  USB_LPM_ATTRIBUT_BLINKSTATE(value)    ((value & 0xF) << 0)
+#define  USB_LPM_ATTRIBUT_FIRD(value)          ((value & 0xF) << 4)
+#define  USB_LPM_ATTRIBUT_REMOTEWAKE(value)    ((value & 1) << 8)
+#define  USB_LPM_ATTRIBUT_BLINKSTATE_L1        USB_LPM_ATTRIBUT_BLINKSTATE(1)
+
+/**
+ * \brief Standard USB endpoint transfer types
+ */
+enum usb_ep_type {
+	USB_EP_TYPE_CONTROL = 0x00,
+	USB_EP_TYPE_ISOCHRONOUS = 0x01,
+	USB_EP_TYPE_BULK = 0x02,
+	USB_EP_TYPE_INTERRUPT = 0x03,
+	USB_EP_TYPE_MASK = 0x03,
+};
+
+/**
+ * \brief Standard USB language IDs for string descriptors
+ */
+enum usb_langid {
+	USB_LANGID_EN_US = 0x0409, //!< English (United States)
+};
+
+/**
+ * \brief Mask selecting the index part of an endpoint address
+ */
+#define  USB_EP_ADDR_MASK     0x0f
+
+//! \brief USB address identifier
+typedef uint8_t usb_add_t;
+
+/**
+ * \brief Endpoint transfer direction is IN
+ */
+#define  USB_EP_DIR_IN        0x80
+
+/**
+ * \brief Endpoint transfer direction is OUT
+ */
+#define  USB_EP_DIR_OUT       0x00
+
+//! \brief Endpoint identifier
+typedef uint8_t usb_ep_t;
+
+/**
+ * \brief Maximum length in bytes of a USB descriptor
+ *
+ * The maximum length of a USB descriptor is limited by the 8-bit
+ * bLength field.
+ */
+#define  USB_MAX_DESC_LEN     255
+
+/*
+ * 2-byte alignment requested for all USB structures.
+ */
+COMPILER_PACK_SET(1)
+
+/**
+ * \brief A USB Device SETUP request
+ *
+ * The data payload of SETUP packets always follows this structure.
+ */
+typedef struct {
+	uint8_t bmRequestType;
+	uint8_t bRequest;
+	le16_t wValue;
+	le16_t wIndex;
+	le16_t wLength;
+} usb_setup_req_t;
+
+/**
+ * \brief Standard USB device descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	le16_t bcdUSB;
+	uint8_t bDeviceClass;
+	uint8_t bDeviceSubClass;
+	uint8_t bDeviceProtocol;
+	uint8_t bMaxPacketSize0;
+	le16_t idVendor;
+	le16_t idProduct;
+	le16_t bcdDevice;
+	uint8_t iManufacturer;
+	uint8_t iProduct;
+	uint8_t iSerialNumber;
+	uint8_t bNumConfigurations;
+} usb_dev_desc_t;
+
+/**
+ * \brief Standard USB device qualifier descriptor structure
+ *
+ * This descriptor contains information about the device when running at
+ * the "other" speed (i.e. if the device is currently operating at high
+ * speed, this descriptor can be used to determine what would change if
+ * the device was operating at full speed.)
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	le16_t bcdUSB;
+	uint8_t bDeviceClass;
+	uint8_t bDeviceSubClass;
+	uint8_t bDeviceProtocol;
+	uint8_t bMaxPacketSize0;
+	uint8_t bNumConfigurations;
+	uint8_t bReserved;
+} usb_dev_qual_desc_t;
+
+/**
+ * \brief USB Device BOS descriptor structure
+ *
+ * The BOS descriptor (Binary device Object Store) defines a root
+ * descriptor that is similar to the configuration descriptor, and is
+ * the base descriptor for accessing a family of related descriptors.
+ * A host can read a BOS descriptor and learn from the wTotalLength field
+ * the entire size of the device-level descriptor set, or it can read in
+ * the entire BOS descriptor set of device capabilities.
+ * The host accesses this descriptor using the GetDescriptor() request.
+ * The descriptor type in the GetDescriptor() request is set to BOS.
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	le16_t  wTotalLength;
+	uint8_t bNumDeviceCaps;
+} usb_dev_bos_desc_t;
+
+
+/**
+ * \brief USB Device Capabilities - USB 2.0 Extension Descriptor structure
+ *
+ * Defines the set of USB 1.1-specific device level capabilities.
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bDevCapabilityType;
+	le32_t  bmAttributes;
+} usb_dev_capa_ext_desc_t;
+
+/**
+ * \brief USB Device LPM Descriptor structure
+ *
+ * The BOS descriptor and capabilities descriptors for LPM.
+ */
+typedef struct {
+	usb_dev_bos_desc_t bos;
+	usb_dev_capa_ext_desc_t capa_ext;
+} usb_dev_lpm_desc_t;
+
+/**
+ * \brief Standard USB Interface Association Descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;          //!< size of this descriptor in bytes
+	uint8_t bDescriptorType;  //!< INTERFACE descriptor type
+	uint8_t bFirstInterface;  //!< Number of interface
+	uint8_t bInterfaceCount;  //!< value to select alternate setting
+	uint8_t bFunctionClass;   //!< Class code assigned by the USB
+	uint8_t bFunctionSubClass;//!< Sub-class code assigned by the USB
+	uint8_t bFunctionProtocol;//!< Protocol code assigned by the USB
+	uint8_t iFunction;        //!< Index of string descriptor
+} usb_association_desc_t;
+
+
+/**
+ * \brief Standard USB configuration descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	le16_t wTotalLength;
+	uint8_t bNumInterfaces;
+	uint8_t bConfigurationValue;
+	uint8_t iConfiguration;
+	uint8_t bmAttributes;
+	uint8_t bMaxPower;
+} usb_conf_desc_t;
+
+
+#define  USB_CONFIG_ATTR_MUST_SET         (1 << 7) //!< Must always be set
+#define  USB_CONFIG_ATTR_BUS_POWERED      (0 << 6) //!< Bus-powered
+#define  USB_CONFIG_ATTR_SELF_POWERED     (1 << 6) //!< Self-powered
+#define  USB_CONFIG_ATTR_REMOTE_WAKEUP    (1 << 5) //!< remote wakeup supported
+
+#define  USB_CONFIG_MAX_POWER(ma)         (((ma) + 1) / 2) //!< Max power in mA
+
+/**
+ * \brief Standard USB association descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;              //!< Size of this descriptor in bytes
+	uint8_t bDescriptorType;      //!< Interface descriptor type
+	uint8_t bFirstInterface;      //!< Number of interface
+	uint8_t bInterfaceCount;      //!< value to select alternate setting
+	uint8_t bFunctionClass;       //!< Class code assigned by the USB
+	uint8_t bFunctionSubClass;    //!< Sub-class code assigned by the USB
+	uint8_t bFunctionProtocol;    //!< Protocol code assigned by the USB
+	uint8_t iFunction;            //!< Index of string descriptor
+} usb_iad_desc_t;
+
+/**
+ * \brief Standard USB interface descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bInterfaceNumber;
+	uint8_t bAlternateSetting;
+	uint8_t bNumEndpoints;
+	uint8_t bInterfaceClass;
+	uint8_t bInterfaceSubClass;
+	uint8_t bInterfaceProtocol;
+	uint8_t iInterface;
+} usb_iface_desc_t;
+
+/**
+ * \brief Standard USB endpoint descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t bEndpointAddress;
+	uint8_t bmAttributes;
+	le16_t wMaxPacketSize;
+	uint8_t bInterval;
+} usb_ep_desc_t;
+
+
+/**
+ * \brief A standard USB string descriptor structure
+ */
+typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+} usb_str_desc_t;
+
+typedef struct {
+	usb_str_desc_t desc;
+	le16_t string[1];
+} usb_str_lgid_desc_t;
+
+COMPILER_PACK_RESET()
+
+//! @}
+
+#endif /* _USB_PROTOCOL_H_ */

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_cdc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_cdc.h
@@ -1,0 +1,318 @@
+/**
+ * \file
+ *
+ * \brief USB Communication Device Class (CDC) protocol definitions
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+#ifndef _USB_PROTOCOL_CDC_H_
+#define _USB_PROTOCOL_CDC_H_
+
+#include "compiler.h"
+
+/**
+ * \ingroup usb_protocol_group
+ * \defgroup cdc_protocol_group Communication Device Class Definitions
+ * @{
+ */
+
+/**
+ * \name Possible values of class
+ */
+//@{
+#define  CDC_CLASS_DEVICE     0x02	//!< USB Communication Device Class
+#define  CDC_CLASS_COMM       0x02	//!< CDC Communication Class Interface
+#define  CDC_CLASS_DATA       0x0A	//!< CDC Data Class Interface
+//@}
+
+//! \name USB CDC Subclass IDs
+//@{
+#define  CDC_SUBCLASS_DLCM    0x01	//!< Direct Line Control Model
+#define  CDC_SUBCLASS_ACM     0x02	//!< Abstract Control Model
+#define  CDC_SUBCLASS_TCM     0x03	//!< Telephone Control Model
+#define  CDC_SUBCLASS_MCCM    0x04	//!< Multi-Channel Control Model
+#define  CDC_SUBCLASS_CCM     0x05	//!< CAPI Control Model
+#define  CDC_SUBCLASS_ETH     0x06	//!< Ethernet Networking Control Model
+#define  CDC_SUBCLASS_ATM     0x07	//!< ATM Networking Control Model
+//@}
+
+//! \name USB CDC Communication Interface Protocol IDs
+//@{
+#define  CDC_PROTOCOL_V25TER  0x01	//!< Common AT commands
+//@}
+
+//! \name USB CDC Data Interface Protocol IDs
+//@{
+#define  CDC_PROTOCOL_I430    0x30	//!< ISDN BRI
+#define  CDC_PROTOCOL_HDLC    0x31	//!< HDLC
+#define  CDC_PROTOCOL_TRANS   0x32	//!< Transparent
+#define  CDC_PROTOCOL_Q921M   0x50	//!< Q.921 management protocol
+#define  CDC_PROTOCOL_Q921    0x51	//!< Q.931 [sic] Data link protocol
+#define  CDC_PROTOCOL_Q921TM  0x52	//!< Q.921 TEI-multiplexor
+#define  CDC_PROTOCOL_V42BIS  0x90	//!< Data compression procedures
+#define  CDC_PROTOCOL_Q931    0x91	//!< Euro-ISDN protocol control
+#define  CDC_PROTOCOL_V120    0x92	//!< V.24 rate adaption to ISDN
+#define  CDC_PROTOCOL_CAPI20  0x93	//!< CAPI Commands
+#define  CDC_PROTOCOL_HOST    0xFD	//!< Host based driver
+/**
+ * \brief Describes the Protocol Unit Functional Descriptors [sic]
+ * on Communication Class Interface
+ */
+#define  CDC_PROTOCOL_PUFD    0xFE
+//@}
+
+//! \name USB CDC Functional Descriptor Types
+//@{
+#define  CDC_CS_INTERFACE     0x24	//!< Interface Functional Descriptor
+#define  CDC_CS_ENDPOINT      0x25	//!< Endpoint Functional Descriptor
+//@}
+
+//! \name USB CDC Functional Descriptor Subtypes
+//@{
+#define  CDC_SCS_HEADER       0x00	//!< Header Functional Descriptor
+#define  CDC_SCS_CALL_MGMT    0x01	//!< Call Management
+#define  CDC_SCS_ACM          0x02	//!< Abstract Control Management
+#define  CDC_SCS_UNION        0x06	//!< Union Functional Descriptor
+//@}
+
+//! \name USB CDC Request IDs
+//@{
+#define  USB_REQ_CDC_SEND_ENCAPSULATED_COMMAND                   0x00
+#define  USB_REQ_CDC_GET_ENCAPSULATED_RESPONSE                   0x01
+#define  USB_REQ_CDC_SET_COMM_FEATURE                            0x02
+#define  USB_REQ_CDC_GET_COMM_FEATURE                            0x03
+#define  USB_REQ_CDC_CLEAR_COMM_FEATURE                          0x04
+#define  USB_REQ_CDC_SET_AUX_LINE_STATE                          0x10
+#define  USB_REQ_CDC_SET_HOOK_STATE                              0x11
+#define  USB_REQ_CDC_PULSE_SETUP                                 0x12
+#define  USB_REQ_CDC_SEND_PULSE                                  0x13
+#define  USB_REQ_CDC_SET_PULSE_TIME                              0x14
+#define  USB_REQ_CDC_RING_AUX_JACK                               0x15
+#define  USB_REQ_CDC_SET_LINE_CODING                             0x20
+#define  USB_REQ_CDC_GET_LINE_CODING                             0x21
+#define  USB_REQ_CDC_SET_CONTROL_LINE_STATE                      0x22
+#define  USB_REQ_CDC_SEND_BREAK                                  0x23
+#define  USB_REQ_CDC_SET_RINGER_PARMS                            0x30
+#define  USB_REQ_CDC_GET_RINGER_PARMS                            0x31
+#define  USB_REQ_CDC_SET_OPERATION_PARMS                         0x32
+#define  USB_REQ_CDC_GET_OPERATION_PARMS                         0x33
+#define  USB_REQ_CDC_SET_LINE_PARMS                              0x34
+#define  USB_REQ_CDC_GET_LINE_PARMS                              0x35
+#define  USB_REQ_CDC_DIAL_DIGITS                                 0x36
+#define  USB_REQ_CDC_SET_UNIT_PARAMETER                          0x37
+#define  USB_REQ_CDC_GET_UNIT_PARAMETER                          0x38
+#define  USB_REQ_CDC_CLEAR_UNIT_PARAMETER                        0x39
+#define  USB_REQ_CDC_GET_PROFILE                                 0x3A
+#define  USB_REQ_CDC_SET_ETHERNET_MULTICAST_FILTERS              0x40
+#define  USB_REQ_CDC_SET_ETHERNET_POWER_MANAGEMENT_PATTERNFILTER 0x41
+#define  USB_REQ_CDC_GET_ETHERNET_POWER_MANAGEMENT_PATTERNFILTER 0x42
+#define  USB_REQ_CDC_SET_ETHERNET_PACKET_FILTER                  0x43
+#define  USB_REQ_CDC_GET_ETHERNET_STATISTIC                      0x44
+#define  USB_REQ_CDC_SET_ATM_DATA_FORMAT                         0x50
+#define  USB_REQ_CDC_GET_ATM_DEVICE_STATISTICS                   0x51
+#define  USB_REQ_CDC_SET_ATM_DEFAULT_VC                          0x52
+#define  USB_REQ_CDC_GET_ATM_VC_STATISTICS                       0x53
+// Added bNotification codes according cdc spec 1.1 chapter 6.3
+#define  USB_REQ_CDC_NOTIFY_RING_DETECT                          0x09
+#define  USB_REQ_CDC_NOTIFY_SERIAL_STATE                         0x20
+#define  USB_REQ_CDC_NOTIFY_CALL_STATE_CHANGE                    0x28
+#define  USB_REQ_CDC_NOTIFY_LINE_STATE_CHANGE                    0x29
+//@}
+
+/*
+ * Need to pack structures tightly, or the compiler might insert padding
+ * and violate the spec-mandated layout.
+ */
+COMPILER_PACK_SET(1)
+
+//! \name USB CDC Descriptors
+//@{
+
+
+//! CDC Header Functional Descriptor
+typedef struct {
+	uint8_t bFunctionLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	le16_t bcdCDC;
+} usb_cdc_hdr_desc_t;
+
+//! CDC Call Management Functional Descriptor
+typedef struct {
+	uint8_t bFunctionLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	uint8_t bmCapabilities;
+	uint8_t bDataInterface;
+} usb_cdc_call_mgmt_desc_t;
+
+//! CDC ACM Functional Descriptor
+typedef struct {
+	uint8_t bFunctionLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	uint8_t bmCapabilities;
+} usb_cdc_acm_desc_t;
+
+//! CDC Union Functional Descriptor
+typedef struct {
+	uint8_t bFunctionLength;
+	uint8_t bDescriptorType;
+	uint8_t bDescriptorSubtype;
+	uint8_t bMasterInterface;
+	uint8_t bSlaveInterface0;
+} usb_cdc_union_desc_t;
+
+
+//! \name USB CDC Call Management Capabilities
+//@{
+//! Device handles call management itself
+#define  CDC_CALL_MGMT_SUPPORTED             (1 << 0)
+//! Device can send/receive call management info over a Data Class interface
+#define  CDC_CALL_MGMT_OVER_DCI              (1 << 1)
+//@}
+
+//! \name USB CDC ACM Capabilities
+//@{
+//! Device supports the request combination of
+//! Set_Comm_Feature, Clear_Comm_Feature, and Get_Comm_Feature.
+#define  CDC_ACM_SUPPORT_FEATURE_REQUESTS    (1 << 0)
+//! Device supports the request combination of
+//! Set_Line_Coding, Set_Control_Line_State, Get_Line_Coding,
+//! and the notification Serial_State.
+#define  CDC_ACM_SUPPORT_LINE_REQUESTS       (1 << 1)
+//! Device supports the request Send_Break
+#define  CDC_ACM_SUPPORT_SENDBREAK_REQUESTS  (1 << 2)
+//! Device supports the notification Network_Connection.
+#define  CDC_ACM_SUPPORT_NOTIFY_REQUESTS     (1 << 3)
+//@}
+//@}
+
+//! \name USB CDC line control
+//@{
+
+//! \name USB CDC line coding
+//@{
+//! Line Coding structure
+typedef struct {
+	le32_t dwDTERate;
+	uint8_t bCharFormat;
+	uint8_t bParityType;
+	uint8_t bDataBits;
+} usb_cdc_line_coding_t;
+//! Possible values of bCharFormat
+enum cdc_char_format {
+	CDC_STOP_BITS_1 = 0,	//!< 1 stop bit
+	CDC_STOP_BITS_1_5 = 1,	//!< 1.5 stop bits
+	CDC_STOP_BITS_2 = 2,	//!< 2 stop bits
+};
+//! Possible values of bParityType
+enum cdc_parity {
+	CDC_PAR_NONE = 0,	//!< No parity
+	CDC_PAR_ODD = 1,	//!< Odd parity
+	CDC_PAR_EVEN = 2,	//!< Even parity
+	CDC_PAR_MARK = 3,	//!< Parity forced to 0 (space)
+	CDC_PAR_SPACE = 4,	//!< Parity forced to 1 (mark)
+};
+//@}
+
+//! \name USB CDC control signals
+//! spec 1.1 chapter 6.2.14
+//@{
+
+//! Control signal structure
+typedef struct {
+	uint16_t value;
+} usb_cdc_control_signal_t;
+
+//! \name Possible values in usb_cdc_control_signal_t
+//@{
+//! Carrier control for half duplex modems.
+//! This signal corresponds to V.24 signal 105 and RS-232 signal RTS.
+//! The device ignores the value of this bit
+//! when operating in full duplex mode.
+#define  CDC_CTRL_SIGNAL_ACTIVATE_CARRIER    (1 << 1)
+//! Indicates to DCE if DTE is present or not.
+//! This signal corresponds to V.24 signal 108/2 and RS-232 signal DTR.
+#define  CDC_CTRL_SIGNAL_DTE_PRESENT         (1 << 0)
+//@}
+//@}
+
+
+//! \name USB CDC notification message
+//@{
+
+typedef struct {
+	uint8_t bmRequestType;
+	uint8_t bNotification;
+	le16_t wValue;
+	le16_t wIndex;
+	le16_t wLength;
+} usb_cdc_notify_msg_t;
+
+//! \name USB CDC serial state
+//@{*
+
+//! Hardware handshake support (cdc spec 1.1 chapter 6.3.5)
+typedef struct {
+	usb_cdc_notify_msg_t header;
+	le16_t value;
+} usb_cdc_notify_serial_state_t;
+
+//! \name Possible values in usb_cdc_notify_serial_state_t
+//@{
+#define  CDC_SERIAL_STATE_DCD       CPU_TO_LE16((1<<0))
+#define  CDC_SERIAL_STATE_DSR       CPU_TO_LE16((1<<1))
+#define  CDC_SERIAL_STATE_BREAK     CPU_TO_LE16((1<<2))
+#define  CDC_SERIAL_STATE_RING      CPU_TO_LE16((1<<3))
+#define  CDC_SERIAL_STATE_FRAMING   CPU_TO_LE16((1<<4))
+#define  CDC_SERIAL_STATE_PARITY    CPU_TO_LE16((1<<5))
+#define  CDC_SERIAL_STATE_OVERRUN   CPU_TO_LE16((1<<6))
+//@}
+//! @}
+
+//! @}
+
+COMPILER_PACK_RESET()
+
+//! @}
+
+#endif // _USB_PROTOCOL_CDC_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_msc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_msc.h
@@ -1,0 +1,147 @@
+/**
+ * \file
+ *
+ * \brief USB Mass Storage Class (MSC) protocol definitions.
+ *
+ * Copyright (c) 2009-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _USB_PROTOCOL_MSC_H_
+#define _USB_PROTOCOL_MSC_H_
+
+
+/**
+ * \ingroup usb_protocol_group
+ * \defgroup usb_msc_protocol USB Mass Storage Class (MSC) protocol definitions
+ *
+ * @{
+ */
+
+/**
+ * \name Possible Class value
+ */
+//@{
+#define  MSC_CLASS                  0x08
+//@}
+
+/**
+ * \name Possible SubClass value
+ * \note In practise, most devices should use
+ * #MSC_SUBCLASS_TRANSPARENT and specify the actual command set in
+ * the standard INQUIRY data block, even if the MSC spec indicates
+ * otherwise. In particular, RBC is not supported by certain major
+ * operating systems like Windows XP.
+ */
+//@{
+#define  MSC_SUBCLASS_RBC           0x01	//!< Reduced Block Commands
+#define  MSC_SUBCLASS_ATAPI         0x02	//!< CD/DVD devices
+#define  MSC_SUBCLASS_QIC_157       0x03	//!< Tape devices
+#define  MSC_SUBCLASS_UFI           0x04	//!< Floppy disk drives
+#define  MSC_SUBCLASS_SFF_8070I     0x05	//!< Floppy disk drives
+#define  MSC_SUBCLASS_TRANSPARENT   0x06	//!< Determined by INQUIRY
+//@}
+
+/**
+ * \name Possible protocol value
+ * \note Only the BULK protocol should be used in new designs.
+ */
+//@{
+#define  MSC_PROTOCOL_CBI           0x00	//!< Command/Bulk/Interrupt
+#define  MSC_PROTOCOL_CBI_ALT       0x01	//!< W/o command completion
+#define  MSC_PROTOCOL_BULK          0x50	//!< Bulk-only
+//@}
+
+
+/**
+ * \brief MSC USB requests (bRequest)
+ */
+enum usb_reqid_msc {
+	USB_REQ_MSC_BULK_RESET = 0xFF,	//!< Mass Storage Reset
+	USB_REQ_MSC_GET_MAX_LUN = 0xFE,	//!< Get Max LUN
+};
+
+
+COMPILER_PACK_SET(1)
+
+/**
+ * \name A Command Block Wrapper (CBW).
+ */
+//@{
+struct usb_msc_cbw {
+	le32_t dCBWSignature;	//!< Must contain 'USBC'
+	le32_t dCBWTag;	//!< Unique command ID
+	le32_t dCBWDataTransferLength;	//!< Number of bytes to transfer
+	uint8_t bmCBWFlags;	//!< Direction in bit 7
+	uint8_t bCBWLUN;	//!< Logical Unit Number
+	uint8_t bCBWCBLength;	//!< Number of valid CDB bytes
+	uint8_t CDB[16];	//!< SCSI Command Descriptor Block
+};
+
+#define  USB_CBW_SIGNATURE          0x55534243	//!< dCBWSignature value
+#define  USB_CBW_DIRECTION_IN       (1<<7)	//!< Data from device to host
+#define  USB_CBW_DIRECTION_OUT      (0<<7)	//!< Data from host to device
+#define  USB_CBW_LUN_MASK           0x0F	//!< Valid bits in bCBWLUN
+#define  USB_CBW_LEN_MASK           0x1F	//!< Valid bits in bCBWCBLength
+//@}
+
+
+/**
+ * \name A Command Status Wrapper (CSW).
+ */
+//@{
+struct usb_msc_csw {
+	le32_t dCSWSignature;	//!< Must contain 'USBS'
+	le32_t dCSWTag;	//!< Same as dCBWTag
+	le32_t dCSWDataResidue;	//!< Number of bytes not transfered
+	uint8_t bCSWStatus;	//!< Status code
+};
+
+#define  USB_CSW_SIGNATURE          0x55534253	//!< dCSWSignature value
+#define  USB_CSW_STATUS_PASS        0x00	//!< Command Passed
+#define  USB_CSW_STATUS_FAIL        0x01	//!< Command Failed
+#define  USB_CSW_STATUS_PE          0x02	//!< Phase Error
+//@}
+
+COMPILER_PACK_RESET()
+
+//@}
+
+#endif // _USB_PROTOCOL_MSC_H_

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -1,0 +1,186 @@
+/**
+ * \file
+ *
+ * \brief Main functions for USB composite example
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+
+#include "conf_usb.h"
+#include "udc.h"
+
+static volatile bool main_b_msc_enable = false;
+static volatile bool main_b_cdc_enable = false;
+
+void HAL_init(void) {
+	udd_disable();
+	UDD_SetStack(&USBD_ISR);
+
+	// Start USB stack to authorize VBus monitoring
+	udc_start();
+}
+
+void HAL_idletask(void)
+{
+
+	// Attend SD card access from the USB MSD -- Priotize access to improve speed
+	int delay = 2;
+	while (main_b_msc_enable && --delay > 0 ) {
+		if (udi_msc_process_trans()) {
+			delay = 10000;
+		}
+		
+		/* Reset the watchdog, just to be sure */
+		REG_WDT_CR = WDT_CR_WDRSTT | WDT_CR_KEY(0xA5);
+	}
+}
+
+/*! \brief Example of extra USB string management
+ * This feature is available for single or composite device
+ * which want implement additional USB string than
+ * Manufacture, Product and serial number ID.
+ *
+ * return true, if the string ID requested is know and managed by this functions
+ */
+bool usb_task_extra_string(void)
+{
+	static uint8_t udi_cdc_name[] = "CDC interface";
+	static uint8_t udi_msc_name[] = "MSC interface";
+
+	struct extra_strings_desc_t{
+		usb_str_desc_t header;
+		le16_t string[Max(sizeof(udi_cdc_name)-1, sizeof(udi_msc_name)-1)];
+	};
+	static UDC_DESC_STORAGE struct extra_strings_desc_t extra_strings_desc = {
+		.header.bDescriptorType = USB_DT_STRING
+	};
+
+	uint8_t i;
+	uint8_t *str;
+	uint8_t str_lgt=0;
+
+	// Link payload pointer to the string corresponding at request
+	switch (udd_g_ctrlreq.req.wValue & 0xff) {
+	case UDI_CDC_IAD_STRING_ID:
+		str_lgt = sizeof(udi_cdc_name)-1;
+		str = udi_cdc_name;
+		break;
+	case UDI_MSC_STRING_ID:
+		str_lgt = sizeof(udi_msc_name)-1;
+		str = udi_msc_name;
+		break;
+	default:
+		return false;
+	}
+
+	if (str_lgt!=0) {
+		for( i=0; i<str_lgt; i++) {
+			extra_strings_desc.string[i] = cpu_to_le16((le16_t)str[i]);
+		}
+		extra_strings_desc.header.bLength = 2+ (str_lgt)*2;
+		udd_g_ctrlreq.payload_size = extra_strings_desc.header.bLength;
+		udd_g_ctrlreq.payload = (uint8_t *) &extra_strings_desc;
+	}
+
+	// if the string is larger than request length, then cut it
+	if (udd_g_ctrlreq.payload_size > udd_g_ctrlreq.req.wLength) {
+		udd_g_ctrlreq.payload_size = udd_g_ctrlreq.req.wLength;
+	}
+	return true;
+}
+
+bool usb_task_msc_enable(void)
+{
+	main_b_msc_enable = true;
+	return true;
+}
+
+void usb_task_msc_disable(void)
+{
+	main_b_msc_enable = false;
+}
+
+bool usb_task_msc_isenabled(void)
+{
+	return main_b_msc_enable;
+}
+
+bool usb_task_cdc_enable(uint8_t port)
+{
+	main_b_cdc_enable = true;
+	return true;
+}
+
+void usb_task_cdc_disable(uint8_t port)
+{
+	main_b_cdc_enable = false;
+}
+
+bool usb_task_cdc_isenabled(void)
+{
+	return main_b_cdc_enable;
+}
+
+/*! \brief Called by CDC interface
+ * Callback running when CDC device have received data
+ */
+void usb_task_cdc_rx_notify(uint8_t port)
+{
+}
+
+/*! \brief Configures communication line
+ *
+ * \param cfg      line configuration
+ */
+void usb_task_cdc_config(uint8_t port, usb_cdc_line_coding_t * cfg)
+{
+}
+
+void usb_task_cdc_set_dtr(uint8_t port, bool b_enable)
+{
+	if (b_enable) {
+	} else {
+	}
+}
+
+#endif

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.h
@@ -1,0 +1,101 @@
+/**
+ * \file
+ *
+ * \brief Declaration of main function used by Composite example 4
+ *
+ * Copyright (c) 2011-2015 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+/*
+ * Support and FAQ: visit <a href="http://www.atmel.com/design-support/">Atmel Support</a>
+ */
+
+#ifndef _USB_TASK_H_
+#define _USB_TASK_H_
+
+#include "usb_protocol_cdc.h"
+
+/*! \brief Called by MSC interface
+ * Callback running when USB Host enable MSC interface
+ *
+ * \retval true if MSC startup is ok
+ */
+bool usb_task_msc_enable(void);
+
+/*! \brief Called by MSC interface
+ * Callback running when USB Host disable MSC interface
+ */
+void usb_task_msc_disable(void);
+
+/*! \brief Opens the communication port
+ * This is called by CDC interface when USB Host enable it.
+ *
+ * \retval true if cdc startup is successfully done
+ */
+bool usb_task_cdc_enable(uint8_t port);
+
+/*! \brief Closes the communication port
+ * This is called by CDC interface when USB Host disable it.
+ */
+void usb_task_cdc_disable(uint8_t port);
+
+/*! \brief Save new DTR state to change led behavior.
+ * The DTR notify that the terminal have open or close the communication port.
+ */
+void usb_task_cdc_set_dtr(uint8_t port, bool b_enable);
+
+/*! \brief Called by UDC when USB Host request a extra string different
+ * of this specified in USB device descriptor
+ */
+bool usb_task_extra_string(void);
+
+/*! \brief Called by CDC interface
+ * Callback running when CDC device have received data
+ */
+void usb_task_cdc_rx_notify(uint8_t port);
+
+/*! \brief Configures communication line
+ *
+ * \param cfg      line configuration
+ */
+void usb_task_cdc_config(uint8_t port, usb_cdc_line_coding_t * cfg); 
+
+/* The USB device interrupt
+ */
+void USBD_ISR(void);
+
+#endif // _MAIN_H_

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -548,6 +548,10 @@ void idle(
       lastUpdateMillis = millis();
     }
   #endif
+
+  #ifdef HAL_IDLETASK
+    HAL_idletask();
+  #endif
 }
 
 /**

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -637,6 +637,10 @@ void stop() {
  */
 void setup() {
 
+  #ifdef HAL_INIT
+    HAL_init();
+  #endif
+
   #if ENABLED(MAX7219_DEBUG)
     Max7219_init();
   #endif

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -44,13 +44,13 @@
 //===========================================================================
 
 // Voltage reference on potentiometer on Green Pololus in millivolts
-#define Vref_mV   800
+#define Vref_mV   800UL
 
 // Rsc value used on PCB of the Green Pololus
-#define Rsc_mOhms 100
+#define Rsc_mOhms 100UL
 
 // Estimated maximum acceleration for X and Y axis
-#define MAX_XYAXIS_ACCEL (3 * (Vref_mV) * 100 / (Rsc_mOhms))
+#define MAX_XYAXIS_ACCEL (3UL * (Vref_mV) * 100UL / (Rsc_mOhms))
 
 // Notes:
 //  If we could use 1.65A as motor current, then 3000 mm/s^2 as acceleration

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128_64_sw_spi.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128_64_sw_spi.cpp
@@ -158,9 +158,9 @@ FORCE_INLINE static void DELAY_CYCLES(uint32_t x) {
     do {
       WRITE(ST7920_CLK_PIN, LOW);
       WRITE(ST7920_DAT_PIN, val & 0x80);
-      DELAY_NS(500);
+      DELAY_NS(700); /* RE-ARM requires 700ns to be stable, RAMPS4DUE works with 500ns */
       WRITE(ST7920_CLK_PIN, HIGH);
-      DELAY_NS(500);
+      DELAY_NS(700); /* RE-ARM requires 700ns to be stable, RAMPS4DUE works with 500ns */
       val <<= 1;
     } while (--n);
   }
@@ -171,9 +171,9 @@ FORCE_INLINE static void DELAY_CYCLES(uint32_t x) {
   #define ST7920_SND_BIT(nr)              \
     WRITE(ST7920_CLK_PIN, LOW);           \
     WRITE(ST7920_DAT_PIN, TEST(val, nr)); \
-    DELAY_NS(500);                        \
+    DELAY_NS(700);                        \
     WRITE(ST7920_CLK_PIN, HIGH);          \
-    DELAY_NS(500);
+    DELAY_NS(700);
 
   static void ST7920_SWSPI_SND_8BIT(const uint8_t val) {
     ST7920_SND_BIT(7); // MSBit

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -23,6 +23,7 @@
 /**
  * Arduino Sd2Card Library
  * Copyright (C) 2009 by William Greiman
+ * Updated with backports of the latest SdFat library from the same author
  *
  * This file is part of the Arduino Sd2Card Library
  */
@@ -31,29 +32,92 @@
 
 #if ENABLED(SDSUPPORT)
 
+/* Enable FAST CRC computations - You can trade speed for FLASH space if
+ * needed by disabling the following define */
+#define FAST_CRC 1
+
 #include "Sd2Card.h"
 
 #include "../Marlin.h"
 
+#if ENABLED(SD_CHECK_AND_RETRY)
+  #ifdef FAST_CRC
+    static const uint8_t crctab7[] PROGMEM = {
+      0x00,0x09,0x12,0x1b,0x24,0x2d,0x36,0x3f,0x48,0x41,0x5a,0x53,0x6c,0x65,0x7e,0x77,
+      0x19,0x10,0x0b,0x02,0x3d,0x34,0x2f,0x26,0x51,0x58,0x43,0x4a,0x75,0x7c,0x67,0x6e,
+      0x32,0x3b,0x20,0x29,0x16,0x1f,0x04,0x0d,0x7a,0x73,0x68,0x61,0x5e,0x57,0x4c,0x45,
+      0x2b,0x22,0x39,0x30,0x0f,0x06,0x1d,0x14,0x63,0x6a,0x71,0x78,0x47,0x4e,0x55,0x5c,
+      0x64,0x6d,0x76,0x7f,0x40,0x49,0x52,0x5b,0x2c,0x25,0x3e,0x37,0x08,0x01,0x1a,0x13,
+      0x7d,0x74,0x6f,0x66,0x59,0x50,0x4b,0x42,0x35,0x3c,0x27,0x2e,0x11,0x18,0x03,0x0a,
+      0x56,0x5f,0x44,0x4d,0x72,0x7b,0x60,0x69,0x1e,0x17,0x0c,0x05,0x3a,0x33,0x28,0x21,
+      0x4f,0x46,0x5d,0x54,0x6b,0x62,0x79,0x70,0x07,0x0e,0x15,0x1c,0x23,0x2a,0x31,0x38,
+      0x41,0x48,0x53,0x5a,0x65,0x6c,0x77,0x7e,0x09,0x00,0x1b,0x12,0x2d,0x24,0x3f,0x36,
+      0x58,0x51,0x4a,0x43,0x7c,0x75,0x6e,0x67,0x10,0x19,0x02,0x0b,0x34,0x3d,0x26,0x2f,
+      0x73,0x7a,0x61,0x68,0x57,0x5e,0x45,0x4c,0x3b,0x32,0x29,0x20,0x1f,0x16,0x0d,0x04,
+      0x6a,0x63,0x78,0x71,0x4e,0x47,0x5c,0x55,0x22,0x2b,0x30,0x39,0x06,0x0f,0x14,0x1d,
+      0x25,0x2c,0x37,0x3e,0x01,0x08,0x13,0x1a,0x6d,0x64,0x7f,0x76,0x49,0x40,0x5b,0x52,
+      0x3c,0x35,0x2e,0x27,0x18,0x11,0x0a,0x03,0x74,0x7d,0x66,0x6f,0x50,0x59,0x42,0x4b,
+      0x17,0x1e,0x05,0x0c,0x33,0x3a,0x21,0x28,0x5f,0x56,0x4d,0x44,0x7b,0x72,0x69,0x60,
+      0x0e,0x07,0x1c,0x15,0x2a,0x23,0x38,0x31,0x46,0x4f,0x54,0x5d,0x62,0x6b,0x70,0x79
+    };
+
+    static uint8_t CRC7(const uint8_t* data, uint8_t n) {
+      uint8_t crc = 0;
+      while ( n > 0 ) {
+        crc = pgm_read_byte(&crctab7[ (crc << 1) ^ *data++ ]);
+        n--;
+      }
+      return (crc << 1) | 1;
+    }
+  #else
+    static uint8_t CRC7(const uint8_t* data, uint8_t n) {
+      uint8_t crc = 0;
+      for (uint8_t i = 0; i < n; i++) {
+        uint8_t d = data[i];
+        d ^= crc << 1;
+        if (d & 0x80) d ^= 9;
+        crc = d ^ (crc & 0x78) ^ (crc << 4) ^ ((crc >> 3) & 15);
+        crc &= 0x7f;
+      }
+      crc = (crc << 1) ^ (crc << 4) ^ (crc & 0x70) ^ ((crc >> 3) & 0x0f);
+      return crc | 1;
+    }
+  #endif
+#endif
+
 // send command and return error code.  Return zero for OK
 uint8_t Sd2Card::cardCommand(uint8_t cmd, uint32_t arg) {
   // select card
-  chipSelectLow();
+  chipSelect();
 
   // wait up to 300 ms if busy
-  waitNotBusy(300);
+  waitNotBusy( SD_WRITE_TIMEOUT );
 
+  uint8_t *pa = (uint8_t *)(&arg);
+
+#if ENABLED(SD_CHECK_AND_RETRY)
+
+  // form message
+  uint8_t d[6] = {(uint8_t) (cmd | 0x40), pa[3], pa[2], pa[1], pa[0] };
+
+  // add crc
+  d[5] = CRC7(d, 5);
+
+  // send message
+  for (uint8_t k = 0; k < 6; k++ )
+    spiSend( d[k] );
+
+#else
   // send command
   spiSend(cmd | 0x40);
 
   // send argument
-  for (int8_t s = 24; s >= 0; s -= 8) spiSend(arg >> s);
+  for( int8_t i = 3; i >= 0; i-- )
+    spiSend( pa[i] );
 
-  // send CRC
-  uint8_t crc = 0xFF;
-  if (cmd == CMD0) crc = 0x95;  // correct crc for CMD0 with arg 0
-  if (cmd == CMD8) crc = 0x87;  // correct crc for CMD8 with arg 0x1AA
-  spiSend(crc);
+  // send CRC - correct for CMD0 with arg zero or CMD8 with arg 0X1AA
+  spiSend( cmd == CMD0 ? 0X95 : 0X87 );
+#endif
 
   // skip stuff byte for stop read
   if (cmd == CMD12) spiRec();
@@ -91,14 +155,15 @@ uint32_t Sd2Card::cardSize() {
   }
 }
 
-void Sd2Card::chipSelectHigh() {
+void Sd2Card::chipDeselect() {
   digitalWrite(chipSelectPin_, HIGH);
+
+  // insure MISO goes high impedance
+  spiSend( 0xFF );
 }
 
-void Sd2Card::chipSelectLow() {
-  #if DISABLED(SOFTWARE_SPI)
-    spiInit(spiRate_);
-  #endif  // SOFTWARE_SPI
+void Sd2Card::chipSelect() {
+  spiInit(spiRate_);
   digitalWrite(chipSelectPin_, LOW);
 }
 
@@ -142,10 +207,10 @@ bool Sd2Card::erase(uint32_t firstBlock, uint32_t lastBlock) {
     error(SD_CARD_ERROR_ERASE_TIMEOUT);
     goto FAIL;
   }
-  chipSelectHigh();
+  chipDeselect();
   return true;
   FAIL:
-  chipSelectHigh();
+  chipDeselect();
   return false;
 }
 
@@ -200,22 +265,36 @@ bool Sd2Card::init(uint8_t sckRateID, pin_t chipSelectPin) {
       goto FAIL;
     }
   }
-  // check SD version
-  if ((cardCommand(CMD8, 0x1AA) & R1_ILLEGAL_COMMAND)) {
-    type(SD_CARD_TYPE_SD1);
+
+#if ENABLED(SD_CHECK_AND_RETRY)
+  if (cardCommand( CMD59, 1 ) != R1_IDLE_STATE) {
+    error(SD_CARD_ERROR_CMD59);
+    goto FAIL;
   }
-  else {
+#endif
+
+  // check SD version
+  while (1) {
+    if (cardCommand(CMD8, 0x1AA) == (R1_ILLEGAL_COMMAND | R1_IDLE_STATE)) {
+    type(SD_CARD_TYPE_SD1);
+      break;
+  }
+
     // only need last byte of r7 response
     for (uint8_t i = 0; i < 4; i++) status_ = spiRec();
-    if (status_ != 0xAA) {
+    if (status_ == 0xAA) {
+      type(SD_CARD_TYPE_SD2);
+      break;
+    }
+
+    if (((uint16_t)millis() - t0) > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_CMD8);
       goto FAIL;
     }
-    type(SD_CARD_TYPE_SD2);
   }
+
   // initialize card and send host supports SDHC if SD2
   arg = type() == SD_CARD_TYPE_SD2 ? 0x40000000 : 0;
-
   while ((status_ = cardAcmd(ACMD41, arg)) != R1_READY_STATE) {
     // check for timeout
     if (((uint16_t)millis() - t0) > SD_INIT_TIMEOUT) {
@@ -233,17 +312,12 @@ bool Sd2Card::init(uint8_t sckRateID, pin_t chipSelectPin) {
     // discard rest of ocr - contains allowed voltage range
     for (uint8_t i = 0; i < 3; i++) spiRec();
   }
-  chipSelectHigh();
+  chipDeselect();
 
-  #if DISABLED(SOFTWARE_SPI)
-    return setSckRate(sckRateID);
-  #else  // SOFTWARE_SPI
-    UNUSED(sckRateID);
-    return true;
-  #endif  // SOFTWARE_SPI
+  return setSckRate(sckRateID);
 
   FAIL:
-  chipSelectHigh();
+  chipDeselect();
   return false;
 }
 
@@ -268,7 +342,7 @@ bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
 
       if (!--retryCnt) break;
 
-      chipSelectHigh();
+      chipDeselect();
       cardCommand(CMD12, 0); // Try sending a stop command, ignore the result.
       errorCode_ = 0;
     }
@@ -279,7 +353,7 @@ bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
       return readData(dst, 512);
   #endif
 
-  chipSelectHigh();
+  chipDeselect();
   return false;
 }
 
@@ -291,12 +365,13 @@ bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
  * \return true for success, false for failure.
  */
 bool Sd2Card::readData(uint8_t* dst) {
-  chipSelectLow();
+  chipSelect();
   return readData(dst, 512);
 }
 
 #if ENABLED(SD_CHECK_AND_RETRY)
-  static const uint16_t crctab[] PROGMEM = {
+  #ifdef FAST_CRC
+  static const uint16_t crctab16[] PROGMEM = {
     0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50A5, 0x60C6, 0x70E7,
     0x8108, 0x9129, 0xA14A, 0xB16B, 0xC18C, 0xD1AD, 0xE1CE, 0xF1EF,
     0x1231, 0x0210, 0x3273, 0x2252, 0x52B5, 0x4294, 0x72F7, 0x62D6,
@@ -330,13 +405,30 @@ bool Sd2Card::readData(uint8_t* dst) {
     0xEF1F, 0xFF3E, 0xCF5D, 0xDF7C, 0xAF9B, 0xBFBA, 0x8FD9, 0x9FF8,
     0x6E17, 0x7E36, 0x4E55, 0x5E74, 0x2E93, 0x3EB2, 0x0ED1, 0x1EF0
   };
+    // faster CRC-CCITT
+    // uses the x^16,x^12,x^5,x^1 polynomial.
   static uint16_t CRC_CCITT(const uint8_t* data, size_t n) {
     uint16_t crc = 0;
     for (size_t i = 0; i < n; i++) {
-      crc = pgm_read_word(&crctab[(crc >> 8 ^ data[i]) & 0xFF]) ^ (crc << 8);
+      crc = pgm_read_word(&crctab16[(crc >> 8 ^ data[i]) & 0xFF]) ^ (crc << 8);
     }
     return crc;
   }
+  #else
+    // slower CRC-CCITT
+    // uses the x^16,x^12,x^5,x^1 polynomial.
+    static uint16_t CRC_CCITT(const uint8_t* data, size_t n) {
+      uint16_t crc = 0;
+      for (size_t i = 0; i < n; i++) {
+        crc = (uint8_t)(crc >> 8) | (crc << 8);
+        crc ^= data[i];
+        crc ^= (uint8_t)(crc & 0xff) >> 4;
+        crc ^= crc << 12;
+        crc ^= (crc & 0xff) << 5;
+      }
+      return crc;
+    }
+  #endif
 #endif // SD_CHECK_AND_RETRY
 
 bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
@@ -357,11 +449,9 @@ bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
 
 #if ENABLED(SD_CHECK_AND_RETRY)
   {
-    uint16_t calcCrc = CRC_CCITT(dst, count);
-    uint16_t recvCrc = spiRec() << 8;
-    recvCrc |= spiRec();
-    if (calcCrc != recvCrc) {
-      error(SD_CARD_ERROR_CRC);
+    uint16_t recvCrc = (spiRec() << 8) | spiRec();
+    if (recvCrc != CRC_CCITT(dst, count)) {
+      error(SD_CARD_ERROR_READ_CRC);
       goto FAIL;
     }
   }
@@ -370,14 +460,10 @@ bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
   spiRec();
   spiRec();
 #endif
-  chipSelectHigh();
-  // Send an additional dummy byte, required by Toshiba Flash Air SD Card
-  spiSend(0xFF);
+  chipDeselect();
   return true;
   FAIL:
-  chipSelectHigh();
-  // Send an additional dummy byte, required by Toshiba Flash Air SD Card
-  spiSend(0xFF);
+  chipDeselect();
   return false;
 }
 
@@ -386,7 +472,7 @@ bool Sd2Card::readRegister(uint8_t cmd, void* buf) {
   uint8_t* dst = reinterpret_cast<uint8_t*>(buf);
   if (cardCommand(cmd, 0)) {
     error(SD_CARD_ERROR_READ_REG);
-    chipSelectHigh();
+    chipDeselect();
     return false;
   }
   return readData(dst, 16);
@@ -406,10 +492,10 @@ bool Sd2Card::readStart(uint32_t blockNumber) {
   if (type() != SD_CARD_TYPE_SDHC) blockNumber <<= 9;
   if (cardCommand(CMD18, blockNumber)) {
     error(SD_CARD_ERROR_CMD18);
-    chipSelectHigh();
+    chipDeselect();
     return false;
   }
-  chipSelectHigh();
+  chipDeselect();
   return true;
 }
 
@@ -419,13 +505,13 @@ bool Sd2Card::readStart(uint32_t blockNumber) {
  * \return true for success, false for failure.
  */
 bool Sd2Card::readStop() {
-  chipSelectLow();
+  chipSelect();
   if (cardCommand(CMD12, 0)) {
     error(SD_CARD_ERROR_CMD12);
-    chipSelectHigh();
+    chipDeselect();
     return false;
   }
-  chipSelectHigh();
+  chipDeselect();
   return true;
 }
 
@@ -485,10 +571,10 @@ bool Sd2Card::writeBlock(uint32_t blockNumber, const uint8_t* src) {
     error(SD_CARD_ERROR_WRITE_PROGRAMMING);
     goto FAIL;
   }
-  chipSelectHigh();
+  chipDeselect();
   return true;
   FAIL:
-  chipSelectHigh();
+  chipDeselect();
   return false;
 }
 
@@ -498,28 +584,33 @@ bool Sd2Card::writeBlock(uint32_t blockNumber, const uint8_t* src) {
  * \return true for success, false for failure.
  */
 bool Sd2Card::writeData(const uint8_t* src) {
-  chipSelectLow();
+  chipSelect();
   // wait for previous write to finish
   if (!waitNotBusy(SD_WRITE_TIMEOUT) || !writeData(WRITE_MULTIPLE_TOKEN, src)) {
     error(SD_CARD_ERROR_WRITE_MULTIPLE);
-    chipSelectHigh();
+    chipDeselect();
     return false;
   }
-  chipSelectHigh();
+  chipDeselect();
   return true;
 }
 
 // send one block of data for write block or write multiple blocks
 bool Sd2Card::writeData(uint8_t token, const uint8_t* src) {
-  spiSendBlock(token, src);
 
-  spiSend(0xFF);  // dummy crc
-  spiSend(0xFF);  // dummy crc
+#if ENABLED(SD_CHECK_AND_RETRY)
+  uint16_t crc = CRC_CCITT( src, 512 );
+#else  // ENABLED(SD_CHECK_AND_RETRY)
+  uint16_t crc = 0xFFFF;
+#endif  // ENABLED(SD_CHECK_AND_RETRY)
+  spiSendBlock( token, src );
+  spiSend( crc >> 8 );
+  spiSend( crc & 0XFF );
 
   status_ = spiRec();
   if ((status_ & DATA_RES_MASK) != DATA_RES_ACCEPTED) {
     error(SD_CARD_ERROR_WRITE);
-    chipSelectHigh();
+    chipDeselect();
     return false;
   }
   return true;
@@ -548,10 +639,10 @@ bool Sd2Card::writeStart(uint32_t blockNumber, uint32_t eraseCount) {
     error(SD_CARD_ERROR_CMD25);
     goto FAIL;
   }
-  chipSelectHigh();
+  chipDeselect();
   return true;
   FAIL:
-  chipSelectHigh();
+  chipDeselect();
   return false;
 }
 
@@ -561,15 +652,15 @@ bool Sd2Card::writeStart(uint32_t blockNumber, uint32_t eraseCount) {
  * \return true for success, false for failure.
  */
 bool Sd2Card::writeStop() {
-  chipSelectLow();
+  chipSelect();
   if (!waitNotBusy(SD_WRITE_TIMEOUT)) goto FAIL;
   spiSend(STOP_TRAN_TOKEN);
   if (!waitNotBusy(SD_WRITE_TIMEOUT)) goto FAIL;
-  chipSelectHigh();
+  chipDeselect();
   return true;
   FAIL:
   error(SD_CARD_ERROR_STOP_TRAN);
-  chipSelectHigh();
+  chipDeselect();
   return false;
 }
 

--- a/Marlin/src/sd/Sd2Card.h
+++ b/Marlin/src/sd/Sd2Card.h
@@ -71,7 +71,8 @@ uint8_t const SD_CARD_ERROR_CMD0 = 0x01,                // timeout error for com
               SD_CARD_ERROR_WRITE_TIMEOUT = 0x17,       // timeout occurred during write programming
               SD_CARD_ERROR_SCK_RATE = 0x18,            // incorrect rate selected
               SD_CARD_ERROR_INIT_NOT_CALLED = 0x19,     // init() not called
-              SD_CARD_ERROR_CRC = 0x20;                 // crc check error
+              SD_CARD_ERROR_CMD59 = 0x1A,               // card returned an error for CMD59 (CRC_ON_OFF)
+              SD_CARD_ERROR_READ_CRC = 0x1B;            // invalid read CRC
 
 // card types
 uint8_t const SD_CARD_TYPE_SD1  = 1,                    // Standard capacity V1 SD card
@@ -196,8 +197,8 @@ class Sd2Card {
 
   bool readData(uint8_t* dst, uint16_t count);
   bool readRegister(uint8_t cmd, void* buf);
-  void chipSelectHigh();
-  void chipSelectLow();
+  void chipDeselect();
+  void chipSelect();
   void type(uint8_t value) { type_ = value; }
   bool waitNotBusy(uint16_t timeoutMillis);
   bool writeData(uint8_t token, const uint8_t* src);

--- a/Marlin/src/sd/SdInfo.h
+++ b/Marlin/src/sd/SdInfo.h
@@ -54,12 +54,13 @@ uint8_t const CMD0 = 0x00,    // GO_IDLE_STATE - init card in spi mode if CS low
               CMD24 = 0x18,   // WRITE_BLOCK - write a single data block to the card
               CMD25 = 0x19,   // WRITE_MULTIPLE_BLOCK - write blocks of data until a STOP_TRANSMISSION
               CMD32 = 0x20,   // ERASE_WR_BLK_START - sets the address of the first block to be erased
-              CMD33 = 0x21,   // ERASE_WR_BLK_END - sets the address of the last block of the continuous range to be erased*/
-              CMD38 = 0x26,   // ERASE - erase all previously selected blocks */
-              CMD55 = 0x37,   // APP_CMD - escape for application specific command */
-              CMD58 = 0x3A,   // READ_OCR - read the OCR register of a card */
-              ACMD23 = 0x17,  // SET_WR_BLK_ERASE_COUNT - Set the number of write blocks to be pre-erased before writing */
-              ACMD41 = 0x29;  // SD_SEND_OP_COMD - Sends host capacity support information and activates the card's initialization process */
+              CMD33 = 0x21,   // ERASE_WR_BLK_END - sets the address of the last block of the continuous range to be erased
+              CMD38 = 0x26,   // ERASE - erase all previously selected blocks
+              CMD55 = 0x37,   // APP_CMD - escape for application specific command
+              CMD58 = 0x3A,   // READ_OCR - read the OCR register of a card
+              CMD59 = 0x3B,   // CRC_ON_OFF - enable or disable CRC checking
+              ACMD23 = 0x17,  // SET_WR_BLK_ERASE_COUNT - Set the number of write blocks to be pre-erased before writing
+              ACMD41 = 0x29;  // SD_SEND_OP_COMD - Sends host capacity support information and activates the card's initialization process
 
 /** status for card in the ready state */
 uint8_t const R1_READY_STATE = 0x00;

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -86,6 +86,7 @@ public:
   FORCE_INLINE uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
   FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
 
+  Sd2Card& getSd2Card() { return card; }
 public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];


### PR DESCRIPTION
Well, this patchset does some very interesting and requested things for Arduino DUE:
-Improves the SW SPI even further, now we actually reach 12mhz on the SPI clock, and that improves SD card transfer speeds to about 600kbytes/second. This is very desirable, so we can access the SD as an external disk drive
-Fixes the timing of the ST7290 so it works on RE-ARM boards and also on RAMPS4DUE (Thanks @Bergerac56 for testing this!! )
-Implements a new USB CDC device with USB native flow control. No more overruns should be possible
-Implemented CRC7 checks on SDcard commands and also several improvements there, including backports of fixes from the latest SdFat library.
-Now the Sd2Card also switches speed on SW SPI implementations properly (this is required for proper implementation of the last feature of this patch)
-Finally, we also implement a USB MSD (external disk), so when you plug the native usb port of the DUE to your PC, you will get the SD card reflected as an external storage device. Transfer speeds are about 600kbytes/per second

@thinkyhead : Some files (*.c and *.h on the usb subfolder i added) came from ATMELs ASF SDK. I isolated the required files from the mess the ASF source code is, modified them to be able to compile them under Arduino environment and runtime, (Arduino runtime is quite old, so the files had to be modified... but i tried to keep modifications as small as possible. That is the reason i didn't reformat them. Hope you'll understand)

