### PR TITLE
[2.0.x] remove SET_OUTPUT glitch - LPC1768 & DUE

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -78,14 +78,17 @@
 #define _TOGGLE(IO)  _WRITE(IO, !READ(IO))
 
 /// set pin as input
-#define _SET_INPUT(IO)  pmc_enable_periph_clk(g_APinDescription[IO].ulPeripheralId); \
-                        PIO_Configure(g_APinDescription[IO].pPort, PIO_INPUT, g_APinDescription[IO].ulPin, 0)
+#define _SET_INPUT(IO)  do{ pmc_enable_periph_clk(g_APinDescription[IO].ulPeripheralId); \
+                            PIO_Configure(g_APinDescription[IO].pPort, PIO_INPUT, g_APinDescription[IO].ulPin, 0); \
+                        }while(0)
 /// set pin as output
-#define _SET_OUTPUT(IO)  PIO_Configure(g_APinDescription[IO].pPort, PIO_OUTPUT_1, \
-                         g_APinDescription[IO].ulPin, g_APinDescription[IO].ulPinConfiguration)
+#define _SET_OUTPUT(IO) do{ pmc_enable_periph_clk(g_APinDescription[IO].ulPeripheralId); \
+                            PIO_Configure(g_APinDescription[IO].pPort, _READ(IO) ? PIO_OUTPUT_1 : PIO_OUTPUT_0, \
+                                          g_APinDescription[IO].ulPin, g_APinDescription[IO].ulPinConfiguration); \
+                        }while(0)
 
 /// set pin as input with pullup mode
-#define _PULLUP(IO, v)  { pinMode(IO, (v!=LOW ? INPUT_PULLUP : INPUT)); }
+#define _PULLUP(IO, v)  { pinMode(IO, v != LOW ? INPUT_PULLUP : INPUT); }
 
 /// check if pin is an input
 #define _GET_INPUT(IO)
@@ -109,9 +112,8 @@
 #define SET_INPUT(IO)  _SET_INPUT(IO)
 /// set pin as input with pullup wrapper
 #define SET_INPUT_PULLUP(IO) do{ _SET_INPUT(IO); _PULLUP(IO, HIGH); }while(0)
-/// set pin as output wrapper
-#define SET_OUTPUT(IO)  do{ _SET_OUTPUT(IO); _WRITE(IO, LOW); }while(0)
-
+/// set pin as output wrapper -  reads the pin and sets the output to that value
+#define SET_OUTPUT(IO)  _SET_OUTPUT(IO)
 /// check if pin is an input wrapper
 #define GET_INPUT(IO)  _GET_INPUT(IO)
 /// check if pin is an output wrapper

--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -119,8 +119,8 @@ bool useable_hardware_PWM(pin_t pin);
 #define SET_INPUT(IO)  _SET_INPUT(IO)
 /// set pin as input with pullup wrapper
 #define SET_INPUT_PULLUP(IO) do{ _SET_INPUT(IO); _PULLUP(IO, HIGH); }while(0)
-/// set pin as output wrapper
-#define SET_OUTPUT(IO)  do{ _SET_OUTPUT(IO); _WRITE(IO, LOW); }while(0)
+/// set pin as output wrapper  -  reads the pin and sets the output to that value
+#define SET_OUTPUT(IO)  do{ _WRITE(IO, _READ(IO)); _SET_OUTPUT(IO); }while(0)
 
 /// check if pin is an input wrapper
 #define GET_INPUT(IO)  _GET_INPUT(IO)


### PR DESCRIPTION
Currently the SET_OUTPUT code drives the output pin high on the DUE and on the LPC1768 it drives it high and then low.  This results in a glitch if using pull up or pull down resistors.

The new code reads the pin and then sets to output to the same value.

The DUE can sometimes have a glitch if pinMode is used.  Since it's a library function there isn't anything that can be done.

The LPC1768 does NOT have a pinMode glitch.