### PR TITLE
[2.0.x] NEEDS TESTING - Always Completely Initialize Character LCD (Garbled Custom Characters)

### DIFF
--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -222,9 +222,11 @@ static void createChar_P(const char c, const byte * const ptr) {
   lcd.createChar(c, temp);
 }
 
-#define CHARSET_MENU 0
-#define CHARSET_INFO 1
-#define CHARSET_BOOT 2
+enum HD44780CharSet : char {
+  CHARSET_MENU,
+  CHARSET_INFO,
+  CHARSET_BOOT
+};
 
 static void lcd_set_custom_characters(
   #if ENABLED(LCD_PROGRESS_BAR) || ENABLED(SHOW_BOOTSCREEN)
@@ -399,49 +401,38 @@ static void lcd_set_custom_characters(
 
   #endif // SDSUPPORT
 
-  #if ENABLED(SHOW_BOOTSCREEN) || ENABLED(LCD_PROGRESS_BAR)
-    static uint8_t char_mode = CHARSET_MENU;
-    #define CHAR_COND (screen_charset != char_mode)
-  #else
-    #define CHAR_COND true
+  #if ENABLED(SHOW_BOOTSCREEN)
+    // Set boot screen corner characters
+    if (screen_charset == CHARSET_BOOT) {
+      for (uint8_t i = 4; i--;)
+        createChar_P(i, corner[i]);
+    }
+    else
   #endif
+    { // Info Screen uses 5 special characters
+      createChar_P(LCD_BEDTEMP_CHAR, bedTemp);
+      createChar_P(LCD_DEGREE_CHAR, degree);
+      createChar_P(LCD_STR_THERMOMETER[0], thermometer);
+      createChar_P(LCD_FEEDRATE_CHAR, feedrate);
+      createChar_P(LCD_CLOCK_CHAR, clock);
 
-  if (CHAR_COND) {
-    #if ENABLED(SHOW_BOOTSCREEN) || ENABLED(LCD_PROGRESS_BAR)
-      char_mode = screen_charset;
-      #if ENABLED(SHOW_BOOTSCREEN)
-        // Set boot screen corner characters
-        if (screen_charset == CHARSET_BOOT) {
-          for (uint8_t i = 4; i--;)
-            createChar_P(i, corner[i]);
+      #if ENABLED(LCD_PROGRESS_BAR)
+        if (screen_charset == CHARSET_INFO) { // 3 Progress bar characters for info screen
+          for (int16_t i = 3; i--;)
+            createChar_P(LCD_STR_PROGRESS[i], progress[i]);
         }
         else
       #endif
-    #endif
-        { // Info Screen uses 5 special characters
-          createChar_P(LCD_BEDTEMP_CHAR, bedTemp);
-          createChar_P(LCD_DEGREE_CHAR, degree);
-          createChar_P(LCD_STR_THERMOMETER[0], thermometer);
-          createChar_P(LCD_FEEDRATE_CHAR, feedrate);
-          createChar_P(LCD_CLOCK_CHAR, clock);
-
-          #if ENABLED(LCD_PROGRESS_BAR)
-            if (screen_charset == CHARSET_INFO) { // 3 Progress bar characters for info screen
-              for (int16_t i = 3; i--;)
-                createChar_P(LCD_STR_PROGRESS[i], progress[i]);
-            }
-            else
+        {
+          createChar_P(LCD_UPLEVEL_CHAR, uplevel);
+          #if ENABLED(SDSUPPORT)
+            // SD Card sub-menu special characters
+            createChar_P(LCD_STR_REFRESH[0], refresh);
+            createChar_P(LCD_STR_FOLDER[0], folder);
           #endif
-            {
-              createChar_P(LCD_UPLEVEL_CHAR, uplevel);
-              #if ENABLED(SDSUPPORT)
-                // SD Card sub-menu special characters
-                createChar_P(LCD_STR_REFRESH[0], refresh);
-                createChar_P(LCD_STR_FOLDER[0], folder);
-              #endif
-            }
         }
-  }
+    }
+
 }
 
 static void lcd_implementation_init(


### PR DESCRIPTION
The Hitachi HD44780 based 20x4 character based LCDs will sometimes have garbled custom characters after switching displays via clicking the encoder.  

This may apply to character based LCDs other than the RepRap Discount Smart Controller.

This is being caused by the custom character RAM within the HD44780 sometimes being corrupted during the initialization sequence.  The chip is initialized whenever the display is switched via the encoder.  The garbled characters stay garbled because the custom character RAM is currently only initialized on power up. 

The two options are:
1. In **ultralcd.cpp** remove the "revive the LCD if static electricity killed it" section when the encoder is clicked.
2. In **ultralcd_impl_HD44780.h** remove the logic that only allows the custom character RAM to be initialized once.

This PR implements option 2.

This PR fixes Issues #9741 & #9853.

Bugfix-1.1.x will be fixed on PR #9986.

----

Because of the indentation changes, the code changes are hard to understand as shown in the **Files changed** section.  [Here is an easier to follow dif](https://github.com/MarlinFirmware/Marlin/pull/9981/files?w=1). 

----

 "revive the LCD if static electricity killed it" section of **ultralcd.cpp**

```
  #if ENABLED(ULTIPANEL)

    if (use_click()) {
      #if ENABLED(FILAMENT_LCD_DISPLAY) && ENABLED(SDSUPPORT)
        previous_lcd_status_ms = millis();  // get status message to show up for a while
      #endif
      lcd_implementation_init( // to maybe revive the LCD if static electricity killed it.
        #if ENABLED(LCD_PROGRESS_BAR)
          CHARSET_MENU
        #endif
      );
```