### PR TITLE
[2.0.x] Add tone support for Due

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.h
@@ -157,10 +157,16 @@ void HAL_enable_AdcFreerun(void);
 /**
  * Pin Map
  */
-
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
+
+/**
+ * Tone
+ */
+void toneInit();
+void tone(const pin_t _pin, const unsigned int frequency, const unsigned long duration=0);
+void noTone(const pin_t _pin);
 
 // Enable hooks into idle and setup for USB stack
 #define HAL_IDLETASK 1

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
@@ -67,7 +67,7 @@ const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
   { TC1, 0, TC3_IRQn, 2},  // 3 - stepper
   { TC1, 1, TC4_IRQn, 15}, // 4 - temperature
   { TC1, 2, TC5_IRQn, 0},  // 5 - [servo timer3]
-  { TC2, 0, TC6_IRQn, 0},  // 6
+  { TC2, 0, TC6_IRQn, 0},  // 6 - tone
   { TC2, 1, TC7_IRQn, 0},  // 7
   { TC2, 2, TC8_IRQn, 0},  // 8
 };

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -45,6 +45,7 @@ typedef uint32_t hal_timer_t;
 
 #define STEP_TIMER_NUM 3  // index of timer to use for stepper
 #define TEMP_TIMER_NUM 4  // index of timer to use for temperature
+#define TONE_TIMER_NUM 6  // index of timer to use for beeper tones
 
 #define HAL_TIMER_RATE         ((F_CPU) / 2)    // frequency of timers peripherals
 #define STEPPER_TIMER_PRESCALE 1.0              // prescaler for setting stepper frequency
@@ -64,6 +65,7 @@ typedef uint32_t hal_timer_t;
 
 #define HAL_STEP_TIMER_ISR  void TC3_Handler()
 #define HAL_TEMP_TIMER_ISR  void TC4_Handler()
+#define HAL_TONE_TIMER_ISR  void TC6_Handler()
 
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 #define PULSE_TIMER_PRESCALE STEPPER_TIMER_PRESCALE

--- a/Marlin/src/HAL/HAL_DUE/Tone.cpp
+++ b/Marlin/src/HAL/HAL_DUE/Tone.cpp
@@ -1,0 +1,62 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Description: Tone function for Arduino Due and compatible (SAM3X8E)
+ * Derived from http://forum.arduino.cc/index.php?topic=136500.msg2903012#msg2903012
+ */
+
+#ifdef ARDUINO_ARCH_SAM
+
+#include "HAL_Due.h"
+#include "HAL_timers_Due.h"
+
+static pin_t tone_pin;
+volatile static int32_t toggles;
+
+void toneInit() {
+  HAL_timer_start(TONE_TIMER_NUM, 1); // Lowest frequency possible
+}
+
+void tone(const pin_t _pin, const unsigned int frequency, const unsigned long duration) {
+  tone_pin = _pin;
+  toggles = 2 * frequency * duration / 1000;
+  HAL_timer_set_compare(TONE_TIMER_NUM, VARIANT_MCK / 2 / frequency); // 84MHz / 2 prescaler / Hz
+  HAL_timer_enable_interrupt(TONE_TIMER_NUM);
+}
+
+void noTone(const pin_t _pin) {
+  HAL_timer_disable_interrupt(TONE_TIMER_NUM);
+  digitalWrite(_pin, LOW);
+}
+
+HAL_TONE_TIMER_ISR {
+  static uint8_t pin_state = 0;
+  HAL_timer_isr_prologue(TONE_TIMER_NUM);
+  if (toggles) {
+    toggles--;
+    digitalWrite(tone_pin, (pin_state ^= 1));
+  }
+  else noTone(tone_pin);                                  // seems superfluous ?
+}
+
+#endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -254,8 +254,10 @@ bool usb_task_other_requests(void) {
   return true;
 }
 
-
 void HAL_init(void) {
+
+  toneInit();
+
   uint16_t *ptr;
 
   udd_disable();


### PR DESCRIPTION
This is a quick-and-dirty implementation of `tone` supporting a single pin for the Due platform. This will allow you to play single tones on a Piezo speaker. It uses index 6 in the interrupt table.