### PR TITLE
[1.1.x] Update of comments in thermistor table files. No functional changes.

### DIFF
--- a/Marlin/thermistornames.h
+++ b/Marlin/thermistornames.h
@@ -44,11 +44,11 @@
 #elif THERMISTOR_ID == 6
   #define THERMISTOR_NAME "EPCOS (alt)"
 #elif THERMISTOR_ID == 7
-  #define THERMISTOR_NAME "HW 104LAG"
+  #define THERMISTOR_NAME "Honeywell 104LAG"
 #elif THERMISTOR_ID == 71
-  #define THERMISTOR_NAME "HW 104LAF"
+  #define THERMISTOR_NAME "Honeywell 104LAF"
 #elif THERMISTOR_ID == 8
-  #define THERMISTOR_NAME "E3104FXT"
+  #define THERMISTOR_NAME "E3104FHT"
 #elif THERMISTOR_ID == 9
   #define THERMISTOR_NAME "GE AL03006"
 #elif THERMISTOR_ID == 10
@@ -56,9 +56,9 @@
 #elif THERMISTOR_ID == 11
   #define THERMISTOR_NAME "1% beta 3950"
 #elif THERMISTOR_ID == 12
-  #define THERMISTOR_NAME "E3104FXT (alt)"
+  #define THERMISTOR_NAME "Unknown"
 #elif THERMISTOR_ID == 13
-  #define THERMISTOR_NAME "Hisens 3950"
+  #define THERMISTOR_NAME "Hisens"
 #elif THERMISTOR_ID == 20
   #define THERMISTOR_NAME "PT100 UltiMB"
 #elif THERMISTOR_ID == 60

