### PR TITLE
[2.0.x] add VIKI2 test to Travis & fix LCD contrast (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -438,3 +438,12 @@ script:
   - cp Marlin/Configuration.h Marlin/src/config/default/Configuration.h
   - cp Marlin/Configuration_adv.h Marlin/src/config/default/Configuration_adv.h
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #
+  # Enable VIKI2, SDSUPPORT
+  #
+  - restore_configs
+  - opt_set MOTHERBOARD BOARD_RAMPS_14_RE_ARM_EFB
+  - cp Marlin/Configuration.h Marlin/src/config/default/Configuration.h
+  - cp Marlin/Configuration_adv.h Marlin/src/config/default/Configuration_adv.h
+  - opt_enable VIKI2 SDSUPPORT
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3166,6 +3166,7 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     #if HAS_LCD_CONTRAST
+      // please don't remove the "(int16_t*)" - it's needed for the VIKI2 display  --- see PR #9132 before changing it
       MENU_ITEM_EDIT_CALLBACK(int3, MSG_CONTRAST, &lcd_contrast, LCD_CONTRAST_MIN, LCD_CONTRAST_MAX, lcd_callback_set_contrast, true);
     #endif
     #if ENABLED(FWRETRACT)
@@ -5243,7 +5244,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
 #if HAS_LCD_CONTRAST
 
-  void set_lcd_contrast(const uint16_t value) {
+  void set_lcd_contrast(const int16_t value) {
     lcd_contrast = constrain(value, LCD_CONTRAST_MIN, LCD_CONTRAST_MAX);
     u8g.setContrast(lcd_contrast);
   }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -84,8 +84,8 @@
   #endif
 
   #if ENABLED(DOGLCD)
-    extern uint16_t lcd_contrast;
-    void set_lcd_contrast(const uint16_t value);
+    extern int16_t lcd_contrast;
+    void set_lcd_contrast(const int16_t value);
   #endif
 
   #if ENABLED(SHOW_BOOTSCREEN)

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -230,7 +230,7 @@
 
 #include "utf_mapper.h"
 
-uint16_t lcd_contrast; // Initialized by settings.load()
+int16_t lcd_contrast; // Initialized by settings.load()
 static char currentfont = 0;
 
 // The current graphical page being rendered

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -189,7 +189,7 @@ typedef struct SettingsDataStruct {
   //
   // HAS_LCD_CONTRAST
   //
-  uint16_t lcd_contrast;                                // M250 C
+  int16_t lcd_contrast;                                // M250 C
 
   //
   // FWRETRACT
@@ -596,7 +596,7 @@ void MarlinSettings::postprocess() {
     _FIELD_TEST(lcd_contrast);
 
     #if !HAS_LCD_CONTRAST
-      const uint16_t lcd_contrast = 32;
+      const int16_t lcd_contrast = 32;
     #endif
     EEPROM_WRITE(lcd_contrast);
 
@@ -1143,7 +1143,7 @@ void MarlinSettings::postprocess() {
       _FIELD_TEST(lcd_contrast);
 
       #if !HAS_LCD_CONTRAST
-        uint16_t lcd_contrast;
+        int16_t lcd_contrast;
       #endif
       EEPROM_READ(lcd_contrast);
 


### PR DESCRIPTION
VIKI2 no longer compiles because of a type mismatch in ultralcd.cpp.

This problem keeps coming back.  I'm adding a test to Travis to compile VIKI2 so that whoever is changing it will be aware of the VIKI2 issue.

~I'll bet there is someone out there wondering why his LCD contrast problem keeps coming back.  Hopefully we'll meet up one of these days and arrive at a solution that makes everyone happy.~

UPDATE - I've changed the LCD_contrast variable from uint16_t to int16_t & now everything is happy.  The same changes are being done to 1.1.x via PR #9148.
