### PR TITLE
[2.0.x] Due - fix power up garbage on RRDFG LCD

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -89,6 +89,27 @@ static const uint8_t u8g_dev_st7920_128x64_HAL_init_seq[] PROGMEM = {
   U8G_ESC_END                /* end of sequence */
 };
 
+void clear_graphics_DRAM(u8g_t *u8g, u8g_dev_t *dev){
+  u8g_SetChipSelect(u8g, dev, 1);
+  u8g_Delay(1);
+  u8g_SetAddress(u8g, dev, 0);         // cmd mode
+  u8g_WriteByte(u8g, dev, 0x08);       //display off, cursor+blink off
+  u8g_WriteByte(u8g, dev, 0x3E);       //extended mode + GDRAM active
+  for (uint8_t y = 0; y < (HEIGHT) / 2; y++) { //clear GDRAM
+    u8g_WriteByte(u8g, dev, 0x80 | y); //set y
+    u8g_WriteByte(u8g, dev, 0x80);     //set x = 0
+    u8g_SetAddress(u8g, dev, 1);                  /* data mode */
+    for (uint8_t i = 0; i < 2 * (WIDTH) / 8; i++) //2x width clears both segments
+      u8g_WriteByte(u8g, dev, 0);
+    u8g_SetAddress(u8g, dev, 0);           /* cmd mode */
+  }
+
+  u8g_WriteByte(u8g, dev, 0x0C); //display on, cursor+blink off
+
+  u8g_SetChipSelect(u8g, dev, 0);
+
+}
+
 uint8_t u8g_dev_st7920_128x64_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
 {
   switch(msg)
@@ -96,6 +117,7 @@ uint8_t u8g_dev_st7920_128x64_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_400NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_st7920_128x64_HAL_init_seq);
+      clear_graphics_DRAM(u8g, dev);
       break;
     case U8G_DEV_MSG_STOP:
       break;
@@ -143,6 +165,7 @@ uint8_t u8g_dev_st7920_128x64_HAL_4x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg,
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_400NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_st7920_128x64_HAL_init_seq);
+      clear_graphics_DRAM(u8g, dev);
       break;
 
     case U8G_DEV_MSG_STOP:


### PR DESCRIPTION
Apparently the LCD init routine was being run way before the Due had fully initialized it's internal peripherals which left the SCK & MOSI signals high.  This basically meant the first byte of the init routine wasn't being sent properly.

The apparent fix is to add low level writes to those pins.

This also allows the LCD to be run a little faster.  The rate in now about 825KHz.
 
----

When reset is pressed the very top line of the display stays through the display of the next screen.  This was fixed by adding a routine to the device driver to clear the ST7920's graphics memory before the next screen is displayed.
