### PR TITLE
[1.1.x] Added missing SoftwareSerial initialization to TMC2208

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -1510,17 +1510,17 @@ static_assert(1 >= 0
  * TMC2208 software UART and ENDSTOP_INTERRUPTS both use pin change interrupts (PCI)
  */
 #if ENABLED(HAVE_TMC2208) && ENABLED(ENDSTOP_INTERRUPTS_FEATURE) && !( \
-       ENABLED( X_HARDWARE_SERIAL  ) \
-    || ENABLED( X2_HARDWARE_SERIAL ) \
-    || ENABLED( Y_HARDWARE_SERIAL  ) \
-    || ENABLED( Y2_HARDWARE_SERIAL ) \
-    || ENABLED( Z_HARDWARE_SERIAL  ) \
-    || ENABLED( Z2_HARDWARE_SERIAL ) \
-    || ENABLED( E0_HARDWARE_SERIAL ) \
-    || ENABLED( E1_HARDWARE_SERIAL ) \
-    || ENABLED( E2_HARDWARE_SERIAL ) \
-    || ENABLED( E3_HARDWARE_SERIAL ) \
-    || ENABLED( E4_HARDWARE_SERIAL ) )
+       defined(X_HARDWARE_SERIAL ) \
+    || defined(X2_HARDWARE_SERIAL) \
+    || defined(Y_HARDWARE_SERIAL ) \
+    || defined(Y2_HARDWARE_SERIAL) \
+    || defined(Z_HARDWARE_SERIAL ) \
+    || defined(Z2_HARDWARE_SERIAL) \
+    || defined(E0_HARDWARE_SERIAL) \
+    || defined(E1_HARDWARE_SERIAL) \
+    || defined(E2_HARDWARE_SERIAL) \
+    || defined(E3_HARDWARE_SERIAL) \
+    || defined(E4_HARDWARE_SERIAL) )
   #error "select hardware UART for TMC2208 to use both TMC2208 and ENDSTOP_INTERRUPTS_FEATURE."
 #endif
 

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -252,82 +252,82 @@
   #include "planner.h"
 
   #define _TMC2208_DEFINE_HARDWARE(ST) TMC2208Stepper stepper##ST(&ST##_HARDWARE_SERIAL)
-  #define _TMC2208_DEFINE_SOFTWARE(ST) SoftwareSerial stepper##ST##_serial = SoftwareSerial(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN); \
+  #define _TMC2208_DEFINE_SOFTWARE(ST) SoftwareSerial ST##_HARDWARE_SERIAL = SoftwareSerial(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN); \
                                        TMC2208Stepper stepper##ST(&stepper##ST##_serial, ST##_SERIAL_RX_PIN > -1)
 
   // Stepper objects of TMC2208 steppers used
   #if ENABLED(X_IS_TMC2208)
-    #if defined(X_HARDWARE_SERIAL)
+    #ifdef X_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(X);
     #else
       _TMC2208_DEFINE_SOFTWARE(X);
     #endif
   #endif
   #if ENABLED(X2_IS_TMC2208)
-    #if defined(X2_HARDWARE_SERIAL)
+    #ifdef X2_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(X2);
     #else
       _TMC2208_DEFINE_SOFTWARE(X2);
     #endif
   #endif
   #if ENABLED(Y_IS_TMC2208)
-    #if defined(Y_HARDWARE_SERIAL)
+    #ifdef Y_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(Y);
     #else
       _TMC2208_DEFINE_SOFTWARE(Y);
     #endif
   #endif
   #if ENABLED(Y2_IS_TMC2208)
-    #if defined(Y2_HARDWARE_SERIAL)
+    #ifdef Y2_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(Y2);
     #else
       _TMC2208_DEFINE_SOFTWARE(Y2);
     #endif
   #endif
   #if ENABLED(Z_IS_TMC2208)
-    #if defined(Z_HARDWARE_SERIAL)
+    #ifdef Z_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(Z);
     #else
       _TMC2208_DEFINE_SOFTWARE(Z);
     #endif
   #endif
   #if ENABLED(Z2_IS_TMC2208)
