### PR TITLE
[2.0.x] Move tmc_util.* extended_axis_codes to PROGMEM

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/usb/genclk.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/genclk.h
@@ -73,7 +73,7 @@ extern "C" {
 //! \name Programmable Clock Sources (PCK)
 //@{
 
-enum genclk_source {
+enum genclk_source : char {
 	GENCLK_PCK_SRC_SLCK_RC       = 0, //!< Internal 32kHz RC oscillator as PCK source clock
 	GENCLK_PCK_SRC_SLCK_XTAL     = 1, //!< External 32kHz crystal oscillator as PCK source clock
 	GENCLK_PCK_SRC_SLCK_BYPASS   = 2, //!< External 32kHz bypass oscillator as PCK source clock
@@ -92,7 +92,7 @@ enum genclk_source {
 //! \name Programmable Clock Prescalers (PCK)
 //@{
 
-enum genclk_divider {
+enum genclk_divider : char {
 	GENCLK_PCK_PRES_1  = PMC_PCK_PRES_CLK_1, //!< Set PCK clock prescaler to 1
 	GENCLK_PCK_PRES_2  = PMC_PCK_PRES_CLK_2, //!< Set PCK clock prescaler to 2
 	GENCLK_PCK_PRES_4  = PMC_PCK_PRES_CLK_4, //!< Set PCK clock prescaler to 4

--- a/Marlin/src/HAL/HAL_DUE/usb/pll.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/pll.h
@@ -76,7 +76,7 @@ extern "C" {
 
 #define PLL_COUNT           0x3fU
 
-enum pll_source {
+enum pll_source : char {
 	PLL_SRC_MAINCK_4M_RC        = OSC_MAINCK_4M_RC,     //!< Internal 4MHz RC oscillator.
 	PLL_SRC_MAINCK_8M_RC        = OSC_MAINCK_8M_RC,     //!< Internal 8MHz RC oscillator.
 	PLL_SRC_MAINCK_12M_RC       = OSC_MAINCK_12M_RC,    //!< Internal 12MHz RC oscillator.

--- a/Marlin/src/HAL/HAL_DUE/usb/sbc_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sbc_protocol.h
@@ -80,7 +80,7 @@
 //! \name SBC-2 Mode page definitions
 //@{
 
-enum scsi_sbc_mode {
+enum scsi_sbc_mode : char {
 	SCSI_MS_MODE_RW_ERR_RECOV = 0x01,	//!< Read-Write Error Recovery mode page
 	SCSI_MS_MODE_FORMAT_DEVICE = 0x03,	//!< Format Device mode page
 	SCSI_MS_MODE_FLEXIBLE_DISK = 0x05,	//!< Flexible Disk mode page

--- a/Marlin/src/HAL/HAL_DUE/usb/spc_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/spc_protocol.h
@@ -184,7 +184,7 @@ struct scsi_request_sense_data {
 COMPILER_PACK_RESET()
 
 /* Vital Product Data page codes */
-enum scsi_vpd_page_code {
+enum scsi_vpd_page_code : char {
 	SCSI_VPD_SUPPORTED_PAGES = 0x00,
 	SCSI_VPD_UNIT_SERIAL_NUMBER = 0x80,
 	SCSI_VPD_DEVICE_IDENTIFICATION = 0x83,
@@ -202,7 +202,7 @@ enum scsi_vpd_page_code {
 
 
 /* Sense keys */
-enum scsi_sense_key {
+enum scsi_sense_key : char {
 	SCSI_SK_NO_SENSE = 0x0,
 	SCSI_SK_RECOVERED_ERROR = 0x1,
 	SCSI_SK_NOT_READY = 0x2,
@@ -220,7 +220,7 @@ enum scsi_sense_key {
 };
 
 /* Additional Sense Code / Additional Sense Code Qualifier pairs */
-enum scsi_asc_ascq {
+enum scsi_asc_ascq : char {
 	SCSI_ASC_NO_ADDITIONAL_SENSE_INFO = 0x0000,
 	SCSI_ASC_LU_NOT_READY_REBUILD_IN_PROGRESS = 0x0405,
 	SCSI_ASC_WRITE_ERROR = 0x0c00,
@@ -239,7 +239,7 @@ enum scsi_asc_ascq {
  * used with MODE SELECT and MODE SENSE commands
  * that are applicable to all SCSI devices.
  */
-enum scsi_spc_mode {
+enum scsi_spc_mode : char {
 	SCSI_MS_MODE_VENDOR_SPEC = 0x00,
 	SCSI_MS_MODE_INFEXP = 0x1C,    // Informational exceptions control page
 	SCSI_MS_MODE_ALL = 0x3f,
@@ -273,7 +273,7 @@ struct spc_control_page_info_execpt {
 };
 
 
-enum scsi_spc_mode_sense_pc {
+enum scsi_spc_mode_sense_pc : char {
 	SCSI_MS_SENSE_PC_CURRENT = 0,
 	SCSI_MS_SENSE_PC_CHANGEABLE = 1,
 	SCSI_MS_SENSE_PC_DEFAULT = 2,

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol.h
@@ -107,7 +107,7 @@
 /**
  * \brief Standard USB requests (bRequest)
  */
-enum usb_reqid {
+enum usb_reqid : char {
 	USB_REQ_GET_STATUS = 0,
 	USB_REQ_CLEAR_FEATURE = 1,
 	USB_REQ_SET_FEATURE = 3,
@@ -125,7 +125,7 @@ enum usb_reqid {
  * \brief Standard USB device status flags
  *
  */
-enum usb_device_status {
+enum usb_device_status : char {
 	USB_DEV_STATUS_BUS_POWERED = 0,
 	USB_DEV_STATUS_SELF_POWERED = 1,
 	USB_DEV_STATUS_REMOTEWAKEUP = 2
@@ -135,7 +135,7 @@ enum usb_device_status {
  * \brief Standard USB Interface status flags
  *
  */
-enum usb_interface_status {
+enum usb_interface_status : char {
 	USB_IFACE_STATUS_RESERVED = 0
 };
 
@@ -143,7 +143,7 @@ enum usb_interface_status {
  * \brief Standard USB endpoint status flags
  *
  */
-enum usb_endpoint_status {
+enum usb_endpoint_status : char {
 	USB_EP_STATUS_HALTED = 1,
 };
 
@@ -152,7 +152,7 @@ enum usb_endpoint_status {
  *
  * \note valid for SetFeature request.
  */
-enum usb_device_feature {
+enum usb_device_feature : char {
 	USB_DEV_FEATURE_REMOTE_WAKEUP = 1, //!< Remote wakeup enabled
 	USB_DEV_FEATURE_TEST_MODE = 2,     //!< USB test mode
 	USB_DEV_FEATURE_OTG_B_HNP_ENABLE = 3,
@@ -165,7 +165,7 @@ enum usb_device_feature {
  *
  * \note valid for USB_DEV_FEATURE_TEST_MODE request.
  */
-enum usb_device_hs_test_mode {
+enum usb_device_hs_test_mode : char {
 	USB_DEV_TEST_MODE_J = 1,
 	USB_DEV_TEST_MODE_K = 2,
 	USB_DEV_TEST_MODE_SE0_NAK = 3,
@@ -176,14 +176,14 @@ enum usb_device_hs_test_mode {
 /**
  * \brief Standard USB endpoint feature/status flags
  */
-enum usb_endpoint_feature {
+enum usb_endpoint_feature : char {
 	USB_EP_FEATURE_HALT = 0,
 };
 
 /**
  * \brief Standard USB Test Mode Selectors
  */
-enum usb_test_mode_selector {
+enum usb_test_mode_selector : char {
 	USB_TEST_J = 0x01,
 	USB_TEST_K = 0x02,
 	USB_TEST_SE0_NAK = 0x03,
@@ -194,7 +194,7 @@ enum usb_test_mode_selector {
 /**
  * \brief Standard USB descriptor types
  */
-enum usb_descriptor_type {
+enum usb_descriptor_type : char {
 	USB_DT_DEVICE = 1,
 	USB_DT_CONFIGURATION = 2,
 	USB_DT_STRING = 3,
@@ -212,7 +212,7 @@ enum usb_descriptor_type {
 /**
  * \brief USB Device Capability types
  */
-enum usb_capability_type {
+enum usb_capability_type : char {
 	USB_DC_USB20_EXTENSION = 0x02,
 };
 
@@ -220,7 +220,7 @@ enum usb_capability_type {
  * \brief USB Device Capability - USB 2.0 Extension
  * To fill bmAttributes field of usb_capa_ext_desc_t structure.
  */
-enum usb_capability_extension_attr {
+enum usb_capability_extension_attr : char {
 	USB_DC_EXT_LPM  = 0x00000002,
 };
 
@@ -253,7 +253,7 @@ enum usb_capability_extension_attr {
 /**
  * \brief Standard USB endpoint transfer types
  */
-enum usb_ep_type {
+enum usb_ep_type : char {
 	USB_EP_TYPE_CONTROL = 0x00,
 	USB_EP_TYPE_ISOCHRONOUS = 0x01,
 	USB_EP_TYPE_BULK = 0x02,
@@ -264,7 +264,7 @@ enum usb_ep_type {
 /**
  * \brief Standard USB language IDs for string descriptors
  */
-enum usb_langid {
+enum usb_langid : char {
 	USB_LANGID_EN_US = 0x0409, //!< English (United States)
 };
 

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_cdc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_cdc.h
@@ -239,13 +239,13 @@ typedef struct {
 	uint8_t bDataBits;
 } usb_cdc_line_coding_t;
 //! Possible values of bCharFormat
-enum cdc_char_format {
+enum cdc_char_format : char {
 	CDC_STOP_BITS_1 = 0,	//!< 1 stop bit
 	CDC_STOP_BITS_1_5 = 1,	//!< 1.5 stop bits
 	CDC_STOP_BITS_2 = 2,	//!< 2 stop bits
 };
 //! Possible values of bParityType
-enum cdc_parity {
+enum cdc_parity : char {
 	CDC_PAR_NONE = 0,	//!< No parity
 	CDC_PAR_ODD = 1,	//!< Odd parity
 	CDC_PAR_EVEN = 2,	//!< Even parity

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_msc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_msc.h
@@ -93,9 +93,9 @@
 /**
  * \brief MSC USB requests (bRequest)
  */
-enum usb_reqid_msc {
+enum usb_reqid_msc : unsigned char {
 	USB_REQ_MSC_BULK_RESET = 0xFF,	//!< Mass Storage Reset
-	USB_REQ_MSC_GET_MAX_LUN = 0xFE,	//!< Get Max LUN
+	USB_REQ_MSC_GET_MAX_LUN = 0xFE 	//!< Get Max LUN
 };
 
 

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Stm32f1.cpp
@@ -87,7 +87,7 @@ uint8 adc_pins[] = {
   #endif
 };
 
-enum TEMP_PINS {
+enum TEMP_PINS : char {
   #if HAS_TEMP_0
     TEMP_0,
   #endif

--- a/Marlin/src/core/enum.h
+++ b/Marlin/src/core/enum.h
@@ -31,8 +31,7 @@
  *  - X_HEAD and Y_HEAD is used for systems that don't have a 1:1 relationship
  *    between X_AXIS and X Head movement, like CoreXY bots
  */
-enum AxisEnum {
-  NO_AXIS   = -1,
+enum AxisEnum : unsigned char {
   X_AXIS    = 0,
   A_AXIS    = 0,
   Y_AXIS    = 1,
@@ -43,7 +42,8 @@ enum AxisEnum {
   X_HEAD    = 4,
   Y_HEAD    = 5,
   Z_HEAD    = 6,
-  ALL_AXES  = 100
+  ALL_AXES  = 0xFE,
+  NO_AXIS   = 0xFF
 };
 
 #define LOOP_S_LE_N(VAR, S, N) for (uint8_t VAR=S; VAR<=N; VAR++)
@@ -73,12 +73,12 @@ typedef enum {
 /**
  * SD Card
  */
-enum LsAction { LS_SerialPrint, LS_Count, LS_GetFilename };
+enum LsAction : char { LS_SerialPrint, LS_Count, LS_GetFilename };
 
 /**
  * Ultra LCD
  */
-enum LCDViewAction {
+enum LCDViewAction : char {
   LCDVIEW_NONE,
   LCDVIEW_REDRAW_NOW,
   LCDVIEW_CALL_REDRAW_NEXT,

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -32,7 +32,7 @@
 /**
  * Define debug bit-masks
  */
-enum DebugFlags {
+enum DebugFlags : unsigned char {
   DEBUG_NONE          = 0,
   DEBUG_ECHO          = _BV(0), ///< Echo commands in order as they are processed
   DEBUG_INFO          = _BV(1), ///< Print messages for code that has debug output
@@ -45,7 +45,7 @@ enum DebugFlags {
 };
 
 #if ENABLED(EMERGENCY_PARSER)
-  enum e_parser_state {
+  enum e_parser_state : char {
     state_RESET,
     state_N,
     state_M,

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
@@ -25,7 +25,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-enum MeshLevelingState {
+enum MeshLevelingState : char {
   MeshReport,
   MeshStart,
   MeshNext,

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -47,7 +47,7 @@
 
 // ubl_G29.cpp
 
-enum MeshPointType { INVALID, REAL, SET_IN_BITMAP };
+enum MeshPointType : char { INVALID, REAL, SET_IN_BITMAP };
 
 // External references
 

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -32,13 +32,13 @@
 
 #include "../inc/MarlinConfigPre.h"
 
-enum AdvancedPauseMode {
+enum AdvancedPauseMode : char {
   ADVANCED_PAUSE_MODE_PAUSE_PRINT,
   ADVANCED_PAUSE_MODE_LOAD_FILAMENT,
   ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT
 };
 
-enum AdvancedPauseMessage {
+enum AdvancedPauseMessage : char {
   ADVANCED_PAUSE_MESSAGE_INIT,
   ADVANCED_PAUSE_MESSAGE_UNLOAD,
   ADVANCED_PAUSE_MESSAGE_INSERT,
@@ -51,7 +51,7 @@ enum AdvancedPauseMessage {
   ADVANCED_PAUSE_MESSAGE_WAIT_FOR_NOZZLES_TO_HEAT
 };
 
-enum AdvancedPauseMenuResponse {
+enum AdvancedPauseMenuResponse : char {
   ADVANCED_PAUSE_RESPONSE_WAIT_FOR,
   ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE,
   ADVANCED_PAUSE_RESPONSE_RESUME_PRINT

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -253,7 +253,7 @@ void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
 
 #if ENABLED(TMC_DEBUG)
 
-  enum TMC_debug_enum {
+  enum TMC_debug_enum : char {
     TMC_CODES,
     TMC_ENABLED,
     TMC_CURRENT,
@@ -277,7 +277,7 @@ void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
     TMC_HSTRT,
     TMC_SGT
   };
-  enum TMC_drv_status_enum {
+  enum TMC_drv_status_enum : char {
     TMC_DRV_CODES,
     TMC_STST,
     TMC_OLB,

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -37,7 +37,6 @@
 #endif
 
 bool report_tmc_status = false;
-char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1", "E2", "E3", "E4" };
 
 /**
  * Check for over temperature or short to ground error flags.
@@ -96,18 +95,17 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
   #endif
 
   template<typename TMC>
-  void monitor_tmc_driver(TMC &st, const char * const axisName, uint8_t &otpw_cnt) {
+  void monitor_tmc_driver(TMC &st, const TMC_AxisEnum axis, uint8_t &otpw_cnt) {
     TMC_driver_data data = get_driver_data(st);
 
     #if ENABLED(STOP_ON_ERROR)
       if (data.is_error) {
         SERIAL_EOL();
-        SERIAL_ECHO(axisName);
-        SERIAL_ECHOPGM(" driver error detected:");
-        if (data.is_ot) SERIAL_ECHOPGM("\novertemperature");
-        if (st.s2ga()) SERIAL_ECHOPGM("\nshort to ground (coil A)");
-        if (st.s2gb()) SERIAL_ECHOPGM("\nshort to ground (coil B)");
-        SERIAL_EOL();
+        _tmc_say_axis(axis);
+        SERIAL_ECHOLNPGM(" driver error detected:");
+        if (data.is_ot) SERIAL_ECHOLNPGM("overtemperature");
+        if (st.s2ga()) SERIAL_ECHOLNPGM("short to ground (coil A)");
+        if (st.s2gb()) SERIAL_ECHOLNPGM("short to ground (coil B)");
         #if ENABLED(TMC_DEBUG)
           tmc_report_all();
         #endif
@@ -124,7 +122,7 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
       SERIAL_EOL();
       SERIAL_ECHO(timestamp);
       SERIAL_ECHOPGM(": ");
-      SERIAL_ECHO(axisName);
+      _tmc_say_axis(axis);
       SERIAL_ECHOPGM(" driver overtemperature warning! (");
       SERIAL_ECHO(st.getCurrent());
       SERIAL_ECHOLNPGM("mA)");
@@ -134,7 +132,7 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
       if (data.is_otpw && !st.isEnabled() && otpw_cnt > 4) {
         st.setCurrent(st.getCurrent() - CURRENT_STEP_DOWN, R_SENSE, HOLD_MULTIPLIER);
         #if ENABLED(REPORT_CURRENT_CHANGE)
-          SERIAL_ECHO(axisName);
+          _tmc_say_axis(axis);
           SERIAL_ECHOLNPAIR(" current decreased to ", st.getCurrent());
         #endif
       }
@@ -148,7 +146,7 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
 
     if (report_tmc_status) {
       const uint32_t pwm_scale = get_pwm_scale(st);
-      SERIAL_ECHO(axisName);
+      _tmc_say_axis(axis);
       SERIAL_ECHOPAIR(":", pwm_scale);
       SERIAL_ECHOPGM(" |0b"); SERIAL_PRINT(get_status_response(st), BIN);
       SERIAL_ECHOPGM("| ");
@@ -169,47 +167,47 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
       next_cOT = millis() + 500;
       #if HAS_HW_COMMS(X) || ENABLED(IS_TRAMS)
         static uint8_t x_otpw_cnt = 0;
-        monitor_tmc_driver(stepperX, extended_axis_codes[TMC_X], x_otpw_cnt);
+        monitor_tmc_driver(stepperX, TMC_X, x_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Y) || ENABLED(IS_TRAMS)
         static uint8_t y_otpw_cnt = 0;
-        monitor_tmc_driver(stepperY, extended_axis_codes[TMC_Y], y_otpw_cnt);
+        monitor_tmc_driver(stepperY, TMC_Y, y_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Z) || ENABLED(IS_TRAMS)
         static uint8_t z_otpw_cnt = 0;
-        monitor_tmc_driver(stepperZ, extended_axis_codes[TMC_Z], z_otpw_cnt);
+        monitor_tmc_driver(stepperZ, TMC_Z, z_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(X2)
         static uint8_t x2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperX2, extended_axis_codes[TMC_X], x2_otpw_cnt);
+        monitor_tmc_driver(stepperX2, TMC_X, x2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Y2)
         static uint8_t y2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperY2, extended_axis_codes[TMC_Y], y2_otpw_cnt);
+        monitor_tmc_driver(stepperY2, TMC_Y, y2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(Z2)
         static uint8_t z2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperZ2, extended_axis_codes[TMC_Z], z2_otpw_cnt);
+        monitor_tmc_driver(stepperZ2, TMC_Z, z2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E0) || ENABLED(IS_TRAMS)
         static uint8_t e0_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE0, extended_axis_codes[TMC_E0], e0_otpw_cnt);
+        monitor_tmc_driver(stepperE0, TMC_E0, e0_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E1)
         static uint8_t e1_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE1, extended_axis_codes[TMC_E1], e1_otpw_cnt);
+        monitor_tmc_driver(stepperE1, TMC_E1, e1_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E2)
         static uint8_t e2_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE2, extended_axis_codes[TMC_E2], e2_otpw_cnt);
+        monitor_tmc_driver(stepperE2, TMC_E2, e2_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E3)
         static uint8_t e3_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE3, extended_axis_codes[TMC_E3], e3_otpw_cnt);
+        monitor_tmc_driver(stepperE3, TMC_E3, e3_otpw_cnt);
       #endif
       #if HAS_HW_COMMS(E4)
         static uint8_t e4_otpw_cnt = 0;
-        monitor_tmc_driver(stepperE4, extended_axis_codes[TMC_E4], e4_otpw_cnt);
+        monitor_tmc_driver(stepperE4, TMC_E4, e4_otpw_cnt);
       #endif
 
       if (report_tmc_status) SERIAL_EOL();
@@ -218,26 +216,37 @@ char extended_axis_codes[11][3] = { "X", "X2", "Y", "Y2", "Z", "Z2", "E0", "E1",
 
 #endif // MONITOR_DRIVER_STATUS
 
-void _tmc_say_current(const char name[], const uint16_t curr) {
-  SERIAL_ECHO(name);
+void _tmc_say_axis(const TMC_AxisEnum axis) {
+  const static char ext_X[]  PROGMEM = "X",  ext_X2[] PROGMEM = "X2",
+                    ext_Y[]  PROGMEM = "Y",  ext_Y2[] PROGMEM = "Y2",
+                    ext_Z[]  PROGMEM = "Z",  ext_Z2[] PROGMEM = "Z2",
+                    ext_E0[] PROGMEM = "E0", ext_E1[] PROGMEM = "E1",
+                    ext_E2[] PROGMEM = "E2", ext_E3[] PROGMEM = "E3",
+                    ext_E4[] PROGMEM = "E4";
+  const static char* const tmc_axes[] PROGMEM = { ext_X, ext_X2, ext_Y, ext_Y2, ext_Z, ext_Z2, ext_E0, ext_E1, ext_E2, ext_E3, ext_E4 };
+  serialprintPGM(tmc_axes[axis]);
+}
+
+void _tmc_say_current(const TMC_AxisEnum axis, const uint16_t curr) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOLNPAIR(" axis driver current: ", curr);
 }
-void _tmc_say_otpw(const char name[], const bool otpw) {
-  SERIAL_ECHO(name);
+void _tmc_say_otpw(const TMC_AxisEnum axis, const bool otpw) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOPGM(" axis temperature prewarn triggered: ");
   serialprintPGM(otpw ? PSTR("true") : PSTR("false"));
   SERIAL_EOL();
 }
-void _tmc_say_otpw_cleared(const char name[]) {
-  SERIAL_ECHO(name);
+void _tmc_say_otpw_cleared(const TMC_AxisEnum axis) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOLNPGM(" prewarn flag cleared");
 }
-void _tmc_say_pwmthrs(const char name[], const uint32_t thrs) {
-  SERIAL_ECHO(name);
+void _tmc_say_pwmthrs(const TMC_AxisEnum axis, const uint32_t thrs) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOLNPAIR(" stealthChop max speed set to ", thrs);
 }
-void _tmc_say_sgt(const char name[], const int8_t sgt) {
-  SERIAL_ECHO(name);
+void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
+  _tmc_say_axis(axis);
   SERIAL_ECHOPGM(" driver homing sensitivity set to ");
   SERIAL_PRINTLN(sgt, DEC);
 }
@@ -290,8 +299,8 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
     TMC_S2VSB,
     TMC_S2VSA
   };
-  static void drv_status_print_hex(const char name[], const uint32_t drv_status) {
-    SERIAL_ECHO(name);
+  static void drv_status_print_hex(const TMC_AxisEnum axis, const uint32_t drv_status) {
+    _tmc_say_axis(axis);
     SERIAL_ECHOPGM(" = 0x");
     for (int B = 24; B >= 8; B -= 8){
       SERIAL_PRINT((drv_status >> (B + 4)) & 0xF, HEX);
@@ -345,10 +354,10 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
   #endif
 
   template <typename TMC>
-  static void tmc_status(TMC &st, TMC_AxisEnum axis, const TMC_debug_enum i, const float spmm) {
+  static void tmc_status(TMC &st, const TMC_AxisEnum axis, const TMC_debug_enum i, const float spmm) {
     SERIAL_ECHO('\t');
     switch(i) {
-      case TMC_CODES: SERIAL_ECHO(extended_axis_codes[axis]); break;
+      case TMC_CODES: _tmc_say_axis(axis); break;
       case TMC_ENABLED: serialprintPGM(st.isEnabled() ? PSTR("true") : PSTR("false")); break;
       case TMC_CURRENT: SERIAL_ECHO(st.getCurrent()); break;
       case TMC_RMS_CURRENT: SERIAL_PROTOCOL(st.rms_current()); break;
@@ -390,10 +399,10 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
   }
 
   template <typename TMC>
-  static void tmc_parse_drv_status(TMC &st, TMC_AxisEnum axis, const TMC_drv_status_enum i) {
+  static void tmc_parse_drv_status(TMC &st, const TMC_AxisEnum axis, const TMC_drv_status_enum i) {
     SERIAL_CHAR('\t');
     switch(i) {
-      case TMC_DRV_CODES:     SERIAL_ECHO(extended_axis_codes[axis]);  break;
+      case TMC_DRV_CODES:     _tmc_say_axis(axis);  break;
       case TMC_STST:          if (st.stst())         SERIAL_CHAR('X'); break;
       case TMC_OLB:           if (st.olb())          SERIAL_CHAR('X'); break;
       case TMC_OLA:           if (st.ola())          SERIAL_CHAR('X'); break;
@@ -402,7 +411,7 @@ void _tmc_say_sgt(const char name[], const int8_t sgt) {
       case TMC_DRV_OTPW:      if (st.otpw())         SERIAL_CHAR('X'); break;
       case TMC_OT:            if (st.ot())           SERIAL_CHAR('X'); break;
       case TMC_DRV_CS_ACTUAL: SERIAL_PRINT(st.cs_actual(), DEC);       break;
-      case TMC_DRV_STATUS_HEX:drv_status_print_hex(extended_axis_codes[axis], st.DRV_STATUS()); break;
+      case TMC_DRV_STATUS_HEX:drv_status_print_hex(axis, st.DRV_STATUS()); break;
       default: tmc_parse_drv_status(st, i); break;
     }
   }

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -28,58 +28,55 @@
 #include "../inc/MarlinConfig.h"
 
 extern bool report_tmc_status;
-extern char extended_axis_codes[11][3];
 
-enum TMC_AxisEnum {
-  TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2,
-  TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4
-};
+enum TMC_AxisEnum { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
 
 constexpr uint32_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);
 }
 
-void _tmc_say_current(const char name[], const uint16_t curr);
-void _tmc_say_otpw(const char name[], const bool otpw);
-void _tmc_say_otpw_cleared(const char name[]);
-void _tmc_say_pwmthrs(const char name[], const uint32_t thrs);
-void _tmc_say_sgt(const char name[], const int8_t sgt);
+void _tmc_say_axis(const TMC_AxisEnum axis);
+void _tmc_say_current(const TMC_AxisEnum axis, const uint16_t curr);
+void _tmc_say_otpw(const TMC_AxisEnum axis, const bool otpw);
+void _tmc_say_otpw_cleared(const TMC_AxisEnum axis);
+void _tmc_say_pwmthrs(const TMC_AxisEnum axis, const uint32_t thrs);
+void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt);
 
 template<typename TMC>
-void tmc_get_current(TMC &st, const char name[]) {
-  _tmc_say_current(name, st.getCurrent());
+void tmc_get_current(TMC &st, const TMC_AxisEnum axis) {
+  _tmc_say_current(axis, st.getCurrent());
 }
 template<typename TMC>
-void tmc_set_current(TMC &st, const char name[], const int mA) {
+void tmc_set_current(TMC &st, const TMC_AxisEnum axis, const int mA) {
   st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
-  tmc_get_current(st, name);
+  tmc_get_current(st, axis);
 }
 template<typename TMC>
-void tmc_report_otpw(TMC &st, const char name[]) {
-  _tmc_say_otpw(name, st.getOTPW());
+void tmc_report_otpw(TMC &st, const TMC_AxisEnum axis) {
+  _tmc_say_otpw(axis, st.getOTPW());
 }
 template<typename TMC>
-void tmc_clear_otpw(TMC &st, const char name[]) {
+void tmc_clear_otpw(TMC &st, const TMC_AxisEnum axis) {
   st.clear_otpw();
-  _tmc_say_otpw_cleared(name);
+  _tmc_say_otpw_cleared(axis);
 }
 template<typename TMC>
-void tmc_get_pwmthrs(TMC &st, const char name[], const uint16_t spmm) {
-  _tmc_say_pwmthrs(name, _tmc_thrs(st.microsteps(), st.TPWMTHRS(), spmm));
+void tmc_get_pwmthrs(TMC &st, const TMC_AxisEnum axis, const uint16_t spmm) {
+  _tmc_say_pwmthrs(axis, _tmc_thrs(st.microsteps(), st.TPWMTHRS(), spmm));
 }
 template<typename TMC>
-void tmc_set_pwmthrs(TMC &st, const char name[], const int32_t thrs, const uint32_t spmm) {
+void tmc_set_pwmthrs(TMC &st, const TMC_AxisEnum axis, const int32_t thrs, const uint32_t spmm) {
   st.TPWMTHRS(_tmc_thrs(st.microsteps(), thrs, spmm));
-  tmc_get_pwmthrs(st, name, spmm);
+  tmc_get_pwmthrs(st, axis, spmm);
 }
 template<typename TMC>
-void tmc_get_sgt(TMC &st, const char name[]) {
-  _tmc_say_sgt(name, st.sgt());
+void tmc_get_sgt(TMC &st, const TMC_AxisEnum axis) {
+  _tmc_say_sgt(axis, st.sgt());
 }
 template<typename TMC>
-void tmc_set_sgt(TMC &st, const char name[], const int8_t sgt_val) {
+void tmc_set_sgt(TMC &st, const TMC_AxisEnum axis, const int8_t sgt_val) {
   st.sgt(sgt_val);
-  tmc_get_sgt(st, name);
+  tmc_get_sgt(st, axis);
 }
 
 void monitor_tmc_driver();

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -29,7 +29,7 @@
 
 extern bool report_tmc_status;
 
-enum TMC_AxisEnum { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
+enum TMC_AxisEnum : char { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
 
 constexpr uint32_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -43,7 +43,7 @@
 constexpr uint8_t _7P_STEP = 1,              // 7-point step - to change number of calibration points
                   _4P_STEP = _7P_STEP * 2,   // 4-point step
                   NPP      = _7P_STEP * 6;   // number of calibration points on the radius
-enum CalEnum {                               // the 7 main calibration points - add definitions if needed
+enum CalEnum : char {                               // the 7 main calibration points - add definitions if needed
   CEN      = 0,
   __A      = 1,
   _AB      = __A + _7P_STEP,

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -37,8 +37,8 @@ void GcodeSuite::M906() {
   LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
 
   #define TMC_SET_GET_CURRENT(P,Q) do { \
-    if (values[P##_AXIS]) tmc_set_current(stepper##Q, extended_axis_codes[TMC_##Q], values[P##_AXIS]); \
-    else tmc_get_current(stepper##Q, extended_axis_codes[TMC_##Q]); } while(0)
+    if (values[P##_AXIS]) tmc_set_current(stepper##Q, TMC_##Q, values[P##_AXIS]); \
+    else tmc_get_current(stepper##Q, TMC_##Q); } while(0)
 
   #if X_IS_TRINAMIC
     TMC_SET_GET_CURRENT(X,X);

--- a/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
@@ -36,16 +36,16 @@
  */
 void GcodeSuite::M911() {
   #if ENABLED(X_IS_TMC2130) || (ENABLED(X_IS_TMC2208) && PIN_EXISTS(X_SERIAL_RX)) || ENABLED(IS_TRAMS)
-    tmc_report_otpw(stepperX, extended_axis_codes[TMC_X]);
+    tmc_report_otpw(stepperX, TMC_X);
   #endif
   #if ENABLED(Y_IS_TMC2130) || (ENABLED(Y_IS_TMC2208) && PIN_EXISTS(Y_SERIAL_RX)) || ENABLED(IS_TRAMS)
-    tmc_report_otpw(stepperY, extended_axis_codes[TMC_Y]);
+    tmc_report_otpw(stepperY, TMC_Y);
   #endif
   #if ENABLED(Z_IS_TMC2130) || (ENABLED(Z_IS_TMC2208) && PIN_EXISTS(Z_SERIAL_RX)) || ENABLED(IS_TRAMS)
-    tmc_report_otpw(stepperZ, extended_axis_codes[TMC_Z]);
+    tmc_report_otpw(stepperZ, TMC_Z);
   #endif
   #if ENABLED(E0_IS_TMC2130) || (ENABLED(E0_IS_TMC2208) && PIN_EXISTS(E0_SERIAL_RX)) || ENABLED(IS_TRAMS)
-    tmc_report_otpw(stepperE0, extended_axis_codes[TMC_E0]);
+    tmc_report_otpw(stepperE0, TMC_E0);
   #endif
 }
 
@@ -56,22 +56,22 @@ void GcodeSuite::M912() {
   const bool clearX = parser.seen(axis_codes[X_AXIS]), clearY = parser.seen(axis_codes[Y_AXIS]), clearZ = parser.seen(axis_codes[Z_AXIS]), clearE = parser.seen(axis_codes[E_AXIS]),
            clearAll = (!clearX && !clearY && !clearZ && !clearE) || (clearX && clearY && clearZ && clearE);
   #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS) || (ENABLED(X_IS_TMC2208) && PIN_EXISTS(X_SERIAL_RX))
-    if (clearX || clearAll) tmc_clear_otpw(stepperX, extended_axis_codes[TMC_X]);
+    if (clearX || clearAll) tmc_clear_otpw(stepperX, TMC_X);
   #endif
   #if ENABLED(X2_IS_TMC2130) || (ENABLED(X2_IS_TMC2208) && PIN_EXISTS(X_SERIAL_RX))
-    if (clearX || clearAll) tmc_clear_otpw(stepperX, extended_axis_codes[TMC_X]);
+    if (clearX || clearAll) tmc_clear_otpw(stepperX, TMC_X);
   #endif
 
   #if ENABLED(Y_IS_TMC2130) || (ENABLED(Y_IS_TMC2208) && PIN_EXISTS(Y_SERIAL_RX))
-    if (clearY || clearAll) tmc_clear_otpw(stepperY, extended_axis_codes[TMC_Y]);
+    if (clearY || clearAll) tmc_clear_otpw(stepperY, TMC_Y);
   #endif
 
   #if ENABLED(Z_IS_TMC2130) || (ENABLED(Z_IS_TMC2208) && PIN_EXISTS(Z_SERIAL_RX))
-    if (clearZ || clearAll) tmc_clear_otpw(stepperZ, extended_axis_codes[TMC_Z]);
+    if (clearZ || clearAll) tmc_clear_otpw(stepperZ, TMC_Z);
   #endif
 
   #if ENABLED(E0_IS_TMC2130) || (ENABLED(E0_IS_TMC2208) && PIN_EXISTS(E0_SERIAL_RX))
-    if (clearE || clearAll) tmc_clear_otpw(stepperE0, extended_axis_codes[TMC_E0]);
+    if (clearE || clearAll) tmc_clear_otpw(stepperE0, TMC_E0);
   #endif
 }
 
@@ -84,8 +84,8 @@ void GcodeSuite::M912() {
     LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
 
     #define TMC_SET_GET_PWMTHRS(P,Q) do { \
-      if (values[P##_AXIS]) tmc_set_pwmthrs(stepper##Q, extended_axis_codes[TMC_##Q], values[P##_AXIS], planner.axis_steps_per_mm[P##_AXIS]); \
-      else tmc_get_pwmthrs(stepper##Q, extended_axis_codes[TMC_##Q], planner.axis_steps_per_mm[P##_AXIS]); } while(0)
+      if (values[P##_AXIS]) tmc_set_pwmthrs(stepper##Q, TMC_##Q, values[P##_AXIS], planner.axis_steps_per_mm[P##_AXIS]); \
+      else tmc_get_pwmthrs(stepper##Q, TMC_##Q, planner.axis_steps_per_mm[P##_AXIS]); } while(0)
 
     #if X_IS_TRINAMIC
       TMC_SET_GET_PWMTHRS(X,X);
@@ -129,8 +129,8 @@ void GcodeSuite::M912() {
 #if ENABLED(SENSORLESS_HOMING)
   void GcodeSuite::M914() {
     #define TMC_SET_GET_SGT(P,Q) do { \
-      if (parser.seen(axis_codes[P##_AXIS])) tmc_set_sgt(stepper##Q, extended_axis_codes[TMC_##Q], parser.value_int()); \
-      else tmc_get_sgt(stepper##Q, extended_axis_codes[TMC_##Q]); } while(0)
+      if (parser.seen(axis_codes[P##_AXIS])) tmc_set_sgt(stepper##Q, TMC_##Q, parser.value_int()); \
+      else tmc_get_sgt(stepper##Q, TMC_##Q); } while(0)
 
     #ifdef X_HOMING_SENSITIVITY
       #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -267,7 +267,7 @@ public:
      * Workspace planes only apply to G2/G3 moves
      * (and "canned cycles" - not a current feature)
      */
-    enum WorkspacePlane { PLANE_XY, PLANE_ZX, PLANE_YZ };
+    enum WorkspacePlane : char { PLANE_XY, PLANE_ZX, PLANE_YZ };
     static WorkspacePlane workspace_plane;
   #endif
 
@@ -304,7 +304,7 @@ public:
      * States for managing Marlin and host communication
      * Marlin sends messages if blocked or busy
      */
-    enum MarlinBusyState {
+    enum MarlinBusyState : char {
       NOT_BUSY,           // Not in a handler
       IN_HANDLER,         // Processing a GCode
       IN_PROCESS,         // Known to be blocking command input (as in G29)

--- a/Marlin/src/libs/stopwatch.h
+++ b/Marlin/src/libs/stopwatch.h
@@ -36,7 +36,7 @@
  */
 class Stopwatch {
   private:
-    enum State {
+    enum State : char {
       STOPPED,
       RUNNING,
       PAUSED

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -30,7 +30,7 @@
 #include "../inc/MarlinConfig.h"
 #include <stdint.h>
 
-enum EndstopEnum {
+enum EndstopEnum : char {
   X_MIN,
   Y_MIN,
   Z_MIN,

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -288,7 +288,7 @@ void homeaxis(const AxisEnum axis);
  */
 #if ENABLED(DUAL_X_CARRIAGE)
 
-  enum DualXMode {
+  enum DualXMode : char {
     DXC_FULL_CONTROL_MODE,  // DUAL_X_CARRIAGE only
     DXC_AUTO_PARK_MODE,     // DUAL_X_CARRIAGE only
     DXC_DUPLICATION_MODE
@@ -308,7 +308,7 @@ void homeaxis(const AxisEnum axis);
 
 #elif ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
 
-  enum DualXMode {
+  enum DualXMode : char {
     DXC_DUPLICATION_MODE = 2
   };
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -44,7 +44,7 @@
   #include "../libs/vector_3.h"
 #endif
 
-enum BlockFlagBit {
+enum BlockFlagBit : char {
   // Recalculate trapezoids on entry junction. For optimization.
   BLOCK_BIT_RECALCULATE,
 
@@ -60,7 +60,7 @@ enum BlockFlagBit {
   BLOCK_BIT_CONTINUED
 };
 
-enum BlockFlag {
+enum BlockFlag : char {
   BLOCK_FLAG_RECALCULATE          = _BV(BLOCK_BIT_RECALCULATE),
   BLOCK_FLAG_NOMINAL_LENGTH       = _BV(BLOCK_BIT_NOMINAL_LENGTH),
   BLOCK_FLAG_BUSY                 = _BV(BLOCK_BIT_BUSY),

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -49,7 +49,7 @@
 /**
  * States for ADC reading in the ISR
  */
-enum ADCSensorState {
+enum ADCSensorState : char {
   #if HAS_TEMP_0
     PrepareTemp_0,
     MeasureTemp_0,
@@ -610,7 +610,7 @@ class Temperature {
 
     #if ENABLED(THERMAL_PROTECTION_HOTENDS) || HAS_THERMALLY_PROTECTED_BED
 
-      typedef enum TRState { TRInactive, TRFirstHeating, TRStable, TRRunaway } TRstate;
+      typedef enum TRState : char { TRInactive, TRFirstHeating, TRStable, TRRunaway } TRstate;
 
       static void thermal_runaway_protection(TRState * const state, millis_t * const timer, const float &current, const float &target, const int8_t heater_id, const uint16_t period_seconds, const uint16_t hysteresis_degc);
 


### PR DESCRIPTION
Some SRAM savings can be had by moving the `extended_axis_codes` array to PROGMEM.

Counterpart to #9973