### PR TITLE
[1.1.x] Allow override of RAMPS CS Pins

### DIFF
--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -91,27 +91,37 @@
 #define X_STEP_PIN         54
 #define X_DIR_PIN          55
 #define X_ENABLE_PIN       38
-#define X_CS_PIN           53
+#ifndef X_CS_PIN
+  #define X_CS_PIN         53
+#endif
 
 #define Y_STEP_PIN         60
 #define Y_DIR_PIN          61
 #define Y_ENABLE_PIN       56
-#define Y_CS_PIN           49
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN         49
+#endif
 
 #define Z_STEP_PIN         46
 #define Z_DIR_PIN          48
 #define Z_ENABLE_PIN       62
-#define Z_CS_PIN           40
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN         40
+#endif
 
 #define E0_STEP_PIN        26
 #define E0_DIR_PIN         28
 #define E0_ENABLE_PIN      24
-#define E0_CS_PIN          42
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN        42
+#endif
 
 #define E1_STEP_PIN        36
 #define E1_DIR_PIN         34
 #define E1_ENABLE_PIN      30
-#define E1_CS_PIN          44
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN        44
+#endif
 
 /**
  * Default pins for TMC software SPI
@@ -127,7 +137,6 @@
     #define TMC_SW_SCK     64
   #endif
 #endif
-
 
 #if ENABLED(HAVE_TMC2208)
   /**


### PR DESCRIPTION
I have installed an LCD and the TMC2130 drivers. So some of the default pins are blocked. With this change the pins could be redefined.