### PR TITLE
[2.0.x] Add support for Cohesion3D ReMix and Mini

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -163,6 +163,8 @@
 #define BOARD_AZTEEG_X5_GT        1752  // Azteeg X5 GT (Power outputs: Hotend0, Hotend1, Bed, Fan)
 #define BOARD_BIQU_BQ111_A4       1753  // BIQU BQ111-A4 (Power outputs: Hotend, Fan, Bed)
 #define BOARD_SELENA_COMPACT      1754  // Selena Compact (Power outputs: Hotend0, Hotend1, Bed0, Bed1, Fan0, Fan1)
+#define BOARD_COHESION3D_REMIX    1755  // Cohesion3D ReMix
+#define BOARD_COHESION3D_MINI     1756  // Cohesion3D Mini
 
 //
 // SAM3X8E ARM Cortex M3

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -343,6 +343,8 @@
   #include "pins_THE_BORG.h"
 #elif MB(SELENA_COMPACT)
   #include "pins_SELENA_COMPACT.h"
+#elif MB(COHESION3D_REMIX) || MB(COHESION3D_MINI)
+  #include "pins_COHESION3D.h"
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -343,8 +343,10 @@
   #include "pins_THE_BORG.h"
 #elif MB(SELENA_COMPACT)
   #include "pins_SELENA_COMPACT.h"
-#elif MB(COHESION3D_REMIX) || MB(COHESION3D_MINI)
-  #include "pins_COHESION3D.h"
+#elif MB(COHESION3D_REMIX)
+  #include "pins_COHESION3D_REMIX.h"
+#elif MB(COHESION3D_MINI)
+  #include "pins_COHESION3D_MINI.h"
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif

