### PR TITLE
[1.1.x] Ensure smooth printer movements

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1341,7 +1341,8 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
 
   // Initialize block entry speed. Compute based on deceleration to user-defined MINIMUM_PLANNER_SPEED.
   const float v_allowable = max_allowable_speed(-block->acceleration, MINIMUM_PLANNER_SPEED, block->millimeters);
-  // If stepper ISR is disabled, this indicates buffer_segment wants to add a splitted block. In this case start with the max. allowed speed to avoid an interrupted first move.
+  // If stepper ISR is disabled, this indicates buffer_segment wants to add a split block.
+  // In this case start with the max. allowed speed to avoid an interrupted first move.
   block->entry_speed = TEST(TIMSK1, OCIE1A) ? MINIMUM_PLANNER_SPEED : min(vmax_junction, v_allowable);
 
   // Initialize planner efficiency flags
@@ -1352,7 +1353,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE], float fr_mm_s, const 
   // block nominal speed limits both the current and next maximum junction speeds. Hence, in both
   // the reverse and forward planners, the corresponding block junction speed will always be at the
   // the maximum junction speed and may always be ignored for any speed reduction checks.
-  block->flag |= BLOCK_FLAG_RECALCULATE | (block->nominal_speed <= v_allowable ? BLOCK_FLAG_NOMINAL_LENGTH : 0);
+  block->flag |= block->nominal_speed <= v_allowable ? BLOCK_FLAG_RECALCULATE | BLOCK_FLAG_NOMINAL_LENGTH : BLOCK_FLAG_RECALCULATE;
 
   // Update previous path unit_vector and nominal speed
   COPY(previous_speed, current_speed);

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -536,7 +536,8 @@ class Planner {
           block_t* next = &block_buffer[next_block_index(block_buffer_tail)];
           if (TEST(block->flag, BLOCK_BIT_RECALCULATE) || TEST(next->flag, BLOCK_BIT_RECALCULATE))
             return NULL;
-        } else if (TEST(block->flag, BLOCK_BIT_RECALCULATE))
+        }
+        else if (TEST(block->flag, BLOCK_BIT_RECALCULATE))
           return NULL;
         
         #if ENABLED(ULTRA_LCD)

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -530,6 +530,15 @@ class Planner {
     static block_t* get_current_block() {
       if (blocks_queued()) {
         block_t * const block = &block_buffer[block_buffer_tail];
+        
+        // If the trapezoid of this block has to be recalculated, it's not save to execute it.
+        if (movesplanned() > 1) {
+          block_t* next = &block_buffer[next_block_index(block_buffer_tail)];
+          if (TEST(block->flag, BLOCK_BIT_RECALCULATE) || TEST(next->flag, BLOCK_BIT_RECALCULATE))
+            return NULL;
+        } else if (TEST(block->flag, BLOCK_BIT_RECALCULATE))
+          return NULL;
+        
         #if ENABLED(ULTRA_LCD)
           block_buffer_runtime_us -= block->segment_time_us; // We can't be sure how long an active block will take, so don't count it.
         #endif


### PR DESCRIPTION
- Never execute a block if it has no up-to-date trapezoid
- Initialize blocks with MINIMUM_PLANNER_SPEED, except when coming from a
full stop

This way even if the planner has no chance to keep the buffer filled, it will fail gracefully. Fixes #9093, see also speed graphs there fore a comparison before / after.

Please give it a try and report any bugs.