### PR TITLE
[2.0.x] PLATFORMIO.INI - TMC26xx regression, ELF improvement, re-arrange

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -23,22 +23,17 @@ libdeps_dir = .piolibdeps
 env_default = megaatmega2560
 
 [common]
+default_src_filter = +<src/*> -<src/config>
+build_flags = -fmax-errors=5
 lib_deps =
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   LiquidCrystal_I2C@1.1.2
   TMC2130Stepper
   https://github.com/teemuatlut/TMC2208Stepper/archive/v0.0.3.zip
   Adafruit NeoPixel@1.1.3
-  https://github.com/lincomatic/LiquidTWI2/archive/master.zip
-#  https://github.com/trinamic/TMC26XStepper/archive/master.zip
-  https://github.com/trinamic/TMC26XStepper.git
-  https://github.com/ameyer/Arduino-L6470/archive/master.zip
-
-default_src_filter = +<src/*> -<src/config>
-
-build_flags = -fmax-errors=5
-  -g
-  -ggdb
+  https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
+  https://github.com/ameyer/Arduino-L6470/archive/3cd0993.zip
+  https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
 
 #################################
 #                               #
@@ -75,6 +70,30 @@ lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
 
 #
+# Melzi and clones (ATmega1284p)
+#
+[env:melzi]
+platform     = atmelavr
+framework    = arduino
+board        = sanguino_atmega1284p
+build_flags  = ${common.build_flags}
+upload_speed = 57600
+lib_deps     = ${common.lib_deps}
+src_filter   = ${common.default_src_filter}
+
+#
+# Melzi and clones (Optiboot bootloader)
+#
+[env:melzi_optiboot]
+platform     = atmelavr
+framework    = arduino
+board        = sanguino_atmega1284p
+build_flags  = ${common.build_flags}
+upload_speed = 115200
+lib_deps     = ${common.lib_deps}
+src_filter   = ${common.default_src_filter}
+
+#
 # Due (Atmel SAM3X8E ARM Cortex-M3)
 #
 #  - RAMPS4DUE
@@ -86,7 +105,7 @@ framework   = arduino
 board       = due
 build_flags = ${common.build_flags}
 lib_deps    = ${common.lib_deps}
-lib_ignore  = TMC26XStepper
+lib_ignore  = c1921b4
 src_filter  = ${common.default_src_filter}
 
 #
@@ -141,30 +160,6 @@ debug_server   =
   -speed
   auto
   -noir
-
-#
-# Melzi and clones (ATmega1284p)
-#
-[env:melzi]
-platform     = atmelavr
-framework    = arduino
-board        = sanguino_atmega1284p
-build_flags  = ${common.build_flags}
-upload_speed = 57600
-lib_deps     = ${common.lib_deps}
-src_filter   = ${common.default_src_filter}
-
-#
-# Melzi and clones (Optiboot bootloader)
-#
-[env:melzi_optiboot]
-platform     = atmelavr
-framework    = arduino
-board        = sanguino_atmega1284p
-build_flags  = ${common.build_flags}
-upload_speed = 115200
-lib_deps     = ${common.lib_deps}
-src_filter   = ${common.default_src_filter}
 
 #
 # RAMBo

--- a/platformio.ini
+++ b/platformio.ini
@@ -30,12 +30,15 @@ lib_deps =
   https://github.com/teemuatlut/TMC2208Stepper/archive/v0.0.3.zip
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/master.zip
-  https://github.com/trinamic/TMC26XStepper/archive/master.zip
+#  https://github.com/trinamic/TMC26XStepper/archive/master.zip
+  https://github.com/trinamic/TMC26XStepper.git
   https://github.com/ameyer/Arduino-L6470/archive/master.zip
 
 default_src_filter = +<src/*> -<src/config>
 
 build_flags = -fmax-errors=5
+  -g
+  -ggdb
 
 #################################
 #                               #
@@ -70,30 +73,6 @@ build_flags = ${common.build_flags}
 board_f_cpu = 16000000L
 lib_deps    = ${common.lib_deps}
 src_filter  = ${common.default_src_filter}
-
-#
-# Melzi and clones (ATmega1284p)
-#
-[env:melzi]
-platform     = atmelavr
-framework    = arduino
-board        = sanguino_atmega1284p
-build_flags  = ${common.build_flags}
-upload_speed = 57600
-lib_deps     = ${common.lib_deps}
-src_filter   = ${common.default_src_filter}
-
-#
-# Melzi and clones (Optiboot bootloader)
-#
-[env:melzi_optiboot]
-platform     = atmelavr
-framework    = arduino
-board        = sanguino_atmega1284p
-build_flags  = ${common.build_flags}
-upload_speed = 115200
-lib_deps     = ${common.lib_deps}
-src_filter   = ${common.default_src_filter}
 
 #
 # Due (Atmel SAM3X8E ARM Cortex-M3)
@@ -162,6 +141,30 @@ debug_server   =
   -speed
   auto
   -noir
+
+#
+# Melzi and clones (ATmega1284p)
+#
+[env:melzi]
+platform     = atmelavr
+framework    = arduino
+board        = sanguino_atmega1284p
+build_flags  = ${common.build_flags}
+upload_speed = 57600
+lib_deps     = ${common.lib_deps}
+src_filter   = ${common.default_src_filter}
+
+#
+# Melzi and clones (Optiboot bootloader)
+#
+[env:melzi_optiboot]
+platform     = atmelavr
+framework    = arduino
+board        = sanguino_atmega1284p
+build_flags  = ${common.build_flags}
+upload_speed = 115200
+lib_deps     = ${common.lib_deps}
+src_filter   = ${common.default_src_filter}
 
 #
 # RAMBo


### PR DESCRIPTION
1) When compiling for DUE the new TMC26xx library gives a "_BV()" not defined compile error.  This PR reverts it to the previous one.

2) Add build flags so that the ELF file contains debugging information so that the source code can be seen along with the assembly code

3) Re-arranged the order of the environments.  Kept Mega2560  * Mega1280 at the top and moved MELZI so that everything else is in alphabetical order.