### PR TITLE
[2.0.x] Fix SENSORLESS_HOMING for Core Kinematics

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -63,12 +63,8 @@
                 fr_mm_s = min(homing_feedrate(X_AXIS), homing_feedrate(Y_AXIS)) * SQRT(sq(mlratio) + 1.0);
 
     #if ENABLED(SENSORLESS_HOMING)
-      #if ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY)
-        tmc_sensorless_homing(stepperX);
-      #endif
-      #if ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY)
-        tmc_sensorless_homing(stepperY);
-      #endif
+      sensorless_homing_per_axis(X_AXIS);
+      sensorless_homing_per_axis(Y_AXIS);
     #endif
 
     do_blocking_move_to_xy(1.5 * mlx * x_axis_home_dir, 1.5 * mly * home_dir(Y_AXIS), fr_mm_s);
@@ -76,12 +72,8 @@
     current_position[X_AXIS] = current_position[Y_AXIS] = 0.0;
 
     #if ENABLED(SENSORLESS_HOMING)
-      #if ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY)
-        tmc_sensorless_homing(stepperX, false);
-      #endif
-      #if ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY)
-        tmc_sensorless_homing(stepperY, false);
-      #endif
+      sensorless_homing_per_axis(X_AXIS, false);
+      sensorless_homing_per_axis(Y_AXIS, false);
       safe_delay(500); // Short delay needed to settle
     #endif
   }

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -718,8 +718,13 @@
 #define E4_IS_TRINAMIC (ENABLED(E4_IS_TMC2130) || ENABLED(E4_IS_TMC2208))
 
 // Disable Z axis sensorless homing if a probe is used to home the Z axis
-#if ENABLED(SENSORLESS_HOMING) && HOMING_Z_WITH_PROBE
-  #undef Z_HOMING_SENSITIVITY
+#if ENABLED(SENSORLESS_HOMING)
+  #define X_SENSORLESS (ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY))
+  #define Y_SENSORLESS (ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY))
+  #define Z_SENSORLESS (ENABLED(Z_IS_TMC2130) && defined(Z_HOMING_SENSITIVITY))
+  #if HOMING_Z_WITH_PROBE
+    #undef Z_HOMING_SENSITIVITY
+  #endif
 #endif
 
 // Endstops and bed probe

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1557,6 +1557,15 @@ static_assert(1 >= 0
     #error "SENSORLESS_HOMING on DELTA currently requires STEALTHCHOP."
   #endif
 
+  // Sensorless homing is required for both combined steppers in an H-bot
+  #if CORE_IS_XY && X_SENSORLESS != Y_SENSORLESS
+    #error "CoreXY requires both X and Y to use sensorless homing if either does."
+  #elif CORE_IS_XZ && X_SENSORLESS != Z_SENSORLESS
+    #error "CoreXZ requires both X and Z to use sensorless homing if either does."
+  #elif CORE_IS_YZ && Y_SENSORLESS != Z_SENSORLESS
+    #error "CoreYZ requires both Y and Z to use sensorless homing if either does."
+  #endif
+
 #elif ENABLED(SENSORLESS_HOMING)
 
   #error "SENSORLESS_HOMING requires TMC2130 stepper drivers."

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -232,15 +232,9 @@ bool home_delta() {
 
   // Disable stealthChop if used. Enable diag1 pin on driver.
   #if ENABLED(SENSORLESS_HOMING)
-    #if ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY)
-      tmc_sensorless_homing(stepperX);
-    #endif
-    #if ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY)
-      tmc_sensorless_homing(stepperY);
-    #endif
-    #if ENABLED(Z_IS_TMC2130) && defined(Z_HOMING_SENSITIVITY)
-      tmc_sensorless_homing(stepperZ);
-    #endif
+    sensorless_homing_per_axis(X_AXIS);
+    sensorless_homing_per_axis(Y_AXIS);
+    sensorless_homing_per_axis(Z_AXIS);
   #endif
 
   // Move all carriages together linearly until an endstop is hit.
@@ -251,15 +245,9 @@ bool home_delta() {
 
   // Re-enable stealthChop if used. Disable diag1 pin on driver.
   #if ENABLED(SENSORLESS_HOMING)
-    #if ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY)
-      tmc_sensorless_homing(stepperX, false);
-    #endif
-    #if ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY)
-      tmc_sensorless_homing(stepperY, false);
-    #endif
-    #if ENABLED(Z_IS_TMC2130) && defined(Z_HOMING_SENSITIVITY)
-      tmc_sensorless_homing(stepperZ, false);
-    #endif
+    sensorless_homing_per_axis(X_AXIS, false);
+    sensorless_homing_per_axis(Y_AXIS, false);
+    sensorless_homing_per_axis(Z_AXIS, false);
   #endif
 
   // If an endstop was not hit, then damage can occur if homing is continued.

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -191,6 +191,10 @@ void set_axis_is_at_home(const AxisEnum axis);
 void homeaxis(const AxisEnum axis);
 #define HOMEAXIS(LETTER) homeaxis(LETTER##_AXIS)
 
+#if ENABLED(SENSORLESS_HOMING)
+  void sensorless_homing_per_axis(const AxisEnum axis, const bool enable=true);
+#endif
+
 //
 // Macros
 //


### PR DESCRIPTION
Responding to #9839 

Implement sensorless homing for Core Kinematics, adding a general function to set sensorless homing given an axis index. Applies to single axis homing, quick homing, and delta homing.

Counterpart to #9871