### PR TITLE
[2.0.x] Due - allow compile without SD card enabled & misc improvements (replaces PR #9007)

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_pinsDebug_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_pinsDebug_Due.h
@@ -72,8 +72,8 @@
 #define VALID_PIN(pin) (pin >= 0 && pin < (int8_t)NUMBER_PINS_TOTAL ? 1 : 0)
 #define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
 #define IS_ANALOG(P) (((P) >= analogInputToDigitalPin(0)) && ((P) <= analogInputToDigitalPin(NUM_ANALOG_INPUTS - 1)))
-#define pwm_status(pin) ((g_pinStatus[pin] & 0xF) == PIN_STATUS_PWM) && \
-                        ((g_APinDescription[pin].ulPinAttribute & PIN_ATTR_PWM) == PIN_ATTR_PWM)
+#define pwm_status(pin) (((g_pinStatus[pin] & 0xF) == PIN_STATUS_PWM) && \
+                        ((g_APinDescription[pin].ulPinAttribute & PIN_ATTR_PWM) == PIN_ATTR_PWM))
 #define MULTI_NAME_PAD 14 // space needed to be pretty if not first name assigned to a pin
 
 bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
@@ -53,7 +53,12 @@
 /*! \name Activation of Logical Unit Numbers
  */
 //! @{
-#define LUN_0                ENABLE    //!< SD/MMC Card over MCI Slot 0.
+
+#ifdef SDSUPPORT
+  #define LUN_0              ENABLE    //!< SD/MMC Card over MCI Slot 0.
+#else
+  #define LUN_0              DISABLE
+#endif
 #define LUN_1                DISABLE   
 #define LUN_2                DISABLE   
 #define LUN_3                DISABLE   

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_usb.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_usb.h
@@ -72,7 +72,11 @@
 
 //! USB Device string definitions (Optional)
 #define  USB_DEVICE_MANUFACTURE_NAME      "marlinfw.org"
-#define  USB_DEVICE_PRODUCT_NAME          CUSTOM_MACHINE_NAME
+#ifdef CUSTOM_MACHINE_NAME
+  #define  USB_DEVICE_PRODUCT_NAME        CUSTOM_MACHINE_NAME
+#else
+  #define  USB_DEVICE_PRODUCT_NAME        "3D Printer"
+#endif
 #define  USB_DEVICE_SERIAL_NAME           "123985739853"
 
 /**

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -2,7 +2,7 @@
  * Interface from Atmel USB MSD to Marlin SD card
  */
 
-#ifdef ARDUINO_ARCH_SAM
+#if defined(ARDUINO_ARCH_SAM) && defined(SDSUPPORT)
 
 #include "../../../inc/MarlinConfig.h"
 #include "../../../sd/cardreader.h"

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -47,6 +47,7 @@
 
 #include "conf_usb.h"
 #include "udc.h"
+#include <Arduino.h>
 
 static volatile bool main_b_msc_enable = false;
 static volatile bool main_b_cdc_enable = false;
@@ -252,6 +253,7 @@ bool usb_task_other_requests(void) {
 
   return true;
 }
+
 
 void HAL_init(void) {
   uint16_t *ptr;


### PR DESCRIPTION
The Due's code for the native USB port currently assumes that the SD card on the LCD will be enabled.  There's been a request to allow compiling for 2.0.x Due with SDSUPPORT disabled.

This also addresses these errors:
Marlin\src\HAL\HAL_DUE\usb/usb_task.c:275: undefined reference to `PSTR'
Marlin\src\HAL\HAL_DUE\usb/usb_task.c:275: undefined reference to `sprint
won't compile if CUSTOM_MACHINE_NAME is undefined

