### PR TITLE
[2.0.x]TMC followup

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -1149,6 +1149,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -985,7 +985,7 @@
 
 #endif
 
-// @section TMC2130
+// @section TMC2130, TMC2208
 
 /**
  * Enable this for SilentStepStick Trinamic TMC2130 SPI-configurable stepper drivers.
@@ -999,7 +999,19 @@
  */
 //#define HAVE_TMC2130
 
-#if ENABLED(HAVE_TMC2130)
+/**
+ * Enable this for SilentStepStick Trinamic TMC2208 UART-configurable stepper drivers.
+ * Connect #_SERIAL_TX_PIN to the driver side PDN_UART pin.
+ * To use the reading capabilities, also connect #_SERIAL_RX_PIN
+ * to #_SERIAL_TX_PIN with a 1K resistor.
+ * The drivers can also be used with hardware serial.
+ *
+ * You'll also need the TMC2208Stepper Arduino library
+ * (https://github.com/teemuatlut/TMC2208Stepper).
+ */
+//#define HAVE_TMC2208
+
+#if ENABLED(HAVE_TMC2130) || ENABLED(HAVE_TMC2208)
 
   // CHOOSE YOUR MOTORS HERE, THIS IS MANDATORY
   //#define X_IS_TMC2130
@@ -1014,46 +1026,58 @@
   //#define E3_IS_TMC2130
   //#define E4_IS_TMC2130
 
+  //#define X_IS_TMC2208
+  //#define X2_IS_TMC2208
+  //#define Y_IS_TMC2208
+  //#define Y2_IS_TMC2208
+  //#define Z_IS_TMC2208
+  //#define Z2_IS_TMC2208
+  //#define E0_IS_TMC2208
+  //#define E1_IS_TMC2208
+  //#define E2_IS_TMC2208
+  //#define E3_IS_TMC2208
+  //#define E4_IS_TMC2208
+
   /**
    * Stepper driver settings
    */
 
   #define R_SENSE           0.11  // R_sense resistor for SilentStepStick2130
   #define HOLD_MULTIPLIER    0.5  // Scales down the holding current from run current
-  #define INTERPOLATE          1  // Interpolate X/Y/Z_MICROSTEPS to 256
+  #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
 
-  #define X_CURRENT         1000  // rms current in mA. Multiply by 1.41 for peak current.
+  #define X_CURRENT          800  // rms current in mA. Multiply by 1.41 for peak current.
   #define X_MICROSTEPS        16  // 0..256
 
-  #define Y_CURRENT         1000
+  #define Y_CURRENT          800
   #define Y_MICROSTEPS        16
 
-  #define Z_CURRENT         1000
+  #define Z_CURRENT          800
   #define Z_MICROSTEPS        16
 
-  //#define X2_CURRENT      1000
-  //#define X2_MICROSTEPS     16
+  #define X2_CURRENT         800
+  #define X2_MICROSTEPS       16
 
-  //#define Y2_CURRENT      1000
-  //#define Y2_MICROSTEPS     16
+  #define Y2_CURRENT         800
+  #define Y2_MICROSTEPS       16
 
-  //#define Z2_CURRENT      1000
-  //#define Z2_MICROSTEPS     16
+  #define Z2_CURRENT         800
+  #define Z2_MICROSTEPS       16
 
-  //#define E0_CURRENT      1000
-  //#define E0_MICROSTEPS     16
+  #define E0_CURRENT         800
+  #define E0_MICROSTEPS       16
 
-  //#define E1_CURRENT      1000
-  //#define E1_MICROSTEPS     16
+  #define E1_CURRENT         800
+  #define E1_MICROSTEPS       16
 
-  //#define E2_CURRENT      1000
-  //#define E2_MICROSTEPS     16
+  #define E2_CURRENT         800
+  #define E2_MICROSTEPS       16
 
-  //#define E3_CURRENT      1000
-  //#define E3_MICROSTEPS     16
+  #define E3_CURRENT         800
+  #define E3_MICROSTEPS       16
 
