### PR TITLE
[2.0.x] sd issue fix

### DIFF
--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -339,21 +339,22 @@ bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
       else if (readData(dst, 512))
         return true;
 
+      chipDeselect();
       if (!--retryCnt) break;
 
-      chipDeselect();
       cardCommand(CMD12, 0); // Try sending a stop command, ignore the result.
       errorCode_ = 0;
     }
+  return false;
   #else
-    if (cardCommand(CMD17, blockNumber))
+    if (cardCommand(CMD17, blockNumber)) {
       error(SD_CARD_ERROR_CMD17);
+      chipDeselect();
+      return false;
+    }
     else
       return readData(dst, 512);
   #endif
-
-  chipDeselect();
-  return false;
 }
 
 /**

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -41,6 +41,8 @@
 #include "../Marlin.h"
 
 #if ENABLED(SD_CHECK_AND_RETRY)
+  static bool crcSupported = true;
+
   #ifdef FAST_CRC
     static const uint8_t crctab7[] PROGMEM = {
       0x00,0x09,0x12,0x1b,0x24,0x2d,0x36,0x3f,0x48,0x41,0x5a,0x53,0x6c,0x65,0x7e,0x77,
@@ -267,10 +269,7 @@ bool Sd2Card::init(uint8_t sckRateID, pin_t chipSelectPin) {
   }
 
 #if ENABLED(SD_CHECK_AND_RETRY)
-  if (cardCommand( CMD59, 1 ) != R1_IDLE_STATE) {
-    error(SD_CARD_ERROR_CMD59);
-    goto FAIL;
-  }
+  crcSupported = (cardCommand(CMD59, 1) == R1_IDLE_STATE);
 #endif
 
   // check SD version
@@ -450,7 +449,7 @@ bool Sd2Card::readData(uint8_t* dst, uint16_t count) {
 #if ENABLED(SD_CHECK_AND_RETRY)
   {
     uint16_t recvCrc = (spiRec() << 8) | spiRec();
-    if (recvCrc != CRC_CCITT(dst, count)) {
+    if (crcSupported && recvCrc != CRC_CCITT(dst, count)) {
       error(SD_CARD_ERROR_READ_CRC);
       goto FAIL;
     }

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -345,7 +345,7 @@ bool Sd2Card::readBlock(uint32_t blockNumber, uint8_t* dst) {
       cardCommand(CMD12, 0); // Try sending a stop command, ignore the result.
       errorCode_ = 0;
     }
-  return false;
+    return false;
   #else
     if (cardCommand(CMD17, blockNumber)) {
       error(SD_CARD_ERROR_CMD17);

--- a/Marlin/src/sd/Sd2Card.h
+++ b/Marlin/src/sd/Sd2Card.h
@@ -71,7 +71,7 @@ uint8_t const SD_CARD_ERROR_CMD0 = 0x01,                // timeout error for com
               SD_CARD_ERROR_WRITE_TIMEOUT = 0x17,       // timeout occurred during write programming
               SD_CARD_ERROR_SCK_RATE = 0x18,            // incorrect rate selected
               SD_CARD_ERROR_INIT_NOT_CALLED = 0x19,     // init() not called
-              SD_CARD_ERROR_CMD59 = 0x1A,               // card returned an error for CMD59 (CRC_ON_OFF)
+              // 0x1A is unused now, it was: card returned an error for CMD59 (CRC_ON_OFF)
               SD_CARD_ERROR_READ_CRC = 0x1B;            // invalid read CRC
 
 // card types


### PR DESCRIPTION
This PR will solve the problem I had with SD (issue #8969).
For no known reason CMD59 is not supported by my SD card (old card).

Since CRC check is better than not have it, a single card should not obbligate to deactivate it in the whole system.

This fix aims to give a little more flexibility.

In this PR there is also a "program memory save" change (just 4 bytes but better than nothing) and should not affect speed.