### PR TITLE
[2.0.x] Memory overflow protection

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -92,7 +92,7 @@ uint8_t lcd_status_update_delay = 1, // First update one loop delayed
         lcd_status_message_level;    // Higher level blocks lower level
 
 #if ENABLED(STATUS_MESSAGE_SCROLLING)
-  #define MAX_MESSAGE_LENGTH max(2 * CHARSIZE * (LCD_WIDTH), LONG_FILENAME_LENGTH)
+  #define MAX_MESSAGE_LENGTH max(CHARSIZE * (LCD_WIDTH), LONG_FILENAME_LENGTH)
   uint8_t status_scroll_pos = 0;
 #else
   #define MAX_MESSAGE_LENGTH CHARSIZE * (LCD_WIDTH)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -5218,7 +5218,7 @@ bool lcd_hasstatus() { return (lcd_status_message[0] != '\0'); }
 
 void lcd_setstatus(const char * const message, const bool persist) {
   if (lcd_status_message_level > 0) return;
-  strncpy_P(lcd_status_message, message, COUNT(lcd_status_message) - 1);
+  strncpy(lcd_status_message, message, COUNT(lcd_status_message) - 1);
   lcd_finishstatus(persist);
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -92,7 +92,7 @@ uint8_t lcd_status_update_delay = 1, // First update one loop delayed
         lcd_status_message_level;    // Higher level blocks lower level
 
 #if ENABLED(STATUS_MESSAGE_SCROLLING)
-  #define MAX_MESSAGE_LENGTH max(2 * CHARSIZE * LCD_WIDTH, LONG_FILENAME_LENGTH)
+  #define MAX_MESSAGE_LENGTH max(2 * CHARSIZE * (LCD_WIDTH), LONG_FILENAME_LENGTH)
   uint8_t status_scroll_pos = 0;
 #else
   #define MAX_MESSAGE_LENGTH CHARSIZE * (LCD_WIDTH)
@@ -5218,7 +5218,7 @@ bool lcd_hasstatus() { return (lcd_status_message[0] != '\0'); }
 
 void lcd_setstatus(const char * const message, const bool persist) {
   if (lcd_status_message_level > 0) return;
-  strncpy(lcd_status_message, message, 3 * (LCD_WIDTH));
+  strncpy_P(lcd_status_message, message, COUNT(lcd_status_message) - 1);
   lcd_finishstatus(persist);
 }
 
@@ -5226,7 +5226,7 @@ void lcd_setstatusPGM(const char * const message, int8_t level) {
   if (level < 0) level = lcd_status_message_level = 0;
   if (level < lcd_status_message_level) return;
   lcd_status_message_level = level;
-  strncpy_P(lcd_status_message, message, 3 * (LCD_WIDTH));
+  strncpy_P(lcd_status_message, message, COUNT(lcd_status_message) - 1);
   lcd_finishstatus(level > 0);
 }
 
@@ -5235,7 +5235,7 @@ void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...) {
   lcd_status_message_level = level;
   va_list args;
   va_start(args, fmt);
-  vsnprintf_P(lcd_status_message, 3 * (LCD_WIDTH), fmt, args);
+  vsnprintf_P(lcd_status_message, COUNT(lcd_status_message) - 1, fmt, args);
   va_end(args);
   lcd_finishstatus(level > 0);
 }
@@ -5330,7 +5330,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
           if (false) {
             // for the else-ifs below
           }
-          #if BUTTON_EXISTS(UP)
+          #if BUTTON_EXISTS(UP)3 * 
             else if (BUTTON_PRESSED(UP)) {
               encoderDiff = -(ENCODER_UD_STEPS);
               next_button_update_ms = now + 300;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -92,7 +92,7 @@ uint8_t lcd_status_update_delay = 1, // First update one loop delayed
         lcd_status_message_level;    // Higher level blocks lower level
 
 #if ENABLED(STATUS_MESSAGE_SCROLLING)
-  #define MAX_MESSAGE_LENGTH max(CHARSIZE * (LCD_WIDTH), LONG_FILENAME_LENGTH)
+  #define MAX_MESSAGE_LENGTH max(CHARSIZE * 2 * (LCD_WIDTH), LONG_FILENAME_LENGTH)
   uint8_t status_scroll_pos = 0;
 #else
   #define MAX_MESSAGE_LENGTH CHARSIZE * (LCD_WIDTH)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -5330,7 +5330,7 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
           if (false) {
             // for the else-ifs below
           }
-          #if BUTTON_EXISTS(UP)3 * 
+          #if BUTTON_EXISTS(UP)
             else if (BUTTON_PRESSED(UP)) {
               encoderDiff = -(ENCODER_UD_STEPS);
               next_button_update_ms = now + 300;


### PR DESCRIPTION
Be sure not to overflow message buffer

@thinkyhead 
  1) why there is strcpy and strcpy_P that are almost the same thing?
  2) There are many parts in firmware that simply do strcpy do lcd_message without taking care of its size..not a little bit dangerous? they can corrupt memory and it will be difficult to discover them

There is one call in G26 that use strcpy directly without taking care of message max len...this can be dangerous