### PR TITLE
[1.1.x] New EEPROM powers

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -306,8 +306,8 @@ extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
   void update_software_endstops(const AxisEnum axis);
 #endif
 
+#define MAX_COORDINATE_SYSTEMS 9
 #if ENABLED(CNC_COORDINATE_SYSTEMS)
-  #define MAX_COORDINATE_SYSTEMS 9
   extern float coordinate_system[MAX_COORDINATE_SYSTEMS][XYZ];
   bool select_coordinate_system(const int8_t _new);
 #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9837,6 +9837,18 @@ inline void gcode_M502() {
   }
 #endif
 
+#if ENABLED(EEPROM_SETTINGS)
+  /**
+   * M504: Validate EEPROM Contents
+   */
+  inline void gcode_M504() {
+    if (settings.validate()) {
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPGM("EEPROM OK");
+    }
+  }
+#endif
+
 #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
 
   /**
@@ -12049,6 +12061,9 @@ void process_parsed_command() {
       case 502: gcode_M502(); break;                              // M502: Revert Settings to defaults
       #if DISABLED(DISABLE_M503)
         case 503: gcode_M503(); break;                            // M503: Report Settings (in SRAM)
+      #endif
+      #if ENABLED(EEPROM_SETTINGS)
+        case 504: gcode_M504(); break;                            // M504: Validate EEPROM
       #endif
 
       #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -589,79 +589,71 @@ void MarlinSettings::postprocess() {
 
     #endif
 
+    //
     // Save TMC2130 or TMC2208 Configuration, and placeholder values
-    uint16_t val;
-    #if HAS_TRINAMIC
-      #if X_IS_TRINAMIC
-        val = stepperX.getCurrent();
+    //
+    uint16_t currents[11] = {
+      #if HAS_TRINAMIC
+        #if X_IS_TRINAMIC
+          stepperX.getCurrent(),
+        #else
+          0,
+        #endif
+        #if Y_IS_TRINAMIC
+          stepperY.getCurrent(),
+        #else
+          0,
+        #endif
+        #if Z_IS_TRINAMIC
+          stepperZ.getCurrent(),
+        #else
+          0,
+        #endif
+        #if X2_IS_TRINAMIC
+          stepperX2.getCurrent(),
+        #else
+          0,
+        #endif
+        #if Y2_IS_TRINAMIC
+          stepperY2.getCurrent(),
+        #else
+          0,
+        #endif
+        #if Z2_IS_TRINAMIC
+          stepperZ2.getCurrent(),
+        #else
+          0,
+        #endif
+        #if E0_IS_TRINAMIC
+          stepperE0.getCurrent(),
+        #else
+          0,
+        #endif
+        #if E1_IS_TRINAMIC
+          stepperE1.getCurrent(),
+        #else
+          0,
+        #endif
+        #if E2_IS_TRINAMIC
+          stepperE2.getCurrent(),
+        #else
+          0,
+        #endif
+        #if E3_IS_TRINAMIC
+          stepperE3.getCurrent(),
+        #else
+          0,
+        #endif
+        #if E4_IS_TRINAMIC
+          stepperE4.getCurrent()
+        #else
+          0
+        #endif
       #else
-        val = 0;
+        0
       #endif
-      EEPROM_WRITE(val);
-      #if Y_IS_TRINAMIC
-        val = stepperY.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if Z_IS_TRINAMIC
-        val = stepperZ.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if X2_IS_TRINAMIC
-        val = stepperX2.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if Y2_IS_TRINAMIC
-        val = stepperY2.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if Z2_IS_TRINAMIC
-        val = stepperZ2.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if E0_IS_TRINAMIC
-        val = stepperE0.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if E1_IS_TRINAMIC
-        val = stepperE1.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if E2_IS_TRINAMIC
-        val = stepperE2.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if E3_IS_TRINAMIC
-        val = stepperE3.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-      #if E4_IS_TRINAMIC
-        val = stepperE4.getCurrent();
-      #else
-        val = 0;
-      #endif
-      EEPROM_WRITE(val);
-    #else
-      val = 0;
-      for (uint8_t q = 11; q--;) EEPROM_WRITE(val);
-    #endif
+    };
+    EEPROM_WRITE(currents);
 
     //
     // TMC2130 Sensorless homing threshold

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -587,6 +587,13 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(dummy);
       }
 
+    #else
+
+      const bool volumetric_enabled = false;
+      dummy = DEFAULT_NOMINAL_FILAMENT_DIA;
+      EEPROM_WRITE(volumetric_enabled);
+      for (uint8_t q = MAX_EXTRUDERS; q--;) EEPROM_WRITE(dummy);
+
     #endif
 
     //
@@ -1087,6 +1094,11 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(dummy);
           if (q < COUNT(planner.filament_size)) planner.filament_size[q] = dummy;
         }
+
+      #else
+
+        EEPROM_READ(dummyb);
+        for (uint8_t q=MAX_EXTRUDERS; q--;) EEPROM_READ(dummy);
 
       #endif
 

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -29,6 +29,8 @@ class MarlinSettings {
   public:
     MarlinSettings() { }
 
+    static uint16_t datasize();
+
     static void reset();
     static bool save();   // Return 'true' if data was saved
 

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -38,13 +38,10 @@ class MarlinSettings {
       bool success = true;
       reset();
       #if ENABLED(EEPROM_SETTINGS)
-        if ((success = save())) {
-          #if ENABLED(AUTO_BED_LEVELING_UBL)
-            success = load(); // UBL uses load() to know the end of EEPROM
-          #elif ENABLED(EEPROM_CHITCHAT)
-            report();
-          #endif
-        }
+        success = save();
+        #if ENABLED(EEPROM_CHITCHAT)
+          if (success) report();
+        #endif
       #endif
       return success;
     }
@@ -55,8 +52,8 @@ class MarlinSettings {
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
-        FORCE_INLINE static int16_t get_start_of_meshes() { return meshes_begin; }
-        FORCE_INLINE static int16_t get_end_of_meshes() { return meshes_end; }
+        static int16_t meshes_start_index();
+        FORCE_INLINE static int16_t meshes_end_index() { return meshes_end; }
         static uint16_t calc_num_meshes();
         static void store_mesh(const int8_t slot);
         static void load_mesh(const int8_t slot, void * const into=NULL);

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -30,7 +30,7 @@ class MarlinSettings {
     MarlinSettings() { }
 
     static void reset();
-    static bool save();
+    static bool save();   // Return 'true' if data was saved
 
     FORCE_INLINE static bool init_eeprom() {
       bool success = true;
@@ -48,7 +48,8 @@ class MarlinSettings {
     }
 
     #if ENABLED(EEPROM_SETTINGS)
-      static bool load();
+      static bool load();     // Return 'true' if data was loaded ok
+      static bool validate(); // Return 'true' if EEPROM data is ok
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
@@ -77,7 +78,8 @@ class MarlinSettings {
     static void postprocess();
 
     #if ENABLED(EEPROM_SETTINGS)
-      static bool eeprom_error;
+
+      static bool eeprom_error, validating;
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
@@ -87,8 +89,9 @@ class MarlinSettings {
 
       #endif
 
+      static bool _load();
       static void write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc);
-      static void read_data(int &pos, uint8_t *value, uint16_t size, uint16_t *crc);
+      static void read_data(int &pos, uint8_t *value, uint16_t size, uint16_t *crc, const bool force=false);
     #endif
 };
 

--- a/Marlin/configuration_store.h
+++ b/Marlin/configuration_store.h
@@ -94,6 +94,7 @@ class MarlinSettings {
       static bool _load();
       static void write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc);
       static void read_data(int &pos, uint8_t *value, uint16_t size, uint16_t *crc, const bool force=false);
+      static bool size_error(const uint16_t size);
     #endif
 };
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -308,12 +308,6 @@
 
   void unified_bed_leveling::G29() {
 
-    if (!settings.calc_num_meshes()) {
-      SERIAL_PROTOCOLLNPGM("?Enable EEPROM and init with");
-      SERIAL_PROTOCOLLNPGM("M502, M500, M501 in that order.\n");
-      return;
-    }
-
     if (g29_parameter_parsing()) return; // abort if parsing the simple parameters causes a problem,
 
     // Check for commands that require the printer to be homed
@@ -1273,8 +1267,8 @@
       SERIAL_EOL();
       safe_delay(50);
 
-      SERIAL_PROTOCOLPAIR("Meshes go from ", hex_address((void*)settings.get_start_of_meshes()));
-      SERIAL_PROTOCOLLNPAIR(" to ", hex_address((void*)settings.get_end_of_meshes()));
+      SERIAL_PROTOCOLPAIR("Meshes go from ", hex_address((void*)settings.meshes_start_index()));
+      SERIAL_PROTOCOLLNPAIR(" to ", hex_address((void*)settings.meshes_end_index()));
       safe_delay(50);
 
       SERIAL_PROTOCOLLNPAIR("sizeof(ubl) :  ", (int)sizeof(ubl));
@@ -1283,7 +1277,7 @@
       SERIAL_EOL();
       safe_delay(25);
 
-      SERIAL_PROTOCOLLNPAIR("EEPROM free for UBL: ", hex_address((void*)(settings.get_end_of_meshes() - settings.get_start_of_meshes())));
+      SERIAL_PROTOCOLLNPAIR("EEPROM free for UBL: ", hex_address((void*)(settings.meshes_end_index() - settings.meshes_start_index())));
       safe_delay(50);
 
       SERIAL_PROTOCOLPAIR("EEPROM can hold ", settings.calc_num_meshes());

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2303,7 +2303,6 @@ void kill_screen(const char* lcd_msg) {
       MENU_BACK(MSG_UBL_LEVEL_BED);
       if (!WITHIN(ubl_storage_slot, 0, a - 1)) {
         STATIC_ITEM(MSG_NO_STORAGE);
-        STATIC_ITEM(MSG_INIT_EEPROM);
       }
       else {
         MENU_ITEM_EDIT(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, a - 1);

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -4538,6 +4538,24 @@ void kill_screen(const char* lcd_msg) {
       END_SCREEN();
     }
 
+    FORCE_INLINE screenFunc_t ap_message_screen(const AdvancedPauseMessage message) {
+      switch (message) {
+        case ADVANCED_PAUSE_MESSAGE_INIT: return lcd_advanced_pause_init_message;
+        case ADVANCED_PAUSE_MESSAGE_UNLOAD: return lcd_advanced_pause_unload_message;
+        case ADVANCED_PAUSE_MESSAGE_INSERT: return lcd_advanced_pause_insert_message;
+        case ADVANCED_PAUSE_MESSAGE_LOAD: return lcd_advanced_pause_load_message;
+        case ADVANCED_PAUSE_MESSAGE_PURGE: return lcd_advanced_pause_purge_message;
+        case ADVANCED_PAUSE_MESSAGE_RESUME: return lcd_advanced_pause_resume_message;
+        case ADVANCED_PAUSE_MESSAGE_CLICK_TO_HEAT_NOZZLE: return lcd_advanced_pause_heat_nozzle;
+        case ADVANCED_PAUSE_MESSAGE_WAIT_FOR_NOZZLES_TO_HEAT: return lcd_advanced_pause_wait_for_nozzles_to_heat;
+        case ADVANCED_PAUSE_MESSAGE_OPTION: advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_WAIT_FOR;
+                                            return lcd_advanced_pause_option_menu;
+        case ADVANCED_PAUSE_MESSAGE_STATUS:
+        default: break;
+      }
+      return NULL;
+    }
+
     void lcd_advanced_pause_show_message(
       const AdvancedPauseMessage message,
       const AdvancedPauseMode mode/*=ADVANCED_PAUSE_MODE_PAUSE_PRINT*/,
