### PR TITLE
[1.1.x] LA 1.5: Useless line removed

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -774,8 +774,6 @@ void Stepper::isr() {
 
   void Stepper::advance_isr() {
 
-    nextAdvanceISR = eISR_Rate;
-
     #if ENABLED(MK2_MULTIPLEXER)
       // Even-numbered steppers are reversed
       #define SET_E_STEP_DIR(INDEX) \


### PR DESCRIPTION
This is a small one I recognised during porting LA 1.5 to Prusa FW:
nextAdvanceISR is set in the next if structure in every possible
situation, so it's useless to set it once more before.