### PR TITLE
[1.1.x] Add Z_PROBE_HYSTERESIS to mitigate Z jerking while probing

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -657,8 +657,7 @@
 //#define PROBING_HEATERS_OFF       // Turn heaters off when probing
 //#define PROBING_FANS_OFF          // Turn fans off when probing
 //#define DELAY_BEFORE_PROBING 200  // (ms) To prevent vibrations from triggering piezo sensors
-#define Z_PROBE_HYSTERESIS 1.0      // MM between Z_CLEARANCE_DEPLOY_PROBE and Current Z Hieght before probe will decend fast.
-                                    // Useful for uneven beds to mitigate fast/jerky (Z_PROBE_SPEED_FAST) probe moves downward before probing.
+
 // A probe that is deployed and stowed with a solenoid pin (SOL1_PIN)
 //#define SOLENOID_PROBE
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -657,7 +657,8 @@
 //#define PROBING_HEATERS_OFF       // Turn heaters off when probing
 //#define PROBING_FANS_OFF          // Turn fans off when probing
 //#define DELAY_BEFORE_PROBING 200  // (ms) To prevent vibrations from triggering piezo sensors
-
+#define Z_PROBE_HYSTERESIS 1.0      // MM between Z_CLEARANCE_DEPLOY_PROBE and Current Z Hieght before probe will decend fast.
+                                    // Useful for uneven beds to mitigate fast/jerky (Z_PROBE_SPEED_FAST) probe moves downward before probing.
 // A probe that is deployed and stowed with a solenoid pin (SOL1_PIN)
 //#define SOLENOID_PROBE
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2249,7 +2249,7 @@ static void clean_up_after_endstop_or_probe_move() {
       float z = Z_CLEARANCE_DEPLOY_PROBE;
       if (zprobe_zoffset < 0) z -= zprobe_zoffset;
 
-      if (z < current_position[Z_AXIS]) {
+      if (z + Z_PROBE_HYSTERESIS < current_position[Z_AXIS]) {
 
         // If we don't make it to the z position (i.e. the probe triggered), move up to make clearance for the probe
         if (!do_probe_move(z, Z_PROBE_SPEED_FAST))

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2244,13 +2244,12 @@ static void clean_up_after_endstop_or_probe_move() {
 
     #else
 
-      // If the nozzle is above the travel height then
+      // If the nozzle is well over the travel height then
       // move down quickly before doing the slow probe
-      float z = Z_CLEARANCE_DEPLOY_PROBE;
+      float z = Z_CLEARANCE_DEPLOY_PROBE + 5.0;
       if (zprobe_zoffset < 0) z -= zprobe_zoffset;
 
-      if (z + Z_PROBE_HYSTERESIS < current_position[Z_AXIS]) {
-
+      if (current_position[Z_AXIS] > z) {
         // If we don't make it to the z position (i.e. the probe triggered), move up to make clearance for the probe
         if (!do_probe_move(z, Z_PROBE_SPEED_FAST))
           do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_BETWEEN_PROBES, MMM_TO_MMS(Z_PROBE_SPEED_FAST));


### PR DESCRIPTION
Added `Z_PROBE_HYSTERESIS` to keep the z axis from trying to quickly get to `Z_CLEARANCE_DEPLOY_PROBE` height before each probe if that last probe was slightly higher than 0.00mm Has proven to make probing more accurate and smoother on my cr-10 with bltouch. 
Here is an example of the "Jerky" type movement myself and others were experiencing before this edit. https://youtu.be/ka9lZfgDax4