### PR TITLE
[2.0.x] LA 1.5: Useless line removed

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -747,7 +747,6 @@ void Stepper::isr() {
   // Timer interrupt for E. e_steps is set in the main routine;
 
   void Stepper::advance_isr() {
-    nextAdvanceISR = eISR_Rate;
 
     #if ENABLED(MK2_MULTIPLEXER)
       // Even-numbered steppers are reversed


### PR DESCRIPTION
This is a small one I recognised during porting LA 1.5 to Prusa FW:
nextAdvanceISR is set in the next if structure in every possible
situation, so it's useless to set it once more before.