### PR TITLE
[2.0.x] Fix SD file sorting after Stop SD Print

### DIFF
--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -228,7 +228,11 @@ void process_lcd_p_command(const char* command) {
     case 'X':
       // cancel print
       write_to_lcd_P(PSTR("{SYS:CANCELING}"));
-      card.stopSDPrint();
+      card.stopSDPrint(
+        #if SD_RESORT
+          true
+        #endif
+      );
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();
@@ -448,4 +452,4 @@ void lcd_setalertstatusPGM(const char* message) {
   write_to_lcd(message_buffer);
 }
 
-#endif // Malyan LCD
+#endif // MALYAN_LCD

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -856,7 +856,11 @@ void kill_screen(const char* lcd_msg) {
     }
 
     void lcd_sdcard_stop() {
-      card.stopSDPrint();
+      card.stopSDPrint(
+        #if SD_RESORT
+          true
+        #endif
+      );
       clear_command_queue();
       quickstop_stepper();
       print_job_timer.stop();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -328,12 +328,19 @@ void CardReader::startFileprint() {
   }
 }
 
-void CardReader::stopSDPrint() {
+void CardReader::stopSDPrint(
+  #if SD_RESORT
+    const bool re_sort/*=false*/
+  #endif
+) {
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     did_pause_print = 0;
   #endif
   sdprinting = false;
   if (isFileOpen()) file.close();
+  #if SD_RESORT
+    if (re_sort) presort();
+  #endif
 }
 
 void CardReader::openLogFile(char* name) {
@@ -700,13 +707,13 @@ int8_t CardReader::updir() {
    */
   void CardReader::presort() {
 
+    // Throw away old sort index
+    flush_presort();
+
     // Sorting may be turned off
     #if ENABLED(SDSORT_GCODE)
       if (!sort_alpha) return;
     #endif
-
-    // Throw away old sort index
-    flush_presort();
 
     // If there are files, sort up to the limit
     uint16_t fileCnt = getnrfilenames();
@@ -940,7 +947,6 @@ void CardReader::printingHasFinished() {
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif
-
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
       lcd_reselect_last_file();
     #endif

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -23,11 +23,15 @@
 #ifndef _CARDREADER_H_
 #define _CARDREADER_H_
 
+#include "../inc/MarlinConfig.h"
+
+#if ENABLED(SDSUPPORT)
+
+#define SD_RESORT ENABLED(SDCARD_SORT_ALPHA) && ENABLED(SDSORT_DYNAMIC_RAM)
+
 #define MAX_DIR_DEPTH 10          // Maximum folder depth
 
 #include "SdFile.h"
-
-#include "../inc/MarlinConfig.h"
 
 class CardReader {
 public:
@@ -48,7 +52,11 @@ public:
   void release();
   void openAndPrintFile(const char *name);
   void startFileprint();
-  void stopSDPrint();
+  void stopSDPrint(
+    #if SD_RESORT
+      const bool re_sort=false
+    #endif
+  );
   void getStatus(
     #if NUM_SERIAL > 1
       const int8_t port = -1
@@ -217,9 +225,13 @@ private:
     #define IS_SD_INSERTED (READ(SD_DETECT_PIN) == LOW)
   #endif
 #else
-  //No card detect line? Assume the card is inserted.
+  // No card detect line? Assume the card is inserted.
   #define IS_SD_INSERTED true
 #endif
+
+extern CardReader card;
+
+#endif // SDSUPPORT
 
 #if ENABLED(SDSUPPORT)
   #define IS_SD_PRINTING (card.sdprinting)
@@ -228,7 +240,5 @@ private:
   #define IS_SD_PRINTING (false)
   #define IS_SD_FILE_OPEN (false)
 #endif
-
-extern CardReader card;
 
 #endif // _CARDREADER_H_


### PR DESCRIPTION
After canceling a print the files in the SD menu will not be alpha sorted until you change directories. I noticed this the other day but thought nothing of it. Thanks to Chuck Hellebuyck for bringing it up and prompting further investigation.