### PR TITLE
[1.1.x] Include Z Fade in log_machine_info

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4362,32 +4362,40 @@ void home_all_axes() { gcode_G28(true); }
    */
   inline void gcode_G29() {
 
+    #if ENABLED(DEBUG_LEVELING_FEATURE) || ENABLED(PROBE_MANUALLY)
+      const bool seenQ = parser.seen('Q');
+    #else
+      constexpr bool seenQ = false;
+    #endif
+
     // G29 Q is also available if debugging
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      const bool query = parser.seen('Q');
       const uint8_t old_debug_flags = marlin_debug_flags;
-      if (query) marlin_debug_flags |= DEBUG_LEVELING;
+      if (seenQ) marlin_debug_flags |= DEBUG_LEVELING;
       if (DEBUGGING(LEVELING)) {
         DEBUG_POS(">>> G29", current_position);
         log_machine_info();
       }
       marlin_debug_flags = old_debug_flags;
       #if DISABLED(PROBE_MANUALLY)
-        if (query) return;
+        if (seenQ) return;
       #endif
     #endif
 
     #if ENABLED(PROBE_MANUALLY)
-      const bool seenA = parser.seen('A'), seenQ = parser.seen('Q'), no_action = seenA || seenQ;
+      const bool seenA = parser.seen('A');
+    #else
+      constexpr bool seenA = false;
     #endif
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE) && DISABLED(PROBE_MANUALLY)
-      const bool faux = parser.boolval('C');
-    #elif ENABLED(PROBE_MANUALLY)
-      const bool faux = no_action;
-    #else
-      bool constexpr faux = false;
-    #endif
+    const bool  no_action = seenA || seenQ,
+                faux =
+                  #if ENABLED(DEBUG_LEVELING_FEATURE) && DISABLED(PROBE_MANUALLY)
+                    parser.boolval('C')
+                  #else
+                    no_action
+                  #endif
+                ;
 
     // Don't allow auto-leveling without homing first
     if (axis_unhomed_error()) return;
@@ -4618,7 +4626,7 @@ void home_all_axes() { gcode_G28(true); }
 
       // Disable auto bed leveling during G29.
       // Be formal so G29 can be done successively without G28.
-      set_bed_leveling_enabled(false);
+      if (!no_action) set_bed_leveling_enabled(false);
 
       #if HAS_BED_PROBE
         // Deploy the probe. Probe will raise if needed.

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -253,7 +253,7 @@
 
   #define _TMC2208_DEFINE_HARDWARE(ST) TMC2208Stepper stepper##ST(&ST##_HARDWARE_SERIAL)
   #define _TMC2208_DEFINE_SOFTWARE(ST) SoftwareSerial ST##_HARDWARE_SERIAL = SoftwareSerial(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN); \
-                                       TMC2208Stepper stepper##ST(&stepper##ST##_serial, ST##_SERIAL_RX_PIN > -1)
+                                       TMC2208Stepper stepper##ST(&ST##_HARDWARE_SERIAL, ST##_SERIAL_RX_PIN > -1)
 
   // Stepper objects of TMC2208 steppers used
   #if ENABLED(X_IS_TMC2208)


### PR DESCRIPTION
For debugging purposes it can help to see the Z fade height and its current effect on leveling compensation.