### PR TITLE
[2.0.x] Display up to 3 extruders on char LCD

### DIFF
--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -78,12 +78,12 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
 
     #if BUTTON_EXISTS(ENC)
       // the pause/stop/restart button is connected to BTN_ENC when used
-      #define B_ST (EN_C)                              // Map the pause/stop/resume button into its normalized functional name
+      #define B_ST (EN_C)                            // Map the pause/stop/resume button into its normalized functional name
       #undef LCD_CLICKED
-      #define LCD_CLICKED (buttons & (B_MI|B_RI|B_ST)) // pause/stop button also acts as click until we implement proper pause/stop.
+      #define LCD_CLICKED (buttons&(B_MI|B_RI|B_ST)) // pause/stop button also acts as click until we implement proper pause/stop.
     #else
       #undef LCD_CLICKED
-      #define LCD_CLICKED (buttons & (B_MI|B_RI))
+      #define LCD_CLICKED (buttons&(B_MI|B_RI))
     #endif
 
     // I2C buttons take too long to read inside an interrupt context and so we read them during lcd_update
@@ -635,7 +635,11 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
 }
 
 FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, const bool blink) {
-  const bool isBed = heater < 0;
+  #if TEMP_SENSOR_BED
+    const bool isBed = heater < 0;
+  #else
+    constexpr bool isBed = false;
+  #endif
 
   const float t1 = (isBed ? thermalManager.degBed()       : thermalManager.degHotend(heater)),
               t2 = (isBed ? thermalManager.degTargetBed() : thermalManager.degTargetHotend(heater));
@@ -735,7 +739,7 @@ static void lcd_implementation_status_screen() {
     //
     // Hotend 1 or Bed Temperature
     //
-    #if HOTENDS > 1 || TEMP_SENSOR_BED != 0
+    #if HOTENDS > 1 || TEMP_SENSOR_BED
 
       lcd.setCursor(8, 0);
       #if HOTENDS > 1
@@ -746,7 +750,7 @@ static void lcd_implementation_status_screen() {
         _draw_heater_status(-1, -1, blink);
       #endif
 
-    #endif // HOTENDS > 1 || TEMP_SENSOR_BED != 0
+    #endif // HOTENDS > 1 || TEMP_SENSOR_BED
 
   #else // LCD_WIDTH >= 20
 
@@ -758,12 +762,17 @@ static void lcd_implementation_status_screen() {
     //
     // Hotend 1 or Bed Temperature
     //
-    #if HOTENDS > 1 || TEMP_SENSOR_BED != 0
+    #if HOTENDS > 1 || TEMP_SENSOR_BED
       lcd.setCursor(10, 0);
       #if HOTENDS > 1
         _draw_heater_status(1, LCD_STR_THERMOMETER[0], blink);
       #else
-        _draw_heater_status(-1, LCD_BEDTEMP_CHAR, blink);
+        _draw_heater_status(-1, (
+          #if HAS_LEVELING
+            planner.leveling_active && blink ? '_' :
+          #endif
+          LCD_BEDTEMP_CHAR
+        ), blink);
       #endif
 
     #endif // HOTENDS > 1 || TEMP_SENSOR_BED != 0
@@ -792,14 +801,25 @@ static void lcd_implementation_status_screen() {
 
       lcd.setCursor(0, 1);
 
-      #if HOTENDS > 1 && TEMP_SENSOR_BED != 0
+      // If the first line has two extruder temps,
+      // show more temperatures on the next line
+      // instead of 
 
-        // If we both have a 2nd extruder and a heated bed,
-        // show the heated bed temp on the left,
-        // since the first line is filled with extruder temps
-      _draw_heater_status(-1, LCD_BEDTEMP_CHAR, blink);
+      #if HOTENDS > 2 || (HOTENDS > 1 && TEMP_SENSOR_BED)
 
-      #else
+        #if HOTENDS > 2
+          _draw_heater_status(2, LCD_STR_THERMOMETER[0], blink);
+          lcd.setCursor(10, 1);
+        #endif
+
+        _draw_heater_status(-1, (
+          #if HAS_LEVELING
+            planner.leveling_active && blink ? '_' :
+          #endif
+          LCD_BEDTEMP_CHAR
+        ), blink);
+
+      #else // HOTENDS <= 2 && (HOTENDS <= 1 || !TEMP_SENSOR_BED)
         // Before homing the axis letters are blinking 'X' <-> '?'.
         // When axis is homed but axis_known_position is false the axis letters are blinking 'X' <-> ' '.
         // When everything is ok you see a constant 'X'.
@@ -812,7 +832,7 @@ static void lcd_implementation_status_screen() {
         _draw_axis_label(Y_AXIS, PSTR(MSG_Y), blink);
         lcd.print(ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])));
 
-      #endif // HOTENDS > 1 || TEMP_SENSOR_BED != 0
+      #endif // HOTENDS <= 2 && (HOTENDS <= 1 || !TEMP_SENSOR_BED)
 
     #endif // LCD_WIDTH >= 20
 
@@ -820,7 +840,7 @@ static void lcd_implementation_status_screen() {
     _draw_axis_label(Z_AXIS, PSTR(MSG_Z), blink);
     lcd.print(ftostr52sp(FIXFLOAT(current_position[Z_AXIS])));
 
-    #if HAS_LEVELING
+    #if HAS_LEVELING && !TEMP_SENSOR_BED
       lcd.write(planner.leveling_active || blink ? '_' : ' ');
     #endif
 


### PR DESCRIPTION
Currently only 2 extruders will be shown on the character display, despite plenty of space. With his PR the character LCD will display up to 3 extruders. This also moves the bed level indicator to the position of the [H] icon when a heated bed exists.