### PR TITLE
Live z offset adjusting

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1688,6 +1688,9 @@
 // Support for PCA9632 PWM LED driver
 //#define PCA9632
 
+// Support for Live Z Offset Changing
+// #define LIVE_Z_OFFSET_ADJUST
+
 /**
  * RGB LED / LED Strip Control
  *

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -741,6 +741,9 @@
 #ifndef MSG_ZPROBE_ZOFFSET
   #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Offset")
 #endif
+#ifndef MSG_LIVE_ZPROBE_ZOFFSET
+  #define MSG_LIVE_ZPROBE_ZOFFSET             _UxGT("Live Z Offset")
+#endif
 #ifndef MSG_BABYSTEP_X
   #define MSG_BABYSTEP_X                      _UxGT("Babystep X")
 #endif


### PR DESCRIPTION
So, when trying to find just the right z offset for my 3d printer, the way i would adjust it is by trial and error, meaning i test one z offset, then adjust it in the desired direction, save the new z offset, restart the printer, auto home, and check if the result is satisfying.

Because this was tedious, i wanted to be able to update the z offset live, to allow more convenient/easy/precise adjustment of the z offset.

I implemented it in the marlin fw, replacing the "Z Offset" menu item of the Motion->Control menu by "Live Z Offset".
Im not entirely sure that the way i did it is 100% correct, and if i messed anything up, feedback is greatly appreciated.

However, this feature helped me greatly, and i hope this, or some cleaned up version of this, makes it into future marlin releases!