### PR TITLE
[2.0.x] complete moving AUTO_POWER_CONTROLLERFAN into 2.0.x

### DIFF
--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -208,6 +208,10 @@ extern millis_t max_inactive_time, stepper_inactive_time;
   #endif
 #endif
 
+#if ENABLED(USE_CONTROLLER_FAN)
+  extern uint8_t controllerFanSpeed;
+#endif
+
 #if ENABLED(PID_EXTRUSION_SCALING)
   extern int lpq_len;
 #endif

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -27,6 +27,8 @@
 #include "../module/stepper_indirection.h"
 #include "../module/temperature.h"
 
+uint8_t controllerFanSpeed;
+
 void controllerfan_update() {
   static millis_t lastMotorOn = 0, // Last time a motor was turned on
                   nextMotorCheck = 0; // Last time the state was checked
@@ -56,6 +58,7 @@ void controllerfan_update() {
 
     // Fan off if no steppers have been enabled for CONTROLLERFAN_SECS seconds
     uint8_t speed = (!lastMotorOn || ELAPSED(ms, lastMotorOn + (CONTROLLERFAN_SECS) * 1000UL)) ? 0 : CONTROLLERFAN_SPEED;
+    controllerFanSpeed = speed;
 
     // allows digital or PWM fan output to be used (see M42 handling)
     WRITE(CONTROLLER_FAN_PIN, speed);

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -46,7 +46,7 @@ bool Power::is_power_needed() {
     HOTEND_LOOP() if (thermalManager.autofan_speed[e] > 0) return true;
   #endif
 
-  #if ENABLED(AUTO_POWER_CONTROLLERFAN) && HAS_CONTROLLER_FAN
+  #if ENABLED(AUTO_POWER_CONTROLLERFAN) && HAS_CONTROLLER_FAN && ENABLED(USE_CONTROLLER_FAN)
     if (controllerFanSpeed > 0) return true;
   #endif
 


### PR DESCRIPTION
While researching PR #9665 I noticed that the AUTO_POWER_CONTROLLERFAN option hadn't been fully implemented in 2.0.x.

