### PR TITLE
Revert "[2.0.x] platformio.ini - add DUE native port support"

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,15 +77,7 @@ src_filter  = ${common.default_src_filter}
 #  - RAMPS4DUE
 #  - RADDS
 #
-[env:DUE native port]
-platform    = atmelsam
-framework   = arduino
-board       = dueUSB
-build_flags = ${common.build_flags}
-lib_deps    = ${common.lib_deps}
-lib_ignore  = c1921b4
-src_filter  = ${common.default_src_filter}
-[env:DUE programming port]
+[env:DUE]
 platform    = atmelsam
 framework   = arduino
 board       = due


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#10096

Causes TRAVIS errors.