### PR TITLE
[2.0.x] Fix Malyan M200 auto fan

### DIFF
--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -107,6 +107,15 @@
 #define SERIAL_PORT 0
 
 /**
+ * Select a secondary serial port on the board to use for communication with the host.
+ * This allows the connection of wireless adapters (for instance) to non-default port pins.
+ * Serial port -1 is the USB emulated serial port, if avaialble.
+ *
+ * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
+ */
+#define SERIAL_PORT_2 -1
+
+/**
  * This setting determines the communication speed of the printer.
  *
  * 250000 works in most cases, but you might try a lower speed if

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -214,7 +214,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN PB8
+//#define E0_AUTO_FAN_PIN -1
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -550,20 +550,40 @@
 //
 // Assign auto fan pins if needed
 //
-#if !defined(E0_AUTO_FAN_PIN) && defined(ORIG_E0_AUTO_FAN_PIN)
-  #define E0_AUTO_FAN_PIN ORIG_E0_AUTO_FAN_PIN
+#ifndef E0_AUTO_FAN_PIN
+  #ifdef ORIG_E0_AUTO_FAN_PIN
+    #define E0_AUTO_FAN_PIN ORIG_E0_AUTO_FAN_PIN
+  #else
+    #define E0_AUTO_FAN_PIN -1
+  #endif
 #endif
-#if !defined(E1_AUTO_FAN_PIN) && defined(ORIG_E1_AUTO_FAN_PIN)
-  #define E1_AUTO_FAN_PIN ORIG_E1_AUTO_FAN_PIN
+#ifndef E1_AUTO_FAN_PIN
+  #ifdef ORIG_E1_AUTO_FAN_PIN
+    #define E1_AUTO_FAN_PIN ORIG_E1_AUTO_FAN_PIN
+  #else
+    #define E1_AUTO_FAN_PIN -1
+  #endif
 #endif
-#if !defined(E2_AUTO_FAN_PIN) && defined(ORIG_E2_AUTO_FAN_PIN)
-  #define E2_AUTO_FAN_PIN ORIG_E2_AUTO_FAN_PIN
+#ifndef E2_AUTO_FAN_PIN
+  #ifdef ORIG_E2_AUTO_FAN_PIN
+    #define E2_AUTO_FAN_PIN ORIG_E2_AUTO_FAN_PIN
+  #else
+    #define E2_AUTO_FAN_PIN -1
+  #endif
 #endif
-#if !defined(E3_AUTO_FAN_PIN) && defined(ORIG_E3_AUTO_FAN_PIN)
-  #define E3_AUTO_FAN_PIN ORIG_E3_AUTO_FAN_PIN
+#ifndef E3_AUTO_FAN_PIN
+  #ifdef ORIG_E3_AUTO_FAN_PIN
+    #define E3_AUTO_FAN_PIN ORIG_E3_AUTO_FAN_PIN
+  #else
+    #define E3_AUTO_FAN_PIN -1
+  #endif
 #endif
-#if !defined(E4_AUTO_FAN_PIN) && defined(ORIG_E4_AUTO_FAN_PIN)
-  #define E4_AUTO_FAN_PIN ORIG_E4_AUTO_FAN_PIN
+#ifndef E4_AUTO_FAN_PIN
+  #ifdef ORIG_E4_AUTO_FAN_PIN
+    #define E4_AUTO_FAN_PIN ORIG_E4_AUTO_FAN_PIN
+  #else
+    #define E4_AUTO_FAN_PIN -1
+  #endif
 #endif
 
 // List of pins which to ignore when asked to change by gcode, 0 and 1 are RX and TX, do not mess with those!

--- a/Marlin/src/pins/pins_MALYAN_M200.h
+++ b/Marlin/src/pins/pins_MALYAN_M200.h
@@ -79,8 +79,10 @@
 // This board has only the controller fan and the extruder fan
 // If someone hacks to put a direct power fan on the controller, PB3 could
 // be used as a separate print cooling fan.
-// FAN_PIN is commented out because in configuration_adv, we have
-// it set to E0_AUTO_FAN_PIN
-// #define FAN_PIN            PB8 // FAN1 header on board - PRINT FAN
+#define ORIG_E0_AUTO_FAN_PIN PB8
+
+// FAN_PIN is commented out here because the M200 example
+// Configuration_adv.h does NOT override E0_AUTO_FAN_PIN.
+//#define FAN_PIN            PB8 // FAN1 header on board - PRINT FAN
 #define FAN1_PIN           PB3 // FAN2 header on board - CONTROLLER FAN
 #define FAN2_PIN           -1 // FAN3 header on board - EXTRUDER0 FAN

--- a/Marlin/src/pins/pins_SILVER_GATE.h
+++ b/Marlin/src/pins/pins_SILVER_GATE.h
@@ -1,4 +1,4 @@
-/*
+/**
  * Marlin 3D Printer Firmware
  * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
@@ -60,7 +60,7 @@
 
 #define HEATER_0_PIN        7
 
-#define E0_AUTO_FAN_PIN     3
+#define ORIG_E0_AUTO_FAN_PIN 3  // Use this by NOT overriding E0_AUTO_FAN_PIN
 #define CONTROLLER_FAN_PIN  2
 
 #define TEMP_0_PIN          7   // Analog Input

--- a/Marlin/src/pins/pins_THE_BORG.h
+++ b/Marlin/src/pins/pins_THE_BORG.h
@@ -48,7 +48,6 @@
 
 #define _STM32_PIN(_PORT,_PIN) ((_PORT * 16) + _PIN)
 
-
 //
 // Limit Switches
 //
@@ -60,6 +59,7 @@
 #define Z_MAX_PIN          _STM32_PIN(PORTG, 0)
 #define E_MIN_PIN          _STM32_PIN(PORTE, 2)
 #define E_MAX_PIN          _STM32_PIN(PORTE, 3)
+
 //
 // Z Probe (when not Z_MIN_PIN)
 //
@@ -70,7 +70,6 @@
 //
 // Steppers
 //
-
 #define STEPPER_ENABLE_PIN _STM32_PIN(PORTE, 0)
 
 #define X_STEP_PIN         _STM32_PIN(PORTC, 6) //96, 39 in arduino
@@ -106,11 +105,6 @@
 #define Z2_ENABLE_PIN      _STM32_PIN(PORTC, 15)
 
 
-
-
-
-
-
 #define SCK_PIN            _STM32_PIN(PORTA, 5)
 #define MISO_PIN           _STM32_PIN(PORTA, 6)
 #define MOSI_PIN           _STM32_PIN(PORTA, 7)
@@ -122,9 +116,6 @@
 #define SPI6_SCK_PIN       _STM32_PIN(PORTG, 13)
 #define SPI6_MISO_PIN      _STM32_PIN(PORTG, 12)
 #define SPI6_MOSI_PIN      _STM32_PIN(PORTG, 14)
-
-
-
 
 //
 // Temperature Sensors
@@ -139,7 +130,6 @@
 
 #define TEMP_5_PIN         _STM32_PIN(PORTE, 12)  // Analog Input, Probe temp
 
-
 //
 // Heaters / Fans
 //
@@ -151,7 +141,7 @@
 #define FAN1_PIN           _STM32_PIN(PORTA, 0)
 #define FAN2_PIN           _STM32_PIN(PORTA, 1)
 
-//#define E0_AUTO_FAN_PIN  _STM32_PIN(PORTA, 1)
+#define ORIG_E0_AUTO_FAN_PIN  _STM32_PIN(PORTA, 1) // Use this by NOT overriding E0_AUTO_FAN_PIN
 
 //
 // Misc. Functions
@@ -184,13 +174,11 @@
 #define PWR_LOSS           _STM32_PIN(PORTG, 5)         //Power loss / nAC_FAULT
 
 //
-//MAX7219_DEBUG
+// MAX7219_DEBUG
 //
 #define MAX7219_CLK_PIN    _STM32_PIN(PORTG, 10)     //EXP1-1
 #define MAX7219_DIN_PIN    _STM32_PIN(PORTD, 7)      //EXP1-3
 #define MAX7219_LOAD_PIN   _STM32_PIN(PORTD, 1)     //EXP1-5
-
-//#define NEOPIXEL_PIN    4
 
 //
 // LCD / Controller


### PR DESCRIPTION
Fixes #8794

An extruder auto-fan is enabled by either setting a custom pin in `Configuration_adv.h` or by commenting out the define that sets it to -1. This PR fixes the M200 config so it follows this pattern, and adds comments to some other pins files.