### PR TITLE
[2.0.x] Revert "Followup to #8698"

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1076,6 +1076,9 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
     CRITICAL_SECTION_END
   #endif
 
+  block->nominal_speed = block->millimeters * inverse_secs;           //   (mm/sec) Always > 0
+  block->nominal_rate = CEIL(block->step_event_count * inverse_secs); // (step/sec) Always > 0
+
   #if ENABLED(FILAMENT_WIDTH_SENSOR)
     static float filwidth_e_count = 0, filwidth_delay_dist = 0;
 


### PR DESCRIPTION
This reverts commit 4e891e9fb7af63f1cf8691e0d6810b414d574e45, which was paired with #8698 and should have been reverted along with 97d509d4d281ec8cafd6815aa9f2a4d7ba647548.