### PR TITLE
[2.0.x] Add board MKS_BASE_HEROIC

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -59,6 +59,7 @@
 #define BOARD_BAM_DICE          401   // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402   // 2PrintBeta BAM&DICE Due with STK drivers
 #define BOARD_MKS_BASE          40    // MKS BASE 1.0
+#define BOARD_MKS_BASE_HEROIC   41    // MKS BASE 1.0 with Heroic HR4982 stepper drivers
 #define BOARD_MKS_13            47    // MKS v1.3 or 1.4 (maybe higher)
 #define BOARD_MKS_GEN_L         53    // MKS GEN L
 #define BOARD_ZRIB_V20          504   // zrib V2.0 control board (Chinese knock off RAMPS replica)

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -252,8 +252,12 @@
 
 // MS1 MS2 Stepper Driver Microstepping mode table
 #define MICROSTEP1 LOW,LOW
-#define MICROSTEP2 HIGH,LOW
-#define MICROSTEP4 LOW,HIGH
+#if ENABLED(HEROIC_STEPPER_DRIVERS)
+  #define MICROSTEP128 LOW,HIGH
+#else
+  #define MICROSTEP2 HIGH,LOW
+  #define MICROSTEP4 LOW,HIGH
+#endif
 #define MICROSTEP8 HIGH,HIGH
 #ifdef __SAM3X8E__
   #if MB(ALLIGATOR)
@@ -263,7 +267,7 @@
     #define MICROSTEP16 HIGH,HIGH
   #endif
 #else
-#define MICROSTEP16 HIGH,HIGH
+  #define MICROSTEP16 HIGH,HIGH
 #endif
 
 /**

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1591,13 +1591,18 @@ void Stepper::report_positions() {
   void Stepper::microstep_mode(const uint8_t driver, const uint8_t stepping_mode) {
     switch (stepping_mode) {
       case 1: microstep_ms(driver, MICROSTEP1); break;
-      case 2: microstep_ms(driver, MICROSTEP2); break;
-      case 4: microstep_ms(driver, MICROSTEP4); break;
+      #if ENABLED(HEROIC_STEPPER_DRIVERS)
+        case 128: microstep_ms(driver, MICROSTEP128); break;
+      #else
+        case 2: microstep_ms(driver, MICROSTEP2); break;
+        case 4: microstep_ms(driver, MICROSTEP4); break;
+      #endif
       case 8: microstep_ms(driver, MICROSTEP8); break;
       case 16: microstep_ms(driver, MICROSTEP16); break;
       #if MB(ALLIGATOR)
         case 32: microstep_ms(driver, MICROSTEP32); break;
       #endif
+      default: SERIAL_ERROR_START(); SERIAL_ERRORLNPGM("Microsteps unavailable"); break;
     }
   }
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -102,6 +102,8 @@
   #include "pins_BAM_DICE_DUE.h"      // ATmega1280, ATmega2560
 #elif MB(MKS_BASE)
   #include "pins_MKS_BASE.h"          // ATmega1280, ATmega2560
+#elif MB(MKS_BASE_HEROIC)
+  #include "pins_MKS_BASE_HEROIC.h"   // ATmega1280, ATmega2560
 #elif MB(MKS_13)
   #include "pins_MKS_13.h"            // ATmega1280, ATmega2560
 #elif MB(MKS_GEN_L)

--- a/Marlin/src/pins/pins_MKS_BASE.h
+++ b/Marlin/src/pins/pins_MKS_BASE.h
@@ -32,24 +32,6 @@
 
 #define BOARD_NAME "MKS BASE 1.0"
 
-/* Microstepping pins (reverse engineered at V1.4 - due to closed source schematics)
-// Some new batches have the HR4982 (Heroic) instead of the A4982 (Allegro) as stepper driver. While most of the functionality is similar, the HR variant obviously doesn't work with diode smoothers (no fast decay)
-// But the Heroic has a 128 µStepping mode where the A4982 is doing quarter steps (MS1=L / MS2=H). To achieve comfortable tests with the M350/M351 commands, the following definitions have to made:
-// Example: M350 X4 Y4 ; Set X and Y Axis to quarterstep Mode to achieve MS1=0 and MS2=1
-// A new board with a HR4982 will now perform 128 µSteps per Fullstep
-// XSTEP,YSTEP ... must be adapted with M92 accordingly (128/16 => multiply by factor 8).
-*/
-#define X_MS1_PIN           5   // Digital 3  / Pin 5   / PE3
-#define X_MS2_PIN           6   // Digital 6  / Pin 14  / PH3
-#define Y_MS1_PIN           59  // Analog 5   / Pin 92  / PF5
-#define Y_MS2_PIN           58  // Analog 4   / Pin 93  / PF4
-#define Z_MS1_PIN           22  // Digital 22 / Pin 78  / PA0
-#define Z_MS2_PIN           39  // Digital 39 / Pin 70  / PG2
-#define E0_MS1_PIN          63  // Analog 9   / Pin 86  / PK1
-#define E0_MS2_PIN          64  // Analog 10  / Pin 87  / PK2
-#define E1_MS1_PIN          57  // Analog 3   / Pin 93  / PF3
-#define E1_MS2_PIN          4   // Digital 4  / Pin 1   / PG5
-
 //
 // Heaters / Fans
 //

--- a/Marlin/src/pins/pins_MKS_BASE_HEROIC.h
+++ b/Marlin/src/pins/pins_MKS_BASE_HEROIC.h
@@ -1,0 +1,46 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MKS BASE with Heroic HR4982 stepper drivers
+ */
+
+#include "pins_MKS_BASE.h"
+
+/**
+ * Microstepping pins (reverse engineered at V1.4 - due to closed source schematics).
+ * Some new boards use HR4982 (Heroic) instead of the A4982 (Allegro) stepper drivers.
+ * While most of the functionality is similar, the HR variant obviously doesn't work
+ * with diode smoothers (no fast decay). And the Heroic has a 128 µStepping mode where
+ * the A4982 is doing quarter steps (MS1=L / MS2=H).
+ */
+#define HEROIC_STEPPER_DRIVERS
+#define X_MS1_PIN            5  // Digital 3  / Pin 5   / PE3  / SERVO2_PIN
+#define X_MS2_PIN            6  // Digital 6  / Pin 14  / PH3  / SERVO1_PIN
+#define Y_MS1_PIN           59  // Analog 5   / Pin 92  / PF5
+#define Y_MS2_PIN           58  // Analog 4   / Pin 93  / PF4
+#define Z_MS1_PIN           22  // Digital 22 / Pin 78  / PA0
+#define Z_MS2_PIN           39  // Digital 39 / Pin 70  / PG2
+#define E0_MS1_PIN          63  // Analog 9   / Pin 86  / PK1
+#define E0_MS2_PIN          64  // Analog 10  / Pin 87  / PK2
+#define E1_MS1_PIN          57  // Analog 3   / Pin 93  / PF3
+#define E1_MS2_PIN           4  // Digital 4  / Pin 1   / PG5  / SERVO3_PIN


### PR DESCRIPTION
Followup to #9008

- Don't define micro-stepping pins for boards that lack them.
- Allow setting of 128 microsteps with `M350`.

Counterpart to #9924