### PR TITLE
[1.1.x] EEPROM init fix

### DIFF
--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -32,6 +32,21 @@ class MarlinSettings {
     static void reset();
     static bool save();
 
+    FORCE_INLINE static bool init_eeprom() {
+      bool success = true;
+      reset();
+      #if ENABLED(EEPROM_SETTINGS)
+        if ((success = save())) {
+          #if ENABLED(AUTO_BED_LEVELING_UBL)
+            success = load(); // UBL uses load() to know the end of EEPROM
+          #elif ENABLED(EEPROM_CHITCHAT)
+            report();
+          #endif
+        }
+      #endif
+      return success;
+    }
+
     #if ENABLED(EEPROM_SETTINGS)
       static bool load();
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3127,8 +3127,7 @@ void kill_screen(const char* lcd_msg) {
   #if ENABLED(EEPROM_SETTINGS)
 
     static void lcd_init_eeprom() {
-      settings.init_eeprom();
-      lcd_completion_feedback();
+      lcd_completion_feedback(settings.init_eeprom());
       lcd_goto_previous_menu();
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3127,8 +3127,8 @@ void kill_screen(const char* lcd_msg) {
   #if ENABLED(EEPROM_SETTINGS)
 
     static void lcd_init_eeprom() {
-      lcd_factory_settings();
-      settings.save();
+      settings.init_eeprom();
+      lcd_completion_feedback();
       lcd_goto_previous_menu();
     }
 


### PR DESCRIPTION
The LCD option, `Initialize EEPROM`, has not worked for quite some time.

This fixes that.