### PR TITLE
[1.1.x] Fix missing deceleration steps

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -218,7 +218,7 @@ void Planner::calculate_trapezoid_for_block(block_t* const block, const float &e
 
           // Steps required for acceleration, deceleration to/from nominal rate
   int32_t accelerate_steps = CEIL(estimate_acceleration_distance(initial_rate, block->nominal_rate, accel)),
-          decelerate_steps = FLOOR(estimate_acceleration_distance(block->nominal_rate, final_rate, -accel)),
+          decelerate_steps = CEIL(estimate_acceleration_distance(block->nominal_rate, final_rate, -accel)),
           // Steps between acceleration and deceleration, if any
           plateau_steps = block->step_event_count - accelerate_steps - decelerate_steps;
 

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -733,8 +733,11 @@ void Stepper::isr() {
 
     #endif // LIN_ADVANCE
   }
-  else if (step_events_completed > (uint32_t)current_block->decelerate_after) {
+  else if (step_events_completed >= (uint32_t)current_block->decelerate_after && current_block->step_event_count != (uint32_t)current_block->decelerate_after) {
     uint16_t step_rate;
+    // If we are entering the deceleration phase for the first time, we have to see how long we have been decelerating up to now. Equals last acceleration time interval.
+    if (!deceleration_time)
+      deceleration_time = calc_timer_interval(acc_step_rate);
     MultiU24X32toH16(step_rate, deceleration_time, current_block->acceleration_rate);
 
     if (step_rate < acc_step_rate) { // Still decelerating?


### PR DESCRIPTION
Marlin never reached final_speed after deceleration. Fixes the issue first noted by @Bob-the-Kuhn where he tried to incorporate a magic factor in #8761 for a fix.

A bunch of small bugs lead to this too high real final rate:
- `decelerate_steps` within the trapezoid generator was calculated with `FLOOR()`, so it could miss a single step. It should be calculated with `CEIL()` just as accelerate_steps does.
- Within the stepper ISR, the deceleration phase has to start when `step_events_completed >= (uint32_t)current_block->decelerate_after` and not only if ">" - also same as acceleration phase does.
- When the deceleration starts, it's already running for some time. Just as the `acceleration_time` doesn't start from 0 but from the time the last step took, the `deceleration_time` has to start at the time the last step took.

With this changes, final_rate is now reached after the deceleration. Confirmed by Excel speed graphs.

As far as I know, this was the last small issue known with planner / step execution. Other things I checked before I found the reason for this bug, just to write them down for the future:
My first thought was that inaccuracies are summing up within `calc_timer_interval` and or `MultiU24X32toH16`. After tests I can say that's not the case.
`calc_timer_interval` has an accuracy of +-0.3%, but it's not cumulating. After a complete deceleration, the sum of all times calculated has only a deviation of 0.05%.
`MultiU24X32toH16 `can be off by 1% when acceleration time is very low but stabilizes after very few steps. No error at all at end of deceleration.