### PR TITLE
[1.1.x] UBL Mesh Storage Message

### DIFF
--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -340,14 +340,11 @@
 #ifndef MSG_UBL_SAVE_MESH
   #define MSG_UBL_SAVE_MESH                   _UxGT("Save Bed Mesh")
 #endif
-#ifndef MSG_MESH
-  #define MSG_MESH                            _UxGT("Mesh ")
+#ifndef MSG_MESH_LOADED
+  #define MSG_MESH_LOADED                     _UxGT("Mesh %i loaded")
 #endif
-#ifndef MSG_LOADED
-  #define MSG_LOADED                          _UxGT(" loaded")
-#endif
-#ifndef MSG_SAVED
-  #define MSG_SAVED                           _UxGT(" saved")
+#ifndef MSG_MESH_SAVED
+  #define MSG_MESH_SAVED                      _UxGT("Mesh %i saved")
 #endif
 #ifndef MSG_NO_STORAGE
   #define MSG_NO_STORAGE                      _UxGT("No storage")

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -340,11 +340,14 @@
 #ifndef MSG_UBL_SAVE_MESH
   #define MSG_UBL_SAVE_MESH                   _UxGT("Save Bed Mesh")
 #endif
-#ifndef MSG_MESH_LOADED
-  #define MSG_MESH_LOADED                     _UxGT("Mesh %i loaded")
+#ifndef MSG_MESH
+  #define MSG_MESH                            _UxGT("Mesh ")
 #endif
-#ifndef MSG_MESH_SAVED
-  #define MSG_MESH_SAVED                      _UxGT("Mesh %i saved")
+#ifndef MSG_LOADED
+  #define MSG_LOADED                          _UxGT(" loaded")
+#endif
+#ifndef MSG_SAVED
+  #define MSG_SAVED                           _UxGT(" saved")
 #endif
 #ifndef MSG_NO_STORAGE
   #define MSG_NO_STORAGE                      _UxGT("No storage")

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2273,10 +2273,10 @@ void kill_screen(const char* lcd_msg) {
      * UBL Load Mesh Command
      */
     void _lcd_ubl_load_mesh_cmd() {
-      char UBL_LCD_GCODE[20];
+      char UBL_LCD_GCODE[25];
       sprintf_P(UBL_LCD_GCODE, PSTR("G29 L%i"), ubl_storage_slot);
       lcd_enqueue_command(UBL_LCD_GCODE);
-      sprintf_P(UBL_LCD_GCODE, PSTR("M117 " MSG_MESH "%i" MSG_LOADED "."), ubl_storage_slot);
+      sprintf_P(UBL_LCD_GCODE, PSTR("M117 " MSG_MESH_LOADED), ubl_storage_slot);
       lcd_enqueue_command(UBL_LCD_GCODE);
     }
 
@@ -2284,10 +2284,10 @@ void kill_screen(const char* lcd_msg) {
      * UBL Save Mesh Command
      */
     void _lcd_ubl_save_mesh_cmd() {
-      char UBL_LCD_GCODE[20];
+      char UBL_LCD_GCODE[25];
       sprintf_P(UBL_LCD_GCODE, PSTR("G29 S%i"), ubl_storage_slot);
       lcd_enqueue_command(UBL_LCD_GCODE);
-      sprintf_P(UBL_LCD_GCODE, PSTR("M117 " MSG_MESH "%i" MSG_SAVED "."), ubl_storage_slot);
+      sprintf_P(UBL_LCD_GCODE, PSTR("M117 " MSG_MESH_SAVED), ubl_storage_slot);
       lcd_enqueue_command(UBL_LCD_GCODE);
     }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -2273,20 +2273,22 @@ void kill_screen(const char* lcd_msg) {
      * UBL Load Mesh Command
      */
     void _lcd_ubl_load_mesh_cmd() {
-      char UBL_LCD_GCODE[10];
+      char UBL_LCD_GCODE[20];
       sprintf_P(UBL_LCD_GCODE, PSTR("G29 L%i"), ubl_storage_slot);
       lcd_enqueue_command(UBL_LCD_GCODE);
-      enqueue_and_echo_commands_P(PSTR("M117 " MSG_MESH_LOADED "."));
+      sprintf_P(UBL_LCD_GCODE, PSTR("M117 " MSG_MESH "%i" MSG_LOADED "."), ubl_storage_slot);
+      lcd_enqueue_command(UBL_LCD_GCODE);
     }
 
     /**
      * UBL Save Mesh Command
      */
     void _lcd_ubl_save_mesh_cmd() {
-      char UBL_LCD_GCODE[10];
+      char UBL_LCD_GCODE[20];
       sprintf_P(UBL_LCD_GCODE, PSTR("G29 S%i"), ubl_storage_slot);
       lcd_enqueue_command(UBL_LCD_GCODE);
-      enqueue_and_echo_commands_P(PSTR("M117 " MSG_MESH_SAVED "."));
+      sprintf_P(UBL_LCD_GCODE, PSTR("M117 " MSG_MESH "%i" MSG_SAVED "."), ubl_storage_slot);
+      lcd_enqueue_command(UBL_LCD_GCODE);
     }
 
     /**


### PR DESCRIPTION
This got broken somewhere along the line...
The M117 message was displaying:
`Mesh %i loaded` or `Mesh %i saved`

This corrects this to display the storage slot used.