### PR TITLE
[2.0.x] Clear retracted status when homing the Z axis

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -55,6 +55,10 @@
   #include "../feature/tmc_util.h"
 #endif
 
+#if ENABLED(FWRETRACT)
+  #include "../feature/fwretract.h"
+#endif
+
 #define XYZ_CONSTS(type, array, CONFIG) const PROGMEM type array##_P[XYZ] = { X_##CONFIG, Y_##CONFIG, Z_##CONFIG }
 
 XYZ_CONSTS(float, base_min_pos,   MIN_POS);
@@ -1283,6 +1287,12 @@ void homeaxis(const AxisEnum axis) {
   // Put away the Z probe
   #if HOMING_Z_WITH_PROBE
     if (axis == Z_AXIS && STOW_PROBE()) return;
+  #endif
+
+  // Clear retracted status if homing the Z axis
+  #if ENABLED(FWRETRACT)
+    if (axis == Z_AXIS)
+      for (uint8_t i = 0; i < EXTRUDERS; i++) fwretract.retracted[i] = false;
   #endif
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)


### PR DESCRIPTION
Slic3r likes to issue a `G10` at the end of a print with no corresponding `G11`. I had noticed this, and decided to add a `G11` to my start G-code to ensure that the first retract on the next print wasn't missed. However, I realized that the sequence `G10`, `G28`, `G11` will cause the nozzle to be lowered  by the hop amount after the `G28`. This is bad because now the nozzle is actually lower than expected and will likely cause it to crash into the bed. This PR addresses both issues by clearing the `retracted` status of all of the extruders when the Z axis is homed.