-    #if defined(Z2_HARDWARE_SERIAL)
+    #ifdef Z2_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(Z2);
     #else
       _TMC2208_DEFINE_SOFTWARE(Z2);
     #endif
   #endif
   #if ENABLED(E0_IS_TMC2208)
-    #if defined(E0_HARDWARE_SERIAL)
+    #ifdef E0_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(E0);
     #else
       _TMC2208_DEFINE_SOFTWARE(E0);
     #endif
   #endif
   #if ENABLED(E1_IS_TMC2208)
-    #if defined(E1_HARDWARE_SERIAL)
+    #ifdef E1_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(E1);
     #else
       _TMC2208_DEFINE_SOFTWARE(E1);
     #endif
   #endif
   #if ENABLED(E2_IS_TMC2208)
-    #if defined(E2_HARDWARE_SERIAL)
+    #ifdef E2_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(E2);
     #else
       _TMC2208_DEFINE_SOFTWARE(E2);
     #endif
   #endif
   #if ENABLED(E3_IS_TMC2208)
-    #if defined(E3_HARDWARE_SERIAL)
+    #ifdef E3_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(E3);
     #else
       _TMC2208_DEFINE_SOFTWARE(E3);
     #endif
   #endif
   #if ENABLED(E4_IS_TMC2208)
-    #if defined(E4_HARDWARE_SERIAL)
+    #ifdef E4_HARDWARE_SERIAL
       _TMC2208_DEFINE_HARDWARE(E4);
     #else
       _TMC2208_DEFINE_SOFTWARE(E4);
@@ -335,38 +335,38 @@
   #endif
 
   void tmc2208_serial_begin() {
-    #if ENABLED(X_IS_TMC2208) && defined(X_HARDWARE_SERIAL)
-      X_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(X_IS_TMC2208)
+      X_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(X2_IS_TMC2208) && defined(X2_HARDWARE_SERIAL)
-      X2_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(X2_IS_TMC2208)
+      X2_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(Y_IS_TMC2208) && defined(Y_HARDWARE_SERIAL)
-      Y_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(Y_IS_TMC2208)
+      Y_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(Y2_IS_TMC2208) && defined(Y2_HARDWARE_SERIAL)
-      Y2_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(Y2_IS_TMC2208)
+      Y2_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(Z_IS_TMC2208) && defined(Z_HARDWARE_SERIAL)
-      Z_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(Z_IS_TMC2208)
+      Z_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(Z2_IS_TMC2208) && defined(Z2_HARDWARE_SERIAL)
-      Z2_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(Z2_IS_TMC2208)
+      Z2_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(E0_IS_TMC2208) && defined(E0_HARDWARE_SERIAL)
-      E0_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(E0_IS_TMC2208)
+      E0_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(E1_IS_TMC2208) && defined(E1_HARDWARE_SERIAL)
-      E1_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(E1_IS_TMC2208)
+      E1_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(E2_IS_TMC2208) && defined(E2_HARDWARE_SERIAL)
-      E2_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(E2_IS_TMC2208)
+      E2_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(E3_IS_TMC2208) && defined(E3_HARDWARE_SERIAL)
-      E3_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(E3_IS_TMC2208)
+      E3_HARDWARE_SERIAL.begin(115200);
     #endif
-    #if ENABLED(E4_IS_TMC2208) && defined(E4_HARDWARE_SERIAL)
-      E4_HARDWARE_SERIAL.begin(250000);
+    #if ENABLED(E4_IS_TMC2208)
+      E4_HARDWARE_SERIAL.begin(115200);
     #endif
   }
 
@@ -535,4 +535,3 @@
   }
 
 #endif // HAVE_L6470DRIVER
-


### PR DESCRIPTION
Hi,
i found that in the tmc2208_serial_begin() function only the HardwareSerial is initialized correctly, the SoftwareSerial begin is missing.

After this, I decreased the baudrate to 115200 from 250000, safe is better in serial communication :P