### PR TITLE
[1.1.x] Option to show fan speed instead of feedrate

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -341,6 +341,7 @@
   #define LCD_STR_REFRESH     "\x04"
   #define LCD_STR_FOLDER      "\x05"
   #define LCD_FEEDRATE_CHAR    0x06
+  #define LCD_FANSPEED_CHAR    LCD_FEEDRATE_CHAR
   #define LCD_CLOCK_CHAR       0x07
   #define LCD_STR_ARROW_RIGHT ">"  /* from the default character set */
 #endif

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
@@ -531,6 +531,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 #define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 #define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 #define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
@@ -526,6 +526,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -530,6 +530,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -525,6 +525,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -523,6 +523,9 @@
 // Include a page of printer information in the LCD Main Menu
 //#define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -524,6 +524,9 @@
 // Include a page of printer information in the LCD Main Menu
 #define LCD_INFO_MENU
 
+// Show a fanspeed instead of feed rate on HD44780 LCD status screen
+//#define LCD_SHOW_FANSPEED
+
 // Scroll a longer status message into view
 //#define STATUS_MESSAGE_SCROLLING
 

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -312,16 +312,29 @@ static void lcd_set_custom_characters(
     B00000
   };
 
-  const static PROGMEM byte feedrate[8] = {
-    B11100,
-    B10000,
-    B11000,
-    B10111,
-    B00101,
-    B00110,
-    B00101,
-    B00000
-  };
+  #if ENABLED(LCD_SHOW_FANSPEED)
+    const static PROGMEM byte fanspeed[8] = {
+      B11100,
+      B10000,
+      B11011,
+      B10100,
+      B00111,
+      B00001,
+      B00110,
+      B00000
+    };
+  #else
+    const static PROGMEM byte feedrate[8] = {
+      B11100,
+      B10000,
+      B11000,
+      B10111,
+      B00101,
+      B00110,
+      B00101,
+      B00000
+    };
+  #endif
 
   const static PROGMEM byte clock[8] = {
     B00000,
@@ -406,7 +419,13 @@ static void lcd_set_custom_characters(
       createChar_P(LCD_BEDTEMP_CHAR, bedTemp);
       createChar_P(LCD_DEGREE_CHAR, degree);
       createChar_P(LCD_STR_THERMOMETER[0], thermometer);
-      createChar_P(LCD_FEEDRATE_CHAR, feedrate);
+      createChar_P(
+        #if ENABLED(LCD_SHOW_FANSPEED)
+          LCD_FANSPEED_CHAR, fanspeed
+        #else
+          LCD_FEEDRATE_CHAR, feedrate
+        #endif
+      );
       createChar_P(LCD_CLOCK_CHAR, clock);
 
       #if ENABLED(LCD_PROGRESS_BAR)
@@ -859,8 +878,23 @@ static void lcd_implementation_status_screen() {
   #if LCD_HEIGHT > 3
 
     lcd.setCursor(0, 2);
-    lcd.print((char)LCD_FEEDRATE_CHAR);
-    lcd.print(itostr3(feedrate_percentage));
+    #if ENABLED(LCD_SHOW_FANSPEED)
+      lcd.print((char)LCD_FANSPEED_CHAR);
+      lcd.print(itostr3(
+        100 * fanSpeeds[
+          #if HAS_FAN0
+            0
+          #elif HAS_FAN1
+            1
+          #elif HAS_FAN2
+            2
+          #endif
+        ] / 255
+      ));
+    #else
+      lcd.print((char)LCD_FEEDRATE_CHAR);
+      lcd.print(itostr3(feedrate_percentage));
+    #endif
     lcd.write('%');
 
     #if LCD_WIDTH >= 20 && ENABLED(SDSUPPORT)


### PR DESCRIPTION
Since I do not change the feedrate on my printer I thought it would be useful to put another information on that location on the LCD. So I created an option to display the fanspeed instead.