### PR TITLE
[1.1.x] MBL cleanup, has_mesh() method

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -383,6 +383,11 @@ void report_current_position();
   float bilinear_z_offset(const float raw[XYZ]);
 #endif
 
+#if ENABLED(AUTO_BED_LEVELING_BILINEAR) || ENABLED(MESH_BED_LEVELING)
+  typedef float (*element_2d_fn)(const uint8_t, const uint8_t);
+  void print_2d_array(const uint8_t sx, const uint8_t sy, const uint8_t precision, const element_2d_fn fn);
+#endif
+
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   typedef struct { double A, B, D; } linear_fit;
   linear_fit* lsf_linear_fit(double x[], double y[], double z[], const int);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2537,7 +2537,7 @@ static void clean_up_after_endstop_or_probe_move() {
   /**
    * Print calibration results for plotting or manual frame adjustment.
    */
-  static void print_2d_array(const uint8_t sx, const uint8_t sy, const uint8_t precision, float (*fn)(const uint8_t, const uint8_t)) {
+  void print_2d_array(const uint8_t sx, const uint8_t sy, const uint8_t precision, const element_2d_fn fn) {
     #ifndef SCAD_MESH_OUTPUT
       for (uint8_t x = 0; x < sx; x++) {
         for (uint8_t i = 0; i < precision + 2 + (x < 10 ? 1 : 0); i++)
@@ -4089,15 +4089,6 @@ void home_all_axes() { gcode_G28(true); }
   // Save 130 bytes with non-duplication of PSTR
   void echo_not_entered() { SERIAL_PROTOCOLLNPGM(" not entered."); }
 
-  void mbl_mesh_report() {
-    SERIAL_PROTOCOLLNPGM("Num X,Y: " STRINGIFY(GRID_MAX_POINTS_X) "," STRINGIFY(GRID_MAX_POINTS_Y));
-    SERIAL_PROTOCOLPGM("Z offset: "); SERIAL_PROTOCOL_F(mbl.z_offset, 5);
-    SERIAL_PROTOCOLLNPGM("\nMeasured points:");
-    print_2d_array(GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y, 5,
-      [](const uint8_t ix, const uint8_t iy) { return mbl.z_values[ix][iy]; }
-    );
-  }
-
   /**
    * G29: Mesh-based Z probe, probes a grid and produces a
    *      mesh to compensate for variable bed height
@@ -4138,7 +4129,7 @@ void home_all_axes() { gcode_G28(true); }
       case MeshReport:
         if (leveling_is_valid()) {
           SERIAL_PROTOCOLLNPAIR("State: ", planner.leveling_active ? MSG_ON : MSG_OFF);
-          mbl_mesh_report();
+          mbl.report_mesh();
         }
         else
           SERIAL_PROTOCOLLNPGM("Mesh bed leveling has no data.");
@@ -9630,7 +9621,7 @@ void quickstop_stepper() {
             #endif
           #elif ENABLED(MESH_BED_LEVELING)
             SERIAL_ECHOLNPGM("Mesh Bed Level data:");
-            mbl_mesh_report();
+            mbl.report_mesh();
           #endif
         }
       #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2374,7 +2374,7 @@ static void clean_up_after_endstop_or_probe_move() {
   bool leveling_is_valid() {
     return
       #if ENABLED(MESH_BED_LEVELING)
-        mbl.has_mesh
+        mbl.has_mesh()
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
         !!bilinear_grid_spacing[X_AXIS]
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
@@ -2503,10 +2503,7 @@ static void clean_up_after_endstop_or_probe_move() {
     #endif
     set_bed_leveling_enabled(false);
     #if ENABLED(MESH_BED_LEVELING)
-      if (leveling_is_valid()) {
-        mbl.reset();
-        mbl.has_mesh = false;
-      }
+      mbl.reset();
     #elif ENABLED(AUTO_BED_LEVELING_UBL)
       ubl.reset();
     #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
@@ -4184,7 +4181,6 @@ void home_all_axes() { gcode_G28(true); }
           SERIAL_PROTOCOLLNPGM("Mesh probing done.");
           BUZZ(100, 659);
           BUZZ(100, 698);
-          mbl.has_mesh = true;
 
           home_all_axes();
           set_bed_leveling_enabled(true);
@@ -4233,7 +4229,6 @@ void home_all_axes() { gcode_G28(true); }
           SERIAL_CHAR('Z'); echo_not_entered();
           return;
         }
-        mbl.has_mesh = true; // set since user manually entered a mesh point
         break;
 
       case MeshSetZOffset:

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V48"
+#define EEPROM_VERSION "V49"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -114,7 +114,6 @@ typedef struct SettingsDataStruct {
   //
   // MESH_BED_LEVELING
   //
-  bool mbl_has_mesh;                                    // mbl.has_mesh
   float mbl_z_offset;                                   // mbl.z_offset
   uint8_t mesh_num_x, mesh_num_y;                       // GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y
   #if ENABLED(MESH_BED_LEVELING)
@@ -453,16 +452,13 @@ void MarlinSettings::postprocess() {
         "MBL Z array is the wrong size."
       );
       const uint8_t mesh_num_x = GRID_MAX_POINTS_X, mesh_num_y = GRID_MAX_POINTS_Y;
-      EEPROM_WRITE(mbl.has_mesh);
       EEPROM_WRITE(mbl.z_offset);
       EEPROM_WRITE(mesh_num_x);
       EEPROM_WRITE(mesh_num_y);
       EEPROM_WRITE(mbl.z_values);
     #else // For disabled MBL write a default mesh
-      const bool leveling_is_on = false;
       dummy = 0.0f;
       const uint8_t mesh_num_x = 3, mesh_num_y = 3;
-      EEPROM_WRITE(leveling_is_on);
       EEPROM_WRITE(dummy); // z_offset
       EEPROM_WRITE(mesh_num_x);
       EEPROM_WRITE(mesh_num_y);
@@ -960,10 +956,7 @@ void MarlinSettings::postprocess() {
       EEPROM_READ_ALWAYS(mesh_num_y);
 
       #if ENABLED(MESH_BED_LEVELING)
-        if (!validating) {
-          mbl.has_mesh = leveling_is_on;
-          mbl.z_offset = dummy;
-        }
+        if (!validating) mbl.z_offset = dummy;
         if (mesh_num_x == GRID_MAX_POINTS_X && mesh_num_y == GRID_MAX_POINTS_Y) {
           // EEPROM data fits the current mesh
           EEPROM_READ(mbl.z_values);

--- a/Marlin/mesh_bed_leveling.cpp
+++ b/Marlin/mesh_bed_leveling.cpp
@@ -25,6 +25,8 @@
 #if ENABLED(MESH_BED_LEVELING)
 
   #include "mesh_bed_leveling.h"
+  #include "Marlin.h"
+  #include "serial.h"
 
   mesh_bed_leveling mbl;
 
@@ -47,6 +49,15 @@
     has_mesh = false;
     z_offset = 0;
     ZERO(z_values);
+  }
+
+  void mesh_bed_leveling::report_mesh() {
+    SERIAL_PROTOCOLLNPGM("Num X,Y: " STRINGIFY(GRID_MAX_POINTS_X) "," STRINGIFY(GRID_MAX_POINTS_Y));
+    SERIAL_PROTOCOLPGM("Z offset: "); SERIAL_PROTOCOL_F(z_offset, 5);
+    SERIAL_PROTOCOLLNPGM("\nMeasured points:");
+    print_2d_array(GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y, 5,
+      [](const uint8_t ix, const uint8_t iy) { return z_values[ix][iy]; }
+    );
   }
 
 #endif // MESH_BED_LEVELING

--- a/Marlin/mesh_bed_leveling.cpp
+++ b/Marlin/mesh_bed_leveling.cpp
@@ -20,9 +20,11 @@
  *
  */
 
-#include "mesh_bed_leveling.h"
+#include "MarlinConfig.h"
 
 #if ENABLED(MESH_BED_LEVELING)
+
+  #include "mesh_bed_leveling.h"
 
   mesh_bed_leveling mbl;
 

--- a/Marlin/mesh_bed_leveling.cpp
+++ b/Marlin/mesh_bed_leveling.cpp
@@ -30,8 +30,6 @@
 
   mesh_bed_leveling mbl;
 
-  bool mesh_bed_leveling::has_mesh;
-
   float mesh_bed_leveling::z_offset,
         mesh_bed_leveling::z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y],
         mesh_bed_leveling::index_to_xpos[GRID_MAX_POINTS_X],
@@ -46,7 +44,6 @@
   }
 
   void mesh_bed_leveling::reset() {
-    has_mesh = false;
     z_offset = 0;
     ZERO(z_values);
   }

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -50,6 +50,12 @@ public:
 
   static void reset();
 
+  FORCE_INLINE static bool has_mesh() {
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
+      for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
+        if (z_values[x][y]) return true;
+    return false;
+  }
 
   static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
 

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -20,92 +20,93 @@
  *
  */
 
-#include "Marlin.h"
+#ifndef _MESH_BED_LEVELING_H_
+#define _MESH_BED_LEVELING_H_
 
-#if ENABLED(MESH_BED_LEVELING)
+#include "MarlinConfig.h"
 
-  enum MeshLevelingState {
-    MeshReport,
-    MeshStart,
-    MeshNext,
-    MeshSet,
-    MeshSetZOffset,
-    MeshReset
-  };
+enum MeshLevelingState {
+  MeshReport,
+  MeshStart,
+  MeshNext,
+  MeshSet,
+  MeshSetZOffset,
+  MeshReset
+};
 
-  #define MESH_X_DIST ((MESH_MAX_X - (MESH_MIN_X)) / (GRID_MAX_POINTS_X - 1))
-  #define MESH_Y_DIST ((MESH_MAX_Y - (MESH_MIN_Y)) / (GRID_MAX_POINTS_Y - 1))
+#define MESH_X_DIST ((MESH_MAX_X - (MESH_MIN_X)) / (GRID_MAX_POINTS_X - 1))
+#define MESH_Y_DIST ((MESH_MAX_Y - (MESH_MIN_Y)) / (GRID_MAX_POINTS_Y - 1))
 
-  class mesh_bed_leveling {
-  public:
-    static bool has_mesh;
-    static float z_offset,
-                 z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y],
-                 index_to_xpos[GRID_MAX_POINTS_X],
-                 index_to_ypos[GRID_MAX_POINTS_Y];
+class mesh_bed_leveling {
+public:
+  static bool has_mesh;
+  static float z_offset,
+               z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y],
+               index_to_xpos[GRID_MAX_POINTS_X],
+               index_to_ypos[GRID_MAX_POINTS_Y];
 
-    mesh_bed_leveling();
+  mesh_bed_leveling();
 
-    static void reset();
+  static void reset();
 
-    static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
+  static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
 
-    static inline void zigzag(const int8_t index, int8_t &px, int8_t &py) {
-      px = index % (GRID_MAX_POINTS_X);
-      py = index / (GRID_MAX_POINTS_X);
-      if (py & 1) px = (GRID_MAX_POINTS_X - 1) - px; // Zig zag
-    }
+  static inline void zigzag(const int8_t index, int8_t &px, int8_t &py) {
+    px = index % (GRID_MAX_POINTS_X);
+    py = index / (GRID_MAX_POINTS_X);
+    if (py & 1) px = (GRID_MAX_POINTS_X - 1) - px; // Zig zag
+  }
 
-    static void set_zigzag_z(const int8_t index, const float &z) {
-      int8_t px, py;
-      zigzag(index, px, py);
-      set_z(px, py, z);
-    }
+  static void set_zigzag_z(const int8_t index, const float &z) {
+    int8_t px, py;
+    zigzag(index, px, py);
+    set_z(px, py, z);
+  }
 
-    static int8_t cell_index_x(const float &x) {
-      int8_t cx = (x - (MESH_MIN_X)) * (1.0 / (MESH_X_DIST));
-      return constrain(cx, 0, (GRID_MAX_POINTS_X) - 2);
-    }
+  static int8_t cell_index_x(const float &x) {
+    int8_t cx = (x - (MESH_MIN_X)) * (1.0 / (MESH_X_DIST));
+    return constrain(cx, 0, (GRID_MAX_POINTS_X) - 2);
+  }
 
-    static int8_t cell_index_y(const float &y) {
-      int8_t cy = (y - (MESH_MIN_Y)) * (1.0 / (MESH_Y_DIST));
-      return constrain(cy, 0, (GRID_MAX_POINTS_Y) - 2);
-    }
+  static int8_t cell_index_y(const float &y) {
+    int8_t cy = (y - (MESH_MIN_Y)) * (1.0 / (MESH_Y_DIST));
+    return constrain(cy, 0, (GRID_MAX_POINTS_Y) - 2);
+  }
 
-    static int8_t probe_index_x(const float &x) {
-      int8_t px = (x - (MESH_MIN_X) + 0.5 * (MESH_X_DIST)) * (1.0 / (MESH_X_DIST));
-      return WITHIN(px, 0, GRID_MAX_POINTS_X - 1) ? px : -1;
-    }
+  static int8_t probe_index_x(const float &x) {
+    int8_t px = (x - (MESH_MIN_X) + 0.5 * (MESH_X_DIST)) * (1.0 / (MESH_X_DIST));
+    return WITHIN(px, 0, GRID_MAX_POINTS_X - 1) ? px : -1;
+  }
 
-    static int8_t probe_index_y(const float &y) {
-      int8_t py = (y - (MESH_MIN_Y) + 0.5 * (MESH_Y_DIST)) * (1.0 / (MESH_Y_DIST));
-      return WITHIN(py, 0, GRID_MAX_POINTS_Y - 1) ? py : -1;
-    }
+  static int8_t probe_index_y(const float &y) {
+    int8_t py = (y - (MESH_MIN_Y) + 0.5 * (MESH_Y_DIST)) * (1.0 / (MESH_Y_DIST));
+    return WITHIN(py, 0, GRID_MAX_POINTS_Y - 1) ? py : -1;
+  }
 
-    static float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
-      const float delta_z = (z2 - z1) / (a2 - a1),
-                  delta_a = a0 - a1;
-      return z1 + delta_a * delta_z;
-    }
+  static float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
+    const float delta_z = (z2 - z1) / (a2 - a1),
+                delta_a = a0 - a1;
+    return z1 + delta_a * delta_z;
+  }
 
