### PR TITLE
fix fwretract structure reference #9102

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6633,7 +6633,7 @@ inline void gcode_M17() {
     #if ENABLED(FWRETRACT)
       // If retracted before goto pause
       if (fwretract.retracted[active_extruder])
-        do_pause_e_move(-retract_length, fwretract.retract_feedrate_mm_s);
+        do_pause_e_move(-fwretract.retract_length, fwretract.retract_feedrate_mm_s);
     #else
       // If resume_position negative
       if (resume_position[E_AXIS] < 0) do_pause_e_move(resume_position[E_AXIS], PAUSE_PARK_RETRACT_FEEDRATE);


### PR DESCRIPTION
Followup to #9054

```
Marlin_main.cpp: In function 'void resume_print(const float&, const float&, int8_t)':
Marlin_main.cpp:6646: error: 'retract_length' was not declared in this scope
         do_pause_e_move(-retract_length, fwretract.retract_feedrate_mm_s);
                          ^
```