### PR TITLE
[2.0.x] Fix support for Malyan M150

### DIFF
--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -133,7 +133,7 @@
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_MELZI
+  #define MOTHERBOARD BOARD_MELZI_MALYAN
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/src/config/examples/Malyan/M150/README.md
+++ b/Marlin/src/config/examples/Malyan/M150/README.md
@@ -1,3 +1,55 @@
-# Configuration for Malyan M150 hobbyking printer
-# config without automatic bed level sensor
-# or in other words, "as stock"
+# Configuration for Malyan M150 HobbyKing printer
+
+Config without automatic bed level sensor, or in other words, "as stock"
+
+## To install:
+
+1. Install [Arduino](https://www.arduino.cc/en/Main/Software)
+
+1. Install U8glib
+    * `Sketch` -> `Include Library` -> `Manage Libraries...`
+    * Search for and install `U8glib` by oliver
+
+1. Install Sanguino
+    * `File` -> `Preferences`
+    * Add
+    `https://raw.githubusercontent.com/Lauszus/Sanguino/master/package_lauszus_sanguino_index.json`
+    to `Additional Boards Manager URLs`
+
+1. Modify Sanguino `boards.txt`
+    * Close Arduino
+    * Locate Arduino15 folder
+        - `C:\Users\<username>\AppData\Local\Arduino15` for Windows
+        - `~/.arduino15` for Linux
+
+    * Locate `boards.txt` in `packages/Sanguino/hardware/avr/1.0.2`
+    (version number may change)
+    * Add the following to the end of `boards.txt`
+    (note that it is the same as sanguino.menu.cpu.atmega1284p but with
+    a different name and upload speed)
+
+            ## Malyan M150 W/ ATmega1284P 16MHz
+            sanguino.menu.cpu.malyan_m150=Malyan M150
+            sanguino.menu.cpu.malyan_m150.upload.maximum_size=130048
+            sanguino.menu.cpu.malyan_m150.upload.maximum_data_size=16384
+            sanguino.menu.cpu.malyan_m150.upload.speed=57600
+            sanguino.menu.cpu.malyan_m150.bootloader.file=optiboot/optiboot_atmega1284p.hex
+            sanguino.menu.cpu.malyan_m150.build.mcu=atmega1284p
+            sanguino.menu.cpu.malyan_m150.build.f_cpu=16000000L
+
+1. Configure Marlin
+    * Copy `_Bootscreen.h`, `Configuration.h`, and `Configuration_adv.h`
+    from `Marlin/config/examples/Malyan/M150` to `Marlin`
+    (overwrite files)
+    * Read `Configuration.h` and make any necessary changes
+
+1. Flash Marlin
+    * Turn on printer while pressing scroll wheel button
+    * Plug printer in to computer with USB cable
+    * Open `Marlin/Marlin.ino` with Arduino
+    * Configure Arduino
+        - `Tools` -> `Board` -> `Sanguino`
+        - `Tools` -> `Processor` -> `Malyan M150`
+        - `Tools` -> `Port` -> Select your port
+
+    * `Sketch` -> `Upload` or click arrow in top right corner

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -114,6 +114,7 @@
 #define BOARD_MELZI             63    // Melzi
 #define BOARD_MELZI_MAKR3D      66    // Melzi with ATmega1284 (MaKr3d version)
 #define BOARD_MELZI_CREALITY    89    // Melzi Creality3D board (for CR-10 etc)
+#define BOARD_MELZI_MALYAN      92    // Melzi Malyan M150 board
 #define BOARD_STB_11            64    // STB V1.1
 #define BOARD_AZTEEG_X1         65    // Azteeg X1
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -193,6 +193,8 @@
   #include "pins_MELZI_MAKR3D.h"      // ATmega644P, ATmega1284P
 #elif MB(MELZI_CREALITY)
   #include "pins_MELZI_CREALITY.h"    // ATmega644P, ATmega1284P
+#elif MB(MELZI_MALYAN)
+  #include "pins_MELZI_MALYAN.h"      // ATmega644P, ATmega1284P
 #elif MB(STB_11)
   #include "pins_STB_11.h"            // ATmega644P, ATmega1284P
 #elif MB(AZTEEG_X1)

--- a/Marlin/src/pins/pins_MELZI_MALYAN.h
+++ b/Marlin/src/pins/pins_MELZI_MALYAN.h
@@ -1,0 +1,50 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Melzi (Malyan M150) pin assignments
+ */
+
+#define BOARD_NAME "Melzi (Malyan)"
+#define IS_MELZI
+
+#include "pins_SANGUINOLOLU_12.h"
+
+#undef LCD_SDSS
+#undef LCD_PINS_RS
+#undef LCD_PINS_ENABLE
+#undef LCD_PINS_D4
+#undef BTN_EN1
+#undef BTN_EN2
+#undef BTN_ENC
+
+#define LCD_PINS_RS     17 // st9720 CS
+#define LCD_PINS_ENABLE 16 // st9720 DAT
+#define LCD_PINS_D4     11 // st9720 CLK
+#define BTN_EN1         30
+#define BTN_EN2         29
+#define BTN_ENC         28
+
+// Alter timing for graphical display
+#define ST7920_DELAY_1 DELAY_2_NOP
+#define ST7920_DELAY_2 DELAY_2_NOP
+#define ST7920_DELAY_3 DELAY_2_NOP


### PR DESCRIPTION
The current Malyan M150 example configuration does not work with the LCD without changes to `pins_SANGUINOLOLU_11.h` (documented [here](http://forums.reprap.org/read.php?110,716538,728278)).

This pull request creates a new Melzi-based board with those modifications, and adds instructions for compiling and uploading to the Malyan M150.

From #9146