### PR TITLE
[2.0.x] Silence M204

### DIFF
--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -91,20 +91,17 @@ void GcodeSuite::M203() {
  *    T = Travel (non printing) moves
  */
 void GcodeSuite::M204() {
-  if (parser.seen('S')) {  // Kept for legacy compatibility. Should NOT BE USED for new developments.
+  if (parser.seen('S')) // Kept for legacy compatibility. Should NOT BE USED for new developments.
     planner.travel_acceleration = planner.acceleration = parser.value_linear_units();
-    SERIAL_ECHOLNPAIR("Setting Print and Travel Acceleration: ", planner.acceleration);
-  }
-  if (parser.seen('P')) {
+  else if (parser.seen('P'))
     planner.acceleration = parser.value_linear_units();
-    SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
-  }
-  if (parser.seen('R')) {
+  else if (parser.seen('R'))
     planner.retract_acceleration = parser.value_linear_units();
-    SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
-  }
-  if (parser.seen('T')) {
+  else if (parser.seen('T'))
     planner.travel_acceleration = parser.value_linear_units();
+  else {
+    SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
+    SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
     SERIAL_ECHOLNPAIR("Setting Travel Acceleration: ", planner.travel_acceleration);
   }
 }

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -91,18 +91,27 @@ void GcodeSuite::M203() {
  *    T = Travel (non printing) moves
  */
 void GcodeSuite::M204() {
-  if (parser.seen('S')) // Kept for legacy compatibility. Should NOT BE USED for new developments.
+  bool report = true;
+  if (parser.seenval('S')) { // Kept for legacy compatibility. Should NOT BE USED for new developments.
     planner.travel_acceleration = planner.acceleration = parser.value_linear_units();
-  else if (parser.seen('P'))
+    report = false;
+  }
+  if (parser.seenval('P')) {
     planner.acceleration = parser.value_linear_units();
-  else if (parser.seen('R'))
+    report = false;
+  }
+  if (parser.seenval('R')) {
     planner.retract_acceleration = parser.value_linear_units();
-  else if (parser.seen('T'))
+    report = false;
+  }
+  if (parser.seenval('T')) {
     planner.travel_acceleration = parser.value_linear_units();
-  else {
-    SERIAL_ECHOLNPAIR("Setting Print Acceleration: ", planner.acceleration);
-    SERIAL_ECHOLNPAIR("Setting Retract Acceleration: ", planner.retract_acceleration);
-    SERIAL_ECHOLNPAIR("Setting Travel Acceleration: ", planner.travel_acceleration);
+    report = false;
+  }
+  if (report) {
+    SERIAL_ECHOPAIR("Acceleration: P", planner.acceleration);
+    SERIAL_ECHOPAIR(" R", planner.retract_acceleration);
+    SERIAL_ECHOLNPAIR(" T", planner.travel_acceleration);
   }
 }
 


### PR DESCRIPTION
M204 is often used by slicers to set acceleration depending on perimeter, infill and so on so Marlins answers are flooding the serial windows. Silence M204 according to the philosophy that commands should only send an answer if no parameter is given.