### PR TITLE
[2.0.x] PRINTCOUNTER compatibility with I2C EEPROM

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -730,7 +730,11 @@ void setup() {
   // Load data from EEPROM if available (or use defaults)
   // This also updates variables in the planner, elsewhere
   (void)settings.load();
-
+  
+  #if ENABLED(PRINTCOUNTER)
+    print_job_timer.init();
+  #endif  
+  
   #if HAS_M206_COMMAND
     // Initialize current position based on home_offset
     COPY(current_position, home_offset);

--- a/Marlin/src/libs/stopwatch.h
+++ b/Marlin/src/libs/stopwatch.h
@@ -53,6 +53,11 @@ class Stopwatch {
     Stopwatch();
 
     /**
+     * @brief Initialize the stopwatch
+     */
+    inline void init() {}
+
+    /**
      * @brief Stops the stopwatch
      * @details Stops the running timer, it will silently ignore the request if
      * no timer is currently running.

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -28,10 +28,6 @@
 
 #include "../Marlin.h"
 
-PrintCounter::PrintCounter(): super() {
-  this->loadStats();
-}
-
 millis_t PrintCounter::deltaDuration() {
   #if ENABLED(DEBUG_PRINTCOUNTER)
     PrintCounter::debug(PSTR("deltaDuration"));

--- a/Marlin/src/module/printcounter.h
+++ b/Marlin/src/module/printcounter.h
@@ -99,10 +99,14 @@ class PrintCounter: public Stopwatch {
     millis_t deltaDuration();
 
   public:
+
     /**
-     * @brief Class constructor
+     * @brief Initialize the print counter
      */
-    PrintCounter();
+    inline void PrintCounter::init() {
+      super::init();
+      this->loadStats();
+    }
 
     /**
      * @brief Checks if Print Statistics has been loaded


### PR DESCRIPTION
Marlin crashes during startup when **PRINTCOUNTER** and **I2C_EEPROM** are both enabled.

This is because PrintCounter::loadStats() is being called before the TWI object has been created.  

The solution is to move the loadStats() function from the PrintCounter object creation routine.  ~to the Marlin.cpp setup() routine.~

~FILES CHANGED:~
~1. printcounter.cpp - comment `out this->loadStats();` in the PrintCounter::PrintCounter() routine~
~2. Marlin.cpp - add conditional code `print_job_timer.loadStats();`~

This PR fixes Issues #9484 and #9782.

This is not a problem in 1.1.x because it does not support I2C_EEPROM.

----

See Scott's comments below.  He's created an init method that properly handles the object creation and initialization.