### PR TITLE
[1.1.x] For M112, don't call kill from the serial interrupt

### DIFF
--- a/Marlin/MarlinSerial.cpp
+++ b/Marlin/MarlinSerial.cpp
@@ -80,6 +80,8 @@
 
   #if ENABLED(EMERGENCY_PARSER)
 
+    bool killed_by_M112; // = false
+
     #include "stepper.h"
     #include "language.h"
 
@@ -155,7 +157,7 @@
                 wait_for_user = wait_for_heatup = false;
                 break;
               case state_M112:
-                kill(PSTR(MSG_KILLED));
+                killed_by_M112 = true;
                 break;
               case state_M410:
                 quickstop_stepper();

--- a/Marlin/MarlinSerial.h
+++ b/Marlin/MarlinSerial.h
@@ -21,13 +21,12 @@
  */
 
 /**
-  MarlinSerial.h - Hardware serial library for Wiring
-  Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
-
-  Modified 28 September 2010 by Mark Sproul
-  Modified 14 February 2016 by Andreas Hardtung (added tx buffer)
-
-*/
+ * MarlinSerial.h - Hardware serial library for Wiring
+ * Copyright (c) 2006 Nicholas Zambetti.  All right reserved.
+ *
+ * Modified 28 September 2010 by Mark Sproul
+ * Modified 14 February 2016 by Andreas Hardtung (added tx buffer)
+ */
 
 #ifndef MARLINSERIAL_H
 #define MARLINSERIAL_H
@@ -100,6 +99,10 @@
 
   #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
     extern ring_buffer_pos_t rx_max_enqueued;
+  #endif
+
+  #if ENABLED(EMERGENCY_PARSER)
+    extern bool killed_by_M112;
   #endif
 
   class MarlinSerial { //: public Stream

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -744,6 +744,10 @@ void Temperature::manage_heater() {
     static bool last_pause_state;
   #endif
 
+  #if ENABLED(EMERGENCY_PARSER)
+    if (killed_by_M112) kill(PSTR(MSG_KILLED));
+  #endif
+
   if (!temp_meas_ready) return;
 
   updateTemperaturesFromRawValues(); // also resets the watchdog


### PR DESCRIPTION
Fix #9906

If `kill()` is called from the emergency parser there is no serial output. This PR modifies the handling of `M112` so it sets a flag which is checked in `manage_heaters`, so that `kill()` will be called from the main loop.

Counterpart to #9923