### PR TITLE
[2.0.x] Fix LCD timer string length

### DIFF
--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -151,7 +151,7 @@ struct duration_t {
     if (with_days) {
       uint16_t d = this->day();
       sprintf_P(buffer, PSTR("%ud %02u:%02u"), d, h % 24, m);
-      return d >= 10 ? 8 : 7;
+      return d >= 10 ? 9 : 8;
     }
     else if (h < 100) {
       sprintf_P(buffer, PSTR("%02u:%02u"), h % 24, m);


### PR DESCRIPTION
The lengths returned by toDigital are incorrect when the duration has days.  The results in the timer string rendering incorrectly when `DOGM_SD_PERCENT` is enabled.

Before:
![img_20180117_212614](https://user-images.githubusercontent.com/23322579/35067962-8a6e6878-fbcd-11e7-9f3d-7fb8da9c8ab4.jpg)

After:
![img_20180117_212218](https://user-images.githubusercontent.com/23322579/35067966-8ebf3e98-fbcd-11e7-9099-db488a786473.jpg)

There is also another issue here where if days is greater than 9 the leading digit and the % symbol occupy the same character on the display.  It seems like it might be best to constrain the number of days displayed in the timer generally, but especially when `DOGM_SD_PERCENT` is enabled.  I'm not sure how best to implement that.