### PR TITLE
Report sd card progress [FR]  #9751

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -547,6 +547,10 @@ void idle(
     }
   #endif
 
+  #if ENABLED(AUTO_REPORT_SD_STATUS)
+    card.auto_report_sd_status();
+  #endif
+
   #ifdef HAL_IDLETASK
     HAL_idletask();
   #endif

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/BIBO/TouchX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1415,6 +1415,11 @@
 #define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Disable all Volumetric extrusion options
  */
 //#define NO_VOLUMETRICS

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1413,6 +1413,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1409,6 +1409,11 @@
  */
 //#define AUTO_REPORT_TEMPERATURES
 
+
+/**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
 /**
  * Include capabilities in M115 output
  */

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -1411,6 +1411,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1418,6 +1418,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/TheBorg/Configuration_adv.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1423,6 +1423,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -1417,6 +1417,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1412,6 +1412,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1410,6 +1410,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1411,6 +1411,11 @@
 #define AUTO_REPORT_TEMPERATURES
 
 /**
+ * Auto-report SdCard status with M27 S<seconds>
+ */
+//#define AUTO_REPORT_SD_STATUS
+
+/**
  * Include capabilities in M115 output
  */
 #define EXTENDED_CAPABILITIES_REPORT

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -85,7 +85,7 @@
  * M24  - Start/resume SD print. (Requires SDSUPPORT)
  * M25  - Pause SD print. (Requires SDSUPPORT)
  * M26  - Set SD position in bytes: "M26 S12345". (Requires SDSUPPORT)
- * M27  - Report SD print status. (Requires SDSUPPORT)
+ * M27  - Report SD print status. (Requires SDSUPPORT) With 'S<seconds>' sets the SD status auto-report interval. (Requires AUTO_REPORT_SD_STATUS)
  * M28  - Start SD write: "M28 /path/file.gco". (Requires SDSUPPORT)
  * M29  - Stop SD write. (Requires SDSUPPORT)
  * M30  - Delete file from SD: "M30 /path/file.gco"

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -139,5 +139,12 @@ void GcodeSuite::M115() {
       #endif
     );
 
+    // AUTOREPORT_SD_STATUS (M27 extension)
+    cap_line(PSTR("AUTOREPORT_SD_STATUS")
+      #if ENABLED(AUTO_REPORT_SD_STATUS)
+        , true
+      #endif
+    );
+
   #endif // EXTENDED_CAPABILITIES_REPORT
 }

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
@@ -115,6 +115,14 @@ void GcodeSuite::M27() {
       command_queue_port[cmd_queue_index_r]
     #endif
   );
+  #if ENABLED(AUTO_REPORT_SD_STATUS)
+  if (parser.seenval('S'))
+    card.set_auto_report_interval(parser.value_byte()
+      #if NUM_SERIAL > 1
+        , command_queue_port[cmd_queue_index_r]
+      #endif
+    );
+  #endif
 }
 
 /**

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2603,7 +2603,7 @@ void kill_screen(const char* lcd_msg) {
           _lcd_goto_ubl_level_bed
         #else
           _lcd_ubl_level_bed
-        #endif        
+        #endif
       );
     #elif ENABLED(LCD_BED_LEVELING)
       #if ENABLED(PROBE_MANUALLY)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -947,4 +947,25 @@ void CardReader::printingHasFinished() {
   }
 }
 
+#if ENABLED(AUTO_REPORT_SD_STATUS)
+  uint8_t CardReader::auto_report_sd_interval = 0;
+  millis_t CardReader::next_sd_report_ms;
+  #if NUM_SERIAL > 1
+    int8_t CardReader::serialport;
+  #endif
+
+  void CardReader::auto_report_sd_status() {
+    millis_t current_ms = millis();
+    if (auto_report_sd_interval && ELAPSED(current_ms, next_sd_report_ms)) {
+      next_sd_report_ms = current_ms + 1000UL * auto_report_sd_interval;
+      getStatus(
+        #if NUM_SERIAL > 1
+          serialport
+        #endif
+      );
+      SERIAL_EOL();
+    }
+  }
+#endif // AUTO_REPORT_SD_STATUS
+
 #endif // SDSUPPORT

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -536,7 +536,7 @@ void CardReader::getStatus(
     const int8_t port/*= -1*/
   #endif
 ) {
-  if (cardOK) {
+  if (cardOK && sdprinting) {
     SERIAL_PROTOCOLPGM_P(port, MSG_SD_PRINTING_BYTE);
     SERIAL_PROTOCOL_P(port, sdpos);
     SERIAL_PROTOCOLCHAR_P(port, '/');
@@ -963,7 +963,6 @@ void CardReader::printingHasFinished() {
           serialport
         #endif
       );
-      SERIAL_EOL();
     }
   }
 #endif // AUTO_REPORT_SD_STATUS

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -99,6 +99,23 @@ public:
   FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
 
   Sd2Card& getSd2Card() { return card; }
+
+  #if ENABLED(AUTO_REPORT_SD_STATUS)
+    void auto_report_sd_status(void);
+    FORCE_INLINE void set_auto_report_interval(uint8_t v
+      #if NUM_SERIAL > 1
+        , int8_t port
+      #endif
+    ) {
+      #if NUM_SERIAL > 1
+        serialport = port;
+      #endif
+      NOMORE(v, 60);
+      auto_report_sd_interval = v;
+      next_sd_report_ms = millis() + 1000UL * v;
+    }
+  #endif
+
 public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
@@ -182,6 +199,14 @@ private:
 
   #if ENABLED(SDCARD_SORT_ALPHA)
     void flush_presort();
+  #endif
+
+  #if ENABLED(AUTO_REPORT_SD_STATUS)
+    static uint8_t auto_report_sd_interval;
+    static millis_t next_sd_report_ms;
+    #if NUM_SERIAL > 1
+      static int8_t serialport;
+    #endif
   #endif
 };
 


### PR DESCRIPTION
This feature enables an automatic SD Card status report when printing from SD card. It works like the temperature auto status, but is enabled through an improvement of the M27 code. For now, I've added it to the configuration_adv, disabled by default.