### PR TITLE
ReadMe: Add project description (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 <img align="top" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
 
+Optimized firmware for [RepRap 3D printers](http://reprap.org/) based on the [Arduino](https://www.arduino.cc/) platform.
+
 Additional documentation can be found at the [Marlin Home Page](http://marlinfw.org/).
 Please test this firmware and let us know if it misbehaves in any way. Volunteers are standing by!
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <img align="top" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
 
-Optimized firmware for [RepRap 3D printers](http://reprap.org/) based on the [Arduino](https://www.arduino.cc/) platform.
+Optimized firmware for [RepRap 3D printers](http://reprap.org/) based on the [Arduino](https://www.arduino.cc/) platform. First created in 2011 for RepRap and Ultimaker, today Marlin drives most of the world's 3D printers. Reliable and precise, it delivers outstanding print quality while keeping you in full control of the process.
 
 Additional documentation can be found at the [Marlin Home Page](http://marlinfw.org/).
 Please test this firmware and let us know if it misbehaves in any way. Volunteers are standing by!


### PR DESCRIPTION
Follow-up to #9052, now on the 2.0 development branch. 

The ReadMe did not feature a project description. Use the description from
GitHub and add some links to tell everyone what this actually is.

Also add the (longer) description from the Marlin homepage.

I leave it open for discussion (or the mergers decision) if both commits or just the first should be pulled.
  