### PR TITLE
[1.1.x] Fix setPwmFrequency compile error

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1269,7 +1269,7 @@ void Temperature::init() {
 
 #if ENABLED(FAST_PWM_FAN)
 
-  void setPwmFrequency(const pin_t pin, int val) {
+  void Temperature::setPwmFrequency(const pin_t pin, int val) {
     val &= 0x07;
     switch (digitalPinToTimer(pin)) {
       #ifdef TCCR0A

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -588,7 +588,7 @@ class Temperature {
   private:
 
     #if ENABLED(FAST_PWM_FAN)
-      void setPwmFrequency(const pin_t pin, int val);
+      static void setPwmFrequency(const pin_t pin, int val);
     #endif
 
     static void set_current_temp_raw();


### PR DESCRIPTION
When FAST_PWM_FAN is enabled we get a **undefined reference to `Temperature::setPwmFrequency(signed char, int)'**  compile error.

Apparently the `setPwmFrequency(const pin_t pin, int val);` declaration in **temperature.h** isn't being recognized in  **temperature.cpp**.

This PR does the following:
1) remove setPwmFrequency from **temperature.h**
2) In **temperature.cpp**, move the setPwmFrequency routine to before it is used.

This fixes Issue #9683.