### PR TITLE
[2.0.x] Cleanup MKS-SBASE compile warnings

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/spi_pins.h
+++ b/Marlin/src/HAL/HAL_LPC1768/spi_pins.h
@@ -23,50 +23,29 @@
 #ifndef SPI_PINS_LPC1768_H
 #define SPI_PINS_LPC1768_H
 
-#include "../../inc/MarlinConfig.h"
+#define LPC_SOFTWARE_SPI  // Re-ARM board needs a software SPI because using the
+                          // standard LCD adapter results in the LCD and the
+                          // SD card sharing a single SPI when the RepRap Full
+                          // Graphic Smart Controller is selected
 
-#if MB(MKS_SBASE)
-
-  #define LPC_SOFTWARE_SPI  // MKS_SBASE needs a software SPI because the
-                            // selected pins are not on a hardware SPI controller
-
-  // A custom cable is needed. See the README file in the
-  // Marlin\src\config\examples\Mks\Sbase directory
-
-  #define SCK_PIN           P1_22  // J8-2 (moved from EXP2 P0.7)
-  #define MISO_PIN          P1_23  // J8-3 (moved from EXP2 P0.8)
-  #define MOSI_PIN          P2_12  // J8-4 (moved from EXP2 P0.5)
-  #define SS_PIN            P0_28
-  #define SD_DETECT_PIN     P0_27
-
-#else
-
-  #define LPC_SOFTWARE_SPI  // Re-ARM board needs a software SPI because using the
-                            // standard LCD adapter results in the LCD and the
-                            // SD card sharing a single SPI when the RepRap Full
-                            // Graphic Smart Controller is selected
-
-  /** onboard SD card */
-  //#define SCK_PIN           P0_07
-  //#define MISO_PIN          P0_08
-  //#define MOSI_PIN          P0_09
-  //#define SS_PIN            P0_06
-  /** external */
-  #ifndef SCK_PIN
-    #define SCK_PIN           P0_15
-  #endif
-  #ifndef MISO_PIN
-    #define MISO_PIN          P0_17
-  #endif
-  #ifndef MOSI_PIN
-    #define MOSI_PIN          P0_18
-  #endif
-  #ifndef SS_PIN
-    #define SS_PIN            P1_23
-  #endif
-
-#endif // MKS_SBASE
-
+/** onboard SD card */
+//#define SCK_PIN           P0_07
+//#define MISO_PIN          P0_08
+//#define MOSI_PIN          P0_09
+//#define SS_PIN            P0_06
+/** external */
+#ifndef SCK_PIN
+  #define SCK_PIN           P0_15
+#endif
+#ifndef MISO_PIN
+  #define MISO_PIN          P0_17
+#endif
+#ifndef MOSI_PIN
+  #define MOSI_PIN          P0_18
+#endif
+#ifndef SS_PIN
+  #define SS_PIN            P1_23
+#endif
 #ifndef SDSS
   #define SDSS              SS_PIN
 #endif

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -184,6 +184,17 @@
 //
 // Misc. Functions
 //
+#define LPC_SOFTWARE_SPI  // MKS_SBASE needs a software SPI because the
+                          // selected pins are not on a hardware SPI controller
+
+// A custom cable is needed. See the README file in the
+// Marlin\src\config\examples\Mks\Sbase directory
+
+#define SCK_PIN            P1_22  // J8-2 (moved from EXP2 P0.7)
+#define MISO_PIN           P1_23  // J8-3 (moved from EXP2 P0.8)
+#define MOSI_PIN           P2_12  // J8-4 (moved from EXP2 P0.5)
+#define SS_PIN             P0_28
+#define SD_DETECT_PIN      P0_27
 #define SDSS               P0_06
 
 /**


### PR DESCRIPTION
Compiling for MKS-SBASE results in a  bunch of SD_DETECT_PIN already defined warnings. This PR moves the board-specific defined out of the top-level header file and into the board's pins file.

I think we need a better solution for `LPC_SOFTWARE_SPI`, but that may come with @teemuatlut's work on the TMC2130 drivers.