### PR TITLE
[1.1.x] More reliable PROBING_HEATERS_OFF with BED_LIMIT_SWITCHING

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -226,10 +226,6 @@ void clear_command_queue();
 extern millis_t previous_cmd_ms;
 inline void refresh_cmd_timeout() { previous_cmd_ms = millis(); }
 
-#if ENABLED(FAST_PWM_FAN)
-  void setPwmFrequency(uint8_t pin, int val);
-#endif
-
 /**
  * Feedrate scaling and conversion
  */

--- a/Marlin/Sd2Card.cpp
+++ b/Marlin/Sd2Card.cpp
@@ -297,7 +297,7 @@ bool Sd2Card::eraseSingleBlockEnable() {
  * \return true for success, false for failure.
  * The reason for failure can be determined by calling errorCode() and errorData().
  */
-bool Sd2Card::init(uint8_t sckRateID, uint8_t chipSelectPin) {
+bool Sd2Card::init(uint8_t sckRateID, pin_t chipSelectPin) {
   errorCode_ = type_ = 0;
   chipSelectPin_ = chipSelectPin;
   // 16-bit init start time allows over a minute

--- a/Marlin/Sd2Card.h
+++ b/Marlin/Sd2Card.h
@@ -140,7 +140,7 @@ class Sd2Card {
    * \return true for success or false for failure.
    */
   bool init(uint8_t sckRateID = SPI_FULL_SPEED,
-            uint8_t chipSelectPin = SD_CHIP_SELECT_PIN);
+            pin_t chipSelectPin = SD_CHIP_SELECT_PIN);
   bool readBlock(uint32_t block, uint8_t* dst);
 
   /**

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -29,6 +29,10 @@
 #ifndef _FASTIO_ARDUINO_H
 #define _FASTIO_ARDUINO_H
 
+#include <stdint.h>
+
+typedef uint8_t pin_t;
+
 #include <avr/io.h>
 
 #define AVR_AT90USB1286_FAMILY (defined(__AVR_AT90USB1287__) || defined(__AVR_AT90USB1286__) || defined(__AVR_AT90USB1286P__) || defined(__AVR_AT90USB646__) || defined(__AVR_AT90USB646P__)  || defined(__AVR_AT90USB647__))

--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -71,7 +71,7 @@ bool endstop_monitor_flag = false;
 
 typedef struct {
   const char * const name;
-  uint8_t pin;
+  pin_t pin;
   bool is_digital;
 } PinInfo;
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -587,6 +587,10 @@ class Temperature {
 
   private:
 
+    #if ENABLED(FAST_PWM_FAN)
+      void setPwmFrequency(const pin_t pin, int val);
+    #endif
+
     static void set_current_temp_raw();
 
     static void updateTemperaturesFromRawValues();


### PR DESCRIPTION
Addressing #7248

Heaters are updated much less frequently with `BED_LIMIT_SWITCHING`, so heaters may not turn off quickly enough when probing with `PROBING_HEATERS_OFF`. This PR checks for a change in `thermalManager.paused` and passes through to update PWM if the state changes.

Also:
- Add `typedef pin_t` to AVR Marlin.
- Move `setPwmFrequency` to the `Temperature` class for parity with 2.0.x.