### PR TITLE
[1.1.x] Silence M204

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8863,18 +8863,27 @@ inline void gcode_M203() {
  *    T = Travel (non printing) moves
  */
 inline void gcode_M204() {
-  if (parser.seen('S')) // Kept for legacy compatibility. Should NOT BE USED for new developments.
+  bool report = true;
+  if (parser.seenval('S')) { // Kept for legacy compatibility. Should NOT BE USED for new developments.
     planner.travel_acceleration = planner.acceleration = parser.value_linear_units();
-  else if (parser.seen('P'))
+    report = false;
+  }
+  if (parser.seenval('P')) {
     planner.acceleration = parser.value_linear_units();
-  else if (parser.seen('R'))
+    report = false;
+  }
+  if (parser.seenval('R')) {
     planner.retract_acceleration = parser.value_linear_units();
-  else if (parser.seen('T'))
+    report = false;
+  }
+  if (parser.seenval('T')) {
     planner.travel_acceleration = parser.value_linear_units();
-  else {
-    SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
-    SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
-    SERIAL_ECHOLNPAIR("Setting Travel Acceleration: ", planner.travel_acceleration);
+    report = false;
+  }
+  if (report) {
+    SERIAL_ECHOPAIR("Acceleration: P", planner.acceleration);
+    SERIAL_ECHOPAIR(" R", planner.retract_acceleration);
+    SERIAL_ECHOLNPAIR(" T", planner.travel_acceleration);
   }
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8863,20 +8863,17 @@ inline void gcode_M203() {
  *    T = Travel (non printing) moves
  */
 inline void gcode_M204() {
-  if (parser.seen('S')) {  // Kept for legacy compatibility. Should NOT BE USED for new developments.
+  if (parser.seen('S')) // Kept for legacy compatibility. Should NOT BE USED for new developments.
     planner.travel_acceleration = planner.acceleration = parser.value_linear_units();
-    SERIAL_ECHOLNPAIR("Setting Print and Travel Acceleration: ", planner.acceleration);
-  }
-  if (parser.seen('P')) {
+  else if (parser.seen('P'))
     planner.acceleration = parser.value_linear_units();
-    SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
-  }
-  if (parser.seen('R')) {
+  else if (parser.seen('R'))
     planner.retract_acceleration = parser.value_linear_units();
-    SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
-  }
-  if (parser.seen('T')) {
+  else if (parser.seen('T'))
     planner.travel_acceleration = parser.value_linear_units();
+  else {
+    SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
+    SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
     SERIAL_ECHOLNPAIR("Setting Travel Acceleration: ", planner.travel_acceleration);
   }
 }


### PR DESCRIPTION
M204 is often used by slicers to set acceleration depending on perimeter, infill and so on so Marlins answers are flooding the serial windows. Silence M204 according to the philosophy that commands should
only send an answer if no parameter is given.