### PR TITLE
[2.0.x] Init CS pins before loading settings

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -689,6 +689,13 @@ void setup() {
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START();
 
+  #if ENABLED(HAVE_TMC2130)
+    tmc_init_cs_pins();
+  #endif
+  #if ENABLED(HAVE_TMC2208)
+    tmc2208_serial_begin();
+  #endif
+
   // Check startup - does nothing if bootloader sets MCUSR to 0
   byte mcu = HAL_get_reset_source();
   if (mcu &  1) SERIAL_ECHOLNPGM(MSG_POWERUP);

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -582,4 +582,43 @@ void _tmc_say_sgt(const char name[], const uint32_t sgt) {
 
 #endif // SENSORLESS_HOMING
 
+#if ENABLED(HAVE_TMC2130)
+  #define SET_CS_PIN(st) OUT_WRITE(st##_CS_PIN, HIGH)
+  void tmc_init_cs_pins() {
+    #if ENABLED(X_IS_TMC2130)
+      SET_CS_PIN(X);
+    #endif
+    #if ENABLED(Y_IS_TMC2130)
+      SET_CS_PIN(Y);
+    #endif
+    #if ENABLED(Z_IS_TMC2130)
+      SET_CS_PIN(Z);
+    #endif
+    #if ENABLED(X2_IS_TMC2130)
+      SET_CS_PIN(X2);
+    #endif
+    #if ENABLED(Y2_IS_TMC2130)
+      SET_CS_PIN(Y2);
+    #endif
+    #if ENABLED(Z2_IS_TMC2130)
+      SET_CS_PIN(Z2);
+    #endif
+    #if ENABLED(E0_IS_TMC2130)
+      SET_CS_PIN(E0);
+    #endif
+    #if ENABLED(E1_IS_TMC2130)
+      SET_CS_PIN(E1);
+    #endif
+    #if ENABLED(E2_IS_TMC2130)
+      SET_CS_PIN(E2);
+    #endif
+    #if ENABLED(E3_IS_TMC2130)
+      SET_CS_PIN(E3);
+    #endif
+    #if ENABLED(E4_IS_TMC2130)
+      SET_CS_PIN(E4);
+    #endif
+  }
+#endif // HAVE_TMC2130
+
 #endif // HAS_TRINAMIC

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -100,4 +100,8 @@ void monitor_tmc_driver();
   void tmc_sensorless_homing(TMC2130Stepper &st, bool enable=true);
 #endif
 
+#if ENABLED(HAVE_TMC2130)
+  void tmc_init_cs_pins();
+#endif
+
 #endif // _TMC_UTIL_H_


### PR DESCRIPTION
The driver CS pin modes need to be set before calling settings.load as it will try to read from the driver IF the current is set to greater than ~950mA. The response is 0xFFFFFFFFF and that will be saved in the shadow register which is then pushed back into the driver the next time communication is working as expected. The result is unexpected behavior like enabling double stepping.

Should fix issues https://github.com/MarlinFirmware/Marlin/issues/8478 and https://github.com/MarlinFirmware/Marlin/issues/9230.

Also added a missing call for initiating TMC2208 serial pins.