### PR TITLE
[2.0.x] Malyan M200 LCD

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/default/Configuration.h
+++ b/Marlin/src/config/default/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1575,6 +1575,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
+++ b/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Anet/A6/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration.h
@@ -1705,6 +1705,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Anet/A8/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration.h
@@ -1564,6 +1564,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/BIBO/TouchX/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/Configuration.h
@@ -1540,6 +1540,12 @@ const bool Z_MIN_PROBE_ENDSTOP_INVERTING = true; // set to true to invert the lo
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
@@ -1543,6 +1543,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
@@ -1556,6 +1556,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -1543,6 +1543,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Cartesio/Configuration.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration.h
@@ -1554,6 +1554,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration.h
@@ -1565,6 +1565,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -1541,6 +1541,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Creality/Ender/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender/Configuration.h
@@ -1544,6 +1544,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Felix/Configuration.h
+++ b/Marlin/src/config/examples/Felix/Configuration.h
@@ -1537,6 +1537,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Felix/DUAL/Configuration.h
+++ b/Marlin/src/config/examples/Felix/DUAL/Configuration.h
@@ -1537,6 +1537,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -1561,6 +1561,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
@@ -1570,6 +1570,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
@@ -1559,6 +1559,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration.h
@@ -1566,6 +1566,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -1562,6 +1562,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * Maylan M150 Configuration
+ * Malyan M150 Configuration
  * Non-Automatic Bed Level config by default
  */
 
@@ -1581,6 +1581,12 @@
 // LCD for Melzi Card with Graphical LCD
 //
 //#define LCD_FOR_MELZI
+
+//
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: I2C

--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -1545,6 +1545,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
@@ -1559,6 +1559,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -1559,6 +1559,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -1557,6 +1557,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/RigidBot/Configuration.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -1567,6 +1567,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/STM32F10/Configuration.h
+++ b/Marlin/src/config/examples/STM32F10/Configuration.h
@@ -1558,6 +1558,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Sanguinololu/Configuration.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration.h
@@ -1586,6 +1586,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/TheBorg/Configuration.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/TinyBoy2/Configuration.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration.h
@@ -1611,6 +1611,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Tronxy/X1/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X1/Configuration.h
@@ -1540,6 +1540,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
@@ -1546,6 +1546,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration.h
@@ -1588,6 +1588,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -1549,6 +1549,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1499,6 +1499,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
+++ b/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
@@ -1555,6 +1555,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1689,6 +1689,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1674,6 +1674,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1687,6 +1687,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/generic/Configuration.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration.h
@@ -1676,6 +1676,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
@@ -1679,6 +1679,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
@@ -1679,6 +1679,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
@@ -1688,6 +1688,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1569,6 +1569,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/makibox/Configuration.h
+++ b/Marlin/src/config/examples/makibox/Configuration.h
@@ -1558,6 +1558,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -1429,6 +1429,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
@@ -1550,6 +1550,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/config/examples/wt150/Configuration.h
+++ b/Marlin/src/config/examples/wt150/Configuration.h
@@ -1560,6 +1560,12 @@
 //#define LCD_FOR_MELZI
 
 //
+// LCD for Malyan M200 printers.
+// This requires SDSUPPORT to be enabled
+//
+//#define MALYAN_LCD
+
+//
 // CONTROLLER TYPE: I2C
 //
 // Note: These controllers require the installation of Arduino's LiquidCrystal_I2C

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -51,11 +51,7 @@
 
   #if ENABLED(NEWPANEL)
     void lcd_return_to_status();
-    void lcd_mesh_edit_setup(float initial);
-    float lcd_mesh_edit();
-    void lcd_z_offset_edit_setup(float);
     extern void _lcd_ubl_output_map_lcd();
-    float lcd_z_offset_edit();
   #endif
 
   extern float meshedit_done;

--- a/Marlin/src/gcode/temperature/M104_M109.cpp
+++ b/Marlin/src/gcode/temperature/M104_M109.cpp
@@ -70,8 +70,10 @@ void GcodeSuite::M104() {
       }
     #endif
 
