### PR TITLE
[2.0.x] For M112, don't call kill from the serial interrupt

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
@@ -81,6 +81,8 @@
 
   #if ENABLED(EMERGENCY_PARSER)
 
+    bool killed_by_M112; // = false
+
     #include "../../module/stepper.h"
 
     // Currently looking for: M108, M112, M410
@@ -155,7 +157,7 @@
                 wait_for_user = wait_for_heatup = false;
                 break;
               case state_M112:
-                kill(PSTR(MSG_KILLED));
+                killed_by_M112 = true;
                 break;
               case state_M410:
                 quickstop_stepper();

--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.h
@@ -94,6 +94,10 @@
     extern ring_buffer_pos_t rx_max_enqueued;
   #endif
 
+  #if ENABLED(EMERGENCY_PARSER)
+    extern bool killed_by_M112;
+  #endif
+
   class MarlinSerial { //: public Stream
 
     public:

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
@@ -108,6 +108,8 @@
 
   #if ENABLED(EMERGENCY_PARSER)
 
+    bool killed_by_M112; // = false
+
     // Currently looking for: M108, M112, M410
     // If you alter the parser please don't forget to update the capabilities in Conditionals_post.h
 
@@ -180,7 +182,7 @@
                 wait_for_user = wait_for_heatup = false;
                 break;
               case state_M112:
-                kill(PSTR(MSG_KILLED));
+                killed_by_M112 = true;
                 break;
               case state_M410:
                 quickstop_stepper();

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
@@ -74,6 +74,10 @@
   extern ring_buffer_pos_t rx_max_enqueued;
 #endif
 
+#if ENABLED(EMERGENCY_PARSER)
+  extern bool killed_by_M112;
+#endif
+
 class MarlinSerial {
 
 public:

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -750,6 +750,10 @@ void Temperature::manage_heater() {
     static bool last_pause_state;
   #endif
 
+  #if ENABLED(EMERGENCY_PARSER)
+    if (killed_by_M112) kill(PSTR(MSG_KILLED));
+  #endif
+
   if (!temp_meas_ready) return;
 
   updateTemperaturesFromRawValues(); // also resets the watchdog


### PR DESCRIPTION
Fix #9906

If `kill()` is called from the emergency parser there is no serial output. This PR modifies the handling of `M112` so it sets a flag which is checked in `manage_heaters`, so that `kill()` will be called from the main loop.

Counterpart to #9922