### PR TITLE
[1.1.x] Misc. cleanups

### DIFF
--- a/Marlin/Conditionals_LCD.h
+++ b/Marlin/Conditionals_LCD.h
@@ -277,7 +277,11 @@
 
   #if ENABLED(DOGLCD) // Change number of lines to match the DOG graphic display
     #ifndef LCD_WIDTH
-      #define LCD_WIDTH 22
+      #ifdef LCD_WIDTH_OVERRIDE
+        #define LCD_WIDTH LCD_WIDTH_OVERRIDE
+      #else
+        #define LCD_WIDTH 22
+      #endif
     #endif
     #ifndef LCD_HEIGHT
       #define LCD_HEIGHT 5

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1114,15 +1114,15 @@ inline void get_serial_commands() {
       }
 
       #if DISABLED(EMERGENCY_PARSER)
-        // If command was e-stop process now
+        // Process critical commands early
         if (strcmp(command, "M108") == 0) {
           wait_for_heatup = false;
-          #if ENABLED(ULTIPANEL)
+          #if HAS_DISPLAY
             wait_for_user = false;
           #endif
         }
         if (strcmp(command, "M112") == 0) kill(PSTR(MSG_KILLED));
-        if (strcmp(command, "M410") == 0) { quickstop_stepper(); }
+        if (strcmp(command, "M410") == 0) quickstop_stepper();
       #endif
 
       #if defined(NO_TIMEOUTS) && NO_TIMEOUTS > 0

--- a/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
@@ -1815,8 +1815,8 @@
  */
 #if ENABLED(ULTIMAKERCONTROLLER) || ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) || ENABLED(G3D_PANEL) || ENABLED(MKS_MINI_12864)
   #define SDSUPPORT   // Force SD Card support on for these displays
-#elif ENABLED(ULTRA_LCD) && ENABLED(DOGLCD) // No panel, just graphical LCD?
-  #define LCD_WIDTH 20 // Default is 22. For this Geeetech use 20
+#else
+  #define LCD_WIDTH_OVERRIDE 20 // Default is 22. For this Geeetech use 20.
 #endif
 
 #endif // CONFIGURATION_H

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -54,10 +54,6 @@
 #include "cardreader.h"
 #include "speed_lookuptable.h"
 
-#if ENABLED(AUTO_BED_LEVELING_UBL) && ENABLED(ULTIPANEL)
-  #include "ubl.h"
-#endif
-
 #if HAS_DIGIPOTSS
   #include <SPI.h>
 #endif

--- a/Marlin/utility.cpp
+++ b/Marlin/utility.cpp
@@ -47,7 +47,7 @@ void safe_delay(millis_t ms) {
 
 #endif // EEPROM_SETTINGS
 
-#if ENABLED(ULTRA_LCD)
+#if ENABLED(ULTRA_LCD) || (ENABLED(DEBUG_LEVELING_FEATURE) && (ENABLED(MESH_BED_LEVELING) || (HAS_ABL && !ABL_PLANAR)))
 
   char conv[8] = { 0 };
 
@@ -254,4 +254,4 @@ void safe_delay(millis_t ms) {
     return &conv[1];
   }
 
-#endif // ULTRA_LCD
+#endif // ULTRA_LCD || (DEBUG_LEVELING_FEATURE && (MESH_BED_LEVELING || (HAS_ABL && !ABL_PLANAR)))

--- a/Marlin/utility.h
+++ b/Marlin/utility.h
@@ -29,7 +29,7 @@ void safe_delay(millis_t ms);
   void crc16(uint16_t *crc, const void * const data, uint16_t cnt);
 #endif
 
-#if ENABLED(ULTRA_LCD) || ENABLED(DEBUG_LEVELING_FEATURE)
+#if ENABLED(ULTRA_LCD) || (ENABLED(DEBUG_LEVELING_FEATURE) && (ENABLED(MESH_BED_LEVELING) || (HAS_ABL && !ABL_PLANAR)))
 
   // Convert uint8_t to string with 123 format
   char* i8tostr3(const uint8_t x);
@@ -81,6 +81,6 @@ void safe_delay(millis_t ms);
     FORCE_INLINE char *ftostr4sign(const float &x) { return itostr4sign((int)x); }
   #endif
 
-#endif // ULTRA_LCD
+#endif // ULTRA_LCD || (DEBUG_LEVELING_FEATURE && (MESH_BED_LEVELING || (HAS_ABL && !ABL_PLANAR)))
 
 #endif // __UTILITY_H__


### PR DESCRIPTION
- Drop extra include of leveling in `stepper.cpp`
- Make `ftostr43sign` available for `DEBUG_LEVELING_FEATURE`
- Allow `LCD_WIDTH` override from a config, use in GT2560
- Tweak to non-emergency early handler