-    if (parser.value_celsius() > thermalManager.degHotend(e))
-      lcd_status_printf_P(0, PSTR("E%i %s"), e + 1, MSG_HEATING);
+    #if ENABLED(ULTRA_LCD)
+      if (parser.value_celsius() > thermalManager.degHotend(e))
+        lcd_status_printf_P(0, PSTR("E%i %s"), e + 1, MSG_HEATING);
+    #endif
   }
 
   #if ENABLED(AUTOTEMP)
@@ -124,7 +126,10 @@ void GcodeSuite::M109() {
         print_job_timer.start();
     #endif
 
-    if (thermalManager.isHeatingHotend(target_extruder)) lcd_status_printf_P(0, PSTR("E%i %s"), target_extruder + 1, MSG_HEATING);
+    #if ENABLED(ULTRA_LCD)
+      if (thermalManager.isHeatingHotend(target_extruder))
+        lcd_status_printf_P(0, PSTR("E%i %s"), target_extruder + 1, MSG_HEATING);
+    #endif
   }
   else return;
 

--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -1,0 +1,449 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * malyanlcd.cpp
+ *
+ * LCD implementation for Malyan's LCD, a separate ESP8266 MCU running
+ * on Serial1 for the M200 board. This module outputs a pseudo-gcode
+ * wrapped in curly braces which the LCD implementation translates into
+ * actual G-code commands.
+ *
+ * Added to Marlin for Mini/Malyan M200
+ * Unknown commands as of Jan 2018: {H:}
+ * Not currently implemented:
+ * {E:} when sent by LCD. Meaning unknown.
+ *
+ * Notes for connecting to boards that are not Malyan:
+ * The LCD is 3.3v, so if powering from a RAMPS 1.4 board or
+ * other 5v/12v board, use a buck converter to power the LCD and
+ * the 3.3v side of a logic level shifter. Aux1 on the RAMPS board
+ * has Serial1 and 12v, making it perfect for this.
+ * Copyright (c) 2017 Jason Nelson (xC0000005)
+ */
+
+#include "../inc/MarlinConfig.h"
+#include "../sd/cardreader.h"
+#include "../sd/SdFatConfig.h"
+#include "../module/temperature.h"
+#include "../module/planner.h"
+#include "../module/stepper.h"
+#include "../module/motion.h"
+#include "../module/probe.h"
+#include "../libs/duration_t.h"
+#include "../module/printcounter.h"
+#include "../gcode/gcode.h"
+#include "../gcode/queue.h"
+#include "../module/configuration_store.h"
+
+#include "../Marlin.h"
+
+#if ENABLED(MALYAN_LCD)
+
+// On the Malyan M200, this will be Serial1. On a RAMPS board,
+// it might not be.
+#define LCD_SERIAL Serial1
+
+// This is based on longest sys command + a filename, plus some buffer
+// in case we encounter some data we don't recognize
+// There is no evidence a line will ever be this long, but better safe than sory
+#define MAX_CURLY_COMMAND (32 + LONG_FILENAME_LENGTH) * 2
+
+// Track incoming command bytes from the LCD
+int inbound_count;
+
+// Everything written needs the high bit set.
+void write_to_lcd_P(const char * const message) {
+  char encoded_message[MAX_CURLY_COMMAND];
+  uint8_t message_length = min(strlen_P(message), sizeof(encoded_message));
+
+  for (uint8_t i = 0; i < message_length; i++)
+    encoded_message[i] = pgm_read_byte(message[i]) | 0x80;
+
+  LCD_SERIAL.Print::write(encoded_message, message_length);
+}
+
+void write_to_lcd(const char * const message) {
+  char encoded_message[MAX_CURLY_COMMAND];
+  const uint8_t message_length = min(strlen(message), sizeof(encoded_message));
+
+  for (uint8_t i = 0; i < message_length; i++)
+    encoded_message[i] = message[i] | 0x80;
+
+  LCD_SERIAL.Print::write(encoded_message, message_length);
+}
+
+/**
+ * Process an LCD 'C' command.
+ * These are currently all temperature commands
+ * {C:T0190}
+ * Set temp for hotend to 190
+ * {C:P050}
+ * Set temp for bed to 50
+ * 
+ * the command portion begins after the :
+ */
+void process_lcd_c_command(const char* command) {
+  switch (command[0]) {
+    case 'T': {
+      // M104 S<temperature>
+      char cmd[20];
+      sprintf_P(cmd, PSTR("M104 S%s"), command + 1);
+      enqueue_and_echo_command_now(cmd, false);
+    } break;
+
+    case 'P': {
+      // M140 S<temperature>
+      char cmd[20];
+      sprintf_P(cmd, PSTR("M140 S%s"), command + 1);
+      enqueue_and_echo_command_now(cmd, false);
+    } break;
+
+    default:
+      SERIAL_ECHOLNPAIR("UNKNOWN C COMMAND", command);
+      return;
+  }
+}
+
+/**
+ * Process an LCD 'B' command.
+ * {B:0} results in: {T0:008/195}{T1:000/000}{TP:000/000}{TQ:000C}{TT:000000}
+ * T0/T1 are hot end temperatures, TP is bed, TQ is percent, and TT is probably
+ * time remaining (HH:MM:SS). The UI can't handle displaying a second hotend,
+ * but the stock firmware always sends it, and it's always zero.
+ */
+void process_lcd_eb_command(const char* command) {
+  char elapsed_buffer[10];
+  duration_t elapsed;
+  bool has_days;
+  uint8_t len;
+  switch (command[0]) {
+    case '0': {
+      elapsed = print_job_timer.duration();
+      sprintf_P(elapsed_buffer, PSTR("%02u%02u%02u"), uint16_t(elapsed.hour()), uint16_t(elapsed.minute()) % 60UL, elapsed.second());
+
+      char message_buffer[MAX_CURLY_COMMAND];
+      sprintf_P(message_buffer,
+              PSTR("{T0:%03.0f/%03i}{T1:000/000}{TP:%03.0f/%03i}{TQ:%03i}{TT:%s}"),
+              thermalManager.degHotend(0),
+              thermalManager.degTargetHotend(0),
+              thermalManager.degBed(),
+              thermalManager.degTargetBed(),
+              card.percentDone(),
+              elapsed_buffer);
+      write_to_lcd(message_buffer);
+    } break;
+
+    default:
+      SERIAL_ECHOLNPAIR("UNKNOWN E/B COMMAND", command);
+      return;
+  }
+}
+
+/**
+ * Process an LCD 'J' command.
+ * These are currently all movement commands.
+ * The command portion begins after the :
+ * Move X Axis
+ * 
+ * {J:E}{J:X-200}{J:E}
+ * {J:E}{J:X+200}{J:E}
+ * X, Y, Z, A (extruder)
+ */
+void process_lcd_j_command(const char* command) {
+  static bool steppers_enabled = false;
+  char axis = command[0];
+
+  switch (axis) {
+    case 'E':
+      // enable or disable steppers
+      // switch to relative
+      enqueue_and_echo_command_now("G91");
+      enqueue_and_echo_command_now(steppers_enabled ? "M18" : "M17");
+      steppers_enabled = !steppers_enabled;
+      break;
+    case 'A':
+      axis = 'E';
+      // fallthru
+    case 'Y':
+    case 'Z':
+    case 'X': {
+      // G0 <AXIS><distance>
+      // The M200 class UI seems to send movement in .1mm values.
+      char cmd[20];
+      sprintf_P(cmd, PSTR("G1 %c%03.1f"), axis, atof(command + 1) / 10.0);
+      enqueue_and_echo_command_now(cmd);
+    } break;
+    default:
+      SERIAL_ECHOLNPAIR("UNKNOWN J COMMAND", command);
+      return;
+  }
+}
+
+/**
+ * Process an LCD 'P' command, related to homing and printing.
+ * Cancel:
+ * {P:X}
+ * 
+ * Home all axes:
+ * {P:H}
+ * 
+ * Print a file:
+ * {P:000}
+ * The File number is specified as a three digit value.
+ * Printer responds with:
+ * {PRINTFILE:Mini_SNES_Bottom.gcode}
+ * {SYS:BUILD}echo:Now fresh file: Mini_SNES_Bottom.gcode
+ * File opened: Mini_SNES_Bottom.gcode Size: 5805813
+ * File selected
+ * {SYS:BUILD}
+ * T:-2526.8 E:0
+ * T:-2533.0 E:0
+ * T:-2537.4 E:0
+ * Note only the curly brace stuff matters.
+ */
+void process_lcd_p_command(const char* command) {
+
+  switch (command[0]) {
+    case 'X':
+      // cancel print
+      write_to_lcd_P(PSTR("{SYS:CANCELING}"));
+      clear_command_queue();
+      quickstop_stepper();
+      print_job_timer.stop();
+      thermalManager.disable_all_heaters();
+      #if FAN_COUNT > 0
+        for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+      #endif
+      wait_for_heatup = false;
+      write_to_lcd_P(PSTR("{SYS:STARTED}"));
+      break;
+    case 'H':
+      // Home all axis
+      enqueue_and_echo_command_now("G28");
+      break;
+    default: {
+      // Print file 000 - a three digit number indicating which
+      // file to print in the SD card. If it's a directory,
+      // then switch to the directory.
+
+      // Find the name of the file to print.
+      // It's needed to echo the PRINTFILE option.
+      // The {S:L} command should've ensured the SD card was mounted.
+      card.getfilename(atoi(command));
+
+      // There may be a difference in how V1 and V2 LCDs handle subdirectory
+      // prints. Investigate more. This matches the V1 motion controller actions
+      // but the V2 LCD switches to "print" mode on {SYS:DIR} response.
+      if (card.filenameIsDir) {
+        card.chdir(card.filename);
+        write_to_lcd_P(PSTR("{SYS:DIR}"));
+      }
+      else {
+        char message_buffer[MAX_CURLY_COMMAND];
+        sprintf_P(message_buffer, PSTR("{PRINTFILE:%s}"), card.filename);
+        write_to_lcd(message_buffer);
+        write_to_lcd_P(PSTR("{SYS:BUILD}"));
+        card.openAndPrintFile(card.filename);
+      }
+    } break; // default
+  } // switch
+}
+
+/**
+ * Handle an lcd 'S' command
+ * {S:I} - Temperature request
+ * {T0:999/000}{T1:000/000}{TP:004/000}
+ * 
+ * {S:L} - File Listing request
+ * Printer Response:
+ * {FILE:buttons.gcode}
+ * {FILE:update.bin}
+ * {FILE:nupdate.bin}
+ * {FILE:fcupdate.flg}
+ * {SYS:OK}
+ */
+void process_lcd_s_command(const char* command) {
+  switch (command[0]) {
+    case 'I': {
+      // temperature information
+      char message_buffer[MAX_CURLY_COMMAND];
+      sprintf_P(message_buffer, PSTR("{T0:%03.0f/%03i}{T1:000/000}{TP:%03.0f/%03i}"),
+        thermalManager.degHotend(0), thermalManager.degTargetHotend(0),
+        thermalManager.degBed(), thermalManager.degTargetBed()
+      );
+      write_to_lcd(message_buffer);
+    } break;
+
+    case 'H':
+      // Home all axis
+      enqueue_and_echo_command("G28", false);
+      break;
+
+    case 'L': {
+      if (!card.cardOK) card.initsd();
+
+      // A more efficient way to do this would be to
+      // implement a callback in the ls_SerialPrint code, but
+      // that requires changes to the core cardreader class that
+      // would not benefit the majority of users. Since one can't
+      // select a file for printing during a print, there's
+      // little reason not to do it this way.
+      char message_buffer[MAX_CURLY_COMMAND];
+      uint16_t file_count = card.get_num_Files();
+      for (uint16_t i = 0; i < file_count; i++) {
+        card.getfilename(i);
+        sprintf_P(message_buffer, card.filenameIsDir ? PSTR("{DIR:%s}") : PSTR("{FILE:%s}"), card.filename);
+        write_to_lcd(message_buffer);
+      }
+
+      write_to_lcd_P(PSTR("{SYS:OK}"));
+    } break;
+
+    default:
+      SERIAL_ECHOLNPAIR("UNKNOWN S COMMAND", command);
+      return;
+  }
+}
+
+/**
+ * Receive a curly brace command and translate to G-code.
+ * Currently {E:0} is not handled. Its function is unknown,
+ * but it occurs during the temp window after a sys build.
+ */
+void process_lcd_command(const char* command) {
+  const char *current = command;
+
+  current++; // skip the leading {. The trailing one is already gone.
+  byte command_code = *current++;
+  if (*current != ':') {
+    SERIAL_ECHOLNPAIR("UNKNOWN COMMAND FORMAT", command);
+    return;
+  }
+
+  current++; // skip the :
+
+  switch (command_code) {
+    case 'S':
+      process_lcd_s_command(current);
+      break;
+    case 'J':
+      process_lcd_j_command(current);
+      break;
+    case 'P':
+      process_lcd_p_command(current);
+      break;
+    case 'C':
+      process_lcd_c_command(current);
+      break;
+    case 'B':
+    case 'E':
+      process_lcd_eb_command(current);
+      break;
+    default:
+      SERIAL_ECHOLNPAIR("UNKNOWN COMMAND", command);
+      return;
+  }
+}
+
+/**
+ * UC means connected.
+ * UD means disconnected
+ * The stock firmware considers USB initialied as "connected."
+ */
+void update_usb_status(const bool forceUpdate) {
+  static bool last_usb_connected_status = false;
+  // This is mildly different than stock, which
+  // appears to use the usb discovery status.
+  // This is more logical.
+  if (last_usb_connected_status != Serial || forceUpdate) {
+    last_usb_connected_status =  Serial;
+    write_to_lcd_P(last_usb_connected_status ? PSTR("{R:UC}\r\n") : PSTR("{R:UD}\r\n"));
+  }
+}
+
+/**
+ * - from printer on startup:
+ * {SYS:STARTED}{VER:29}{SYS:STARTED}{R:UD}
+ * The optimize attribute fixes a register Compile
+ * error for amtel.
+ */
+void lcd_update() _O2 {
+  static char inbound_buffer[MAX_CURLY_COMMAND];
+
+  // First report USB status.
+  update_usb_status(false);
+
+  // now drain commands...
+  while (LCD_SERIAL.available()) {
+    const byte b = (byte)LCD_SERIAL.read() & 0x7F;
+    inbound_buffer[inbound_count++] = b;
+    if (b == '}' || inbound_count == sizeof(inbound_buffer) - 1) {
+      inbound_buffer[inbound_count - 1] = '\0';
+      process_lcd_command(inbound_buffer);
+      inbound_count = 0;
+      inbound_buffer[0] = 0;
+    }
+  }
+
+  // If there's a print in progress, we need to emit the status as
+  // {TQ:<PERCENT>}
+  if (card.sdprinting) {
+    // We also need to send: T:-2538.0 E:0
+    // I have no idea what this means.
+    char message_buffer[10];
+    sprintf_P(message_buffer, PSTR("{TQ:%03i}"), card.percentDone());
+    write_to_lcd(message_buffer);
+  }
+}
+
+/**
+ * The Malyan LCD actually runs as a separate MCU on Serial 1.
+ * This code's job is to siphon the weird curly-brace commands from
+ * it and translate into gcode, which then gets injected into
+ * the command queue where possible.
+ */
+void lcd_init() {
+  inbound_count = 0;
+  LCD_SERIAL.begin(500000);
+
+  // Signal init
+  write_to_lcd_P(PSTR("{SYS:STARTED}\r\n"));
+
+  // send a version that says "unsuported"
+  write_to_lcd_P(PSTR("{VER:66}\r\n"));
+
+  // No idea why it does this twice.
+  write_to_lcd_P(PSTR("{SYS:STARTED}\r\n"));
+  update_usb_status(true);
+}
+
+/**
+ * Set an alert.
+ */
+void lcd_setalertstatusPGM(const char* message) {
+  char message_buffer[MAX_CURLY_COMMAND];
+  sprintf_P(message_buffer, PSTR("{E:%s}"), message);
+  write_to_lcd(message_buffer);
+}
+
+#endif // Malyan LCD

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1208,7 +1208,7 @@ void kill_screen(const char* lcd_msg) {
       return mesh_edit_value;
     }
 
