### PR TITLE
[2.0.x] fix Teensy2 compile error (PlatformIO LDF problem)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -195,6 +195,7 @@ board         = teensy20pp
 build_flags   = ${common.build_flags} -I $BUILDSRC_DIR
 #board_f_cpu  = 20000000L     ; Bug in Arduino framework disallows boards running at 20Mhz
 lib_deps      = ${common.lib_deps}
+lib_ldf_mode  = deep+
 src_filter    = ${common.default_src_filter}
 
 #


### PR DESCRIPTION
Per issue #8898, PR #8853 (DUE USB changes) resulted in Teensy2 no longer compiling.

~This appears to be a compiler problem as an include was being processed even though a `#ifdef ARDUINO_ARCH_SAM` should have prevented it.~

~Apparently the compiler couldn't find "sleep.h" in the local directory so it grabbed the one in the tool chain.  The work around is to fully specify the path for (the non-existent) sleep.h so that only the local directory will qualify.~
  
 Thanks to @p3p for identifying the root cause.  It's a result of PlatformIO's LDF.  See below for details.