### PR TITLE
[2.0.x] G26 circle fix

### DIFF
--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -738,14 +738,18 @@ void GcodeSuite::G26() {
   /**
    * Pre-generate radius offset values at 30 degree intervals to reduce CPU load.
    */
-
-  #define A_CNT ((360 / 30) / 2)  // must be a multiple of 2 for _COS() and _SIN() macro to work correctly!
-  #define NEGATION_of_COS_TABLE(A) (((A + A_CNT * 16) % (A_CNT * 2)) >= A_CNT ? -1 : 1) 
-  #define _COS(A) (trig_table[(A + A_CNT * 16) % A_CNT] * NEGATION_of_COS_TABLE(A))
-  #define _SIN(A) (-_COS((A + A_CNT / 2) % (A_CNT * 2)))
+  #define A_INT 30
+  #define _ANGS (360 / A_INT)
+  #define A_CNT (_ANGS / 2)
+  #define _IND(A) ((A + _ANGS * 8) % _ANGS)
+  #define _COS(A) (trig_table[_IND(A) % A_CNT] * (_IND(A) >= A_CNT ? -1 : 1))
+  #define _SIN(A) (-_COS((A + A_CNT / 2) % _ANGS))
+  #if A_CNT & 1
+    #error "A_CNT must be a positive value. Please change A_INT."
+  #endif
   float trig_table[A_CNT];
   for (uint8_t i = 0; i < A_CNT; i++)
-    trig_table[i] = INTERSECTION_CIRCLE_RADIUS * cos(RADIANS(i * 30));
+    trig_table[i] = INTERSECTION_CIRCLE_RADIUS * cos(RADIANS(i * A_INT));
 
   mesh_index_pair location;
   do {


### PR DESCRIPTION
Fix #9439

Forgot to account for negative indices with the trig table method.

Also: Allow `G26 B0` and set lower bed temp limit to 40C.