--- a/Marlin/thermistortable_1.h
+++ b/Marlin/thermistortable_1.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k bed thermistor
+// R25 = 100 kOhm, beta25 = 4092 K, 4.7 kOhm pull-up, bed thermistor
 const short temptable_1[][2] PROGMEM = {
   { OV(  23), 300 },
   { OV(  25), 295 },

--- a/Marlin/thermistortable_10.h
+++ b/Marlin/thermistortable_10.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k RS thermistor 198-961 (4.7k pullup)
+// R25 = 100 kOhm, beta25 = 3960 K, 4.7 kOhm pull-up, RS thermistor 198-961
 const short temptable_10[][2] PROGMEM = {
   { OV(   1), 929 },
   { OV(  36), 299 },

--- a/Marlin/thermistortable_11.h
+++ b/Marlin/thermistortable_11.h
@@ -20,7 +20,7 @@
  *
  */
 
-// QU-BD silicone bed QWG-104F-3950 thermistor
+// R25 = 100 kOhm, beta25 = 3950 K, 4.7 kOhm pull-up, QU-BD silicone bed QWG-104F-3950 thermistor
 const short temptable_11[][2] PROGMEM = {
   { OV(   1), 938 },
   { OV(  31), 314 },

--- a/Marlin/thermistortable_12.h
+++ b/Marlin/thermistortable_12.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup) (calibrated for Makibox hot bed)
+// R25 = 100 kOhm, beta25 = 4700 K, 4.7 kOhm pull-up, (personal calibration for Makibox hot bed)
 const short temptable_12[][2] PROGMEM = {
   { OV(  35), 180 }, // top rating 180C
   { OV( 211), 140 },

--- a/Marlin/thermistortable_13.h
+++ b/Marlin/thermistortable_13.h
@@ -20,7 +20,7 @@
  *
  */
 
-// Hisens thermistor B25/50 =3950 +/-1%
+// R25 = 100 kOhm, beta25 = 4100 K, 4.7 kOhm pull-up, Hisens thermistor
 const short temptable_13[][2] PROGMEM = {
   { OV( 20.04), 300 },
   { OV( 23.19), 290 },

--- a/Marlin/thermistortable_2.h
+++ b/Marlin/thermistortable_2.h
@@ -21,7 +21,7 @@
  */
 
 //
-// 200k ATC Semitec 204GT-2
+// R25 = 200 kOhm, beta25 = 4338 K, 4.7 kOhm pull-up, ATC Semitec 204GT-2
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf
 // Calculated using 4.7kohm pullup, voltage divider math, and manufacturer provided temp/resistance
 //

--- a/Marlin/thermistortable_3.h
+++ b/Marlin/thermistortable_3.h
@@ -20,7 +20,7 @@
  *
  */
 
-// mendel-parts
+// R25 = 100 kOhm, beta25 = 4120 K, 4.7 kOhm pull-up, mendel-parts
 const short temptable_3[][2] PROGMEM = {
   { OV(   1), 864 },
   { OV(  21), 300 },

--- a/Marlin/thermistortable_4.h
+++ b/Marlin/thermistortable_4.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 10k thermistor
+// R25 = 10 kOhm, beta25 = 3950 K, 4.7 kOhm pull-up, Generic 10k thermistor
 const short temptable_4[][2] PROGMEM = {
   { OV(   1), 430 },
   { OV(  54), 137 },

--- a/Marlin/thermistortable_5.h
+++ b/Marlin/thermistortable_5.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 4267 K, 4.7 kOhm pull-up
 // 100k ParCan thermistor (104GT-2)
 // ATC Semitec 104GT-2 (Used in ParCan)
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf

--- a/Marlin/thermistortable_51.h
+++ b/Marlin/thermistortable_51.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 4092 K, 1 kOhm pull-up,
 // 100k EPCOS (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
 // Verified by linagee.
 // Calculated using 1kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Marlin/thermistortable_52.h
+++ b/Marlin/thermistortable_52.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 200 kOhm, beta25 = 4338 K, 1 kOhm pull-up,
 // 200k ATC Semitec 204GT-2 (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf
 // Calculated using 1kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Marlin/thermistortable_55.h
+++ b/Marlin/thermistortable_55.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 4267 K, 1 kOhm pull-up,
 // 100k ATC Semitec 104GT-2 (Used on ParCan) (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf
 // Calculated using 1kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Marlin/thermistortable_6.h
+++ b/Marlin/thermistortable_6.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k Epcos thermistor
+// R25 = 100 kOhm, beta25 = 4092 K, 8.2 kOhm pull-up, 100k Epcos (?) thermistor
 const short temptable_6[][2] PROGMEM = {
   { OV(   1), 350 },
   { OV(  28), 250 }, // top rating 250C

--- a/Marlin/thermistortable_60.h
+++ b/Marlin/thermistortable_60.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 3950 K, 4.7 kOhm pull-up,
 // Maker's Tool Works Kapton Bed Thermistor
 // ./createTemperatureLookup.py --r0=100000 --t0=25 --r1=0 --r2=4700 --beta=3950
 // r0: 100000

--- a/Marlin/thermistortable_66.h
+++ b/Marlin/thermistortable_66.h
@@ -20,7 +20,7 @@
  *
  */
 
-// DyzeDesign 500°C Thermistor
+// R25 = 2.5 MOhm, beta25 = 4500 K, 4.7 kOhm pull-up, DyzeDesign 500 °C Thermistor
 const short temptable_66[][2] PROGMEM = {
   { OV(  17.5), 850 },
   { OV(  17.9), 500 },

--- a/Marlin/thermistortable_7.h
+++ b/Marlin/thermistortable_7.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k Honeywell 135-104LAG-J01
+// R25 = 100 kOhm, beta25 = 3974 K, 4.7 kOhm pull-up, Honeywell 135-104LAG-J01
 const short temptable_7[][2] PROGMEM = {
   { OV(   1), 941 },
   { OV(  19), 362 },

--- a/Marlin/thermistortable_70.h
+++ b/Marlin/thermistortable_70.h
@@ -20,7 +20,7 @@
  *
  */
 
-// bqh2 stock thermistor
+// R25 = 100 kOhm, beta25 = 4100 K, 4.7 kOhm pull-up, bqh2 stock thermistor
 const short temptable_70[][2] PROGMEM = {
   { OV(  22), 300 },
   { OV(  24), 295 },

--- a/Marlin/thermistortable_71.h
+++ b/Marlin/thermistortable_71.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k Honeywell 135-104LAF-J01
+// R25 = 100 kOhm, beta25 = 3974 K, 4.7 kOhm pull-up, Honeywell 135-104LAF-J01
 // R0 = 100000 Ohm
 // T0 = 25 °C
 // Beta = 3974

--- a/Marlin/thermistortable_75.h
+++ b/Marlin/thermistortable_75.h
@@ -20,7 +20,8 @@
  *
  */
 
-// Generic Silicon Heat Pad with NTC 100K thermistor ( Beta 25/50 3950K)
+// R25 = 100 kOhm, beta25 = 4100 K, 4.7 kOhm pull-up,
+// Generic Silicon Heat Pad with NTC 100K thermistor
 //
 // Many of the generic silicon heat pads use the MGB18-104F39050L32 Thermistor   It is used for various
 // wattage and voltage heat pads.  This table is correct if this part is used.   It has been

--- a/Marlin/thermistortable_8.h
+++ b/Marlin/thermistortable_8.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup)
+// R25 = 100 kOhm, beta25 = 3950 K, 10 kOhm pull-up, NTCS0603E3104FHT
 const short temptable_8[][2] PROGMEM = {
   { OV(   1), 704 },
   { OV(  54), 216 },

--- a/Marlin/thermistortable_9.h
+++ b/Marlin/thermistortable_9.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k GE Sensing AL03006-58.2K-97-G1 (4.7k pullup)
+// R25 = 100 kOhm, beta25 = 3960 K, 4.7 kOhm pull-up, GE Sensing AL03006-58.2K-97-G1
 const short temptable_9[][2] PROGMEM = {
   { OV(   1), 936 },
   { OV(  36), 300 },


### PR DESCRIPTION
There are a lot of mistakes in the comments for various thermistor tables. I checked all the bed thermistor tables (not Pt100 tables) and updated the comments.
One issue is reported here:
#8862

Table 8 is for 10k pull-up and beta_25 == 3950. Device name is NTCS0402E3104FHT, not NTCS0603E3104FXT.
Table 12 is for 4.7k pull-up and beta_25 == 4700K, not for beta_25 == 4100K
Table 13 is for 4.7k pull-up and beta_25 == 4700K, not for beta_25 == 3950K
Table 6 is supposed to be an alternative EPCOS linearization. Assuming that the "EPCOS" device has R25 == 100 kOhm and beta25 = 4092K, then the only pull-up that gives reasonable (but not very good) results is 8.2 kOhm. A 4.7kOhm pull-up cannot give reasonable results for any beta25 value.

It seems that some of these tables are results of peoples measurements, which doesn't make sense. The tables that are included in Marlin should correspond to nominal values of thermistor parameters and nominal values of pull-up resistors. Nominal values, as given in datasheets for a particular NTC resistor are supposed to be the best general fit in average. People can make fine-tuned tables from measurements on their own devices and circuits, but such tables are not relevant in general.