### PR TITLE
[1.1.x] Fix MKS_12864_OLED blank issue #10071

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -350,15 +350,14 @@ void lcd_printPGM_utf(const char *str, uint8_t n=LCD_WIDTH) {
 // Initialize or re-initialize the LCD
 static void lcd_implementation_init() {
 
-  #if ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
-    SET_OUTPUT(LCD_PINS_DC);
-    OUT_WRITE(LCD_PINS_RS, LOW);
-    delay(1000);
-    WRITE(LCD_PINS_RS, HIGH);
-  #endif
-
   #if PIN_EXISTS(LCD_BACKLIGHT) // Enable LCD backlight
     OUT_WRITE(LCD_BACKLIGHT_PIN, HIGH);
+  #endif
+
+  #if ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
+    OUT_WRITE(LCD_PINS_RS, LOW);
+    _delay_ms(500);
+    OUT_WRITE(LCD_PINS_RS, HIGH);
   #endif
 
   #if PIN_EXISTS(LCD_RESET)
@@ -366,7 +365,10 @@ static void lcd_implementation_init() {
     _delay_ms(5);
     OUT_WRITE(LCD_RESET_PIN, HIGH);
     _delay_ms(5); // delay to allow the display to initalize
-    u8g.begin(); // re-initialize the display
+  #endif
+
+  #if PIN_EXISTS(LCD_RESET) || ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
+    u8g.begin();
   #endif
 
   #if DISABLED(MINIPANEL) // setContrast not working for Mini Panel


### PR DESCRIPTION
### Description

Fix issue with #10071 unable to light MKS_12864_OLED screen, move OLED reset from `Marlin_main.cpp` to `ultralcd_implement_DOGM.h`, change `delay` function with `_delay_ms` and restart u8g with `u8g.begin()`. Tested on `MKS_12864_OLED` and `BOARD_MKS_13`.

