### PR TITLE
[2.0.x] DUE - add USEABLE_HARDWARE_PWM & clear up some compiler warnings

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_spi_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_spi_Due.cpp
@@ -130,7 +130,7 @@
     register uint32_t MOSI_MASK = PIN_MASK(MOSI_PIN);
     register uint32_t SCK_PORT_PLUS30 = ((uint32_t) PORT(SCK_PIN)) + 0x30;    /* SODR of port */
     register uint32_t SCK_MASK = PIN_MASK(SCK_PIN);
-    register uint32_t idx;
+    register uint32_t idx = 0;
 
     /* Negate bout, as the assembler requires a negated value */
     bout = ~bout;
@@ -209,8 +209,8 @@
 
   // run at ~8 .. ~10Mhz - Rx version (Tx line not altered)
   static uint8_t spiTransferRx0(uint8_t bout) { // using Mode 0
-    register uint32_t bin;
-    register uint32_t work;
+    register uint32_t bin = 0;
+    register uint32_t work = 0;
     register uint32_t BITBAND_MISO_PORT = BITBAND_ADDRESS( ((uint32_t)PORT(MISO_PIN))+0x3C, PIN_SHIFT(MISO_PIN));  /* PDSR of port in bitband area */
     register uint32_t SCK_PORT_PLUS30 = ((uint32_t) PORT(SCK_PIN)) + 0x30;    /* SODR of port */
     register uint32_t SCK_MASK = PIN_MASK(SCK_PIN);
@@ -327,8 +327,8 @@
     register uint32_t MOSI_MASK = PIN_MASK(MOSI_PIN);
     register uint32_t SCK_PORT_PLUS30 = ((uint32_t) PORT(SCK_PIN)) + 0x30;    /* SODR of port */
     register uint32_t SCK_MASK = PIN_MASK(SCK_PIN);
-    register uint32_t work;
-    register uint32_t txval;
+    register uint32_t work = 0;
+    register uint32_t txval = 0;
 
     /* The software SPI routine */
     __asm__ __volatile__(
@@ -402,8 +402,8 @@
   }
 
   static void spiRxBlock0(uint8_t* ptr, uint32_t todo) {
-    register uint32_t bin;
-    register uint32_t work;
+    register uint32_t bin = 0;
+    register uint32_t work = 0;
     register uint32_t BITBAND_MISO_PORT = BITBAND_ADDRESS( ((uint32_t)PORT(MISO_PIN))+0x3C, PIN_SHIFT(MISO_PIN));  /* PDSR of port in bitband area */
     register uint32_t SCK_PORT_PLUS30 = ((uint32_t) PORT(SCK_PIN)) + 0x30;    /* SODR of port */
     register uint32_t SCK_MASK = PIN_MASK(SCK_PIN);

--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -43,6 +43,10 @@
  * Utility functions
  */
 
+// Due has 12 PWMs assigned to logical pins 2-13.
+// 6, 7, 8 & 9 come from the PWM controller. The others come from the timers.
+#define USEABLE_HARDWARE_PWM(p) ((2 >= p) && (p <= 13))
+
 #ifndef MASK
   #define MASK(PIN)  (1 << PIN)
 #endif

--- a/Marlin/src/HAL/HAL_DUE/usb/compiler.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/compiler.h
@@ -105,7 +105,7 @@
  * \brief Marking \a v as a unused parameter or value.
  */
 #ifndef UNUSED
-#define UNUSED(v)          (void)(v)
+#define UNUSED(x) (void) (x)
 #endif
 
 /**
@@ -444,8 +444,8 @@ typedef struct
 #define ENABLE    1
 #ifndef __cplusplus
 #if !defined(__bool_true_false_are_defined)
-#define false     0
-#define true      1
+#define false 0
+#define true 1
 #endif
 #endif
 #ifndef PASS
@@ -455,10 +455,10 @@ typedef struct
 #define FAIL      1
 #endif
 #ifndef LOW
-#define LOW       0
+#define LOW  0x0
 #endif
 #ifndef HIGH
-#define HIGH      1
+#define HIGH 0x1
 #endif
 //! @}
 


### PR DESCRIPTION
1) Add USEABLE_HARDWARE_PWM macro for DUE
2) Clear up compiler warnings for uninitialized variables
3) Clear up compiler warnings for slightly different definitions

I couldn't clear up the warnings on the definitions of **true** and **false** because **framework-arduinosam** and **toolchain-gccarmnoneeabi** are the cause of the warnings.  One defines them as 0x1 & 0x0 while the other is 1 & 0.

This PR fixes the problem in Issue #7385.