### PR TITLE
[1.1.x] Fix DIGITAL_PIN_TO_ANALOG_PIN macro for Atmega1284p

### DIFF
--- a/Marlin/pinsDebug.h
+++ b/Marlin/pinsDebug.h
@@ -26,11 +26,12 @@ bool endstop_monitor_flag = false;
                                // "-" left justify, "28" minimum width of name, pad with blanks
 
 #if AVR_ATmega1284_FAMILY
-  #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(7) && (P) <= analogInputToDigitalPin(0)) 
-#else  
+  #define DIGITAL_PIN_TO_ANALOG_PIN(P) int(analogInputToDigitalPin(0) - (P))
+  #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(7) && (P) <= analogInputToDigitalPin(0))
+#else
+  #define DIGITAL_PIN_TO_ANALOG_PIN(P) int((P) - analogInputToDigitalPin(0))
   #define IS_ANALOG(P) ((P) >= analogInputToDigitalPin(0) && ((P) <= analogInputToDigitalPin(15) || (P) <= analogInputToDigitalPin(7)))
 #endif
-
 
 /**
  *  This routine minimizes RAM usage by creating a FLASH resident array to


### PR DESCRIPTION
Further accommodation in M43 for the ATmega 1284p boards.