### PR TITLE
replaced by PR #9003    ( [2.0.x] add Due PINS_DEBUG support & misc improvements )

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/pinsDebug_AVR_8_bit.h
+++ b/Marlin/src/HAL/HAL_AVR/pinsDebug_AVR_8_bit.h
@@ -29,6 +29,8 @@
 
 #include "../../inc/MarlinConfig.h"
 
+#define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
+
 #if AVR_AT90USB1286_FAMILY
   // Working with Teensyduino extension so need to re-define some things
   #include "pinsDebug_Teensyduino.h"
@@ -57,6 +59,7 @@
 #define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
 #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && ((P) <= analogInputToDigitalPin(15) || (P) <= analogInputToDigitalPin(7)))
 #define GET_ARRAY_PIN(p) pgm_read_byte(&pin_array[p].pin)
+#define MULTI_NAME_PAD 14 // space needed to be pretty if not first name assigned to a pin
 
 void PRINT_ARRAY_NAME(uint8_t x) {
   char *name_mem_pointer = (char*)pgm_read_ptr(&pin_array[x].name);

--- a/Marlin/src/HAL/HAL_DUE/HAL_pinsDebug_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_pinsDebug_Due.h
@@ -1,0 +1,190 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2018 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Support routines for Due
+ */
+
+/**
+ * Translation of routines & variables used by pinsDebug.h
+ */
+
+#include "Arduino.h"
+
+/**
+ * Due/Marlin quirks
+ *
+ * a) determining the state of a pin
+ *     The Due/Arduino status definitions for the g_pinStatus[pin] array are:
+ *       #define PIN_STATUS_DIGITAL_INPUT_PULLUP  (0x01)
+ *       #define PIN_STATUS_DIGITAL_INPUT         (0x02)
+ *       #define PIN_STATUS_DIGITAL_OUTPUT        (0x03)
+ *       #define PIN_STATUS_ANALOG                (0x04)
+ *       #define PIN_STATUS_PWM                   (0x05)
+ *       #define PIN_STATUS_TIMER                 (0x06)
+ *
+ *     These are only valid if the following Due/Arduino provided functions are used:
+ *       analogRead
+ *       analogWrite
+ *       digitalWrite
+ *       pinMode
+ *
+ *     The FASTIO routines do not touch the g_pinStatus[pin] array.
+ *
+ *     The net result is that both the g_pinStatus[pin] array and the PIO_OSR register
+ *     needs to be looked at when determining if a pin is an input or an output.
+ *
+ * b) Due has only pins 6, 7, 8 & 9 enabled for PWMs.  FYI - they run at 1KHz
+ *
+ * c) NUM_DIGITAL_PINS does not include the analog pins
+ *
+ * d) Pins 0-78 are defined for Due but 78 has a comment of "unconnected!".  78 is
+ *    included just in case.
+ */
+
+#define NUMBER_PINS_TOTAL PINS_COUNT
+
+#define digitalRead_mod(p)  digitalRead(p)  // AVR digitalRead disabled PWM before it read the pin
+#define PRINT_PORT(p)
+#define NAME_FORMAT(p) PSTR("%-##p##s")
+#define PRINT_ARRAY_NAME(x)  do {sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer);} while (0)
+#define PRINT_PIN(p) do {sprintf_P(buffer, PSTR("%02d"), p); SERIAL_ECHO(buffer);} while (0)
+#define GET_ARRAY_PIN(p) pin_array[p].pin
+#define VALID_PIN(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL ? 1 : 0)
+#define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
+#define IS_ANALOG(P) (((P) >= analogInputToDigitalPin(0)) && ((P) <= analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
+#define pwm_status(pin) ((g_pinStatus[pin] & 0xF) == PIN_STATUS_PWM) && \
+                        ((g_APinDescription[pin].ulPinAttribute & PIN_ATTR_PWM) == PIN_ATTR_PWM)
+#define MULTI_NAME_PAD 14 // space needed to be pretty if not first name assigned to a pin
+
+bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
+  volatile Pio* port = g_APinDescription[pin].pPort;
+  uint32_t mask = g_APinDescription[pin].ulPin;
+  uint8_t pin_status = g_pinStatus[pin] & 0xF;
+  return (  (pin_status == 0 && (port->PIO_OSR & mask))
+          || pin_status == PIN_STATUS_DIGITAL_OUTPUT
+          || pwm_status(pin));
+}
+
+bool GET_ARRAY_IS_DIGITAL(int8_t pin) {
+  uint8_t pin_status = g_pinStatus[pin] & 0xF;
+  return  !(pin_status == PIN_STATUS_ANALOG);
+}
+
+void pwm_details(int32_t pin) {
+  if (pwm_status(pin)) {
+    uint32_t chan = g_APinDescription[pin].ulPWMChannel;
+    SERIAL_PROTOCOLPAIR("PWM = ", PWM_INTERFACE->PWM_CH_NUM[chan].PWM_CDTY);
+  }
+}
+
+/**
+ * DUE Board pin   |  PORT  | Label
+ * ----------------+--------+-------
+ *   0             |  PA8   | "RX0"
+ *   1             |  PA9   | "TX0"
+ *   2       TIOA0 |  PB25  |
+ *   3       TIOA7 |  PC28  |
+ *   4       NPCS1 |  PA29  |
+ *           TIOB6 |  PC26  |
+ *   5       TIOA6 |  PC25  |
+ *   6       PWML7 |  PC24  |
+ *   7       PWML6 |  PC23  |
+ *   8       PWML5 |  PC22  |
+ *   9       PWML4 |  PC21  |
+ *  10       NPCS0 |  PA28  |
+ *           TIOB7 |  PC29  |
+ *  11       TIOA8 |  PD7   |
+ *  12       TIOB8 |  PD8   |
+ *  13       TIOB0 |  PB27  | LED AMBER "L"
+ *  14       TXD3  |  PD4   | "TX3"
+ *  15       RXD3  |  PD5   | "RX3"
+ *  16       TXD1  |  PA13  | "TX2"
+ *  17       RXD1  |  PA12  | "RX2"
+ *  18       TXD0  |  PA11  | "TX1"
+ *  19       RXD0  |  PA10  | "RX1"
+ *  20             |  PB12  | "SDA"
+ *  21             |  PB13  | "SCL"
+ *  22             |  PB26  |
+ *  23             |  PA14  |
+ *  24             |  PA15  |
+ *  25             |  PD0   |
+ *  26             |  PD1   |
+ *  27             |  PD2   |
+ *  28             |  PD3   |
+ *  29             |  PD6   |
+ *  30             |  PD9   |
+ *  31             |  PA7   |
+ *  32             |  PD10  |
+ *  33             |  PC1   |
+ *  34             |  PC2   |
+ *  35             |  PC3   |
+ *  36             |  PC4   |
+ *  37             |  PC5   |
+ *  38             |  PC6   |
+ *  39             |  PC7   |
+ *  40             |  PC8   |
+ *  41             |  PC9   |
+ *  42             |  PA19  |
+ *  43             |  PA20  |
+ *  44             |  PC19  |
+ *  45             |  PC18  |
+ *  46             |  PC17  |
+ *  47             |  PC16  |
+ *  48             |  PC15  |
+ *  49             |  PC14  |
+ *  50             |  PC13  |
+ *  51             |  PC12  |
+ *  52       NPCS2 |  PB21  |
+ *  53             |  PB14  |
+ *  54             |  PA16  | "A0"
+ *  55             |  PA24  | "A1"
+ *  56             |  PA23  | "A2"
+ *  57             |  PA22  | "A3"
+ *  58       TIOB2 |  PA6   | "A4"
+ *  69             |  PA4   | "A5"
+ *  60       TIOB1 |  PA3   | "A6"
+ *  61       TIOA1 |  PA2   | "A7"
+ *  62             |  PB17  | "A8"
+ *  63             |  PB18  | "A9"
+ *  64             |  PB19  | "A10"
+ *  65             |  PB20  | "A11"
+ *  66             |  PB15  | "DAC0"
+ *  67             |  PB16  | "DAC1"
+ *  68             |  PA1   | "CANRX"
+ *  69             |  PA0   | "CANTX"
+ *  70             |  PA17  | "SDA1"
+ *  71             |  PA18  | "SCL1"
+ *  72             |  PC30  | LED AMBER "RX"
+ *  73             |  PA21  | LED AMBER "TX"
+ *  74       MISO  |  PA25  |
+ *  75       MOSI  |  PA26  |
+ *  76       SCLK  |  PA27  |
+ *  77       NPCS0 |  PA28  |
+ *  78       NPCS3 |  PB23  | unconnected!
+ *
+ * USB pin         |  PORT
+ * ----------------+--------
+ *  ID             |  PB11
+ *  VBOF           |  PB10
+ *
+ */

