### PR TITLE
[2.0.x] Drop HAL_timer_set_count

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -149,7 +149,6 @@ extern "C" {
 #define _CAT(a, ...) a ## __VA_ARGS__
 #define HAL_timer_set_compare(timer, compare) (_CAT(TIMER_OCR_, timer) = compare)
 #define HAL_timer_get_compare(timer) _CAT(TIMER_OCR_, timer)
-#define HAL_timer_set_count(timer, count) (_CAT(TIMER_COUNTER_, timer) = count)
 #define HAL_timer_get_count(timer) _CAT(TIMER_COUNTER_, timer)
 
 #define HAL_timer_isr_prologue(timer_num)

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -101,11 +101,6 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_RC;
 }
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
-  const tTimerConfig * const pConfig = &TimerConfig[timer_num];
-  pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV = count;
-}
-
 FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   const tTimerConfig * const pConfig = &TimerConfig[timer_num];
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV;

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -110,13 +110,6 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return 0;
 }
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
-  switch (timer_num) {
-    case 0: LPC_TIM0->TC = count; break;
-    case 1: LPC_TIM1->TC = count; break;
-  }
-}
-
 FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return LPC_TIM0->TC;

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -83,7 +83,6 @@ typedef uint16_t hal_timer_t;
 #define DISABLE_TEMPERATURE_INTERRUPT() timer_disable_irq(TEMP_TIMER_DEV, TEMP_TIMER_CHAN)
 
 #define HAL_timer_get_count(timer_num) timer_get_count(TIMER_DEV(timer_num))
-#define HAL_timer_set_count(timer_num, count) timer_set_count(TIMER_DEV(timer_num), (uint16)count)
 
 
 #define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr)DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
@@ -121,10 +121,6 @@ void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare) {
   __HAL_TIM_SetAutoreload(&timerConfig[timer_num].timerdef, compare);
 }
 
-void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count) {
-  __HAL_TIM_SetAutoreload(&timerConfig[timer_num].timerdef, count);
-}
-
 void HAL_timer_enable_interrupt(const uint8_t timer_num) {
   HAL_NVIC_EnableIRQ(timerConfig[timer_num].IRQ_Id);
 }

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
@@ -95,11 +95,6 @@ void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare);
 hal_timer_t HAL_timer_get_compare(const uint8_t timer_num);
 uint32_t HAL_timer_get_count(const uint8_t timer_num);
 
-void HAL_timer_set_count(const uint8_t timer_num, const uint32_t count); // New
-/*FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
-  // To do ??
-}*/
-
 void HAL_timer_isr_prologue(const uint8_t timer_num);
 
 #endif // _HAL_TIMERS_STM32F7_H

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
@@ -95,13 +95,6 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return 0;
 }
 
-FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t count) {
-  switch (timer_num) {
-    case 0: FTM0_CNT = count;
-    case 1: FTM1_CNT = count;
-  }
-}
-
 FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   switch (timer_num) {
     case 0: return FTM0_CNT;

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -46,7 +46,7 @@
 #define _O3          __attribute__((optimize("O3")))
 
 // Clock speed factors
-#ifndef CYCLES_PER_MICROSECOND
+#if !defined(CYCLES_PER_MICROSECOND) && !defined(__STM32F1__)
   #define CYCLES_PER_MICROSECOND (F_CPU / 1000000L) // 16 or 20 on AVR
 #endif
 

--- a/Marlin/src/pins/pins_STM32F1R.h
+++ b/Marlin/src/pins/pins_STM32F1R.h
@@ -20,7 +20,7 @@
  *
  */
 
-#if !defined(__STM32F1__)
+#ifndef __STM32F1__
     #error "Oops!  Make sure you have an STM32F1 board selected from the 'Tools -> Boards' menu."
 #endif
 


### PR DESCRIPTION
We don't need to set timer count directly, and most platforms don't support it anyway, so this HAL function can be dropped.

And, somehow STM32F1 defines `CYCLES_PER_MICROSECOND`. When I added that to Marlin I had no idea it would ever conflict with something, but here we are. So this makes sure not to define it for STM32F1.

Reference: #9607