### PR TITLE
[2.0.x] Add delays to AVR driver for RRD Full Graphic Smart Controller

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -24,6 +24,7 @@
 // file u8g_dev_st7920_128x64_HAL.cpp for the HAL version.
 
 #include "../../inc/MarlinConfig.h"
+#include <U8glib.h>
 
 #if ENABLED(U8GLIB_ST7920)
 
@@ -39,8 +40,6 @@
 
 #define LCD_PIXEL_WIDTH 128
 #define LCD_PIXEL_HEIGHT 64
-
-#include <U8glib.h>
 
 //set optimization so ARDUINO optimizes this file
 #pragma GCC optimize (3)
@@ -84,29 +83,35 @@
   #define ST7920_DELAY_3 CPU_ST7920_DELAY_3
 #endif
 
+#define ST7920_SND_BIT \
+  WRITE(ST7920_CLK_PIN, LOW);        ST7920_DELAY_1; \
+  WRITE(ST7920_DAT_PIN, val & 0x80); ST7920_DELAY_2; \
+  WRITE(ST7920_CLK_PIN, HIGH);       ST7920_DELAY_3; \
+  val <<= 1
+
+static void ST7920_SWSPI_SND_8BIT(uint8_t val) {
+  ST7920_SND_BIT; // 1
+  ST7920_SND_BIT; // 2
+  ST7920_SND_BIT; // 3
+  ST7920_SND_BIT; // 4
+  ST7920_SND_BIT; // 5
+  ST7920_SND_BIT; // 6
+  ST7920_SND_BIT; // 7
+  ST7920_SND_BIT; // 8
+}
+
 #if defined(DOGM_SPI_DELAY_US) && DOGM_SPI_DELAY_US > 0
   #define U8G_DELAY() delayMicroseconds(DOGM_SPI_DELAY_US)
 #else
   #define U8G_DELAY() u8g_10MicroDelay()
 #endif
 
-static void ST7920_WRITE_BYTE(uint8_t val) {
-  for (uint8_t i = 0; i < 8; i++) {
-    WRITE(ST7920_DAT_PIN, val & 0x80);
-    WRITE(ST7920_CLK_PIN, HIGH);
-    WRITE(ST7920_CLK_PIN, LOW);
-    val <<= 1;
-  }
-}
-
-#define ST7920_SET_CMD()         { ST7920_WRITE_BYTE(0xF8); U8G_DELAY(); }
-#define ST7920_SET_DAT()         { ST7920_WRITE_BYTE(0xFA); U8G_DELAY(); }
-#define ST7920_WRITE_NIBBLES(a)  { ST7920_WRITE_BYTE((uint8_t)((a)&0xF0u)); ST7920_WRITE_BYTE((uint8_t)((a)<<4u)); U8G_DELAY(); }
-#define ST7920_WRITE_NIBBLES_P(p,l)  { for (uint8_t i = l + 1; --i;) { ST7920_WRITE_BYTE(*p&0xF0); ST7920_WRITE_BYTE(*p<<4); p++; } U8G_DELAY(); }
-
-
 #define ST7920_CS()              { WRITE(ST7920_CS_PIN,1); U8G_DELAY(); }
 #define ST7920_NCS()             { WRITE(ST7920_CS_PIN,0); }
+#define ST7920_SET_CMD()         { ST7920_SWSPI_SND_8BIT(0xF8); U8G_DELAY(); }
+#define ST7920_SET_DAT()         { ST7920_SWSPI_SND_8BIT(0xFA); U8G_DELAY(); }
+#define ST7920_WRITE_BYTE(a)     { ST7920_SWSPI_SND_8BIT((uint8_t)((a)&0xF0u)); ST7920_SWSPI_SND_8BIT((uint8_t)((a)<<4u)); U8G_DELAY(); }
+#define ST7920_WRITE_BYTES(p,l)  { for (uint8_t i = l + 1; --i;) { ST7920_SWSPI_SND_8BIT(*p&0xF0); ST7920_SWSPI_SND_8BIT(*p<<4); p++; } U8G_DELAY(); }
 
 uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
   uint8_t i, y;
