### PR TITLE
[bugfix-1.1.x] add TMC2208 sanity check & fix typo

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -1480,6 +1480,24 @@ static_assert(1 >= 0
   #error "HAVE_TMC2208 requires at least one TMC2208 stepper to be set."
 #endif
 
+/**
+ * TMC2208 software UART and ENDSTOP_INTERRUPTS both use pin change interrupts (PCI)
+ */
+#if ENABLED(HAVE_TMC2208) && ENABLED(ENDSTOP_INTERRUPTS_FEATURE) && !( \
+       ENABLED( X_HARDWARE_SERIAL  ) \
+    || ENABLED( X2_HARDWARE_SERIAL ) \
+    || ENABLED( Y_HARDWARE_SERIAL  ) \
+    || ENABLED( Y2_HARDWARE_SERIAL ) \
+    || ENABLED( Z_HARDWARE_SERIAL  ) \
+    || ENABLED( Z2_HARDWARE_SERIAL ) \
+    || ENABLED( E0_HARDWARE_SERIAL ) \
+    || ENABLED( E1_HARDWARE_SERIAL ) \
+    || ENABLED( E2_HARDWARE_SERIAL ) \
+    || ENABLED( E3_HARDWARE_SERIAL ) \
+    || ENABLED( E4_HARDWARE_SERIAL ) )
+  #error "select hardware UART for TMC2208 to use both TMC2208 and ENDSTOP_INTERRUPTS_FEATURE."
+#endif
+
 #if ENABLED(HYBRID_THRESHOLD) && DISABLED(STEALTHCHOP)
   #error "Enable STEALTHCHOP to use HYBRID_THRESHOLD."
 #endif

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -131,7 +131,7 @@
   //#define E1_HARDWARE_SERIAL Serial1
   //#define E2_HARDWARE_SERIAL Serial1
   //#define E3_HARDWARE_SERIAL Serial1
-  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
 
   /**
    * Software serial


### PR DESCRIPTION
Currently if you enable both **HAVE_TMC2208** and **ENDSTOPS_INTERRUPT_FEATURE** you get some pretty useless compile errors.  This is because the default for the TMC2208 is to use a software UART and the UART uses the pin change interrupts (PCI) as does ENDSTOPS_INTERRUPT_FEATURE.

This PR adds a sanity check for this situation telling the user to switch the TMC2208 to a hardware UART.

It also corrects a typo in pins_RAMPS.h

This was the cause of issue #9221.