### PR TITLE
[2.0.x] DUE compatibility with shared SPI LCDs, USB mass storage, add pin defs & update examples\MakerParts\Configuration.h

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.h
@@ -41,15 +41,7 @@
 // Defines
 //
 #define NUM_SERIAL 1
-
-//#undef SERIAL_PORT
-//#define SERIAL_PORT -1
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL0 SerialUSB
-#else
-  #define MYSERIAL0 customizedSerial
-#endif
+#define MYSERIAL0 customizedSerial
 
 // We need the previous define before the include, or compilation bombs...
 #include "MarlinSerial_Due.h"

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_shared_hw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_shared_hw_spi.cpp
@@ -1,0 +1,163 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017, 2018 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/*
+
+  based on u8g_com_msp430_hw_spi.c
+
+  Universal 8bit Graphics Library
+
+  Copyright (c) 2012, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list
+  of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice, this
+  list of conditions and the following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+
+#ifdef __SAM3X8E__
+
+//  #include <inttypes.h>
+
+//  #include "src/core/macros.h"
+//  #include "Configuration.h"
+#include "../../Marlin.h"
+#include "../../inc/MarlinConfig.h"
+
+  #include <U8glib.h>
+
+  #define SPI_FULL_SPEED 0
+  #define SPI_HALF_SPEED 1
+  #define SPI_QUARTER_SPEED 2
+  #define SPI_EIGHTH_SPEED 3
+  #define SPI_SIXTEENTH_SPEED 4
+  #define SPI_SPEED_5 5
+  #define SPI_SPEED_6 6
+
+  void spiBegin();
+  void spiInit(uint8_t spiRate);
+  void spiSend(uint8_t b);
+  void spiSend(const uint8_t* buf, size_t n);
+
+  #include <Arduino.h>
+  #include "../../core/macros.h"
+  #include "fastio_Due.h"
+
+
+  void u8g_SetPIOutput_DUE_hw_spi(u8g_t *u8g, uint8_t pin_index) {
+     PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,
+       g_APinDescription[u8g->pin_list[pin_index]].ulPin, g_APinDescription[u8g->pin_list[pin_index]].ulPinConfiguration);  // OUTPUT
+  }
+
+  void u8g_SetPILevel_DUE_hw_spi(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
+    volatile Pio* port = g_APinDescription[u8g->pin_list[pin_index]].pPort;
+    uint32_t mask = g_APinDescription[u8g->pin_list[pin_index]].ulPin;
+    if (level) port->PIO_SODR = mask;
+    else port->PIO_CODR = mask;
+  }
+
+  uint8_t u8g_com_HAL_DUE_shared_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+  {
+    switch(msg)
+    {
+      case U8G_COM_MSG_STOP:
+        break;
+
+      case U8G_COM_MSG_INIT:
+        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_CS, 1);
+        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_A0, 1);
+
+        u8g_SetPIOutput_DUE_hw_spi(u8g, U8G_PI_CS);
+        u8g_SetPIOutput_DUE_hw_spi(u8g, U8G_PI_A0);
+
+        u8g_Delay(5);
+
+        spiBegin();
+
+        #ifndef SPI_SPEED
+          #define SPI_SPEED SPI_FULL_SPEED  // use same SPI speed as SD card
+        #endif
+        spiInit(2);
+
+        break;
+
+      case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_A0, arg_val);
+        break;
+
+      case U8G_COM_MSG_CHIP_SELECT:
+        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_CS, (arg_val ? 0 : 1));
+        break;
+
+      case U8G_COM_MSG_RESET:
+        break;
+
+      case U8G_COM_MSG_WRITE_BYTE:
+
+        spiSend((uint8_t)arg_val);
+        break;
+
+      case U8G_COM_MSG_WRITE_SEQ: {
+          uint8_t *ptr = (uint8_t*) arg_ptr;
+          while (arg_val > 0) {
+            spiSend(*ptr++);
+            arg_val--;
+          }
+        }
+        break;
+
+      case U8G_COM_MSG_WRITE_SEQ_P: {
+          uint8_t *ptr = (uint8_t*) arg_ptr;
+          while (arg_val > 0) {
+            spiSend(*ptr++);
+            arg_val--;
+          }
+        }
+        break;
+    }
+    return 1;
+  }
+
+#endif  //__SAM3X8E__

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -125,7 +125,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Select a secondary serial port on the board to use for communication with the host.
@@ -134,7 +134,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT_2 -1
+#define SERIAL_PORT_2 0
 
 /**
  * This setting determines the communication speed of the printer.

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -775,7 +775,7 @@
       wait_for_release();
       while (!is_lcd_clicked()) {
         idle();
-        refresh_cmd_timeout();
+        gcode.refresh_cmd_timeout();
         if (encoder_diff) {
           do_blocking_move_to_z(current_position[Z_AXIS] + float(encoder_diff) * multiplier);
           encoder_diff = 0;

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -775,6 +775,7 @@
       wait_for_release();
       while (!is_lcd_clicked()) {
         idle();
+        refresh_cmd_timeout();
         if (encoder_diff) {
           do_blocking_move_to_z(current_position[Z_AXIS] + float(encoder_diff) * multiplier);
           encoder_diff = 0;

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -517,7 +517,7 @@ void advance_command_queue() {
         card.closefile();
         SERIAL_PROTOCOLLNPGM(MSG_FILE_SAVED);
 
-        #ifndef USBCON
+        #if !defined(__AVR__) || !defined(USBCON)
           #if ENABLED(SERIAL_STATS_DROPPED_RX)
             SERIAL_ECHOLNPAIR("Dropped bytes: ", customizedSerial.dropped());
           #endif
@@ -525,7 +525,7 @@ void advance_command_queue() {
           #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
             SERIAL_ECHOLNPAIR("Max RX Queue Size: ", customizedSerial.rxMaxEnqueued());
           #endif
-        #endif // !USBCON
+        #endif //  !defined(__AVR__) || !defined(USBCON)
 
         ok_to_send();
       }

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -28,7 +28,7 @@
 #ifndef CONDITIONALS_ADV_H
 #define CONDITIONALS_ADV_H
 
-  #ifndef USBCON
+  #if !defined(__AVR__) || !defined(USBCON)
     // Define constants and variables for buffering serial data.
     // Use only 0 or powers of 2 greater than 1
     // : [0, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...]

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -275,7 +275,7 @@
 /**
  * Serial
  */