@@ -114,26 +119,24 @@ uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
     case U8G_DEV_MSG_INIT: {
       OUT_WRITE(ST7920_CS_PIN, LOW);
       OUT_WRITE(ST7920_DAT_PIN, LOW);
-      OUT_WRITE(ST7920_CLK_PIN, LOW);
+      OUT_WRITE(ST7920_CLK_PIN, HIGH);
 
       ST7920_CS();
       u8g_Delay(120);                 //initial delay for boot up
       ST7920_SET_CMD();
-      ST7920_WRITE_NIBBLES(0x08);       //display off, cursor+blink off
-      ST7920_WRITE_NIBBLES(0x01);       //clear CGRAM ram
+      ST7920_WRITE_BYTE(0x08);       //display off, cursor+blink off
+      ST7920_WRITE_BYTE(0x01);       //clear CGRAM ram
       u8g_Delay(15);                 //delay for CGRAM clear
-      ST7920_WRITE_NIBBLES(0x3E);       //extended mode + GDRAM active
+      ST7920_WRITE_BYTE(0x3E);       //extended mode + GDRAM active
       for (y = 0; y < (LCD_PIXEL_HEIGHT) / 2; y++) { //clear GDRAM
-        ST7920_WRITE_NIBBLES(0x80 | y); //set y
-        ST7920_WRITE_NIBBLES(0x80);     //set x = 0
+        ST7920_WRITE_BYTE(0x80 | y); //set y
+        ST7920_WRITE_BYTE(0x80);     //set x = 0
         ST7920_SET_DAT();
         for (i = 0; i < 2 * (LCD_PIXEL_WIDTH) / 8; i++) //2x width clears both segments
-          ST7920_WRITE_NIBBLES(0);
+          ST7920_WRITE_BYTE(0);
         ST7920_SET_CMD();
       }
-
-      ST7920_WRITE_NIBBLES(0x0C); //display on, cursor+blink off
-
+      ST7920_WRITE_BYTE(0x0C); //display on, cursor+blink off
       ST7920_NCS();
     }
     break;
@@ -150,15 +153,15 @@ uint8_t u8g_dev_rrd_st7920_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
       for (i = 0; i < PAGE_HEIGHT; i ++) {
         ST7920_SET_CMD();
         if (y < 32) {
-          ST7920_WRITE_NIBBLES(0x80 | y);       //y
-          ST7920_WRITE_NIBBLES(0x80);           //x=0
+          ST7920_WRITE_BYTE(0x80 | y);       //y
+          ST7920_WRITE_BYTE(0x80);           //x=0
         }
         else {
-          ST7920_WRITE_NIBBLES(0x80 | (y - 32)); //y
-          ST7920_WRITE_NIBBLES(0x80 | 8);       //x=64
+          ST7920_WRITE_BYTE(0x80 | (y - 32)); //y
+          ST7920_WRITE_BYTE(0x80 | 8);       //x=64
         }
         ST7920_SET_DAT();
-        ST7920_WRITE_NIBBLES_P(ptr, (LCD_PIXEL_WIDTH) / 8); //ptr is incremented inside of macro
+        ST7920_WRITE_BYTES(ptr, (LCD_PIXEL_WIDTH) / 8); //ptr is incremented inside of macro
         y++;
       }
       ST7920_NCS();


### PR DESCRIPTION
Some users were having trouble with the RRD Full Graphic Smart Controller not working properly.  In at least one case this was traced to the soft SPI delays not being carried forward from 1.x.x to 2.0.x.

This PR moves the 1.1.x soft SPI code from 1.x.x to 2.0.x.  

This change does two things (both the same as in 1.x.x):
1) Adds user configurable delays between MOSI and SCK transitions.
2) Changes SCK polarity from low idle to high idle.  Some testing has shown the ST7920 to be able to run at faster speeds with this configuration.  

See Issue #5703 for details.