### PR TITLE
updated to new SdFat Lib

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1332,6 +1332,16 @@
 //#define SDSUPPORT
 
 /**
+ *  Use the new SdFat library from the Arduino repository
+ *  SdFat library must be added if enabled (https://github.com/greiman/SdFat)
+ *  Also speed can be increased if ENABLE_EXTENDED_TRANSFER_CLASS is set 
+ *  in SdFatConfig.h (in SdFat library)
+ *  *** Beta, use with caution *** 
+ *   
+ */ 
+//#define USE_NEW_SD_FAT_LIB
+
+/**
  * SD CARD: SPI SPEED
  *
  * Enable one of the following items for a slower SPI transfer speed.

--- a/Marlin/MarlinConfig.h
+++ b/Marlin/MarlinConfig.h
@@ -23,6 +23,7 @@
 #ifndef MARLIN_CONFIG_H
 #define MARLIN_CONFIG_H
 
+#include <Arduino.h>
 #include "fastio.h"
 #include "macros.h"
 #include "boards.h"

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -29,7 +29,24 @@
 
 #define MAX_DIR_DEPTH 10          // Maximum folder depth
 
+#ifdef USE_NEW_SD_FAT_LIB
+
+#define ENABLE_ARDUINO_FEATURES 1
+/** Number of UTF-16 characters per entry */
+#define FILENAME_LENGTH 13
+/**
+* Defines for long (vfat) filenames
+*/
+/** Number of VFAT entries used. Every entry has 13 UTF-16 characters */
+#define MAX_VFAT_ENTRIES (2)
+/** Total size of the buffer used to store the long filenames */
+#define LONG_FILENAME_LENGTH (FILENAME_LENGTH*MAX_VFAT_ENTRIES+1)
+
+#include <SdFat.h>
+#else
 #include "SdFile.h"
+#endif
+
 #include "types.h"
 #include "enum.h"
 
@@ -88,7 +105,12 @@ public:
   FORCE_INLINE int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
   FORCE_INLINE void setIndex(long index) { sdpos = index; file.seekSet(index); }
   FORCE_INLINE uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
-  FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
+
+  #ifdef USE_NEW_SD_FAT_LIB
+    FORCE_INLINE char* getWorkDirName() { workDir.getSFN(filename); return filename; }
+  #else
+    FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
+  #endif
 
 public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir;
@@ -148,8 +170,23 @@ private:
 
   #endif // SDCARD_SORT_ALPHA
 
-  Sd2Card card;
-  SdVolume volume;
+  #ifdef USE_NEW_SD_FAT_LIB
+
+    /* if ENABLE_EXTENDED_TRANSFER_CLASS is enabled SdFatEX will be used.
+    * This class uses extended multi-block SD I/O for better performance.
+    * the SPI bus may not be shared with other devices in this mode.
+    */
+    #if ENABLE_EXTENDED_TRANSFER_CLASS
+      SdFatEX volume;
+    #else
+      SdFat volume;
+    #endif
+    
+    #else
+      Sd2Card card;
+      SdVolume volume;
+  #endif
+
   SdFile file;
 
   #define SD_PROCEDURE_DEPTH 1

--- a/Marlin/fastio_1280.h
+++ b/Marlin/fastio_1280.h
@@ -41,10 +41,10 @@
 #define TXD         DIO1
 
 // SPI
-#define SCK         DIO52
-#define MISO        DIO50
-#define MOSI        DIO51
-#define SS          DIO53
+#define PIN_SCK     DIO52
+#define PIN_MISO    DIO50
+#define PIN_MOSI    DIO51
+#define PIN_SS      DIO53
 
 // TWI (I2C)
 #define SCL         DIO21

--- a/Marlin/fastio_1281.h
+++ b/Marlin/fastio_1281.h
@@ -41,10 +41,10 @@
 #define TXD         DIO1
 
 // SPI
-#define SCK         DIO10
-#define MISO        DIO12
-#define MOSI        DIO11
-#define SS          DIO16
+#define PIN_SCK     DIO10
+#define PIN_MISO    DIO12
+#define PIN_MOSI    DIO11
+#define PIN_SS      DIO16
 
 // TWI (I2C)
 #define SCL         DIO17

--- a/Marlin/fastio_168.h
+++ b/Marlin/fastio_168.h
@@ -40,10 +40,10 @@
 #define TXD         DIO1
 
 // SPI
-#define SCK         DIO13
-#define MISO        DIO12
-#define MOSI        DIO11
-#define SS          DIO10
+#define PIN_SCK     DIO13
+#define PIN_MISO    DIO12
+#define PIN_MOSI    DIO11
+#define PIN_SS      DIO10
 
 // TWI (I2C)
 #define SCL         AIO5

--- a/Marlin/fastio_644.h
+++ b/Marlin/fastio_644.h
@@ -45,10 +45,10 @@
 #define TXD1        DIO11
 
 // SPI
-#define SCK         DIO7
-#define MISO        DIO6
-#define MOSI        DIO5
-#define SS          DIO4
+#define PIN_SCK     DIO7
+#define PIN_MISO    DIO6
+#define PIN_MOSI    DIO5
+#define PIN_SS      DIO4
 
 // TWI (I2C)
 #define SCL         DIO16

--- a/Marlin/fastio_AT90USB.h
+++ b/Marlin/fastio_AT90USB.h
@@ -38,10 +38,10 @@
 #define DEBUG_LED   DIO31 /* led D5 red */
 
 // SPI
-#define SCK         DIO21  //  9
-#define MISO        DIO23  // 11
-#define MOSI        DIO22  // 10
-#define SS          DIO20  //  8
+#define PIN_SCK     DIO21  //  9
+#define PIN_MISO    DIO23  // 11
+#define PIN_MOSI    DIO22  // 10
+#define PIN_SS      DIO20  //  8
 
 // Digital I/O
 


### PR DESCRIPTION
Updated the code to use the SdFat library from the Arduino repository. 
If  USE_NEW_SD_FAT_LIB is not defined then the old library is used.

Had to include "Arduino.h" in MarlinConfig.h to compile it and had to rename some pins from FastIO which where conflicting with Arduino names. Any idea on a more elegant solution?

On Trigorilla board using the new library and the bench test form examples I got ~600k/s speed, so the hardware has some raw speed there... :)   {also SdFatEX was enabled, the ENABLE_EXTENDED_TRANSFER_CLASS set to 1} 
  