### PR TITLE
[1.1.x] Set laser/spindle PWM to lowest speed on M5

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6283,6 +6283,9 @@ inline void gcode_G92() {
   inline void gcode_M5() {
     stepper.synchronize();
     WRITE(SPINDLE_LASER_ENABLE_PIN, !SPINDLE_LASER_ENABLE_INVERT);
+    #if ENABLED(SPINDLE_LASER_PWM)
+      analogWrite(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);
+    #endif
     delay_for_power_down();
   }
 


### PR DESCRIPTION
Redo #9079 targeting bugfix-1.1.x.
  