-    void lcd_mesh_edit_setup(const float initial) {
+    void lcd_mesh_edit_setup(const float &initial) {
       mesh_edit_value = mesh_edit_accumulator = initial;
       lcd_goto_screen(_lcd_mesh_edit_NOP);
     }
@@ -1222,7 +1222,7 @@ void kill_screen(const char* lcd_msg) {
       return mesh_edit_value;
     }
 
-    void lcd_z_offset_edit_setup(float initial) {
+    void lcd_z_offset_edit_setup(const float &initial) {
       mesh_edit_value = mesh_edit_accumulator = initial;
       lcd_goto_screen(_lcd_z_offset_edit);
     }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -25,6 +25,11 @@
 
 #include "../inc/MarlinConfig.h"
 
+#if ENABLED(ULTRA_LCD) || ENABLED(MALYAN_LCD)
+  void lcd_init();
+  bool lcd_detected();
+#endif
+
 #if ENABLED(ULTRA_LCD)
 
   #include "../Marlin.h"
@@ -53,16 +58,14 @@
   int16_t lcd_strlen(const char* s);
   int16_t lcd_strlen_P(const char* s);
   void lcd_update();
-  void lcd_init();
   bool lcd_hasstatus();
   void lcd_setstatus(const char* message, const bool persist=false);
   void lcd_setstatusPGM(const char* message, const int8_t level=0);
   void lcd_setalertstatusPGM(const char* message);
-  void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...);
   void lcd_reset_alert_level();
+  void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...);
   void lcd_kill_screen();
   void kill_screen(const char* lcd_msg);
