### PR TITLE
[2.0.x] Implement digipots for MKS SBASE

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/include/digipot_mcp4451_I2C_routines.c
+++ b/Marlin/src/HAL/HAL_LPC1768/include/digipot_mcp4451_I2C_routines.c
@@ -23,22 +23,20 @@
 // adapted from  I2C/master/master.c example
 //   https://www-users.cs.york.ac.uk/~pcc/MCP/HAPR-Course-web/CMSIS/examples/html/master_8c_source.html
 
-#ifdef TARGET_LPC1768
+#include "../../../inc/MarlinConfigPre.h"
+
+#if MB(MKS_SBASE)
+
+#include "digipot_mcp4451_I2C_routines.h"
 
 #ifdef __cplusplus
   extern "C" {
 #endif
 
-#include <lpc17xx_i2c.h>
-#include <lpc17xx_pinsel.h>
-#include <lpc17xx_libcfg_default.h>
-
-//////////////////////////////////////////////////////////////////////////////////////
-
 // These two routines are exact copies of the lpc17xx_i2c.c routines.  Couldn't link to
 // to the lpc17xx_i2c.c routines so had to copy them into this file & rename them.
 
-static uint32_t _I2C_Start (LPC_I2C_TypeDef *I2Cx) {
+static uint32_t _I2C_Start(LPC_I2C_TypeDef *I2Cx) {
   // Reset STA, STO, SI
   I2Cx->I2CONCLR = I2C_I2CONCLR_SIC|I2C_I2CONCLR_STOC|I2C_I2CONCLR_STAC;
 
@@ -51,8 +49,8 @@ static uint32_t _I2C_Start (LPC_I2C_TypeDef *I2Cx) {
   return (I2Cx->I2STAT & I2C_STAT_CODE_BITMASK);
 }
 
-static void _I2C_Stop (LPC_I2C_TypeDef *I2Cx) {
-  /* Make sure start bit is not active */
+static void _I2C_Stop(LPC_I2C_TypeDef *I2Cx) {
+  // Make sure start bit is not active
   if (I2Cx->I2CONSET & I2C_I2CONSET_STA)
     I2Cx->I2CONCLR = I2C_I2CONCLR_STAC;
 
@@ -60,34 +58,16 @@ static void _I2C_Stop (LPC_I2C_TypeDef *I2Cx) {
   I2Cx->I2CONCLR = I2C_I2CONCLR_SIC;
 }
 
-
-//////////////////////////////////////////////////////////////////////////////////////
-
-
-#define USEDI2CDEV_M  1  // use I2C1 controller
-
-#if (USEDI2CDEV_M == 0)
-  #define I2CDEV_M LPC_I2C0
-#elif (USEDI2CDEV_M == 1)
-  #define I2CDEV_M LPC_I2C1
-#elif (USEDI2CDEV_M == 2)
-  #define I2CDEV_M LPC_I2C2
-#else
-  #error "Master I2C device not defined!"
-#endif
-
-
 PINSEL_CFG_Type PinCfg;
 I2C_M_SETUP_Type transferMCfg;
 
 #define I2C_status (LPC_I2C1->I2STAT & I2C_STAT_CODE_BITMASK)
 
-
 uint8_t digipot_mcp4451_start(uint8_t sla) {  // send slave address and write bit
   // Sometimes TX data ACK or NAK status is returned.  That mean the start state didn't
   // happen which means only the value of the slave address was send.  Keep looping until
   // the slave address and write bit are actually sent.
-  do{
+  do {
     _I2C_Stop(I2CDEV_M); // output stop state on I2C bus
     _I2C_Start(I2CDEV_M); // output start state on I2C bus
     while ((I2C_status != I2C_I2STAT_M_TX_START)
@@ -96,42 +76,38 @@ uint8_t digipot_mcp4451_start(uint8_t sla) {  // send slave address and write bi
         && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK));  //wait for start to be asserted
 
     LPC_I2C1->I2CONCLR = I2C_I2CONCLR_STAC; // clear start state before tansmitting slave address
-    LPC_I2C1->I2DAT = (sla <<1) & I2C_I2DAT_BITMASK; // transmit slave address & write bit
+    LPC_I2C1->I2DAT = (sla << 1) & I2C_I2DAT_BITMASK; // transmit slave address & write bit
     LPC_I2C1->I2CONSET = I2C_I2CONSET_AA;
     LPC_I2C1->I2CONCLR = I2C_I2CONCLR_SIC;
     while ((I2C_status != I2C_I2STAT_M_TX_SLAW_ACK)
         && (I2C_status != I2C_I2STAT_M_TX_SLAW_NACK)
         && (I2C_status != I2C_I2STAT_M_TX_DAT_ACK)
-        && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK));  //wait for slaw to finish
-  }while ( (I2C_status == I2C_I2STAT_M_TX_DAT_ACK) ||  (I2C_status == I2C_I2STAT_M_TX_DAT_NACK));
+        && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK)) { /* wait for slaw to finish */ }
+  } while ( (I2C_status == I2C_I2STAT_M_TX_DAT_ACK) || (I2C_status == I2C_I2STAT_M_TX_DAT_NACK));
   return 1;
 }
 
-
 void digipot_mcp4451_init(void) {
-
   /**
    * Init I2C pin connect
    */
   PinCfg.OpenDrain = 0;
   PinCfg.Pinmode = 0;
-  #if ((USEDI2CDEV_M == 0))
+  #if USEDI2CDEV_M == 0
     PinCfg.Funcnum = 1;
     PinCfg.Pinnum = 27;
     PinCfg.Portnum = 0;
     PINSEL_ConfigPin(&PinCfg); // SDA0 / D57  AUX-1
     PinCfg.Pinnum = 28;
     PINSEL_ConfigPin(&PinCfg); // SCL0 / D58  AUX-1
-  #endif
-  #if ((USEDI2CDEV_M == 1))
+  #elif USEDI2CDEV_M == 1
     PinCfg.Funcnum = 3;
     PinCfg.Pinnum = 0;
     PinCfg.Portnum = 0;
     PINSEL_ConfigPin(&PinCfg);  // SDA1 / D20 SCA
     PinCfg.Pinnum = 1;
     PINSEL_ConfigPin(&PinCfg);  // SCL1 / D21 SCL
-  #endif
-  #if ((USEDI2CDEV_M == 2))
+  #elif USEDI2CDEV_M == 2
     PinCfg.Funcnum = 2;
     PinCfg.Pinnum = 10;
     PinCfg.Portnum = 0;
@@ -142,16 +118,15 @@ void digipot_mcp4451_init(void) {
   // Initialize I2C peripheral
   I2C_Init(I2CDEV_M, 400000);  // hardwired to 400KHz bit rate, 100KHz is the other option
 
-  /* Enable Master I2C operation */
+  // Enable Master I2C operation
   I2C_Cmd(I2CDEV_M, I2C_MASTER_MODE, ENABLE);
 }
-
 
 uint8_t digipot_mcp4451_send_byte(uint8_t data) {
   LPC_I2C1->I2DAT = data & I2C_I2DAT_BITMASK; // transmit data
   LPC_I2C1->I2CONSET = I2C_I2CONSET_AA;
   LPC_I2C1->I2CONCLR = I2C_I2CONCLR_SIC;
-  while ((I2C_status != I2C_I2STAT_M_TX_DAT_ACK) && (I2C_status != I2C_I2STAT_M_TX_DAT_NACK));  // wait for xmit to finish
+  while (I2C_status != I2C_I2STAT_M_TX_DAT_ACK && I2C_status != I2C_I2STAT_M_TX_DAT_NACK);  // wait for xmit to finish
   return 1;
 }
 
@@ -159,4 +134,4 @@ uint8_t digipot_mcp4451_send_byte(uint8_t data) {
   }
 #endif
 
-#endif // TARGET_LPC1768
+#endif // MB(MKS_SBASE)

--- a/Marlin/src/HAL/HAL_LPC1768/include/digipot_mcp4451_I2C_routines.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/digipot_mcp4451_I2C_routines.h
@@ -1,0 +1,57 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// adapted from  I2C/master/master.c example
+//   https://www-users.cs.york.ac.uk/~pcc/MCP/HAPR-Course-web/CMSIS/examples/html/master_8c_source.html
+
+#ifndef _DIGIPOT_MCP4451_I2C_ROUTINES_H_
+#define _DIGIPOT_MCP4451_I2C_ROUTINES_H_
+
+#define USEDI2CDEV_M  1  // use I2C1 controller
+
+#if USEDI2CDEV_M == 0
+  #define I2CDEV_M LPC_I2C0
+#elif USEDI2CDEV_M == 1
+  #define I2CDEV_M LPC_I2C1
+#elif USEDI2CDEV_M == 2
+  #define I2CDEV_M LPC_I2C2
+#else
+  #error "Master I2C device not defined!"
+#endif
+
+#ifdef __cplusplus
+  extern "C" {
+#endif
+
+#include <lpc17xx_i2c.h>
+#include <lpc17xx_pinsel.h>
+#include <lpc17xx_libcfg_default.h>
+
+uint8_t digipot_mcp4451_start(uint8_t sla);
+void digipot_mcp4451_init(void);
+uint8_t digipot_mcp4451_send_byte(uint8_t data);
+
+#ifdef __cplusplus
+  }
+#endif
+
+#endif // _DIGIPOT_MCP4451_I2C_ROUTINES_H_


### PR DESCRIPTION
Addressing #9477

Attempt to restore MKS SBASE digipots to working order. When the selected board is MKS SBASE, use the custom i2c functions supplied for the MCP4451 in place of the `Wire.h` methods.