### PR TITLE
[1.1.x] Move tmc_util.* extended_axis_codes to PROGMEM

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10473,8 +10473,8 @@ inline void gcode_M502() {
     LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
 
     #define TMC_SET_GET_CURRENT(P,Q) do { \
-      if (values[P##_AXIS]) tmc_set_current(stepper##Q, extended_axis_codes[TMC_##Q], values[P##_AXIS]); \
-      else tmc_get_current(stepper##Q, extended_axis_codes[TMC_##Q]); } while(0)
+      if (values[P##_AXIS]) tmc_set_current(stepper##Q, TMC_##Q, values[P##_AXIS]); \
+      else tmc_get_current(stepper##Q, TMC_##Q); } while(0)
 
     #if X_IS_TRINAMIC
       TMC_SET_GET_CURRENT(X,X);
@@ -10517,16 +10517,16 @@ inline void gcode_M502() {
    */
   inline void gcode_M911() {
     #if ENABLED(X_IS_TMC2130) || (ENABLED(X_IS_TMC2208) && PIN_EXISTS(X_SERIAL_RX)) || ENABLED(IS_TRAMS)
-      tmc_report_otpw(stepperX, extended_axis_codes[TMC_X]);
+      tmc_report_otpw(stepperX, TMC_X);
     #endif
     #if ENABLED(Y_IS_TMC2130) || (ENABLED(Y_IS_TMC2208) && PIN_EXISTS(Y_SERIAL_RX)) || ENABLED(IS_TRAMS)
-      tmc_report_otpw(stepperY, extended_axis_codes[TMC_Y]);
+      tmc_report_otpw(stepperY, TMC_Y);
     #endif
     #if ENABLED(Z_IS_TMC2130) || (ENABLED(Z_IS_TMC2208) && PIN_EXISTS(Z_SERIAL_RX)) || ENABLED(IS_TRAMS)
-      tmc_report_otpw(stepperZ, extended_axis_codes[TMC_Z]);
+      tmc_report_otpw(stepperZ, TMC_Z);
     #endif
     #if ENABLED(E0_IS_TMC2130) || (ENABLED(E0_IS_TMC2208) && PIN_EXISTS(E0_SERIAL_RX)) || ENABLED(IS_TRAMS)
-      tmc_report_otpw(stepperE0, extended_axis_codes[TMC_E0]);
+      tmc_report_otpw(stepperE0, TMC_E0);
     #endif
   }
 
@@ -10537,22 +10537,22 @@ inline void gcode_M502() {
     const bool clearX = parser.seen(axis_codes[X_AXIS]), clearY = parser.seen(axis_codes[Y_AXIS]), clearZ = parser.seen(axis_codes[Z_AXIS]), clearE = parser.seen(axis_codes[E_AXIS]),
              clearAll = (!clearX && !clearY && !clearZ && !clearE) || (clearX && clearY && clearZ && clearE);
     #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS) || (ENABLED(X_IS_TMC2208) && PIN_EXISTS(X_SERIAL_RX))
-      if (clearX || clearAll) tmc_clear_otpw(stepperX, extended_axis_codes[TMC_X]);
+      if (clearX || clearAll) tmc_clear_otpw(stepperX, TMC_X);
     #endif
     #if ENABLED(X2_IS_TMC2130) || (ENABLED(X2_IS_TMC2208) && PIN_EXISTS(X_SERIAL_RX))
-      if (clearX || clearAll) tmc_clear_otpw(stepperX, extended_axis_codes[TMC_X]);
+      if (clearX || clearAll) tmc_clear_otpw(stepperX, TMC_X);
     #endif
 
     #if ENABLED(Y_IS_TMC2130) || (ENABLED(Y_IS_TMC2208) && PIN_EXISTS(Y_SERIAL_RX))
-      if (clearY || clearAll) tmc_clear_otpw(stepperY, extended_axis_codes[TMC_Y]);
+      if (clearY || clearAll) tmc_clear_otpw(stepperY, TMC_Y);
     #endif
 
     #if ENABLED(Z_IS_TMC2130) || (ENABLED(Z_IS_TMC2208) && PIN_EXISTS(Z_SERIAL_RX))
-      if (clearZ || clearAll) tmc_clear_otpw(stepperZ, extended_axis_codes[TMC_Z]);
+      if (clearZ || clearAll) tmc_clear_otpw(stepperZ, TMC_Z);
     #endif
 
     #if ENABLED(E0_IS_TMC2130) || (ENABLED(E0_IS_TMC2208) && PIN_EXISTS(E0_SERIAL_RX))
-      if (clearE || clearAll) tmc_clear_otpw(stepperE0, extended_axis_codes[TMC_E0]);
+      if (clearE || clearAll) tmc_clear_otpw(stepperE0, TMC_E0);
     #endif
   }
 
@@ -10565,8 +10565,8 @@ inline void gcode_M502() {
       LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
 
       #define TMC_SET_GET_PWMTHRS(P,Q) do { \
-        if (values[P##_AXIS]) tmc_set_pwmthrs(stepper##Q, extended_axis_codes[TMC_##Q], values[P##_AXIS], planner.axis_steps_per_mm[P##_AXIS]); \
-        else tmc_get_pwmthrs(stepper##Q, extended_axis_codes[TMC_##Q], planner.axis_steps_per_mm[P##_AXIS]); } while(0)
+        if (values[P##_AXIS]) tmc_set_pwmthrs(stepper##Q, TMC_##Q, values[P##_AXIS], planner.axis_steps_per_mm[P##_AXIS]); \
+        else tmc_get_pwmthrs(stepper##Q, TMC_##Q, planner.axis_steps_per_mm[P##_AXIS]); } while(0)
 
       #if X_IS_TRINAMIC
         TMC_SET_GET_PWMTHRS(X,X);
@@ -10610,8 +10610,8 @@ inline void gcode_M502() {
   #if ENABLED(SENSORLESS_HOMING)
     inline void gcode_M914() {
       #define TMC_SET_GET_SGT(P,Q) do { \
-        if (parser.seen(axis_codes[P##_AXIS])) tmc_set_sgt(stepper##Q, extended_axis_codes[TMC_##Q], parser.value_int()); \
-        else tmc_get_sgt(stepper##Q, extended_axis_codes[TMC_##Q]); } while(0)
+        if (parser.seen(axis_codes[P##_AXIS])) tmc_set_sgt(stepper##Q, TMC_##Q, parser.value_int()); \
+        else tmc_get_sgt(stepper##Q, TMC_##Q); } while(0)
 
       #ifdef X_HOMING_SENSITIVITY
         #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5312,7 +5312,7 @@ void home_all_axes() { gcode_G28(true); }
   constexpr uint8_t _7P_STEP = 1,              // 7-point step - to change number of calibration points
                     _4P_STEP = _7P_STEP * 2,   // 4-point step
                     NPP      = _7P_STEP * 6;   // number of calibration points on the radius
-  enum CalEnum {                               // the 7 main calibration points - add definitions if needed
+  enum CalEnum : char {                               // the 7 main calibration points - add definitions if needed
     CEN      = 0,
     __A      = 1,
     _AB      = __A + _7P_STEP,

--- a/Marlin/enum.h
+++ b/Marlin/enum.h
@@ -33,8 +33,7 @@
  *  - X_HEAD and Y_HEAD is used for systems that don't have a 1:1 relationship
  *    between X_AXIS and X Head movement, like CoreXY bots
  */
-enum AxisEnum {
-  NO_AXIS   = -1,
+enum AxisEnum : unsigned char {
   X_AXIS    = 0,
   A_AXIS    = 0,
   Y_AXIS    = 1,
@@ -45,7 +44,8 @@ enum AxisEnum {
   X_HEAD    = 4,
   Y_HEAD    = 5,
   Z_HEAD    = 6,
-  ALL_AXES  = 100
+  ALL_AXES  = 0xFE,
+  NO_AXIS   = 0xFF
 };
 
 #define LOOP_S_LE_N(VAR, S, N) for (uint8_t VAR=S; VAR<=N; VAR++)
@@ -76,7 +76,7 @@ typedef enum {
  * Debug flags
  * Not yet widely applied
  */
-enum DebugFlags {
+enum DebugFlags : unsigned char {
   DEBUG_NONE          = 0,
   DEBUG_ECHO          = _BV(0), ///< Echo commands in order as they are processed
   DEBUG_INFO          = _BV(1), ///< Print messages for code that has debug output
@@ -88,7 +88,7 @@ enum DebugFlags {
   DEBUG_ALL           = 0xFF
 };
 
-enum EndstopEnum {
+enum EndstopEnum : char {
   X_MIN,
   Y_MIN,
   Z_MIN,
@@ -105,7 +105,7 @@ enum EndstopEnum {
 };
 
 #if ENABLED(EMERGENCY_PARSER)
-  enum e_parser_state {
+  enum e_parser_state : char {
     state_RESET,
     state_N,
     state_M,
@@ -122,14 +122,14 @@ enum EndstopEnum {
 #endif
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
-  enum AdvancedPauseMenuResponse {
+  enum AdvancedPauseMenuResponse : char {
     ADVANCED_PAUSE_RESPONSE_WAIT_FOR,
     ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE,
     ADVANCED_PAUSE_RESPONSE_RESUME_PRINT
   };
 
   #if ENABLED(ULTIPANEL)
-    enum AdvancedPauseMessage {
+    enum AdvancedPauseMessage : char {
       ADVANCED_PAUSE_MESSAGE_INIT,
       ADVANCED_PAUSE_MESSAGE_UNLOAD,
       ADVANCED_PAUSE_MESSAGE_INSERT,
@@ -143,7 +143,7 @@ enum EndstopEnum {
     };
   #endif
 
-  enum AdvancedPauseMode {
+  enum AdvancedPauseMode : char {
     ADVANCED_PAUSE_MODE_PAUSE_PRINT,
     ADVANCED_PAUSE_MODE_LOAD_FILAMENT,
     ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT
@@ -155,7 +155,7 @@ enum EndstopEnum {
  * Marlin sends messages if blocked or busy
  */
 #if ENABLED(HOST_KEEPALIVE_FEATURE)
-  enum MarlinBusyState {
+  enum MarlinBusyState : char {
     NOT_BUSY,           // Not in a handler
     IN_HANDLER,         // Processing a GCode
     IN_PROCESS,         // Known to be blocking command input (as in G29)
@@ -167,12 +167,12 @@ enum EndstopEnum {
 /**
  * SD Card
  */
-enum LsAction { LS_SerialPrint, LS_Count, LS_GetFilename };
+enum LsAction : char { LS_SerialPrint, LS_Count, LS_GetFilename };
 
 /**
  * Ultra LCD
  */
-enum LCDViewAction {
+enum LCDViewAction : char {
   LCDVIEW_NONE,
   LCDVIEW_REDRAW_NOW,
   LCDVIEW_CALL_REDRAW_NEXT,
@@ -184,7 +184,7 @@ enum LCDViewAction {
  * Dual X Carriage modes. A Dual Nozzle can also do duplication.
  */
 #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
-  enum DualXMode {
+  enum DualXMode : char {
     DXC_FULL_CONTROL_MODE,  // DUAL_X_CARRIAGE only
     DXC_AUTO_PARK_MODE,     // DUAL_X_CARRIAGE only
     DXC_DUPLICATION_MODE
@@ -196,7 +196,7 @@ enum LCDViewAction {
  * (and "canned cycles" - not a current feature)
  */
 #if ENABLED(CNC_WORKSPACE_PLANES)
-  enum WorkspacePlane { PLANE_XY, PLANE_ZX, PLANE_YZ };
+  enum WorkspacePlane : char { PLANE_XY, PLANE_ZX, PLANE_YZ };
 #endif
 
 #endif // __ENUM_H__

--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -41,7 +41,6 @@ typedef int8_t pin_t;
 #define AVR_ATmega2561_FAMILY (defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__))
 #define AVR_ATmega328_FAMILY (defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328p__))
 
-
 /**
  * Include Ports and Functions
  */
@@ -118,7 +117,7 @@ typedef int8_t pin_t;
  */
 
 // Waveform Generation Modes
-typedef enum {
+enum WaveGenMode : char {
   WGM_NORMAL,          //  0
   WGM_PWM_PC_8,        //  1
   WGM_PWM_PC_9,        //  2
@@ -135,18 +134,18 @@ typedef enum {
   WGM_reserved,        // 13
   WGM_FAST_PWM_ICRn,   // 14  COM OCnA
   WGM_FAST_PWM_OCRnA   // 15  COM OCnA
-} WaveGenMode;
+};
 
 // Compare Modes
-typedef enum {
+enum CompareMode : char {
   COM_NORMAL,          //  0
   COM_TOGGLE,          //  1  Non-PWM: OCnx ... Both PWM (WGM 9,11,14,15): OCnA only ... else NORMAL
   COM_CLEAR_SET,       //  2  Non-PWM: OCnx ... Fast PWM: OCnx/Bottom ... PF-FC: OCnx Up/Down
   COM_SET_CLEAR        //  3  Non-PWM: OCnx ... Fast PWM: OCnx/Bottom ... PF-FC: OCnx Up/Down
-} CompareMode;
+};
 
 // Clock Sources
-typedef enum {
+enum ClockSource : char {
   CS_NONE,             //  0
   CS_PRESCALER_1,      //  1
   CS_PRESCALER_8,      //  2
@@ -155,10 +154,10 @@ typedef enum {
   CS_PRESCALER_1024,   //  5
   CS_EXT_FALLING,      //  6
   CS_EXT_RISING        //  7
-} ClockSource;
+};
 
 // Clock Sources (Timer 2 only)
-typedef enum {
+enum ClockSource2 : char {
   CS2_NONE,            //  0
   CS2_PRESCALER_1,     //  1
   CS2_PRESCALER_8,     //  2
@@ -167,7 +166,7 @@ typedef enum {
   CS2_PRESCALER_128,   //  5
   CS2_PRESCALER_256,   //  6
   CS2_PRESCALER_1024   //  7
-} ClockSource2;
+};
 
 // Get interrupt bits in an orderly way
 #define GET_WGM(T)   (((TCCR##T##A >> WGM##T##0) & 0x3) | ((TCCR##T##B >> WGM##T##2 << 2) & 0xC))

--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -25,7 +25,7 @@
 
 #include "MarlinConfig.h"
 
-enum MeshLevelingState {
+enum MeshLevelingState : char {
   MeshReport,
   MeshStart,
   MeshNext,

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -40,7 +40,7 @@
   #include "vector_3.h"
 #endif
 
-enum BlockFlagBit {
+enum BlockFlagBit : char {
   // Recalculate trapezoids on entry junction. For optimization.
   BLOCK_BIT_RECALCULATE,
 
@@ -56,7 +56,7 @@ enum BlockFlagBit {
   BLOCK_BIT_CONTINUED
 };
 
-enum BlockFlag {
+enum BlockFlag : char {
   BLOCK_FLAG_RECALCULATE          = _BV(BLOCK_BIT_RECALCULATE),
   BLOCK_FLAG_NOMINAL_LENGTH       = _BV(BLOCK_BIT_NOMINAL_LENGTH),
   BLOCK_FLAG_BUSY                 = _BV(BLOCK_BIT_BUSY),

--- a/Marlin/stopwatch.h
+++ b/Marlin/stopwatch.h
@@ -36,7 +36,7 @@
  */
 class Stopwatch {
   private:
-    enum State {
+    enum State : char {
       STOPPED,
       RUNNING,
       PAUSED

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -56,7 +56,7 @@
 /**
  * States for ADC reading in the ISR
  */
-enum ADCSensorState {
+enum ADCSensorState : char {
   #if HAS_TEMP_0
     PrepareTemp_0,
     MeasureTemp_0,
@@ -613,7 +613,7 @@ class Temperature {
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) || HAS_THERMALLY_PROTECTED_BED
 
-      typedef enum TRState { TRInactive, TRFirstHeating, TRStable, TRRunaway } TRstate;
+      enum TRState : char { TRInactive, TRFirstHeating, TRStable, TRRunaway };
 
       static void thermal_runaway_protection(TRState * const state, millis_t * const timer, const float &current, const float &target, const int8_t heater_id, const uint16_t period_seconds, const uint16_t hysteresis_degc);
 

--- a/Marlin/tmc_util.cpp
+++ b/Marlin/tmc_util.cpp
@@ -35,7 +35,6 @@
 #endif
 
 bool report_tmc_status = false;
-char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1", "E2", "E3", "E4" };
 
 /**
  * Check for over temperature or short to ground error flags.
@@ -94,18 +93,17 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
   #endif
 
   template<typename TMC>
-  void monitor_tmc_driver(TMC &st, const char * const axisName, uint8_t &otpw_cnt) {
+  void monitor_tmc_driver(TMC &st, const TMC_AxisEnum axis, uint8_t &otpw_cnt) {
     TMC_driver_data data = get_driver_data(st);
 
     #if ENABLED(STOP_ON_ERROR)
       if (data.is_error) {
         SERIAL_EOL();
-        SERIAL_ECHO(axisName);
-        SERIAL_ECHOPGM(" driver error detected:");
-        if (data.is_ot) SERIAL_ECHOPGM("\novertemperature");
-        if (st.s2ga()) SERIAL_ECHOPGM("\nshort to ground (coil A)");
-        if (st.s2gb()) SERIAL_ECHOPGM("\nshort to ground (coil B)");
-        SERIAL_EOL();
+        _tmc_say_axis(axis);
+        SERIAL_ECHOLNPGM(" driver error detected:");
+        if (data.is_ot) SERIAL_ECHOLNPGM("overtemperature");
+        if (st.s2ga()) SERIAL_ECHOLNPGM("short to ground (coil A)");
+        if (st.s2gb()) SERIAL_ECHOLNPGM("short to ground (coil B)");
         #if ENABLED(TMC_DEBUG)
           tmc_report_all();
         #endif
@@ -122,7 +120,7 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
       SERIAL_EOL();
       SERIAL_ECHO(timestamp);
       SERIAL_ECHOPGM(": ");
-      SERIAL_ECHO(axisName);
+      _tmc_say_axis(axis);
       SERIAL_ECHOPGM(" driver overtemperature warning! (");
       SERIAL_ECHO(st.getCurrent());
       SERIAL_ECHOLNPGM("mA)");
@@ -132,7 +130,7 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
       if (data.is_otpw && !st.isEnabled() && otpw_cnt > 4) {
         st.setCurrent(st.getCurrent() - CURRENT_STEP_DOWN, R_SENSE, HOLD_MULTIPLIER);
         #if ENABLED(REPORT_CURRENT_CHANGE)
-          SERIAL_ECHO(axisName);
+          _tmc_say_axis(axis);
           SERIAL_ECHOLNPAIR(" current decreased to ", st.getCurrent());
         #endif
       }
@@ -146,7 +144,7 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
 
     if (report_tmc_status) {
       const uint32_t pwm_scale = get_pwm_scale(st);
-      SERIAL_ECHO(axisName);
+      _tmc_say_axis(axis);
       SERIAL_ECHOPAIR(":", pwm_scale);
       SERIAL_ECHOPGM(" |0b"); SERIAL_PRINT(get_status_response(st), BIN);
       SERIAL_ECHOPGM("| ");
@@ -167,47 +165,47 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
       next_cOT = millis() + 500;
       #if HAS_HW_COMMS(X) || ENABLED(IS_TRAMS)
         static uint8_t x_otpw_cnt = 0;
-        monitor_tmc_driver(stepperX, extended_axis_codes[TMC_X], x_otpw_cnt);
+        monitor_tmc_driver(stepperX, TMC_X, x_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Y) || ENABLED(IS_TRAMS)
         static uint8_t y_otpw_cnt = 0;
-        monitor_tmc_driver(stepperY, extended_axis_codes[TMC_Y], y_otpw_cnt);
+        monitor_tmc_driver(stepperY, TMC_Y, y_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Z) || ENABLED(IS_TRAMS)
         static uint8_t z_otpw_cnt = 0;
-        monitor_tmc_driver(stepperZ, extended_axis_codes[TMC_Z], z_otpw_cnt);
+        monitor_tmc_driver(stepperZ, TMC_Z, z_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(X2)
         static uint8_t x2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperX2, extended_axis_codes[TMC_X], x2_otpw_cnt);
+        monitor_tmc_driver(stepperX2, TMC_X, x2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Y2)
         static uint8_t y2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperY2, extended_axis_codes[TMC_Y], y2_otpw_cnt);
+        monitor_tmc_driver(stepperY2, TMC_Y, y2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Z2)
         static uint8_t z2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperZ2, extended_axis_codes[TMC_Z], z2_otpw_cnt);
+        monitor_tmc_driver(stepperZ2, TMC_Z, z2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E0) || ENABLED(IS_TRAMS)
         static uint8_t e0_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE0, extended_axis_codes[TMC_E0], e0_otpw_cnt);
+        monitor_tmc_driver(stepperE0, TMC_E0, e0_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E1)
         static uint8_t e1_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE1, extended_axis_codes[TMC_E1], e1_otpw_cnt);
+        monitor_tmc_driver(stepperE1, TMC_E1, e1_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E2)
         static uint8_t e2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE2, extended_axis_codes[TMC_E2], e2_otpw_cnt);
+        monitor_tmc_driver(stepperE2, TMC_E2, e2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E3)
         static uint8_t e3_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE3, extended_axis_codes[TMC_E3], e3_otpw_cnt);
+        monitor_tmc_driver(stepperE3, TMC_E3, e3_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E4)
         static uint8_t e4_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE4, extended_axis_codes[TMC_E4], e4_otpw_cnt);
+        monitor_tmc_driver(stepperE4, TMC_E4, e4_otpw_cnt);
       #endif
 
       if (report_tmc_status) SERIAL_EOL();
@@ -216,26 +214,37 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
 
 #endif // MONITOR_DRIVER_STATUS
 
-void _tmc_say_current(const char name[], const uint16_t curr) {
-  SERIAL_ECHO(name);
+void _tmc_say_axis(const TMC_AxisEnum axis) {
+  const static char ext_X[]  PROGMEM = "X",  ext_X2[] PROGMEM = "X2",
+                    ext_Y[]  PROGMEM = "Y",  ext_Y2[] PROGMEM = "Y2",
+                    ext_Z[]  PROGMEM = "Z",  ext_Z2[] PROGMEM = "Z2",
+                    ext_E0[] PROGMEM = "E0", ext_E1[] PROGMEM = "E1",
+                    ext_E2[] PROGMEM = "E2", ext_E3[] PROGMEM = "E3",
+                    ext_E4[] PROGMEM = "E4";
+  const static char* const tmc_axes[] PROGMEM = { ext_X, ext_X2, ext_Y, ext_Y2, ext_Z, ext_Z2, ext_E0, ext_E1, ext_E2, ext_E3, ext_E4 };
+  serialprintPGM(tmc_axes[axis]);
+}
+
+void _tmc_say_current(const TMC_AxisEnum axis, const uint16_t curr) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOLNPAIR(" axis driver current: ", curr);
 }
-void _tmc_say_otpw(const char name[], const bool otpw) {
-  SERIAL_ECHO(name);
+void _tmc_say_otpw(const TMC_AxisEnum axis, const bool otpw) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOPGM(" axis temperature prewarn triggered: ");
   serialprintPGM(otpw ? PSTR("true") : PSTR("false"));
   SERIAL_EOL();
 }
-void _tmc_say_otpw_cleared(const char name[]) {
-  SERIAL_ECHO(name);
+void _tmc_say_otpw_cleared(const TMC_AxisEnum axis) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOLNPGM(" prewarn flag cleared");
 }
-void _tmc_say_pwmthrs(const char name[], const uint32_t thrs) {
-  SERIAL_ECHO(name);
+void _tmc_say_pwmthrs(const TMC_AxisEnum axis, const uint32_t thrs) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOLNPAIR(" stealthChop max speed set to ", thrs);
 }
-void _tmc_say_sgt(const char name[], const int8_t sgt) {
-  SERIAL_ECHO(name);
+void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOPGM(" driver homing sensitivity set to ");
   SERIAL_PRINTLN(sgt, DEC);
 }
@@ -288,8 +297,8 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
     TMC_S2VSB,
     TMC_S2VSA
   };
-  static void drv_status_print_hex(const char name[], const uint32_t drv_status) {
-    SERIAL_ECHO(name);
+  static void drv_status_print_hex(const TMC_AxisEnum axis, const uint32_t drv_status) {
+    _tmc_say_axis(axis);
     SERIAL_ECHOPGM(" = 0x");
     for (int B = 24; B >= 8; B -= 8){
       SERIAL_PRINT((drv_status >> (B + 4)) & 0xF, HEX);
@@ -343,10 +352,10 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
   #endif
 
   template <typename TMC>
-  static void tmc_status(TMC &st, TMC_AxisEnum axis, const TMC_debug_enum i, const float spmm) {
+  static void tmc_status(TMC &st, const TMC_AxisEnum axis, const TMC_debug_enum i, const float spmm) {
     SERIAL_ECHO('\t');
     switch(i) {
-      case TMC_CODES: SERIAL_ECHO(extended_axis_codes[axis]); break;
+      case TMC_CODES: _tmc_say_axis(axis); break;
       case TMC_ENABLED: serialprintPGM(st.isEnabled() ? PSTR("true") : PSTR("false")); break;
       case TMC_CURRENT: SERIAL_ECHO(st.getCurrent()); break;
       case TMC_RMS_CURRENT: SERIAL_PROTOCOL(st.rms_current()); break;
@@ -388,10 +397,10 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
   }
 
   template <typename TMC>
-  static void tmc_parse_drv_status(TMC &st, TMC_AxisEnum axis, const TMC_drv_status_enum i) {
+  static void tmc_parse_drv_status(TMC &st, const TMC_AxisEnum axis, const TMC_drv_status_enum i) {
     SERIAL_CHAR('\t');
     switch(i) {
-      case TMC_DRV_CODES:     SERIAL_ECHO(extended_axis_codes[axis]);  break;
+      case TMC_DRV_CODES:     _tmc_say_axis(axis);  break;
       case TMC_STST:          if (st.stst())         SERIAL_CHAR('X'); break;
       case TMC_OLB:           if (st.olb())          SERIAL_CHAR('X'); break;
       case TMC_OLA:           if (st.ola())          SERIAL_CHAR('X'); break;
@@ -400,7 +409,7 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
       case TMC_DRV_OTPW:      if (st.otpw())         SERIAL_CHAR('X'); break;
       case TMC_OT:            if (st.ot())           SERIAL_CHAR('X'); break;
       case TMC_DRV_CS_ACTUAL: SERIAL_PRINT(st.cs_actual(), DEC);       break;
-      case TMC_DRV_STATUS_HEX:drv_status_print_hex(extended_axis_codes[axis], st.DRV_STATUS()); break;
+      case TMC_DRV_STATUS_HEX:drv_status_print_hex(axis, st.DRV_STATUS()); break;
       default: tmc_parse_drv_status(st, i); break;
     }
   }

--- a/Marlin/tmc_util.cpp
+++ b/Marlin/tmc_util.cpp
@@ -251,7 +251,7 @@ void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
 
 #if ENABLED(TMC_DEBUG)
 
-  enum TMC_debug_enum {
+  enum TMC_debug_enum : char {
     TMC_CODES,
     TMC_ENABLED,
     TMC_CURRENT,
@@ -275,7 +275,7 @@ void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
     TMC_HSTRT,
     TMC_SGT
   };
-  enum TMC_drv_status_enum {
+  enum TMC_drv_status_enum : char {
     TMC_DRV_CODES,
     TMC_STST,
     TMC_OLB,

--- a/Marlin/tmc_util.h
+++ b/Marlin/tmc_util.h
@@ -28,58 +28,55 @@
 #include "MarlinConfig.h"
 
 extern bool report_tmc_status;
-extern char extended_axis_codes[11][3];
 
-enum TMC_AxisEnum {
-  TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2,
-  TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4
-};
+enum TMC_AxisEnum { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
 
 constexpr uint32_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);
 }
 
-void _tmc_say_current(const char name[], const uint16_t curr);
-void _tmc_say_otpw(const char name[], const bool otpw);
-void _tmc_say_otpw_cleared(const char name[]);
-void _tmc_say_pwmthrs(const char name[], const uint32_t thrs);
-void _tmc_say_sgt(const char name[], const int8_t sgt);
+void _tmc_say_axis(const TMC_AxisEnum axis);
+void _tmc_say_current(const TMC_AxisEnum axis, const uint16_t curr);
+void _tmc_say_otpw(const TMC_AxisEnum axis, const bool otpw);
+void _tmc_say_otpw_cleared(const TMC_AxisEnum axis);
+void _tmc_say_pwmthrs(const TMC_AxisEnum axis, const uint32_t thrs);
+void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt);
 
 template<typename TMC>
-void tmc_get_current(TMC &st, const char name[]) {
-  _tmc_say_current(name, st.getCurrent());
+void tmc_get_current(TMC &st, const TMC_AxisEnum axis) {
+  _tmc_say_current(axis, st.getCurrent());
 }
 template<typename TMC>
-void tmc_set_current(TMC &st, const char name[], const int mA) {
+void tmc_set_current(TMC &st, const TMC_AxisEnum axis, const int mA) {
   st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
-  tmc_get_current(st, name);
+  tmc_get_current(st, axis);
 }
 template<typename TMC>
-void tmc_report_otpw(TMC &st, const char name[]) {
-  _tmc_say_otpw(name, st.getOTPW());
+void tmc_report_otpw(TMC &st, const TMC_AxisEnum axis) {
+  _tmc_say_otpw(axis, st.getOTPW());
 }
 template<typename TMC>
-void tmc_clear_otpw(TMC &st, const char name[]) {
+void tmc_clear_otpw(TMC &st, const TMC_AxisEnum axis) {
   st.clear_otpw();
-  _tmc_say_otpw_cleared(name);
+  _tmc_say_otpw_cleared(axis);
 }
 template<typename TMC>
-void tmc_get_pwmthrs(TMC &st, const char name[], const uint16_t spmm) {
-  _tmc_say_pwmthrs(name, _tmc_thrs(st.microsteps(), st.TPWMTHRS(), spmm));
+void tmc_get_pwmthrs(TMC &st, const TMC_AxisEnum axis, const uint16_t spmm) {
+  _tmc_say_pwmthrs(axis, _tmc_thrs(st.microsteps(), st.TPWMTHRS(), spmm));
 }
 template<typename TMC>
-void tmc_set_pwmthrs(TMC &st, const char name[], const int32_t thrs, const uint32_t spmm) {
+void tmc_set_pwmthrs(TMC &st, const TMC_AxisEnum axis, const int32_t thrs, const uint32_t spmm) {
   st.TPWMTHRS(_tmc_thrs(st.microsteps(), thrs, spmm));
-  tmc_get_pwmthrs(st, name, spmm);
+  tmc_get_pwmthrs(st, axis, spmm);
 }
 template<typename TMC>
-void tmc_get_sgt(TMC &st, const char name[]) {
-  _tmc_say_sgt(name, st.sgt());
+void tmc_get_sgt(TMC &st, const TMC_AxisEnum axis) {
+  _tmc_say_sgt(axis, st.sgt());
 }
 template<typename TMC>
-void tmc_set_sgt(TMC &st, const char name[], const int8_t sgt_val) {
+void tmc_set_sgt(TMC &st, const TMC_AxisEnum axis, const int8_t sgt_val) {
   st.sgt(sgt_val);
-  tmc_get_sgt(st, name);
+  tmc_get_sgt(st, axis);
 }
 
 void monitor_tmc_driver();

--- a/Marlin/tmc_util.h
+++ b/Marlin/tmc_util.h
@@ -29,7 +29,7 @@
 
 extern bool report_tmc_status;
 
-enum TMC_AxisEnum { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
+enum TMC_AxisEnum : char { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
 
 constexpr uint32_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -50,7 +50,7 @@
 
 // ubl_G29.cpp
 
-enum MeshPointType { INVALID, REAL, SET_IN_BITMAP };
+enum MeshPointType : char { INVALID, REAL, SET_IN_BITMAP };
 
 // External references
 


### PR DESCRIPTION
Some SRAM savings can be had by moving the `extended_axis_codes` array to PROGMEM.

Counterpart to #9974