### PR TITLE
[2.0.x] Use a different ST7920 for Due

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -818,15 +818,18 @@
 /**
  * Helper Macros for heaters and extruder fan
  */
-#define WRITE_HEATER_0P(v) WRITE(HEATER_0_PIN, v)
+#ifndef HEATER_HOTEND_INVERTING
+  #define HEATER_HOTEND_INVERTING false
+#endif
+#define WRITE_HEATER_0P(v) WRITE(HEATER_0_PIN, (v) ^ HEATER_HOTEND_INVERTING)
 #if HOTENDS > 1 || ENABLED(HEATERS_PARALLEL)
-  #define WRITE_HEATER_1(v) WRITE(HEATER_1_PIN, v)
+  #define WRITE_HEATER_1(v) WRITE(HEATER_1_PIN, (v) ^ HEATER_HOTEND_INVERTING)
   #if HOTENDS > 2
-    #define WRITE_HEATER_2(v) WRITE(HEATER_2_PIN, v)
+    #define WRITE_HEATER_2(v) WRITE(HEATER_2_PIN, (v) ^ HEATER_HOTEND_INVERTING)
     #if HOTENDS > 3
-      #define WRITE_HEATER_3(v) WRITE(HEATER_3_PIN, v)
+      #define WRITE_HEATER_3(v) WRITE(HEATER_3_PIN, (v) ^ HEATER_HOTEND_INVERTING)
       #if HOTENDS > 4
-        #define WRITE_HEATER_4(v) WRITE(HEATER_4_PIN, v)
+        #define WRITE_HEATER_4(v) WRITE(HEATER_4_PIN, (v) ^ HEATER_HOTEND_INVERTING)
       #endif // HOTENDS > 4
     #endif // HOTENDS > 3
   #endif // HOTENDS > 2
@@ -863,15 +866,18 @@
   #define FAN_COUNT 0
 #endif
 
+#ifndef FAN_PIN_INVERTING
+  #define FAN_PIN_INVERTING false
+#endif
 #if HAS_FAN0
-  #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+  #define WRITE_FAN(v) WRITE(FAN_PIN, (v) ^ FAN_PIN_INVERTING)
   #define WRITE_FAN0(v) WRITE_FAN(v)
 #endif
 #if HAS_FAN1
-  #define WRITE_FAN1(v) WRITE(FAN1_PIN, v)
+  #define WRITE_FAN1(v) WRITE(FAN1_PIN, (v) ^ FAN_PIN_INVERTING)
 #endif
 #if HAS_FAN2
-  #define WRITE_FAN2(v) WRITE(FAN2_PIN, v)
+  #define WRITE_FAN2(v) WRITE(FAN2_PIN, (v) ^ FAN_PIN_INVERTING)
 #endif
 #define WRITE_FAN_N(n, v) WRITE_FAN##n(v)
 

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -156,9 +156,11 @@
 
 #define START_COL              0
 
+#define LCD_SD_SHARED_BUS (DISABLED(SDSUPPORT) && LCD_PINS_D4 == SCK_PIN && LCD_PINS_ENABLE == MOSI_PIN)
+
 // LCD selection
 #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
-  #ifdef DISABLED(SDSUPPORT) && (LCD_PINS_D4 == SCK_PIN) && (LCD_PINS_ENABLE == MOSI_PIN)
+  #if LCD_SD_SHARED_BUS
     U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_RS); // 2 stripes, HW SPI (shared with SD card)
   #else
     U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
@@ -166,10 +168,11 @@
 
 #elif ENABLED(U8GLIB_ST7920)
   // RepRap Discount Full Graphics Smart Controller
-  #if DISABLED(SDSUPPORT) && (LCD_PINS_D4 == SCK_PIN) && (LCD_PINS_ENABLE == MOSI_PIN)
+  #if LCD_SD_SHARED_BUS
     U8GLIB_ST7920_128X64_4X_HAL u8g(LCD_PINS_RS); // 2 stripes, HW SPI (shared with SD card, on AVR does not use standard LCD adapter)
+  #elif defined(__SAM3X8E__)
+    U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
   #else
-    //U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
     U8GLIB_ST7920_128X64_RRD u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Number of stripes can be adjusted in ultralcd_st7920_u8glib_rrd.h with PAGE_HEIGHT
                                                                            // AVR version ignores these pin settings
                                                                            // HAL version uses these pin settings

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -35,9 +35,15 @@
   #define BOARD_NAME       "RAMPS-FD"
 #endif
 
-#define INVERTED_HEATER_PINS
-#define INVERTED_BED_PINS
-#define INVERTED_FAN_PINS
+#ifndef HEATER_HOTEND_INVERTING
+  #define HEATER_HOTEND_INVERTING true
+#endif
+#ifndef HEATER_BED_INVERTING
+  #define HEATER_BED_INVERTING true
+#endif
+#ifndef FAN_PIN_INVERTING
+  #define FAN_PIN_INVERTING true
+#endif
 
 //
 // Servos

--- a/Marlin/src/pins/pins_RAMPS_FD_V2.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V2.h
@@ -29,10 +29,10 @@
 
 #define BOARD_NAME         "RAMPS-FD v2"
 
-#include "pins_RAMPS_FD_V1.h"
+#define HEATER_HOTEND_INVERTING false
+#define HEATER_BED_INVERTING    false
+#define FAN_PIN_INVERTING       false
 
-#undef INVERTED_HEATER_PINS
-#undef INVERTED_BED_PINS
-#undef INVERTED_FAN_PINS
+#include "pins_RAMPS_FD_V1.h"
 
 #define I2C_EEPROM


### PR DESCRIPTION
As mentioned in #7989 

- Auto-select a 2 stripe ST7920 device for Due.
- Fix a bug in `REPRAPWORLD_GRAPHICAL_LCD` U8G condition test
- Implement hotend heater and fan pin inverting.
- Make `HEPHESTOS2_HEATED_BED_KIT` an option for all machines.