### PR TITLE
[2.0.x] HAL timer set/get count => set/get compare

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -149,8 +149,8 @@ extern "C" {
 #define _CAT(a, ...) a ## __VA_ARGS__
 #define HAL_timer_set_compare(timer, compare) (_CAT(TIMER_OCR_, timer) = compare)
 #define HAL_timer_get_compare(timer) _CAT(TIMER_OCR_, timer)
-#define HAL_timer_set_current_count(timer, count) (_CAT(TIMER_COUNTER_, timer) = count)
-#define HAL_timer_get_current_count(timer) _CAT(TIMER_COUNTER_, timer)
+#define HAL_timer_set_count(timer, count) (_CAT(TIMER_COUNTER_, timer) = count)
+#define HAL_timer_get_count(timer) _CAT(TIMER_COUNTER_, timer)
 
 #define HAL_timer_isr_prologue(timer_num)
 

--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -147,8 +147,8 @@ extern "C" {
 #define HAL_timer_start(timer_num, frequency)
 
 #define _CAT(a, ...) a ## __VA_ARGS__
-#define HAL_timer_set_count(timer, count) (_CAT(TIMER_OCR_, timer) = count)
-#define HAL_timer_get_count(timer) _CAT(TIMER_OCR_, timer)
+#define HAL_timer_set_compare(timer, compare) (_CAT(TIMER_OCR_, timer) = compare)
+#define HAL_timer_get_compare(timer) _CAT(TIMER_OCR_, timer)
 #define HAL_timer_set_current_count(timer, count) (_CAT(TIMER_COUNTER_, timer) = count)
 #define HAL_timer_get_current_count(timer) _CAT(TIMER_COUNTER_, timer)
 

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
@@ -127,9 +127,9 @@ bool HAL_timer_interrupt_enabled(const uint8_t timer_num) {
 }
 
 #if 0
-  void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count) {
+  void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare) {
     const tTimerConfig * const pConfig = &TimerConfig[timer_num];
-    TC_SetRC(pConfig->pTimerRegs, pConfig->channel, count);
+    TC_SetRC(pConfig->pTimerRegs, pConfig->channel, compare);
   }
 
   void HAL_timer_isr_prologue(const uint8_t timer_num) {

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -101,12 +101,12 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC;
 }
 
-FORCE_INLINE static void HAL_timer_set_current_count(const uint8_t timer_num, const hal_timer_t count) {
+FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
   const tTimerConfig * const pConfig = &TimerConfig[timer_num];
   pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV = count;
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_current_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   const tTimerConfig * const pConfig = &TimerConfig[timer_num];
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV;
 }

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -91,12 +91,12 @@ extern const tTimerConfig TimerConfig[];
 
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
+FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
   const tTimerConfig * const pConfig = &TimerConfig[timer_num];
-  pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC = count;
+  pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC = compare;
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   const tTimerConfig * const pConfig = &TimerConfig[timer_num];
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC;
 }

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -110,14 +110,14 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return 0;
 }
 
