### PR TITLE
[1.1.x] Fix SENSORLESS_HOMING for Core Kinematics

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -650,8 +650,13 @@
   #define E4_IS_TRINAMIC (ENABLED(E4_IS_TMC2130) || ENABLED(E4_IS_TMC2208))
 
   // Disable Z axis sensorless homing if a probe is used to home the Z axis
-  #if ENABLED(SENSORLESS_HOMING) && HOMING_Z_WITH_PROBE
-    #undef Z_HOMING_SENSITIVITY
+  #if ENABLED(SENSORLESS_HOMING)
+    #define X_SENSORLESS (ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY))
+    #define Y_SENSORLESS (ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY))
+    #define Z_SENSORLESS (ENABLED(Z_IS_TMC2130) && defined(Z_HOMING_SENSITIVITY))
+    #if HOMING_Z_WITH_PROBE
+      #undef Z_HOMING_SENSITIVITY
+    #endif
   #endif
 
   // Endstops and bed probe

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -1525,6 +1525,15 @@ static_assert(1 >= 0
     #error "SENSORLESS_HOMING on DELTA currently requires STEALTHCHOP."
   #endif
 
+  // Sensorless homing is required for both combined steppers in an H-bot
+  #if CORE_IS_XY && X_SENSORLESS != Y_SENSORLESS
+    #error "CoreXY requires both X and Y to use sensorless homing if either does."
+  #elif CORE_IS_XZ && X_SENSORLESS != Z_SENSORLESS
+    #error "CoreXZ requires both X and Z to use sensorless homing if either does."
+  #elif CORE_IS_YZ && Y_SENSORLESS != Z_SENSORLESS
+    #error "CoreYZ requires both Y and Z to use sensorless homing if either does."
+  #endif
+
 #elif ENABLED(SENSORLESS_HOMING)
 
   #error "SENSORLESS_HOMING requires TMC2130 stepper drivers."


### PR DESCRIPTION
Responding to #9839 

Implement sensorless homing for Core Kinematics, adding a general function to set sensorless homing given an axis index. Applies to single axis homing, quick homing, and delta homing.

Counterpart to #9868