@@ -4545,48 +4563,13 @@ void kill_screen(const char* lcd_msg) {
     ) {
       advanced_pause_mode = mode;
       hotend_status_extruder = extruder;
-      switch (message) {
-        case ADVANCED_PAUSE_MESSAGE_INIT:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_init_message);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_UNLOAD:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_unload_message);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_INSERT:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_insert_message);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_LOAD:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_load_message);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_PURGE:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_purge_message);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_CLICK_TO_HEAT_NOZZLE:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_heat_nozzle);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_WAIT_FOR_NOZZLES_TO_HEAT:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_wait_for_nozzles_to_heat);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_OPTION:
-          defer_return_to_status = true;
-          advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_WAIT_FOR;
-          lcd_goto_screen(lcd_advanced_pause_option_menu);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_RESUME:
-          defer_return_to_status = true;
-          lcd_goto_screen(lcd_advanced_pause_resume_message);
-          break;
-        case ADVANCED_PAUSE_MESSAGE_STATUS:
-          lcd_return_to_status();
-          break;
+      const screenFunc_t next_screen = ap_message_screen(message);
+      if (next_screen) {
+        defer_return_to_status = true;
+        lcd_goto_screen(next_screen);
       }
+      else
+        lcd_return_to_status();
     }
 
   #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/vector_3.cpp
