### PR TITLE
[2.0.x] Update of comments in thermistor files. No functional changes.

### DIFF
--- a/Marlin/src/module/thermistor/thermistor_1.h
+++ b/Marlin/src/module/thermistor/thermistor_1.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k bed thermistor
+// R25 = 100 kOhm, beta25 = 4092 K, 4.7 kOhm pull-up, bed thermistor
 const short temptable_1[][2] PROGMEM = {
   { OV(  23), 300 },
   { OV(  25), 295 },

--- a/Marlin/src/module/thermistor/thermistor_10.h
+++ b/Marlin/src/module/thermistor/thermistor_10.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k RS thermistor 198-961 (4.7k pullup)
+// R25 = 100 kOhm, beta25 = 3960 K, 4.7 kOhm pull-up, RS thermistor 198-961
 const short temptable_10[][2] PROGMEM = {
   { OV(   1), 929 },
   { OV(  36), 299 },

--- a/Marlin/src/module/thermistor/thermistor_11.h
+++ b/Marlin/src/module/thermistor/thermistor_11.h
@@ -20,7 +20,7 @@
  *
  */
 
-// QU-BD silicone bed QWG-104F-3950 thermistor
+// R25 = 100 kOhm, beta25 = 3950 K, 4.7 kOhm pull-up, QU-BD silicone bed QWG-104F-3950 thermistor
 const short temptable_11[][2] PROGMEM = {
   { OV(   1), 938 },
   { OV(  31), 314 },

--- a/Marlin/src/module/thermistor/thermistor_12.h
+++ b/Marlin/src/module/thermistor/thermistor_12.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup) (calibrated for Makibox hot bed)
+// R25 = 100 kOhm, beta25 = 4700 K, 4.7 kOhm pull-up, (personal calibration for Makibox hot bed)
 const short temptable_12[][2] PROGMEM = {
   { OV(  35), 180 }, // top rating 180C
   { OV( 211), 140 },

--- a/Marlin/src/module/thermistor/thermistor_13.h
+++ b/Marlin/src/module/thermistor/thermistor_13.h
@@ -20,7 +20,7 @@
  *
  */
 
-// Hisens thermistor B25/50 =3950 +/-1%
+// R25 = 100 kOhm, beta25 = 4100 K, 4.7 kOhm pull-up, Hisens thermistor
 const short temptable_13[][2] PROGMEM = {
   { OV( 20.04), 300 },
   { OV( 23.19), 290 },

--- a/Marlin/src/module/thermistor/thermistor_2.h
+++ b/Marlin/src/module/thermistor/thermistor_2.h
@@ -21,7 +21,7 @@
  */
 
 //
-// 200k ATC Semitec 204GT-2
+// R25 = 200 kOhm, beta25 = 4338 K, 4.7 kOhm pull-up, ATC Semitec 204GT-2
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf
 // Calculated using 4.7kohm pullup, voltage divider math, and manufacturer provided temp/resistance
 //

--- a/Marlin/src/module/thermistor/thermistor_3.h
+++ b/Marlin/src/module/thermistor/thermistor_3.h
@@ -20,7 +20,7 @@
  *
  */
 
-// mendel-parts
+// R25 = 100 kOhm, beta25 = 4120 K, 4.7 kOhm pull-up, mendel-parts
 const short temptable_3[][2] PROGMEM = {
   { OV(   1), 864 },
   { OV(  21), 300 },

--- a/Marlin/src/module/thermistor/thermistor_4.h
+++ b/Marlin/src/module/thermistor/thermistor_4.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 10k thermistor
+// R25 = 10 kOhm, beta25 = 3950 K, 4.7 kOhm pull-up, Generic 10k thermistor
 const short temptable_4[][2] PROGMEM = {
   { OV(   1), 430 },
   { OV(  54), 137 },

--- a/Marlin/src/module/thermistor/thermistor_5.h
+++ b/Marlin/src/module/thermistor/thermistor_5.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 4267 K, 4.7 kOhm pull-up
 // 100k ParCan thermistor (104GT-2)
 // ATC Semitec 104GT-2/104NT-4-R025H42G (Used in ParCan)
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf

--- a/Marlin/src/module/thermistor/thermistor_51.h
+++ b/Marlin/src/module/thermistor/thermistor_51.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 4092 K, 1 kOhm pull-up,
 // 100k EPCOS (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
 // Verified by linagee.
 // Calculated using 1kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Marlin/src/module/thermistor/thermistor_52.h
+++ b/Marlin/src/module/thermistor/thermistor_52.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 200 kOhm, beta25 = 4338 K, 1 kOhm pull-up,
 // 200k ATC Semitec 204GT-2 (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf
 // Calculated using 1kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Marlin/src/module/thermistor/thermistor_55.h
+++ b/Marlin/src/module/thermistor/thermistor_55.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 4267 K, 1 kOhm pull-up,
 // 100k ATC Semitec 104GT-2 (Used on ParCan) (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
 // Verified by linagee. Source: http://shop.arcol.hu/static/datasheets/thermistors.pdf
 // Calculated using 1kohm pullup, voltage divider math, and manufacturer provided temp/resistance

--- a/Marlin/src/module/thermistor/thermistor_6.h
+++ b/Marlin/src/module/thermistor/thermistor_6.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k Epcos thermistor
+// R25 = 100 kOhm, beta25 = 4092 K, 8.2 kOhm pull-up, 100k Epcos (?) thermistor
 const short temptable_6[][2] PROGMEM = {
   { OV(   1), 350 },
   { OV(  28), 250 }, // top rating 250C

--- a/Marlin/src/module/thermistor/thermistor_60.h
+++ b/Marlin/src/module/thermistor/thermistor_60.h
@@ -20,6 +20,7 @@
  *
  */
 
+// R25 = 100 kOhm, beta25 = 3950 K, 4.7 kOhm pull-up,
 // Maker's Tool Works Kapton Bed Thermistor
 // ./createTemperatureLookup.py --r0=100000 --t0=25 --r1=0 --r2=4700 --beta=3950
 // r0: 100000

--- a/Marlin/src/module/thermistor/thermistor_66.h
+++ b/Marlin/src/module/thermistor/thermistor_66.h
@@ -20,7 +20,7 @@
  *
  */
 
-// DyzeDesign 500°C Thermistor
+// R25 = 2.5 MOhm, beta25 = 4500 K, 4.7 kOhm pull-up, DyzeDesign 500 °C Thermistor
 const short temptable_66[][2] PROGMEM = {
   { OV(  17.5), 850 },
   { OV(  17.9), 500 },

--- a/Marlin/src/module/thermistor/thermistor_7.h
+++ b/Marlin/src/module/thermistor/thermistor_7.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k Honeywell 135-104LAG-J01
+// R25 = 100 kOhm, beta25 = 3974 K, 4.7 kOhm pull-up, Honeywell 135-104LAG-J01
 const short temptable_7[][2] PROGMEM = {
   { OV(   1), 941 },
   { OV(  19), 362 },

--- a/Marlin/src/module/thermistor/thermistor_70.h
+++ b/Marlin/src/module/thermistor/thermistor_70.h
@@ -20,7 +20,7 @@
  *
  */
 
-// bqh2 stock thermistor
+// R25 = 100 kOhm, beta25 = 4100 K, 4.7 kOhm pull-up, bqh2 stock thermistor
 const short temptable_70[][2] PROGMEM = {
   { OV(  22), 300 },
   { OV(  24), 295 },

--- a/Marlin/src/module/thermistor/thermistor_71.h
+++ b/Marlin/src/module/thermistor/thermistor_71.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k Honeywell 135-104LAF-J01
+// R25 = 100 kOhm, beta25 = 3974 K, 4.7 kOhm pull-up, Honeywell 135-104LAF-J01
 // R0 = 100000 Ohm
 // T0 = 25 °C
 // Beta = 3974

--- a/Marlin/src/module/thermistor/thermistor_75.h
+++ b/Marlin/src/module/thermistor/thermistor_75.h
@@ -20,7 +20,8 @@
  *
  */
 
-// Generic Silicon Heat Pad with NTC 100K thermistor ( Beta 25/50 3950K)
+// R25 = 100 kOhm, beta25 = 4100 K, 4.7 kOhm pull-up,
+// Generic Silicon Heat Pad with NTC 100K thermistor
 //
 // Many of the generic silicon heat pads use the MGB18-104F39050L32 Thermistor   It is used for various
 // wattage and voltage heat pads.  This table is correct if this part is used.   It has been

--- a/Marlin/src/module/thermistor/thermistor_8.h
+++ b/Marlin/src/module/thermistor/thermistor_8.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup)
+// R25 = 100 kOhm, beta25 = 3950 K, 10 kOhm pull-up, NTCS0603E3104FHT
 const short temptable_8[][2] PROGMEM = {
   { OV(   1), 704 },
   { OV(  54), 216 },

--- a/Marlin/src/module/thermistor/thermistor_9.h
+++ b/Marlin/src/module/thermistor/thermistor_9.h
@@ -20,7 +20,7 @@
  *
  */
 
-// 100k GE Sensing AL03006-58.2K-97-G1 (4.7k pullup)
+// R25 = 100 kOhm, beta25 = 3960 K, 4.7 kOhm pull-up, GE Sensing AL03006-58.2K-97-G1
 const short temptable_9[][2] PROGMEM = {
   { OV(   1), 936 },
   { OV(  36), 300 },

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -40,43 +40,43 @@
 #define PtAdVal(T,R0,Rup) (short)(1024/(Rup/PtRt(T,R0)+1))
 #define PtLine(T,R0,Rup) { OV(PtAdVal(T,R0,Rup)), T },
 
-#if ANY_THERMISTOR_IS(1) // 100k bed thermistor
+#if ANY_THERMISTOR_IS(1) // beta25 = 4092 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "EPCOS"
   #include "thermistor_1.h"
 #endif
-#if ANY_THERMISTOR_IS(2) // 200k bed thermistor
+#if ANY_THERMISTOR_IS(2) // 4338 K, R25 = 200 kOhm, Pull-up = 4.7 kOhm, "ATC Semitec 204GT-2"
   #include "thermistor_2.h"
 #endif
-#if ANY_THERMISTOR_IS(3) // mendel-parts
+#if ANY_THERMISTOR_IS(3) // beta25 = 4120 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Mendel-parts"
   #include "thermistor_3.h"
 #endif
-#if ANY_THERMISTOR_IS(4) // 10k thermistor
+#if ANY_THERMISTOR_IS(4) // beta25 = 3950 K, R25 = 10 kOhm, Pull-up = 4.7 kOhm, "Generic"
   #include "thermistor_4.h"
 #endif
-#if ANY_THERMISTOR_IS(5) // 100k ParCan thermistor (104GT-2)
+#if ANY_THERMISTOR_IS(5) // beta25 = 4267 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "ParCan, ATC 104GT-2"
   #include "thermistor_5.h"
 #endif
-#if ANY_THERMISTOR_IS(6) // 100k Epcos thermistor
+#if ANY_THERMISTOR_IS(6) // beta25 = 4092 K, R25 = 100 kOhm, Pull-up = 8.2 kOhm, "EPCOS ?"
   #include "thermistor_6.h"
 #endif
-#if ANY_THERMISTOR_IS(7) // 100k Honeywell 135-104LAG-J01
+#if ANY_THERMISTOR_IS(7) // beta25 = 3974 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Honeywell 135-104LAG-J01"
   #include "thermistor_7.h"
 #endif
-#if ANY_THERMISTOR_IS(71) // 100k Honeywell 135-104LAF-J01
+#if ANY_THERMISTOR_IS(71) // beta25 = 3974 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Honeywell 135-104LAF-J01"
   #include "thermistor_71.h"
 #endif
-#if ANY_THERMISTOR_IS(8) // 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup)
+#if ANY_THERMISTOR_IS(8) // beta25 = 3950 K, R25 = 100 kOhm, Pull-up = 10 kOhm, "Vishay E3104FHT"
   #include "thermistor_8.h"
 #endif
-#if ANY_THERMISTOR_IS(9) // 100k GE Sensing AL03006-58.2K-97-G1 (4.7k pullup)
+#if ANY_THERMISTOR_IS(9) // beta25 = 3960 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "GE Sensing AL03006-58.2K-97-G1"
   #include "thermistor_9.h"
 #endif
-#if ANY_THERMISTOR_IS(10) // 100k RS thermistor 198-961 (4.7k pullup)
+#if ANY_THERMISTOR_IS(10) // beta25 = 3960 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "RS 198-961"
   #include "thermistor_10.h"
 #endif
-#if ANY_THERMISTOR_IS(11) // QU-BD silicone bed QWG-104F-3950 thermistor
+#if ANY_THERMISTOR_IS(11) // beta25 = 3950 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "QU-BD silicone bed, QWG-104F-3950"
   #include "thermistor_11.h"
 #endif
-#if ANY_THERMISTOR_IS(13) // Hisens thermistor B25/50 =3950 +/-1%
+#if ANY_THERMISTOR_IS(13) // beta25 = 4100 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Hisens"
   #include "thermistor_13.h"
 #endif
 #if ANY_THERMISTOR_IS(15) // JGAurora A5 thermistor calibration
@@ -85,28 +85,28 @@
 #if ANY_THERMISTOR_IS(20) // PT100 with INA826 amp on Ultimaker v2.0 electronics
   #include "thermistor_20.h"
 #endif
-#if ANY_THERMISTOR_IS(51) // 100k EPCOS (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
+#if ANY_THERMISTOR_IS(51) // beta25 = 4092 K, R25 = 100 kOhm, Pull-up = 1 kOhm, "EPCOS"
   #include "thermistor_51.h"
 #endif
-#if ANY_THERMISTOR_IS(52) // 200k ATC Semitec 204GT-2 (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
+#if ANY_THERMISTOR_IS(52) // beta25 = 4338 K, R25 = 200 kOhm, Pull-up = 1 kOhm, "ATC Semitec 204GT-2"
   #include "thermistor_52.h"
 #endif
-#if ANY_THERMISTOR_IS(55) // 100k ATC Semitec 104GT-2 (Used on ParCan) (WITH 1kohm RESISTOR FOR PULLUP, R9 ON SANGUINOLOLU! NOT FOR 4.7kohm PULLUP! THIS IS NOT NORMAL!)
+#if ANY_THERMISTOR_IS(55) // beta25 = 4267 K, R25 = 100 kOhm, Pull-up = 1 kOhm, "ATC Semitec 104GT-2 (Used on ParCan)"
   #include "thermistor_55.h"
 #endif
-#if ANY_THERMISTOR_IS(60) // Maker's Tool Works Kapton Bed Thermistor
+#if ANY_THERMISTOR_IS(60) // beta25 = 3950 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Maker's Tool Works Kapton Bed"
   #include "thermistor_60.h"
 #endif
-#if ANY_THERMISTOR_IS(66) // DyzeDesign 500Â°C Thermistor
+#if ANY_THERMISTOR_IS(66) // beta25 = 4500 K, R25 = 2.5 MOhm, Pull-up = 4.7 kOhm, "DyzeDesign 500 °C Thermistor"
   #include "thermistor_66.h"
 #endif
-#if ANY_THERMISTOR_IS(12) // 100k 0603 SMD Vishay NTCS0603E3104FXT (4.7k pullup) (calibrated for Makibox hot bed)
+#if ANY_THERMISTOR_IS(12) // beta25 = 4700 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Personal calibration for Makibox hot bed"
   #include "thermistor_12.h"
 #endif
-#if ANY_THERMISTOR_IS(70) // bqh2 stock thermistor
+#if ANY_THERMISTOR_IS(70) // beta25 = 4100 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "Hephestos 2, bqh2 stock thermistor"
   #include "thermistor_70.h"
 #endif
-#if ANY_THERMISTOR_IS(75) // Many of the generic silicon heat pads use the MGB18-104F39050L32 Thermistor
+#if ANY_THERMISTOR_IS(75) // beta25 = 4100 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "MGB18-104F39050L32 thermistor"
   #include "thermistor_75.h"
 #endif
 #if ANY_THERMISTOR_IS(110) // Pt100 with 1k0 pullup


### PR DESCRIPTION
There are a lot of mistakes in the comments for various thermistor tables. I checked all the bed thermistor tables (not Pt100 tables) and updated the comments.
One issue is reported here:
#8862

Table 8 is for 10k pull-up and beta_25 == 3950. Device name is NTCS0402E3104FHT, not NTCS0603E3104FXT.
Table 12 is for 4.7k pull-up and beta_25 == 4700K, not for beta_25 == 4100K
Table 13 is for 4.7k pull-up and beta_25 == 4700K, not for beta_25 == 3950K
Table 6 is supposed to be an alternative EPCOS linearization. Assuming that the "EPCOS" device has R25 == 100 kOhm and beta25 = 4092K, then the only pull-up that gives reasonable (but not very good) results is 8.2 kOhm. A 4.7kOhm pull-up cannot give reasonable results for any beta25 value.

It seems that some of these tables are results of peoples measurements, which doesn't make sense. The tables that are included in Marlin should correspond to nominal values of thermistor parameters and nominal values of pull-up resistors. Nominal values, as given in datasheets for a particular NTC resistor are supposed to be the best general fit in average. People can make fine-tuned tables from measurements on their own devices and circuits, but such tables are not relevant in general.