### PR TITLE
[2.0.x] HAL Timer API noless

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL_AVR.h
@@ -126,6 +126,8 @@ extern "C" {
 #define HAL_STEPPER_TIMER_RATE  HAL_TIMER_RATE
 #define STEPPER_TIMER_PRESCALE  8
 
+#define STEP_TIMER_MIN_INTERVAL 8 // minimum time in µs between stepper interrupts
+
 #define STEP_TIMER_NUM          1
 #define TIMER_OCR_1             OCR1A
 #define TIMER_COUNTER_1         TCNT1
@@ -148,6 +150,8 @@ extern "C" {
 
 #define _CAT(a, ...) a ## __VA_ARGS__
 #define HAL_timer_set_compare(timer, compare) (_CAT(TIMER_OCR_, timer) = compare)
+#define HAL_timer_restrain(timer, interval_µs) NOLESS(_CAT(TIMER_OCR_, timer), _CAT(TIMER_COUNTER_, timer) + interval_µs * HAL_TICKS_PER_US)
+
 #define HAL_timer_get_compare(timer) _CAT(TIMER_OCR_, timer)
 #define HAL_timer_get_count(timer) _CAT(TIMER_COUNTER_, timer)
 

--- a/Marlin/src/HAL/HAL_AVR/HAL_spi_AVR.cpp
+++ b/Marlin/src/HAL/HAL_AVR/HAL_spi_AVR.cpp
@@ -221,7 +221,7 @@ void spiBegin (void) {
   /** Soft SPI receive byte */
   uint8_t spiRec() {
     uint8_t data = 0;
-    // no interrupts during byte receive - about 8 us
+    // no interrupts during byte receive - about 8µs
     cli();
     // output pin high - like sending 0xFF
     WRITE(MOSI_PIN, HIGH);
@@ -252,7 +252,7 @@ void spiBegin (void) {
   //------------------------------------------------------------------------------
   /** Soft SPI send byte */
   void spiSend(uint8_t data) {
-    // no interrupts during byte send - about 8 us
+    // no interrupts during byte send - about 8µs
     cli();
     for (uint8_t i = 0; i < 8; i++) {
       WRITE(SCK_PIN, LOW);

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -50,9 +50,10 @@ typedef uint32_t hal_timer_t;
 #define HAL_TIMER_RATE         ((F_CPU) / 2)    // frequency of timers peripherals
 #define STEPPER_TIMER_PRESCALE 1.0              // prescaler for setting stepper frequency
 #define HAL_STEPPER_TIMER_RATE HAL_TIMER_RATE   // frequency of stepper timer (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)
-#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per us
+#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 
 #define TEMP_TIMER_FREQUENCY   1000 // temperature interrupt frequency
+#define STEP_TIMER_MIN_INTERVAL   8 // minimum time in µs between stepper interrupts
 
 #define ENABLE_STEPPER_DRIVER_INTERRUPT() HAL_timer_enable_interrupt(STEP_TIMER_NUM)
 #define DISABLE_STEPPER_DRIVER_INTERRUPT()  HAL_timer_disable_interrupt(STEP_TIMER_NUM)
@@ -106,6 +107,11 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
 FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   const tTimerConfig * const pConfig = &TimerConfig[timer_num];
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV;
+}
+
+FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_µs) {
+  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_µs * HAL_TICKS_PER_US;
+  if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_compare(timer_num, mincmp);
 }
 
 void HAL_timer_enable_interrupt(const uint8_t timer_num);

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -49,9 +49,11 @@ typedef uint32_t hal_timer_t;
 #define HAL_TIMER_RATE         ((SystemCoreClock) / 4)  // frequency of timers peripherals
 #define STEPPER_TIMER_PRESCALE 1.0              // prescaler for setting stepper frequency
 #define HAL_STEPPER_TIMER_RATE HAL_TIMER_RATE   // frequency of stepper timer (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)
-#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per us
+#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 #define HAL_TEMP_TIMER_RATE    1000000
 #define TEMP_TIMER_FREQUENCY   1000 // temperature interrupt frequency
+
+#define STEP_TIMER_MIN_INTERVAL   8 // minimum time in µs between stepper interrupts
 
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 #define PULSE_TIMER_PRESCALE STEPPER_TIMER_PRESCALE
@@ -116,6 +118,11 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
     case 1: return LPC_TIM1->TC;
   }
   return 0;
+}
+
+FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_µs) {
+  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_µs * HAL_TICKS_PER_US;
+  if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_compare(timer_num, mincmp);
 }
 
 void HAL_timer_enable_interrupt(const uint8_t timer_num);

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -67,13 +67,15 @@ typedef uint16_t hal_timer_t;
 #define HAL_TIMER_RATE         (F_CPU)  // frequency of timers peripherals
 #define STEPPER_TIMER_PRESCALE 18             // prescaler for setting stepper timer, 4Mhz
 #define HAL_STEPPER_TIMER_RATE (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)   // frequency of stepper timer (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)
-#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per us
+#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 #define PULSE_TIMER_PRESCALE STEPPER_TIMER_PRESCALE
 
 #define TEMP_TIMER_PRESCALE     1000 // prescaler for setting Temp timer, 72Khz
-#define TEMP_TIMER_FREQUENCY    100 // temperature interrupt frequency
+#define TEMP_TIMER_FREQUENCY     100 // temperature interrupt frequency
+
+#define STEP_TIMER_MIN_INTERVAL    8 // minimum time in µs between stepper interrupts
 
 #define ENABLE_STEPPER_DRIVER_INTERRUPT() timer_enable_irq(STEP_TIMER_DEV, STEP_TIMER_CHAN)
 #define DISABLE_STEPPER_DRIVER_INTERRUPT() timer_disable_irq(STEP_TIMER_DEV, STEP_TIMER_CHAN)
@@ -150,6 +152,11 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   default:
     return 0;
   }
+}
+
+FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_µs) {
+  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_µs * HAL_TICKS_PER_US;
+  if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_compare(timer_num, mincmp);
 }
 
 FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
