### PR TITLE
[1.1.x] fix USE_CONTROLLER_FAN compile issue

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -440,7 +440,7 @@ void report_current_position();
   #endif
 #endif
 
-#if HAS_CONTROLLERFAN
+#if ENABLED(USE_CONTROLLER_FAN)
   extern int controllerFanSpeed;
 #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -487,7 +487,7 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
   #endif
 #endif
 
-#if HAS_CONTROLLERFAN
+#if ENABLED(USE_CONTROLLER_FAN)
   int controllerFanSpeed = 0;
 #endif
 

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -45,7 +45,7 @@ bool Power::is_power_needed() {
     HOTEND_LOOP() if (thermalManager.autofan_speed[e] > 0) return true;
   #endif
 
-  #if ENABLED(AUTO_POWER_CONTROLLERFAN) && HAS_CONTROLLER_FAN
+  #if ENABLED(AUTO_POWER_CONTROLLERFAN) && HAS_CONTROLLER_FAN && ENABLED(USE_CONTROLLER_FAN)
     if (controllerFanSpeed > 0) return true;
   #endif
 


### PR DESCRIPTION
Compile errors are generated when the USE_CONTROLLER_FAN option is enabled in Configuration_adv.h. This was first identified in Issue #9589.

This is apparently a pre-compiler issue.  HAS_CONTROLLERFAN works as expected in other files but not here.

I also modified power.cpp so that the USE_CONTROLLER_FAN option must be enabled before controllerFanSpeed can be used.  