### PR TITLE
[2.0.x] Enhance github helper scripts

### DIFF
--- a/buildroot/share/git/README.md
+++ b/buildroot/share/git/README.md
@@ -4,31 +4,30 @@
 
 A Pull Request is often just the start of a longer process of patching and refining the code until it's ready to merge. In that process it's common to accumulate a lot of commits, some of which are non-functional. Before merging any PR, excess commits need to be "squashed" and sometimes rearranged or reworked to produce a well-packaged set of changes and keep the commit history relatively clean.
 
-In addition, while a PR is being worked on other commits may be merged, leading to conflicts that need resolution. For this reason, it's a best practice to periodically refresh the PR so the working copy closely reflects the final merge.
+In addition, while a PR is being worked on other commits may be merged, leading to conflicts that need resolution. For this reason, it's a best practice to periodically refresh the PR so the working copy closely reflects the final merge into upstream `MarlinFirmware`.
 
 #### Merge vs Rebase
 
-I recommend not using Github Desktop to sync and merge. Use the command line instead. Github Desktop provides a "merge" option, but for best results "`git rebase`" is recommended. Merge applies new work after your commits. This buries them and makes it hard to bring them together as a final packaged unit. Rebase moves your commits to the end of the branch, ensuring that your commits will be adapted to the current code. This makes it easier to keep revising the commits in-place.
+If you plan to create PRs and work on them after submission I recommend not using Github Desktop to sync and merge. Use the command line instead. Github Desktop provides a "merge" option, but I've found that "`git rebase`" is much cleaner and easier to manage. Merge applies new work _after_ your commits, which buries them deeper in the commit history and makes it hard to bring them together as a final packaged unit. Rebase helpfully moves your commits to the tip of the branch, ensuring that your commits are adapted to the current code. This makes it easier to keep revising the commits in-place.
 
 ### The Scripts
 
-The following scripts can be used on macOS or Linux to speed up the process of working with Marlin and submitting changes to the project.
+The following scripts can be used on any system with a GNU environment to speed up the process of working with Marlin branches and submitting changes to the project.
 
 #### Remotes
 
 File|Description
 ----|-----------
-mfadd&nbsp;[user]|Add Remote - Add another Github user's fork of Marlin as a remote, then fetch it. After this you can check out one of their branches and either make a PR targeted at their fork or targeted at `bugfix-2.0.x`.
-mfinit|Init Working Copy - Creates a remote named '`upstream`' (for use by the other scripts) pointing to the '`MarlinFirmware`' fork. Use once after checking out your fork.
-
+mfadd&nbsp;[user]|Add and Fetch Remote - Add another Github user's fork of Marlin as a remote, then fetch it. Optionally, check out one of their branches.
+mfinit|Init Working Copy - Create a remote named '`upstream`' (for use by the other scripts) pointing to the '`MarlinFirmware`' fork. This only needs to be used once. Newer versions of Github Desktop may create `upstream` on your behalf.
 
 #### Branches
 
 File|Description
 ----|-----------
-mfnew&nbsp;[branch]|New Branch - Creates a new branch based on `upstream/[PR-target]`. All new work should start here.
+mfnew&nbsp;[branch]|New Branch - Creates a new branch based on `upstream/[PR-target]`. All new work should start with this command.
+mffp|Fast Push - Push the HEAD or a commit ID to `upstream` immediately. Requires privileged access to the MarlinFirmware repo.
 firstpush|Push the current branch to 'origin' -your fork on Github- and set it to track '`origin`'. The branch needs to reside on Github before you can use it to make a PR.
-
 
 #### Making / Amending PRs
 
@@ -36,7 +35,7 @@ File|Description
 ----|-----------
 mfpr|Pull Request - Open the Compare / Pull Request page on Github for the current branch.
 mfrb|Do a `git rebase` then `git rebase -i` of the current branch onto `upstream/[PR-target]`. Use this to edit your commits anytime.
