### PR TITLE
[2.0.x] pid autotune fix

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -413,8 +413,8 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
       // Report heater states every 2 seconds
       if (ELAPSED(ms, next_temp_ms)) {
         #if HAS_TEMP_HOTEND || HAS_TEMP_BED
-          print_heaterstates();
-          SERIAL_EOL();
+          //print_heaterstates();
+          //SERIAL_EOL();
         #endif
         next_temp_ms = ms + 2000UL;
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -413,8 +413,8 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
       // Report heater states every 2 seconds
       if (ELAPSED(ms, next_temp_ms)) {
         #if HAS_TEMP_HOTEND || HAS_TEMP_BED
-          //print_heaterstates();
-          //SERIAL_EOL();
+          print_heaterstates();
+          SERIAL_EOL();
         #endif
         next_temp_ms = ms + 2000UL;
 
@@ -2154,7 +2154,7 @@ void Temperature::isr() {
       SERIAL_PROTOCOLPAIR_P(port, " (", r / OVERSAMPLENR);
       SERIAL_PROTOCOLCHAR_P(port, ')');
     #endif
-    safe_delay(2);
+    delay(2);       // Don't use safe_delay because it breaks PID_autotune
   }
 
   void Temperature::print_heaterstates(


### PR DESCRIPTION
Temporary fix until some maintainer can give the solution (#9233)

Save_Delay will call thermalmanager that can stop pwm output