### PR TITLE
resolve issue " invalid conversion from ‘const char*’ to ‘char*’" without needing -fpermissive

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1261,14 +1261,14 @@ void kill_screen(const char* lcd_msg) {
       #else
         char *command_M600;
         switch (extruder) {
-          case 0: command_M600 = PSTR("M600 B0 T0"); break;
-          case 1: command_M600 = PSTR("M600 B0 T1"); break;
+          case 0: command_M600 = (char *) PSTR("M600 B0 T0"); break;
+          case 1: command_M600 = (char *) PSTR("M600 B0 T1"); break;
           #if EXTRUDERS > 2
-            case 2: command_M600 = PSTR("M600 B0 T2"); break;
+            case 2: command_M600 = (char *) PSTR("M600 B0 T2"); break;
             #if EXTRUDERS > 3
-              case 3: command_M600 = PSTR("M600 B0 T3"); break;
+              case 3: command_M600 = (char *)  PSTR("M600 B0 T3"); break;
               #if EXTRUDERS > 4
-                case 4: command_M600 = PSTR("M600 B0 T4"); break;
+                case 4: command_M600 = (char *) PSTR("M600 B0 T4"); break;
               #endif
             #endif
           #endif


### PR DESCRIPTION
Resolves compile issue:
```
ultralcd.cpp: In function ‘void lcd_enqueue_filament_change(uint8_t)’:
ultralcd.cpp:1264:34: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
           case 0: command_M600 = PSTR("M600 B0 T0"); break;
                                  ^
ultralcd.cpp:1265:34: error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
           case 1: command_M600 = PSTR("M600 B0 T1"); break;
                                  ^
PSTR is defined as:
#define PSTR(s) \
	((const PROGMEM char *)(s))

trying a cast  to (char *)
```