### PR TITLE
[1.1.x] Fix parser.has_value, M118 parameters

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9165,7 +9165,7 @@ inline void gcode_M226() {
     }
     else {
       SERIAL_ERROR_START();
-      SERIAL_ERRORLN("Bad i2c request");
+      SERIAL_ERRORLNPGM("Bad i2c request");
     }
   }
 
@@ -9296,7 +9296,7 @@ inline void gcode_M226() {
     }
     else {
       SERIAL_ERROR_START();
-      SERIAL_ERRORLN(MSG_INVALID_EXTRUDER);
+      SERIAL_ERRORLNPGM(MSG_INVALID_EXTRUDER);
     }
   }
 
@@ -10786,10 +10786,10 @@ inline void gcode_M355() {
     // always report case light status
     SERIAL_ECHO_START();
     if (!case_light_on) {
-      SERIAL_ECHOLN("Case light: off");
+      SERIAL_ECHOLNPGM("Case light: off");
     }
     else {
-      if (!USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN)) SERIAL_ECHOLN("Case light: on");
+      if (!USEABLE_HARDWARE_PWM(CASE_LIGHT_PIN)) SERIAL_ECHOLNPGM("Case light: on");
       else SERIAL_ECHOLNPAIR("Case light: ", (int)case_light_brightness);
     }
 