-  //#define E4_CURRENT      1000
-  //#define E4_MICROSTEPS     16
+  #define E4_CURRENT         800
+  #define E4_MICROSTEPS       16
 
   /**
    * Use Trinamic's ultra quiet stepping mode.
@@ -1062,24 +1086,22 @@
   #define STEALTHCHOP
 
   /**
-   * Let Marlin automatically control stepper current.
-   * This is still an experimental feature.
-   * Increase current every 5s by CURRENT_STEP until stepper temperature prewarn gets triggered,
-   * then decrease current by CURRENT_STEP until temperature prewarn is cleared.
-   * Adjusting starts from X/Y/Z/E_CURRENT but will not increase over AUTO_ADJUST_MAX
+   * Monitor Trinamic TMC2130 and TMC2208 drivers for error conditions,
+   * like overtemperature and short to ground. TMC2208 requires hardware serial.
+   * In the case of overtemperature Marlin can decrease the driver current until error condition clears.
+   * Other detected conditions can be used to stop the current print.
    * Relevant g-codes:
    * M906 - Set or get motor current in milliamps using axis codes X, Y, Z, E. Report values if no axis codes given.
-   * M906 S1 - Start adjusting current
-   * M906 S0 - Stop adjusting current
    * M911 - Report stepper driver overtemperature pre-warn condition.
    * M912 - Clear stepper driver overtemperature pre-warn condition flag.
+   * M122 S0/1 - Report driver parameters (Requires TMC_DEBUG)
    */
-  //#define AUTOMATIC_CURRENT_CONTROL
+  //#define MONITOR_DRIVER_STATUS
 
-  #if ENABLED(AUTOMATIC_CURRENT_CONTROL)
-    #define CURRENT_STEP          50  // [mA]
-    #define AUTO_ADJUST_MAX     1300  // [mA], 1300mA_rms = 1840mA_peak
+  #if ENABLED(MONITOR_DRIVER_STATUS)
+    #define CURRENT_STEP_DOWN     50  // [mA]
     #define REPORT_CURRENT_CHANGE
+    #define STOP_ON_ERROR
   #endif
 
   /**
@@ -1094,8 +1116,8 @@
   #define X2_HYBRID_THRESHOLD    100
   #define Y_HYBRID_THRESHOLD     100
   #define Y2_HYBRID_THRESHOLD    100
-  #define Z_HYBRID_THRESHOLD       4
-  #define Z2_HYBRID_THRESHOLD      4
+  #define Z_HYBRID_THRESHOLD       3
+  #define Z2_HYBRID_THRESHOLD      3
   #define E0_HYBRID_THRESHOLD     30
   #define E1_HYBRID_THRESHOLD     30
   #define E2_HYBRID_THRESHOLD     30
@@ -1105,7 +1127,7 @@
   /**
    * Use stallGuard2 to sense an obstacle and trigger an endstop.
    * You need to place a wire from the driver's DIAG1 pin to the X/Y endstop pin.
-   * If used along with STEALTHCHOP, the movement will be louder when homing. This is normal.
+   * X and Y homing will always be done in spreadCycle mode.
    *
    * X/Y_HOMING_SENSITIVITY is used for tuning the trigger sensitivity.
    * Higher values make the system LESS sensitive.
@@ -1114,27 +1136,48 @@
    * It is advised to set X/Y_HOME_BUMP_MM to 0.
    * M914 X/Y to live tune the setting
    */
-  //#define SENSORLESS_HOMING
+  //#define SENSORLESS_HOMING // TMC2130 only
 
   #if ENABLED(SENSORLESS_HOMING)
-    #define X_HOMING_SENSITIVITY  19
-    #define Y_HOMING_SENSITIVITY  19
+    #define X_HOMING_SENSITIVITY  8
+    #define Y_HOMING_SENSITIVITY  8
+  #endif
+
+  /**
+   * Enable M122 debugging command for TMC stepper drivers.
+   * M122 S0/1 will enable continous reporting.
+   */
+  //#define TMC_DEBUG
+
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
   #endif
 
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page
    * https://github.com/teemuatlut/TMC2130Stepper
+   * https://github.com/teemuatlut/TMC2208Stepper
    *
    * Example:
-   * #define TMC2130_ADV() { \
+   * #define TMC_ADV() { \
    *   stepperX.diag0_temp_prewarn(1); \
-   *   stepperX.interpolate(0); \
+   *   stepperY.interpolate(0); \
    * }
    */
-  #define  TMC2130_ADV() {  }
+  #define  TMC_ADV() {  }
 
-#endif // HAVE_TMC2130
+#endif // TMC2130 || TMC2208
 
 // @section L6470
 

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1149,6 +1149,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1156,6 +1156,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1137,6 +1137,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1159,6 +1159,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1150,6 +1150,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1150,6 +1150,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1150,6 +1150,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1150,6 +1150,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1150,6 +1150,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -1155,6 +1155,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1150,6 +1150,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1148,6 +1148,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1149,6 +1149,20 @@
    */
   //#define TMC_DEBUG
 
