### PR TITLE
[2.0.x] Support duplication mode in LIN_ADVANCE

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -122,8 +122,13 @@ volatile uint32_t Stepper::step_events_completed = 0; // The number of step even
            Stepper::final_adv_steps,
            Stepper::max_adv_steps;
 
-  int8_t Stepper::e_steps = 0,
-         Stepper::LA_active_extruder; // Copy from current executed block. Needed because current_block is set to NULL "too early".
+  int8_t Stepper::e_steps = 0;
+
+  #if E_STEPPERS > 1
+    int8_t Stepper::LA_active_extruder; // Copy from current executed block. Needed because current_block is set to NULL "too early".
+  #else
+    constexpr int8_t Stepper::LA_active_extruder;
+  #endif
 
   bool Stepper::use_advance_lead;
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -755,23 +755,21 @@ void Stepper::isr() {
 
   void Stepper::advance_isr() {
 
-    #if ENABLED(MK2_MULTIPLEXER)
-      // Even-numbered steppers are reversed
-      #define SET_E_STEP_DIR(INDEX) \
-        if (e_steps) E## INDEX ##_DIR_WRITE(e_steps < 0 ? !INVERT_E## INDEX ##_DIR ^ TEST(INDEX, 0) : INVERT_E## INDEX ##_DIR ^ TEST(INDEX, 0))
+    #if ENABLED(MK2_MULTIPLEXER) // For SNMM even-numbered steppers are reversed
+      #define SET_E_STEP_DIR(INDEX) do{ if (e_steps) E## INDEX ##_DIR_WRITE(e_steps < 0 ? !INVERT_E## INDEX ##_DIR ^ TEST(INDEX, 0) : INVERT_E## INDEX ##_DIR ^ TEST(INDEX, 0)); }while(0)
+    #elif ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
+      #define SET_E_STEP_DIR(INDEX) do{ if (e_steps) { e_steps < 0 ? REV_E_DIR() : NORM_E_DIR(); } }while(0)
     #else
-      #define SET_E_STEP_DIR(INDEX) \
-        if (e_steps) E## INDEX ##_DIR_WRITE(e_steps < 0 ? INVERT_E## INDEX ##_DIR : !INVERT_E## INDEX ##_DIR)
+      #define SET_E_STEP_DIR(INDEX) do{ if (e_steps) E## INDEX ##_DIR_WRITE(e_steps < 0 ? INVERT_E## INDEX ##_DIR : !INVERT_E## INDEX ##_DIR); }while(0)
     #endif
 
-    #define START_E_PULSE(INDEX) \
-      if (e_steps) E## INDEX ##_STEP_WRITE(!INVERT_E_STEP_PIN)
-
-    #define STOP_E_PULSE(INDEX) \
-      if (e_steps) { \
-        e_steps < 0 ? ++e_steps : --e_steps; \
-        E## INDEX ##_STEP_WRITE(INVERT_E_STEP_PIN); \
-      }
+    #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
+      #define START_E_PULSE(INDEX) do{ if (e_steps) E_STEP_WRITE(!INVERT_E_STEP_PIN); }while(0)
+      #define STOP_E_PULSE(INDEX) do{ if (e_steps) { E_STEP_WRITE(INVERT_E_STEP_PIN); e_steps < 0 ? ++e_steps : --e_steps; } }while(0)
+    #else
+      #define START_E_PULSE(INDEX) do{ if (e_steps) E## INDEX ##_STEP_WRITE(!INVERT_E_STEP_PIN); }while(0)
+      #define STOP_E_PULSE(INDEX) do { if (e_steps) { E## INDEX ##_STEP_WRITE(INVERT_E_STEP_PIN); e_steps < 0 ? ++e_steps : --e_steps; } }while(0)
+    #endif
 
     if (current_block->use_advance_lead) {
       if (step_events_completed > LA_decelerate_after && current_adv_steps > final_adv_steps) {
@@ -793,7 +791,7 @@ void Stepper::isr() {
     else
       nextAdvanceISR = ADV_NEVER;
 
-    switch(LA_active_extruder) {
+    switch (LA_active_extruder) {
       case 0: SET_E_STEP_DIR(0); break;
       #if EXTRUDERS > 1
         case 1: SET_E_STEP_DIR(1); break;
@@ -816,7 +814,7 @@ void Stepper::isr() {
         hal_timer_t pulse_start = HAL_timer_get_count(PULSE_TIMER_NUM);
       #endif
 
-      switch(LA_active_extruder) {
+      switch (LA_active_extruder) {
         case 0: START_E_PULSE(0); break;
         #if EXTRUDERS > 1
           case 1: START_E_PULSE(1); break;
@@ -840,7 +838,7 @@ void Stepper::isr() {
         DELAY_NOPS(EXTRA_CYCLES_E);
       #endif
 
-      switch(LA_active_extruder) {
+      switch (LA_active_extruder) {
         case 0: STOP_E_PULSE(0); break;
         #if EXTRUDERS > 1
           case 1: STOP_E_PULSE(1); break;

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -104,8 +104,12 @@ class Stepper {
       static uint16_t current_adv_steps, final_adv_steps, max_adv_steps; // Copy from current executed block. Needed because current_block is set to NULL "too early".
       #define _NEXT_ISR(T) nextMainISR = T
       static int8_t e_steps;
-      static int8_t LA_active_extruder; // Copy from current executed block. Needed because current_block is set to NULL "too early".
       static bool use_advance_lead;
+      #if E_STEPPERS > 1
+        static int8_t LA_active_extruder; // Copy from current executed block. Needed because current_block is set to NULL "too early".
+      #else
+        constexpr int8_t LA_active_extruder = 0;
+      #endif
 
     #else // !LIN_ADVANCE
 
@@ -352,19 +356,18 @@ class Stepper {
       static int8_t last_extruder = -1;
 
       #if ENABLED(LIN_ADVANCE)
-        if (current_block->active_extruder != last_extruder) {
-          current_adv_steps = 0; // If the now active extruder wasn't in use during the last move, its pressure is most likely gone.
-          LA_active_extruder = current_block->active_extruder;
-        }
+        #if E_STEPPERS > 1
+          if (current_block->active_extruder != last_extruder) {
+            current_adv_steps = 0; // If the now active extruder wasn't in use during the last move, its pressure is most likely gone.
+            LA_active_extruder = current_block->active_extruder;
+          }
+        #endif
 
-        if (current_block->use_advance_lead) {
+        if ((use_advance_lead = current_block->use_advance_lead)) {
           LA_decelerate_after = current_block->decelerate_after;
           final_adv_steps = current_block->final_adv_steps;
           max_adv_steps = current_block->max_adv_steps;
-          use_advance_lead = true;
         }
-        else
-          use_advance_lead = false;
       #endif
 
       if (current_block->direction_bits != last_direction_bits || current_block->active_extruder != last_extruder) {


### PR DESCRIPTION
Fix #9929 — Add support for duplication mode to `LIN_ADVANCE`.

Counterpart to #9970
[Concise Diff](9971/files?w=1)