### PR TITLE
[2.0.x] Mesh export in Bilinear + UBL M503

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -63,6 +63,7 @@
           SERIAL_ECHOPAIR_P(port, " ; X", LOGICAL_X_POSITION(mesh_index_to_xpos(x)));
           SERIAL_ECHOPAIR_P(port, ", Y", LOGICAL_Y_POSITION(mesh_index_to_ypos(y)));
           SERIAL_EOL_P(port);
+          safe_delay(75); // Prevent Printrun from exploding
         }
   }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -44,6 +44,28 @@
     SERIAL_PROTOCOLPGM_P(port, "Unified Bed Leveling");
   }
 
+  void unified_bed_leveling::report_current_mesh(
+    #if NUM_SERIAL > 1
+      const int8_t port/*= -1*/
+    #endif
+  ) {
+    if (!leveling_is_valid()) return;
+    SERIAL_ECHO_START_P(port);
+    SERIAL_ECHOLNPGM_P(port, "  G29 I 999");
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
+      for (uint8_t y = 0;  y < GRID_MAX_POINTS_Y; y++)
+        if (!isnan(z_values[x][y])) {
+          SERIAL_ECHO_START_P(port);
+          SERIAL_ECHOPAIR_P(port, "  M421 I", x);
+          SERIAL_ECHOPAIR_P(port, " J", y);
+          SERIAL_ECHOPGM_P(port, " Z");
+          SERIAL_ECHO_F_P(port, z_values[x][y], 6);
+          SERIAL_ECHOPAIR_P(port, " ; X", LOGICAL_X_POSITION(mesh_index_to_xpos(x)));
+          SERIAL_ECHOPAIR_P(port, ", Y", LOGICAL_Y_POSITION(mesh_index_to_ypos(y)));
+          SERIAL_EOL_P(port);
+        }
+  }
+
   void unified_bed_leveling::report_state(
     #if NUM_SERIAL > 1
       const int8_t port/*= -1*/

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -107,6 +107,11 @@ class unified_bed_leveling {
         const int8_t port = -1
       #endif
     );
+    static void report_current_mesh(
+      #if NUM_SERIAL > 1
+        const int8_t port = -1
+      #endif
+    );
     static void report_state(
       #if NUM_SERIAL > 1
         const int8_t port = -1

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -600,21 +600,8 @@
     if (parser.seen('S')) {     // Store (or Save) Current Mesh Data
       g29_storage_slot = parser.has_value() ? parser.value_int() : storage_slot;
 
-      if (g29_storage_slot == -1) {                     // Special case, we are going to 'Export' the mesh to the
-        SERIAL_ECHOLNPGM("G29 I 999");              // host in a form it can be reconstructed on a different machine
-        for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
-          for (uint8_t y = 0;  y < GRID_MAX_POINTS_Y; y++)
-            if (!isnan(z_values[x][y])) {
-              SERIAL_ECHOPAIR("M421 I ", x);
-              SERIAL_ECHOPAIR(" J ", y);
-              SERIAL_ECHOPGM(" Z ");
-              SERIAL_ECHO_F(z_values[x][y], 6);
-              SERIAL_ECHOPAIR(" ; X ", LOGICAL_X_POSITION(mesh_index_to_xpos(x)));
-              SERIAL_ECHOPAIR(", Y ", LOGICAL_Y_POSITION(mesh_index_to_ypos(y)));
-              SERIAL_EOL();
-            }
-        return;
-      }
+      if (g29_storage_slot == -1)                     // Special case, we are going to 'Export' the mesh to the
+        return report_current_mesh();
 
       int16_t a = settings.calc_num_meshes();
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2098,14 +2098,16 @@ void MarlinSettings::reset(
 
       #if ENABLED(MESH_BED_LEVELING)
 
-        for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
-          for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
-            CONFIG_ECHO_START;
-            SERIAL_ECHOPAIR_P(port, "  G29 S3 X", (int)px + 1);
-            SERIAL_ECHOPAIR_P(port, " Y", (int)py + 1);
-            SERIAL_ECHOPGM_P(port, " Z");
-            SERIAL_PROTOCOL_F_P(port, LINEAR_UNIT(mbl.z_values[px][py]), 5);
-            SERIAL_EOL_P(port);
+        if (leveling_is_valid()) {
+          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
+            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
+              CONFIG_ECHO_START;
+              SERIAL_ECHOPAIR_P(port, "  G29 S3 X", (int)px + 1);
+              SERIAL_ECHOPAIR_P(port, " Y", (int)py + 1);
+              SERIAL_ECHOPGM_P(port, " Z");
+              SERIAL_PROTOCOL_F_P(port, LINEAR_UNIT(mbl.z_values[px][py]), 5);
+              SERIAL_EOL_P(port);
+            }
           }
         }
 
@@ -2117,6 +2119,27 @@ void MarlinSettings::reset(
           SERIAL_ECHOLNPAIR_P(port, "\nActive Mesh Slot: ", ubl.storage_slot);
           SERIAL_ECHOPAIR_P(port, "EEPROM can hold ", calc_num_meshes());
           SERIAL_ECHOLNPGM_P(port, " meshes.\n");
+        }
+
+        ubl.report_current_mesh(
+          #if ADD_PORT_ARG
+            port
+          #endif
+        );
+
+      #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
+
+        if (leveling_is_valid()) {
+          for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
+            for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
+              CONFIG_ECHO_START;
+              SERIAL_ECHOPAIR_P(port, "  G29 W I", (int)px + 1);
+              SERIAL_ECHOPAIR_P(port, " J", (int)py + 1);
+              SERIAL_ECHOPGM_P(port, " Z");
+              SERIAL_PROTOCOL_F_P(port, LINEAR_UNIT(z_values[px][py]), 5);
+              SERIAL_EOL_P(port);
+            }
+          }
         }
 
       #endif


### PR DESCRIPTION
While reviewing `M503` to answer a question from @dosono on #9724 I discovered that `M503` was incomplete. The mesh data is included for MBL but not ABL or UBL.

This PR adds the current mesh to the `M503` output so that it can be saved and restored later. To facilitate this, UBL code pertaining to both this and `G29 S-1` was moved to the `report_current_mesh` method.