### PR TITLE
[1.1.x] Add support for BACK button (if any)

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -4816,11 +4816,9 @@ void lcd_init() {
     #if BUTTON_EXISTS(EN1)
       SET_INPUT_PULLUP(BTN_EN1);
     #endif
-
     #if BUTTON_EXISTS(EN2)
       SET_INPUT_PULLUP(BTN_EN2);
     #endif
-
     #if BUTTON_EXISTS(ENC)
       SET_INPUT_PULLUP(BTN_ENC);
     #endif
@@ -4965,6 +4963,14 @@ void lcd_update() {
       }
     }
     else wait_for_unclick = false;
+
+    #if BUTTON_EXISTS(BACK)
+      if (LCD_BACK_CLICKED) {
+        lcd_quick_feedback();
+        lcd_goto_previous_menu();
+      }
+    #endif
+
   #endif
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
@@ -5335,6 +5341,9 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
         #if BUTTON_EXISTS(ENC)
           if (BUTTON_PRESSED(ENC)) newbutton |= EN_C;
+        #endif
+        #if BUTTON_EXISTS(BACK)
+          if (BUTTON_PRESSED(BACK)) newbutton |= EN_D;
         #endif
 
         //

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -40,9 +40,6 @@
     constexpr bool lcd_external_control = false;
   #endif
 
-  #define BUTTON_EXISTS(BN) (defined(BTN_## BN) && BTN_## BN >= 0)
-  #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
-
   extern int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
 
   #if ENABLED(LCD_BED_LEVELING)
@@ -92,6 +89,8 @@
   #endif
 
   #define LCD_UPDATE_INTERVAL 100
+  #define BUTTON_EXISTS(BN) (defined(BTN_## BN) && BTN_## BN >= 0)
+  #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
 
   #if ENABLED(ULTIPANEL)
 
@@ -103,15 +102,24 @@
 
     void lcd_goto_screen(screenFunc_t screen, const uint32_t encoder=0);
 
+    // Encoder click is directly connected
+
     #define BLEN_A 0
     #define BLEN_B 1
-    // Encoder click is directly connected
-    #if BUTTON_EXISTS(ENC)
-      #define BLEN_C 2
-    #endif
+
     #define EN_A (_BV(BLEN_A))
     #define EN_B (_BV(BLEN_B))
-    #define EN_C (_BV(BLEN_C))
+
+    #if BUTTON_EXISTS(ENC)
+      #define BLEN_C 2
+      #define EN_C (_BV(BLEN_C))
+    #endif
+
+    #if BUTTON_EXISTS(BACK)
+      #define BLEN_D 3
+      #define EN_D BIT(BLEN_D)
+      #define LCD_BACK_CLICKED (buttons & EN_D)
+    #endif
 
     extern volatile uint8_t buttons;  // The last-checked buttons in a bit array.
     void lcd_buttons_update();
@@ -209,9 +217,13 @@
                                             )
 
   #elif ENABLED(NEWPANEL)
+
     #define LCD_CLICKED (buttons & EN_C)
+
   #else
+
     #define LCD_CLICKED false
+
   #endif
 
   #if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(G26_MESH_VALIDATION)

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -73,13 +73,12 @@ extern volatile uint8_t buttons;  //an extended version of the last checked butt
     #define B_DW (BUTTON_DOWN<<B_I2C_BTN_OFFSET)
     #define B_RI (BUTTON_RIGHT<<B_I2C_BTN_OFFSET)
 
+    #undef LCD_CLICKED
     #if BUTTON_EXISTS(ENC)
       // the pause/stop/restart button is connected to BTN_ENC when used
       #define B_ST (EN_C)                            // Map the pause/stop/resume button into its normalized functional name
-      #undef LCD_CLICKED
       #define LCD_CLICKED (buttons&(B_MI|B_RI|B_ST)) // pause/stop button also acts as click until we implement proper pause/stop.
     #else
-      #undef LCD_CLICKED
       #define LCD_CLICKED (buttons&(B_MI|B_RI))
     #endif
 


### PR DESCRIPTION
In response to #9833.
Add support for the BACK button (currently only existing on `RADDS_DISPLAY`).