### PR TITLE
[2.0.x] fix USEABLE_HARDWARE_PWM for DUE

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -45,7 +45,7 @@
 
 // Due has 12 PWMs assigned to logical pins 2-13.
 // 6, 7, 8 & 9 come from the PWM controller. The others come from the timers.
-#define USEABLE_HARDWARE_PWM(p) ((2 >= p) && (p <= 13))
+#define USEABLE_HARDWARE_PWM(p) ((2 <= p) && (p <= 13))
 
 #ifndef MASK
   #define MASK(PIN)  (1 << PIN)


### PR DESCRIPTION
This fixes a bug introduced by PR #9345.
