### PR TITLE
[1.1.x] Update to new SdFat Lib

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1332,6 +1332,16 @@
 //#define SDSUPPORT
 
 /**
+ *  Use the new SdFat library from the Arduino repository
+ *  SdFat library must be added if enabled (https://github.com/greiman/SdFat)
+ *  Also speed can be increased if ENABLE_EXTENDED_TRANSFER_CLASS is set 
+ *  in SdFatConfig.h (in SdFat library)
+ *  *** Beta, use with caution *** 
+ *   
+ */ 
+//#define USE_NEW_SD_FAT_LIB
+
+/**
  * SD CARD: SPI SPEED
  *
  * Enable one of the following items for a slower SPI transfer speed.

--- a/Marlin/Sd2Card.cpp
+++ b/Marlin/Sd2Card.cpp
@@ -28,7 +28,7 @@
  */
 #include "MarlinConfig.h"
 
-#if ENABLED(SDSUPPORT)
+#if ENABLED(SDSUPPORT) && DISABLED(USE_NEW_SD_FAT_LIB)
 
 #include "Sd2Card.h"
 

--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -29,7 +29,7 @@
 
 #include "MarlinConfig.h"
 
-#if ENABLED(SDSUPPORT)
+#if ENABLED(SDSUPPORT) && DISABLED(USE_NEW_SD_FAT_LIB)
 
 #include "SdBaseFile.h"
 #include "Marlin.h"

--- a/Marlin/SdFile.cpp
+++ b/Marlin/SdFile.cpp
@@ -28,7 +28,7 @@
  */
 #include "MarlinConfig.h"
 
-#if ENABLED(SDSUPPORT)
+#if ENABLED(SDSUPPORT) && DISABLED(USE_NEW_SD_FAT_LIB)
 
 #include "SdFile.h"
 

--- a/Marlin/SdVolume.cpp
+++ b/Marlin/SdVolume.cpp
@@ -28,7 +28,7 @@
  */
 #include "MarlinConfig.h"
 
-#if ENABLED(SDSUPPORT)
+#if ENABLED(SDSUPPORT) && DISABLED(USE_NEW_SD_FAT_LIB)
 
 #include "SdVolume.h"
 


### PR DESCRIPTION
Updated the code to use the SdFat library from the Arduino repository.
If `USE_NEW_SD_FAT_LIB` is not defined then the old library is used.

Had to include "Arduino.h" in `MarlinConfig.h` to compile it and had to rename some pins from FastIO which where conflicting with Arduino names. Any idea on a more elegant solution?

On Trigorilla board using the new library and the bench test form examples I got ~600k/s speed, so the hardware has some raw speed there... :) {also `SdFatEX` was enabled, the `ENABLE_EXTENDED_TRANSFER_CLASS` set to 1 in `SdFatConfig.h` in SdFat library}
  