### PR TITLE
[2.0.x] Move #include <U8glib.h> in ultralcd_st7920_u8glib_rrd_AVR.cpp (fix bug introduced in PR #9624)

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -24,7 +24,6 @@
 // file u8g_dev_st7920_128x64_HAL.cpp for the HAL version.
 
 #include "../../inc/MarlinConfig.h"
-#include <U8glib.h>
 
 #if ENABLED(U8GLIB_ST7920)
 
@@ -40,6 +39,8 @@
 
 #define LCD_PIXEL_WIDTH 128
 #define LCD_PIXEL_HEIGHT 64
+
+#include <U8glib.h>
 
 //set optimization so ARDUINO optimizes this file
 #pragma GCC optimize (3)


### PR DESCRIPTION
PR #9624 moved the **#include <U8glib.h>** in **ultralcd_st7920_u8glib_rrd_AVR.cpp** to the beginning.  This results in a compile error in Arduino when the U8G library isn't installed.  This was because the include was now before the conditional compile statements so was being included even when an LCD was not being used.

This PR moves it back to the original location.

This fixes Issue #9716.