--- a/Marlin/src/pins/pins_COHESION3D.h
+++ b/Marlin/src/pins/pins_COHESION3D.h
@@ -1,0 +1,214 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Cohesion3D ReMix and Mini pin assignments
+ */
+
+#ifndef TARGET_LPC1768
+  #error "Oops!  Make sure you have LPC1768 selected."
+#endif
+
+#ifndef BOARD_NAME
+  #if MB(COHESION3D_REMIX)
+    #define BOARD_NAME "Cohesion3D ReMix"
+  #elif MB(COHESION3D_MINI)
+    #define BOARD_NAME "Cohesion3D Mini"
+  #endif
+#endif
+
+//
+// Servos
+//
+#if MB(COHESION3D_REMIX)
+  #define SERVO0_PIN        P2_04
+#elif MB(COHESION3D_MINI)
+  #define SERVO0_PIN        P1_23
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN           P1_24 // 10k pullup to 3.3V
+#define X_MAX_PIN           P1_25 // 10k pullup to 3.3V
+#define Y_MIN_PIN           P1_26 // 10k pullup to 3.3V
+#define Y_MAX_PIN           P1_27 // 10k pullup to 3.3V
+#define Z_MIN_PIN           P1_28 // 10k pullup to 3.3V
+#define Z_MAX_PIN           P1_29 // 10k pullup to 3.3V
+
+//
+// Steppers
+//
+#define X_STEP_PIN          P2_00
+#define X_DIR_PIN           P0_05
+#define X_ENABLE_PIN        P0_04
+#define X_CS_PIN            P1_10 // Ethernet Expansion - Pin 9
+
+#define Y_STEP_PIN          P2_01
+#define Y_DIR_PIN           P0_11
+#define Y_ENABLE_PIN        P0_10
+#define Y_CS_PIN            P1_09 // Ethernet Expansion - Pin 10
+
+#define Z_STEP_PIN          P2_02
+#define Z_DIR_PIN           P0_20
+#define Z_ENABLE_PIN        P0_19
+#define Z_CS_PIN            P1_00 // Ethernet Expansion - Pin 11
+
+#define E0_STEP_PIN         P2_03
+#define E0_DIR_PIN          P0_22
+#define E0_ENABLE_PIN       P0_21
+#define E0_CS_PIN           P1_04 // Ethernet Expansion - Pin 12
+
+#if MB(COHESION3D_REMIX)
+  #define E1_STEP_PIN       P2_08
+  #define E1_DIR_PIN        P2_13
+  #define E1_ENABLE_PIN     P4_29
+  #define E1_CS_PIN         P1_01 // Ethernet Expansion - Pin 14
+
+  #define E2_STEP_PIN       P1_20
+  #define E2_DIR_PIN        P1_19
+  #define E2_ENABLE_PIN     P1_21
+  #define E2_CS_PIN         P1_18 // FET 6
+#endif
+
+//
+// Default pins for TMC software SPI
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI     P1_16 // Ethernet Expansion - Pin 5
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO     P1_17 // Ethernet Expansion - Pin 6
+  #endif
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK      P1_08 // Ethernet Expansion - Pin 7
+  #endif
+#endif
+
+//
+// Analog Inputs
+//  3.3V max when defined as an analog input
+//
+#define TEMP_0_PIN          0 // P0_23
+#define TEMP_BED_PIN        1 // P0_24
+#if MB(COHESION3D_REMIX)
+  #define TEMP_1_PIN        2 // P0_25
+  #if ENABLED(FILAMENT_WIDTH_SENSOR)
+    #define FILWIDTH_PIN    3 // P0_26
+  #else
+    #define TEMP_2_PIN      3 // P0_26
+  #endif
+#endif
+
+//
+// Heaters / Fans
+//
+#define HEATER_BED_PIN      P2_05
+#define HEATER_0_PIN        P2_07 // FET 1
+#if MB(COHESION3D_REMIX)
+  #define HEATER_1_PIN      P1_23 // FET 2
+  #if HOTENDS == 3
+    #define HEATER_2_PIN    P1_22 // FET 3
+    #define AUTO_FAN_PIN    P1_18 // FET 6
+  #else
+    #define AUTO_FAN_PIN    P1_22 // FET 3
+  #endif
+#elif MB(COHESION3D_MINI)
+  #define AUTO_FAN_PIN      P2_04 // FET 4
+#endif
+#define FAN_PIN             P2_06 // ReMix FET 4, Mini FET 3
+
+//
+// Auto fans
+//
+#define ORIG_E0_AUTO_FAN_PIN  AUTO_FAN_PIN
+#define ORIG_E1_AUTO_FAN_PIN  AUTO_FAN_PIN
+#define ORIG_E2_AUTO_FAN_PIN  AUTO_FAN_PIN
+
+//
+// Misc. Functions
+//
+#define LED_PIN             P4_28 // Play LED
+
+//
+// M3/M4/M5 - Spindle/Laser Control
+//
+#if ENABLED(SPINDLE_LASER_ENABLE)
+  #undef HEATER_0_PIN
+  #define SPINDLE_LASER_ENABLE_PIN  P2_07 // FET 1
+  #undef HEATER_BED_PIN
+  #define SPINDLE_LASER_PWM_PIN     P2_05 // Bed FET
+  #undef FAN_PIN
+  #define SPINDLE_DIR_PIN           P2_06 // ReMix FET 4, Mini FET 3
+#endif
+
+//
+// LCD / Controller
+//
+// LCD_PINS_D5, LCD_PINS_D6 or LCD_PINS_D7 are not present in the EXP1 connector,
+// and will need to be defined in order to use the REPRAP_DISCOUNT_SMART_CONTROLLER.
+//
+// A remote SD card is currently not supported due to the pins routed to the EXP2
+// conecter are shared with the onboard SD card, and Marlin does not support reading
+// G-code files from the onboard SD card.
+//
+#if ENABLED(ULTRA_LCD)
+
+  #if MB(COHESION3D_REMIX)
+    #define BEEPER_PIN      P1_31 // EXP1-1
+    #define SD_DETECT_PIN   P0_27 // EXP2-7
+  #elif MB(COHESION3D_MINI)
+    #define BEEPER_PIN      P0_27 // EXP2-7 - open drain
+  #endif
+
+  #define BTN_EN1           P3_26 // EXP2-5
+  #define BTN_EN2           P3_25 // EXP2-3
+  #define BTN_ENC           P1_30 // EXP1-2
+
+  #define LCD_PINS_RS       P0_16 // EXP1-4
+  #define LCD_SDSS          P0_28 // EXP2-4
+  #define LCD_PINS_ENABLE   P0_18 // EXP1-3
+  #define LCD_PINS_D4       P0_15 // EXP1-5
+
+  #define KILL_PIN          P2_11 // EXP2-10
+
+  #if ENABLED(SDSUPPORT)
+    #error "SDSUPPORT is not currently supported by the Cohesion3D boards"
+  #endif
+
+#endif // ULTRA_LCD
+
+//
+// Ethernet pins
+//
+#define ENET_MDIO           P1_17
+#define ENET_RX_ER          P1_14
+#define ENET_RXD1           P1_10
+#define ENET_MOC            P1_16
+#define REF_CLK             P1_15
+#define ENET_RXD0           P1_09
+#define ENET_CRS            P1_08
+#define ENET_TX_EN          P1_04
+#define ENET_TXD0           P1_00
+#define ENET_TXD1           P1_01