-FORCE_INLINE static void HAL_timer_set_current_count(const uint8_t timer_num, const hal_timer_t count) {
+FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
   switch (timer_num) {
     case 0: LPC_TIM0->TC = count; break;
     case 1: LPC_TIM1->TC = count; break;
   }
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_current_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return LPC_TIM0->TC;
     case 1: return LPC_TIM1->TC;

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -87,22 +87,22 @@ typedef uint32_t hal_timer_t;
 void HAL_timer_init(void);
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
+FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
   switch (timer_num) {
     case 0:
-      LPC_TIM0->MR0 = count;
-      if (LPC_TIM0->TC > count)
-        LPC_TIM0->TC = count - 5; // generate an immediate stepper ISR
+      LPC_TIM0->MR0 = compare;
+      if (LPC_TIM0->TC > compare)
+        LPC_TIM0->TC = compare - 5; // generate an immediate stepper ISR
       break;
     case 1:
-      LPC_TIM1->MR0 = count;
-      if (LPC_TIM1->TC > count)
-        LPC_TIM1->TC = count - 5; // make sure we don't have one extra long period
+      LPC_TIM1->MR0 = compare;
+      if (LPC_TIM1->TC > compare)
+        LPC_TIM1->TC = compare - 5; // make sure we don't have one extra long period
       break;
   }
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return LPC_TIM0->MR0;
     case 1: return LPC_TIM1->MR0;

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -46,7 +46,7 @@
 typedef uint16_t hal_timer_t;
 #define HAL_TIMER_TYPE_MAX 0xFFFF
 
-#if defined MCU_STM32F103CB  || defined(MCU_STM32F103C8)
+#if defined(MCU_STM32F103CB) || defined(MCU_STM32F103C8)
   #define STEP_TIMER_NUM 4 // For C8/CB boards, use timer 4
 #else
   #define STEP_TIMER_NUM 5 // for other boards, five is fine.
@@ -128,21 +128,21 @@ bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
  * Todo: Look at that possibility later.
  */
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
-  //count = min(count, HAL_TIMER_TYPE_MAX);
+FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
+  //compare = min(compare, HAL_TIMER_TYPE_MAX);
   switch (timer_num) {
   case STEP_TIMER_NUM:
-    timer_set_compare(STEP_TIMER_DEV, STEP_TIMER_CHAN, count);
+    timer_set_compare(STEP_TIMER_DEV, STEP_TIMER_CHAN, compare);
     return;
   case TEMP_TIMER_NUM:
-    timer_set_compare(TEMP_TIMER_DEV, TEMP_TIMER_CHAN, count);
+    timer_set_compare(TEMP_TIMER_DEV, TEMP_TIMER_CHAN, compare);
     return;
   default:
     return;
   }
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   switch (timer_num) {
   case STEP_TIMER_NUM:
     return timer_get_compare(STEP_TIMER_DEV, STEP_TIMER_CHAN);

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -82,8 +82,8 @@ typedef uint16_t hal_timer_t;
 #define ENABLE_TEMPERATURE_INTERRUPT() timer_enable_irq(TEMP_TIMER_DEV, TEMP_TIMER_CHAN)
 #define DISABLE_TEMPERATURE_INTERRUPT() timer_disable_irq(TEMP_TIMER_DEV, TEMP_TIMER_CHAN)
 
-#define HAL_timer_get_current_count(timer_num) timer_get_count(TIMER_DEV(timer_num))
-#define HAL_timer_set_current_count(timer_num, count) timer_set_count(TIMER_DEV(timer_num), (uint16)count)
+#define HAL_timer_get_count(timer_num) timer_get_count(TIMER_DEV(timer_num))
+#define HAL_timer_set_count(timer_num, count) timer_set_count(TIMER_DEV(timer_num), (uint16)count)
 
 
 #define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr)DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
@@ -117,8 +117,8 @@ extern "C" void TIM7_IRQHandler() {
   ((void(*)(void))timerConfig[1].callback)();
 }
 
-void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count) {
-  __HAL_TIM_SetAutoreload(&timerConfig[timer_num].timerdef, count);
+void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare) {
+  __HAL_TIM_SetAutoreload(&timerConfig[timer_num].timerdef, compare);
 }
 
 void HAL_timer_set_current_count(const uint8_t timer_num, const uint32_t count) {
@@ -133,7 +133,7 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num) {
   HAL_NVIC_DisableIRQ(timerConfig[timer_num].IRQ_Id);
 }
 
-hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
+hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return __HAL_TIM_GetAutoreload(&timerConfig[timer_num].timerdef);
 }
 

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
@@ -121,7 +121,7 @@ void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare) {
   __HAL_TIM_SetAutoreload(&timerConfig[timer_num].timerdef, compare);
 }
 
