### PR TITLE
PronterFace M105 work around

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -34,6 +34,7 @@
   #include "temperature.h"
   #include "ultralcd.h"
   #include "gcode.h"
+  #include "serial.h"
   #include "bitmap_flags.h"
 
   #if ENABLED(MESH_BED_LEVELING)
@@ -499,6 +500,9 @@
               SERIAL_EOL();
             }
             idle();
+            MYSERIAL.flush();  // G26 takes a long time to complete.   PronterFace can
+                               // over run the serial character buffer with M105's without
+                               // this fix
           }
       #if ENABLED(ULTRA_LCD)
         }
@@ -521,8 +525,11 @@
         SERIAL_EOL();
       }
       idle();
-    }
 
+      MYSERIAL.flush();  // G26 takes a long time to complete.   PronterFace can
+                         // over run the serial character buffer with M105's without
+                         // this fix
+    }
     #if ENABLED(ULTRA_LCD)
       lcd_reset_status();
       lcd_quick_feedback(true);
@@ -820,6 +827,9 @@
         if (look_for_lines_to_connect())
           goto LEAVE;
       }
+      MYSERIAL.flush();  // G26 takes a long time to complete.   PronterFace can
+                         // over run the serial character buffer with M105's without
+                         // this fix
     } while (--g26_repeats && location.x_index >= 0 && location.y_index >= 0);
 
     LEAVE:

--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -385,7 +385,7 @@
     // reading rx_buffer_head and updating rx_buffer_tail, the previous rx_buffer_head
     // may be written to rx_buffer_tail, making the buffer appear full rather than empty.
     CRITICAL_SECTION_START;
-      rx_buffer.head = rx_buffer.tail;
+      rx_buffer.head = rx_buffer.tail = 0;
     CRITICAL_SECTION_END;
 
     #if ENABLED(SERIAL_XON_XOFF)

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
@@ -1562,7 +1562,7 @@
  * Fully assembled MAX7219 boards can be found on the internet for under $2(US).
  * For example, see https://www.ebay.com/sch/i.html?_nkw=332349290049
  */
-//#define MAX7219_DEBUG
+#define MAX7219_DEBUG
 #if ENABLED(MAX7219_DEBUG)
 //#define MAX7219_CLK_PIN   64  // on RAMPS       // Configuration of the 3 pins to control the display
 //#define MAX7219_DIN_PIN   57  // on RAMPS

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -92,14 +92,14 @@
         static void move_z_with_encoder(const float &multiplier);
         static float measure_point_with_encoder();
         static float measure_business_card_thickness(const float);
-        static void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool);
-        static void fine_tune_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map);
+        static void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool) _O0;
+        static void fine_tune_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map) _O0;
       #endif
 
-      static bool g29_parameter_parsing();
+      static bool g29_parameter_parsing() _O0;
       static void find_mean_mesh_height();
       static void shift_mesh_height();
-      static void probe_entire_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
+      static void probe_entire_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest) _O0;
       static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
       static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
       static void g29_what_command();
@@ -114,16 +114,16 @@
       static void report_state();
       static void save_ubl_active_state_and_disable();
       static void restore_ubl_active_state_and_leave();
-      static void display_map(const int);
-      static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, uint16_t[16]);
-      static mesh_index_pair find_furthest_invalid_mesh_point();
+      static void display_map(const int) _O0;
+      static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, uint16_t[16]) _O0;
+      static mesh_index_pair find_furthest_invalid_mesh_point() _O0;
       static void reset();
       static void invalidate();
       static void set_all_mesh_points_to_value(const float);
       static bool sanity_check();
 
-      static void G29() _O0;                          // O0 for no optimization
-      static void smart_fill_wlsf(const float &) _O2; // O2 gives smaller code than Os on A2560
+      static void G29() _O0;                      // O0 for no optimization
+      static void smart_fill_wlsf(const float &); // O2 gives smaller code than Os on A2560
       static int8_t storage_slot;
 
       static float z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];


### PR DESCRIPTION
PronterFace keeps sending M105 requests during long operations like G29 P1, G29 P2, G29 P4 and G26.   The serial buffer fills up before the operation is complete.    The problem is, a corrupted command gets executed.   It is very typical for the M105 to turn into a M1 (actually...  M1M105 is typical).

This causes the printer to say "Click to resume..."     

This is a temporary fix until we figure out the correct way to resolve the issue.

More work needed for G26.

