### PR TITLE
[2.0.x] platformio.ini - add DUE native port support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,7 +77,15 @@ src_filter  = ${common.default_src_filter}
 #  - RAMPS4DUE
 #  - RADDS
 #
-[env:DUE]
+[env:DUE native port]
+platform    = atmelsam
+framework   = arduino
+board       = dueUSB
+build_flags = ${common.build_flags}
+lib_deps    = ${common.lib_deps}
+lib_ignore  = c1921b4
+src_filter  = ${common.default_src_filter}
+[env:DUE programming port]
 platform    = atmelsam
 framework   = arduino
 board       = due


### PR DESCRIPTION
Added **DUE native port** environment so that PlatformIO can upload via DUE's native port.

Renamed the current DUE environment to DUE programming port.