@@ -10912,7 +10912,7 @@ inline void invalid_extruder_error(const uint8_t e) {
   SERIAL_CHAR('T');
   SERIAL_ECHO_F(e, DEC);
   SERIAL_CHAR(' ');
-  SERIAL_ECHOLN(MSG_INVALID_EXTRUDER);
+  SERIAL_ECHOLNPGM(MSG_INVALID_EXTRUDER);
 }
 
 #if ENABLED(PARKING_EXTRUDER)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8590,8 +8590,8 @@ inline void gcode_M117() { lcd_setstatus(parser.string_arg); }
  *  E1  Have the host 'echo:' the text
  */
 inline void gcode_M118() {
-  if (parser.boolval('E')) SERIAL_ECHO_START();
-  if (parser.boolval('A')) SERIAL_ECHOPGM("// ");
+  if (parser.seenval('E') && parser.value_bool()) SERIAL_ECHO_START();
+  if (parser.seenval('A') && parser.value_bool()) SERIAL_ECHOPGM("// ");
   SERIAL_ECHOLN(parser.string_arg);
 }
 

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -335,7 +335,7 @@ void CardReader::openFile(char* name, const bool read, const bool subcall/*=fals
       if (file_subcall_ctr > SD_PROCEDURE_DEPTH - 1) {
         SERIAL_ERROR_START();
         SERIAL_ERRORPGM("trying to call sub-gcode files with too many levels. MAX level is:");
-        SERIAL_ERRORLN(SD_PROCEDURE_DEPTH);
+        SERIAL_ERRORLN((int)SD_PROCEDURE_DEPTH);
         kill(PSTR(MSG_KILLED));
         return;
       }

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -30,7 +30,6 @@
 #define _FASTIO_ARDUINO_H
 
 #include <avr/io.h>
-#include "macros.h"
 
 #define AVR_AT90USB1286_FAMILY (defined(__AVR_AT90USB1287__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1286P__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB646P__)  || defined(__AVR_AT90USB647__))
 #define AVR_ATmega1284_FAMILY (defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__))
@@ -56,9 +55,7 @@
   #error "Pins for this chip not defined in Arduino.h! If you have a working pins definition, please contribute!"
 #endif
 
-#ifndef _BV
-  #define _BV(PIN) (1UL << PIN)
-#endif
+#include "macros.h"
 
 /**
  * Magic I/O routines

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -276,7 +276,7 @@ void GCodeParser::unknown_command_error() {
     SERIAL_ECHO(codenum);
     SERIAL_ECHOLNPGM(")");
     #if ENABLED(FASTER_GCODE_PARSER)
-      SERIAL_ECHO(" args: \"");
+      SERIAL_ECHOPGM(" args: \"");
       for (char c = 'A'; c <= 'Z'; ++c)
         if (seen(c)) { SERIAL_CHAR(c); SERIAL_CHAR(' '); }
     #else

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -211,13 +211,7 @@ void GCodeParser::parse(char *p) {
       #endif
 
       #if ENABLED(FASTER_GCODE_PARSER)
-      {
-        set(code, has_num ? p : NULL            // Set parameter exists and pointer (NULL for no number)
-          #if ENABLED(DEBUG_GCODE_PARSER)
-            , debug
-          #endif
-        );
-      }
+        set(code, has_num ? p : NULL);          // Set parameter exists and pointer (NULL for no number)
       #endif
     }
     else if (!string_arg) {                     // Not A-Z? First time, keep as the string_arg

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -53,7 +53,7 @@ int GCodeParser::codenum;
 
 #if ENABLED(FASTER_GCODE_PARSER)
   // Optimized Parameters
-  byte GCodeParser::codebits[4];   // found bits
+  uint32_t GCodeParser::codebits;  // found bits
   uint8_t GCodeParser::param[26];  // parameter offsets from command_ptr
 #else
   char *GCodeParser::command_args; // start of parameters
@@ -76,7 +76,7 @@ void GCodeParser::reset() {
     subcode = 0;                        // No command sub-code
   #endif
   #if ENABLED(FASTER_GCODE_PARSER)
-    ZERO(codebits);                     // No codes yet
+    codebits = 0;                       // No codes yet
     //ZERO(param);                      // No parameters (should be safe to comment out this line)
   #endif
 }

--- a/Marlin/gcode.cpp
+++ b/Marlin/gcode.cpp
@@ -189,14 +189,7 @@ void GCodeParser::parse(char *p) {
 
       while (*p == ' ') p++;                    // Skip spaces between parameters & values
 
-      const bool has_num = NUMERIC(p[0])                            // [0-9]
-                        || (p[0] == '.' && NUMERIC(p[1]))           // .[0-9]
-                        || (
-                              (p[0] == '-' || p[0] == '+') && (     // [-+]
-                                NUMERIC(p[1])                       //     [0-9]
-                                || (p[1] == '.' && NUMERIC(p[2]))   //     .[0-9]
-                              )
-                            );
+      const bool has_num = valid_float(p);
 
       #if ENABLED(DEBUG_GCODE_PARSER)
         if (debug) {

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -116,17 +116,13 @@ public:
     }
 
     // Set the flag and pointer for a parameter
-    static void set(const char c, char * const ptr
-      #if ENABLED(DEBUG_GCODE_PARSER)
-        , const bool debug=false
-      #endif
-    ) {
+    static void set(const char c, char * const ptr) {
       const uint8_t ind = LETTER_BIT(c);
       if (ind >= COUNT(param)) return;           // Only A-Z
       SBI(codebits, ind);                        // parameter exists
       param[ind] = ptr ? ptr - command_ptr : 0;  // parameter offset or 0
       #if ENABLED(DEBUG_GCODE_PARSER)
-        if (debug) {
+        if (codenum == 800) {
           const uint16_t * const adr = (uint16_t*)&codebits;
           SERIAL_ECHOPAIR("Set bit ", (int)ind);
           SERIAL_ECHOPAIR(" of codebits (", hex_address((void*)adr[1]));
@@ -143,6 +139,11 @@ public:
       if (ind >= COUNT(param)) return false; // Only A-Z
       const bool b = TEST(codebits, ind);
       if (b) {
+        #if ENABLED(DEBUG_GCODE_PARSER)
+          if (codenum == 800) {
+            SERIAL_CHAR('\''); SERIAL_CHAR(c); SERIAL_ECHOLNPGM("' is seen");
+          }
+        #endif
         char * const ptr = command_ptr + param[ind];
         value_ptr = param[ind] && valid_float(ptr) ? ptr : (char*)NULL;
       }

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -62,7 +62,7 @@ private:
   static char *value_ptr;           // Set by seen, used to fetch the value
 
   #if ENABLED(FASTER_GCODE_PARSER)
-    static byte codebits[4];        // Parameters pre-scanned
+    static uint32_t codebits;       // Parameters pre-scanned
     static uint8_t param[26];       // For A-Z, offsets into command args
   #else
     static char *command_args;      // Args start here, for slow scan
@@ -99,12 +99,7 @@ public:
   // Reset is done before parsing
   static void reset();
 
-  // Index so that 'X' falls on index 24
-  #define PARAM_IND(N)  ((N) >> 3)
-  #define PARAM_BIT(N)  ((N) & 0x7)
-  #define LETTER_OFF(N) ((N) - 'A')
-  #define LETTER_IND(N) PARAM_IND(LETTER_OFF(N))
-  #define LETTER_BIT(N) PARAM_BIT(LETTER_OFF(N))
+  #define LETTER_BIT(N) ((N) - 'A')
 
   #if ENABLED(FASTER_GCODE_PARSER)
 
@@ -126,15 +121,17 @@ public:
         , const bool debug=false
       #endif
     ) {
-      const uint8_t ind = LETTER_OFF(c);
+      const uint8_t ind = LETTER_BIT(c);
       if (ind >= COUNT(param)) return;           // Only A-Z
-      SBI(codebits[PARAM_IND(ind)], PARAM_BIT(ind));        // parameter exists
+      SBI(codebits, ind);                        // parameter exists
       param[ind] = ptr ? ptr - command_ptr : 0;  // parameter offset or 0
       #if ENABLED(DEBUG_GCODE_PARSER)
         if (debug) {
-          SERIAL_ECHOPAIR("Set bit ", (int)PARAM_BIT(ind));
-          SERIAL_ECHOPAIR(" of index ", (int)PARAM_IND(ind));
-          SERIAL_ECHOLNPAIR(" | param = ", (int)param[ind]);
+          const uint16_t * const adr = (uint16_t*)&codebits;
+          SERIAL_ECHOPAIR("Set bit ", (int)ind);
+          SERIAL_ECHOPAIR(" of codebits (", hex_address((void*)adr[1]));
+          print_hex_word(adr[0]);
+          SERIAL_ECHOLNPAIR(") | param = ", (int)param[ind]);
         }
       #endif
     }
@@ -142,19 +139,19 @@ public:
     // Code seen bit was set. If not found, value_ptr is unchanged.
     // This allows "if (seen('A')||seen('B'))" to use the last-found value.
     static bool seen(const char c) {
-      const uint8_t ind = LETTER_OFF(c);
+      const uint8_t ind = LETTER_BIT(c);
       if (ind >= COUNT(param)) return false; // Only A-Z
-      const bool b = TEST(codebits[PARAM_IND(ind)], PARAM_BIT(ind));
+      const bool b = TEST(codebits, ind);
       if (b) {
-        const char * const ptr = command_ptr + param[ind];
+        char * const ptr = command_ptr + param[ind];
         value_ptr = param[ind] && valid_float(ptr) ? ptr : (char*)NULL;
       }
       return b;
     }
 
-    static bool seen_any() { return codebits[3] || codebits[2] || codebits[1] || codebits[0]; }
+    static bool seen_any() { return !!codebits; }
 
-    #define SEEN_TEST(L) TEST(codebits[LETTER_IND(L)], LETTER_BIT(L))
+    #define SEEN_TEST(L) TEST(codebits, LETTER_BIT(L))
 
   #else // !FASTER_GCODE_PARSER
 

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -101,6 +101,8 @@
 #define STRINGIFY(M) STRINGIFY_(M)
 
 // Macros for bit masks
+#undef _BV // Marlin needs 32-bit unsigned!
+#define _BV(b) (1UL << (b))
 #define TEST(n,b) (((n)&_BV(b))!=0)
 #define SBI(n,b) (n |= _BV(b))
 #define CBI(n,b) (n &= ~_BV(b))

--- a/Marlin/stepper_dac.cpp
+++ b/Marlin/stepper_dac.cpp
@@ -114,7 +114,7 @@
     SERIAL_ECHOPAIR(" (",   dac_amps(Z_AXIS));
     SERIAL_ECHOPAIR(") E:", dac_perc(E_AXIS));
     SERIAL_ECHOPAIR(" (",   dac_amps(E_AXIS));
-    SERIAL_ECHOLN(")");
+    SERIAL_ECHOLNPGM(")");
   }
 
   void dac_commit_eeprom() {

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -264,11 +264,11 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS],
     #endif
 
     if (!WITHIN(hotend, _BOT_HOTEND, _TOP_HOTEND)) {
-      SERIAL_ECHOLN(MSG_PID_BAD_EXTRUDER_NUM);
+      SERIAL_ECHOLNPGM(MSG_PID_BAD_EXTRUDER_NUM);
       return;
     }
 
-    SERIAL_ECHOLN(MSG_PID_AUTOTUNE_START);
+    SERIAL_ECHOLNPGM(MSG_PID_AUTOTUNE_START);
 
     disable_all_heaters(); // switch off all heaters.
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1220,7 +1220,7 @@
     SERIAL_PROTOCOLLNPAIR("UBL object count: ", (int)ubl_cnt);
 
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      SERIAL_PROTOCOL("planner.z_fade_height : ");
+      SERIAL_PROTOCOLPGM("planner.z_fade_height : ");
       SERIAL_PROTOCOL_F(planner.z_fade_height, 4);
       SERIAL_EOL();
     #endif


### PR DESCRIPTION
`M118` interprets any letter `A` or `E` in the line as a parameter. This patch updates `M118` so the `A` and `E` parameters require a numeric value.

To allow for this, the G-code parser has been tweaked in various ways.

Counterpart to #9327