--- a/Marlin/src/pins/pins_COHESION3D_MINI.h
+++ b/Marlin/src/pins/pins_COHESION3D_MINI.h
@@ -1,0 +1,171 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Cohesion3D Mini pin assignments
+ */
+
+#ifndef TARGET_LPC1768
+  #error "Oops!  Make sure you have LPC1768 selected."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "Cohesion3D Mini"
+#endif
+
+//
+// Servos
+//
+#define SERVO0_PIN          P1_23
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN           P1_24 // 10k pullup to 3.3V
+#define X_MAX_PIN           P1_25 // 10k pullup to 3.3V
+#define Y_MIN_PIN           P1_26 // 10k pullup to 3.3V
+#define Y_MAX_PIN           P1_27 // 10k pullup to 3.3V
+#define Z_MIN_PIN           P1_28 // 10k pullup to 3.3V
+#define Z_MAX_PIN           P1_29 // 10k pullup to 3.3V
+
+//
+// Steppers
+//
+#define X_STEP_PIN          P2_00
+#define X_DIR_PIN           P0_05
+#define X_ENABLE_PIN        P0_04
+#define X_CS_PIN            P1_10 // Ethernet Expansion - Pin 9
+
+#define Y_STEP_PIN          P2_01
+#define Y_DIR_PIN           P0_11
+#define Y_ENABLE_PIN        P0_10
+#define Y_CS_PIN            P1_09 // Ethernet Expansion - Pin 10
+
+#define Z_STEP_PIN          P2_02
+#define Z_DIR_PIN           P0_20
+#define Z_ENABLE_PIN        P0_19
+#define Z_CS_PIN            P1_00 // Ethernet Expansion - Pin 11
+
+#define E0_STEP_PIN         P2_03
+#define E0_DIR_PIN          P0_22
+#define E0_ENABLE_PIN       P0_21
+#define E0_CS_PIN           P1_04 // Ethernet Expansion - Pin 12
+
+//
+// Default pins for TMC software SPI
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI     P1_16 // Ethernet Expansion - Pin 5
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO     P1_17 // Ethernet Expansion - Pin 6
+  #endif
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK      P1_08 // Ethernet Expansion - Pin 7
+  #endif
+#endif
+
+//
+// Analog Inputs
+//  3.3V max when defined as an analog input
+//
+#define TEMP_0_PIN          0 // P0_23
+#define TEMP_BED_PIN        1 // P0_24
+
+//
+// Heaters / Fans
+//
+#define HEATER_BED_PIN      P2_05
+#define HEATER_0_PIN        P2_07 // FET 1
+#define AUTO_FAN_PIN        P2_04 // FET 4
+#define FAN_PIN             P2_06 // ReMix FET 4, Mini FET 3
+
+//
+// Auto fans
+//
+#define ORIG_E0_AUTO_FAN_PIN  AUTO_FAN_PIN
+#define ORIG_E1_AUTO_FAN_PIN  AUTO_FAN_PIN
+#define ORIG_E2_AUTO_FAN_PIN  AUTO_FAN_PIN
+
+//
+// Misc. Functions
+//
+#define LED_PIN             P4_28 // Play LED
+
+//
+// M3/M4/M5 - Spindle/Laser Control
+//
+#if ENABLED(SPINDLE_LASER_ENABLE)
+  #undef HEATER_0_PIN
+  #define SPINDLE_LASER_ENABLE_PIN  P2_07 // FET 1
+  #undef HEATER_BED_PIN
+  #define SPINDLE_LASER_PWM_PIN     P2_05 // Bed FET
+  #undef FAN_PIN
+  #define SPINDLE_DIR_PIN           P2_06 // ReMix FET 4, Mini FET 3
+#endif
+
+//
+// LCD / Controller
+//
+// LCD_PINS_D5, D6, and D7 are not present in the EXP1 connector, and will need to be
+// defined to use the REPRAP_DISCOUNT_SMART_CONTROLLER.
+//
+// A remote SD card is currently not supported because the pins routed to the EXP2
+// connector are shared with the onboard SD card, and Marlin does not support reading
+// G-code files from the onboard SD card.
+//
+#if ENABLED(ULTRA_LCD)
+
+  #define BEEPER_PIN        P0_27 // EXP2-7 - open drain
+
+  #define BTN_EN1           P3_26 // EXP2-5
+  #define BTN_EN2           P3_25 // EXP2-3
+  #define BTN_ENC           P1_30 // EXP1-2
+
+  #define LCD_PINS_RS       P0_16 // EXP1-4
+  #define LCD_SDSS          P0_28 // EXP2-4
+  #define LCD_PINS_ENABLE   P0_18 // EXP1-3
+  #define LCD_PINS_D4       P0_15 // EXP1-5
+
+  #define KILL_PIN          P2_11 // EXP2-10
+
+  #if ENABLED(SDSUPPORT)
+    #error "SDSUPPORT is not currently supported by the Cohesion3D boards"
+  #endif
+
+#endif // ULTRA_LCD
+
+//
+// Ethernet pins
+//
+#define ENET_MDIO           P1_17
+#define ENET_RX_ER          P1_14
+#define ENET_RXD1           P1_10
+#define ENET_MOC            P1_16
+#define REF_CLK             P1_15
+#define ENET_RXD0           P1_09
+#define ENET_CRS            P1_08
+#define ENET_TX_EN          P1_04
+#define ENET_TXD0           P1_00
+#define ENET_TXD1           P1_01