@@ -137,6 +137,11 @@ uint32_t HAL_timer_get_count(const uint8_t timer_num) {
   return __HAL_TIM_GetCounter(&timerConfig[timer_num].timerdef);
 }
 
+void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_µs) {
+  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_µs * HAL_TICKS_PER_US;
+  if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_compare(timer_num, mincmp);
+}
+
 void HAL_timer_isr_prologue(const uint8_t timer_num) {
   if (__HAL_TIM_GET_FLAG(&timerConfig[timer_num].timerdef, TIM_FLAG_UPDATE) == SET) {
     __HAL_TIM_CLEAR_FLAG(&timerConfig[timer_num].timerdef, TIM_FLAG_UPDATE);

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
@@ -44,13 +44,15 @@
 #define HAL_TIMER_RATE         (HAL_RCC_GetSysClockFreq() / 2)  // frequency of timer peripherals
 #define STEPPER_TIMER_PRESCALE 54            // was 40,prescaler for setting stepper timer, 2Mhz
 #define HAL_STEPPER_TIMER_RATE (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)   // frequency of stepper timer (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE)
-#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per us
+#define HAL_TICKS_PER_US       ((HAL_STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 #define PULSE_TIMER_PRESCALE STEPPER_TIMER_PRESCALE
 
 #define TEMP_TIMER_PRESCALE     1000 // prescaler for setting Temp timer, 72Khz
 #define TEMP_TIMER_FREQUENCY    1000 // temperature interrupt frequency
+
+#define STEP_TIMER_MIN_INTERVAL    8 // minimum time in µs between stepper interrupts
 
 #define ENABLE_STEPPER_DRIVER_INTERRUPT() HAL_timer_enable_interrupt(STEP_TIMER_NUM)
 #define DISABLE_STEPPER_DRIVER_INTERRUPT() HAL_timer_disable_interrupt(STEP_TIMER_NUM)
@@ -94,6 +96,7 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num);
 void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare);
 hal_timer_t HAL_timer_get_compare(const uint8_t timer_num);
 uint32_t HAL_timer_get_count(const uint8_t timer_num);
+void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_µs);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
 

--- a/Marlin/src/HAL/HAL_STM32F7/TMC2660.h
+++ b/Marlin/src/HAL/HAL_STM32F7/TMC2660.h
@@ -315,7 +315,7 @@ class TMC26XStepper {
     /*!
      * \brief readout the motor maximum current in mA (1000 is an Amp)
      * This is the maximum current. to get the current current - which may be affected by CoolStep us getCurrentCurrent()
-     *\return the maximum motor current in milli amps
+     * \return the maximum motor current in milli amps
      * \sa getCurrentCurrent()
      */
     unsigned int getCurrent(void);

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
@@ -66,6 +66,8 @@ typedef uint32_t hal_timer_t;
 
 #define TEMP_TIMER_FREQUENCY   1000
 
+#define STEP_TIMER_MIN_INTERVAL   8 // minimum time in µs between stepper interrupts
+
 #define ENABLE_STEPPER_DRIVER_INTERRUPT() HAL_timer_enable_interrupt(STEP_TIMER_NUM)
 #define DISABLE_STEPPER_DRIVER_INTERRUPT() HAL_timer_disable_interrupt(STEP_TIMER_NUM)
 #define STEPPER_ISR_ENABLED() HAL_timer_interrupt_enabled(STEP_TIMER_NUM)
@@ -101,6 +103,11 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
     case 1: return FTM1_CNT;
   }
   return 0;
+}
+
+FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_µs) {
+  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_µs * HAL_TICKS_PER_US;
+  if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_compare(timer_num, mincmp);
 }
 
 void HAL_timer_enable_interrupt(const uint8_t timer_num);


### PR DESCRIPTION
### Description
Creates a HAL Timer API function `HAL_timer_restrain(timer, interval_µs)` that will make sure there is at least the specified number of ticks before the timer will fire its interrupt again.

### Benefits
Removes a few places where 'ifdef CPU_32_BIT' sections were still necessary clarifying program flow in stepper.cpp, the new constant `STEP_TIMER_MIN_INTERVAL ` allows for the individual platforms to determine how much idle time they need between interrupts.

### Problems
All default implementations I added other than the AVR macro are the same, this may seem like unnecessary code repetition, (platform developers may be able to optimise them). My imagination failed me when naming things, plus passing the ticks value seems redundant (can be calculated on the other side of the api) but the function may have uses in other places.