--- a/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinmapping.h
@@ -248,8 +248,12 @@ constexpr pin_t adc_pin_table[] = {
   #endif
 };
 
-constexpr int16_t NUM_ANALOG_INPUTS = COUNT(adc_pin_table);
-
+#if SERIAL_PORT != 0
+  #define NUM_ANALOG_INPUTS 8
+#else
+  #define NUM_ANALOG_INPUTS 6
+#endif
+  
 // P0.6 thru P0.9 are for the onboard SD card
 // P0.29 and P0.30 are for the USB port
 #define HAL_SENSITIVE_PINS P0_06, P0_07, P0_08, P0_09, P0_29, P0_30

--- a/Marlin/src/HAL/HAL_LPC1768/pinsDebug_LPC1768.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinsDebug_LPC1768.h
@@ -28,17 +28,17 @@
  * Translation of routines & variables used by pinsDebug.h
  */
 
+#define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
 #define pwm_details(pin) pin = pin    // do nothing  // print PWM details
 #define pwm_status(pin) false //Print a pin's PWM status. Return true if it's currently a PWM pin.
 #define IS_ANALOG(P) (DIGITAL_PIN_TO_ANALOG_PIN(P) >= 0 ? 1 : 0)
 #define digitalRead_mod(p)  digitalRead(p)
