### PR TITLE
[2.0.x] //Actions on Pause / Resume (M600, M125, etc.)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -1431,6 +1431,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1433,6 +1433,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -1402,6 +1402,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1427,6 +1427,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1431,6 +1431,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1438,6 +1438,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1419,6 +1419,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1441,6 +1441,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1431,6 +1431,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1432,6 +1432,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1432,6 +1432,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1432,6 +1432,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1432,6 +1432,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1432,6 +1432,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -1437,6 +1437,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1432,6 +1432,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1430,6 +1430,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1431,6 +1431,14 @@
  */
 //#define ACTION_ON_KILL "poweroff"
 
+/**
+ * Specify an action command to send to the host on pause and resume.
+ * Will be sent in the form '//action:ACTION_ON_PAUSE', e.g. '//action:pause'.
+ * The host must be configured to handle the action command.
+ */
+//#define ACTION_ON_PAUSE "pause"
+//#define ACTION_ON_RESUME "resume"
+
 //===========================================================================
 //====================== I2C Position Encoder Settings ======================
 //===========================================================================

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -173,27 +173,25 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
  * Reset calibration results to zero.
  */
 void reset_bed_level() {
+  #if ENABLED(DEBUG_LEVELING_FEATURE)
+    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("reset_bed_level");
+  #endif
   set_bed_leveling_enabled(false);
   #if ENABLED(MESH_BED_LEVELING)
     if (leveling_is_valid()) {
       mbl.reset();
       mbl.has_mesh = false;
     }
-  #else
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("reset_bed_level");
-    #endif
-    #if ABL_PLANAR
-      planner.bed_level_matrix.set_to_identity();
-    #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
-      bilinear_start[X_AXIS] = bilinear_start[Y_AXIS] =
-      bilinear_grid_spacing[X_AXIS] = bilinear_grid_spacing[Y_AXIS] = 0;
-      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
-        for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
-          z_values[x][y] = NAN;
-    #elif ENABLED(AUTO_BED_LEVELING_UBL)
-      ubl.reset();
-    #endif
+  #elif ENABLED(AUTO_BED_LEVELING_UBL)
+    ubl.reset();
+  #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
+    bilinear_start[X_AXIS] = bilinear_start[Y_AXIS] =
+    bilinear_grid_spacing[X_AXIS] = bilinear_grid_spacing[Y_AXIS] = 0;
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
+      for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
+        z_values[x][y] = NAN;
+  #elif ABL_PLANAR
+    planner.bed_level_matrix.set_to_identity();
   #endif
 }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -310,7 +310,8 @@
   void unified_bed_leveling::G29() {
 
     if (!settings.calc_num_meshes()) {
-      SERIAL_PROTOCOLLNPGM("?Enable EEPROM and init with M502, M500.\n");
+      SERIAL_PROTOCOLLNPGM("?Enable EEPROM and init with");
+      SERIAL_PROTOCOLLNPGM("M502, M500, M501 in that order.\n");
       return;
     }
 
@@ -608,7 +609,7 @@
     if (parser.seen('L')) {     // Load Current Mesh Data
       g29_storage_slot = parser.has_value() ? parser.value_int() : storage_slot;
 
-      int16_t a = settings.calc_num_meshes();
+      uint16_t a = settings.calc_num_meshes();
 
       if (!a) {
         SERIAL_PROTOCOLLNPGM("?EEPROM storage not available.");
@@ -650,7 +651,7 @@
         return;
       }
 
-      int16_t a = settings.calc_num_meshes();
+      uint16_t a = settings.calc_num_meshes();
 
       if (!a) {
         SERIAL_PROTOCOLLNPGM("?EEPROM storage not available.");

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -114,6 +114,10 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
 ) {
   if (move_away_flag) return false; // already paused
 
+  #ifdef ACTION_ON_PAUSE
+    SERIAL_ECHOLNPGM("//action:" ACTION_ON_PAUSE);
+  #endif
+
   if (!DEBUGGING(DRYRUN) && unload_length != 0) {
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       if (!thermalManager.allow_cold_extrude &&
@@ -340,6 +344,10 @@ void resume_print(const float &load_length/*=0*/, const float &initial_extrude_l
   #if ENABLED(ULTIPANEL)
     // Show pause status screen
     lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+  #endif
+
+  #ifdef ACTION_ON_RESUME
+    SERIAL_ECHOLNPGM("//action:" ACTION_ON_RESUME);
   #endif
 
   #if ENABLED(SDSUPPORT)

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -54,7 +54,7 @@ void GcodeSuite::M420() {
 
       #if ENABLED(EEPROM_SETTINGS)
         const int8_t storage_slot = parser.has_value() ? parser.value_int() : ubl.storage_slot;
-        const int16_t a = settings.calc_num_meshes();
+        const uint16_t a = settings.calc_num_meshes();
 
         if (!a) {
           SERIAL_PROTOCOLLNPGM("?EEPROM storage not available.");

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -390,7 +390,8 @@ void GcodeSuite::G29() {
     stepper.synchronize();
 
     // Disable auto bed leveling during G29
-    planner.leveling_active = false;
+    // Be formal so G29 can be done successively without G28.
+    set_bed_leveling_enabled(false);
 
     if (!dryrun) {
       // Re-orient the current position without leveling
@@ -404,7 +405,7 @@ void GcodeSuite::G29() {
     #if HAS_BED_PROBE
       // Deploy the probe. Probe will raise if needed.
       if (DEPLOY_PROBE()) {
-        planner.leveling_active = abl_should_enable;
+        set_bed_leveling_enabled(abl_should_enable);
         return;
       }
     #endif
@@ -421,10 +422,6 @@ void GcodeSuite::G29() {
         || left_probe_bed_position != bilinear_start[X_AXIS]
         || front_probe_bed_position != bilinear_start[Y_AXIS]
       ) {
-        if (dryrun) {
-          // Before reset bed level, re-enable to correct the position
-          planner.leveling_active = abl_should_enable;
-        }
         // Reset grid to 0.0 or "not probed". (Also disables ABL)
         reset_bed_level();
 
@@ -468,7 +465,7 @@ void GcodeSuite::G29() {
       #if HAS_SOFTWARE_ENDSTOPS
         soft_endstops_enabled = enable_soft_endstops;
       #endif
-      planner.leveling_active = abl_should_enable;
+      set_bed_leveling_enabled(abl_should_enable);
       g29_in_progress = false;
       #if ENABLED(LCD_BED_LEVELING)
         lcd_wait_for_move = false;
@@ -673,7 +670,7 @@ void GcodeSuite::G29() {
           measured_z = faux ? 0.001 * random(-100, 101) : probe_pt(xProbe, yProbe, stow_probe_after_each, verbose_level);
 
           if (isnan(measured_z)) {
-            planner.leveling_active = abl_should_enable;
+            set_bed_leveling_enabled(abl_should_enable);
             break;
           }
 
@@ -709,7 +706,7 @@ void GcodeSuite::G29() {
         yProbe = points[i].y;
         measured_z = faux ? 0.001 * random(-100, 101) : probe_pt(xProbe, yProbe, stow_probe_after_each, verbose_level);
         if (isnan(measured_z)) {
-          planner.leveling_active = abl_should_enable;
+          set_bed_leveling_enabled(abl_should_enable);
           break;
         }
         points[i].z = measured_z;
@@ -732,7 +729,7 @@ void GcodeSuite::G29() {
 
     // Raise to _Z_CLEARANCE_DEPLOY_PROBE. Stow the probe.
     if (STOW_PROBE()) {
-      planner.leveling_active = abl_should_enable;
+      set_bed_leveling_enabled(abl_should_enable);
       measured_z = NAN;
     }
   }

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -49,8 +49,6 @@
  *    Z = override Z raise
  */
 void GcodeSuite::M125() {
-  point_t park_point = NOZZLE_PARK_POINT;
-
   // Initial retract before move to filament change position
   const float retract = parser.seen('L') ? parser.value_axis_units(E_AXIS) : 0
     #ifdef PAUSE_PARK_RETRACT_LENGTH
@@ -58,16 +56,14 @@ void GcodeSuite::M125() {
     #endif
   ;
 
-  // Lift Z axis
-  if (parser.seenval('Z'))
-    park_point.z = parser.linearval('Z');
+  point_t park_point = NOZZLE_PARK_POINT;
 
   // Move XY axes to filament change position or given position
-  if (parser.seenval('X'))
-    park_point.x = parser.linearval('X');
+  if (parser.seenval('X')) park_point.x = parser.linearval('X');
+  if (parser.seenval('Y')) park_point.y = parser.linearval('Y');
 
-  if (parser.seenval('Y'))
-    park_point.y = parser.linearval('Y');
+  // Lift Z axis
+  if (parser.seenval('Z')) park_point.z = parser.linearval('Z');
 
   #if HOTENDS > 1 && DISABLED(DUAL_X_CARRIAGE)
     park_point.x += (active_extruder ? hotend_offset[X_AXIS][active_extruder] : 0);

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2285,7 +2285,7 @@ void kill_screen(const char* lcd_msg) {
      *    Save Bed Mesh
      */
     void _lcd_ubl_storage_mesh() {
-      int16_t a = settings.calc_num_meshes();
+      uint16_t a = settings.calc_num_meshes();
       START_MENU();
       MENU_BACK(MSG_UBL_LEVEL_BED);
       if (!WITHIN(ubl_storage_slot, 0, a - 1)) {

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -37,11 +37,11 @@ class MarlinSettings {
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
-        FORCE_INLINE static int get_start_of_meshes() { return meshes_begin; }
-        FORCE_INLINE static int get_end_of_meshes() { return meshes_end; }
-        static int calc_num_meshes();
-        static void store_mesh(int8_t slot);
-        static void load_mesh(int8_t slot, void *into = 0);
+        FORCE_INLINE static int16_t get_start_of_meshes() { return meshes_begin; }
+        FORCE_INLINE static int16_t get_end_of_meshes() { return meshes_end; }
+        static uint16_t calc_num_meshes();
+        static void store_mesh(const int8_t slot);
+        static void load_mesh(const int8_t slot, void * const into=NULL);
 
         //static void delete_mesh();    // necessary if we have a MAT
         //static void defrag_meshes();  // "
@@ -66,9 +66,9 @@ class MarlinSettings {
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
-        static int meshes_begin;
-        const static int meshes_end = E2END - 128; // 128 is a placeholder for the size of the MAT; the MAT will always
-                                                   // live at the very end of the eeprom
+        static int16_t meshes_begin;
+        const static int16_t meshes_end = E2END - 128; // 128 is a placeholder for the size of the MAT; the MAT will always
+                                                       // live at the very end of the eeprom
 
       #endif
 

--- a/Marlin/src/pins/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/pins_GT2560_REV_A.h
@@ -30,8 +30,11 @@
   #error "Oops!  Make sure you have 'Arduino Mega' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define BOARD_NAME           "GT2560 Rev.A"
+#ifndef BOARD_NAME
+  #define BOARD_NAME "GT2560 Rev.A"
+#endif
 #define DEFAULT_MACHINE_NAME "Prusa i3 Pro B"
+
 //
 // Limit Switches
 //

--- a/Marlin/src/pins/pins_GT2560_REV_A_PLUS.h
+++ b/Marlin/src/pins/pins_GT2560_REV_A_PLUS.h
@@ -24,13 +24,12 @@
  * Geeetech GT2560 Revision A+ board pin assignments
  */
 
+#define BOARD_NAME "GT2560 Rev.A+"
+
 #include "pins_GT2560_REV_A.h"
 
-#undef BOARD_NAME
-#define BOARD_NAME  "GT2560 Rev.A+"
-
 #if ENABLED(BLTOUCH)
-  #define SERVO0_PIN  32
-#else
   #define SERVO0_PIN  11
+#else
+  #define SERVO0_PIN  32
 #endif


### PR DESCRIPTION
Added two new configuration options for Pause and Resume action commands to be sent to streamers such as octoprint during M600 filament change command.

Based on #8849