-mfqp|Quick Patch - Commit all current changes as "patch", `mfrb`, and `git push -f`.
+mfqp|Quick Patch - Commit all current changes as "patch", then do `mfrb`, followed by `git push -f` if no conflicts need resolution.
 
 #### Documentation
 
@@ -50,7 +49,7 @@ mfpub|Build the documentation and publish it to marlinfw.org via Github.
 File|Description
 ----|-----------
 ghtp -[h/s]|Set the protocol to use for all remotes. -h for HTTPS, -s for SSL.
-mfinfo|This utility script is used by the other scripts to get:<br/>- The upstream project ('`MarlinFirmware`')<br/>- the '`origin`' project (i.e., your Github username),<br/>- the repository name ('`Marlin`'),<br/>- the PR target branch ('`bugfix-2.0.x`'), and<br/>- the current branch (or the first command-line argument).<br/><br/>By itself, `mfinfo` simply prints these values to the console.
+mfinfo|This utility script is used by the other scripts to get:<br/>- The upstream project ('`MarlinFirmware`')<br/>- the '`origin`' project (i.e., your Github username),<br/>- the repository name ('`Marlin`'),<br/>- the PR target branch ('`bugfix-1.1.x`'), and<br/>- the current branch (or the first command-line argument).<br/><br/>By itself, `mfinfo` simply prints these values to the console.
 mfclean&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;|Prune your merged and remotely-deleted branches.
 
 ---

--- a/buildroot/share/git/mfadd
+++ b/buildroot/share/git/mfadd
@@ -2,12 +2,22 @@
 #
 # mfadd
 #
-# Add a remote and fetch it
+# Add a remote and fetch it. Optionally copy a branch.
+#
+# Example: mfadd thinkyhead:patch-1 copy_of_patch-1
 #
 
