### PR TITLE
[2.0.x] Un-pause print on cancellation

### DIFF
--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -228,6 +228,7 @@ void process_lcd_p_command(const char* command) {
     case 'X':
       // cancel print
       write_to_lcd_P(PSTR("{SYS:CANCELING}"));
+      card.stopSDPrint();
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -33,6 +33,10 @@
 #include "../core/language.h"
 #include "../gcode/queue.h"
 
+#if ENABLED(ADVANCED_PAUSE_FEATURE)
+  #include "../feature/pause.h"
+#endif
+
 #include <ctype.h>
 
 #define LONGEST_FILENAME (longFilename[0] ? longFilename : filename)
@@ -325,6 +329,9 @@ void CardReader::startFileprint() {
 }
 
 void CardReader::stopSDPrint() {
+  #if ENABLED(ADVANCED_PAUSE_FEATURE)
+    did_pause_print = 0;
+  #endif
   sdprinting = false;
   if (isFileOpen()) file.close();
 }


### PR DESCRIPTION
Fix #8703

Clear `did_pause_print` when a print is canceled so that `resume_print` won't move the head back on the next print.