### PR TITLE
Serial buffer over run work around for v2.0.0

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
@@ -69,6 +69,8 @@
     uint8_t xon_xoff_state = XON_XOFF_CHAR_SENT | XON_CHAR;
   #endif
 
+  void clear_command_queue(); 
+
   #if ENABLED(SERIAL_STATS_DROPPED_RX)
     uint8_t rx_dropped_bytes = 0;
   #endif
@@ -388,7 +390,8 @@
     // reading rx_buffer_head and updating rx_buffer_tail, the previous rx_buffer_head
     // may be written to rx_buffer_tail, making the buffer appear full rather than empty.
     CRITICAL_SECTION_START;
-      rx_buffer.head = rx_buffer.tail;
+      rx_buffer.head = rx_buffer.tail = 0;
+      clear_command_queue(); 
     CRITICAL_SECTION_END;
 
     #if ENABLED(SERIAL_XON_XOFF)

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -555,7 +555,7 @@
  * Override with M203
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 250, 250, 2, 17 }
+#define DEFAULT_MAX_FEEDRATE          { 250, 250, 4, 17 }
 
 /**
  * Default Max Acceleration (change/s) change = mm/s
@@ -587,7 +587,7 @@
  */
 #define DEFAULT_XJERK                  8.5
 #define DEFAULT_YJERK                  8.5
-#define DEFAULT_ZJERK                  0.3
+#define DEFAULT_ZJERK                  0.75
 #define DEFAULT_EJERK                  4.0
 
 //===========================================================================

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -916,7 +916,7 @@
   /**
    * Enable the G26 Mesh Validation Pattern tool.
    */
-  //#define G26_MESH_VALIDATION
+  #define G26_MESH_VALIDATION
   #if ENABLED(G26_MESH_VALIDATION)
     #define MESH_TEST_NOZZLE_SIZE    0.4  // (mm) Diameter of primary nozzle.
     #define MESH_TEST_LAYER_HEIGHT   0.2  // (mm) Default layer height for the G26 Mesh Validation Tool.

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1562,7 +1562,7 @@
  * Fully assembled MAX7219 boards can be found on the internet for under $2(US).
  * For example, see https://www.ebay.com/sch/i.html?_nkw=332349290049
  */
-//#define MAX7219_DEBUG
+#define MAX7219_DEBUG
 #if ENABLED(MAX7219_DEBUG)
 //#define MAX7219_CLK_PIN   64  // on RAMPS       // Configuration of the 3 pins to control the display
 //#define MAX7219_DIN_PIN   57  // on RAMPS

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -93,7 +93,7 @@ class unified_bed_leveling {
     static bool g29_parameter_parsing();
     static void find_mean_mesh_height();
     static void shift_mesh_height();
-    static void probe_entire_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest);
+    static void probe_entire_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest) _O0;
     static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
     static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
     static void g29_what_command();
@@ -117,8 +117,8 @@ class unified_bed_leveling {
     static void save_ubl_active_state_and_disable();
     static void restore_ubl_active_state_and_leave();
     static void display_map(const int);
-    static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, uint16_t[16]);
-    static mesh_index_pair find_furthest_invalid_mesh_point();
+    static mesh_index_pair find_closest_mesh_point_of_type(const MeshPointType, const float&, const float&, const bool, uint16_t[16]) _O0;
+    static mesh_index_pair find_furthest_invalid_mesh_point() _O0;
     static void reset();
     static void invalidate();
     static void set_all_mesh_points_to_value(const float);

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -437,6 +437,9 @@ inline bool turn_on_heaters() {
             SERIAL_EOL();
           }
           idle();
+          MYSERIAL0.flush(); // G26 takes a long time to complete.   PronterFace can
+                             // over run the serial character buffer with M105's without
+                             // this fix
         }
     #if ENABLED(ULTRA_LCD)
       }
@@ -459,6 +462,10 @@ inline bool turn_on_heaters() {
       SERIAL_EOL();
     }
     idle();
