### PR TITLE
[2.0.x]DUE: Fix includes for SDSUPPORT

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
@@ -48,8 +48,7 @@
 #define _CONF_ACCESS_H_
 
 #include "compiler.h"
-#include "../../../core/macros.h"
-#include "../../../../Configuration.h"
+#include "../../../inc/MarlinConfigPre.h"
 
 /*! \name Activation of Logical Unit Numbers
  */

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_access.h
@@ -48,7 +48,8 @@
 #define _CONF_ACCESS_H_
 
 #include "compiler.h"
-
+#include "../../../core/macros.h"
+#include "../../../../Configuration.h"
 
 /*! \name Activation of Logical Unit Numbers
  */

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -2,9 +2,10 @@
  * Interface from Atmel USB MSD to Marlin SD card
  */
 
+#include "../../../inc/MarlinConfig.h"
+
 #if defined(ARDUINO_ARCH_SAM) && defined(SDSUPPORT)
 
-#include "../../../inc/MarlinConfig.h"
 #include "../../../sd/cardreader.h"
 extern "C" {
 #include "sd_mmc_spi_mem.h"

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -2,9 +2,11 @@
  * Interface from Atmel USB MSD to Marlin SD card
  */
 
+#ifdef ARDUINO_ARCH_SAM
+
 #include "../../../inc/MarlinConfig.h"
 
-#if defined(ARDUINO_ARCH_SAM) && defined(SDSUPPORT)
+#if ENABLED(SDSUPPORT)
 
 #include "../../../sd/cardreader.h"
 extern "C" {
@@ -13,37 +15,31 @@ extern "C" {
 
 #define SD_MMC_BLOCK_SIZE 512
 
-void sd_mmc_spi_mem_init(void)
-{
+void sd_mmc_spi_mem_init(void) {
 }
 
-Ctrl_status sd_mmc_spi_test_unit_ready(void)
-{
+Ctrl_status sd_mmc_spi_test_unit_ready(void) {
   if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
     return CTRL_NO_PRESENT;
   return CTRL_GOOD;
 }
 
-Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector)
-{
+Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector) {
   if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
     return CTRL_NO_PRESENT;
   *nb_sector = card.getSd2Card().cardSize();
   return CTRL_GOOD;
 }
 
-bool sd_mmc_spi_unload(bool unload)
-{
+bool sd_mmc_spi_unload(bool unload) {
   return true;
 }
 
-bool sd_mmc_spi_wr_protect(void)
-{
+bool sd_mmc_spi_wr_protect(void) {
   return false;
 }
 
-bool sd_mmc_spi_removal(void)
-{
+bool sd_mmc_spi_removal(void) {
   if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
     return true;
   return false;
@@ -62,16 +58,15 @@ uint8_t sector_buf[SD_MMC_BLOCK_SIZE];
 
 // #define DEBUG_MMC
 
-Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector)
-{
+Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
   if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
     return CTRL_NO_PRESENT;
 
-#ifdef DEBUG_MMC
-  char buffer[80];
-  sprintf(buffer, "SDRD: %d @ 0x%08x\n", nb_sector, addr);
-  MYSERIAL.print(buffer);
-#endif
+  #ifdef DEBUG_MMC
+    char buffer[80];
+    sprintf(buffer, "SDRD: %d @ 0x%08x\n", nb_sector, addr);
+    MYSERIAL.print(buffer);
+  #endif
 
   // Start reading
   if (!card.getSd2Card().readStart(addr))
@@ -97,16 +92,15 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector)
   return CTRL_GOOD;
 }
 
-Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector)
-{
+Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
   if (!IS_SD_INSERTED || IS_SD_PRINTING || IS_SD_FILE_OPEN || !card.cardOK)
     return CTRL_NO_PRESENT;
 
-#ifdef DEBUG_MMC
-  char buffer[80];
-  sprintf(buffer, "SDWR: %d @ 0x%08x\n", nb_sector, addr);
-  MYSERIAL.print(buffer);
-#endif
+  #ifdef DEBUG_MMC
+    char buffer[80];
+    sprintf(buffer, "SDWR: %d @ 0x%08x\n", nb_sector, addr);
+    MYSERIAL.print(buffer);
+  #endif
 
   if (!card.getSd2Card().writeStart(addr, nb_sector))
     return CTRL_FAIL;
@@ -133,4 +127,5 @@ Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector)
 
 #endif // ACCESS_USB == true
 
-#endif
+#endif // SDSUPPORT
+#endif // ARDUINO_ARCH_SAM


### PR DESCRIPTION
Fixes communication where the host couldn't connect to a Due based boards (tested on Archim2 and Arduino Due board).
This is not a complete fix however as you still need to define SDSUPPORT for communication to work.

Last known good commit is https://github.com/MarlinFirmware/Marlin/commit/0b4a46fa6c889d5048a78ea5f35c0432a02a298e

Likely related: https://github.com/MarlinFirmware/Marlin/commit/5294fd132f5f3696cd187ae4c039092663981514 and https://github.com/MarlinFirmware/Marlin/commit/448b0a001493e26ab278d12ba86c6885c697ad75

@thinkyhead @Bob-the-Kuhn @ejtagle 
 
Edit: Clarification that the issues occur with USB Native port