### PR TITLE
[2.0.x] Set has_mesh if user issues G29 S3 with MBL

### DIFF
--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -185,6 +185,9 @@ void GcodeSuite::G29() {
         SERIAL_CHAR('Z'); echo_not_entered();
         return;
       }
+
+      mbl.has_mesh = true; // set since user manually entered a mesh point
+
       break;
 
     case MeshSetZOffset:


### PR DESCRIPTION
Minor improvement prevents user from having to run through entire manual leveling process only to enable mesh so they can manually restore their offline MBL mesh backup
  