### PR TITLE
[1.1.x] Fix broken G29 W I J

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -4490,7 +4490,8 @@ void home_all_axes() { gcode_G28(true); }
 
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-        if (parser.seen('W')) {
+        const bool seen_w = parser.seen('W');
+        if (seen_w) {
           if (!leveling_is_valid()) {
             SERIAL_ERROR_START();
             SERIAL_ERRORLNPGM("No bilinear grid");
@@ -4528,10 +4529,14 @@ void home_all_axes() { gcode_G28(true); }
           return;
         } // parser.seen('W')
 
+      #else
+
+        constexpr bool seen_w = false;
+
       #endif
 
       // Jettison bed leveling data
-      if (parser.seen('J')) {
+      if (!seen_w && parser.seen('J')) {
         reset_bed_level();
         return;
       }


### PR DESCRIPTION
The `J` parameter should not jettison leveling data if it was used with `W`.