### PR TITLE
[2.0.x] Fix DIGITAL_PIN_TO_ANALOG_PIN macro for Atmega1284p

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/pinsDebug_AVR_8_bit.h
+++ b/Marlin/src/HAL/HAL_AVR/pinsDebug_AVR_8_bit.h
@@ -56,10 +56,11 @@
 #endif
 
 #define VALID_PIN(pin) (pin >= 0 && pin < NUM_DIGITAL_PINS ? 1 : 0)
-#define DIGITAL_PIN_TO_ANALOG_PIN(p) int(p - analogInputToDigitalPin(0))
 #if AVR_ATmega1284_FAMILY
-  #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(7) && (P) <= analogInputToDigitalPin(0)) 
-#else  
+  #define DIGITAL_PIN_TO_ANALOG_PIN(P) int(analogInputToDigitalPin(0) - (P))
+  #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(7) && (P) <= analogInputToDigitalPin(0))
+#else
+  #define DIGITAL_PIN_TO_ANALOG_PIN(P) int((P) - analogInputToDigitalPin(0))
   #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && ((P) <= analogInputToDigitalPin(15) || (P) <= analogInputToDigitalPin(7)))
 #endif
 #define GET_ARRAY_PIN(p) pgm_read_byte(&pin_array[p].pin)


### PR DESCRIPTION
Further accommodation in M43 for the ATmega 1284p boards