### PR TITLE
[1.1.x] Un-pause on print cancellation

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -449,6 +449,7 @@ void report_current_position();
 #endif
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
+  extern int8_t did_pause_print;
   extern AdvancedPauseMenuResponse advanced_pause_menu_response;
   extern float filament_change_unload_length[EXTRUDERS],
                filament_change_load_length[EXTRUDERS];

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6406,7 +6406,7 @@ inline void gcode_M17() {
   }
 
   static float resume_position[XYZE];
-  static int8_t did_pause_print = 0;
+  int8_t did_pause_print = 0;
 
   #if HAS_BUZZER
     static void filament_change_beep(const int8_t max_beep_count, const bool init=false) {

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -296,6 +296,9 @@ void CardReader::startFileprint() {
 }
 
 void CardReader::stopSDPrint() {
+  #if ENABLED(ADVANCED_PAUSE_FEATURE)
+    did_pause_print = 0;
+  #endif
   sdprinting = false;
   if (isFileOpen()) file.close();
 }

--- a/Marlin/malyanlcd.cpp
+++ b/Marlin/malyanlcd.cpp
@@ -225,6 +225,7 @@ void process_lcd_p_command(const char* command) {
     case 'X':
       // cancel print
       write_to_lcd_P(PSTR("{SYS:CANCELING}"));
+      card.stopSDPrint();
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();


### PR DESCRIPTION
Fix #8703

Clear `did_pause_print` when a print is canceled so that `resume_print` won't move the head back on the next print.