-[[ $# == 1 ]] || { echo "Usage: `basename $0` user" 1>&2 ; exit 1; }
+[[ $# > 0 && $# < 3 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` (user | ref copyname)" 1>&2 ; exit 1; }
 
-USER=$1
+# If a colon is included, split the parts
+if [[ $1 =~ ":" ]]; then
+  IFS=':' read -a DATA <<< "$1"
+  USER=${DATA[0]}
+  BRANCH=${DATA[1]}
+  NAME=$2
+else
+  USER=$1
+fi
 
 MFINFO=$(mfinfo) || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"
@@ -16,5 +26,7 @@ REPO=${INFO[2]}
 set -e
 
 echo "Adding and fetching $USER..."
-git remote add "$USER" "git@github.com:$USER/$REPO.git"
+git remote add "$USER" "git@github.com:$USER/$REPO.git" >/dev/null 2>&1 || echo "Remote exists."
 git fetch "$USER"
+
+[[ ! -z "$BRANCH" && ! -z "$NAME" ]] && git checkout $USER/$BRANCH -b $NAME

--- a/buildroot/share/git/mffp
+++ b/buildroot/share/git/mffp
@@ -6,7 +6,7 @@
 # By default: `git push upstream HEAD:bugfix-1.1.x`
 #
 
-[[ $# < 3 ]] || { echo "Usage: `basename $0` [1|2] [commit-id]" 1>&2 ; exit 1; }
+[[ $# < 3 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` [1|2] [commit-id]" 1>&2 ; exit 1; }
 
 if [[ $1 == '1' || $1 == '2' ]]; then
   MFINFO=$(mfinfo "$1") || exit 1

--- a/buildroot/share/git/mfinfo
+++ b/buildroot/share/git/mfinfo
@@ -16,6 +16,8 @@ usage() {
   echo "Usage: `basename $0` [1|2] [branch]" 1>&2
 }
 
+[[ $# < 3 && $1 != "-h" && $1 != "--help" ]] || { usage; exit 1; }
+
 CURR=$(git branch 2>/dev/null | grep ^* | sed 's/\* //g')
 [[ -z $CURR ]] && { echo "No git repository here!" 1>&2 ; exit 1; }
 [[ $CURR == "(no"* ]] && { echo "Git is busy with merge, rebase, etc." 1>&2 ; exit 1; }

--- a/buildroot/share/git/mfnew
+++ b/buildroot/share/git/mfnew
@@ -9,7 +9,7 @@ usage() {
   echo "Usage: `basename $0` [1|2] [name]" 1>&2
 }
 
-[[ $# < 3 ]] || { usage ; exit 1 ; }
+[[ $# < 3 && $1 != "-h" && $1 != "--help" ]] || { usage; exit 1; }
 
 MFINFO=$(mfinfo "$@") || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"

--- a/buildroot/share/git/mfpr
+++ b/buildroot/share/git/mfpr
@@ -5,7 +5,7 @@
 # Make a PR of the current branch against RCBugFix or dev
 #
 
-[[ $# < 2 ]] || { echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1; }
+[[ $# < 2 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1; }
 
 MFINFO=$(mfinfo "$@") || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"

--- a/buildroot/share/git/mfpub
+++ b/buildroot/share/git/mfpub
@@ -9,7 +9,7 @@
 # any permanent changes to 'master'.
 #
 
-[[ $# < 2 ]] || { echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1; }
+[[ $# < 2 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` [branch]" 1>&2 ; exit 1; }
 
 MFINFO=$(mfinfo "$@") || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"

--- a/buildroot/share/git/mfqp
+++ b/buildroot/share/git/mfqp
@@ -5,7 +5,7 @@
 # Add all changed files, commit as "patch", do `mfrb` and `git push -f`
 #
 
-[[ $# < 2 ]] || { echo "Usage: `basename $0` [1|2]" 1>&2 ; exit 1; }
+[[ $# < 2 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` [1|2]" 1>&2 ; exit 1; }
 
 MFINFO=$(mfinfo "$@") || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"

--- a/buildroot/share/git/mfrb
+++ b/buildroot/share/git/mfrb
@@ -5,7 +5,7 @@
 # Do "git rebase -i" against the "target" branch (bugfix-1.1.x, bugfix-2.0.x, or master)
 #
 
-[[ $# < 2 ]] || { echo "Usage: `basename $0` [1|2]" 1>&2 ; exit 1; }
+[[ $# < 2 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` [1|2]" 1>&2 ; exit 1; }
 
 MFINFO=$(mfinfo "$@") || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"

--- a/buildroot/share/git/mfup
+++ b/buildroot/share/git/mfup
@@ -7,7 +7,7 @@
 # - Force-push the branch to 'origin'
 #
 
-[[ $# < 3 ]] || { echo "Usage: `basename $0` [1|2] [branch]" 1>&2 ; exit 1; }
+[[ $# < 3 && $1 != "-h" && $1 != "--help" ]] || { echo "Usage: `basename $0` [1|2] [branch]" 1>&2 ; exit 1; }
 
 MFINFO=$(mfinfo "$@") || exit 1
 IFS=' ' read -a INFO <<< "$MFINFO"


### PR DESCRIPTION
This PR adds some small enhancements to the git helper scripts.

- Look for '-h' and '--help' and print the Usage if included.

- Update `README.md`.

- Allow `mfadd` to take the branch reference (as shown in the image below) as the first argument, for easier copy/paste creation of working copies.
Examples:
  - `mfadd thinkyhead:bf1_git_helpers`
  Add (if needed) and fetch remote `thinkyhead`.
  - `mfadd thinkyhead:bf1_git_helpers git_helpers_work`
  As above, plus make a copy of `thinkyhead/bf1_git_helpers` as `git_helpers_work`.

---
![image](https://user-images.githubusercontent.com/698003/36880594-37361e4c-1d8f-11e8-860c-627078ab200f.png)
