### PR TITLE
[2.0.x] Fix for LA

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -773,7 +773,7 @@ void Stepper::isr() {
         E## INDEX ##_STEP_WRITE(INVERT_E_STEP_PIN); \
       }
 
-    if (current_block->use_advance_lead) {
+    if (use_advance_lead) {
       if (step_events_completed > LA_decelerate_after && current_adv_steps > final_adv_steps) {
         e_steps--;
         current_adv_steps--;


### PR DESCRIPTION
Missed in the original LA 1.5 PR: eISR has to use a local copy of current_block->use_advance_lead because it might still run wenn the last block has been set to NULL. Variable was already there, I missed to also use it.

Fixes @VanessaE problem described in #9914.