-void HAL_timer_set_current_count(const uint8_t timer_num, const uint32_t count) {
+void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count) {
   __HAL_TIM_SetAutoreload(&timerConfig[timer_num].timerdef, count);
 }
 
@@ -137,7 +137,7 @@ hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return __HAL_TIM_GetAutoreload(&timerConfig[timer_num].timerdef);
 }
 
-uint32_t HAL_timer_get_current_count(const uint8_t timer_num) {
+uint32_t HAL_timer_get_count(const uint8_t timer_num) {
   return __HAL_TIM_GetCounter(&timerConfig[timer_num].timerdef);
 }
 

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
@@ -91,8 +91,8 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 
-void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count);
-hal_timer_t HAL_timer_get_count(const uint8_t timer_num);
+void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare);
+hal_timer_t HAL_timer_get_compare(const uint8_t timer_num);
 uint32_t HAL_timer_get_current_count(const uint8_t timer_num);
 
 void HAL_timer_set_current_count(const uint8_t timer_num, const uint32_t count); // New

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
@@ -93,10 +93,10 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num);
 
 void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare);
 hal_timer_t HAL_timer_get_compare(const uint8_t timer_num);
-uint32_t HAL_timer_get_current_count(const uint8_t timer_num);
+uint32_t HAL_timer_get_count(const uint8_t timer_num);
 
-void HAL_timer_set_current_count(const uint8_t timer_num, const uint32_t count); // New
-/*FORCE_INLINE static void HAL_timer_set_current_count(const uint8_t timer_num, const hal_timer_t count) {
+void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count); // New
+/*FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
   // To do ??
 }*/
 

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
@@ -95,14 +95,14 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return 0;
 }
 
-FORCE_INLINE static void HAL_timer_set_current_count(const uint8_t timer_num, const hal_timer_t count) {
+FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
   switch (timer_num) {
     case 0: FTM0_CNT = count;
     case 1: FTM1_CNT = count;
   }
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_current_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return FTM0_CNT;
     case 1: return FTM1_CNT;

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
@@ -80,14 +80,14 @@ typedef uint32_t hal_timer_t;
 
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
+FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
   switch (timer_num) {
-    case 0: FTM0_C0V = count; break;
-    case 1: FTM1_C0V = count; break;
+    case 0: FTM0_C0V = compare; break;
+    case 1: FTM1_C0V = compare; break;
   }
 }
 
-FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
+FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return FTM0_C0V;
     case 1: return FTM1_C0V;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -560,7 +560,7 @@ void Stepper::isr() {
      * 10µs = 160 or 200 cycles.
      */
     #if EXTRA_CYCLES_XYZE > 20
-      hal_timer_t pulse_start = HAL_timer_get_current_count(PULSE_TIMER_NUM);
+      hal_timer_t pulse_start = HAL_timer_get_count(PULSE_TIMER_NUM);
     #endif
 
     #if HAS_X_STEP
@@ -592,8 +592,8 @@ void Stepper::isr() {
 
     // For minimum pulse time wait before stopping pulses
     #if EXTRA_CYCLES_XYZE > 20
-      while (EXTRA_CYCLES_XYZE > (uint32_t)(HAL_timer_get_current_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
-      pulse_start = HAL_timer_get_current_count(PULSE_TIMER_NUM);
+      while (EXTRA_CYCLES_XYZE > (uint32_t)(HAL_timer_get_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
+      pulse_start = HAL_timer_get_count(PULSE_TIMER_NUM);
     #elif EXTRA_CYCLES_XYZE > 0
       DELAY_NOPS(EXTRA_CYCLES_XYZE);
     #endif
@@ -633,7 +633,7 @@ void Stepper::isr() {
 
     // For minimum pulse time wait after stopping pulses also
     #if EXTRA_CYCLES_XYZE > 20
-      if (i) while (EXTRA_CYCLES_XYZE > (uint32_t)(HAL_timer_get_current_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
+      if (i) while (EXTRA_CYCLES_XYZE > (uint32_t)(HAL_timer_get_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
     #elif EXTRA_CYCLES_XYZE > 0
       if (i) DELAY_NOPS(EXTRA_CYCLES_XYZE);
     #endif
@@ -751,7 +751,7 @@ void Stepper::isr() {
     #ifdef CPU_32_BIT
       // Make sure stepper interrupt does not monopolise CPU by adjusting count to give about 8 us room
       hal_timer_t stepper_timer_count = HAL_timer_get_compare(STEP_TIMER_NUM),
-                  stepper_timer_current_count = HAL_timer_get_current_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
+                  stepper_timer_current_count = HAL_timer_get_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
       HAL_timer_set_compare(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
     #else
       NOLESS(OCR1A, TCNT1 + 16);
@@ -814,7 +814,7 @@ void Stepper::isr() {
     for (uint8_t i = step_loops; i--;) {
 
       #if EXTRA_CYCLES_E > 20
-        hal_timer_t pulse_start = HAL_timer_get_current_count(PULSE_TIMER_NUM);
+        hal_timer_t pulse_start = HAL_timer_get_count(PULSE_TIMER_NUM);
       #endif
 
       START_E_PULSE(0);
@@ -833,8 +833,8 @@ void Stepper::isr() {
 
       // For minimum pulse time wait before stopping pulses
       #if EXTRA_CYCLES_E > 20
-        while (EXTRA_CYCLES_E > (hal_timer_t)(HAL_timer_get_current_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
-        pulse_start = HAL_timer_get_current_count(PULSE_TIMER_NUM);
+        while (EXTRA_CYCLES_E > (hal_timer_t)(HAL_timer_get_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
+        pulse_start = HAL_timer_get_count(PULSE_TIMER_NUM);
       #elif EXTRA_CYCLES_E > 0
         DELAY_NOPS(EXTRA_CYCLES_E);
       #endif
@@ -855,7 +855,7 @@ void Stepper::isr() {
 
       // For minimum pulse time wait before looping
       #if EXTRA_CYCLES_E > 20
-        if (i) while (EXTRA_CYCLES_E > (hal_timer_t)(HAL_timer_get_current_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
+        if (i) while (EXTRA_CYCLES_E > (hal_timer_t)(HAL_timer_get_count(PULSE_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
       #elif EXTRA_CYCLES_E > 0
         if (i) DELAY_NOPS(EXTRA_CYCLES_E);
       #endif
@@ -898,7 +898,7 @@ void Stepper::isr() {
     #ifdef CPU_32_BIT
       // Make sure stepper interrupt does not monopolise CPU by adjusting count to give about 8 us room
       uint32_t stepper_timer_count = HAL_timer_get_compare(STEP_TIMER_NUM),
-               stepper_timer_current_count = HAL_timer_get_current_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
+               stepper_timer_current_count = HAL_timer_get_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
       HAL_timer_set_compare(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
     #else
       NOLESS(OCR1A, TCNT1 + 16);
@@ -1304,8 +1304,8 @@ void Stepper::report_positions() {
   #define _APPLY_DIR(AXIS, INVERT) AXIS ##_APPLY_DIR(INVERT, true)
 
   #if EXTRA_CYCLES_BABYSTEP > 20
-    #define _SAVE_START const hal_timer_t pulse_start = HAL_timer_get_current_count(STEP_TIMER_NUM)
-    #define _PULSE_WAIT while (EXTRA_CYCLES_BABYSTEP > (uint32_t)(HAL_timer_get_current_count(STEP_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
+    #define _SAVE_START const hal_timer_t pulse_start = HAL_timer_get_count(STEP_TIMER_NUM)
+    #define _PULSE_WAIT while (EXTRA_CYCLES_BABYSTEP > (uint32_t)(HAL_timer_get_count(STEP_TIMER_NUM) - pulse_start) * (PULSE_TIMER_PRESCALE)) { /* nada */ }
   #else
     #define _SAVE_START NOOP
     #if EXTRA_CYCLES_BABYSTEP > 0

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -371,7 +371,7 @@ void Stepper::isr() {
 
     #if DISABLED(LIN_ADVANCE)
       #ifdef CPU_32_BIT
-        HAL_timer_set_count(STEP_TIMER_NUM, ocr_val);
+        HAL_timer_set_compare(STEP_TIMER_NUM, ocr_val);
       #else
         NOLESS(OCR1A, TCNT1 + 16);
       #endif
@@ -750,9 +750,9 @@ void Stepper::isr() {
   #if DISABLED(LIN_ADVANCE)
     #ifdef CPU_32_BIT
       // Make sure stepper interrupt does not monopolise CPU by adjusting count to give about 8 us room
-      hal_timer_t stepper_timer_count = HAL_timer_get_count(STEP_TIMER_NUM),
+      hal_timer_t stepper_timer_count = HAL_timer_get_compare(STEP_TIMER_NUM),
                   stepper_timer_current_count = HAL_timer_get_current_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
-      HAL_timer_set_count(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
+      HAL_timer_set_compare(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
     #else
       NOLESS(OCR1A, TCNT1 + 16);
     #endif
@@ -878,7 +878,7 @@ void Stepper::isr() {
     // Is the next advance ISR scheduled before the next main ISR?
     if (nextAdvanceISR <= nextMainISR) {
       // Set up the next interrupt
-      HAL_timer_set_count(STEP_TIMER_NUM, nextAdvanceISR);
+      HAL_timer_set_compare(STEP_TIMER_NUM, nextAdvanceISR);
       // New interval for the next main ISR
       if (nextMainISR) nextMainISR -= nextAdvanceISR;
       // Will call Stepper::advance_isr on the next interrupt
@@ -886,7 +886,7 @@ void Stepper::isr() {
     }
     else {
       // The next main ISR comes first
-      HAL_timer_set_count(STEP_TIMER_NUM, nextMainISR);
+      HAL_timer_set_compare(STEP_TIMER_NUM, nextMainISR);
       // New interval for the next advance ISR, if any
       if (nextAdvanceISR && nextAdvanceISR != ADV_NEVER)
         nextAdvanceISR -= nextMainISR;
@@ -897,9 +897,9 @@ void Stepper::isr() {
     // Don't run the ISR faster than possible
     #ifdef CPU_32_BIT
       // Make sure stepper interrupt does not monopolise CPU by adjusting count to give about 8 us room
-      uint32_t stepper_timer_count = HAL_timer_get_count(STEP_TIMER_NUM),
+      uint32_t stepper_timer_count = HAL_timer_get_compare(STEP_TIMER_NUM),
                stepper_timer_current_count = HAL_timer_get_current_count(STEP_TIMER_NUM) + 8 * HAL_TICKS_PER_US;
-      HAL_timer_set_count(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
+      HAL_timer_set_compare(STEP_TIMER_NUM, max(stepper_timer_count, stepper_timer_current_count));
     #else
       NOLESS(OCR1A, TCNT1 + 16);
     #endif

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -108,7 +108,7 @@ class Stepper {
                                                  // i.e., the current amount of pressure applied
                                                  // to the spring (=filament).
     #else
-      #define _NEXT_ISR(T) HAL_timer_set_count(STEP_TIMER_NUM, T);
+      #define _NEXT_ISR(T) HAL_timer_set_compare(STEP_TIMER_NUM, T);
     #endif // LIN_ADVANCE
 
     static long acceleration_time, deceleration_time;


### PR DESCRIPTION
To reduce confusion over the current timer count vs. the compare (aka "top") value. Caution: this re-uses the function name, changing its meaning.

Reference: #8796