### PR TITLE
[1.1.x] More EEPROM field debugging, 2.0.x parity

### DIFF
--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V49"
+#define EEPROM_VERSION "V50"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -165,9 +165,6 @@ typedef struct SettingsDataStruct {
     float x_endstop_adj,                                // M666 X
           y_endstop_adj,                                // M666 Y
           z_endstop_adj;                                // M666 Z
-    float xyz_dual_reserved[8];
-  #else
-    float xyz_dual_placeholder[11];
   #endif
 
   //
@@ -300,11 +297,14 @@ void MarlinSettings::postprocess() {
 
   #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
     refresh_bed_level();
-    //set_bed_leveling_enabled(leveling_is_on);
   #endif
 
   #if HAS_MOTOR_CURRENT_PWM
     stepper.refresh_motor_power();
+  #endif
+
+  #if ENABLED(FWRETRACT)
+    fwretract.refresh_autoretract();
   #endif
 
   // Refresh steps_to_mm with the reciprocal of axis_steps_per_mm
@@ -525,7 +525,9 @@ void MarlinSettings::postprocess() {
 
     // 11 floats for DELTA / [XYZ]_DUAL_ENDSTOPS
     #if ENABLED(DELTA)
+
       _FIELD_TEST(delta_height);
+
       EEPROM_WRITE(delta_height);              // 1 float
       EEPROM_WRITE(delta_endstop_adj);         // 3 floats
       EEPROM_WRITE(delta_radius);              // 1 float
@@ -535,7 +537,9 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(delta_tower_angle_trim);    // 3 floats
 
     #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
+
       _FIELD_TEST(x_endstop_adj);
+
       // Write dual endstops in X, Y, Z order. Unused = 0.0
       dummy = 0.0f;
       #if ENABLED(X_DUAL_ENDSTOPS)
@@ -556,11 +560,6 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(dummy);
       #endif
 
-      for (uint8_t q = 8; q--;) EEPROM_WRITE(dummy);
-
-    #else
-      dummy = 0.0f;
-      for (uint8_t q = 11; q--;) EEPROM_WRITE(dummy);
     #endif
 
     _FIELD_TEST(lcd_preheat_hotend_temp);
@@ -599,6 +598,8 @@ void MarlinSettings::postprocess() {
         }
 
     } // Hotends Loop
+
+    _FIELD_TEST(lpq_len);
 
     #if DISABLED(PID_EXTRUSION_SCALING)
       int lpq_len = 20;
@@ -641,7 +642,9 @@ void MarlinSettings::postprocess() {
     //
     // Volumetric & Filament Size
     //
+
     _FIELD_TEST(parser_volumetric_enabled);
+
     #if DISABLED(NO_VOLUMETRICS)
 
       EEPROM_WRITE(parser.volumetric_enabled);
@@ -664,7 +667,9 @@ void MarlinSettings::postprocess() {
     //
     // Save TMC2130 or TMC2208 Configuration, and placeholder values
     //
+
     _FIELD_TEST(tmc_stepper_current);
+
     uint16_t currents[11] = {
       #if HAS_TRINAMIC
         #if X_IS_TRINAMIC
@@ -753,7 +758,9 @@ void MarlinSettings::postprocess() {
     //
     // Linear Advance
     //
+
     _FIELD_TEST(planner_extruder_advance_k);
+
     #if ENABLED(LIN_ADVANCE)
       EEPROM_WRITE(planner.extruder_advance_k);
       EEPROM_WRITE(planner.advance_ed_ratio);
@@ -762,6 +769,8 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(dummy);
       EEPROM_WRITE(dummy);
     #endif
+
+    _FIELD_TEST(motor_current_setting);
 
     #if HAS_MOTOR_CURRENT_PWM
       for (uint8_t q = 3; q--;) EEPROM_WRITE(stepper.motor_current_setting[q]);
@@ -773,7 +782,9 @@ void MarlinSettings::postprocess() {
     //
     // CNC Coordinate Systems
     //
+
     _FIELD_TEST(coordinate_system);
+
     #if ENABLED(CNC_COORDINATE_SYSTEMS)
       EEPROM_WRITE(coordinate_system); // 27 floats
     #else
@@ -784,7 +795,9 @@ void MarlinSettings::postprocess() {
     //
     // Skew correction factors
     //
+
     _FIELD_TEST(planner_xy_skew_factor);
+
     #if ENABLED(SKEW_CORRECTION)
       EEPROM_WRITE(planner.xy_skew_factor);
       EEPROM_WRITE(planner.xz_skew_factor);
@@ -797,7 +810,9 @@ void MarlinSettings::postprocess() {
     //
     // Advanced Pause filament load & unload lengths
     //
+
     _FIELD_TEST(filament_change_unload_length);
+
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
       for (uint8_t q = 0; q < MAX_EXTRUDERS; q++) {
         if (q < COUNT(filament_change_unload_length)) dummy = filament_change_unload_length[q];
@@ -884,6 +899,8 @@ void MarlinSettings::postprocess() {
 
       working_crc = 0;  // Init to 0. Accumulated by EEPROM_READ
 
+      _FIELD_TEST(esteppers);
+
       // Number of esteppers may change
       uint8_t esteppers;
       EEPROM_READ_ALWAYS(esteppers);
@@ -919,6 +936,8 @@ void MarlinSettings::postprocess() {
       // Home Offset (M206)
       //
 
+      _FIELD_TEST(home_offset);
+
       #if !HAS_HOME_OFFSET
         float home_offset[XYZ];
       #endif
@@ -948,9 +967,7 @@ void MarlinSettings::postprocess() {
       // Mesh (Manual) Bed Leveling
       //
 
-      bool leveling_is_on;
       uint8_t mesh_num_x, mesh_num_y;
-      EEPROM_READ_ALWAYS(leveling_is_on);
       EEPROM_READ(dummy);
       EEPROM_READ_ALWAYS(mesh_num_x);
       EEPROM_READ_ALWAYS(mesh_num_y);
@@ -970,6 +987,8 @@ void MarlinSettings::postprocess() {
         // MBL is disabled - skip the stored data
         for (uint16_t q = mesh_num_x * mesh_num_y; q--;) EEPROM_READ(dummy);
       #endif // MESH_BED_LEVELING
+
+      _FIELD_TEST(zprobe_zoffset);
 
       #if !HAS_BED_PROBE
         float zprobe_zoffset;
@@ -1014,6 +1033,8 @@ void MarlinSettings::postprocess() {
       // Unified Bed Leveling active state
       //
 
+      _FIELD_TEST(planner_leveling_active);
+
       #if ENABLED(AUTO_BED_LEVELING_UBL)
         EEPROM_READ(planner.leveling_active);
         EEPROM_READ(ubl.storage_slot);
@@ -1028,6 +1049,9 @@ void MarlinSettings::postprocess() {
       //
 
       #if ENABLED(DELTA)
+
+        _FIELD_TEST(delta_height);
+
         EEPROM_READ(delta_height);              // 1 float
         EEPROM_READ(delta_endstop_adj);         // 3 floats
         EEPROM_READ(delta_radius);              // 1 float
@@ -1037,6 +1061,8 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(delta_tower_angle_trim);    // 3 floats
 
       #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
+
+        _FIELD_TEST(x_endstop_adj);
 
         #if ENABLED(X_DUAL_ENDSTOPS)
           EEPROM_READ(x_endstop_adj);             // 1 float
@@ -1054,17 +1080,13 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(dummy);
         #endif
 
-        for (uint8_t q=8; q--;) EEPROM_READ(dummy);
-
-      #else
-
-        for (uint8_t q=11; q--;) EEPROM_READ(dummy);
-
       #endif
 
       //
       // LCD Preheat settings
       //
+
+      _FIELD_TEST(lcd_preheat_hotend_temp);
 
       #if DISABLED(ULTIPANEL)
         int lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
@@ -1109,6 +1131,8 @@ void MarlinSettings::postprocess() {
       // PID Extrusion Scaling
       //
 
+      _FIELD_TEST(lpq_len);
+
       #if DISABLED(PID_EXTRUSION_SCALING)
         int lpq_len;
       #endif
@@ -1132,6 +1156,8 @@ void MarlinSettings::postprocess() {
       //
       // LCD Contrast
       //
+
+      _FIELD_TEST(lcd_contrast);
 
       #if !HAS_LCD_CONTRAST
         uint16_t lcd_contrast;
@@ -1160,6 +1186,9 @@ void MarlinSettings::postprocess() {
       //
       // Volumetric & Filament Size
       //
+
+      _FIELD_TEST(parser_volumetric_enabled);
+
       #if DISABLED(NO_VOLUMETRICS)
 
         EEPROM_READ(parser.volumetric_enabled);
@@ -1180,10 +1209,13 @@ void MarlinSettings::postprocess() {
       //
       // TMC2130 Stepper Current
       //
+
+      _FIELD_TEST(tmc_stepper_current);
+
       #if HAS_TRINAMIC
-        #define SET_CURR(N,Q) stepper##Q.setCurrent(val[N] ? val[N] : Q##_CURRENT, R_SENSE, HOLD_MULTIPLIER)
-        uint16_t val[11];
-        EEPROM_READ(val);
+        #define SET_CURR(N,Q) stepper##Q.setCurrent(currents[N] ? currents[N] : Q##_CURRENT, R_SENSE, HOLD_MULTIPLIER)
+        uint16_t currents[11];
+        EEPROM_READ(currents);
         if (!validating) {
           #if X_IS_TRINAMIC
             SET_CURR(0, X);
@@ -1257,6 +1289,8 @@ void MarlinSettings::postprocess() {
       // Linear Advance
       //
 
+      _FIELD_TEST(planner_extruder_advance_k);
+
       #if ENABLED(LIN_ADVANCE)
         EEPROM_READ(planner.extruder_advance_k);
         EEPROM_READ(planner.advance_ed_ratio);
@@ -1269,6 +1303,8 @@ void MarlinSettings::postprocess() {
       // Motor Current PWM
       //
 
+      _FIELD_TEST(motor_current_setting);
+
       #if HAS_MOTOR_CURRENT_PWM
         for (uint8_t q = 3; q--;) EEPROM_READ(stepper.motor_current_setting[q]);
       #else
@@ -1280,6 +1316,8 @@ void MarlinSettings::postprocess() {
       // CNC Coordinate System
       //
 
+      _FIELD_TEST(coordinate_system);
+
       #if ENABLED(CNC_COORDINATE_SYSTEMS)
         if (!validating) (void)select_coordinate_system(-1); // Go back to machine space
         EEPROM_READ(coordinate_system);                  // 27 floats
@@ -1290,6 +1328,8 @@ void MarlinSettings::postprocess() {
       //
       // Skew correction factors
       //
+
+      _FIELD_TEST(planner_xy_skew_factor);
 
       #if ENABLED(SKEW_CORRECTION_GCODE)
         EEPROM_READ(planner.xy_skew_factor);
@@ -1307,6 +1347,8 @@ void MarlinSettings::postprocess() {
       //
       // Advanced Pause filament load & unload lengths
       //
+
+      _FIELD_TEST(filament_change_unload_length);
 
       #if ENABLED(ADVANCED_PAUSE_FEATURE)
         for (uint8_t q = 0; q < MAX_EXTRUDERS; q++) {


### PR DESCRIPTION
- Add more field testing to the EEPROM code.
- Make sure `fwretract` is refreshed.
- Remove unnecessary placeholder for DELTA / Dual XYZ.
- Bump version to `V50`.

Corresponds to #9123.