### PR TITLE
[1.1.x] Fix SD file sorting after Stop SD Print

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -290,18 +290,25 @@ void CardReader::openAndPrintFile(const char *name) {
 void CardReader::startFileprint() {
   if (cardOK) {
     sdprinting = true;
-    #if ENABLED(SDCARD_SORT_ALPHA)
+    #if SD_RESORT
       flush_presort();
     #endif
   }
 }
 
-void CardReader::stopSDPrint() {
+void CardReader::stopSDPrint(
+  #if SD_RESORT
+    const bool re_sort/*=false*/
+  #endif
+) {
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     did_pause_print = 0;
   #endif
   sdprinting = false;
   if (isFileOpen()) file.close();
+  #if SD_RESORT
+    if (re_sort) presort();
+  #endif
 }
 
 void CardReader::openLogFile(char* name) {
@@ -664,13 +671,13 @@ int8_t CardReader::updir() {
    */
   void CardReader::presort() {
 
+    // Throw away old sort index
+    flush_presort();
+
     // Sorting may be turned off
     #if ENABLED(SDSORT_GCODE)
       if (!sort_alpha) return;
     #endif
-
-    // Throw away old sort index
-    flush_presort();
 
     // If there are files, sort up to the limit
     uint16_t fileCnt = getnrfilenames();
@@ -904,7 +911,6 @@ void CardReader::printingHasFinished() {
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif
-
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
       lcd_reselect_last_file();
     #endif

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -27,6 +27,8 @@
 
 #if ENABLED(SDSUPPORT)
 
+#define SD_RESORT ENABLED(SDCARD_SORT_ALPHA) && ENABLED(SDSORT_DYNAMIC_RAM)
+
 #define MAX_DIR_DEPTH 10          // Maximum folder depth
 
 #include "SdFile.h"
@@ -52,7 +54,11 @@ public:
   void release();
   void openAndPrintFile(const char *name);
   void startFileprint();
-  void stopSDPrint();
+  void stopSDPrint(
+    #if SD_RESORT
+      const bool re_sort=false
+    #endif
+  );
   void getStatus();
   void printingHasFinished();
 

--- a/Marlin/malyanlcd.cpp
+++ b/Marlin/malyanlcd.cpp
@@ -225,7 +225,11 @@ void process_lcd_p_command(const char* command) {
     case 'X':
       // cancel print
       write_to_lcd_P(PSTR("{SYS:CANCELING}"));
-      card.stopSDPrint();
+      card.stopSDPrint(
+        #if SD_RESORT
+          true
+        #endif
+      );
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -845,7 +845,11 @@ void kill_screen(const char* lcd_msg) {
     }
 
     void lcd_sdcard_stop() {
-      card.stopSDPrint();
+      card.stopSDPrint(
+        #if SD_RESORT
+          true
+        #endif
+      );
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();


### PR DESCRIPTION
After canceling a print the files in the SD menu will not be alpha sorted until you change directories. I noticed this the other day but thought nothing of it. Thanks to Chuck Hellebuyck for bringing it up and prompting further investigation.