+  /*
+   * Enable M915 Z axis calibration.
+   * Marlin will first adjust Z stepper current and then drive
+   * the Z axis to its' physical maximum. Finally it will home
+   * the Z axis to account for the lost steps. Use
+   * M915 S### to specify the current and
+   * M925 Z## to specify the extra Z height that's added to Z_MAX_POS.
+   */
+  //#define TMC_Z_CALIBRATION
+  #if ENABLED(TMC_Z_CALIBRATION)
+    #define CALIBRATION_CURRENT 250
+    #define CALIBRATION_EXTRA_HEIGHT 10
+  #endif
+
   /**
    * You can set your own advanced settings by filling in predefined functions.
    * A list of available functions can be found on the library github page

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -35,56 +35,6 @@
 bool report_tmc_status = false;
 char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1", "E2", "E3", "E4" };
 
-template<typename TMC>
-void tmc_get_current(TMC &st, const char name[]) {
-  SERIAL_ECHO(name);
-  SERIAL_ECHOPGM(" axis driver current: ");
-  SERIAL_ECHOLN(st.getCurrent());
-}
-template<typename TMC>
-void tmc_set_current(TMC &st, const char name[], const int mA) {
-  st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
-  tmc_get_current(st, name);
-}
-
-template<typename TMC>
-void tmc_report_otpw(TMC &st, const char name[]) {
-  SERIAL_ECHO(name);
-  SERIAL_ECHOPGM(" axis temperature prewarn triggered: ");
-  serialprintPGM(st.getOTPW() ? PSTR("true") : PSTR("false"));
-  SERIAL_EOL();
-}
-template<typename TMC>
-void tmc_clear_otpw(TMC &st, const char name[]) {
-  st.clear_otpw();
-  SERIAL_ECHO(name);
-  SERIAL_ECHOLNPGM(" prewarn flag cleared");
-}
-
-template<typename TMC>
-void tmc_get_pwmthrs(TMC &st, const char name[], const uint16_t spmm) {
-  SERIAL_ECHO(name);
-  SERIAL_ECHOPGM(" stealthChop max speed set to ");
-  SERIAL_ECHOLN(12650000UL * st.microsteps() / (256 * st.TPWMTHRS() * spmm));
-}
-template<typename TMC>
-void tmc_set_pwmthrs(TMC &st, const char name[], const int32_t thrs, const uint32_t spmm) {
-  st.TPWMTHRS(12650000UL * st.microsteps() / (256 * thrs * spmm));
-  tmc_get_pwmthrs(st, name, spmm);
-}
-
-template<typename TMC>
-void tmc_get_sgt(TMC &st, const char name[]) {
-  SERIAL_ECHO(name);
-  SERIAL_ECHOPGM(" driver homing sensitivity set to ");
-  MYSERIAL.println(st.sgt(), DEC);
-}
-template<typename TMC>
-void tmc_set_sgt(TMC &st, const char name[], const int8_t sgt_val) {
-  st.sgt(sgt_val);
-  tmc_get_sgt(st, name);
-}
-
 /*
  * Check for over temperature or short to ground error flags.
  * Report and log warning of overtemperature condition.

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -29,27 +29,58 @@
 
 extern bool report_tmc_status;
 extern char extended_axis_codes[11][3];
+
 enum TMC_AxisEnum {
   TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2,
   TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4
 };
 
 template<typename TMC>
-void tmc_get_current(TMC &st, const char name[]);
+void tmc_get_current(TMC &st, const char name[]) {
+  SERIAL_ECHO(name);
+  SERIAL_ECHOPGM(" axis driver current: ");
+  SERIAL_ECHOLN(st.getCurrent());
+}
 template<typename TMC>
-void tmc_set_current(TMC &st, const char name[], const int mA);
+void tmc_set_current(TMC &st, const char name[], const int mA) {
+  st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
+  tmc_get_current(st, name);
+}
 template<typename TMC>
-void tmc_report_otpw(TMC &st, const char name[]);
+void tmc_report_otpw(TMC &st, const char name[]) {
+  SERIAL_ECHO(name);
+  SERIAL_ECHOPGM(" axis temperature prewarn triggered: ");
+  serialprintPGM(st.getOTPW() ? PSTR("true") : PSTR("false"));
+  SERIAL_EOL();
+}
 template<typename TMC>
-void tmc_clear_otpw(TMC &st, const char name[]);
+void tmc_clear_otpw(TMC &st, const char name[]) {
+  st.clear_otpw();
+  SERIAL_ECHO(name);
+  SERIAL_ECHOLNPGM(" prewarn flag cleared");
+}
 template<typename TMC>
-void tmc_get_pwmthrs(TMC &st, const char name[], const uint16_t spmm);
+void tmc_get_pwmthrs(TMC &st, const char name[], const uint16_t spmm) {
+  SERIAL_ECHO(name);
+  SERIAL_ECHOPGM(" stealthChop max speed set to ");
+  SERIAL_ECHOLN(12650000UL * st.microsteps() / (256 * st.TPWMTHRS() * spmm));
+}
 template<typename TMC>
-void tmc_set_pwmthrs(TMC &st, const char name[], const int32_t thrs, const uint32_t spmm);
+void tmc_set_pwmthrs(TMC &st, const char name[], const int32_t thrs, const uint32_t spmm) {
+  st.TPWMTHRS(12650000UL * st.microsteps() / (256 * thrs * spmm));
+  tmc_get_pwmthrs(st, name, spmm);
+}
 template<typename TMC>
-void tmc_get_sgt(TMC &st, const char name[]);
+void tmc_get_sgt(TMC &st, const char name[]) {
+  SERIAL_ECHO(name);
+  SERIAL_ECHOPGM(" driver homing sensitivity set to ");
+  MYSERIAL.println(st.sgt(), DEC);
+}
 template<typename TMC>
-void tmc_set_sgt(TMC &st, const char name[], const int8_t sgt_val);
+void tmc_set_sgt(TMC &st, const char name[], const int8_t sgt_val) {
+  st.sgt(sgt_val);
+  tmc_get_sgt(st, name);
+}
 
 void _M122();
 void monitor_tmc_driver();

--- a/Marlin/src/gcode/feature/trinamic/M122.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M122.cpp
@@ -334,6 +334,6 @@ void _M122() {
 }
 
 // We need to call M122 from monitor_tmc_driver() as well but GcodeSuite::M122 is private.
-inline void GcodeSuite::M122() { _M122(); }
+void GcodeSuite::M122() { _M122(); }
 
 #endif // TMC_DEBUG

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -33,7 +33,7 @@
  * M906: Set motor current in milliamps using axis codes X, Y, Z, E
  * Report driver currents when no axis specified
  */
