### PR TITLE
[2.0.x] Add 'mffp' to quickly push upstream

### DIFF
--- a/buildroot/share/git/mffp
+++ b/buildroot/share/git/mffp
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# mffp
+#
+# Push the given commit (or HEAD) upstream immediately.
+# By default: `git push upstream HEAD:bugfix-1.1.x`
+#
+
+[[ $# < 3 ]] || { echo "Usage: `basename $0` [1|2] [commit-id]" 1>&2 ; exit 1; }
+
+if [[ $1 == '1' || $1 == '2' ]]; then
+  MFINFO=$(mfinfo "$1") || exit 1
+  REF=${2:-HEAD}
+else
+  MFINFO=$(mfinfo) || exit 1
+  REF=${1:-HEAD}
+fi
+
+IFS=' ' read -a INFO <<< "$MFINFO"
+ORG=${INFO[0]}
+TARG=${INFO[3]}
+
+if [[ $ORG == "MarlinFirmware" ]]; then
+  git push upstream $REF:$TARG
+else
+  echo "Not a MarlinFirmware working copy."; exit 1
+fi


### PR DESCRIPTION
Another git helper script. This one is useful for Owners and Collaborators.

Push the given commit (or HEAD) upstream immediately.
By default: `git push upstream HEAD:bugfix-1.1.x`

Usage: `mffp [1|2] [commit-id]`
