### PR TITLE
[1.1.x] Separate 32-bit wide bit macros

### DIFF
--- a/Marlin/MarlinSPI.h
+++ b/Marlin/MarlinSPI.h
@@ -48,7 +48,7 @@ class SPI<MISO_PIN, MOSI_PIN, SCK_PIN> {
     }
     FORCE_INLINE static uint8_t receive() {
       SPDR = 0;
-      for (;!TEST(SPSR, SPIF););
+      while (!TEST(SPSR, SPIF)) { /* nada */ }
       return SPDR;
     }
 

--- a/Marlin/gcode.h
+++ b/Marlin/gcode.h
@@ -136,7 +136,7 @@ public:
     static bool seen(const char c) {
       const uint8_t ind = LETTER_BIT(c);
       if (ind >= COUNT(param)) return false; // Only A-Z
-      const bool b = TEST(codebits, ind);
+      const bool b = TEST32(codebits, ind);
       if (b) {
         #if ENABLED(DEBUG_GCODE_PARSER)
           if (codenum == 800) {
@@ -151,7 +151,7 @@ public:
 
     static bool seen_any() { return !!codebits; }
 
-    #define SEEN_TEST(L) TEST(codebits, LETTER_BIT(L))
+    #define SEEN_TEST(L) TEST32(codebits, LETTER_BIT(L))
 
   #else // !FASTER_GCODE_PARSER
 

--- a/Marlin/macros.h
+++ b/Marlin/macros.h
@@ -101,12 +101,17 @@
 #define STRINGIFY(M) STRINGIFY_(M)
 
 // Macros for bit masks
-#undef _BV // Marlin needs 32-bit unsigned!
-#define _BV(b) (1UL << (b))
-#define TEST(n,b) (((n)&_BV(b))!=0)
+#undef _BV
+#define _BV(b) (1<<(b))
+#define TEST(n,b) !!((n)&_BV(b))
 #define SBI(n,b) (n |= _BV(b))
 #define CBI(n,b) (n &= ~_BV(b))
 #define SET_BIT(n,b,value) (n) ^= ((-value)^(n)) & (_BV(b))
+
+#define _BV32(b) (1UL << (b))
+#define TEST32(n,b) !!((n)&_BV32(b))
+#define SBI32(n,b) (n |= _BV32(b))
+#define CBI32(n,b) (n &= ~_BV32(b))
 
 // Macro to check that a number if a power if 2
 #define IS_POWER_OF_2(x) ((x) && !((x) & ((x) - 1)))


### PR DESCRIPTION
Just apply 32-bit wide macros for cases where needed.