### PR TITLE
[2.0.x] DUE fastio change (final piece to case_light issue)

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -89,6 +89,7 @@
 #define _SET_OUTPUT(IO) do{ pmc_enable_periph_clk(g_APinDescription[IO].ulPeripheralId); \
                             PIO_Configure(g_APinDescription[IO].pPort, _READ(IO) ? PIO_OUTPUT_1 : PIO_OUTPUT_0, \
                                           g_APinDescription[IO].ulPin, g_APinDescription[IO].ulPinConfiguration); \
+                            g_pinStatus[IO] = (g_pinStatus[IO] & 0xF0) | PIN_STATUS_DIGITAL_OUTPUT;\               
                         }while(0)
 
 /// set pin as input with pullup mode


### PR DESCRIPTION
This makes Due's fastio macro  **_SET_OUTPUT** the same as **pinmode** in the SAM library.

Without it M355 P45 S1 did nothing while M42 P13 S45 worked.  The only difference between the two is the use of SET_OUTPUT vs. pinmode.

I've tested this on a Due with RAMPS_FD_V1.