### PR TITLE
[2.0.x] Feature - Move Z axis by holding down the control knob

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -747,6 +747,14 @@
   //#define BABYSTEP_ZPROBE_GFX_OVERLAY // Enable graphical overlay on Z-offset editor
 #endif
 
+/**
+ * Move Z axis by holding down the control knob
+ */
+//#define LONG_PRESS_FOR_MOVE_Z
+#if ENABLED(LONG_PRESS_FOR_MOVE_Z)
+  #define LONG_PRESS_MIN_INTERVAL 1000 // Minimum interval of long press, in milliseconds.
+#endif
+
 // @section extruder
 
 /**


### PR DESCRIPTION
This feature is something that I've seen on recent Prusa firmwares and I really like idea of quick jumping to the move Z axis menu just by holding down control knob.

I don't know if there is a better way to implement this, but this seems to be working fine