### PR TITLE
[2.0.x] Fix compiling with M600 and runout sensor

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -51,6 +51,7 @@
 
 #include "../libs/buzzer.h"
 #include "../libs/nozzle.h"
+#include "pause.h"
 
 // private:
 

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -35,45 +35,45 @@
 #include "../inc/MarlinConfig.h"
 
 class FilamentRunoutSensor {
+  public:
+    FilamentRunoutSensor() {}
 
-  FilamentRunoutSensor() {}
+    static void setup();
 
-  static bool filament_ran_out;
-  static void setup();
+    FORCE_INLINE static void reset() { filament_ran_out = false; }
 
-  FORCE_INLINE static reset() { filament_ran_out = false; }
+    FORCE_INLINE static void run() {
+      if ((IS_SD_PRINTING || print_job_timer.isRunning()) && check() && !filament_ran_out) {
+        filament_ran_out = true;
+        enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
+        stepper.synchronize();
+      }
+    }
+  private:
+    static bool filament_ran_out;
 
-  FORCE_INLINE static bool check() {
-    #if NUM_RUNOUT_SENSORS < 2
-      // A single sensor applying to all extruders
-      return READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING;
-    #else
-      // Read the sensor for the active extruder
-      switch (active_extruder) {
-        case 0: return READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING;
-        case 1: return READ(FIL_RUNOUT2_PIN) == FIL_RUNOUT_INVERTING;
-        #if NUM_RUNOUT_SENSORS > 2
-          case 2: return READ(FIL_RUNOUT3_PIN) == FIL_RUNOUT_INVERTING;
-          #if NUM_RUNOUT_SENSORS > 3
-            case 3: return READ(FIL_RUNOUT4_PIN) == FIL_RUNOUT_INVERTING;
-            #if NUM_RUNOUT_SENSORS > 4
-              case 4: return READ(FIL_RUNOUT5_PIN) == FIL_RUNOUT_INVERTING;
+    FORCE_INLINE static bool check() {
+      #if NUM_RUNOUT_SENSORS < 2
+        // A single sensor applying to all extruders
+        return READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING;
+      #else
+        // Read the sensor for the active extruder
+        switch (active_extruder) {
+          case 0: return READ(FIL_RUNOUT_PIN) == FIL_RUNOUT_INVERTING;
+          case 1: return READ(FIL_RUNOUT2_PIN) == FIL_RUNOUT_INVERTING;
+          #if NUM_RUNOUT_SENSORS > 2
+            case 2: return READ(FIL_RUNOUT3_PIN) == FIL_RUNOUT_INVERTING;
+            #if NUM_RUNOUT_SENSORS > 3
+              case 3: return READ(FIL_RUNOUT4_PIN) == FIL_RUNOUT_INVERTING;
+              #if NUM_RUNOUT_SENSORS > 4
+                case 4: return READ(FIL_RUNOUT5_PIN) == FIL_RUNOUT_INVERTING;
+              #endif
             #endif
           #endif
-        #endif
-      }
-    #endif
-    return false;
-  }
-
-  FORCE_INLINE static void run() {
-    if ((IS_SD_PRINTING || print_job_timer.isRunning()) && check() && !filament_ran_out) {
-      filament_ran_out = true;
-      enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
-      stepper.synchronize();
+        }
+      #endif
+      return false;
     }
-  }
-
 };
 
 extern FilamentRunoutSensor runout;

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -71,6 +71,10 @@
   #include "../feature/fwretract.h"
 #endif
 
+#if ENABLED(ADVANCED_PAUSE_FEATURE)
+  #include "../feature/pause.h"
+#endif
+
 #pragma pack(push, 1) // No padding between variables
 
 typedef struct PID { float Kp, Ki, Kd; } PID;


### PR DESCRIPTION
Some missing includes for ADVANCED_PAUSE_FEATURE
and FilamentRunoutSensor class didn't have any public methods.

The changes in `runout.h` look bigger than they are. It's just two added lines and some shuffling of the code to their correct category.

1.1.x is ok.