-  bool lcd_detected(void);
 
   extern uint8_t lcdDrawUpdate;
   inline void lcd_refresh() { lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; }
@@ -131,9 +134,9 @@
     #endif
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      void lcd_mesh_edit_setup(float initial);
+      void lcd_mesh_edit_setup(const float &initial);
       float lcd_mesh_edit();
-      void lcd_z_offset_edit_setup(float);
+      void lcd_z_offset_edit_setup(const float &initial);
       float lcd_z_offset_edit();
     #endif
 
@@ -224,17 +227,17 @@
 
   constexpr bool lcd_wait_for_move = false;
 
-  inline void lcd_update() {}
   inline void lcd_init() {}
+  inline bool lcd_detected() { return true; }
+  inline void lcd_update() {}
+  inline void lcd_refresh() {}
+  inline void lcd_buttons_update() {}
   inline bool lcd_hasstatus() { return false; }
   inline void lcd_setstatus(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
   inline void lcd_setstatusPGM(const char* const message, const int8_t level=0) { UNUSED(message); UNUSED(level); }
-  inline void lcd_setalertstatusPGM(const char* message) { UNUSED(message); }
   inline void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...) { UNUSED(level); UNUSED(fmt); }
-  inline void lcd_buttons_update() {}
+  inline void lcd_setalertstatusPGM(const char* message) { UNUSED(message); }
   inline void lcd_reset_alert_level() {}
-  inline bool lcd_detected() { return true; }
-  inline void lcd_refresh() {}
 
 #endif // ULTRA_LCD
 


### PR DESCRIPTION
I'm clueless about this display. But, I've rebuilt #9348 for @xC0000005 anyway!

---
This adds support for Malyan M200 LCDs, which are a separate ESP8266 MCU running on Serial1. Most of the commands are simple transations to gcode which are then injected. The exception is print menu support, which requires unique formatting for files and directories.

---
Changes to the original PR:
- Use `PSTR` wherever possible.
- Move globals to `static` locals where possible.
- Use smaller buffers where possible.
- Use stack-based buffers where possible.
- Apply coding standards, formatting, cleanup.