--- a/Marlin/src/pins/pins_COHESION3D_REMIX.h
+++ b/Marlin/src/pins/pins_COHESION3D_REMIX.h
@@ -22,7 +22,7 @@
  */
 
 /**
- * Cohesion3D ReMix and Mini pin assignments
+ * Cohesion3D ReMix pin assignments
  */
 
 #ifndef TARGET_LPC1768
@@ -30,21 +30,13 @@
 #endif
 
 #ifndef BOARD_NAME
-  #if MB(COHESION3D_REMIX)
-    #define BOARD_NAME "Cohesion3D ReMix"
-  #elif MB(COHESION3D_MINI)
-    #define BOARD_NAME "Cohesion3D Mini"
-  #endif
+  #define BOARD_NAME "Cohesion3D ReMix"
 #endif
 
 //
 // Servos
 //
-#if MB(COHESION3D_REMIX)
-  #define SERVO0_PIN        P2_04
-#elif MB(COHESION3D_MINI)
-  #define SERVO0_PIN        P1_23
-#endif
+#define SERVO0_PIN        P2_04
 
 //
 // Limit Switches
@@ -79,17 +71,15 @@
 #define E0_ENABLE_PIN       P0_21
 #define E0_CS_PIN           P1_04 // Ethernet Expansion - Pin 12
 
-#if MB(COHESION3D_REMIX)
-  #define E1_STEP_PIN       P2_08
-  #define E1_DIR_PIN        P2_13
-  #define E1_ENABLE_PIN     P4_29
-  #define E1_CS_PIN         P1_01 // Ethernet Expansion - Pin 14
+#define E1_STEP_PIN         P2_08
+#define E1_DIR_PIN          P2_13
+#define E1_ENABLE_PIN       P4_29
+#define E1_CS_PIN           P1_01 // Ethernet Expansion - Pin 14
 
