### PR TITLE
[2.0.x] Z probe offset for machines that home to +Z 

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -42,6 +42,10 @@
   #include "../../lcd/ultralcd.h"
 #endif
 
+#if HAS_BED_PROBE && Z_HOME_DIR > 0
+  #include "../../module/probe.h"
+#endif
+
 #if ENABLED(G26_MESH_VALIDATION)
   bool g26_debug_flag; // = false
 #endif
@@ -76,6 +80,11 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
   #endif
 
   if (can_change && enable != planner.leveling_active) {
+
+    // If a probe is present and the printer homes away from the bed, account for the probe offset.
+    #if HAS_BED_PROBE && Z_HOME_DIR > 0
+      current_position[Z_AXIS] += (enable ? -1 : 1) * zprobe_zoffset;;
+    #endif
 
     #if ENABLED(MESH_BED_LEVELING)
 
@@ -128,9 +137,9 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
         // so compensation will give the right stepper counts.
         planner.unapply_leveling(current_position);
 
-      SYNC_PLAN_POSITION_KINEMATIC();
-
     #endif // OLDSCHOOL_ABL
+
+    SYNC_PLAN_POSITION_KINEMATIC();
   }
 }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -395,11 +395,11 @@
           restore_ubl_active_state_and_leave();
         }
         else { // grid_size == 0 : A 3-Point leveling has been requested
-          float z3, z2, z1 = probe_pt(UBL_PROBE_PT_1_X, UBL_PROBE_PT_1_Y, false, g29_verbose_level);
+          float z3, z2, z1 = probe_pt(UBL_PROBE_PT_1_X, UBL_PROBE_PT_1_Y, false, g29_verbose_level, true, true);
           if (!isnan(z1)) {
-            z2 = probe_pt(UBL_PROBE_PT_2_X, UBL_PROBE_PT_2_Y, false, g29_verbose_level);
+            z2 = probe_pt(UBL_PROBE_PT_2_X, UBL_PROBE_PT_2_Y, false, g29_verbose_level, true, true);
             if (!isnan(z2))
-              z3 = probe_pt(UBL_PROBE_PT_3_X, UBL_PROBE_PT_3_Y, true, g29_verbose_level);
+              z3 = probe_pt(UBL_PROBE_PT_3_X, UBL_PROBE_PT_3_Y, true, g29_verbose_level, true, true);
           }
 
           if (isnan(z1) || isnan(z2) || isnan(z3)) { // probe_pt will return NAN if unreachable
@@ -795,7 +795,7 @@
           const float rawx = mesh_index_to_xpos(location.x_index),
                       rawy = mesh_index_to_ypos(location.y_index);
 
-          const float measured_z = probe_pt(rawx, rawy, stow_probe, g29_verbose_level); // TODO: Needs error handling
+          const float measured_z = probe_pt(rawx, rawy, stow_probe, g29_verbose_level, true, true); // TODO: Needs error handling
           z_values[location.x_index][location.y_index] = measured_z;
         }
 
@@ -1655,7 +1655,7 @@
         const float rx = float(x_min) + ix * dx;
         for (int8_t iy = 0; iy < g29_grid_size; iy++) {
           const float ry = float(y_min) + dy * (zig_zag ? g29_grid_size - 1 - iy : iy);
-          float measured_z = probe_pt(rx, ry, parser.seen('E'), g29_verbose_level); // TODO: Needs error handling
+          float measured_z = probe_pt(rx, ry, parser.seen('E'), g29_verbose_level, true, true); // TODO: Needs error handling
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) {
               SERIAL_CHAR('(');

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -656,7 +656,7 @@ void GcodeSuite::G29() {
             if (!position_is_reachable_by_probe(xProbe, yProbe)) continue;
           #endif
 
-          measured_z = faux ? 0.001 * random(-100, 101) : probe_pt(xProbe, yProbe, stow_probe_after_each, verbose_level);
+          measured_z = faux ? 0.001 * random(-100, 101) : probe_pt(xProbe, yProbe, stow_probe_after_each, verbose_level, true, true);
 
           if (isnan(measured_z)) {
             set_bed_leveling_enabled(abl_should_enable);
@@ -693,7 +693,7 @@ void GcodeSuite::G29() {
         // Retain the last probe position
         xProbe = points[i].x;
         yProbe = points[i].y;
-        measured_z = faux ? 0.001 * random(-100, 101) : probe_pt(xProbe, yProbe, stow_probe_after_each, verbose_level);
+        measured_z = faux ? 0.001 * random(-100, 101) : probe_pt(xProbe, yProbe, stow_probe_after_each, verbose_level, true, true);
         if (isnan(measured_z)) {
           set_bed_leveling_enabled(abl_should_enable);
           break;

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -605,7 +605,7 @@ static float run_z_probe() {
  *   - Raise to the BETWEEN height
  * - Return the probed Z position
  */
-float probe_pt(const float &rx, const float &ry, const bool stow, const uint8_t verbose_level, const bool probe_relative/*=true*/) {
+float probe_pt(const float &rx, const float &ry, const bool stow, const uint8_t verbose_level, const bool probe_relative/*=true*/, const bool leveling/*=false*/) {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
       SERIAL_ECHOPAIR(">>> probe_pt(", LOGICAL_X_POSITION(rx));
@@ -642,7 +642,13 @@ float probe_pt(const float &rx, const float &ry, const bool stow, const uint8_t 
 
   float measured_z = NAN;
   if (!DEPLOY_PROBE()) {
-    measured_z = run_z_probe() + zprobe_zoffset;
+    measured_z = run_z_probe() +
+      #if Z_HOME_DIR <= 0
+        zprobe_zoffset
+      #else
+        (leveling ? 0 : zprobe_zoffset)
+      #endif
+    ;
 
     if (!stow)
       do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_BETWEEN_PROBES, MMM_TO_MMS(Z_PROBE_SPEED_FAST));

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -32,7 +32,7 @@
 #if HAS_BED_PROBE
   extern float zprobe_zoffset;
   bool set_probe_deployed(const bool deploy);
-  float probe_pt(const float &rx, const float &ry, const bool, const uint8_t, const bool probe_relative=true);
+  float probe_pt(const float &rx, const float &ry, const bool, const uint8_t, const bool probe_relative=true, const bool leveling=false);
   #define DEPLOY_PROBE() set_probe_deployed(true)
   #define STOW_PROBE() set_probe_deployed(false)
 #else


### PR DESCRIPTION
On delta machines with a bed probe, adjustments to the z probe z offset performed using the `BABYSTEP_ZPROBE_OFFSET` feature are lost when the machine is homed. This results in the nozzle returning to a fixed height over the bed regardless of the value of `zprobe_zoffset`. On cartesian machines, adjustments to `zprobe_zoffset` are retained when homing, allowing the live z offset adjustments to persist. This PR aims to allow delta machines to behave in the same manner as cartesian machines when using `BABYSTEP_ZPROBE_OFFSET` by ensuring that changes to the z offset persist.

I tested this using the linear, bilinear, and UBL leveling systems by running various combinations of `G28`, `G33 P1`, and `G29`. In all cases, the nozzle repeatedly returned to the expected position when moving to the Z0 position.