### PR TITLE
[2.0.x] Add sanity checks to Linear Advance 1.5

### DIFF
--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -34,14 +34,19 @@
  *  K<factor>                  Set advance K factor
  */
 void GcodeSuite::M900() {
-    stepper.synchronize();
-
-    const float newK = parser.floatval('K', -1);
-    if (newK >= 0) planner.extruder_advance_K = newK;
-
+  if (parser.seenval('K')) {
+    const float newK = parser.floatval('K');
+    if (WITHIN(newK, 0, 10)) {
+      stepper.synchronize();
+      planner.extruder_advance_K = newK;
+    }
+    else
+      SERIAL_PROTOCOLLNPGM("?K value out of range (0-10).");
+  }
+  else {
     SERIAL_ECHO_START();
-    SERIAL_ECHOPAIR("Advance K=", planner.extruder_advance_K);
-    SERIAL_EOL();
+    SERIAL_ECHOLNPAIR("Advance K=", planner.extruder_advance_K);
+  }
 }
 
 #endif // LIN_ADVANCE

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -555,6 +555,16 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
 #endif
 
 /**
+ * Linear Advance 1.5 - Check K value range
+ */
+#if ENABLED(LIN_ADVANCE)
+  static_assert(
+    WITHIN(LIN_ADVANCE_K, 0, 10),
+    "LIN_ADVANCE_K must be a value from 0 to 10 (Changed in LIN_ADVANCE v1.5, Marlin 1.1.9)."
+  );
+#endif
+
+/**
  * Parking Extruder requirements
  */
 #if ENABLED(PARKING_EXTRUDER)


### PR DESCRIPTION
Based on #9859 by @Sebastianv650

Make sure Linear Advance K values are sane based on version 1.5 value range.