### PR TITLE
[2.0.x] More reliable PROBING_HEATERS_OFF with BED_LIMIT_SWITCHING

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -744,6 +744,10 @@ float Temperature::get_pid_output(const int8_t e) {
  */
 void Temperature::manage_heater() {
 
+  #if ENABLED(PROBING_HEATERS_OFF) && ENABLED(BED_LIMIT_SWITCHING)
+    static bool last_pause_state;
+  #endif
+
   if (!temp_meas_ready) return;
 
   updateTemperaturesFromRawValues(); // also resets the watchdog
@@ -820,8 +824,15 @@ void Temperature::manage_heater() {
   #endif // WATCH_THE_BED
 
   #if DISABLED(PIDTEMPBED)
-    if (PENDING(ms, next_bed_check_ms)) return;
+    if (PENDING(ms, next_bed_check_ms)
+      #if ENABLED(PROBING_HEATERS_OFF) && ENABLED(BED_LIMIT_SWITCHING)
+        && paused == last_pause_state
+      #endif
+    ) return;
     next_bed_check_ms = ms + BED_CHECK_INTERVAL;
+    #if ENABLED(PROBING_HEATERS_OFF) && ENABLED(BED_LIMIT_SWITCHING)
+      last_pause_state = paused;
+    #endif
   #endif
 
   #if HAS_TEMP_BED


### PR DESCRIPTION
Corresponds to #9543

---
Addressing #7248

Heaters are updated much less frequently with `BED_LIMIT_SWITCHING`, so heaters may not turn off quickly enough when probing with `PROBING_HEATERS_OFF`. This PR checks for a change in `thermalManager.paused` and passes through to update PWM if the state changes.