### PR TITLE
[bugfix-2.0.x] Added a missing include to status_screen_DOGM.h 

### DIFF
--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -27,7 +27,6 @@
 #include "printcounter.h"
 
 #include "../Marlin.h"
-#include "../libs/duration_t.h"
 
 PrintCounter::PrintCounter(): super() {
   this->loadStats();

--- a/Marlin/src/module/printcounter.h
+++ b/Marlin/src/module/printcounter.h
@@ -25,6 +25,7 @@
 
 #include "../inc/MarlinConfig.h"
 #include "../libs/stopwatch.h"
+#include "../libs/duration_t.h"
 
 // Print debug messages with M111 S2
 //#define DEBUG_PRINTCOUNTER


### PR DESCRIPTION
I'm not experience with CPP (at all, really) so I'm not entirely certain this is the right place for an include, but it made more sense to have it there than (in trying to put it at the top) having a redundant compile-time `if` or including something unnecessarily. As far as I can tell, that construct is only used in that one compile-time `if` block, so I just put the include there.