### PR TITLE
[2.0.x] Fix compile error when FASTER_GCODE_PARSER is disabled

### DIFF
--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_spi_Teensy.cpp
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_spi_Teensy.cpp
@@ -91,12 +91,12 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
   SPI.beginTransaction(spiConfig);
   SPDR = token;
   for (uint16_t i = 0; i < 512; i += 2) {
-    while (!TEST(SPSR, SPIF)) { /* Intentionally left empty */ }
+    while (!TEST(SPSR, SPIF)) { /* nada */ }; 
     SPDR = buf[i];
-    while (!TEST(SPSR, SPIF)) { /* Intentionally left empty */ }
+    while (!TEST(SPSR, SPIF)) { /* nada */ }; 
     SPDR = buf[i + 1];
   }
-  while (!TEST(SPSR, SPIF)) { /* Intentionally left empty */ }
+  while (!TEST(SPSR, SPIF)) { /* nada */ }; 
   SPI.endTransaction();
 }
 

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -32,6 +32,9 @@
 #include "../inc/MarlinConfig.h"
 
 //#define DEBUG_GCODE_PARSER
+#if ENABLED(DEBUG_GCODE_PARSER)
+  #include "../libs/hex_print_routines.h"
+#endif
 
 /**
  * GCode parser
@@ -90,15 +93,15 @@ public:
 
   #define LETTER_BIT(N) ((N) - 'A')
 
+  FORCE_INLINE static bool valid_signless(const char * const p) {
+    return NUMERIC(p[0]) || (p[0] == '.' && NUMERIC(p[1])); // .?[0-9]
+  }
+
+  FORCE_INLINE static bool valid_float(const char * const p) {
+    return valid_signless(p) || ((p[0] == '-' || p[0] == '+') && valid_signless(&p[1])); // [-+]?.?[0-9]
+  }
+
   #if ENABLED(FASTER_GCODE_PARSER)
-
-    FORCE_INLINE static bool valid_signless(const char * const p) {
-      return NUMERIC(p[0]) || (p[0] == '.' && NUMERIC(p[1])); // .?[0-9]
-    }
-
-    FORCE_INLINE static bool valid_float(const char * const p) {
-      return valid_signless(p) || ((p[0] == '-' || p[0] == '+') && valid_signless(&p[1])); // [-+]?.?[0-9]
-    }
 
     FORCE_INLINE static bool valid_int(const char * const p) {
       return NUMERIC(p[0]) || ((p[0] == '-' || p[0] == '+') && NUMERIC(p[1])); // [-+]?[0-9]

--- a/Marlin/src/lcd/dogm/HAL_LCD_class_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_class_defines.h
@@ -28,10 +28,10 @@ extern u8g_dev_t u8g_dev_st7565_64128n_HAL_2x_hw_spi;
 class U8GLIB_64128N_2X_HAL : public U8GLIB
 {
   public:
-    U8GLIB_64128N_2X_HAL(uint8_t sck, uint8_t mosi, uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE)
+    U8GLIB_64128N_2X_HAL(pin_t sck, pin_t mosi, pin_t cs, pin_t a0, pin_t reset = U8G_PIN_NONE)
       : U8GLIB(&u8g_dev_st7565_64128n_HAL_2x_sw_spi, sck, mosi, cs, a0, reset)
       { }
-    U8GLIB_64128N_2X_HAL(uint8_t cs, uint8_t a0, uint8_t reset = U8G_PIN_NONE)
+    U8GLIB_64128N_2X_HAL(pin_t cs, pin_t a0, pin_t reset = U8G_PIN_NONE)
       : U8GLIB(&u8g_dev_st7565_64128n_HAL_2x_hw_spi, cs, a0, reset)
       { }
 };
@@ -42,10 +42,10 @@ extern u8g_dev_t u8g_dev_st7920_128x64_HAL_4x_hw_spi;
 class U8GLIB_ST7920_128X64_4X_HAL : public U8GLIB
 {
   public:
-    U8GLIB_ST7920_128X64_4X_HAL(uint8_t sck, uint8_t mosi, uint8_t cs, uint8_t reset = U8G_PIN_NONE)
+    U8GLIB_ST7920_128X64_4X_HAL(pin_t sck, pin_t mosi, pin_t cs, pin_t reset = U8G_PIN_NONE)
       : U8GLIB(&u8g_dev_st7920_128x64_HAL_4x_sw_spi, sck, mosi, cs, U8G_PIN_NONE, reset)    // a0 = U8G_PIN_NONE
       { }
-    U8GLIB_ST7920_128X64_4X_HAL(uint8_t cs, uint8_t reset = U8G_PIN_NONE)
+    U8GLIB_ST7920_128X64_4X_HAL(pin_t cs, pin_t reset = U8G_PIN_NONE)
       : U8GLIB(&u8g_dev_st7920_128x64_HAL_4x_hw_spi, cs, U8G_PIN_NONE, reset)   // a0 = U8G_PIN_NONE
       { }
 };
@@ -56,7 +56,7 @@ extern u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi;
 class U8GLIB_ST7920_128X64_RRD : public U8GLIB
 {
   public:
-    U8GLIB_ST7920_128X64_RRD(uint8_t sck, uint8_t mosi, uint8_t cs, uint8_t reset = U8G_PIN_NONE)
+    U8GLIB_ST7920_128X64_RRD(pin_t sck, pin_t mosi, pin_t cs, pin_t reset = U8G_PIN_NONE)
       : U8GLIB(&u8g_dev_st7920_128x64_rrd_sw_spi, sck, mosi, cs, U8G_PIN_NONE, reset)   // a0 = U8G_PIN_NONE
       { }
 };

--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -214,8 +214,10 @@
 //
 // Průša i3 MK2 Multiplexer Support
 //
-#define E_MUX0_PIN         P0_03   // ( 0) Z_CS_PIN
-#define E_MUX1_PIN         P0_02   // ( 1) E0_CS_PIN
+#if SERIAL_PORT != 0 && SERIAL_PORT_2 != 0
+  #define E_MUX0_PIN         P0_03   // ( 0) Z_CS_PIN
+  #define E_MUX1_PIN         P0_02   // ( 1) E0_CS_PIN
+#endif
 #define E_MUX2_PIN         P0_26   // (63) E1_CS_PIN
 
 /**


### PR DESCRIPTION
This PR makes the **parser.h** and **parser.cpp** portion of PR #9327 compatible with 8 bit CPUs plus fixes a few other items I ran into while testing the changes.

1) For 8 bit CPUs the letters P and above were not being recognized.  For AVR, the SBI & TEST only work on 8 & 16 bit values.  The solution was to replace the **_BV** part of the macros with **0x01UL <<**.

2) If faster parsing was disabled then there was a compile error.  The solution was to move the **valid_float** routine (and supporting routines).

3) Fixed compiler warnings. 

4) Fixed a compile error with **pins_RAMPS_RE_ARM.h** where it was calling out pins that weren't defined depending on how the serial ports were defined.

