### PR TITLE
[2.0.x] Minor filament change improvements

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -336,7 +336,10 @@ void disable_all_steppers() {
 void manage_inactivity(bool ignore_stepper_queue/*=false*/) {
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    if ((IS_SD_PRINTING || print_job_timer.isRunning()) && (READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING))
+    if ((IS_SD_PRINTING || print_job_timer.isRunning())
+      && READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING
+      && thermalManager.targetHotEnoughToExtrude(active_extruder)
+    )
       handle_filament_runout();
   #endif
 

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -287,7 +287,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
   COPY(resume_position, current_position);
 
   // Initial retract before move to filament change position
-  if (retract && !thermalManager.tooColdToExtrude(active_extruder))
+  if (retract && thermalManager.hotEnoughToExtrude(active_extruder))
     do_pause_e_move(retract, PAUSE_PARK_RETRACT_FEEDRATE);
 
   // Park the nozzle by moving up by z_lift and then moving to (x_pos, y_pos)
@@ -397,7 +397,7 @@ void resume_print(const float &load_length/*=0*/, const float &extrude_length/*=
     thermalManager.reset_heater_idle_timer(e);
   }
 
-  if (nozzle_timed_out || !thermalManager.tooColdToExtrude(active_extruder)) {
+  if (nozzle_timed_out || thermalManager.hotEnoughToExtrude(active_extruder)) {
     // Load the new filament
     load_filament(load_length, extrude_length, max_beep_count, true, nozzle_timed_out);
   }

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -261,8 +261,10 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
     SERIAL_ERRORLNPGM(MSG_HOTEND_TOO_COLD);
 
     #if ENABLED(ULTIPANEL)
-      if (show_lcd) // Show status screen
+      if (show_lcd) { // Show status screen
         lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+        LCD_MESSAGEPGM(MSG_M600_TOO_COLD);
+      }
     #endif
 
     return false; // unable to reach safe temperature

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -83,6 +83,15 @@ float filament_change_unload_length[EXTRUDERS],
   }
 #endif
 
+/**
+ * Ensure a safe temperature for extrusion
+ *
+ * - Fail if the TARGET temperature is too low
+ * - Display LCD placard with temperature status
+ * - Return when heating is done or aborted
+ *
+ * Returns 'true' if heating was completed, 'false' for abort
+ */
 static bool ensure_safe_temperature(const AdvancedPauseMode mode=ADVANCED_PAUSE_MODE_PAUSE_PRINT) {
 
   #if ENABLED(PREVENT_COLD_EXTRUSION)
@@ -115,7 +124,19 @@ static void do_pause_e_move(const float &length, const float &fr) {
   set_current_from_destination();
 }
 
-bool load_filament(const float &load_length/*=0*/, const float &extrude_length/*=0*/, const int8_t max_beep_count/*=0*/,
+/**
+ * Load filament into the hotend
+ *
+ * - Fail if the a safe temperature was not reached
+ * - If pausing for confirmation, wait for a click or M108
+ * - Show "wait for load" placard
+ * - Load and purge filament
+ * - Show "Purge more" / "Continue" menu
+ * - Return when "Continue" is selected
+ *
+ * Returns 'true' if load was completed, 'false' for abort
+ */
+bool load_filament(const float &load_length/*=0*/, const float &purge_length/*=0*/, const int8_t max_beep_count/*=0*/,
                           const bool show_lcd/*=false*/, const bool pause_for_user/*=false*/,
                           const AdvancedPauseMode mode/*=ADVANCED_PAUSE_MODE_PAUSE_PRINT*/
 ) {
@@ -158,15 +179,15 @@ bool load_filament(const float &load_length/*=0*/, const float &extrude_length/*
   }
 
   #if ENABLED(ULTIPANEL)
-    if (show_lcd) // Show "load" message
+    if (show_lcd) // Show "wait for load" message
       lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_LOAD, mode);
   #endif
 
   // Load filament
-  do_pause_e_move(load_length, FILAMENT_CHANGE_LOAD_FEEDRATE);
+  if (load_length) do_pause_e_move(load_length, FILAMENT_CHANGE_LOAD_FEEDRATE);
 
   do {
-    if (extrude_length > 0) {
+    if (purge_length > 0) {
       // "Wait for filament purge"
       #if ENABLED(ULTIPANEL)
         if (show_lcd)
@@ -174,10 +195,10 @@ bool load_filament(const float &load_length/*=0*/, const float &extrude_length/*
       #endif
 
       // Extrude filament to get into hotend
-      do_pause_e_move(extrude_length, ADVANCED_PAUSE_EXTRUDE_FEEDRATE);
+      do_pause_e_move(purge_length, ADVANCED_PAUSE_EXTRUDE_FEEDRATE);
     }
 
-    // Show "Extrude More" / "Resume" menu and wait for reply
+    // Show "Purge More" / "Resume" menu and wait for reply
     #if ENABLED(ULTIPANEL)
       if (show_lcd) {
         KEEPALIVE_STATE(PAUSED_FOR_USER);
@@ -188,7 +209,7 @@ bool load_filament(const float &load_length/*=0*/, const float &extrude_length/*
       }
     #endif
 
-    // Keep looping if "Extrude More" was selected
+    // Keep looping if "Purge More" was selected
   } while (
     #if ENABLED(ULTIPANEL)
       show_lcd && advanced_pause_menu_response == ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE
@@ -200,6 +221,16 @@ bool load_filament(const float &load_length/*=0*/, const float &extrude_length/*
   return true;
 }
 
+/**
+ * Unload filament from the hotend
+ *
+ * - Fail if the a safe temperature was not reached
+ * - Show "wait for unload" placard
+ * - Retract, pause, then unload filament
+ * - Disable E stepper (on most machines)
+ *
+ * Returns 'true' if unload was completed, 'false' for abort
+ */
 bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
                             const AdvancedPauseMode mode/*=ADVANCED_PAUSE_MODE_PAUSE_PRINT*/
 ) {
@@ -242,6 +273,19 @@ bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
 
 // public:
 
+/**
+ * Pause procedure
+ *
+ * - Abort if already paused
+ * - Send host action for pause, if configured
+ * - Abort if TARGET temperature is too low
+ * - Display "wait for start of filament change" (if a length was specified)
+ * - Initial retract, if current temperature is hot enough
+ * - Park the nozzle at the given position
+ * - Call unload_filament (if a length was specified)
+ *
+ * Returns 'true' if pause was completed, 'false' for abort
+ */
 uint8_t did_pause_print = 0;
 
 bool pause_print(const float &retract, const point_t &park_point, const float &unload_length/*=0*/, const bool show_lcd/*=false*/) {
@@ -277,7 +321,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
   #if ENABLED(SDSUPPORT)
     if (card.sdprinting) {
       card.pauseSDPrint();
-      ++did_pause_print;
+      ++did_pause_print; // Indicate SD pause also
     }
   #endif
   print_job_timer.pause();
@@ -302,6 +346,13 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
   return true;
 }
 
+/**
+ * - Show "Insert filament and press button to continue"
+ * - Wait for a click before returning
+ * - Heaters can time out, reheated before accepting a click
+ *
+ * Used by M125 and M600
+ */
 void wait_for_filament_reload(const int8_t max_beep_count/*=0*/) {
   bool nozzle_timed_out = false;
 
@@ -388,12 +439,29 @@ void wait_for_filament_reload(const int8_t max_beep_count/*=0*/) {
   KEEPALIVE_STATE(IN_HANDLER);
 }
 
-void resume_print(const float &load_length/*=0*/, const float &extrude_length/*=ADVANCED_PAUSE_EXTRUDE_LENGTH*/, const int8_t max_beep_count/*=0*/) {
-  bool nozzle_timed_out = false;
-
+/**
+ * Resume or Start print procedure
+ *
+ * - Abort if not paused
+ * - Reset heater idle timers
+ * - Load filament if specified, but only if:
+ *   - a nozzle timed out, or
+ *   - the nozzle is already heated.
+ * - Display "wait for print to resume"
+ * - Re-prime the nozzle...
+ *   -  FWRETRACT: Recover/prime from the prior G10.
+ *   - !FWRETRACT: Retract by resume_position[E], if negative.
+ *                 Not sure how this logic comes into use.
+ * - Move the nozzle back to resume_position
+ * - Sync the planner E to resume_position[E]
+ * - Send host action for resume, if configured
+ * - Resume the current SD print job, if any
+ */
+void resume_print(const float &load_length/*=0*/, const float &purge_length/*=ADVANCED_PAUSE_EXTRUDE_LENGTH*/, const int8_t max_beep_count/*=0*/) {
   if (!did_pause_print) return;
 
   // Re-enable the heaters if they timed out
+  bool nozzle_timed_out = false;
   HOTEND_LOOP() {
     nozzle_timed_out |= thermalManager.is_heater_idle(e);
     thermalManager.reset_heater_idle_timer(e);
@@ -401,7 +469,7 @@ void resume_print(const float &load_length/*=0*/, const float &extrude_length/*=
 
   if (nozzle_timed_out || thermalManager.hotEnoughToExtrude(active_extruder)) {
     // Load the new filament
-    load_filament(load_length, extrude_length, max_beep_count, true, nozzle_timed_out);
+    load_filament(load_length, purge_length, max_beep_count, true, nozzle_timed_out);
   }
 
   #if ENABLED(ULTIPANEL)
@@ -415,7 +483,7 @@ void resume_print(const float &load_length/*=0*/, const float &extrude_length/*=
     if (fwretract.retracted[active_extruder])
       do_pause_e_move(-fwretract.retract_length, fwretract.retract_feedrate_mm_s);
   #else
-    // If resume_position negative
+    // If resume_position is negative
     if (resume_position[E_AXIS] < 0) do_pause_e_move(resume_position[E_AXIS], PAUSE_PARK_RETRACT_FEEDRATE);
   #endif
 

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -50,11 +50,11 @@
  */
 void GcodeSuite::M125() {
   // Initial retract before move to filament change position
-  const float retract = parser.seen('L') ? parser.value_axis_units(E_AXIS) : 0
+  const float retract = -FABS(parser.seen('L') ? parser.value_axis_units(E_AXIS) : 0
     #ifdef PAUSE_PARK_RETRACT_LENGTH
-      - (PAUSE_PARK_RETRACT_LENGTH)
+      + (PAUSE_PARK_RETRACT_LENGTH)
     #endif
-  ;
+  );
 
   point_t park_point = NOZZLE_PARK_POINT;
 

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M600() {
 
   if (get_target_extruder_from_command()) return;
 
-  // Show initial message
+  // Show initial "wait for start" message
   #if ENABLED(ULTIPANEL)
     lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_INIT, ADVANCED_PAUSE_MODE_PAUSE_PRINT, target_extruder);
   #endif

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -59,7 +59,7 @@ void GcodeSuite::M701() {
   const float load_length = FABS(parser.seen('L') ? parser.value_axis_units(E_AXIS) :
                                                     filament_change_load_length[target_extruder]);
 
-  // Show initial message
+  // Show initial "wait for load" message
   #if ENABLED(ULTIPANEL)
     lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_LOAD, ADVANCED_PAUSE_MODE_LOAD_FILAMENT, target_extruder);
   #endif
@@ -112,7 +112,7 @@ void GcodeSuite::M702() {
   // Z axis lift
   if (parser.seenval('Z')) park_point.z = parser.linearval('Z');
 
-  // Show initial message
+  // Show initial "wait for unload" message
   #if ENABLED(ULTIPANEL)
     lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_UNLOAD, ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, target_extruder);
   #endif

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -959,6 +959,9 @@
 #ifndef MSG_ERR_PROBING_FAILED
   #define MSG_ERR_PROBING_FAILED              _UxGT("Probing failed")
 #endif
+#ifndef MSG_M600_TOO_COLD
+  #define MSG_M600_TOO_COLD                   _UxGT("M600: Too cold")
+#endif
 
 //
 // Filament Change screens show up to 3 lines on a 4-line display

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1402,7 +1402,7 @@ void kill_screen(const char* lcd_msg) {
     //
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
       #if E_STEPPERS == 1 && !ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
-        if (!thermalManager.targetTooColdToExtrude(active_extruder))
+        if (thermalManager.targetHotEnoughToExtrude(active_extruder))
           MENU_ITEM(gcode, MSG_FILAMENTCHANGE, PSTR("M600 B0"));
         else
           MENU_ITEM(submenu, MSG_FILAMENTCHANGE, lcd_temp_menu_e0_filament_change);
@@ -2608,7 +2608,7 @@ void kill_screen(const char* lcd_msg) {
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
       if (!IS_SD_FILE_OPEN) {
         #if E_STEPPERS == 1 && !ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
-          if (!thermalManager.targetTooColdToExtrude(active_extruder))
+          if (thermalManager.targetHotEnoughToExtrude(active_extruder))
             MENU_ITEM(gcode, MSG_FILAMENTCHANGE, PSTR("M600 B0"));
           else
             MENU_ITEM(submenu, MSG_FILAMENTCHANGE, lcd_temp_menu_e0_filament_change);
@@ -4282,21 +4282,21 @@ void kill_screen(const char* lcd_msg) {
 
             // Unload filament
             #if E_STEPPERS == 1
-              if (!thermalManager.targetTooColdToExtrude(active_extruder))
+              if (thermalManager.targetHotEnoughToExtrude(active_extruder))
                 MENU_ITEM(gcode, MSG_FILAMENTUNLOAD, PSTR("M702"));
               else
                 MENU_ITEM(submenu, MSG_FILAMENTUNLOAD, lcd_temp_menu_e0_filament_unload);
             #else
               #if ENABLED(FILAMENT_UNLOAD_ALL_EXTRUDERS)
-                if (!thermalManager.targetTooColdToExtrude(0)
+                if (thermalManager.targetHotEnoughToExtrude(0)
                   #if E_STEPPERS > 1
-                    && !thermalManager.targetTooColdToExtrude(1)
+                    && thermalManager.targetHotEnoughToExtrude(1)
                     #if E_STEPPERS > 2
-                      && !thermalManager.targetTooColdToExtrude(2)
+                      && thermalManager.targetHotEnoughToExtrude(2)
                       #if E_STEPPERS > 3
-                        && !thermalManager.targetTooColdToExtrude(3)
+                        && thermalManager.targetHotEnoughToExtrude(3)
                         #if E_STEPPERS > 4
-                          && !thermalManager.targetTooColdToExtrude(4)
+                          && thermalManager.targetHotEnoughToExtrude(4)
                         #endif // E_STEPPERS > 4
                       #endif // E_STEPPERS > 3
                     #endif // E_STEPPERS > 2
@@ -4306,26 +4306,26 @@ void kill_screen(const char* lcd_msg) {
               else
                 MENU_ITEM(submenu, MSG_FILAMENTUNLOAD_ALL, lcd_unload_filament_all_temp_menu);
               #endif
-              if (!thermalManager.targetTooColdToExtrude(0))
+              if (thermalManager.targetHotEnoughToExtrude(0))
                 MENU_ITEM(gcode, MSG_FILAMENTUNLOAD " " MSG_E1, PSTR("M702 T0"));
               else
                 MENU_ITEM(submenu, MSG_FILAMENTUNLOAD " " MSG_E1, lcd_temp_menu_e0_filament_unload);
-              if (!thermalManager.targetTooColdToExtrude(1))
+              if (thermalManager.targetHotEnoughToExtrude(1))
                 MENU_ITEM(gcode, MSG_FILAMENTUNLOAD " " MSG_E2, PSTR("M702 T1"));
               else
                 MENU_ITEM(submenu, MSG_FILAMENTUNLOAD " " MSG_E2, lcd_temp_menu_e1_filament_unload);
               #if E_STEPPERS > 2
-                if (!thermalManager.targetTooColdToExtrude(2))
+                if (thermalManager.targetHotEnoughToExtrude(2))
                   MENU_ITEM(gcode, MSG_FILAMENTUNLOAD " " MSG_E3, PSTR("M702 T2"));
                 else
                   MENU_ITEM(submenu, MSG_FILAMENTUNLOAD " " MSG_E3, lcd_temp_menu_e2_filament_unload);
                 #if E_STEPPERS > 3
-                  if (!thermalManager.targetTooColdToExtrude(3))
+                  if (thermalManager.targetHotEnoughToExtrude(3))
                     MENU_ITEM(gcode, MSG_FILAMENTUNLOAD " " MSG_E4, PSTR("M702 T3"));
                   else
                     MENU_ITEM(submenu, MSG_FILAMENTUNLOAD " " MSG_E4, lcd_temp_menu_e3_filament_unload);
                   #if E_STEPPERS > 4
-                    if (!thermalManager.targetTooColdToExtrude(4))
+                    if (thermalManager.targetHotEnoughToExtrude(4))
                       MENU_ITEM(gcode, MSG_FILAMENTUNLOAD " " MSG_E5, PSTR("M702 T4"));
                     else
                       MENU_ITEM(submenu, MSG_FILAMENTUNLOAD " " MSG_E5, lcd_temp_menu_e4_filament_unload);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -188,6 +188,9 @@ class Temperature {
       FORCE_INLINE static bool targetTooColdToExtrude(const uint8_t e) { UNUSED(e); return false; }
     #endif
 
+    FORCE_INLINE static bool hotEnoughToExtrude(const uint8_t e) { return !tooColdToExtrude(e); }
+    FORCE_INLINE static bool targetHotEnoughToExtrude(const uint8_t e) { return !targetTooColdToExtrude(e); }
+
   private:
 
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)


### PR DESCRIPTION
Counterpart to #9263

- Add commentary to filament change, pause, and resume functions.
- Show `M600: Too cold` message on LCD when M600 fails.
- Make `L` parameter to `M125` sign-agnostic.