### PR TITLE
[2.0.x] Add 'C' to M27 to echo filename (plus long name, if any)

### DIFF
--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -85,7 +85,9 @@
  * M24  - Start/resume SD print. (Requires SDSUPPORT)
  * M25  - Pause SD print. (Requires SDSUPPORT)
  * M26  - Set SD position in bytes: "M26 S12345". (Requires SDSUPPORT)
- * M27  - Report SD print status. (Requires SDSUPPORT) Or, with 'S<seconds>' set the SD status auto-report interval. (Requires AUTO_REPORT_SD_STATUS)
+ * M27  - Report SD print status. (Requires SDSUPPORT)
+ *        OR, with 'S<seconds>' set the SD status auto-report interval. (Requires AUTO_REPORT_SD_STATUS)
+ *        OR, with 'C' get the current filename.
  * M28  - Start SD write: "M28 /path/file.gco". (Requires SDSUPPORT)
  * M29  - Stop SD write. (Requires SDSUPPORT)
  * M30  - Delete file from SD: "M30 /path/file.gco"

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
@@ -107,24 +107,35 @@ void GcodeSuite::M26() {
 }
 
 /**
- * M27: Get SD Card status or set the SD status auto-report interval.
+ * M27: Get SD Card status
+ *      OR, with 'S<seconds>' set the SD status auto-report interval. (Requires AUTO_REPORT_SD_STATUS)
+ *      OR, with 'C' get the current filename.
  */
 void GcodeSuite::M27() {
+  #if NUM_SERIAL > 1
+    const int16_t port = command_queue_port[cmd_queue_index_r];
+  #endif
+
+  if (parser.seen('C')) {
+    SERIAL_ECHOPGM_P(port, "Current file: ");
+    card.printFilename();
+  }
+
   #if ENABLED(AUTO_REPORT_SD_STATUS)
-    if (parser.seenval('S')) {
+    else if (parser.seenval('S'))
       card.set_auto_report_interval(parser.value_byte()
         #if NUM_SERIAL > 1
-          , command_queue_port[cmd_queue_index_r]
+          , port
         #endif
       );
-    }
-    else
   #endif
-      card.getStatus(
-        #if NUM_SERIAL > 1
-          command_queue_port[cmd_queue_index_r]
-        #endif
-      );
+
+  else
+    card.getStatus(
+      #if NUM_SERIAL > 1
+        port
+      #endif
+    );
 }
 
 /**

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -262,6 +262,32 @@ void CardReader::ls(
 
 #endif // LONG_FILENAME_HOST_SUPPORT
 
+/**
+ * Echo the DOS 8.3 filename (and long filename, if any)
+ */
+void CardReader::printFilename(
+  #if NUM_SERIAL > 1
+    const int8_t port/*= -1*/
+  #endif
+) {
+  if (file.isOpen()) {
+    char lfilename[FILENAME_LENGTH];
+    file.getFilename(lfilename);
+    SERIAL_ECHO_P(port, lfilename);
+    #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
+      getfilename(0, lfilename);
+      if (longFilename[0]) {
+        SERIAL_ECHO_P(port, ' ');
+        SERIAL_ECHO_P(port, longFilename);
+      }
+    #endif
+  }
+  else
+    SERIAL_ECHOPGM_P(port, "(no file)");
+
+  SERIAL_EOL_P(port);
+}
+
 void CardReader::initsd() {
   cardOK = false;
   if (root.isOpen()) root.close();
@@ -460,8 +486,12 @@ void CardReader::openFile(char* name, const bool read, const bool subcall/*=fals
       SERIAL_PROTOCOLPAIR(MSG_SD_FILE_OPENED, fname);
       SERIAL_PROTOCOLLNPAIR(MSG_SD_SIZE, filesize);
       SERIAL_PROTOCOLLNPGM(MSG_SD_FILE_SELECTED);
+
       getfilename(0, fname);
       lcd_setstatus(longFilename[0] ? longFilename : fname);
+      //if (longFilename[0]) {
+      //  SERIAL_PROTOCOLPAIR(MSG_SD_FILE_LONG_NAME, longFilename);
+      //}
     }
     else {
       SERIAL_PROTOCOLPAIR(MSG_SD_OPEN_FILE_FAIL, fname);

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -157,7 +157,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
         case LS_SerialPrint:
           createFilename(filename, p);
-          SERIAL_PROTOCOL_P(port, prepend);
+          if (prepend) SERIAL_PROTOCOL_P(port, prepend);
           SERIAL_PROTOCOL_P(port, filename);
           SERIAL_PROTOCOLCHAR_P(port, ' ');
           SERIAL_PROTOCOLLN_P(port, p.fileSize);
@@ -184,7 +184,7 @@ void CardReader::ls(
 ) {
   lsAction = LS_SerialPrint;
   root.rewind();
-  lsDive("", root
+  lsDive(NULL, root
     #if NUM_SERIAL > 1
       , NULL, port
     #endif
@@ -227,7 +227,7 @@ void CardReader::ls(
 
       // Find the item, setting the long filename
       diveDir.rewind();
-      lsDive("", diveDir, segment
+      lsDive(NULL, diveDir, segment
         #if NUM_SERIAL > 1
           , port
         #endif
@@ -322,7 +322,7 @@ void CardReader::openAndPrintFile(const char *name) {
 void CardReader::startFileprint() {
   if (cardOK) {
     sdprinting = true;
-    #if ENABLED(SDCARD_SORT_ALPHA)
+    #if SD_RESORT
       flush_presort();
     #endif
   }
@@ -639,7 +639,7 @@ void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/) {
   lsAction = LS_GetFilename;
   nrFile_index = nr;
   curDir->rewind();
-  lsDive("", *curDir, match);
+  lsDive(NULL, *curDir, match);
 }
 
 uint16_t CardReader::getnrfilenames() {
@@ -647,7 +647,7 @@ uint16_t CardReader::getnrfilenames() {
   lsAction = LS_Count;
   nrFiles = 0;
   curDir->rewind();
-  lsDive("", *curDir);
+  lsDive(NULL, *curDir);
   //SERIAL_ECHOLN(nrFiles);
   return nrFiles;
 }

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -63,6 +63,11 @@ public:
     #endif
   );
   void printingHasFinished();
+  void printFilename(
+    #if NUM_SERIAL > 1
+      const int8_t port = -1
+    #endif
+  );
 
   #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
     void printLongPath(char *path


### PR DESCRIPTION
### Description

A PR in reply to https://github.com/MarlinFirmware/Marlin/issues/10001 

It adds an option "C" parameter (current) to the M27 command to echo on the serial port the currently opened file's name.

```
Current file: KEEFE_~1.GCO
```

If the long filename is available (`LONG_FILENAME_HOST_SUPPORT`), it also echoes out the long file name.
```
Current file: KEEFE_~1.GCO Keefe_0002.gcode
```

### Benefits

It allows a process/device connected to the serial port to retrieve the name/long name of a file after it was opened via LCD commands, by an other process on an other serial port, or before connection was established on this port.