-  #define E2_STEP_PIN       P1_20
-  #define E2_DIR_PIN        P1_19
-  #define E2_ENABLE_PIN     P1_21
-  #define E2_CS_PIN         P1_18 // FET 6
-#endif
+#define E2_STEP_PIN         P1_20
+#define E2_DIR_PIN          P1_19
+#define E2_ENABLE_PIN       P1_21
+#define E2_CS_PIN           P1_18 // FET 6
 
 //
 // Default pins for TMC software SPI
@@ -112,13 +102,11 @@
 //
 #define TEMP_0_PIN          0 // P0_23
 #define TEMP_BED_PIN        1 // P0_24
-#if MB(COHESION3D_REMIX)
-  #define TEMP_1_PIN        2 // P0_25
-  #if ENABLED(FILAMENT_WIDTH_SENSOR)
-    #define FILWIDTH_PIN    3 // P0_26
-  #else
-    #define TEMP_2_PIN      3 // P0_26
-  #endif
+#define TEMP_1_PIN          2 // P0_25
+#if ENABLED(FILAMENT_WIDTH_SENSOR)
+  #define FILWIDTH_PIN      3 // P0_26
+#else
+  #define TEMP_2_PIN        3 // P0_26
 #endif
 
 //
@@ -126,16 +114,12 @@
 //
 #define HEATER_BED_PIN      P2_05
 #define HEATER_0_PIN        P2_07 // FET 1
-#if MB(COHESION3D_REMIX)
-  #define HEATER_1_PIN      P1_23 // FET 2
-  #if HOTENDS == 3
-    #define HEATER_2_PIN    P1_22 // FET 3
-    #define AUTO_FAN_PIN    P1_18 // FET 6
-  #else
-    #define AUTO_FAN_PIN    P1_22 // FET 3
-  #endif
-#elif MB(COHESION3D_MINI)
-  #define AUTO_FAN_PIN      P2_04 // FET 4
+#define HEATER_1_PIN        P1_23 // FET 2
+#if HOTENDS == 3
+  #define HEATER_2_PIN      P1_22 // FET 3
+  #define AUTO_FAN_PIN      P1_18 // FET 6
+#else
+  #define AUTO_FAN_PIN      P1_22 // FET 3
 #endif
 #define FAN_PIN             P2_06 // ReMix FET 4, Mini FET 3
 
@@ -166,21 +150,17 @@
 //
 // LCD / Controller
 //
-// LCD_PINS_D5, LCD_PINS_D6 or LCD_PINS_D7 are not present in the EXP1 connector,
-// and will need to be defined in order to use the REPRAP_DISCOUNT_SMART_CONTROLLER.
+// LCD_PINS_D5, D6, and D7 are not present in the EXP1 connector, and will need to be
+// defined to use the REPRAP_DISCOUNT_SMART_CONTROLLER.
 //
-// A remote SD card is currently not supported due to the pins routed to the EXP2
-// conecter are shared with the onboard SD card, and Marlin does not support reading
+// A remote SD card is currently not supported because the pins routed to the EXP2
+// connector are shared with the onboard SD card, and Marlin does not support reading
 // G-code files from the onboard SD card.
 //
 #if ENABLED(ULTRA_LCD)
 
-  #if MB(COHESION3D_REMIX)
-    #define BEEPER_PIN      P1_31 // EXP1-1
-    #define SD_DETECT_PIN   P0_27 // EXP2-7
-  #elif MB(COHESION3D_MINI)
-    #define BEEPER_PIN      P0_27 // EXP2-7 - open drain
-  #endif
+  #define BEEPER_PIN        P1_31 // EXP1-1
+  #define SD_DETECT_PIN     P0_27 // EXP2-7
 
   #define BTN_EN1           P3_26 // EXP2-5
   #define BTN_EN2           P3_25 // EXP2-3


### PR DESCRIPTION
Adds the necessary pins file for the Cohesion3D ReMix and Mini LPC1769-based boards.