### PR TITLE
Fix for issue #9005, #8942 - Bed PID autotuning

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -240,8 +240,8 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
     #endif
 
     #if WATCH_THE_BED || WATCH_HOTENDS
-      const int8_t watch_temp_period = TV(WATCH_BED_TEMP_PERIOD, WATCH_TEMP_PERIOD),
-                   watch_temp_increase = TV(WATCH_BED_TEMP_INCREASE, WATCH_TEMP_INCREASE);
+      const uint8_t watch_temp_period = TV(WATCH_BED_TEMP_PERIOD, WATCH_TEMP_PERIOD),
+                    watch_temp_increase = TV(WATCH_BED_TEMP_INCREASE, WATCH_TEMP_INCREASE);
       const float watch_temp_target = target - float(watch_temp_increase + TV(TEMP_BED_HYSTERESIS, TEMP_HYSTERESIS) + 1);
       millis_t temp_change_ms = next_temp_ms + watch_temp_period * 1000UL;
       float next_watch_temp = 0.0;

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -240,8 +240,8 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
     #endif
 
     #if WATCH_THE_BED || WATCH_HOTENDS
-      const uint8_t watch_temp_period = TV(WATCH_BED_TEMP_PERIOD, WATCH_TEMP_PERIOD),
-                    watch_temp_increase = TV(WATCH_BED_TEMP_INCREASE, WATCH_TEMP_INCREASE);
+      const uint16_t watch_temp_period = TV(WATCH_BED_TEMP_PERIOD, WATCH_TEMP_PERIOD);
+      const uint8_t watch_temp_increase = TV(WATCH_BED_TEMP_INCREASE, WATCH_TEMP_INCREASE);
       const float watch_temp_target = target - float(watch_temp_increase + TV(TEMP_BED_HYSTERESIS, TEMP_HYSTERESIS) + 1);
       millis_t temp_change_ms = next_temp_ms + watch_temp_period * 1000UL;
       float next_watch_temp = 0.0;


### PR DESCRIPTION
If watch period is > 127 - which often is the case for heated beds - the value gets zero or negative for autotuning because of the use of signed int for watch_temp_period. This kills the autotune process immediately. Unsigned int fixes the problem.