### PR TITLE
MK2_MUXER should be possible without ADVANCED_PAUSE_FEATURE

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -454,8 +454,6 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
  */
 #ifdef SNMM
   #error "SNMM is now MK2_MULTIPLEXER. Please update your configuration."
-#elif ENABLED(MK2_MULTIPLEXER) && DISABLED(ADVANCED_PAUSE_FEATURE)
-  #error "ADVANCED_PAUSE_FEATURE is required with MK2_MULTIPLEXER."
 #endif
 
 /**


### PR DESCRIPTION
Material changes usually will be handled automatically by the slicer (purge towers and all that stuff), so MK2_MULTIPLEXER should be possible without ADVANCED_PAUSE_FEATURE and therefore also without an LCD.