-#define digitalPinToPort_DEBUG(p)  0
-#define digitalPinToBitMask_DEBUG(pin) 0
-#define PRINT_PORT(p) SERIAL_ECHO_SP(10);
+#define PRINT_PORT(p)
 #define GET_ARRAY_PIN(p) pin_array[p].pin
 #define NAME_FORMAT(p) PSTR("%-##p##s")
 #define PRINT_ARRAY_NAME(x)  do {sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer);} while (0)
 #define PRINT_PIN(p) do {sprintf_P(buffer, PSTR("%d.%02d"), LPC1768_PIN_PORT(p), LPC1768_PIN_PIN(p)); SERIAL_ECHO(buffer);} while (0)
+#define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
 
 // active ADC function/mode/code values for PINSEL registers
 constexpr int8_t ADC_pin_mode(pin_t pin) {

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_pinsDebug_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_pinsDebug_Teensy.h
@@ -22,6 +22,9 @@
 
 #ifndef HAL_PINSDEBUG_TEENSY_H
 
+#define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
+#define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
+
 #define FTM0_CH0_PIN 22
 #define FTM0_CH1_PIN 23
 #define FTM0_CH2_PIN  9

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -260,8 +260,8 @@ void GcodeSuite::M43() {
   }
 
   // Get the range of pins to test or watch
-  const uint8_t first_pin = PARSED_PIN_INDEX('P', 0),
-                last_pin = parser.seenval('P') ? first_pin : NUM_DIGITAL_PINS - 1;
+  uint8_t first_pin = PARSED_PIN_INDEX('P', 0),
+          last_pin = parser.seenval('P') ? first_pin : NUMBER_PINS_TOTAL - 1;
 
   if (first_pin > last_pin) return;
 
@@ -270,6 +270,10 @@ void GcodeSuite::M43() {
   // Watch until click, M108, or reset
   if (parser.boolval('W')) {
     SERIAL_PROTOCOLLNPGM("Watching pins");
+    
+    #ifdef ARDUINO_ARCH_SAM
+      NOLESS(first_pin, 2);  // don't hijack the UART pins
+    #endif
     uint8_t pin_state[last_pin - first_pin + 1];
     for (uint8_t i = first_pin; i <= last_pin; i++) {
       pin_t pin = GET_PIN_MAP_PIN(i);

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -46,7 +46,7 @@
 #line 47
 
 // manually add pins that have names that are macros which don't play well with these macros
-#if SERIAL_PORT == 0 && (AVR_ATmega2560_FAMILY || AVR_ATmega1284_FAMILY)
+#if SERIAL_PORT == 0 && (AVR_ATmega2560_FAMILY || AVR_ATmega1284_FAMILY || defined(ARDUINO_ARCH_SAM))
   static const char RXD_NAME[] PROGMEM = { "RXD" };
   static const char TXD_NAME[] PROGMEM = { "TXD" };
 #endif
@@ -85,7 +85,7 @@ const PinInfo pin_array[] PROGMEM = {
 
   // manually add pins ...
   #if SERIAL_PORT == 0
-    #if AVR_ATmega2560_FAMILY
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
       { RXD_NAME, 0, true },
       { TXD_NAME, 1, true },
     #elif AVR_ATmega1284_FAMILY
@@ -130,7 +130,7 @@ inline void report_pin_state_extended(pin_t pin, bool ignore, bool extended = fa
       }
       else {
         SERIAL_CHAR('.');
-        SERIAL_ECHO_SP(26 + strlen(start_string));  // add padding if not the first instance found
+        SERIAL_ECHO_SP(MULTI_NAME_PAD + strlen(start_string));  // add padding if not the first instance found
       }
       PRINT_ARRAY_NAME(x);
       if (extended) {

--- a/Marlin/src/pins/pinsDebug_list.h
+++ b/Marlin/src/pins/pinsDebug_list.h
@@ -27,7 +27,7 @@
 
 // Pin list updated from 25 JUL 2017 Re-ARM branch   - max length of pin name is 24
 
-#line 0 // set __LINE__ to a known value for both passes
+#line 31 // set __LINE__ to a known value for both passes
 
 #if defined(EXT_AUX_A0) &&  EXT_AUX_A0 >= 0 &&  EXT_AUX_A0 < NUM_ANALOG_INPUTS
   REPORT_NAME_ANALOG(EXT_AUX_A0, __LINE__ )
@@ -50,11 +50,13 @@
 #if PIN_EXISTS(MAIN_VOLTAGE_MEASURE) &&  MAIN_VOLTAGE_MEASURE_PIN < NUM_ANALOG_INPUTS
   REPORT_NAME_ANALOG(MAIN_VOLTAGE_MEASURE_PIN, __LINE__ )
 #endif
-#if defined(TC1) &&  TC1 >= 0 &&  TC1 < NUM_ANALOG_INPUTS
-  REPORT_NAME_ANALOG(TC1, __LINE__ )
-#endif
-#if defined(TC2) &&  TC2 >= 0 &&  TC2 < NUM_ANALOG_INPUTS
-  REPORT_NAME_ANALOG(TC2, __LINE__ )
+#if !defined(ARDUINO_ARCH_SAM)  //TC1 & TC2 are macros in the SAM tool chain
+  #if defined(TC1) &&  TC1 >= 0 &&  TC1 < NUM_ANALOG_INPUTS
+    REPORT_NAME_ANALOG(TC1, __LINE__ )
+  #endif
+  #if defined(TC2) &&  TC2 >= 0 &&  TC2 < NUM_ANALOG_INPUTS
+    REPORT_NAME_ANALOG(TC2, __LINE__ )
+  #endif
 #endif
 #if PIN_EXISTS(TEMP_0) &&  TEMP_0_PIN < NUM_ANALOG_INPUTS
   REPORT_NAME_ANALOG(TEMP_0_PIN, __LINE__ )

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -96,6 +96,8 @@
 #define TEMP_0_PIN          1   // Analog Input
 #define TEMP_1_PIN          2   // Analog Input
 #define TEMP_2_PIN          3   // Analog Input
+#define TEMP_3_PIN         -1   // fewer compiler warnings
+#define TEMP_4_PIN         -1   // fewer compiler warnings
 #define TEMP_BED_PIN        0   // Analog Input
 
 // SPI for Max6675 or Max31855 Thermocouple


### PR DESCRIPTION
1) add PINS_DEBUG support for Due
2) improved display for LPC1768 version of PIN_DEBUG
3) propagate the display changes to the AVR & Teensy versions 
4) added dummy TEMP_4_PIN and TEMP_5_PIN to pins_RAMPS-FDV1h to remove compiler warnings
5) change LPC's NUM_ANALOG_INPUTS definition method so analog pins would be handled properly by M43