### PR TITLE
[1.1.X] Wait for bed target temp before probing

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2160,6 +2160,12 @@ static void clean_up_after_endstop_or_probe_move() {
     #if ENABLED(BLTOUCH)
       if (set_bltouch_deployed(true)) return true;
     #endif
+	
+	// Wait for bed to heat back up between probing
+	while(thermalManager.degBed() < thermalManager.degTargetBed()) 
+    {
+      safe_delay(1000);
+    }
 
     #if QUIET_PROBING
       probing_pause(true);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2163,7 +2163,7 @@ static void clean_up_after_endstop_or_probe_move() {
 	
     #if ENABLED(PROBING_HEATERS_OFF)
       // Wait for bed to heat back up between probing
-      while(thermalManager.degBed() < thermalManager.degTargetBed()) 
+      while(thermalManager.isHeatingBed()) 
       {
         safe_delay(1000);
       }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2161,11 +2161,13 @@ static void clean_up_after_endstop_or_probe_move() {
       if (set_bltouch_deployed(true)) return true;
     #endif
 	
-	// Wait for bed to heat back up between probing
-	while(thermalManager.degBed() < thermalManager.degTargetBed()) 
-    {
-      safe_delay(1000);
-    }
+    #if ENABLED(PROBING_HEATERS_OFF)
+      // Wait for bed to heat back up between probing
+      while(thermalManager.degBed() < thermalManager.degTargetBed()) 
+      {
+        safe_delay(1000);
+      }
+    #endif
 
     #if QUIET_PROBING
       probing_pause(true);


### PR DESCRIPTION
Added code to wait for the bed to heat back up between probing (useful for when you have probe heaters disabled)