### PR TITLE
[2.0.x] Have position_is_reachable_by_probe use the whole bed

### DIFF
--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -263,15 +263,16 @@ void homeaxis(const AxisEnum axis);
 #else // CARTESIAN
 
   inline bool position_is_reachable(const float &rx, const float &ry) {
-      // Add 0.001 margin to deal with float imprecision
-      return WITHIN(rx, X_MIN_POS - 0.001, X_MAX_POS + 0.001)
-          && WITHIN(ry, Y_MIN_POS - 0.001, Y_MAX_POS + 0.001);
+    // Add 0.001 margin to deal with float imprecision
+    return WITHIN(rx, X_MIN_POS - 0.001, X_MAX_POS + 0.001)
+        && WITHIN(ry, Y_MIN_POS - 0.001, Y_MAX_POS + 0.001);
   }
 
   inline bool position_is_reachable_by_probe(const float &rx, const float &ry) {
-      // Add 0.001 margin to deal with float imprecision
-      return WITHIN(rx, MIN_PROBE_X - 0.001, MAX_PROBE_X + 0.001)
-          && WITHIN(ry, MIN_PROBE_Y - 0.001, MAX_PROBE_Y + 0.001);
+    const float nx = rx - (X_PROBE_OFFSET_FROM_EXTRUDER), ny = ry - (Y_PROBE_OFFSET_FROM_EXTRUDER);
+    return position_is_reachable(rx, ry)
+        && WITHIN(nx, X_MIN_BED - 0.001, X_MAX_BED + 0.001)
+        && WITHIN(ny, Y_MIN_BED - 0.001, Y_MAX_BED + 0.001);
   }
 
 #endif // CARTESIAN


### PR DESCRIPTION
Fix #9879

Previously `position_is_reachable_by_probe` was limited to the area specified as the bounds for `G29` mesh leveling (even if leveling was disabled). This change modifies the function to properly consider the entire bed area so that `G30` and other non-leveling probing may take place.

Counterpart to #10019