### PR TITLE
[1.1.x] Update pins_MKS_BASE.h with Microstepping pin definitions

### DIFF
--- a/Marlin/pins_MKS_BASE.h
+++ b/Marlin/pins_MKS_BASE.h
@@ -32,6 +32,24 @@
 
 #define BOARD_NAME "MKS BASE 1.0"
 
+/* Microstepping pins (reverse engineered at V1.4 - due to closed source schematics)
+// Some new batches have the HR4982 (Heroic) instead of the A4982 (Allegro) as stepper driver. While most of the functionality is similar, the HR variant obviously doesn't work with diode smoothers (no fast decay)
+// But the Heroic has a 128 µStepping mode where the A4982 is doing quarter steps (MS1=L / MS2=H). To achieve comfortable tests with the M350/M351 commands, the following definitions have to made:
+// Example: M350 X4 Y4 ; Set X and Y Axis to quarterstep Mode to achieve MS1=0 and MS2=1
+// A new board with a HR4982 will now perform 128 µSteps per Fullstep
+// XSTEP,YSTEP ... must be adapted with M92 accordingly (128/16 => multiply by factor 8).
+*/
+#define X_MS1_PIN           5   // Digital 3  / Pin 5   / PE3
+#define X_MS2_PIN           6   // Digital 6  / Pin 14  / PH3      
+#define Y_MS1_PIN           59  // Analog 5   / Pin 92  / PF5
+#define Y_MS2_PIN           58  // Analog 4   / Pin 93  / PF4
+#define Z_MS1_PIN           22  // Digital 22 / Pin 78  / PA0
+#define Z_MS2_PIN           39  // Digital 39 / Pin 70  / PG2
+#define E0_MS1_PIN          63  // Analog 9   / Pin 86  / PK1
+#define E0_MS2_PIN          64  // Analog 10  / Pin 87  / PK2
+#define E1_MS1_PIN          57  // Analog 3   / Pin 93  / PF3
+#define E1_MS2_PIN          4   // Digital 4  / Pin 1   / PG5
+
 //
 // Heaters / Fans
 //


### PR DESCRIPTION
Microstepping Pins (reverse engineered at V1.4)
Some new batches have the HR4982 (Heroic) instead of the A4982 (Allegro) as stepper driver. While most of the functionality is similar, the HR variant obviously doesn't work with diode smoothers (no fast decay). But the Heroic has a 128 µStepping mode where the A4982 is doing quarter steps (MS1=L / MS2=H). To achieve comfortable tests with the M350/M351 commands, the following definitions have to made.