### PR TITLE
[1.1.x] Update powersupply_on in power_on/off

### DIFF
--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -453,6 +453,12 @@ void report_current_position();
   extern int lpq_len;
 #endif
 
+#if HAS_POWER_SWITCH
+  extern bool powersupply_on;
+  #define PSU_PIN_ON()  do{ OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE); powersupply_on = true; }while(0)
+  #define PSU_PIN_OFF() do{ OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP); powersupply_on = false; }while(0)
+#endif
+
 // Handling multiple extruders pins
 extern uint8_t active_extruder;
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -524,15 +524,6 @@ millis_t previous_cmd_ms = 0;
 static millis_t max_inactive_time = 0;
 static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
 
-// Auto Power Control
-#if ENABLED(AUTO_POWER_CONTROL)
-  #define PSU_ON()  powerManager.power_on()
-  #define PSU_OFF() powerManager.power_off()
-#else
-  #define PSU_ON()  OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE)
-  #define PSU_OFF() OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP)
-#endif
-
 // Buzzer - I2C on the LCD or a BEEPER_PIN
 #if ENABLED(LCD_USE_I2C_BUZZER)
   #define BUZZ(d,f) lcd_buzz(d, f)
@@ -606,6 +597,13 @@ uint8_t target_extruder;
       true
     #endif
   ;
+  #if ENABLED(AUTO_POWER_CONTROL)
+    #define PSU_ON()  powerManager.power_on()
+    #define PSU_OFF() powerManager.power_off()
+  #else
+    #define PSU_ON()  PSU_PIN_ON()
+    #define PSU_OFF() PSU_PIN_OFF()
+  #endif
 #endif
 
 #if ENABLED(DELTA)
@@ -8284,8 +8282,6 @@ inline void gcode_M140() {
       tmc2130_init(); // Settings only stick when the driver has power
     #endif
 
-    powersupply_on = true;
-
     #if ENABLED(ULTIPANEL)
       LCD_MESSAGEPGM(WELCOME_MSG);
     #endif
@@ -8322,7 +8318,6 @@ inline void gcode_M81() {
     suicide();
   #elif HAS_POWER_SWITCH
     PSU_OFF();
-    powersupply_on = false;
   #endif
 
   #if ENABLED(ULTIPANEL)

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -883,7 +883,7 @@ void Planner::_buffer_steps(const int32_t (&target)[XYZE]
 
   #if ENABLED(AUTO_POWER_CONTROL)
     if (block->steps[X_AXIS] || block->steps[Y_AXIS] || block->steps[Z_AXIS])
-        powerManager.power_on();
+      powerManager.power_on();
   #endif
 
   //enable active axes

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -86,11 +86,11 @@ void Power::check() {
 
 void Power::power_on() {
   lastPowerOn = millis();
-  OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE);
+  PSU_PIN_ON();
 }
 
 void Power::power_off() {
-  OUT_WRITE(PS_ON_PIN, PS_ON_ASLEEP);
+  PSU_PIN_OFF();
 }
 
 #endif // AUTO_POWER_CONTROL


### PR DESCRIPTION
Fix #10004

The `powersupply_on` flag needs to be set with auto power or moves will be prevented even with power enabled.