### PR TITLE
[1.1.x] More complete Trinamic driver options

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8278,18 +8278,13 @@ inline void gcode_M140() {
       OUT_WRITE(SUICIDE_PIN, HIGH);
     #endif
 
-    #if ENABLED(HAVE_TMC2130)
-      delay(100);
-      tmc2130_init(); // Settings only stick when the driver has power
+    #if DISABLED(AUTO_POWER_CONTROL)
+      delay(100); // Wait for power to settle
+      restore_stepper_drivers();
     #endif
 
     #if ENABLED(ULTIPANEL)
       LCD_MESSAGEPGM(WELCOME_MSG);
-    #endif
-
-    #if ENABLED(HAVE_TMC2208)
-      delay(100);
-      tmc2208_init();
     #endif
   }
 
@@ -13667,6 +13662,7 @@ void setup() {
   SERIAL_PROTOCOLLNPGM("start");
   SERIAL_ECHO_START();
 
+  // Prepare communication for TMC drivers
   #if ENABLED(HAVE_TMC2130)
     tmc_init_cs_pins();
   #endif
@@ -13722,8 +13718,9 @@ void setup() {
 
   print_job_timer.init();   // Initial setup of print job timer
 
-  stepper.init();    // Initialize stepper, this enables interrupts!
-  servo_init();
+  stepper.init();           // Initialize stepper, this enables interrupts!
+
+  servo_init();             // Initialize all servos, stow servo probe
 
   #if HAS_PHOTOGRAPH
     OUT_WRITE(PHOTOGRAPH_PIN, LOW);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10525,46 +10525,100 @@ inline void gcode_M502() {
    * Report driver currents when no axis specified
    */
   inline void gcode_M906() {
-    uint16_t values[XYZE];
-    LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
+    #define TMC_SAY_CURRENT(Q) tmc_get_current(stepper##Q, TMC_##Q)
+    #define TMC_SET_CURRENT(Q) tmc_set_current(stepper##Q, TMC_##Q, value)
 
-    #define TMC_SET_GET_CURRENT(P,Q) do { \
-      if (values[P##_AXIS]) tmc_set_current(stepper##Q, TMC_##Q, values[P##_AXIS]); \
-      else tmc_get_current(stepper##Q, TMC_##Q); } while(0)
+    bool report = true;
+    LOOP_XYZE(i) if (uint16_t value = parser.intval(axis_codes[i])) {
+      report = false;
+      switch (i) {
+        case X_AXIS:
+          #if X_IS_TRINAMIC
+            TMC_SET_CURRENT(X);
+          #endif
+          #if X2_IS_TRINAMIC
+            TMC_SET_CURRENT(X2);
+          #endif
+          break;
+        case Y_AXIS:
+          #if Y_IS_TRINAMIC
+            TMC_SET_CURRENT(Y);
+          #endif
+          #if Y2_IS_TRINAMIC
+            TMC_SET_CURRENT(Y2);
+          #endif
+          break;
+        case Z_AXIS:
+          #if Z_IS_TRINAMIC
+            TMC_SET_CURRENT(Z);
+          #endif
+          #if Z2_IS_TRINAMIC
+            TMC_SET_CURRENT(Z2);
+          #endif
+          break;
+        case E_AXIS:
+          #if E0_IS_TRINAMIC
+            TMC_SET_CURRENT(E0);
+          #endif
+          #if E1_IS_TRINAMIC
+            TMC_SET_CURRENT(E1);
+          #endif
+          #if E2_IS_TRINAMIC
+            TMC_SET_CURRENT(E2);
+          #endif
+          #if E3_IS_TRINAMIC
+            TMC_SET_CURRENT(E3);
+          #endif
+          #if E4_IS_TRINAMIC
+            TMC_SET_CURRENT(E4);
+          #endif
+          break;
+      }
+    }
 
-    #if X_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(X,X);
-    #endif
-    #if X2_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(X,X2);
-    #endif
-    #if Y_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(Y,Y);
-    #endif
-    #if Y2_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(Y,Y2);
-    #endif
-    #if Z_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(Z,Z);
-    #endif
-    #if Z2_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(Z,Z2);
-    #endif
-    #if E0_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(E,E0);
-    #endif
-    #if E1_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(E,E1);
-    #endif
-    #if E2_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(E,E2);
-    #endif
-    #if E3_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(E,E3);
-    #endif
-    #if E4_IS_TRINAMIC
-      TMC_SET_GET_CURRENT(E,E4);
-    #endif
+    if (report) LOOP_XYZE(i) switch (i) {
+      case X_AXIS:
+        #if X_IS_TRINAMIC
+          TMC_SAY_CURRENT(X);
+        #endif
+        #if X2_IS_TRINAMIC
+          TMC_SAY_CURRENT(X2);
+        #endif
+        break;
+      case Y_AXIS:
+        #if Y_IS_TRINAMIC
+          TMC_SAY_CURRENT(Y);
+        #endif
+        #if Y2_IS_TRINAMIC
+          TMC_SAY_CURRENT(Y2);
+        #endif
+        break;
+      case Z_AXIS:
+        #if Z_IS_TRINAMIC
+          TMC_SAY_CURRENT(Z);
+        #endif
+        #if Z2_IS_TRINAMIC
+          TMC_SAY_CURRENT(Z2);
+        #endif
+        break;
+      case E_AXIS:
+        #if E0_IS_TRINAMIC
+          TMC_SAY_CURRENT(E0);
+        #endif
+        #if E1_IS_TRINAMIC
+          TMC_SAY_CURRENT(E1);
+        #endif
+        #if E2_IS_TRINAMIC
+          TMC_SAY_CURRENT(E2);
+        #endif
+        #if E3_IS_TRINAMIC
+          TMC_SAY_CURRENT(E3);
+        #endif
+        #if E4_IS_TRINAMIC
+          TMC_SAY_CURRENT(E4);
+        #endif
+        break;
+    }
   }
 
   /**
@@ -10617,46 +10671,102 @@ inline void gcode_M502() {
    */
   #if ENABLED(HYBRID_THRESHOLD)
     inline void gcode_M913() {
-      uint16_t values[XYZE];
-      LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
+      #define TMC_SAY_PWMTHRS(P,Q) tmc_get_pwmthrs(stepper##Q, TMC_##Q, planner.axis_steps_per_mm[P##_AXIS])
+      #define TMC_SET_PWMTHRS(P,Q) tmc_set_pwmthrs(stepper##Q, TMC_##Q, value, planner.axis_steps_per_mm[P##_AXIS])
+      #define TMC_SAY_PWMTHRS_E(E) do{ const uint8_t extruder = E; tmc_get_pwmthrs(stepperE##E, TMC_E##E, planner.axis_steps_per_mm[E_AXIS_N]); }while(0)
+      #define TMC_SET_PWMTHRS_E(E) do{ const uint8_t extruder = E; tmc_set_pwmthrs(stepperE##E, TMC_E##E, value, planner.axis_steps_per_mm[E_AXIS_N]); }while(0)
 
-      #define TMC_SET_GET_PWMTHRS(P,Q) do { \
-        if (values[P##_AXIS]) tmc_set_pwmthrs(stepper##Q, TMC_##Q, values[P##_AXIS], planner.axis_steps_per_mm[P##_AXIS]); \
-        else tmc_get_pwmthrs(stepper##Q, TMC_##Q, planner.axis_steps_per_mm[P##_AXIS]); } while(0)
+      bool report = true;
+      LOOP_XYZE(i) if (int32_t value = parser.longval(axis_codes[i])) {
+        report = false;
+        switch (i) {
+          case X_AXIS:
+            #if X_IS_TRINAMIC
+              TMC_SET_PWMTHRS(X,X);
+            #endif
+            #if X2_IS_TRINAMIC
+              TMC_SET_PWMTHRS(X,X2);
+            #endif
+            break;
+          case Y_AXIS:
+            #if Y_IS_TRINAMIC
+              TMC_SET_PWMTHRS(Y,Y);
+            #endif
+            #if Y2_IS_TRINAMIC
+              TMC_SET_PWMTHRS(Y,Y2);
+            #endif
+            break;
+          case Z_AXIS:
+            #if Z_IS_TRINAMIC
+              TMC_SET_PWMTHRS(Z,Z);
+            #endif
+            #if Z2_IS_TRINAMIC
+              TMC_SET_PWMTHRS(Z,Z2);
+            #endif
+            break;
+          case E_AXIS:
+            #if E0_IS_TRINAMIC
+              TMC_SET_PWMTHRS_E(0);
+            #endif
+            #if E1_IS_TRINAMIC
+              TMC_SET_PWMTHRS_E(1);
+            #endif
+            #if E2_IS_TRINAMIC
+              TMC_SET_PWMTHRS_E(2);
+            #endif
+            #if E3_IS_TRINAMIC
+              TMC_SET_PWMTHRS_E(3);
+            #endif
+            #if E4_IS_TRINAMIC
+              TMC_SET_PWMTHRS_E(4);
+            #endif
+            break;
+        }
+      }
 
-      #if X_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(X,X);
-      #endif
-      #if X2_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(X,X2);
-      #endif
-      #if Y_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(Y,Y);
-      #endif
-      #if Y2_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(Y,Y2);
-      #endif
-      #if Z_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(Z,Z);
-      #endif
-      #if Z2_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(Z,Z2);
-      #endif
-      #if E0_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(E,E0);
-      #endif
-      #if E1_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(E,E1);
-      #endif
-      #if E2_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(E,E2);
-      #endif
-      #if E3_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(E,E3);
-      #endif
-      #if E4_IS_TRINAMIC
-        TMC_SET_GET_PWMTHRS(E,E4);
-      #endif
+      if (report) LOOP_XYZE(i) switch (i) {
+        case X_AXIS:
+          #if X_IS_TRINAMIC
+            TMC_SAY_PWMTHRS(X,X);
+          #endif
+          #if X2_IS_TRINAMIC
+            TMC_SAY_PWMTHRS(X,X2);
+          #endif
+          break;
+        case Y_AXIS:
+          #if Y_IS_TRINAMIC
+            TMC_SAY_PWMTHRS(Y,Y);
+          #endif
+          #if Y2_IS_TRINAMIC
+            TMC_SAY_PWMTHRS(Y,Y2);
+          #endif
+          break;
+        case Z_AXIS:
+          #if Z_IS_TRINAMIC
+            TMC_SAY_PWMTHRS(Z,Z);
+          #endif
+          #if Z2_IS_TRINAMIC
+            TMC_SAY_PWMTHRS(Z,Z2);
+          #endif
+          break;
+        case E_AXIS:
+          #if E0_IS_TRINAMIC
+            TMC_SAY_PWMTHRS_E(0);
+          #endif
+          #if E1_IS_TRINAMIC
+            TMC_SAY_PWMTHRS_E(1);
+          #endif
+          #if E2_IS_TRINAMIC
+            TMC_SAY_PWMTHRS_E(2);
+          #endif
+          #if E3_IS_TRINAMIC
+            TMC_SAY_PWMTHRS_E(3);
+          #endif
+          #if E4_IS_TRINAMIC
+            TMC_SAY_PWMTHRS_E(4);
+          #endif
+          break;
+      }
     }
   #endif // HYBRID_THRESHOLD
 
@@ -10665,34 +10775,67 @@ inline void gcode_M502() {
    */
   #if ENABLED(SENSORLESS_HOMING)
     inline void gcode_M914() {
-      #define TMC_SET_GET_SGT(P,Q) do { \
-        if (parser.seen(axis_codes[P##_AXIS])) tmc_set_sgt(stepper##Q, TMC_##Q, parser.value_int()); \
-        else tmc_get_sgt(stepper##Q, TMC_##Q); } while(0)
+      #define TMC_SAY_SGT(Q) tmc_get_sgt(stepper##Q, TMC_##Q)
+      #define TMC_SET_SGT(Q) tmc_set_sgt(stepper##Q, TMC_##Q, value)
 
-      #ifdef X_HOMING_SENSITIVITY
-        #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-          TMC_SET_GET_SGT(X,X);
-        #endif
-        #if ENABLED(X2_IS_TMC2130)
-          TMC_SET_GET_SGT(X,X2);
-        #endif
-      #endif
-      #ifdef Y_HOMING_SENSITIVITY
-        #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-          TMC_SET_GET_SGT(Y,Y);
-        #endif
-        #if ENABLED(Y2_IS_TMC2130)
-          TMC_SET_GET_SGT(Y,Y2);
-        #endif
-      #endif
-      #ifdef Z_HOMING_SENSITIVITY
-        #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-          TMC_SET_GET_SGT(Z,Z);
-        #endif
-        #if ENABLED(Z2_IS_TMC2130)
-          TMC_SET_GET_SGT(Z,Z2);
-        #endif
-      #endif
+      bool report = true;
+      LOOP_XYZ(i) if (parser.seen(axis_codes[i])) {
+        const int8_t value = (int8_t)constrain(parser.value_int(), -63, 64);
+        report = false;
+        switch (i) {
+          case X_AXIS:
+            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+              TMC_SET_SGT(X);
+            #endif
+            #if ENABLED(X2_IS_TMC2130)
+              TMC_SET_SGT(X2);
+            #endif
+            break;
+          case Y_AXIS:
+            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+              TMC_SET_SGT(Y);
+            #endif
+            #if ENABLED(Y2_IS_TMC2130)
+              TMC_SET_SGT(Y2);
+            #endif
+            break;
+          case Z_AXIS:
+            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+              TMC_SET_SGT(Z);
+            #endif
+            #if ENABLED(Z2_IS_TMC2130)
+              TMC_SET_SGT(Z2);
+            #endif
+            break;
+        }
+      }
+
+      if (report) LOOP_XYZ(i) switch (i) {
+        case X_AXIS:
+          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(X);
+          #endif
+          #if ENABLED(X2_IS_TMC2130)
+            TMC_SAY_SGT(X2);
+          #endif
+          break;
+        case Y_AXIS:
+          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(Y);
+          #endif
+          #if ENABLED(Y2_IS_TMC2130)
+            TMC_SAY_SGT(Y2);
+          #endif
+          break;
+        case Z_AXIS:
+          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(Z);
+          #endif
+          #if ENABLED(Z2_IS_TMC2130)
+            TMC_SAY_SGT(Z2);
+          #endif
+          break;
+      }
     }
   #endif // SENSORLESS_HOMING
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10529,50 +10529,54 @@ inline void gcode_M502() {
     #define TMC_SET_CURRENT(Q) tmc_set_current(stepper##Q, TMC_##Q, value)
 
     bool report = true;
+    const uint8_t index = parser.byteval('I');
     LOOP_XYZE(i) if (uint16_t value = parser.intval(axis_codes[i])) {
       report = false;
       switch (i) {
         case X_AXIS:
           #if X_IS_TRINAMIC
-            TMC_SET_CURRENT(X);
+            if (index == 0) TMC_SET_CURRENT(X);
           #endif
           #if X2_IS_TRINAMIC
-            TMC_SET_CURRENT(X2);
+            if (index == 1) TMC_SET_CURRENT(X2);
           #endif
           break;
         case Y_AXIS:
           #if Y_IS_TRINAMIC
-            TMC_SET_CURRENT(Y);
+            if (index == 0) TMC_SET_CURRENT(Y);
           #endif
           #if Y2_IS_TRINAMIC
-            TMC_SET_CURRENT(Y2);
+            if (index == 1) TMC_SET_CURRENT(Y2);
           #endif
           break;
         case Z_AXIS:
           #if Z_IS_TRINAMIC
-            TMC_SET_CURRENT(Z);
+            if (index == 0) TMC_SET_CURRENT(Z);
           #endif
           #if Z2_IS_TRINAMIC
-            TMC_SET_CURRENT(Z2);
+            if (index == 1) TMC_SET_CURRENT(Z2);
           #endif
           break;
-        case E_AXIS:
-          #if E0_IS_TRINAMIC
-            TMC_SET_CURRENT(E0);
-          #endif
-          #if E1_IS_TRINAMIC
-            TMC_SET_CURRENT(E1);
-          #endif
-          #if E2_IS_TRINAMIC
-            TMC_SET_CURRENT(E2);
-          #endif
-          #if E3_IS_TRINAMIC
-            TMC_SET_CURRENT(E3);
-          #endif
-          #if E4_IS_TRINAMIC
-            TMC_SET_CURRENT(E4);
-          #endif
-          break;
+        case E_AXIS: {
+          if (get_target_extruder_from_command(906)) return;
+          switch (target_extruder) {
+            #if E0_IS_TRINAMIC
+              case 0: TMC_SET_CURRENT(E0); break;
+            #endif
+            #if E1_IS_TRINAMIC
+              case 1: TMC_SET_CURRENT(E1); break;
+            #endif
+            #if E2_IS_TRINAMIC
+              case 2: TMC_SET_CURRENT(E2); break;
+            #endif
+            #if E3_IS_TRINAMIC
+              case 3: TMC_SET_CURRENT(E3); break;
+            #endif
+            #if E4_IS_TRINAMIC
+              case 4: TMC_SET_CURRENT(E4); break;
+            #endif
+          }
+        } break;
       }
     }
 
@@ -10677,50 +10681,54 @@ inline void gcode_M502() {
       #define TMC_SET_PWMTHRS_E(E) do{ const uint8_t extruder = E; tmc_set_pwmthrs(stepperE##E, TMC_E##E, value, planner.axis_steps_per_mm[E_AXIS_N]); }while(0)
 
       bool report = true;
+      const uint8_t index = parser.byteval('I');
       LOOP_XYZE(i) if (int32_t value = parser.longval(axis_codes[i])) {
         report = false;
         switch (i) {
           case X_AXIS:
             #if X_IS_TRINAMIC
-              TMC_SET_PWMTHRS(X,X);
+              if (index == 0) TMC_SET_PWMTHRS(X,X);
             #endif
             #if X2_IS_TRINAMIC
-              TMC_SET_PWMTHRS(X,X2);
+              if (index == 1) TMC_SET_PWMTHRS(X,X2);
             #endif
             break;
           case Y_AXIS:
             #if Y_IS_TRINAMIC
-              TMC_SET_PWMTHRS(Y,Y);
+              if (index == 0) TMC_SET_PWMTHRS(Y,Y);
             #endif
             #if Y2_IS_TRINAMIC
-              TMC_SET_PWMTHRS(Y,Y2);
+              if (index == 1) TMC_SET_PWMTHRS(Y,Y2);
             #endif
             break;
           case Z_AXIS:
             #if Z_IS_TRINAMIC
-              TMC_SET_PWMTHRS(Z,Z);
+              if (index == 0) TMC_SET_PWMTHRS(Z,Z);
             #endif
             #if Z2_IS_TRINAMIC
-              TMC_SET_PWMTHRS(Z,Z2);
+              if (index == 1) TMC_SET_PWMTHRS(Z,Z2);
             #endif
             break;
-          case E_AXIS:
-            #if E0_IS_TRINAMIC
-              TMC_SET_PWMTHRS_E(0);
-            #endif
-            #if E1_IS_TRINAMIC
-              TMC_SET_PWMTHRS_E(1);
-            #endif
-            #if E2_IS_TRINAMIC
-              TMC_SET_PWMTHRS_E(2);
-            #endif
-            #if E3_IS_TRINAMIC
-              TMC_SET_PWMTHRS_E(3);
-            #endif
-            #if E4_IS_TRINAMIC
-              TMC_SET_PWMTHRS_E(4);
-            #endif
-            break;
+          case E_AXIS: {
+            if (get_target_extruder_from_command(913)) return;
+            switch (target_extruder) {
+              #if E0_IS_TRINAMIC
+                case 0: TMC_SET_PWMTHRS_E(0); break;
+              #endif
+              #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+                case 1: TMC_SET_PWMTHRS_E(1); break;
+              #endif
+              #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+                case 2: TMC_SET_PWMTHRS_E(2); break;
+              #endif
+              #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+                case 3: TMC_SET_PWMTHRS_E(3); break;
+              #endif
+              #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+                case 4: TMC_SET_PWMTHRS_E(4); break;
+              #endif
+            }
+          } break;
         }
       }
 
@@ -10753,16 +10761,16 @@ inline void gcode_M502() {
           #if E0_IS_TRINAMIC
             TMC_SAY_PWMTHRS_E(0);
           #endif
-          #if E1_IS_TRINAMIC
+          #if E_STEPPERS > 1 && E1_IS_TRINAMIC
             TMC_SAY_PWMTHRS_E(1);
           #endif
-          #if E2_IS_TRINAMIC
+          #if E_STEPPERS > 2 && E2_IS_TRINAMIC
             TMC_SAY_PWMTHRS_E(2);
           #endif
-          #if E3_IS_TRINAMIC
+          #if E_STEPPERS > 3 && E3_IS_TRINAMIC
             TMC_SAY_PWMTHRS_E(3);
           #endif
-          #if E4_IS_TRINAMIC
+          #if E_STEPPERS > 4 && E4_IS_TRINAMIC
             TMC_SAY_PWMTHRS_E(4);
           #endif
           break;
@@ -10779,32 +10787,33 @@ inline void gcode_M502() {
       #define TMC_SET_SGT(Q) tmc_set_sgt(stepper##Q, TMC_##Q, value)
 
       bool report = true;
+      const uint8_t index = parser.byteval('I');
       LOOP_XYZ(i) if (parser.seen(axis_codes[i])) {
         const int8_t value = (int8_t)constrain(parser.value_int(), -63, 64);
         report = false;
         switch (i) {
           case X_AXIS:
             #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-              TMC_SET_SGT(X);
+              if (index == 0) TMC_SET_SGT(X);
             #endif
             #if ENABLED(X2_IS_TMC2130)
-              TMC_SET_SGT(X2);
+              if (index == 1) TMC_SET_SGT(X2);
             #endif
             break;
           case Y_AXIS:
             #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-              TMC_SET_SGT(Y);
+              if (index == 0) TMC_SET_SGT(Y);
             #endif
             #if ENABLED(Y2_IS_TMC2130)
-              TMC_SET_SGT(Y2);
+              if (index == 1) TMC_SET_SGT(Y2);
             #endif
             break;
           case Z_AXIS:
             #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-              TMC_SET_SGT(Z);
+              if (index == 0) TMC_SET_SGT(Z);
             #endif
             #if ENABLED(Z2_IS_TMC2130)
-              TMC_SET_SGT(Z2);
+              if (index == 1) TMC_SET_SGT(Z2);
             #endif
             break;
         }

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V52"
+#define EEPROM_VERSION "V53"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -61,6 +61,8 @@
 
 #if HAS_TRINAMIC
   #include "stepper_indirection.h"
+  #include "tmc_util.h"
+  #define TMC_GET_PWMTHRS(P,Q) _tmc_thrs(stepper##Q.microsteps(), stepper##Q.TPWMTHRS(), planner.axis_steps_per_mm[P##_AXIS])
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -215,7 +217,9 @@ typedef struct SettingsDataStruct {
   //
   // HAS_TRINAMIC
   //
-  uint16_t tmc_stepper_current[11];                     // M906 X Y Z X2 Y2 Z2 E0 E1 E2 E3 E4
+  #define TMC_AXES (MAX_EXTRUDERS + 6)
+  uint16_t tmc_stepper_current[TMC_AXES];               // M906 X Y Z X2 Y2 Z2 E0 E1 E2 E3 E4
+  uint32_t tmc_hybrid_threshold[TMC_AXES];              // M913 X Y Z X2 Y2 Z2 E0 E1 E2 E3 E4
   int16_t tmc_sgt[XYZ];                                 // M914 X Y Z
 
   //
@@ -673,7 +677,7 @@ void MarlinSettings::postprocess() {
 
     _FIELD_TEST(tmc_stepper_current);
 
-    uint16_t currents[11] = {
+    uint16_t tmc_stepper_current[TMC_AXES] = {
       #if HAS_TRINAMIC
         #if X_IS_TRINAMIC
           stepperX.getCurrent(),
@@ -734,24 +738,95 @@ void MarlinSettings::postprocess() {
         0
       #endif
     };
-    EEPROM_WRITE(currents);
+    EEPROM_WRITE(tmc_stepper_current);
+
+    //
+    // Save TMC2130 or TMC2208 Hybrid Threshold, and placeholder values
+    //
+
+    _FIELD_TEST(tmc_hybrid_threshold);
+
+    uint32_t tmc_hybrid_threshold[TMC_AXES] = {
+      #if HAS_TRINAMIC
+        #if X_IS_TRINAMIC
+          TMC_GET_PWMTHRS(X, X),
+        #else
+          X_HYBRID_THRESHOLD,
+        #endif
+        #if Y_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Y, Y),
+        #else
+          Y_HYBRID_THRESHOLD,
+        #endif
+        #if Z_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Z, Z),
+        #else
+          Z_HYBRID_THRESHOLD,
+        #endif
+        #if X2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(X, X2),
+        #else
+          X2_HYBRID_THRESHOLD,
+        #endif
+        #if Y2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Y, Y2),
+        #else
+          Y2_HYBRID_THRESHOLD,
+        #endif
+        #if Z2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Z, Z2),
+        #else
+          Z2_HYBRID_THRESHOLD,
+        #endif
+        #if E0_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E0),
+        #else
+          E0_HYBRID_THRESHOLD,
+        #endif
+        #if E1_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E1),
+        #else
+          E1_HYBRID_THRESHOLD,
+        #endif
+        #if E2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E2),
+        #else
+          E2_HYBRID_THRESHOLD,
+        #endif
+        #if E3_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E3),
+        #else
+          E3_HYBRID_THRESHOLD,
+        #endif
+        #if E4_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E4)
+        #else
+          E4_HYBRID_THRESHOLD
+        #endif
+      #else
+        100, 100, 3,          // X, Y, Z
+        100, 100, 3,          // X2, Y2, Z2
+        30, 30, 30, 30, 30    // E0, E1, E2, E3, E4
+      #endif
+    };
+    EEPROM_WRITE(tmc_hybrid_threshold);
 
     //
     // TMC2130 Sensorless homing threshold
     //
-    int16_t thrs[XYZ] = {
+    int16_t tmc_sgt[XYZ] = {
       #if ENABLED(SENSORLESS_HOMING)
-        #if ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY)
+        #if defined(X_HOMING_SENSITIVITY) && (ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS))
           stepperX.sgt(),
         #else
           0,
         #endif
-        #if ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY)
+        #if defined(Y_HOMING_SENSITIVITY) && (ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS))
           stepperY.sgt(),
         #else
           0
         #endif
-        #if ENABLED(Z_IS_TMC2130) && defined(Z_HOMING_SENSITIVITY)
+        #if defined(Z_HOMING_SENSITIVITY) && (ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS))
           stepperZ.sgt()
         #else
           0
@@ -760,7 +835,7 @@ void MarlinSettings::postprocess() {
         0
       #endif
     };
-    EEPROM_WRITE(thrs);
+    EEPROM_WRITE(tmc_sgt);
 
     //
     // Linear Advance
@@ -1211,54 +1286,101 @@ void MarlinSettings::postprocess() {
 
       #endif
 
+      if (!validating) reset_stepper_drivers();
+
       //
-      // TMC2130 Stepper Current
+      // TMC2130 Stepper Settings
       //
 
       _FIELD_TEST(tmc_stepper_current);
 
       #if HAS_TRINAMIC
-        #define SET_CURR(N,Q) stepper##Q.setCurrent(currents[N] ? currents[N] : Q##_CURRENT, R_SENSE, HOLD_MULTIPLIER)
-        uint16_t currents[11];
+
+        #define SET_CURR(Q) stepper##Q.setCurrent(currents[TMC_##Q] ? currents[TMC_##Q] : Q##_CURRENT, R_SENSE, HOLD_MULTIPLIER)
+        uint16_t currents[TMC_AXES];
         EEPROM_READ(currents);
         if (!validating) {
           #if X_IS_TRINAMIC
-            SET_CURR(0, X);
+            SET_CURR(X);
           #endif
           #if Y_IS_TRINAMIC
-            SET_CURR(1, Y);
+            SET_CURR(Y);
           #endif
           #if Z_IS_TRINAMIC
-            SET_CURR(2, Z);
+            SET_CURR(Z);
           #endif
           #if X2_IS_TRINAMIC
-            SET_CURR(3, X2);
+            SET_CURR(X2);
           #endif
           #if Y2_IS_TRINAMIC
-            SET_CURR(4, Y2);
+            SET_CURR(Y2);
           #endif
           #if Z2_IS_TRINAMIC
-            SET_CURR(5, Z2);
+            SET_CURR(Z2);
           #endif
           #if E0_IS_TRINAMIC
-            SET_CURR(6, E0);
+            SET_CURR(E0);
           #endif
           #if E1_IS_TRINAMIC
-            SET_CURR(7, E1);
+            SET_CURR(E1);
           #endif
           #if E2_IS_TRINAMIC
-            SET_CURR(8, E2);
+            SET_CURR(E2);
           #endif
           #if E3_IS_TRINAMIC
-            SET_CURR(9, E3);
+            SET_CURR(E3);
           #endif
           #if E4_IS_TRINAMIC
-            SET_CURR(10, E4);
+            SET_CURR(E4);
           #endif
         }
       #else
         uint16_t val;
-        for (uint8_t q=11; q--;) EEPROM_READ(val);
+        for (uint8_t q=TMC_AXES; q--;) EEPROM_READ(val);
+      #endif
+
+      #if HAS_TRINAMIC
+        #define TMC_SET_PWMTHRS(P,Q) tmc_set_pwmthrs(stepper##Q, TMC_##Q, tmc_hybrid_threshold[TMC_##Q], planner.axis_steps_per_mm[P##_AXIS])
+        uint16_t tmc_hybrid_threshold[TMC_AXES];
+        EEPROM_READ(tmc_hybrid_threshold);
+        if (!validating) {
+          #if X_IS_TRINAMIC
+            TMC_SET_PWMTHRS(X, X);
+          #endif
+          #if Y_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Y, Y);
+          #endif
+          #if Z_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Z, Z);
+          #endif
+          #if X2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(X, X2);
+          #endif
+          #if Y2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Y, Y2);
+          #endif
+          #if Z2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Z, Z2);
+          #endif
+          #if E0_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E0);
+          #endif
+          #if E1_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E1);
+          #endif
+          #if E2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E2);
+          #endif
+          #if E3_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E3);
+          #endif
+          #if E4_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E4);
+          #endif
+        }
+      #else
+        uint16_t thrs_val;
+        for (uint8_t q=TMC_AXES; q--;) EEPROM_READ(thrs_val);
       #endif
 
       /*
@@ -1267,32 +1389,32 @@ void MarlinSettings::postprocess() {
        * Y and Y2 use the same value
        * Z and Z2 use the same value
        */
-      int16_t thrs[XYZ];
-      EEPROM_READ(thrs);
+      int16_t tmc_sgt[XYZ];
+      EEPROM_READ(tmc_sgt);
       #if ENABLED(SENSORLESS_HOMING)
         if (!validating) {
           #ifdef X_HOMING_SENSITIVITY
-            #if ENABLED(X_IS_TMC2130)
-              stepperX.sgt(thrs[0]);
+            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+              stepperX.sgt(tmc_sgt[0]);
             #endif
             #if ENABLED(X2_IS_TMC2130)
-              stepperX2.sgt(thrs[0]);
+              stepperX2.sgt(tmc_sgt[0]);
             #endif
           #endif
           #ifdef Y_HOMING_SENSITIVITY
-            #if ENABLED(Y_IS_TMC2130)
-              stepperY.sgt(thrs[1]);
+            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+              stepperY.sgt(tmc_sgt[1]);
             #endif
             #if ENABLED(Y2_IS_TMC2130)
-              stepperY2.sgt(thrs[1]);
+              stepperY2.sgt(tmc_sgt[1]);
             #endif
           #endif
           #ifdef Z_HOMING_SENSITIVITY
-            #if ENABLED(Z_IS_TMC2130)
-              stepperZ.sgt(thrs[2]);
+            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+              stepperZ.sgt(tmc_sgt[2]);
             #endif
             #if ENABLED(Z2_IS_TMC2130)
-              stepperZ2.sgt(thrs[2]);
+              stepperZ2.sgt(tmc_sgt[2]);
             #endif
           #endif
         }
@@ -1729,66 +1851,7 @@ void MarlinSettings::reset() {
     #endif
   );
 
-  #if X_IS_TRINAMIC
-    stepperX.setCurrent(X_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Y_IS_TRINAMIC
-    stepperY.setCurrent(Y_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Z_IS_TRINAMIC
-    stepperZ.setCurrent(Z_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if X2_IS_TRINAMIC
-    stepperX2.setCurrent(X2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Y2_IS_TRINAMIC
-    stepperY2.setCurrent(Y2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Z2_IS_TRINAMIC
-    stepperZ2.setCurrent(Z2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E0_IS_TRINAMIC
-    stepperE0.setCurrent(E0_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E1_IS_TRINAMIC
-    stepperE1.setCurrent(E1_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E2_IS_TRINAMIC
-    stepperE2.setCurrent(E2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E3_IS_TRINAMIC
-    stepperE3.setCurrent(E3_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E4_IS_TRINAMIC
-    stepperE4.setCurrent(E4_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-
-  #if ENABLED(SENSORLESS_HOMING)
-    #ifdef X_HOMING_SENSITIVITY
-      #if ENABLED(X_IS_TMC2130)
-        stepperX.sgt(X_HOMING_SENSITIVITY);
-      #endif
-      #if ENABLED(X2_IS_TMC2130)
-        stepperX2.sgt(X_HOMING_SENSITIVITY);
-      #endif
-    #endif
-    #ifdef Y_HOMING_SENSITIVITY
-      #if ENABLED(Y_IS_TMC2130)
-        stepperY.sgt(Y_HOMING_SENSITIVITY);
-      #endif
-      #if ENABLED(Y2_IS_TMC2130)
-        stepperY2.sgt(Y_HOMING_SENSITIVITY);
-      #endif
-    #endif
-    #ifdef Z_HOMING_SENSITIVITY
-      #if ENABLED(Z_IS_TMC2130)
-        stepperZ.sgt(Z_HOMING_SENSITIVITY);
-      #endif
-      #if ENABLED(Z2_IS_TMC2130)
-        stepperZ2.sgt(Z_HOMING_SENSITIVITY);
-      #endif
-    #endif
-  #endif
+  reset_stepper_drivers();
 
   #if ENABLED(LIN_ADVANCE)
     planner.extruder_advance_K = LIN_ADVANCE_K;
@@ -1826,6 +1889,18 @@ void MarlinSettings::reset() {
 #if DISABLED(DISABLE_M503)
 
   #define CONFIG_ECHO_START do{ if (!forReplay) SERIAL_ECHO_START(); }while(0)
+
+  #if HAS_TRINAMIC
+    void say_M906() { SERIAL_ECHOPGM("  M906 "); }
+    void say_M913() { SERIAL_ECHOPGM("  M913 "); }
+    #if ENABLED(SENSORLESS_HOMING)
+      void say_M914() { SERIAL_ECHOPGM("  M914 "); }
+    #endif
+  #endif
+
+  #if ENABLED(ADVANCED_PAUSE_FEATURE)
+    void say_M603() { SERIAL_ECHOPGM("  M603 "); }
+  #endif
 
   /**
    * M503 - Report current settings in RAM
@@ -2109,6 +2184,7 @@ void MarlinSettings::reset() {
     #endif // HAS_LEVELING
 
     #if ENABLED(DELTA)
+
       if (!forReplay) {
         CONFIG_ECHO_START;
         SERIAL_ECHOLNPGM("Endstop adjustment:");
@@ -2133,6 +2209,7 @@ void MarlinSettings::reset() {
       SERIAL_EOL();
 
     #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
+
       if (!forReplay) {
         CONFIG_ECHO_START;
         SERIAL_ECHOLNPGM("Endstop adjustment:");
@@ -2149,7 +2226,8 @@ void MarlinSettings::reset() {
         SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(endstops.z_endstop_adj));
       #endif
       SERIAL_EOL();
-    #endif // DELTA
+
+    #endif // [XYZ]_DUAL_ENDSTOPS
 
     #if ENABLED(ULTIPANEL)
       if (!forReplay) {
@@ -2288,88 +2366,159 @@ void MarlinSettings::reset() {
       #endif
     #endif
 
-    /**
-     * TMC2130 stepper driver current
-     */
     #if HAS_TRINAMIC
+
+      /**
+       * TMC2130 / TMC2208 / TRAMS stepper driver current
+       */
       if (!forReplay) {
         CONFIG_ECHO_START;
         SERIAL_ECHOLNPGM("Stepper driver current:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPGM("  M906");
-      #if ENABLED(X_IS_TMC2130) || ENABLED(X_IS_TMC2208)
-        SERIAL_ECHOPAIR(" X ", stepperX.getCurrent());
+      #if X_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("X", stepperX.getCurrent());
       #endif
-      #if ENABLED(Y_IS_TMC2130) || ENABLED(Y_IS_TMC2208)
-        SERIAL_ECHOPAIR(" Y ", stepperY.getCurrent());
+      #if X2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("I1 X", stepperX2.getCurrent());
       #endif
-      #if ENABLED(Z_IS_TMC2130) || ENABLED(Z_IS_TMC2208)
-        SERIAL_ECHOPAIR(" Z ", stepperZ.getCurrent());
+      #if Y_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("Y", stepperY.getCurrent());
       #endif
-      #if ENABLED(X2_IS_TMC2130) || ENABLED(X2_IS_TMC2208)
-        SERIAL_ECHOPAIR(" X2 ", stepperX2.getCurrent());
+      #if Y2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("I1 Y", stepperY2.getCurrent());
       #endif
-      #if ENABLED(Y2_IS_TMC2130) || ENABLED(Y2_IS_TMC2208)
-        SERIAL_ECHOPAIR(" Y2 ", stepperY2.getCurrent());
+      #if Z_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("Z", stepperZ.getCurrent());
       #endif
-      #if ENABLED(Z2_IS_TMC2130) || ENABLED(Z2_IS_TMC2208)
-        SERIAL_ECHOPAIR(" Z2 ", stepperZ2.getCurrent());
+      #if Z2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("I1 Z", stepperZ2.getCurrent());
       #endif
-      #if ENABLED(E0_IS_TMC2130) || ENABLED(E0_IS_TMC2208)
-        SERIAL_ECHOPAIR(" E0 ", stepperE0.getCurrent());
+      #if E0_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("T0 E", stepperE0.getCurrent());
       #endif
-      #if ENABLED(E1_IS_TMC2130) || ENABLED(E1_IS_TMC2208)
-        SERIAL_ECHOPAIR(" E1 ", stepperE1.getCurrent());
+      #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("T1 E", stepperE1.getCurrent());
       #endif
-      #if ENABLED(E2_IS_TMC2130) || ENABLED(E2_IS_TMC2208)
-        SERIAL_ECHOPAIR(" E2 ", stepperE2.getCurrent());
+      #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("T2 E", stepperE2.getCurrent());
       #endif
-      #if ENABLED(E3_IS_TMC2130) || ENABLED(E3_IS_TMC2208)
-        SERIAL_ECHOPAIR(" E3 ", stepperE3.getCurrent());
+      #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("T3 E", stepperE3.getCurrent());
       #endif
-      #if ENABLED(E4_IS_TMC2130) || ENABLED(E4_IS_TMC2208)
-        SERIAL_ECHOPAIR(" E4 ", stepperE4.getCurrent());
+      #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR("T4 E", stepperE4.getCurrent());
       #endif
       SERIAL_EOL();
-    #endif
 
-    /**
-     * TMC2130 Sensorless homing thresholds
-     */
-    #if ENABLED(SENSORLESS_HOMING)
+      /**
+       * TMC2130 / TMC2208 / TRAMS Hybrid Threshold
+       */
       if (!forReplay) {
         CONFIG_ECHO_START;
-        SERIAL_ECHOLNPGM("Sensorless homing threshold:");
+        SERIAL_ECHOLNPGM("Hybrid Threshold:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPGM("  M914");
-      #ifdef X_HOMING_SENSITIVITY
-        #if ENABLED(X_IS_TMC2130)
-          SERIAL_ECHOPAIR(" X", stepperX.sgt());
-        #endif
-        #if ENABLED(X2_IS_TMC2130)
-          SERIAL_ECHOPAIR(" X2 ", stepperX2.sgt());
-        #endif
+      #if X_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("X", TMC_GET_PWMTHRS(X, X));
       #endif
-      #ifdef Y_HOMING_SENSITIVITY
-        #if ENABLED(Y_IS_TMC2130)
-          SERIAL_ECHOPAIR(" Y", stepperY.sgt());
-        #endif
-        #if ENABLED(X2_IS_TMC2130)
-          SERIAL_ECHOPAIR(" Y2 ", stepperY2.sgt());
-        #endif
+      #if X2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("I1 X", TMC_GET_PWMTHRS(X, X2));
       #endif
-      #ifdef Z_HOMING_SENSITIVITY
-        #if ENABLED(Z_IS_TMC2130)
-          SERIAL_ECHOPAIR(" Z", stepperZ.sgt());
-        #endif
-        #if ENABLED(Z2_IS_TMC2130)
-          SERIAL_ECHOPAIR(" Z2 ", stepperZ2.sgt());
-        #endif
+      #if Y_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("Y", TMC_GET_PWMTHRS(Y, Y));
+      #endif
+      #if Y2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("I1 Y", TMC_GET_PWMTHRS(Y, Y2));
+      #endif
+      #if Z_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("Z", TMC_GET_PWMTHRS(Z, Z));
+      #endif
+      #if Z2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("I1 Z", TMC_GET_PWMTHRS(Z, Z2));
+      #endif
+      #if E0_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("T0 E", TMC_GET_PWMTHRS(E, E0));
+      #endif
+      #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("T1 E", TMC_GET_PWMTHRS(E, E1));
+      #endif
+      #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("T2 E", TMC_GET_PWMTHRS(E, E2));
+      #endif
+      #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("T3 E", TMC_GET_PWMTHRS(E, E3));
+      #endif
+      #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR("T4 E", TMC_GET_PWMTHRS(E, E4));
       #endif
       SERIAL_EOL();
-    #endif
+
+      /**
+       * TMC2130 Sensorless homing thresholds
+       */
+      #if ENABLED(SENSORLESS_HOMING)
+        if (!forReplay) {
+          CONFIG_ECHO_START;
+          SERIAL_ECHOLNPGM("Sensorless homing threshold:");
+        }
+        CONFIG_ECHO_START;
+        #ifdef X_HOMING_SENSITIVITY
+          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+            say_M914();
+            SERIAL_ECHOLNPAIR("X", stepperX.sgt());
+          #endif
+          #if ENABLED(X2_IS_TMC2130)
+            say_M914();
+            SERIAL_ECHOLNPAIR("I1 X", stepperX2.sgt());
+          #endif
+        #endif
+        #ifdef Y_HOMING_SENSITIVITY
+          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+            say_M914();
+            SERIAL_ECHOLNPAIR("Y", stepperY.sgt());
+          #endif
+          #if ENABLED(Y2_IS_TMC2130)
+            say_M914();
+            SERIAL_ECHOLNPAIR("I1 Y", stepperY2.sgt());
+          #endif
+        #endif
+        #ifdef Z_HOMING_SENSITIVITY
+          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+            say_M914();
+            SERIAL_ECHOLNPAIR("Z", stepperZ.sgt());
+          #endif
+          #if ENABLED(Z2_IS_TMC2130)
+            say_M914();
+            SERIAL_ECHOLNPAIR("I1 Z", stepperZ2.sgt());
+          #endif
+        #endif
+        SERIAL_EOL();
+      #endif
+
+    #endif // HAS_TRINAMIC
 
     /**
      * Linear Advance
@@ -2405,25 +2554,31 @@ void MarlinSettings::reset() {
       }
       CONFIG_ECHO_START;
       #if EXTRUDERS == 1
-        SERIAL_ECHOPAIR("  M603 L", LINEAR_UNIT(filament_change_load_length[0]));
+        say_M603();
+        SERIAL_ECHOPAIR("L", LINEAR_UNIT(filament_change_load_length[0]));
         SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(filament_change_unload_length[0]));
       #else
-        SERIAL_ECHOPAIR("  M603 T0 L", LINEAR_UNIT(filament_change_load_length[0]));
+        say_M603();
+        SERIAL_ECHOPAIR("T0 L", LINEAR_UNIT(filament_change_load_length[0]));
         SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(filament_change_unload_length[0]));
         CONFIG_ECHO_START;
-        SERIAL_ECHOPAIR("  M603 T1 L", LINEAR_UNIT(filament_change_load_length[1]));
+        say_M603();
+        SERIAL_ECHOPAIR("T1 L", LINEAR_UNIT(filament_change_load_length[1]));
         SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(filament_change_unload_length[1]));
         #if EXTRUDERS > 2
           CONFIG_ECHO_START;
-          SERIAL_ECHOPAIR("  M603 T2 L", LINEAR_UNIT(filament_change_load_length[2]));
+          say_M603();
+          SERIAL_ECHOPAIR("T2 L", LINEAR_UNIT(filament_change_load_length[2]));
           SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(filament_change_unload_length[2]));
           #if EXTRUDERS > 3
             CONFIG_ECHO_START;
-            SERIAL_ECHOPAIR("  M603 T3 L", LINEAR_UNIT(filament_change_load_length[3]));
+            say_M603();
+            SERIAL_ECHOPAIR("T3 L", LINEAR_UNIT(filament_change_load_length[3]));
             SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(filament_change_unload_length[3]));
             #if EXTRUDERS > 4
               CONFIG_ECHO_START;
-              SERIAL_ECHOPAIR("  M603 T4 L", LINEAR_UNIT(filament_change_load_length[4]));
+              say_M603();
+              SERIAL_ECHOPAIR("T4 L", LINEAR_UNIT(filament_change_load_length[4]));
               SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(filament_change_unload_length[4]));
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3

--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -87,6 +87,11 @@ void Power::check() {
 void Power::power_on() {
   lastPowerOn = millis();
   PSU_PIN_ON();
+
+  #if HAS_TRINAMIC
+    delay(100); // Wait for power to settle
+    restore_stepper_drivers();
+  #endif
 }
 
 void Power::power_off() {

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -948,31 +948,6 @@ void Stepper::init() {
     microstep_init();
   #endif
 
-  // Init TMC Steppers
-  #if ENABLED(HAVE_TMC26X)
-    tmc_init();
-  #endif
-
-  // Init TMC2130 Steppers
-  #if ENABLED(HAVE_TMC2130)
-    tmc2130_init();
-  #endif
-
-  // Init TMC2208 Steppers
-  #if ENABLED(HAVE_TMC2208)
-    tmc2208_init();
-  #endif
-
-  // TRAMS, TMC2130 and TMC2208 advanced settings
-  #if HAS_TRINAMIC
-    TMC_ADV()
-  #endif
-
-  // Init L6470 Steppers
-  #if ENABLED(HAVE_L6470DRIVER)
-    L6470_init();
-  #endif
-
   // Init Dir Pins
   #if HAS_X_DIR
     X_DIR_INIT;

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -42,83 +42,82 @@
   #include <SPI.h>
   #include <TMC26XStepper.h>
 
-  #define _TMC_DEFINE(ST) TMC26XStepper stepper##ST(200, ST##_ENABLE_PIN, ST##_STEP_PIN, ST##_DIR_PIN, ST##_MAX_CURRENT, ST##_SENSE_RESISTOR)
+  #define _TMC26X_DEFINE(ST) TMC26XStepper stepper##ST(200, ST##_ENABLE_PIN, ST##_STEP_PIN, ST##_DIR_PIN, ST##_MAX_CURRENT, ST##_SENSE_RESISTOR)
 
   #if ENABLED(X_IS_TMC26X)
-    _TMC_DEFINE(X);
+    _TMC26X_DEFINE(X);
   #endif
   #if ENABLED(X2_IS_TMC26X)
-    _TMC_DEFINE(X2);
+    _TMC26X_DEFINE(X2);
   #endif
   #if ENABLED(Y_IS_TMC26X)
-    _TMC_DEFINE(Y);
+    _TMC26X_DEFINE(Y);
   #endif
   #if ENABLED(Y2_IS_TMC26X)
-    _TMC_DEFINE(Y2);
+    _TMC26X_DEFINE(Y2);
   #endif
   #if ENABLED(Z_IS_TMC26X)
-    _TMC_DEFINE(Z);
+    _TMC26X_DEFINE(Z);
   #endif
   #if ENABLED(Z2_IS_TMC26X)
-    _TMC_DEFINE(Z2);
+    _TMC26X_DEFINE(Z2);
   #endif
   #if ENABLED(E0_IS_TMC26X)
-    _TMC_DEFINE(E0);
+    _TMC26X_DEFINE(E0);
   #endif
   #if ENABLED(E1_IS_TMC26X)
-    _TMC_DEFINE(E1);
+    _TMC26X_DEFINE(E1);
   #endif
   #if ENABLED(E2_IS_TMC26X)
-    _TMC_DEFINE(E2);
+    _TMC26X_DEFINE(E2);
   #endif
   #if ENABLED(E3_IS_TMC26X)
-    _TMC_DEFINE(E3);
+    _TMC26X_DEFINE(E3);
   #endif
   #if ENABLED(E4_IS_TMC26X)
-    _TMC_DEFINE(E4);
+    _TMC26X_DEFINE(E4);
   #endif
 
-  #define _TMC_INIT(A) do{ \
+  #define _TMC26X_INIT(A) do{ \
     stepper##A.setMicrosteps(A##_MICROSTEPS); \
     stepper##A.start(); \
   }while(0)
 
-  void tmc_init() {
+  void tmc26x_init_to_defaults() {
     #if ENABLED(X_IS_TMC26X)
-      _TMC_INIT(X);
+      _TMC26X_INIT(X);
     #endif
     #if ENABLED(X2_IS_TMC26X)
-      _TMC_INIT(X2);
+      _TMC26X_INIT(X2);
     #endif
     #if ENABLED(Y_IS_TMC26X)
-      _TMC_INIT(Y);
+      _TMC26X_INIT(Y);
     #endif
     #if ENABLED(Y2_IS_TMC26X)
-      _TMC_INIT(Y2);
+      _TMC26X_INIT(Y2);
     #endif
     #if ENABLED(Z_IS_TMC26X)
-      _TMC_INIT(Z);
+      _TMC26X_INIT(Z);
     #endif
     #if ENABLED(Z2_IS_TMC26X)
-      _TMC_INIT(Z2);
+      _TMC26X_INIT(Z2);
     #endif
     #if ENABLED(E0_IS_TMC26X)
-      _TMC_INIT(E0);
+      _TMC26X_INIT(E0);
     #endif
     #if ENABLED(E1_IS_TMC26X)
-      _TMC_INIT(E1);
+      _TMC26X_INIT(E1);
     #endif
     #if ENABLED(E2_IS_TMC26X)
-      _TMC_INIT(E2);
+      _TMC26X_INIT(E2);
     #endif
     #if ENABLED(E3_IS_TMC26X)
-      _TMC_INIT(E3);
+      _TMC26X_INIT(E3);
     #endif
     #if ENABLED(E4_IS_TMC26X)
-      _TMC_INIT(E4);
+      _TMC26X_INIT(E4);
     #endif
   }
-
 #endif // HAVE_TMC26X
 
 //
@@ -136,7 +135,6 @@
   #else
     #define _TMC2130_DEFINE(ST) TMC2130Stepper stepper##ST(ST##_ENABLE_PIN, ST##_DIR_PIN, ST##_STEP_PIN, ST##_CS_PIN)
   #endif
-
 
   // Stepper objects of TMC2130 steppers used
   #if ENABLED(X_IS_TMC2130)
@@ -176,9 +174,9 @@
   // Use internal reference voltage for current calculations. This is the default.
   // Following values from Trinamic's spreadsheet with values for a NEMA17 (42BYGHW609)
   // https://www.trinamic.com/products/integrated-circuits/details/tmc2130/
-  void tmc2130_init(TMC2130Stepper &st, const uint16_t microsteps, const uint32_t thrs, const float spmm) {
+  void tmc2130_init(TMC2130Stepper &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm) {
     st.begin();
-    st.setCurrent(st.getCurrent(), R_SENSE, HOLD_MULTIPLIER);
+    st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
     st.microsteps(microsteps);
     st.blank_time(24);
     st.off_time(5); // Only enables the driver if used with stealthChop
@@ -205,9 +203,9 @@
     st.GSTAT(); // Clear GSTAT
   }
 
-  #define _TMC2130_INIT(ST, SPMM) tmc2130_init(stepper##ST, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, SPMM)
+  #define _TMC2130_INIT(ST, SPMM) tmc2130_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, SPMM)
 
-  void tmc2130_init() {
+  void tmc2130_init_to_defaults() {
     #if ENABLED(X_IS_TMC2130)
       _TMC2130_INIT( X, planner.axis_steps_per_mm[X_AXIS]);
     #endif
@@ -242,7 +240,35 @@
       { constexpr int extruder = 4; _TMC2130_INIT(E4, planner.axis_steps_per_mm[E_AXIS_N]); }
     #endif
 
+    #if ENABLED(SENSORLESS_HOMING)
+      #define TMC_INIT_SGT(P,Q) stepper##Q.sgt(P##_HOMING_SENSITIVITY);
+      #ifdef X_HOMING_SENSITIVITY
+        #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+          stepperX.sgt(X_HOMING_SENSITIVITY);
+        #endif
+        #if ENABLED(X2_IS_TMC2130)
+          stepperX2.sgt(X_HOMING_SENSITIVITY);
+        #endif
+      #endif
+      #ifdef Y_HOMING_SENSITIVITY
+        #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+          stepperY.sgt(Y_HOMING_SENSITIVITY);
+        #endif
+        #if ENABLED(Y2_IS_TMC2130)
+          stepperY2.sgt(Y_HOMING_SENSITIVITY);
+        #endif
+      #endif
+      #ifdef Z_HOMING_SENSITIVITY
+        #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+          stepperZ.sgt(Z_HOMING_SENSITIVITY);
+        #endif
+        #if ENABLED(Z2_IS_TMC2130)
+          stepperZ2.sgt(Z_HOMING_SENSITIVITY);
+        #endif
+      #endif
+    #endif
   }
+
 #endif // HAVE_TMC2130
 
 //
@@ -377,11 +403,11 @@
 
   // Use internal reference voltage for current calculations. This is the default.
   // Following values from Trinamic's spreadsheet with values for a NEMA17 (42BYGHW609)
-  void tmc2208_init(TMC2208Stepper &st, const uint16_t microsteps, const uint32_t thrs, const float spmm) {
+  void tmc2208_init(TMC2208Stepper &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm) {
     st.pdn_disable(true); // Use UART
     st.mstep_reg_select(true); // Select microsteps with UART
     st.I_scale_analog(false);
-    st.rms_current(st.getCurrent(), HOLD_MULTIPLIER, R_SENSE);
+    st.rms_current(mA, HOLD_MULTIPLIER, R_SENSE);
     st.microsteps(microsteps);
     st.blank_time(24);
     st.toff(5);
@@ -411,9 +437,9 @@
     delay(200);
   }
 
-  #define _TMC2208_INIT(ST, SPMM) tmc2208_init(stepper##ST, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, SPMM)
+  #define _TMC2208_INIT(ST, SPMM) tmc2208_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, SPMM)
 
-  void tmc2208_init() {
+  void tmc2208_init_to_defaults() {
     #if ENABLED(X_IS_TMC2208)
       _TMC2208_INIT(X, planner.axis_steps_per_mm[X_AXIS]);
     #endif
@@ -448,7 +474,62 @@
       { constexpr int extruder = 4; _TMC2208_INIT(E4, planner.axis_steps_per_mm[E_AXIS_N]); }
     #endif
   }
+
 #endif // HAVE_TMC2208
+
+void restore_stepper_drivers() {
+  #if X_IS_TRINAMIC
+    stepperX.push();
+  #endif
+  #if X2_IS_TRINAMIC
+    stepperX2.push();
+  #endif
+  #if Y_IS_TRINAMIC
+    stepperY.push();
+  #endif
+  #if Y2_IS_TRINAMIC
+    stepperY2.push();
+  #endif
+  #if Z_IS_TRINAMIC
+    stepperZ.push();
+  #endif
+  #if Z2_IS_TRINAMIC
+    stepperZ2.push();
+  #endif
+  #if E0_IS_TRINAMIC
+    stepperE0.push();
+  #endif
+  #if E1_IS_TRINAMIC
+    stepperE1.push();
+  #endif
+  #if E2_IS_TRINAMIC
+    stepperE2.push();
+  #endif
+  #if E3_IS_TRINAMIC
+    stepperE3.push();
+  #endif
+  #if E4_IS_TRINAMIC
+    stepperE4.push();
+  #endif
+}
+
+void reset_stepper_drivers() {
+  #if ENABLED(HAVE_TMC26X)
+    tmc26x_init_to_defaults();
+  #endif
+  #if ENABLED(HAVE_TMC2130)
+    tmc2130_init_to_defaults();
+  #endif
+  #if ENABLED(HAVE_TMC2208)
+    tmc2208_init_to_defaults();
+  #endif
+  #ifdef TMC_ADV
+    TMC_ADV()
+  #endif
+  #if ENABLED(HAVE_L6470DRIVER)
+    L6470_init_to_defaults();
+  #endif
+}
 
 //
 // L6470 Driver objects and inits
@@ -503,7 +584,7 @@
     stepper##A.setStallCurrent(A##_STALLCURRENT); \
   }while(0)
 
-  void L6470_init() {
+  void L6470_init_to_defaults() {
     #if ENABLED(X_IS_L6470)
       _L6470_INIT(X);
     #endif

--- a/Marlin/stepper_indirection.h
+++ b/Marlin/stepper_indirection.h
@@ -50,29 +50,32 @@
 #if ENABLED(HAVE_TMC26X)
   #include <SPI.h>
   #include <TMC26XStepper.h>
-  void tmc_init();
+  void tmc26x_init_to_defaults();
 #endif
 
 #if ENABLED(HAVE_TMC2130)
   #include <TMC2130Stepper.h>
-  void tmc2130_init();
+  void tmc2130_init_to_defaults();
 #endif
 
 #if ENABLED(HAVE_TMC2208)
   #include <TMC2208Stepper.h>
   void tmc2208_serial_begin();
-  void tmc2208_init();
+  void tmc2208_init_to_defaults();
 #endif
 
 // L6470 has STEP on normal pins, but DIR/ENABLE via SPI
 #if ENABLED(HAVE_L6470DRIVER)
   #include <SPI.h>
   #include <L6470.h>
-  void L6470_init();
+  void L6470_init_to_defaults();
 #endif
 
+void restore_stepper_drivers();  // Called by PSU_ON
+void reset_stepper_drivers();    // Called by settings.load / settings.reset
+
 // X Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(X_IS_L6470)
+#if ENABLED(X_IS_L6470)
   extern L6470 stepperX;
   #define X_ENABLE_INIT NOOP
   #define X_ENABLE_WRITE(STATE) do{ if (STATE) stepperX.Step_Clock(stepperX.getStatus() & STATUS_HIZ); else stepperX.softFree(); }while(0)
@@ -81,15 +84,15 @@
   #define X_DIR_WRITE(STATE) stepperX.Step_Clock(STATE)
   #define X_DIR_READ (stepperX.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(X_IS_TMC26X)
+  #if ENABLED(X_IS_TMC26X)
     extern TMC26XStepper stepperX;
     #define X_ENABLE_INIT NOOP
     #define X_ENABLE_WRITE(STATE) stepperX.setEnabled(STATE)
     #define X_ENABLE_READ stepperX.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(X_IS_TMC2130)
+    #if ENABLED(X_IS_TMC2130)
       extern TMC2130Stepper stepperX;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(X_IS_TMC2208)
+    #elif ENABLED(X_IS_TMC2208)
       extern TMC2208Stepper stepperX;
     #endif
     #define X_ENABLE_INIT SET_OUTPUT(X_ENABLE_PIN)
@@ -105,7 +108,7 @@
 #define X_STEP_READ READ(X_STEP_PIN)
 
 // Y Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(Y_IS_L6470)
+#if ENABLED(Y_IS_L6470)
   extern L6470 stepperY;
   #define Y_ENABLE_INIT NOOP
   #define Y_ENABLE_WRITE(STATE) do{ if (STATE) stepperY.Step_Clock(stepperY.getStatus() & STATUS_HIZ); else stepperY.softFree(); }while(0)
@@ -114,15 +117,15 @@
   #define Y_DIR_WRITE(STATE) stepperY.Step_Clock(STATE)
   #define Y_DIR_READ (stepperY.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(Y_IS_TMC26X)
+  #if ENABLED(Y_IS_TMC26X)
     extern TMC26XStepper stepperY;
     #define Y_ENABLE_INIT NOOP
     #define Y_ENABLE_WRITE(STATE) stepperY.setEnabled(STATE)
     #define Y_ENABLE_READ stepperY.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(Y_IS_TMC2130)
+    #if ENABLED(Y_IS_TMC2130)
       extern TMC2130Stepper stepperY;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(Y_IS_TMC2208)
+    #elif ENABLED(Y_IS_TMC2208)
       extern TMC2208Stepper stepperY;
     #endif
     #define Y_ENABLE_INIT SET_OUTPUT(Y_ENABLE_PIN)
@@ -138,7 +141,7 @@
 #define Y_STEP_READ READ(Y_STEP_PIN)
 
 // Z Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(Z_IS_L6470)
+#if ENABLED(Z_IS_L6470)
   extern L6470 stepperZ;
   #define Z_ENABLE_INIT NOOP
   #define Z_ENABLE_WRITE(STATE) do{ if (STATE) stepperZ.Step_Clock(stepperZ.getStatus() & STATUS_HIZ); else stepperZ.softFree(); }while(0)
@@ -147,15 +150,15 @@
   #define Z_DIR_WRITE(STATE) stepperZ.Step_Clock(STATE)
   #define Z_DIR_READ (stepperZ.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(Z_IS_TMC26X)
+  #if ENABLED(Z_IS_TMC26X)
     extern TMC26XStepper stepperZ;
     #define Z_ENABLE_INIT NOOP
     #define Z_ENABLE_WRITE(STATE) stepperZ.setEnabled(STATE)
     #define Z_ENABLE_READ stepperZ.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(Z_IS_TMC2130)
+    #if ENABLED(Z_IS_TMC2130)
       extern TMC2130Stepper stepperZ;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(Z_IS_TMC2208)
+    #elif ENABLED(Z_IS_TMC2208)
       extern TMC2208Stepper stepperZ;
     #endif
     #define Z_ENABLE_INIT SET_OUTPUT(Z_ENABLE_PIN)
@@ -172,7 +175,7 @@
 
 // X2 Stepper
 #if HAS_X2_ENABLE
-  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(X2_IS_L6470)
+  #if ENABLED(X2_IS_L6470)
     extern L6470 stepperX2;
     #define X2_ENABLE_INIT NOOP
     #define X2_ENABLE_WRITE(STATE) do{ if (STATE) stepperX2.Step_Clock(stepperX2.getStatus() & STATUS_HIZ); else stepperX2.softFree(); }while(0)
@@ -181,15 +184,15 @@
     #define X2_DIR_WRITE(STATE) stepperX2.Step_Clock(STATE)
     #define X2_DIR_READ (stepperX2.getStatus() & STATUS_DIR)
   #else
-    #if ENABLED(HAVE_TMC26X) && ENABLED(X2_IS_TMC26X)
+    #if ENABLED(X2_IS_TMC26X)
       extern TMC26XStepper stepperX2;
       #define X2_ENABLE_INIT NOOP
       #define X2_ENABLE_WRITE(STATE) stepperX2.setEnabled(STATE)
       #define X2_ENABLE_READ stepperX2.isEnabled()
     #else
-      #if ENABLED(HAVE_TMC2130) && ENABLED(X2_IS_TMC2130)
+      #if ENABLED(X2_IS_TMC2130)
         extern TMC2130Stepper stepperX2;
-      #elif ENABLED(HAVE_TMC2208) && ENABLED(X2_IS_TMC2208)
+      #elif ENABLED(X2_IS_TMC2208)
         extern TMC2208Stepper stepperX2;
       #endif
       #define X2_ENABLE_INIT SET_OUTPUT(X2_ENABLE_PIN)
@@ -207,7 +210,7 @@
 
 // Y2 Stepper
 #if HAS_Y2_ENABLE
-  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(Y2_IS_L6470)
+  #if ENABLED(Y2_IS_L6470)
     extern L6470 stepperY2;
     #define Y2_ENABLE_INIT NOOP
     #define Y2_ENABLE_WRITE(STATE) do{ if (STATE) stepperY2.Step_Clock(stepperY2.getStatus() & STATUS_HIZ); else stepperY2.softFree(); }while(0)
@@ -216,15 +219,15 @@
     #define Y2_DIR_WRITE(STATE) stepperY2.Step_Clock(STATE)
     #define Y2_DIR_READ (stepperY2.getStatus() & STATUS_DIR)
   #else
-    #if ENABLED(HAVE_TMC26X) && ENABLED(Y2_IS_TMC26X)
+    #if ENABLED(Y2_IS_TMC26X)
       extern TMC26XStepper stepperY2;
       #define Y2_ENABLE_INIT NOOP
       #define Y2_ENABLE_WRITE(STATE) stepperY2.setEnabled(STATE)
       #define Y2_ENABLE_READ stepperY2.isEnabled()
     #else
-      #if ENABLED(HAVE_TMC2130) && ENABLED(Y2_IS_TMC2130)
+      #if ENABLED(Y2_IS_TMC2130)
         extern TMC2130Stepper stepperY2;
-      #elif ENABLED(HAVE_TMC2208) && ENABLED(Y2_IS_TMC2208)
+      #elif ENABLED(Y2_IS_TMC2208)
         extern TMC2208Stepper stepperY2;
       #endif
       #define Y2_ENABLE_INIT SET_OUTPUT(Y2_ENABLE_PIN)
@@ -242,7 +245,7 @@
 
 // Z2 Stepper
 #if HAS_Z2_ENABLE
-  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(Z2_IS_L6470)
+  #if ENABLED(Z2_IS_L6470)
     extern L6470 stepperZ2;
     #define Z2_ENABLE_INIT NOOP
     #define Z2_ENABLE_WRITE(STATE) do{ if (STATE) stepperZ2.Step_Clock(stepperZ2.getStatus() & STATUS_HIZ); else stepperZ2.softFree(); }while(0)
@@ -251,15 +254,15 @@
     #define Z2_DIR_WRITE(STATE) stepperZ2.Step_Clock(STATE)
     #define Z2_DIR_READ (stepperZ2.getStatus() & STATUS_DIR)
   #else
-    #if ENABLED(HAVE_TMC26X) && ENABLED(Z2_IS_TMC26X)
+    #if ENABLED(Z2_IS_TMC26X)
       extern TMC26XStepper stepperZ2;
       #define Z2_ENABLE_INIT NOOP
       #define Z2_ENABLE_WRITE(STATE) stepperZ2.setEnabled(STATE)
       #define Z2_ENABLE_READ stepperZ2.isEnabled()
     #else
-      #if ENABLED(HAVE_TMC2130) && ENABLED(Z2_IS_TMC2130)
+      #if ENABLED(Z2_IS_TMC2130)
         extern TMC2130Stepper stepperZ2;
-      #elif ENABLED(HAVE_TMC2208) && ENABLED(Z2_IS_TMC2208)
+      #elif ENABLED(Z2_IS_TMC2208)
         extern TMC2208Stepper stepperZ2;
       #endif
       #define Z2_ENABLE_INIT SET_OUTPUT(Z2_ENABLE_PIN)
@@ -276,7 +279,7 @@
 #endif
 
 // E0 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E0_IS_L6470)
+#if ENABLED(E0_IS_L6470)
   extern L6470 stepperE0;
   #define E0_ENABLE_INIT NOOP
   #define E0_ENABLE_WRITE(STATE) do{ if (STATE) stepperE0.Step_Clock(stepperE0.getStatus() & STATUS_HIZ); else stepperE0.softFree(); }while(0)
@@ -285,15 +288,15 @@
   #define E0_DIR_WRITE(STATE) stepperE0.Step_Clock(STATE)
   #define E0_DIR_READ (stepperE0.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(E0_IS_TMC26X)
+  #if ENABLED(E0_IS_TMC26X)
     extern TMC26XStepper stepperE0;
     #define E0_ENABLE_INIT NOOP
     #define E0_ENABLE_WRITE(STATE) stepperE0.setEnabled(STATE)
     #define E0_ENABLE_READ stepperE0.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E0_IS_TMC2130)
+    #if ENABLED(E0_IS_TMC2130)
       extern TMC2130Stepper stepperE0;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E0_IS_TMC2208)
+    #elif ENABLED(E0_IS_TMC2208)
       extern TMC2208Stepper stepperE0;
     #endif
     #define E0_ENABLE_INIT SET_OUTPUT(E0_ENABLE_PIN)
@@ -309,7 +312,7 @@
 #define E0_STEP_READ READ(E0_STEP_PIN)
 
 // E1 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E1_IS_L6470)
+#if ENABLED(E1_IS_L6470)
   extern L6470 stepperE1;
   #define E1_ENABLE_INIT NOOP
   #define E1_ENABLE_WRITE(STATE) do{ if (STATE) stepperE1.Step_Clock(stepperE1.getStatus() & STATUS_HIZ); else stepperE1.softFree(); }while(0)
@@ -318,15 +321,15 @@
   #define E1_DIR_WRITE(STATE) stepperE1.Step_Clock(STATE)
   #define E1_DIR_READ (stepperE1.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(E1_IS_TMC26X)
+  #if ENABLED(E1_IS_TMC26X)
     extern TMC26XStepper stepperE1;
     #define E1_ENABLE_INIT NOOP
     #define E1_ENABLE_WRITE(STATE) stepperE1.setEnabled(STATE)
     #define E1_ENABLE_READ stepperE1.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E1_IS_TMC2130)
+    #if ENABLED(E1_IS_TMC2130)
       extern TMC2130Stepper stepperE1;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E1_IS_TMC2208)
+    #elif ENABLED(E1_IS_TMC2208)
       extern TMC2208Stepper stepperE1;
     #endif
     #define E1_ENABLE_INIT SET_OUTPUT(E1_ENABLE_PIN)
@@ -342,7 +345,7 @@
 #define E1_STEP_READ READ(E1_STEP_PIN)
 
 // E2 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E2_IS_L6470)
+#if ENABLED(E2_IS_L6470)
   extern L6470 stepperE2;
   #define E2_ENABLE_INIT NOOP
   #define E2_ENABLE_WRITE(STATE) do{ if (STATE) stepperE2.Step_Clock(stepperE2.getStatus() & STATUS_HIZ); else stepperE2.softFree(); }while(0)
@@ -351,15 +354,15 @@
   #define E2_DIR_WRITE(STATE) stepperE2.Step_Clock(STATE)
   #define E2_DIR_READ (stepperE2.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(E2_IS_TMC26X)
+  #if ENABLED(E2_IS_TMC26X)
     extern TMC26XStepper stepperE2;
     #define E2_ENABLE_INIT NOOP
     #define E2_ENABLE_WRITE(STATE) stepperE2.setEnabled(STATE)
     #define E2_ENABLE_READ stepperE2.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E2_IS_TMC2130)
+    #if ENABLED(E2_IS_TMC2130)
       extern TMC2130Stepper stepperE2;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E2_IS_TMC2208)
+    #elif ENABLED(E2_IS_TMC2208)
       extern TMC2208Stepper stepperE2;
     #endif
     #define E2_ENABLE_INIT SET_OUTPUT(E2_ENABLE_PIN)
@@ -375,7 +378,7 @@
 #define E2_STEP_READ READ(E2_STEP_PIN)
 
 // E3 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E3_IS_L6470)
+#if ENABLED(E3_IS_L6470)
   extern L6470 stepperE3;
   #define E3_ENABLE_INIT NOOP
   #define E3_ENABLE_WRITE(STATE) do{ if (STATE) stepperE3.Step_Clock(stepperE3.getStatus() & STATUS_HIZ); else stepperE3.softFree(); }while(0)
@@ -384,15 +387,15 @@
   #define E3_DIR_WRITE(STATE) stepperE3.Step_Clock(STATE)
   #define E3_DIR_READ (stepperE3.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(E3_IS_TMC26X)
+  #if ENABLED(E3_IS_TMC26X)
     extern TMC26XStepper stepperE3;
     #define E3_ENABLE_INIT NOOP
     #define E3_ENABLE_WRITE(STATE) stepperE3.setEnabled(STATE)
     #define E3_ENABLE_READ stepperE3.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E3_IS_TMC2130)
+    #if ENABLED(E3_IS_TMC2130)
       extern TMC2130Stepper stepperE3;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E3_IS_TMC2208)
+    #elif ENABLED(E3_IS_TMC2208)
       extern TMC2208Stepper stepperE3;
     #endif
     #define E3_ENABLE_INIT SET_OUTPUT(E3_ENABLE_PIN)
@@ -408,7 +411,7 @@
 #define E3_STEP_READ READ(E3_STEP_PIN)
 
 // E4 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E4_IS_L6470)
+#if ENABLED(E4_IS_L6470)
   extern L6470 stepperE4;
   #define E4_ENABLE_INIT NOOP
   #define E4_ENABLE_WRITE(STATE) do{ if (STATE) stepperE4.Step_Clock(stepperE4.getStatus() & STATUS_HIZ); else stepperE4.softFree(); }while(0)
@@ -417,15 +420,15 @@
   #define E4_DIR_WRITE(STATE) stepperE4.Step_Clock(STATE)
   #define E4_DIR_READ (stepperE4.getStatus() & STATUS_DIR)
 #else
-  #if ENABLED(HAVE_TMC26X) && ENABLED(E4_IS_TMC26X)
+  #if ENABLED(E4_IS_TMC26X)
     extern TMC26XStepper stepperE4;
     #define E4_ENABLE_INIT NOOP
     #define E4_ENABLE_WRITE(STATE) stepperE4.setEnabled(STATE)
     #define E4_ENABLE_READ stepperE4.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E4_IS_TMC2130)
+    #if ENABLED(E4_IS_TMC2130)
       extern TMC2130Stepper stepperE4;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E4_IS_TMC2208)
+    #elif ENABLED(E4_IS_TMC2208)
       extern TMC2208Stepper stepperE4;
     #endif
     #define E4_ENABLE_INIT SET_OUTPUT(E4_ENABLE_PIN)

--- a/Marlin/tmc_util.cpp
+++ b/Marlin/tmc_util.cpp
@@ -329,6 +329,7 @@ void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
       }
     }
   #endif
+
   #if ENABLED(HAVE_TMC2208)
     static void tmc_status(TMC2208Stepper &st, const TMC_debug_enum i) {
       switch (i) {

--- a/Marlin/tmc_util.h
+++ b/Marlin/tmc_util.h
@@ -55,7 +55,6 @@ void tmc_get_current(TMC &st, const TMC_AxisEnum axis) {
 template<typename TMC>
 void tmc_set_current(TMC &st, const TMC_AxisEnum axis, const int mA) {
   st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
-  tmc_get_current(st, axis);
 }
 template<typename TMC>
 void tmc_report_otpw(TMC &st, const TMC_AxisEnum axis) {
@@ -73,7 +72,6 @@ void tmc_get_pwmthrs(TMC &st, const TMC_AxisEnum axis, const uint16_t spmm) {
 template<typename TMC>
 void tmc_set_pwmthrs(TMC &st, const TMC_AxisEnum axis, const int32_t thrs, const uint32_t spmm) {
   st.TPWMTHRS(_tmc_thrs(st.microsteps(), thrs, spmm));
-  tmc_get_pwmthrs(st, axis, spmm);
 }
 template<typename TMC>
 void tmc_get_sgt(TMC &st, const TMC_AxisEnum axis) {
@@ -82,7 +80,6 @@ void tmc_get_sgt(TMC &st, const TMC_AxisEnum axis) {
 template<typename TMC>
 void tmc_set_sgt(TMC &st, const TMC_AxisEnum axis, const int8_t sgt_val) {
   st.sgt(sgt_val);
-  tmc_get_sgt(st, axis);
 }
 
 void monitor_tmc_driver();

--- a/Marlin/tmc_util.h
+++ b/Marlin/tmc_util.h
@@ -35,7 +35,7 @@
 
 extern bool report_tmc_status;
 
-enum TMC_AxisEnum : char { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
+enum TMC_AxisEnum : char { TMC_X, TMC_Y, TMC_Z, TMC_X2, TMC_Y2, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
 
 constexpr uint32_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);


### PR DESCRIPTION
Addressing #10087

- Add EEPROM Init, Load, Save, Report for `M913` Hybrid Threshold.
- Bump EEPROM to V53.
- Reorder `TMC_AxisEnum` to match EEPROM storage.
- Reduce PROGMEM string usage with small functions.
- Add `T` parameter to `M906`/`M913` to specific which extruder.
- Add `I` (index) parameter to `M906`/`M913`/`M914` to specify which dual axis stepper.

[Concise Diff](10101/files?w=1)
Counterpart to #10102