-inline void GcodeSuite::M906() {
+void GcodeSuite::M906() {
   uint16_t values[XYZE];
   LOOP_XYZE(i)
     values[i] = parser.intval(axis_codes[i]);

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -659,8 +659,10 @@ void GcodeSuite::process_parsed_command() {
         #endif
       #endif
 
-      #if HAVE_TRINAMIC
-        case 122: M122(); break;
+      #if HAS_TRINAMIC
+        #if ENABLED(TMC_DEBUG)
+          case 122: M122(); break;
+        #endif
         case 906: M906(); break;    // M906: Set motor current in milliamps using axis codes X, Y, Z, E
         case 911: M911(); break;    // M911: Report TMC2130 prewarn triggered flags
         case 912: M912(); break;    // M912: Clear TMC2130 prewarn triggered flags
@@ -669,6 +671,9 @@ void GcodeSuite::process_parsed_command() {
         #endif
         #if ENABLED(SENSORLESS_HOMING)
           case 914: M914(); break;  // M914: Set SENSORLESS_HOMING sensitivity.
+        #endif
+        #if ENABLED(TMC_Z_CALIBRATION)
+          case 915: M915(); break;  // M915: TMC Z axis calibration.
         #endif
       #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1491,6 +1491,12 @@ static_assert(1 >= 0
   #error "Enable STEALTHCHOP to use HYBRID_THRESHOLD."
 #endif
 
+#include "../feature/tmc_macros.h"
+
+#if ENABLED(TMC_Z_CALIBRATION) && !Z_IS_TRINAMIC && !Z2_IS_TRINAMIC
+  #error "TMC_Z_CALIBRATION requires at least one TMC driver on Z axis"
+#endif
+
 /**
  * Make sure HAVE_L6470DRIVER is warranted
  */


### PR DESCRIPTION
Small typo (HAVE/HAS) meant that the TMC related gcode commands didn't work but there was no compile errors. This fixes errors and commands go through.

Also updated configuration files for `M915`. Had stashed the file instead of committing.
I can add the option to 1.1.x as well if we're still doing updates. Technically it's a feature addition.

Templated functions had to be moved to header files because they are defined on compile time. This is a limitation of the compiler or C++ language.