+
+    MYSERIAL0.flush(); // G26 takes a long time to complete.   PronterFace can
+                       // over run the serial character buffer with M105's without
+                       // this fix
   }
 
   #if ENABLED(ULTRA_LCD)
@@ -680,12 +687,12 @@ void GcodeSuite::G26() {
   set_bed_leveling_enabled(!parser.seen('D'));
 
   if (current_position[Z_AXIS] < Z_CLEARANCE_BETWEEN_PROBES) {
-SERIAL_PROTOCOLLNPGM("! move nozzle to Z_CLEARANCE_BETWEEN_PROBES height.");
-SERIAL_ECHOLNPAIR("  Z at:", current_position[Z_AXIS]);
+//  SERIAL_PROTOCOLLNPGM("! move nozzle to Z_CLEARANCE_BETWEEN_PROBES height.");
+//  SERIAL_ECHOLNPAIR("  Z at:", current_position[Z_AXIS]);
     do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
     stepper.synchronize();
     set_current_from_destination();
-SERIAL_ECHOLNPAIR("  Z now at:", current_position[Z_AXIS]);
+//  SERIAL_ECHOLNPAIR("  Z now at:", current_position[Z_AXIS]);
   }
 
   if (turn_on_heaters() != G26_OK) goto LEAVE;
@@ -711,14 +718,14 @@ SERIAL_ECHOLNPAIR("  Z now at:", current_position[Z_AXIS]);
 
   // Move nozzle to the specified height for the first layer
   set_destination_from_current();
-SERIAL_PROTOCOLLNPGM("! moving nozzle to 1st layer height.");
-SERIAL_ECHOLNPAIR("  Z1 at:", current_position[Z_AXIS]);
+//SERIAL_PROTOCOLLNPGM("! moving nozzle to 1st layer height.");
+//SERIAL_ECHOLNPAIR("  Z1 at:", current_position[Z_AXIS]);
 
   destination[Z_AXIS] = g26_layer_height;
   move_to(destination, 0.0);
-  stepper.synchronize();
-  set_destination_from_current();
-SERIAL_ECHOLNPAIR("  Z2 at:", current_position[Z_AXIS]);
+//stepper.synchronize();
+//set_destination_from_current();
+//SERIAL_ECHOLNPAIR("  Z2 at:", current_position[Z_AXIS]);
   move_to(destination, g26_ooze_amount);
 
   #if ENABLED(ULTRA_LCD)
@@ -823,11 +830,17 @@ SERIAL_ECHOLNPAIR("  Z2 at:", current_position[Z_AXIS]);
         //}
 
         print_line_from_here_to_there(rx, ry, g26_layer_height, xe, ye, g26_layer_height);
+        MYSERIAL0.flush(); // G26 takes a long time to complete.   PronterFace can
+                           // over run the serial character buffer with M105's without
+                           // this fix
 
       }
       if (look_for_lines_to_connect())
         goto LEAVE;
     }
+    MYSERIAL0.flush(); // G26 takes a long time to complete.   PronterFace can
+                       // over run the serial character buffer with M105's without
+                       // this fix
   } while (--g26_repeats && location.x_index >= 0 && location.y_index >= 0);
 
   LEAVE:

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -90,8 +90,7 @@ void queue_setup() {
  * Clear the Marlin command queue
  */
 void clear_command_queue() {
-  cmd_queue_index_r = cmd_queue_index_w;
-  commands_in_queue = 0;
+  cmd_queue_index_r = cmd_queue_index_w = commands_in_queue = 0;
 }
 
 /**


### PR DESCRIPTION
PronterFace sends a lot of M105 commands.  During long operations such
as UBL's G29 P1, G29 P2, G29 P4 and G26 this can over run the serial
buffer.   This results (very often) in a M1 (actually a M1M105) ending
up in the command queue.

Until we figure out a better way to resolve this issue, this will keep
the UBL commands from experiencing bogus commands at thier completion.