### PR TITLE
[2.0.x] Update TMC section with SW SPI pins

### DIFF
--- a/Marlin/src/pins/pins_RAMPS.h
+++ b/Marlin/src/pins/pins_RAMPS.h
@@ -155,8 +155,8 @@
   //#define X2_HARDWARE_SERIAL Serial1
   //#define Y_HARDWARE_SERIAL  Serial1
   //#define Y2_HARDWARE_SERIAL Serial1
-  #define Z_HARDWARE_SERIAL  Serial3
-  #define Z2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial3
+  //#define Z2_HARDWARE_SERIAL Serial1
   //#define E0_HARDWARE_SERIAL Serial1
   //#define E1_HARDWARE_SERIAL Serial1
   //#define E2_HARDWARE_SERIAL Serial1


### PR DESCRIPTION
Add SW SPI pin definition options for TMC2130.
If undefined, the default pins from `_pins.h ` will be used. Although only Archim2, Re-Arm and RAMPS currently have these defaults.

I also uncommented the HW serial definitions as these were left from my own config. This also means that the communication will default to SW serial for Z drivers.

1.1.x version added in https://github.com/MarlinFirmware/Marlin/pull/9362