### PR TITLE
[2.0.x] EEPROM init fix

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3209,8 +3209,7 @@ void kill_screen(const char* lcd_msg) {
   #if ENABLED(EEPROM_SETTINGS)
 
     static void lcd_init_eeprom() {
-      lcd_factory_settings();
-      settings.save();
+      lcd_completion_feedback(settings.init_eeprom());
       lcd_goto_previous_menu();
     }
 

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -32,6 +32,21 @@ class MarlinSettings {
     static void reset();
     static bool save();
 
+    FORCE_INLINE static bool init_eeprom() {
+      bool success = true;
+      reset();
+      #if ENABLED(EEPROM_SETTINGS)
+        if ((success = save())) {
+          #if ENABLED(AUTO_BED_LEVELING_UBL)
+            success = load(); // UBL uses load() to know the end of EEPROM
+          #elif ENABLED(EEPROM_CHITCHAT)
+            report();
+          #endif
+        }
+      #endif
+      return success;
+    }
+
     #if ENABLED(EEPROM_SETTINGS)
       static bool load();
 


### PR DESCRIPTION
The LCD option, `Initialize EEPROM`, has not worked correctly for quite some time.

This fixes that.