+++ b/Marlin/vector_3.cpp
@@ -157,4 +157,3 @@ void matrix_3x3::debug(const char * const title) {
 }
 
 #endif // HAS_ABL
-

--- a/Marlin/vector_3.h
+++ b/Marlin/vector_3.h
@@ -41,8 +41,6 @@
 #ifndef VECTOR_3_H
 #define VECTOR_3_H
 
-#if HAS_ABL
-
 class matrix_3x3;
 
 struct vector_3 {
@@ -79,5 +77,4 @@ struct matrix_3x3 {
 
 void apply_rotation_xyz(matrix_3x3 rotationMatrix, float &x, float &y, float &z);
 
-#endif // HAS_ABL
 #endif // VECTOR_3_H


### PR DESCRIPTION
Add new powers to the EEPROM code:
- Defines an EEPROM `struct` so data size/offsets are known at compile-time.
- Modifies `settings.calc_num_meshes` so UBL doesn't require `settings.load`.
- Adds `MarlinSettings::datasize()` returning the size of the EEPROM `struct`.
- Adds `MarlinSettings::validate()` to test EEPROM data without altering settings.
- Adds `datasize` validation on load/save to catch coder errors.
- Adds a `FIELD_TEST` macro to test for mismatch between the current `eeprom_index` and a field in the data structure during `load`/`save`. (Made possible by the C++ builtin `offsetof`.)

---
- See also #9002 - Adds a formal `MarlinSettings::init_eeprom` method.  
  