-#ifndef USBCON
+#if !defined(__AVR__) || !defined(USBCON)
   #if ENABLED(SERIAL_XON_XOFF) && RX_BUFFER_SIZE < 1024
     #error "SERIAL_XON_XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
   #elif RX_BUFFER_SIZE && (RX_BUFFER_SIZE < 2 || !IS_POWER_OF_2(RX_BUFFER_SIZE))
@@ -1308,7 +1308,7 @@ static_assert(1 >= 0
 /**
  * emergency-command parser
  */
-#if ENABLED(EMERGENCY_PARSER) && defined(USBCON)
+#if ENABLED(EMERGENCY_PARSER) && defined(__AVR__) && defined(USBCON)
   #error "EMERGENCY_PARSER does not work on boards with AT90USB processors (USBCON)."
 #endif
 

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -1,0 +1,189 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016, 2017, 2018 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/*
+
+  based on u8g_dev_uc1701_mini12864_HAL.c (dealextreme)
+
+  Universal 8bit Graphics Library
+
+  Copyright (c) 2011, olikraus@gmail.com
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without modification,
+  are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright notice, this list
+    of conditions and the following disclaimer.
+
+  * Redistributions in binary form must reproduce the above copyright notice, this
+    list of conditions and the following disclaimer in the documentation and/or other
+    materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+  CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(DOGLCD)
+
+#include <U8glib.h>
+
+#include "HAL_LCD_com_defines.h"
+
+#define WIDTH 128
+#define HEIGHT 64
+#define PAGE_HEIGHT 8
+
+static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
+  U8G_ESC_CS(0),             /* disable chip */
+  U8G_ESC_ADR(0),           /* instruction mode */
+  U8G_ESC_RST(1),           /* do reset low pulse with (1*16)+2 milliseconds */
+  U8G_ESC_CS(1),             /* enable chip */
+
+  0x0e2,            /* soft reset */
+  0x040,    /* set display start line to 0 */
+  0x0a0,    /* ADC set to reverse */
+  0x0c8,    /* common output mode */
+  0x0a6,    /* display normal, bit val 0: LCD pixel off. */
+  0x0a2,    /* LCD bias 1/9 */
+  0x02f,    /* all power  control circuits on */
+  0x0f8,    /* set booster ratio to */
+  0x000,    /* 4x */
+  0x023,    /* set V0 voltage resistor ratio to large */
+  0x081,    /* set contrast */
+  0x027,    /* contrast value */
+  0x0ac,    /* indicator */
+  0x000,    /* disable */
+  0x0af,    /* display on */
+
+  U8G_ESC_DLY(100),       /* delay 100 ms */
+  0x0a5,                    /* display all points, ST7565 */
+  U8G_ESC_DLY(100),       /* delay 100 ms */
+  U8G_ESC_DLY(100),       /* delay 100 ms */
+  0x0a4,                    /* normal display */
+  U8G_ESC_CS(0),             /* disable chip */
+  U8G_ESC_END                /* end of sequence */
+};
+
+static const uint8_t u8g_dev_uc1701_mini12864_HAL_data_start[] PROGMEM = {
+  U8G_ESC_ADR(0),           /* instruction mode */
+  U8G_ESC_CS(1),             /* enable chip */
+  0x010,    /* set upper 4 bit of the col adr to 0 */
+  0x000,    /* set lower 4 bit of the col adr to 4  */
+  U8G_ESC_END                /* end of sequence */
+};
+
+uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  switch(msg)
+  {
+    case U8G_DEV_MSG_INIT:
+      u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
+      u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      {
+        u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+        u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_data_start);
+        u8g_WriteByte(u8g, dev, 0x0b0 | pb->p.page); /* select current page */
+        u8g_SetAddress(u8g, dev, 1);           /* data mode */
+        if ( u8g_pb_WriteBuffer(pb, u8g, dev) == 0 )
+          return 0;
+        u8g_SetChipSelect(u8g, dev, 0);
+      }
+      break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) >> 2);
+      u8g_SetChipSelect(u8g, dev, 0);
+      return 1;
+  }
+  return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
+}
+
+uint8_t u8g_dev_uc1701_mini12864_HAL_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  switch(msg)
+  {
+    case U8G_DEV_MSG_INIT:
+      u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
+      u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
+      break;
+    case U8G_DEV_MSG_STOP:
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      {
+        u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+
+        u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_data_start);
+        u8g_WriteByte(u8g, dev, 0x0b0 | (2*pb->p.page)); /* select current page */
+        u8g_SetAddress(u8g, dev, 1);           /* data mode */
+  u8g_WriteSequence(u8g, dev, pb->width, (uint8_t *)pb->buf);
+        u8g_SetChipSelect(u8g, dev, 0);
+
+        u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_data_start);
+        u8g_WriteByte(u8g, dev, 0x0b0 | (2*pb->p.page+1)); /* select current page */
+        u8g_SetAddress(u8g, dev, 1);           /* data mode */
+  u8g_WriteSequence(u8g, dev, pb->width, (uint8_t *)(pb->buf)+pb->width);
+        u8g_SetChipSelect(u8g, dev, 0);
+      }
+      break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) >> 2);
+      u8g_SetChipSelect(u8g, dev, 0);
+      return 1;
+  }
+  return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
+}
+
+U8G_PB_DEV(u8g_dev_uc1701_mini12864_HAL_sw_spi, WIDTH, HEIGHT, PAGE_HEIGHT, u8g_dev_uc1701_mini12864_HAL_fn, U8G_COM_HAL_SW_SPI_FN);
+U8G_PB_DEV(u8g_dev_uc1701_mini12864_HAL_hw_spi, WIDTH, HEIGHT, PAGE_HEIGHT, u8g_dev_uc1701_mini12864_HAL_fn, U8G_COM_HAL_HW_SPI_FN);
+
+uint8_t u8g_dev_uc1701_mini12864_HAL_2x_buf[WIDTH*2] U8G_NOCOMMON ;
+u8g_pb_t u8g_dev_uc1701_mini12864_HAL_2x_pb = { {16, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_uc1701_mini12864_HAL_2x_buf};
+u8g_dev_t u8g_dev_uc1701_mini12864_HAL_2x_sw_spi = { u8g_dev_uc1701_mini12864_HAL_2x_fn, &u8g_dev_uc1701_mini12864_HAL_2x_pb, U8G_COM_HAL_SW_SPI_FN };
+u8g_dev_t u8g_dev_uc1701_mini12864_HAL_2x_hw_spi = { u8g_dev_uc1701_mini12864_HAL_2x_fn, &u8g_dev_uc1701_mini12864_HAL_2x_pb, U8G_COM_HAL_HW_SPI_FN };
+
+#endif // DOGLCD

--- a/Marlin/src/pins/pins_DUE3DOM_MINI.h
+++ b/Marlin/src/pins/pins_DUE3DOM_MINI.h
@@ -156,5 +156,16 @@
     #define BTN_ENC         37
 
     #define BEEPER_PIN      -1
+    
+   #elif ENABLED(MINIPANEL)
+    #define BTN_EN1         52
+    #define BTN_EN2         50
+    #define BTN_ENC         48
+    #define LCD_SDSS        4
+    #define SD_DETECT_PIN   14
+    #define BEEPER_PIN      41
+    #define DOGLCD_A0       46
+    #define DOGLCD_CS       45
+    
   #endif // SPARK_FULL_GRAPHICS
 #endif // ULTRA_LCD

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -140,23 +140,58 @@
 // LCD / Controller
 //
 #if ENABLED(ULTRA_LCD)
+  // ramps-fd lcd adaptor
+  
+  #if ENABLED(DOGLCD)
+    #define BEEPER_PIN          37
+    #define BTN_EN1             33
+    #define BTN_EN2             31
+    #define BTN_ENC             35
+    #define SD_DETECT_PIN       49
+  #endif
+  
   #if ENABLED(NEWPANEL)
-    // ramps-fd lcd adaptor
     #define LCD_PINS_RS         16
     #define LCD_PINS_ENABLE     17
     #define LCD_PINS_D4         23
     #define LCD_PINS_D5         25
     #define LCD_PINS_D6         27
     #define LCD_PINS_D7         29
-
-    #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
-      #define BEEPER_PIN        37
-
-      #define BTN_EN1           33
-      #define BTN_EN2           31
-      #define BTN_ENC           35
-
-      #define SD_DETECT_PIN     49
-    #endif
   #endif
+  
+  #if ENABLED(MINIPANEL)
+    #define DOGLCD_CS           25
+    #define DOGLCD_A0           27
+  #endif  
 #endif // ULTRA_LCD
+
+#if ENABLED(HAVE_TMC2208)
+  /**
+   * TMC2208 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define X2_HARDWARE_SERIAL Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Y2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define Z2_HARDWARE_SERIAL Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial1
+  //#define E2_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
+#endif
+
+//
+// M3/M4/M5 - Spindle/Laser Control
+//
+#if ENABLED(SPINDLE_LASER_ENABLE) && !PIN_EXISTS(SPINDLE_LASER_ENABLE)
+  #if HOTENDS < 3
+    #define SPINDLE_LASER_ENABLE_PIN  45  // Use E2 ENA
+    #define SPINDLE_LASER_PWM_PIN     12  // MUST BE HARDWARE PWM
+    #define SPINDLE_DIR_PIN           47 // Use E2 DIR
+  #endif
+#endif

--- a/Marlin/src/pins/pins_RAMPS_FD_V2.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V2.h
@@ -36,3 +36,11 @@
 #undef INVERTED_FAN_PINS
 
 #define I2C_EEPROM
+
+#ifndef PS_ON_PIN
+  #define PS_ON_PIN        12
+#endif
+
+#ifndef FILWIDTH_PIN
+  #define FILWIDTH_PIN      5   // Analog Input on AUX2
+#endif


### PR DESCRIPTION
This PR makes the DUE compatible with shared SPI LCDs such as the ST7565 displays (VIKI2 style) and the MKS MINI12864.

The LCD sections of these displays can run at the max SD card rate.  If SDSUPPORT is enabled then the LCD will run at the SD card rate.

Changes:
1. file **HAL_spi_Due.cpp** - a) removed the SPI_PIN setup which removed it from direct control of the SPI controller and b) removed the **spiInitMaded** flag which now allows changing the speed of the SPI. 
2. added file **u8g_com_HAL_DUE_shared_hw_spi.cpp** - this is a hardware SPI com device that makes use of the hardware SPI routines in HAL_spi_Due.cpp.  It is adapted from the LPC1768 version.
3. added file **u8g_dev_uc1701_mini12864_HAL.cpp** - this provides a device driver that makes use of the **u8g_com_HAL_DUE_shared_hw_spi.cpp** com driver.  It is almost an exact copy of the driver in the U8G library.
4. file **HAL_LCD_class_defines.h** - added HAL specific class for MKS MINI12864.
5. file **HAL_LCD_com_defines.h** - added links between **u8g_com_HAL_DUE_shared_hw_spi.cpp** and the DUE specific drivers
6. file **ultralcd_impl_DOGM.h** - a) changed MKS MINI12864 to the new HAL version b) removed the `ENABLED(SDSUPPORT) `restrictions because they could sometimes cause the use of a software SPI when a hardware SPI was needed.

----

PRs #8917 and  #9697 are related to this issue.  Further review & testing needs to be done to see what can be closed and what still needs to be addressed.

I've tested VIKI2, MKS MINI12864 and REPRAP DISCOUNT FULL GRAPHIC SMART CONTROLLER on a DUE with a RAMPS_FD_V1 shield.

I've tested MKS MINI12864 and REPRAP DISCOUNT FULL GRAPHIC SMART CONTROLLER on a 2560 with a RAMPS 1.4 shield.

~I don't know if the DUE's USB mass storage device still works.~

@ejtagle & @GarrethX - please review.  **COMPLETED**

----

The DUE software SPI is not compatible with these changes.  This will be addressed on another PR.

----

**UPDATE 9 MAR 2018**

The code changes are now fully tested.

Additional changes have been added to this PR
- DUE's USB mass storage device is working.  It uses the native USB port.  Host interface and programming are on the programming port.
- config/examples/MakerParts/Configuration.h was updated
- pin definitions were added to the following DUE boards:  **pins_DUE3DOM_MINI.h**, **pins_RAMPS_FD_V1.h** & **pins_RAMPS_FD_V2.h**

----

**config/examples/MakerParts/Configuration.h changes**
```
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
-#define SERIAL_PORT_2 -1
+#define SERIAL_PORT_2 0
```

----

**DUE USB mass storage device changes:**

**queue.cpp**
```
     if (card.saving) {
       char* command = command_queue[cmd_queue_index_r];
       if (strstr_P(command, PSTR("M29"))) {
         // M29 closes the file
         card.closefile();
         SERIAL_PROTOCOLLNPGM(MSG_FILE_SAVED);
 
-        #ifndef USBCON
+        #if !defined(__AVR__) || !defined(USBCON)
           #if ENABLED(SERIAL_STATS_DROPPED_RX)
             SERIAL_ECHOLNPAIR("Dropped bytes: ", customizedSerial.dropped());
           #endif
 
           #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
             SERIAL_ECHOLNPAIR("Max RX Queue Size: ", customizedSerial.rxMaxEnqueued());
           #endif
-        #endif // !USBCON
+        #endif //  !defined(__AVR__) || !defined(USBCON)
```
 

**HAL_Due.h**
```
 #define NUM_SERIAL 1
-
-//#undef SERIAL_PORT
-//#define SERIAL_PORT -1
-
-#if SERIAL_PORT == -1
-  #define MYSERIAL0 SerialUSB
-#else
-  #define MYSERIAL0 customizedSerial
-#endif
+#define MYSERIAL0 customizedSerial
```
 

**Conditionals_adv.h**
 ```
-  #ifndef USBCON
+  #if !defined(__AVR__) || !defined(USBCON)
     // Define constants and variables for buffering serial data.
```

**SanityCheck.h**
```
 /**
  * Serial
  */
-#ifndef USBCON
+#if !defined(__AVR__) || !defined(USBCON)
   #if ENABLED(SERIAL_XON_XOFF) && RX_BUFFER_SIZE < 1024

 
 /**
  * emergency-command parser
  */
-#if ENABLED(EMERGENCY_PARSER) && defined(USBCON)
+#if ENABLED(EMERGENCY_PARSER) && defined(__AVR__) && defined(USBCON)
   #error "EMERGENCY_PARSER does not work on boards with AT90USB processors (USBCON)."
 #endif
```


