### PR TITLE
[2.0.x] Relative movements fix

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -94,8 +94,11 @@ bool GcodeSuite::get_target_extruder_from_command() {
 void GcodeSuite::get_destination_from_command() {
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i])) {
-      const float v = parser.value_axis_units((AxisEnum)i) + (axis_relative_modes[i] || relative_mode ? current_position[i] : 0);
-      destination[i] = i == E_AXIS ? v : LOGICAL_TO_NATIVE(v, i);
+      const float v = parser.value_axis_units((AxisEnum)i);
+      if (axis_relative_modes[i] || relative_mode)
+        destination[i] = (current_position[i] + v);
+      else
+        destination[i] = i == E_AXIS ? v : LOGICAL_TO_NATIVE(v, i);
     }
     else
       destination[i] = current_position[i];

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -95,10 +95,9 @@ void GcodeSuite::get_destination_from_command() {
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i])) {
       const float v = parser.value_axis_units((AxisEnum)i);
-      if (axis_relative_modes[i] || relative_mode)
-        destination[i] = (current_position[i] + v);
-      else
-        destination[i] = i == E_AXIS ? v : LOGICAL_TO_NATIVE(v, i);
+      destination[i] = (axis_relative_modes[i] || relative_mode)
+        ? current_position[i] + v
+        : (i == E_AXIS) ? v : LOGICAL_TO_NATIVE(v, i);
     }
     else
       destination[i] = current_position[i];


### PR DESCRIPTION
Relative movements don't need to be converted to native coordinate system

Maybe can have something to do with #9198 because it is relevant when G92 is used