-    static float get_z(const float &x0, const float &y0
+  static float get_z(const float &x0, const float &y0
+    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+      , const float &factor
+    #endif
+  ) {
+    const int8_t cx = cell_index_x(x0), cy = cell_index_y(y0);
+    const float z1 = calc_z0(x0, index_to_xpos[cx], z_values[cx][cy], index_to_xpos[cx + 1], z_values[cx + 1][cy]),
+                z2 = calc_z0(x0, index_to_xpos[cx], z_values[cx][cy + 1], index_to_xpos[cx + 1], z_values[cx + 1][cy + 1]),
+                z0 = calc_z0(y0, index_to_ypos[cy], z1, index_to_ypos[cy + 1], z2);
+
+    return z_offset + z0
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-        , const float &factor
+        * factor
       #endif
-    ) {
-      const int8_t cx = cell_index_x(x0), cy = cell_index_y(y0);
-      const float z1 = calc_z0(x0, index_to_xpos[cx], z_values[cx][cy], index_to_xpos[cx + 1], z_values[cx + 1][cy]),
-                  z2 = calc_z0(x0, index_to_xpos[cx], z_values[cx][cy + 1], index_to_xpos[cx + 1], z_values[cx + 1][cy + 1]),
-                  z0 = calc_z0(y0, index_to_ypos[cy], z1, index_to_ypos[cy + 1], z2);
+    ;
+  }
+};
 
-      return z_offset + z0
-        #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-          * factor
-        #endif
-      ;
-    }
-  };
+extern mesh_bed_leveling mbl;
 
-  extern mesh_bed_leveling mbl;
-
-#endif // MESH_BED_LEVELING
+#endif // _MESH_BED_LEVELING_H_

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -39,7 +39,6 @@ enum MeshLevelingState {
 
 class mesh_bed_leveling {
 public:
-  static bool has_mesh;
   static float z_offset,
                z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y],
                index_to_xpos[GRID_MAX_POINTS_X],
@@ -47,7 +46,10 @@ public:
 
   mesh_bed_leveling();
 
+  static void report_mesh();
+
   static void reset();
+
 
   static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
 


### PR DESCRIPTION
[Concise Diff](9088/files?w=1)

- Properly implement C++ header wrapping for `mesh_bed_leveling.h`.
- Move MBL global functions to static methods.
- Replace obsolete `has_mesh` flag with a `has_mesh` method.

  