### PR TITLE
Update Configuration.h, fix  DEFAULT_NOMINAL_FILAMENT_DIA value

### DIFF
--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
@@ -136,7 +136,7 @@
 #define EXTRUDERS 1
 
 // Generally expected filament diameter (1.75, 2.85, 3.0, ...). Used for Volumetric, Filament Width Sensor, etc.
-#define DEFAULT_NOMINAL_FILAMENT_DIA 3.0
+#define DEFAULT_NOMINAL_FILAMENT_DIA 1.75
 
 // For Cyclops or any "multi-extruder" that shares a single nozzle.
 //#define SINGLENOZZLE


### PR DESCRIPTION
The technical specs (https://www.bq.com/en/hephestos-2) state that the hephestos 2 only supports 1.75mm out-of-the-box. Maybe some hackers update their h2 with 3mm extruders but those will probably know how to update the software-code themselves. 