### PR TITLE
[2.0.x] DUE enum temporary work around

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -429,6 +429,17 @@ script:
   - pins_set RAMPS X_MAX_PIN -1
   - opt_add_adv Z2_MAX_PIN 2
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  
+  #############################
+  # DUE default config test
+  #############################
+  
+  - export TEST_PLATFORM="-e DUE"
+  - restore_configs
+  - opt_set MOTHERBOARD BOARD_RAMPS4DUE_EFB
+  - cp Marlin/Configuration.h Marlin/src/config/default/Configuration.h
+  - cp Marlin/Configuration_adv.h Marlin/src/config/default/Configuration_adv.h
+  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
 
   #############################
   # LPC1768 default config test

--- a/Marlin/src/HAL/HAL_DUE/usb/genclk.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/genclk.h
@@ -73,7 +73,7 @@ extern "C" {
 //! \name Programmable Clock Sources (PCK)
 //@{
 
-enum genclk_source : char {
+enum genclk_source {
 	GENCLK_PCK_SRC_SLCK_RC       = 0, //!< Internal 32kHz RC oscillator as PCK source clock
 	GENCLK_PCK_SRC_SLCK_XTAL     = 1, //!< External 32kHz crystal oscillator as PCK source clock
 	GENCLK_PCK_SRC_SLCK_BYPASS   = 2, //!< External 32kHz bypass oscillator as PCK source clock
@@ -92,7 +92,7 @@ enum genclk_source : char {
 //! \name Programmable Clock Prescalers (PCK)
 //@{
 
-enum genclk_divider : char {
+enum genclk_divider {
 	GENCLK_PCK_PRES_1  = PMC_PCK_PRES_CLK_1, //!< Set PCK clock prescaler to 1
 	GENCLK_PCK_PRES_2  = PMC_PCK_PRES_CLK_2, //!< Set PCK clock prescaler to 2
 	GENCLK_PCK_PRES_4  = PMC_PCK_PRES_CLK_4, //!< Set PCK clock prescaler to 4

--- a/Marlin/src/HAL/HAL_DUE/usb/pll.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/pll.h
@@ -76,7 +76,7 @@ extern "C" {
 
 #define PLL_COUNT           0x3fU
 
-enum pll_source : char {
+enum pll_source {
 	PLL_SRC_MAINCK_4M_RC        = OSC_MAINCK_4M_RC,     //!< Internal 4MHz RC oscillator.
 	PLL_SRC_MAINCK_8M_RC        = OSC_MAINCK_8M_RC,     //!< Internal 8MHz RC oscillator.
 	PLL_SRC_MAINCK_12M_RC       = OSC_MAINCK_12M_RC,    //!< Internal 12MHz RC oscillator.

--- a/Marlin/src/HAL/HAL_DUE/usb/sbc_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sbc_protocol.h
@@ -80,7 +80,7 @@
 //! \name SBC-2 Mode page definitions
 //@{
 
-enum scsi_sbc_mode : char {
+enum scsi_sbc_mode {
 	SCSI_MS_MODE_RW_ERR_RECOV = 0x01,	//!< Read-Write Error Recovery mode page
 	SCSI_MS_MODE_FORMAT_DEVICE = 0x03,	//!< Format Device mode page
 	SCSI_MS_MODE_FLEXIBLE_DISK = 0x05,	//!< Flexible Disk mode page

--- a/Marlin/src/HAL/HAL_DUE/usb/spc_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/spc_protocol.h
@@ -184,7 +184,7 @@ struct scsi_request_sense_data {
 COMPILER_PACK_RESET()
 
 /* Vital Product Data page codes */
-enum scsi_vpd_page_code : char {
+enum scsi_vpd_page_code {
 	SCSI_VPD_SUPPORTED_PAGES = 0x00,
 	SCSI_VPD_UNIT_SERIAL_NUMBER = 0x80,
 	SCSI_VPD_DEVICE_IDENTIFICATION = 0x83,
@@ -202,7 +202,7 @@ enum scsi_vpd_page_code : char {
 
 
 /* Sense keys */
-enum scsi_sense_key : char {
+enum scsi_sense_key {
 	SCSI_SK_NO_SENSE = 0x0,
 	SCSI_SK_RECOVERED_ERROR = 0x1,
 	SCSI_SK_NOT_READY = 0x2,
@@ -220,7 +220,7 @@ enum scsi_sense_key : char {
 };
 
 /* Additional Sense Code / Additional Sense Code Qualifier pairs */
-enum scsi_asc_ascq : char {
+enum scsi_asc_ascq {
 	SCSI_ASC_NO_ADDITIONAL_SENSE_INFO = 0x0000,
 	SCSI_ASC_LU_NOT_READY_REBUILD_IN_PROGRESS = 0x0405,
 	SCSI_ASC_WRITE_ERROR = 0x0c00,
@@ -239,7 +239,7 @@ enum scsi_asc_ascq : char {
  * used with MODE SELECT and MODE SENSE commands
  * that are applicable to all SCSI devices.
  */
-enum scsi_spc_mode : char {
+enum scsi_spc_mode {
 	SCSI_MS_MODE_VENDOR_SPEC = 0x00,
 	SCSI_MS_MODE_INFEXP = 0x1C,    // Informational exceptions control page
 	SCSI_MS_MODE_ALL = 0x3f,
@@ -273,7 +273,7 @@ struct spc_control_page_info_execpt {
 };
 
 
-enum scsi_spc_mode_sense_pc : char {
+enum scsi_spc_mode_sense_pc {
 	SCSI_MS_SENSE_PC_CURRENT = 0,
 	SCSI_MS_SENSE_PC_CHANGEABLE = 1,
 	SCSI_MS_SENSE_PC_DEFAULT = 2,

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol.h
@@ -107,7 +107,7 @@
 /**
  * \brief Standard USB requests (bRequest)
  */
-enum usb_reqid : char {
+enum usb_reqid {
 	USB_REQ_GET_STATUS = 0,
 	USB_REQ_CLEAR_FEATURE = 1,
 	USB_REQ_SET_FEATURE = 3,
@@ -125,7 +125,7 @@ enum usb_reqid : char {
  * \brief Standard USB device status flags
  *
  */
-enum usb_device_status : char {
+enum usb_device_status {
 	USB_DEV_STATUS_BUS_POWERED = 0,
 	USB_DEV_STATUS_SELF_POWERED = 1,
 	USB_DEV_STATUS_REMOTEWAKEUP = 2
@@ -135,7 +135,7 @@ enum usb_device_status : char {
  * \brief Standard USB Interface status flags
  *
  */
-enum usb_interface_status : char {
+enum usb_interface_status {
 	USB_IFACE_STATUS_RESERVED = 0
 };
 
@@ -143,7 +143,7 @@ enum usb_interface_status : char {
  * \brief Standard USB endpoint status flags
  *
  */
-enum usb_endpoint_status : char {
+enum usb_endpoint_status {
 	USB_EP_STATUS_HALTED = 1,
 };
 
@@ -152,7 +152,7 @@ enum usb_endpoint_status : char {
  *
  * \note valid for SetFeature request.
  */
-enum usb_device_feature : char {
+enum usb_device_feature {
 	USB_DEV_FEATURE_REMOTE_WAKEUP = 1, //!< Remote wakeup enabled
 	USB_DEV_FEATURE_TEST_MODE = 2,     //!< USB test mode
 	USB_DEV_FEATURE_OTG_B_HNP_ENABLE = 3,
@@ -165,7 +165,7 @@ enum usb_device_feature : char {
  *
  * \note valid for USB_DEV_FEATURE_TEST_MODE request.
  */
-enum usb_device_hs_test_mode : char {
+enum usb_device_hs_test_mode {
 	USB_DEV_TEST_MODE_J = 1,
 	USB_DEV_TEST_MODE_K = 2,
 	USB_DEV_TEST_MODE_SE0_NAK = 3,
@@ -176,14 +176,14 @@ enum usb_device_hs_test_mode : char {
 /**
  * \brief Standard USB endpoint feature/status flags
  */
-enum usb_endpoint_feature : char {
+enum usb_endpoint_feature {
 	USB_EP_FEATURE_HALT = 0,
 };
 
 /**
  * \brief Standard USB Test Mode Selectors
  */
-enum usb_test_mode_selector : char {
+enum usb_test_mode_selector {
 	USB_TEST_J = 0x01,
 	USB_TEST_K = 0x02,
 	USB_TEST_SE0_NAK = 0x03,
@@ -194,7 +194,7 @@ enum usb_test_mode_selector : char {
 /**
  * \brief Standard USB descriptor types
  */
-enum usb_descriptor_type : char {
+enum usb_descriptor_type {
 	USB_DT_DEVICE = 1,
 	USB_DT_CONFIGURATION = 2,
 	USB_DT_STRING = 3,
@@ -212,7 +212,7 @@ enum usb_descriptor_type : char {
 /**
  * \brief USB Device Capability types
  */
-enum usb_capability_type : char {
+enum usb_capability_type {
 	USB_DC_USB20_EXTENSION = 0x02,
 };
 
@@ -220,7 +220,7 @@ enum usb_capability_type : char {
  * \brief USB Device Capability - USB 2.0 Extension
  * To fill bmAttributes field of usb_capa_ext_desc_t structure.
  */
-enum usb_capability_extension_attr : char {
+enum usb_capability_extension_attr {
 	USB_DC_EXT_LPM  = 0x00000002,
 };
 
@@ -253,7 +253,7 @@ enum usb_capability_extension_attr : char {
 /**
  * \brief Standard USB endpoint transfer types
  */
-enum usb_ep_type : char {
+enum usb_ep_type {
 	USB_EP_TYPE_CONTROL = 0x00,
 	USB_EP_TYPE_ISOCHRONOUS = 0x01,
 	USB_EP_TYPE_BULK = 0x02,
@@ -264,7 +264,7 @@ enum usb_ep_type : char {
 /**
  * \brief Standard USB language IDs for string descriptors
  */
-enum usb_langid : char {
+enum usb_langid {
 	USB_LANGID_EN_US = 0x0409, //!< English (United States)
 };
 

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_cdc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_cdc.h
@@ -239,13 +239,13 @@ typedef struct {
 	uint8_t bDataBits;
 } usb_cdc_line_coding_t;
 //! Possible values of bCharFormat
-enum cdc_char_format : char {
+enum cdc_char_format {
 	CDC_STOP_BITS_1 = 0,	//!< 1 stop bit
 	CDC_STOP_BITS_1_5 = 1,	//!< 1.5 stop bits
 	CDC_STOP_BITS_2 = 2,	//!< 2 stop bits
 };
 //! Possible values of bParityType
-enum cdc_parity : char {
+enum cdc_parity {
 	CDC_PAR_NONE = 0,	//!< No parity
 	CDC_PAR_ODD = 1,	//!< Odd parity
 	CDC_PAR_EVEN = 2,	//!< Even parity

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_msc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_protocol_msc.h
@@ -93,7 +93,7 @@
 /**
  * \brief MSC USB requests (bRequest)
  */
-enum usb_reqid_msc : unsigned char {
+enum usb_reqid_msc {
 	USB_REQ_MSC_BULK_RESET = 0xFF,	//!< Mass Storage Reset
 	USB_REQ_MSC_GET_MAX_LUN = 0xFE 	//!< Get Max LUN
 };


### PR DESCRIPTION
The enum changes in [commit 2057177184](https://github.com/MarlinFirmware/Marlin/commit/20571771848e2d8d3bb4f216c25c3d610c7e47cb ) results in compile errors for DUE boards.

I do not understand what is broken so **this is a work around until someone comes up with a permanent fix**.

This PR backs out the enum changes in the DUE USB section.  None of the other sections seem to have a problem.

This PR also changes a Travis test to use a DUE board so that things like this don't slip through again.

This PR addresses Issue #10005 