### PR TITLE
[2.0.x] More complete Trinamic driver options

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -88,6 +88,11 @@ void Power::check() {
 void Power::power_on() {
   lastPowerOn = millis();
   PSU_PIN_ON();
+
+  #if HAS_TRINAMIC
+    delay(100); // Wait for power to settle
+    restore_stepper_drivers();
+  #endif
 }
 
 void Power::power_off() {

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -331,6 +331,7 @@ void _tmc_say_sgt(const TMC_AxisEnum axis, const int8_t sgt) {
       }
     }
   #endif
+
   #if ENABLED(HAVE_TMC2208)
     static void tmc_status(TMC2208Stepper &st, const TMC_debug_enum i) {
       switch (i) {

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -55,7 +55,6 @@ void tmc_get_current(TMC &st, const TMC_AxisEnum axis) {
 template<typename TMC>
 void tmc_set_current(TMC &st, const TMC_AxisEnum axis, const int mA) {
   st.setCurrent(mA, R_SENSE, HOLD_MULTIPLIER);
-  tmc_get_current(st, axis);
 }
 template<typename TMC>
 void tmc_report_otpw(TMC &st, const TMC_AxisEnum axis) {
@@ -73,7 +72,6 @@ void tmc_get_pwmthrs(TMC &st, const TMC_AxisEnum axis, const uint16_t spmm) {
 template<typename TMC>
 void tmc_set_pwmthrs(TMC &st, const TMC_AxisEnum axis, const int32_t thrs, const uint32_t spmm) {
   st.TPWMTHRS(_tmc_thrs(st.microsteps(), thrs, spmm));
-  tmc_get_pwmthrs(st, axis, spmm);
 }
 template<typename TMC>
 void tmc_get_sgt(TMC &st, const TMC_AxisEnum axis) {
@@ -82,7 +80,6 @@ void tmc_get_sgt(TMC &st, const TMC_AxisEnum axis) {
 template<typename TMC>
 void tmc_set_sgt(TMC &st, const TMC_AxisEnum axis, const int8_t sgt_val) {
   st.sgt(sgt_val);
-  tmc_get_sgt(st, axis);
 }
 
 void monitor_tmc_driver();

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -35,7 +35,7 @@
 
 extern bool report_tmc_status;
 
-enum TMC_AxisEnum : char { TMC_X, TMC_X2, TMC_Y, TMC_Y2, TMC_Z, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
+enum TMC_AxisEnum : char { TMC_X, TMC_Y, TMC_Z, TMC_X2, TMC_Y2, TMC_Z2, TMC_E0, TMC_E1, TMC_E2, TMC_E3, TMC_E4 };
 
 constexpr uint32_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -76,14 +76,9 @@
       OUT_WRITE(SUICIDE_PIN, HIGH);
     #endif
 
-    #if ENABLED(HAVE_TMC2130)
-      delay(100);
-      tmc2130_init(); // Settings only stick when the driver has power
-    #endif
-
-    #if ENABLED(HAVE_TMC2208)
-      delay(100);
-      tmc2208_init();
+    #if DISABLED(AUTO_POWER_CONTROL)
+      delay(100); // Wait for power to settle
+      restore_stepper_drivers();
     #endif
 
     #if ENABLED(ULTIPANEL)

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -37,50 +37,54 @@ void GcodeSuite::M906() {
   #define TMC_SET_CURRENT(Q) tmc_set_current(stepper##Q, TMC_##Q, value)
 
   bool report = true;
+  const uint8_t index = parser.byteval('I');
   LOOP_XYZE(i) if (uint16_t value = parser.intval(axis_codes[i])) {
     report = false;
     switch (i) {
       case X_AXIS:
         #if X_IS_TRINAMIC
-          TMC_SET_CURRENT(X);
+          if (index == 0) TMC_SET_CURRENT(X);
         #endif
         #if X2_IS_TRINAMIC
-          TMC_SET_CURRENT(X2);
+          if (index == 1) TMC_SET_CURRENT(X2);
         #endif
         break;
       case Y_AXIS:
         #if Y_IS_TRINAMIC
-          TMC_SET_CURRENT(Y);
+          if (index == 0) TMC_SET_CURRENT(Y);
         #endif
         #if Y2_IS_TRINAMIC
-          TMC_SET_CURRENT(Y2);
+          if (index == 1) TMC_SET_CURRENT(Y2);
         #endif
         break;
       case Z_AXIS:
         #if Z_IS_TRINAMIC
-          TMC_SET_CURRENT(Z);
+          if (index == 0) TMC_SET_CURRENT(Z);
         #endif
         #if Z2_IS_TRINAMIC
-          TMC_SET_CURRENT(Z2);
+          if (index == 1) TMC_SET_CURRENT(Z2);
         #endif
         break;
-      case E_AXIS:
-        #if E0_IS_TRINAMIC
-          TMC_SET_CURRENT(E0);
-        #endif
-        #if E1_IS_TRINAMIC
-          TMC_SET_CURRENT(E1);
-        #endif
-        #if E2_IS_TRINAMIC
-          TMC_SET_CURRENT(E2);
-        #endif
-        #if E3_IS_TRINAMIC
-          TMC_SET_CURRENT(E3);
-        #endif
-        #if E4_IS_TRINAMIC
-          TMC_SET_CURRENT(E4);
-        #endif
-        break;
+      case E_AXIS: {
+        if (get_target_extruder_from_command()) return;
+        switch (target_extruder) {
+          #if E0_IS_TRINAMIC
+            case 0: TMC_SET_CURRENT(E0); break;
+          #endif
+          #if E1_IS_TRINAMIC
+            case 1: TMC_SET_CURRENT(E1); break;
+          #endif
+          #if E2_IS_TRINAMIC
+            case 2: TMC_SET_CURRENT(E2); break;
+          #endif
+          #if E3_IS_TRINAMIC
+            case 3: TMC_SET_CURRENT(E3); break;
+          #endif
+          #if E4_IS_TRINAMIC
+            case 4: TMC_SET_CURRENT(E4); break;
+          #endif
+        }
+      } break;
     }
   }
 

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -33,46 +33,100 @@
  * Report driver currents when no axis specified
  */
 void GcodeSuite::M906() {
-  uint16_t values[XYZE];
-  LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
+  #define TMC_SAY_CURRENT(Q) tmc_get_current(stepper##Q, TMC_##Q)
+  #define TMC_SET_CURRENT(Q) tmc_set_current(stepper##Q, TMC_##Q, value)
 
-  #define TMC_SET_GET_CURRENT(P,Q) do { \
-    if (values[P##_AXIS]) tmc_set_current(stepper##Q, TMC_##Q, values[P##_AXIS]); \
-    else tmc_get_current(stepper##Q, TMC_##Q); } while(0)
+  bool report = true;
+  LOOP_XYZE(i) if (uint16_t value = parser.intval(axis_codes[i])) {
+    report = false;
+    switch (i) {
+      case X_AXIS:
+        #if X_IS_TRINAMIC
+          TMC_SET_CURRENT(X);
+        #endif
+        #if X2_IS_TRINAMIC
+          TMC_SET_CURRENT(X2);
+        #endif
+        break;
+      case Y_AXIS:
+        #if Y_IS_TRINAMIC
+          TMC_SET_CURRENT(Y);
+        #endif
+        #if Y2_IS_TRINAMIC
+          TMC_SET_CURRENT(Y2);
+        #endif
+        break;
+      case Z_AXIS:
+        #if Z_IS_TRINAMIC
+          TMC_SET_CURRENT(Z);
+        #endif
+        #if Z2_IS_TRINAMIC
+          TMC_SET_CURRENT(Z2);
+        #endif
+        break;
+      case E_AXIS:
+        #if E0_IS_TRINAMIC
+          TMC_SET_CURRENT(E0);
+        #endif
+        #if E1_IS_TRINAMIC
+          TMC_SET_CURRENT(E1);
+        #endif
+        #if E2_IS_TRINAMIC
+          TMC_SET_CURRENT(E2);
+        #endif
+        #if E3_IS_TRINAMIC
+          TMC_SET_CURRENT(E3);
+        #endif
+        #if E4_IS_TRINAMIC
+          TMC_SET_CURRENT(E4);
+        #endif
+        break;
+    }
+  }
 
-  #if X_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(X,X);
-  #endif
-  #if X2_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(X,X2);
-  #endif
-  #if Y_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(Y,Y);
-  #endif
-  #if Y2_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(Y,Y2);
-  #endif
-  #if Z_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(Z,Z);
-  #endif
-  #if Z2_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(Z,Z2);
-  #endif
-  #if E0_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(E,E0);
-  #endif
-  #if E1_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(E,E1);
-  #endif
-  #if E2_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(E,E2);
-  #endif
-  #if E3_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(E,E3);
-  #endif
-  #if E4_IS_TRINAMIC
-    TMC_SET_GET_CURRENT(E,E4);
-  #endif
+  if (report) LOOP_XYZE(i) switch (i) {
+    case X_AXIS:
+      #if X_IS_TRINAMIC
+        TMC_SAY_CURRENT(X);
+      #endif
+      #if X2_IS_TRINAMIC
+        TMC_SAY_CURRENT(X2);
+      #endif
+      break;
+    case Y_AXIS:
+      #if Y_IS_TRINAMIC
+        TMC_SAY_CURRENT(Y);
+      #endif
+      #if Y2_IS_TRINAMIC
+        TMC_SAY_CURRENT(Y2);
+      #endif
+      break;
+    case Z_AXIS:
+      #if Z_IS_TRINAMIC
+        TMC_SAY_CURRENT(Z);
+      #endif
+      #if Z2_IS_TRINAMIC
+        TMC_SAY_CURRENT(Z2);
+      #endif
+      break;
+    case E_AXIS:
+      #if E0_IS_TRINAMIC
+        TMC_SAY_CURRENT(E0);
+      #endif
+      #if E1_IS_TRINAMIC
+        TMC_SAY_CURRENT(E1);
+      #endif
+      #if E2_IS_TRINAMIC
+        TMC_SAY_CURRENT(E2);
+      #endif
+      #if E3_IS_TRINAMIC
+        TMC_SAY_CURRENT(E3);
+      #endif
+      #if E4_IS_TRINAMIC
+        TMC_SAY_CURRENT(E4);
+      #endif
+      break;
+  }
 }
 
 #endif // HAS_TRINAMIC

--- a/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
@@ -80,46 +80,102 @@ void GcodeSuite::M912() {
  */
 #if ENABLED(HYBRID_THRESHOLD)
   void GcodeSuite::M913() {
-    uint16_t values[XYZE];
-    LOOP_XYZE(i) values[i] = parser.intval(axis_codes[i]);
+    #define TMC_SAY_PWMTHRS(P,Q) tmc_get_pwmthrs(stepper##Q, TMC_##Q, planner.axis_steps_per_mm[P##_AXIS])
+    #define TMC_SET_PWMTHRS(P,Q) tmc_set_pwmthrs(stepper##Q, TMC_##Q, value, planner.axis_steps_per_mm[P##_AXIS])
+    #define TMC_SAY_PWMTHRS_E(E) do{ const uint8_t extruder = E; tmc_get_pwmthrs(stepperE##E, TMC_E##E, planner.axis_steps_per_mm[E_AXIS_N]); }while(0)
+    #define TMC_SET_PWMTHRS_E(E) do{ const uint8_t extruder = E; tmc_set_pwmthrs(stepperE##E, TMC_E##E, value, planner.axis_steps_per_mm[E_AXIS_N]); }while(0)
 
-    #define TMC_SET_GET_PWMTHRS(P,Q) do { \
-      if (values[P##_AXIS]) tmc_set_pwmthrs(stepper##Q, TMC_##Q, values[P##_AXIS], planner.axis_steps_per_mm[P##_AXIS]); \
-      else tmc_get_pwmthrs(stepper##Q, TMC_##Q, planner.axis_steps_per_mm[P##_AXIS]); } while(0)
+    bool report = true;
+    LOOP_XYZE(i) if (int32_t value = parser.longval(axis_codes[i])) {
+      report = false;
+      switch (i) {
+        case X_AXIS:
+          #if X_IS_TRINAMIC
+            TMC_SET_PWMTHRS(X,X);
+          #endif
+          #if X2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(X,X2);
+          #endif
+          break;
+        case Y_AXIS:
+          #if Y_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Y,Y);
+          #endif
+          #if Y2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Y,Y2);
+          #endif
+          break;
+        case Z_AXIS:
+          #if Z_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Z,Z);
+          #endif
+          #if Z2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Z,Z2);
+          #endif
+          break;
+        case E_AXIS:
+          #if E0_IS_TRINAMIC
+            TMC_SET_PWMTHRS_E(0);
+          #endif
+          #if E1_IS_TRINAMIC
+            TMC_SET_PWMTHRS_E(1);
+          #endif
+          #if E2_IS_TRINAMIC
+            TMC_SET_PWMTHRS_E(2);
+          #endif
+          #if E3_IS_TRINAMIC
+            TMC_SET_PWMTHRS_E(3);
+          #endif
+          #if E4_IS_TRINAMIC
+            TMC_SET_PWMTHRS_E(4);
+          #endif
+          break;
+      }
+    }
 
-    #if X_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(X,X);
-    #endif
-    #if X2_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(X,X2);
-    #endif
-    #if Y_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(Y,Y);
-    #endif
-    #if Y2_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(Y,Y2);
-    #endif
-    #if Z_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(Z,Z);
-    #endif
-    #if Z2_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(Z,Z2);
-    #endif
-    #if E0_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(E,E0);
-    #endif
-    #if E1_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(E,E1);
-    #endif
-    #if E2_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(E,E2);
-    #endif
-    #if E3_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(E,E3);
-    #endif
-    #if E4_IS_TRINAMIC
-      TMC_SET_GET_PWMTHRS(E,E4);
-    #endif
+    if (report) LOOP_XYZE(i) switch (i) {
+      case X_AXIS:
+        #if X_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(X,X);
+        #endif
+        #if X2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(X,X2);
+        #endif
+        break;
+      case Y_AXIS:
+        #if Y_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Y,Y);
+        #endif
+        #if Y2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Y,Y2);
+        #endif
+        break;
+      case Z_AXIS:
+        #if Z_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Z,Z);
+        #endif
+        #if Z2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Z,Z2);
+        #endif
+        break;
+      case E_AXIS:
+        #if E0_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(0);
+        #endif
+        #if E1_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(1);
+        #endif
+        #if E2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(2);
+        #endif
+        #if E3_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(3);
+        #endif
+        #if E4_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(4);
+        #endif
+        break;
+    }
   }
 #endif // HYBRID_THRESHOLD
 
@@ -128,34 +184,67 @@ void GcodeSuite::M912() {
  */
 #if ENABLED(SENSORLESS_HOMING)
   void GcodeSuite::M914() {
-    #define TMC_SET_GET_SGT(P,Q) do { \
-      if (parser.seen(axis_codes[P##_AXIS])) tmc_set_sgt(stepper##Q, TMC_##Q, parser.value_int()); \
-      else tmc_get_sgt(stepper##Q, TMC_##Q); } while(0)
+    #define TMC_SAY_SGT(Q) tmc_get_sgt(stepper##Q, TMC_##Q)
+    #define TMC_SET_SGT(Q) tmc_set_sgt(stepper##Q, TMC_##Q, value)
 
-    #ifdef X_HOMING_SENSITIVITY
-      #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-        TMC_SET_GET_SGT(X,X);
-      #endif
-      #if ENABLED(X2_IS_TMC2130)
-        TMC_SET_GET_SGT(X,X2);
-      #endif
-    #endif
-    #ifdef Y_HOMING_SENSITIVITY
-      #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-        TMC_SET_GET_SGT(Y,Y);
-      #endif
-      #if ENABLED(Y2_IS_TMC2130)
-        TMC_SET_GET_SGT(Y,Y2);
-      #endif
-    #endif
-    #ifdef Z_HOMING_SENSITIVITY
-      #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-        TMC_SET_GET_SGT(Z,Z);
-      #endif
-      #if ENABLED(Z2_IS_TMC2130)
-        TMC_SET_GET_SGT(Z,Z2);
-      #endif
-    #endif
+    bool report = true;
+    LOOP_XYZ(i) if (parser.seen(axis_codes[i])) {
+      const int8_t value = (int8_t)constrain(parser.value_int(), -63, 64);
+      report = false;
+      switch (i) {
+        case X_AXIS:
+          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SET_SGT(X);
+          #endif
+          #if ENABLED(X2_IS_TMC2130)
+            TMC_SET_SGT(X2);
+          #endif
+          break;
+        case Y_AXIS:
+          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SET_SGT(Y);
+          #endif
+          #if ENABLED(Y2_IS_TMC2130)
+            TMC_SET_SGT(Y2);
+          #endif
+          break;
+        case Z_AXIS:
+          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SET_SGT(Z);
+          #endif
+          #if ENABLED(Z2_IS_TMC2130)
+            TMC_SET_SGT(Z2);
+          #endif
+          break;
+      }
+    }
+
+    if (report) LOOP_XYZ(i) switch (i) {
+      case X_AXIS:
+        #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+          TMC_SAY_SGT(X);
+        #endif
+        #if ENABLED(X2_IS_TMC2130)
+          TMC_SAY_SGT(X2);
+        #endif
+        break;
+      case Y_AXIS:
+        #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+          TMC_SAY_SGT(Y);
+        #endif
+        #if ENABLED(Y2_IS_TMC2130)
+          TMC_SAY_SGT(Y2);
+        #endif
+        break;
+      case Z_AXIS:
+        #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+          TMC_SAY_SGT(Z);
+        #endif
+        #if ENABLED(Z2_IS_TMC2130)
+          TMC_SAY_SGT(Z2);
+        #endif
+        break;
+    }
   }
 #endif // SENSORLESS_HOMING
 

--- a/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
@@ -86,50 +86,54 @@ void GcodeSuite::M912() {
     #define TMC_SET_PWMTHRS_E(E) do{ const uint8_t extruder = E; tmc_set_pwmthrs(stepperE##E, TMC_E##E, value, planner.axis_steps_per_mm[E_AXIS_N]); }while(0)
 
     bool report = true;
+    const uint8_t index = parser.byteval('I');
     LOOP_XYZE(i) if (int32_t value = parser.longval(axis_codes[i])) {
       report = false;
       switch (i) {
         case X_AXIS:
           #if X_IS_TRINAMIC
-            TMC_SET_PWMTHRS(X,X);
+            if (index == 0) TMC_SET_PWMTHRS(X,X);
           #endif
           #if X2_IS_TRINAMIC
-            TMC_SET_PWMTHRS(X,X2);
+            if (index == 1) TMC_SET_PWMTHRS(X,X2);
           #endif
           break;
         case Y_AXIS:
           #if Y_IS_TRINAMIC
-            TMC_SET_PWMTHRS(Y,Y);
+            if (index == 0) TMC_SET_PWMTHRS(Y,Y);
           #endif
           #if Y2_IS_TRINAMIC
-            TMC_SET_PWMTHRS(Y,Y2);
+            if (index == 1) TMC_SET_PWMTHRS(Y,Y2);
           #endif
           break;
         case Z_AXIS:
           #if Z_IS_TRINAMIC
-            TMC_SET_PWMTHRS(Z,Z);
+            if (index == 0) TMC_SET_PWMTHRS(Z,Z);
           #endif
           #if Z2_IS_TRINAMIC
-            TMC_SET_PWMTHRS(Z,Z2);
+            if (index == 1) TMC_SET_PWMTHRS(Z,Z2);
           #endif
           break;
-        case E_AXIS:
-          #if E0_IS_TRINAMIC
-            TMC_SET_PWMTHRS_E(0);
-          #endif
-          #if E1_IS_TRINAMIC
-            TMC_SET_PWMTHRS_E(1);
-          #endif
-          #if E2_IS_TRINAMIC
-            TMC_SET_PWMTHRS_E(2);
-          #endif
-          #if E3_IS_TRINAMIC
-            TMC_SET_PWMTHRS_E(3);
-          #endif
-          #if E4_IS_TRINAMIC
-            TMC_SET_PWMTHRS_E(4);
-          #endif
-          break;
+        case E_AXIS: {
+          if (get_target_extruder_from_command()) return;
+          switch (target_extruder) {
+            #if E0_IS_TRINAMIC
+              case 0: TMC_SET_PWMTHRS_E(0); break;
+            #endif
+            #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+              case 1: TMC_SET_PWMTHRS_E(1); break;
+            #endif
+            #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+              case 2: TMC_SET_PWMTHRS_E(2); break;
+            #endif
+            #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+              case 3: TMC_SET_PWMTHRS_E(3); break;
+            #endif
+            #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+              case 4: TMC_SET_PWMTHRS_E(4); break;
+            #endif
+          }
+        } break;
       }
     }
 
@@ -162,16 +166,16 @@ void GcodeSuite::M912() {
         #if E0_IS_TRINAMIC
           TMC_SAY_PWMTHRS_E(0);
         #endif
-        #if E1_IS_TRINAMIC
+        #if E_STEPPERS > 1 && E1_IS_TRINAMIC
           TMC_SAY_PWMTHRS_E(1);
         #endif
-        #if E2_IS_TRINAMIC
+        #if E_STEPPERS > 2 && E2_IS_TRINAMIC
           TMC_SAY_PWMTHRS_E(2);
         #endif
-        #if E3_IS_TRINAMIC
+        #if E_STEPPERS > 3 && E3_IS_TRINAMIC
           TMC_SAY_PWMTHRS_E(3);
         #endif
-        #if E4_IS_TRINAMIC
+        #if E_STEPPERS > 4 && E4_IS_TRINAMIC
           TMC_SAY_PWMTHRS_E(4);
         #endif
         break;
@@ -188,32 +192,33 @@ void GcodeSuite::M912() {
     #define TMC_SET_SGT(Q) tmc_set_sgt(stepper##Q, TMC_##Q, value)
 
     bool report = true;
+    const uint8_t index = parser.byteval('I');
     LOOP_XYZ(i) if (parser.seen(axis_codes[i])) {
       const int8_t value = (int8_t)constrain(parser.value_int(), -63, 64);
       report = false;
       switch (i) {
         case X_AXIS:
           #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-            TMC_SET_SGT(X);
+            if (index == 0) TMC_SET_SGT(X);
           #endif
           #if ENABLED(X2_IS_TMC2130)
-            TMC_SET_SGT(X2);
+            if (index == 1) TMC_SET_SGT(X2);
           #endif
           break;
         case Y_AXIS:
           #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-            TMC_SET_SGT(Y);
+            if (index == 0) TMC_SET_SGT(Y);
           #endif
           #if ENABLED(Y2_IS_TMC2130)
-            TMC_SET_SGT(Y2);
+            if (index == 1) TMC_SET_SGT(Y2);
           #endif
           break;
         case Z_AXIS:
           #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-            TMC_SET_SGT(Z);
+            if (index == 0) TMC_SET_SGT(Z);
           #endif
           #if ENABLED(Z2_IS_TMC2130)
-            TMC_SET_SGT(Z2);
+            if (index == 1) TMC_SET_SGT(Z2);
           #endif
           break;
       }

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V52"
+#define EEPROM_VERSION "V53"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -74,8 +74,10 @@
   #include "../module/probe.h"
 #endif
 
-#if ENABLED(HAVE_TMC2130)
+#if HAS_TRINAMIC
   #include "stepper_indirection.h"
+  #include "../feature/tmc_util.h"
+  #define TMC_GET_PWMTHRS(P,Q) _tmc_thrs(stepper##Q.microsteps(), stepper##Q.TPWMTHRS(), planner.axis_steps_per_mm[P##_AXIS])
 #endif
 
 #if ENABLED(FWRETRACT)
@@ -230,7 +232,9 @@ typedef struct SettingsDataStruct {
   //
   // HAS_TRINAMIC
   //
-  uint16_t tmc_stepper_current[11];                     // M906 X Y Z X2 Y2 Z2 E0 E1 E2 E3 E4
+  #define TMC_AXES (MAX_EXTRUDERS + 6)
+  uint16_t tmc_stepper_current[TMC_AXES];               // M906 X Y Z X2 Y2 Z2 E0 E1 E2 E3 E4
+  uint32_t tmc_hybrid_threshold[TMC_AXES];              // M913 X Y Z X2 Y2 Z2 E0 E1 E2 E3 E4
   int16_t tmc_sgt[XYZ];                                 // M914 X Y Z
 
   //
@@ -658,7 +662,7 @@ void MarlinSettings::postprocess() {
 
     _FIELD_TEST(tmc_stepper_current);
 
-    uint16_t currents[11] = {
+    uint16_t tmc_stepper_current[TMC_AXES] = {
       #if HAS_TRINAMIC
         #if X_IS_TRINAMIC
           stepperX.getCurrent(),
@@ -719,24 +723,95 @@ void MarlinSettings::postprocess() {
         0
       #endif
     };
-    EEPROM_WRITE(currents);
+    EEPROM_WRITE(tmc_stepper_current);
+
+    //
+    // Save TMC2130 or TMC2208 Hybrid Threshold, and placeholder values
+    //
+
+    _FIELD_TEST(tmc_hybrid_threshold);
+
+    uint32_t tmc_hybrid_threshold[TMC_AXES] = {
+      #if HAS_TRINAMIC
+        #if X_IS_TRINAMIC
+          TMC_GET_PWMTHRS(X, X),
+        #else
+          X_HYBRID_THRESHOLD,
+        #endif
+        #if Y_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Y, Y),
+        #else
+          Y_HYBRID_THRESHOLD,
+        #endif
+        #if Z_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Z, Z),
+        #else
+          Z_HYBRID_THRESHOLD,
+        #endif
+        #if X2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(X, X2),
+        #else
+          X2_HYBRID_THRESHOLD,
+        #endif
+        #if Y2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Y, Y2),
+        #else
+          Y2_HYBRID_THRESHOLD,
+        #endif
+        #if Z2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(Z, Z2),
+        #else
+          Z2_HYBRID_THRESHOLD,
+        #endif
+        #if E0_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E0),
+        #else
+          E0_HYBRID_THRESHOLD,
+        #endif
+        #if E1_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E1),
+        #else
+          E1_HYBRID_THRESHOLD,
+        #endif
+        #if E2_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E2),
+        #else
+          E2_HYBRID_THRESHOLD,
+        #endif
+        #if E3_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E3),
+        #else
+          E3_HYBRID_THRESHOLD,
+        #endif
+        #if E4_IS_TRINAMIC
+          TMC_GET_PWMTHRS(E, E4)
+        #else
+          E4_HYBRID_THRESHOLD
+        #endif
+      #else
+        100, 100, 3,          // X, Y, Z
+        100, 100, 3,          // X2, Y2, Z2
+        30, 30, 30, 30, 30    // E0, E1, E2, E3, E4
+      #endif
+    };
+    EEPROM_WRITE(tmc_hybrid_threshold);
 
     //
     // TMC2130 Sensorless homing threshold
     //
-    int16_t thrs[XYZ] = {
+    int16_t tmc_sgt[XYZ] = {
       #if ENABLED(SENSORLESS_HOMING)
-        #if ENABLED(X_IS_TMC2130) && defined(X_HOMING_SENSITIVITY)
+        #if defined(X_HOMING_SENSITIVITY) && (ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS))
           stepperX.sgt(),
         #else
           0,
         #endif
-        #if ENABLED(Y_IS_TMC2130) && defined(Y_HOMING_SENSITIVITY)
+        #if defined(Y_HOMING_SENSITIVITY) && (ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS))
           stepperY.sgt(),
         #else
           0
         #endif
-        #if ENABLED(Z_IS_TMC2130) && defined(Z_HOMING_SENSITIVITY)
+        #if defined(Z_HOMING_SENSITIVITY) && (ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS))
           stepperZ.sgt()
         #else
           0
@@ -745,7 +820,7 @@ void MarlinSettings::postprocess() {
         0
       #endif
     };
-    EEPROM_WRITE(thrs);
+    EEPROM_WRITE(tmc_sgt);
 
     //
     // Linear Advance
@@ -794,7 +869,7 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(planner.yz_skew_factor);
     #else
       dummy = 0.0f;
-      for (uint8_t q = XYZ; q--;) EEPROM_WRITE(dummy);
+      for (uint8_t q = 3; q--;) EEPROM_WRITE(dummy);
     #endif
 
     //
@@ -1197,54 +1272,101 @@ void MarlinSettings::postprocess() {
 
       #endif
 
+      if (!validating) reset_stepper_drivers();
+
       //
-      // TMC2130 Stepper Current
+      // TMC2130 Stepper Settings
       //
 
       _FIELD_TEST(tmc_stepper_current);
 
       #if HAS_TRINAMIC
-        #define SET_CURR(N,Q) stepper##Q.setCurrent(currents[N] ? currents[N] : Q##_CURRENT, R_SENSE, HOLD_MULTIPLIER)
-        uint16_t currents[11];
+
+        #define SET_CURR(Q) stepper##Q.setCurrent(currents[TMC_##Q] ? currents[TMC_##Q] : Q##_CURRENT, R_SENSE, HOLD_MULTIPLIER)
+        uint16_t currents[TMC_AXES];
         EEPROM_READ(currents);
         if (!validating) {
           #if X_IS_TRINAMIC
-            SET_CURR(0, X);
+            SET_CURR(X);
           #endif
           #if Y_IS_TRINAMIC
-            SET_CURR(1, Y);
+            SET_CURR(Y);
           #endif
           #if Z_IS_TRINAMIC
-            SET_CURR(2, Z);
+            SET_CURR(Z);
           #endif
           #if X2_IS_TRINAMIC
-            SET_CURR(3, X2);
+            SET_CURR(X2);
           #endif
           #if Y2_IS_TRINAMIC
-            SET_CURR(4, Y2);
+            SET_CURR(Y2);
           #endif
           #if Z2_IS_TRINAMIC
-            SET_CURR(5, Z2);
+            SET_CURR(Z2);
           #endif
           #if E0_IS_TRINAMIC
-            SET_CURR(6, E0);
+            SET_CURR(E0);
           #endif
           #if E1_IS_TRINAMIC
-            SET_CURR(7, E1);
+            SET_CURR(E1);
           #endif
           #if E2_IS_TRINAMIC
-            SET_CURR(8, E2);
+            SET_CURR(E2);
           #endif
           #if E3_IS_TRINAMIC
-            SET_CURR(9, E3);
+            SET_CURR(E3);
           #endif
           #if E4_IS_TRINAMIC
-            SET_CURR(10, E4);
+            SET_CURR(E4);
           #endif
         }
       #else
         uint16_t val;
-        for (uint8_t q=11; q--;) EEPROM_READ(val);
+        for (uint8_t q=TMC_AXES; q--;) EEPROM_READ(val);
+      #endif
+
+      #if HAS_TRINAMIC
+        #define TMC_SET_PWMTHRS(P,Q) tmc_set_pwmthrs(stepper##Q, TMC_##Q, tmc_hybrid_threshold[TMC_##Q], planner.axis_steps_per_mm[P##_AXIS])
+        uint16_t tmc_hybrid_threshold[TMC_AXES];
+        EEPROM_READ(tmc_hybrid_threshold);
+        if (!validating) {
+          #if X_IS_TRINAMIC
+            TMC_SET_PWMTHRS(X, X);
+          #endif
+          #if Y_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Y, Y);
+          #endif
+          #if Z_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Z, Z);
+          #endif
+          #if X2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(X, X2);
+          #endif
+          #if Y2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Y, Y2);
+          #endif
+          #if Z2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(Z, Z2);
+          #endif
+          #if E0_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E0);
+          #endif
+          #if E1_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E1);
+          #endif
+          #if E2_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E2);
+          #endif
+          #if E3_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E3);
+          #endif
+          #if E4_IS_TRINAMIC
+            TMC_SET_PWMTHRS(E, E4);
+          #endif
+        }
+      #else
+        uint16_t thrs_val;
+        for (uint8_t q=TMC_AXES; q--;) EEPROM_READ(thrs_val);
       #endif
 
       /*
@@ -1253,32 +1375,32 @@ void MarlinSettings::postprocess() {
        * Y and Y2 use the same value
        * Z and Z2 use the same value
        */
-      int16_t thrs[XYZ];
-      EEPROM_READ(thrs);
+      int16_t tmc_sgt[XYZ];
+      EEPROM_READ(tmc_sgt);
       #if ENABLED(SENSORLESS_HOMING)
         if (!validating) {
           #ifdef X_HOMING_SENSITIVITY
-            #if ENABLED(X_IS_TMC2130)
-              stepperX.sgt(thrs[0]);
+            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+              stepperX.sgt(tmc_sgt[0]);
             #endif
             #if ENABLED(X2_IS_TMC2130)
-              stepperX2.sgt(thrs[0]);
+              stepperX2.sgt(tmc_sgt[0]);
             #endif
           #endif
           #ifdef Y_HOMING_SENSITIVITY
-            #if ENABLED(Y_IS_TMC2130)
-              stepperY.sgt(thrs[1]);
+            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+              stepperY.sgt(tmc_sgt[1]);
             #endif
             #if ENABLED(Y2_IS_TMC2130)
-              stepperY2.sgt(thrs[1]);
+              stepperY2.sgt(tmc_sgt[1]);
             #endif
           #endif
           #ifdef Z_HOMING_SENSITIVITY
-            #if ENABLED(Z_IS_TMC2130)
-              stepperZ.sgt(thrs[2]);
+            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+              stepperZ.sgt(tmc_sgt[2]);
             #endif
             #if ENABLED(Z2_IS_TMC2130)
-              stepperZ2.sgt(thrs[2]);
+              stepperZ2.sgt(tmc_sgt[2]);
             #endif
           #endif
         }
@@ -1338,7 +1460,7 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(dummy);
         #endif
       #else
-        for (uint8_t q = XYZ; q--;) EEPROM_READ(dummy);
+        for (uint8_t q = 3; q--;) EEPROM_READ(dummy);
       #endif
 
       //
@@ -1731,66 +1853,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #endif
   );
 
-  #if X_IS_TRINAMIC
-    stepperX.setCurrent(X_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Y_IS_TRINAMIC
-    stepperY.setCurrent(Y_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Z_IS_TRINAMIC
-    stepperZ.setCurrent(Z_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if X2_IS_TRINAMIC
-    stepperX2.setCurrent(X2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Y2_IS_TRINAMIC
-    stepperY2.setCurrent(Y2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if Z2_IS_TRINAMIC
-    stepperZ2.setCurrent(Z2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E0_IS_TRINAMIC
-    stepperE0.setCurrent(E0_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E1_IS_TRINAMIC
-    stepperE1.setCurrent(E1_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E2_IS_TRINAMIC
-    stepperE2.setCurrent(E2_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E3_IS_TRINAMIC
-    stepperE3.setCurrent(E3_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-  #if E4_IS_TRINAMIC
-    stepperE4.setCurrent(E4_CURRENT, R_SENSE, HOLD_MULTIPLIER);
-  #endif
-
-  #if ENABLED(SENSORLESS_HOMING)
-    #ifdef X_HOMING_SENSITIVITY
-      #if ENABLED(X_IS_TMC2130)
-        stepperX.sgt(X_HOMING_SENSITIVITY);
-      #endif
-      #if ENABLED(X2_IS_TMC2130)
-        stepperX2.sgt(X_HOMING_SENSITIVITY);
-      #endif
-    #endif
-    #ifdef Y_HOMING_SENSITIVITY
-      #if ENABLED(Y_IS_TMC2130)
-        stepperY.sgt(Y_HOMING_SENSITIVITY);
-      #endif
-      #if ENABLED(Y2_IS_TMC2130)
-        stepperY2.sgt(Y_HOMING_SENSITIVITY);
-      #endif
-    #endif
-    #ifdef Z_HOMING_SENSITIVITY
-      #if ENABLED(Z_IS_TMC2130)
-        stepperZ.sgt(Z_HOMING_SENSITIVITY);
-      #endif
-      #if ENABLED(Z2_IS_TMC2130)
-        stepperZ2.sgt(Z_HOMING_SENSITIVITY);
-      #endif
-    #endif
-  #endif
+  reset_stepper_drivers();
 
   #if ENABLED(LIN_ADVANCE)
     planner.extruder_advance_K = LIN_ADVANCE_K;
@@ -1829,6 +1892,10 @@ void MarlinSettings::reset(PORTARG_SOLO) {
 
   #define CONFIG_ECHO_START do{ if (!forReplay) SERIAL_ECHO_START_P(port); }while(0)
 
+  #if ENABLED(ADVANCED_PAUSE_FEATURE)
+    void say_M603() { SERIAL_ECHOPGM_P(port, "  M603 "); }
+  #endif
+
   /**
    * M503 - Report current settings in RAM
    *
@@ -1849,7 +1916,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       SERIAL_ECHOPGM_P(port, "  G2");
       SERIAL_CHAR_P(port, parser.linear_unit_factor == 1.0 ? '1' : '0');
       SERIAL_ECHOPGM_P(port, " ; Units in ");
-      serialprintPGM(parser.linear_unit_factor == 1.0 ? PSTR("mm\n") : PSTR("inches\n"));
+      serialprintPGM_P(port, parser.linear_unit_factor == 1.0 ? PSTR("mm\n") : PSTR("inches\n"));
     #else
       #define LINEAR_UNIT(N) (N)
       #define VOLUMETRIC_UNIT(N) (N)
@@ -2076,7 +2143,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
               SERIAL_ECHOPAIR_P(port, "  G29 S3 X", (int)px + 1);
               SERIAL_ECHOPAIR_P(port, " Y", (int)py + 1);
               SERIAL_ECHOPGM_P(port, " Z");
-              SERIAL_PROTOCOL_F_P(port, LINEAR_UNIT(mbl.z_values[px][py]), 5);
+              SERIAL_ECHO_F_P(port, LINEAR_UNIT(mbl.z_values[px][py]), 5);
               SERIAL_EOL_P(port);
             }
           }
@@ -2103,7 +2170,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
               SERIAL_ECHOPAIR_P(port, "  G29 W I", (int)px + 1);
               SERIAL_ECHOPAIR_P(port, " J", (int)py + 1);
               SERIAL_ECHOPGM_P(port, " Z");
-              SERIAL_PROTOCOL_F_P(port, LINEAR_UNIT(z_values[px][py]), 5);
+              SERIAL_ECHO_F_P(port, LINEAR_UNIT(z_values[px][py]), 5);
               SERIAL_EOL_P(port);
             }
           }
@@ -2289,95 +2356,124 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOPGM_P(port, " K");
         SERIAL_ECHO_F_P(port, LINEAR_UNIT(planner.yz_skew_factor), 6);
         SERIAL_EOL_P(port);
-       #else
+      #else
         SERIAL_ECHOPGM_P(port, "  M852 S");
         SERIAL_ECHO_F_P(port, LINEAR_UNIT(planner.xy_skew_factor), 6);
         SERIAL_EOL_P(port);
       #endif
     #endif
 
-    /**
-     * TMC2130 stepper driver current
-     */
     #if HAS_TRINAMIC
+
+      /**
+       * TMC2130 / TMC2208 / TRAMS stepper driver current
+       */
       if (!forReplay) {
         CONFIG_ECHO_START;
         SERIAL_ECHOLNPGM_P(port, "Stepper driver current:");
       }
       CONFIG_ECHO_START;
       SERIAL_ECHOPGM_P(port, "  M906");
-      #if ENABLED(X_IS_TMC2130) || ENABLED(X_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " X ", stepperX.getCurrent());
+      #if X_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " X", stepperX.getCurrent());
+      #elif X2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " X", stepperX2.getCurrent());
       #endif
-      #if ENABLED(Y_IS_TMC2130) || ENABLED(Y_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " Y ", stepperY.getCurrent());
+      #if Y_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Y", stepperY.getCurrent());
+      #elif Y2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Y", stepperY2.getCurrent());
       #endif
-      #if ENABLED(Z_IS_TMC2130) || ENABLED(Z_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " Z ", stepperZ.getCurrent());
+      #if Z_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Z", stepperZ.getCurrent());
+      #elif Z2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.getCurrent());
       #endif
-      #if ENABLED(X2_IS_TMC2130) || ENABLED(X2_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " X2 ", stepperX2.getCurrent());
+      #if E0_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", stepperE0.getCurrent());
+      #elif E1_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", stepperE1.getCurrent());
+      #elif E2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", stepperE2.getCurrent());
+      #elif E3_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", stepperE3.getCurrent());
+      #elif E4_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", stepperE4.getCurrent());
       #endif
-      #if ENABLED(Y2_IS_TMC2130) || ENABLED(Y2_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " Y2 ", stepperY2.getCurrent());
-      #endif
-      #if ENABLED(Z2_IS_TMC2130) || ENABLED(Z2_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " Z2 ", stepperZ2.getCurrent());
-      #endif
-      #if ENABLED(E0_IS_TMC2130) || ENABLED(E0_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " E0 ", stepperE0.getCurrent());
-      #endif
-      #if ENABLED(E1_IS_TMC2130) || ENABLED(E1_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " E1 ", stepperE1.getCurrent());
-      #endif
-      #if ENABLED(E2_IS_TMC2130) || ENABLED(E2_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " E2 ", stepperE2.getCurrent());
-      #endif
-      #if ENABLED(E3_IS_TMC2130) || ENABLED(E3_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " E3 ", stepperE3.getCurrent());
-      #endif
-      #if ENABLED(E4_IS_TMC2130) || ENABLED(E4_IS_TMC2208)
-        SERIAL_ECHOPAIR_P(port, " E4 ", stepperE4.getCurrent());
-      #endif
-      SERIAL_EOL_P(port);
-    #endif
+      SERIAL_EOL();
 
-    /**
-     * TMC2130 Sensorless homing thresholds
-     */
-    #if ENABLED(SENSORLESS_HOMING)
+      /**
+       * TMC2130 / TMC2208 / TRAMS Hybrid Threshold
+       */
       if (!forReplay) {
         CONFIG_ECHO_START;
-        SERIAL_ECHOLNPGM_P(port, "Sensorless homing threshold:");
+        SERIAL_ECHOLNPGM_P(port, "Hybrid Threshold:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPGM_P(port, "  M914");
-      #ifdef X_HOMING_SENSITIVITY
-        #if ENABLED(X_IS_TMC2130)
-          SERIAL_ECHOPAIR_P(port, " X", stepperX.sgt());
-        #endif
-        #if ENABLED(X2_IS_TMC2130)
-          SERIAL_ECHOPAIR_P(port, " X2 ", stepperX2.sgt());
-        #endif
+      SERIAL_ECHOPGM_P(port, "  M913");
+      #if X_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X));
+      #elif X2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X2));
       #endif
-      #ifdef Y_HOMING_SENSITIVITY
-        #if ENABLED(Y_IS_TMC2130)
-          SERIAL_ECHOPAIR_P(port, " Y", stepperY.sgt());
-        #endif
-        #if ENABLED(Y2_IS_TMC2130)
-          SERIAL_ECHOPAIR_P(port, " Y2 ", stepperY2.sgt());
-        #endif
+      #if Y_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y));
+      #elif Y2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y2));
       #endif
-      #ifdef Z_HOMING_SENSITIVITY
-        #if ENABLED(Z_IS_TMC2130)
-          SERIAL_ECHOPAIR_P(port, " Z ", stepperZ.sgt());
-        #endif
-        #if ENABLED(Z2_IS_TMC2130)
-          SERIAL_ECHOPAIR_P(port, " Z2 ", stepperZ2.sgt());
-        #endif
+      #if Z_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z));
+      #elif Z2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z2));
       #endif
-      SERIAL_EOL_P(port);
-    #endif
+      #if E0_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E0));
+      #elif E1_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E1));
+      #elif E2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E2));
+      #elif E3_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E3));
+      #elif E4_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E4));
+      #endif
+      SERIAL_EOL();
+
+      /**
+       * TMC2130 Sensorless homing thresholds
+       */
+      #if ENABLED(SENSORLESS_HOMING)
+        if (!forReplay) {
+          CONFIG_ECHO_START;
+          SERIAL_ECHOLNPGM_P(port, "Sensorless homing threshold:");
+        }
+        CONFIG_ECHO_START;
+        SERIAL_ECHOPGM_P(port, "  M914");
+        #ifdef X_HOMING_SENSITIVITY
+          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+            SERIAL_ECHOPAIR_P(port, " X", stepperX.sgt());
+          #elif ENABLED(X2_IS_TMC2130)
+            SERIAL_ECHOPAIR_P(port, " X", stepperX2.sgt());
+          #endif
+        #endif
+        #ifdef Y_HOMING_SENSITIVITY
+          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+            SERIAL_ECHOPAIR_P(port, " Y", stepperY.sgt());
+          #elif ENABLED(Y2_IS_TMC2130)
+            SERIAL_ECHOPAIR_P(port, " Y", stepperY2.sgt());
+          #endif
+        #endif
+        #ifdef Z_HOMING_SENSITIVITY
+          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+            SERIAL_ECHOPAIR_P(port, " Z", stepperZ.sgt());
+          #elif ENABLED(Z2_IS_TMC2130)
+            SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.sgt());
+          #endif
+        #endif
+        SERIAL_EOL();
+      #endif
+
+    #endif // HAS_TRINAMIC
 
     /**
      * Linear Advance
@@ -2413,25 +2509,31 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       }
       CONFIG_ECHO_START;
       #if EXTRUDERS == 1
-        SERIAL_ECHOPAIR_P(port, "  M603 L", LINEAR_UNIT(filament_change_load_length[0]));
+        say_M603();
+        SERIAL_ECHOPAIR_P(port, "L", LINEAR_UNIT(filament_change_load_length[0]));
         SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(filament_change_unload_length[0]));
       #else
-        SERIAL_ECHOPAIR_P(port, "  M603 T0 L", LINEAR_UNIT(filament_change_load_length[0]));
+        say_M603();
+        SERIAL_ECHOPAIR_P(port, "T0 L", LINEAR_UNIT(filament_change_load_length[0]));
         SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(filament_change_unload_length[0]));
         CONFIG_ECHO_START;
-        SERIAL_ECHOPAIR_P(port, "  M603 T1 L", LINEAR_UNIT(filament_change_load_length[1]));
+        say_M603();
+        SERIAL_ECHOPAIR_P(port, "T1 L", LINEAR_UNIT(filament_change_load_length[1]));
         SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(filament_change_unload_length[1]));
         #if EXTRUDERS > 2
           CONFIG_ECHO_START;
-          SERIAL_ECHOPAIR_P(port, "  M603 T2 L", LINEAR_UNIT(filament_change_load_length[2]));
+          say_M603();
+          SERIAL_ECHOPAIR_P(port, "T2 L", LINEAR_UNIT(filament_change_load_length[2]));
           SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(filament_change_unload_length[2]));
           #if EXTRUDERS > 3
             CONFIG_ECHO_START;
-            SERIAL_ECHOPAIR_P(port, "  M603 T3 L", LINEAR_UNIT(filament_change_load_length[3]));
+            say_M603();
+            SERIAL_ECHOPAIR_P(port, "T3 L", LINEAR_UNIT(filament_change_load_length[3]));
             SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(filament_change_unload_length[3]));
             #if EXTRUDERS > 4
               CONFIG_ECHO_START;
-              SERIAL_ECHOPAIR_P(port, "  M603 T4 L", LINEAR_UNIT(filament_change_load_length[4]));
+              say_M603();
+              SERIAL_ECHOPAIR_P(port, "T4 L", LINEAR_UNIT(filament_change_load_length[4]));
               SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(filament_change_unload_length[4]));
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1892,6 +1892,14 @@ void MarlinSettings::reset(PORTARG_SOLO) {
 
   #define CONFIG_ECHO_START do{ if (!forReplay) SERIAL_ECHO_START_P(port); }while(0)
 
+  #if HAS_TRINAMIC
+    void say_M906() { SERIAL_ECHOPGM_P(port, "  M906 "); }
+    void say_M913() { SERIAL_ECHOPGM_P(port, "  M913 "); }
+    #if ENABLED(SENSORLESS_HOMING)
+      void say_M914() { SERIAL_ECHOPGM_P(port, "  M914 "); }
+    #endif
+  #endif
+
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     void say_M603() { SERIAL_ECHOPGM_P(port, "  M603 "); }
   #endif
@@ -2373,34 +2381,51 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOLNPGM_P(port, "Stepper driver current:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPGM_P(port, "  M906");
       #if X_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " X", stepperX.getCurrent());
-      #elif X2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " X", stepperX2.getCurrent());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "X", stepperX.getCurrent());
+      #endif
+      #if X2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "I1 X", stepperX2.getCurrent());
       #endif
       #if Y_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Y", stepperY.getCurrent());
-      #elif Y2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Y", stepperY2.getCurrent());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "Y", stepperY.getCurrent());
+      #endif
+      #if Y2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "I1 Y", stepperY2.getCurrent());
       #endif
       #if Z_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Z", stepperZ.getCurrent());
-      #elif Z2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.getCurrent());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "Z", stepperZ.getCurrent());
+      #endif
+      #if Z2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "I1 Z", stepperZ2.getCurrent());
       #endif
       #if E0_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", stepperE0.getCurrent());
-      #elif E1_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", stepperE1.getCurrent());
-      #elif E2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", stepperE2.getCurrent());
-      #elif E3_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", stepperE3.getCurrent());
-      #elif E4_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", stepperE4.getCurrent());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "T0 E", stepperE0.getCurrent());
       #endif
-      SERIAL_EOL();
+      #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "T1 E", stepperE1.getCurrent());
+      #endif
+      #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "T2 E", stepperE2.getCurrent());
+      #endif
+      #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "T3 E", stepperE3.getCurrent());
+      #endif
+      #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(port, "T4 E", stepperE4.getCurrent());
+      #endif
+      SERIAL_EOL_P(port);
 
       /**
        * TMC2130 / TMC2208 / TRAMS Hybrid Threshold
@@ -2410,34 +2435,51 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOLNPGM_P(port, "Hybrid Threshold:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOPGM_P(port, "  M913");
       #if X_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X));
-      #elif X2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X2));
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "X", TMC_GET_PWMTHRS(X, X));
+      #endif
+      #if X2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "I1 X", TMC_GET_PWMTHRS(X, X2));
       #endif
       #if Y_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y));
-      #elif Y2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y2));
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "Y", TMC_GET_PWMTHRS(Y, Y));
+      #endif
+      #if Y2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "I1 Y", TMC_GET_PWMTHRS(Y, Y2));
       #endif
       #if Z_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z));
-      #elif Z2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z2));
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "Z", TMC_GET_PWMTHRS(Z, Z));
+      #endif
+      #if Z2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "I1 Z", TMC_GET_PWMTHRS(Z, Z2));
       #endif
       #if E0_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E0));
-      #elif E1_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E1));
-      #elif E2_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E2));
-      #elif E3_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E3));
-      #elif E4_IS_TRINAMIC
-        SERIAL_ECHOPAIR_P(port, " E", TMC_GET_PWMTHRS(E, E4));
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "T0 E", TMC_GET_PWMTHRS(E, E0));
       #endif
-      SERIAL_EOL();
+      #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "T1 E", TMC_GET_PWMTHRS(E, E1));
+      #endif
+      #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "T2 E", TMC_GET_PWMTHRS(E, E2));
+      #endif
+      #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "T3 E", TMC_GET_PWMTHRS(E, E3));
+      #endif
+      #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+        say_M913();
+        SERIAL_ECHOLNPAIR_P(port, "T4 E", TMC_GET_PWMTHRS(E, E4));
+      #endif
+      SERIAL_EOL_P(port);
 
       /**
        * TMC2130 Sensorless homing thresholds
@@ -2448,29 +2490,37 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           SERIAL_ECHOLNPGM_P(port, "Sensorless homing threshold:");
         }
         CONFIG_ECHO_START;
-        SERIAL_ECHOPGM_P(port, "  M914");
         #ifdef X_HOMING_SENSITIVITY
           #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-            SERIAL_ECHOPAIR_P(port, " X", stepperX.sgt());
-          #elif ENABLED(X2_IS_TMC2130)
-            SERIAL_ECHOPAIR_P(port, " X", stepperX2.sgt());
+            say_M914();
+            SERIAL_ECHOLNPAIR_P(port, "X", stepperX.sgt());
+          #endif
+          #if ENABLED(X2_IS_TMC2130)
+            say_M914();
+            SERIAL_ECHOLNPAIR_P(port, "I1 X", stepperX2.sgt());
           #endif
         #endif
         #ifdef Y_HOMING_SENSITIVITY
           #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-            SERIAL_ECHOPAIR_P(port, " Y", stepperY.sgt());
-          #elif ENABLED(Y2_IS_TMC2130)
-            SERIAL_ECHOPAIR_P(port, " Y", stepperY2.sgt());
+            say_M914();
+            SERIAL_ECHOLNPAIR_P(port, "Y", stepperY.sgt());
+          #endif
+          #if ENABLED(Y2_IS_TMC2130)
+            say_M914();
+            SERIAL_ECHOLNPAIR_P(port, "I1 Y", stepperY2.sgt());
           #endif
         #endif
         #ifdef Z_HOMING_SENSITIVITY
           #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-            SERIAL_ECHOPAIR_P(port, " Z", stepperZ.sgt());
-          #elif ENABLED(Z2_IS_TMC2130)
-            SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.sgt());
+            say_M914();
+            SERIAL_ECHOLNPAIR_P(port, "Z", stepperZ.sgt());
+          #endif
+          #if ENABLED(Z2_IS_TMC2130)
+            say_M914();
+            SERIAL_ECHOLNPAIR_P(port, "I1 Z", stepperZ2.sgt());
           #endif
         #endif
-        SERIAL_EOL();
+        SERIAL_EOL_P(port);
       #endif
 
     #endif // HAS_TRINAMIC

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -921,31 +921,6 @@ void Stepper::init() {
     microstep_init();
   #endif
 
-  // Init TMC Steppers
-  #if ENABLED(HAVE_TMC26X)
-    tmc26x_init();
-  #endif
-
-  // Init TMC2130 Steppers
-  #if ENABLED(HAVE_TMC2130)
-    tmc2130_init();
-  #endif
-
-  // Init TMC2208 Steppers
-  #if ENABLED(HAVE_TMC2208)
-    tmc2208_init();
-  #endif
-
-  // TRAMS, TMC2130 and TMC2208 advanced settings
-  #if HAS_TRINAMIC
-    TMC_ADV()
-  #endif
-
-  // Init L6470 Steppers
-  #if ENABLED(HAVE_L6470DRIVER)
-    L6470_init();
-  #endif
-
   // Init Dir Pins
   #if HAS_X_DIR
     X_DIR_INIT;

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -54,29 +54,32 @@
   #else
     #include <TMC26XStepper.h>
   #endif
-  void tmc26x_init();
+  void tmc26x_init_to_defaults();
 #endif
 
 #if ENABLED(HAVE_TMC2130)
   #include <TMC2130Stepper.h>
-  void tmc2130_init();
+  void tmc2130_init_to_defaults();
 #endif
 
 #if ENABLED(HAVE_TMC2208)
   #include <TMC2208Stepper.h>
   void tmc2208_serial_begin();
-  void tmc2208_init();
+  void tmc2208_init_to_defaults();
 #endif
 
 // L6470 has STEP on normal pins, but DIR/ENABLE via SPI
 #if ENABLED(HAVE_L6470DRIVER)
   #include <SPI.h>
   #include <L6470.h>
-  void L6470_init();
+  void L6470_init_to_defaults();
 #endif
 
+void restore_stepper_drivers();  // Called by PSU_ON
+void reset_stepper_drivers();    // Called by settings.load / settings.reset
+
 // X Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(X_IS_L6470)
+#if ENABLED(X_IS_L6470)
   extern L6470 stepperX;
   #define X_ENABLE_INIT NOOP
   #define X_ENABLE_WRITE(STATE) do{ if (STATE) stepperX.Step_Clock(stepperX.getStatus() & STATUS_HIZ); else stepperX.softFree(); }while(0)
@@ -91,9 +94,9 @@
     #define X_ENABLE_WRITE(STATE) stepperX.setEnabled(STATE)
     #define X_ENABLE_READ stepperX.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(X_IS_TMC2130)
+    #if ENABLED(X_IS_TMC2130)
       extern TMC2130Stepper stepperX;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(X_IS_TMC2208)
+    #elif ENABLED(X_IS_TMC2208)
       extern TMC2208Stepper stepperX;
     #endif
     #define X_ENABLE_INIT SET_OUTPUT(X_ENABLE_PIN)
@@ -109,7 +112,7 @@
 #define X_STEP_READ READ(X_STEP_PIN)
 
 // Y Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(Y_IS_L6470)
+#if ENABLED(Y_IS_L6470)
   extern L6470 stepperY;
   #define Y_ENABLE_INIT NOOP
   #define Y_ENABLE_WRITE(STATE) do{ if (STATE) stepperY.Step_Clock(stepperY.getStatus() & STATUS_HIZ); else stepperY.softFree(); }while(0)
@@ -124,9 +127,9 @@
     #define Y_ENABLE_WRITE(STATE) stepperY.setEnabled(STATE)
     #define Y_ENABLE_READ stepperY.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(Y_IS_TMC2130)
+    #if ENABLED(Y_IS_TMC2130)
       extern TMC2130Stepper stepperY;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(Y_IS_TMC2208)
+    #elif ENABLED(Y_IS_TMC2208)
       extern TMC2208Stepper stepperY;
     #endif
     #define Y_ENABLE_INIT SET_OUTPUT(Y_ENABLE_PIN)
@@ -142,7 +145,7 @@
 #define Y_STEP_READ READ(Y_STEP_PIN)
 
 // Z Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(Z_IS_L6470)
+#if ENABLED(Z_IS_L6470)
   extern L6470 stepperZ;
   #define Z_ENABLE_INIT NOOP
   #define Z_ENABLE_WRITE(STATE) do{ if (STATE) stepperZ.Step_Clock(stepperZ.getStatus() & STATUS_HIZ); else stepperZ.softFree(); }while(0)
@@ -157,9 +160,9 @@
     #define Z_ENABLE_WRITE(STATE) stepperZ.setEnabled(STATE)
     #define Z_ENABLE_READ stepperZ.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(Z_IS_TMC2130)
+    #if ENABLED(Z_IS_TMC2130)
       extern TMC2130Stepper stepperZ;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(Z_IS_TMC2208)
+    #elif ENABLED(Z_IS_TMC2208)
       extern TMC2208Stepper stepperZ;
     #endif
     #define Z_ENABLE_INIT SET_OUTPUT(Z_ENABLE_PIN)
@@ -176,7 +179,7 @@
 
 // X2 Stepper
 #if HAS_X2_ENABLE
-  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(X2_IS_L6470)
+  #if ENABLED(X2_IS_L6470)
     extern L6470 stepperX2;
     #define X2_ENABLE_INIT NOOP
     #define X2_ENABLE_WRITE(STATE) do{ if (STATE) stepperX2.Step_Clock(stepperX2.getStatus() & STATUS_HIZ); else stepperX2.softFree(); }while(0)
@@ -191,9 +194,9 @@
       #define X2_ENABLE_WRITE(STATE) stepperX2.setEnabled(STATE)
       #define X2_ENABLE_READ stepperX2.isEnabled()
     #else
-      #if ENABLED(HAVE_TMC2130) && ENABLED(X2_IS_TMC2130)
+      #if ENABLED(X2_IS_TMC2130)
         extern TMC2130Stepper stepperX2;
-      #elif ENABLED(HAVE_TMC2208) && ENABLED(X2_IS_TMC2208)
+      #elif ENABLED(X2_IS_TMC2208)
         extern TMC2208Stepper stepperX2;
       #endif
       #define X2_ENABLE_INIT SET_OUTPUT(X2_ENABLE_PIN)
@@ -211,7 +214,7 @@
 
 // Y2 Stepper
 #if HAS_Y2_ENABLE
-  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(Y2_IS_L6470)
+  #if ENABLED(Y2_IS_L6470)
     extern L6470 stepperY2;
     #define Y2_ENABLE_INIT NOOP
     #define Y2_ENABLE_WRITE(STATE) do{ if (STATE) stepperY2.Step_Clock(stepperY2.getStatus() & STATUS_HIZ); else stepperY2.softFree(); }while(0)
@@ -226,9 +229,9 @@
       #define Y2_ENABLE_WRITE(STATE) stepperY2.setEnabled(STATE)
       #define Y2_ENABLE_READ stepperY2.isEnabled()
     #else
-      #if ENABLED(HAVE_TMC2130) && ENABLED(Y2_IS_TMC2130)
+      #if ENABLED(Y2_IS_TMC2130)
         extern TMC2130Stepper stepperY2;
-      #elif ENABLED(HAVE_TMC2208) && ENABLED(Y2_IS_TMC2208)
+      #elif ENABLED(Y2_IS_TMC2208)
         extern TMC2208Stepper stepperY2;
       #endif
       #define Y2_ENABLE_INIT SET_OUTPUT(Y2_ENABLE_PIN)
@@ -246,7 +249,7 @@
 
 // Z2 Stepper
 #if HAS_Z2_ENABLE
-  #if ENABLED(HAVE_L6470DRIVER) && ENABLED(Z2_IS_L6470)
+  #if ENABLED(Z2_IS_L6470)
     extern L6470 stepperZ2;
     #define Z2_ENABLE_INIT NOOP
     #define Z2_ENABLE_WRITE(STATE) do{ if (STATE) stepperZ2.Step_Clock(stepperZ2.getStatus() & STATUS_HIZ); else stepperZ2.softFree(); }while(0)
@@ -261,9 +264,9 @@
       #define Z2_ENABLE_WRITE(STATE) stepperZ2.setEnabled(STATE)
       #define Z2_ENABLE_READ stepperZ2.isEnabled()
     #else
-      #if ENABLED(HAVE_TMC2130) && ENABLED(Z2_IS_TMC2130)
+      #if ENABLED(Z2_IS_TMC2130)
         extern TMC2130Stepper stepperZ2;
-      #elif ENABLED(HAVE_TMC2208) && ENABLED(Z2_IS_TMC2208)
+      #elif ENABLED(Z2_IS_TMC2208)
         extern TMC2208Stepper stepperZ2;
       #endif
       #define Z2_ENABLE_INIT SET_OUTPUT(Z2_ENABLE_PIN)
@@ -280,7 +283,7 @@
 #endif
 
 // E0 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E0_IS_L6470)
+#if ENABLED(E0_IS_L6470)
   extern L6470 stepperE0;
   #define E0_ENABLE_INIT NOOP
   #define E0_ENABLE_WRITE(STATE) do{ if (STATE) stepperE0.Step_Clock(stepperE0.getStatus() & STATUS_HIZ); else stepperE0.softFree(); }while(0)
@@ -295,9 +298,9 @@
     #define E0_ENABLE_WRITE(STATE) stepperE0.setEnabled(STATE)
     #define E0_ENABLE_READ stepperE0.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E0_IS_TMC2130)
+    #if ENABLED(E0_IS_TMC2130)
       extern TMC2130Stepper stepperE0;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E0_IS_TMC2208)
+    #elif ENABLED(E0_IS_TMC2208)
       extern TMC2208Stepper stepperE0;
     #endif
     #define E0_ENABLE_INIT SET_OUTPUT(E0_ENABLE_PIN)
@@ -313,7 +316,7 @@
 #define E0_STEP_READ READ(E0_STEP_PIN)
 
 // E1 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E1_IS_L6470)
+#if ENABLED(E1_IS_L6470)
   extern L6470 stepperE1;
   #define E1_ENABLE_INIT NOOP
   #define E1_ENABLE_WRITE(STATE) do{ if (STATE) stepperE1.Step_Clock(stepperE1.getStatus() & STATUS_HIZ); else stepperE1.softFree(); }while(0)
@@ -328,9 +331,9 @@
     #define E1_ENABLE_WRITE(STATE) stepperE1.setEnabled(STATE)
     #define E1_ENABLE_READ stepperE1.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E1_IS_TMC2130)
+    #if ENABLED(E1_IS_TMC2130)
       extern TMC2130Stepper stepperE1;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E1_IS_TMC2208)
+    #elif ENABLED(E1_IS_TMC2208)
       extern TMC2208Stepper stepperE1;
     #endif
     #define E1_ENABLE_INIT SET_OUTPUT(E1_ENABLE_PIN)
@@ -346,7 +349,7 @@
 #define E1_STEP_READ READ(E1_STEP_PIN)
 
 // E2 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E2_IS_L6470)
+#if ENABLED(E2_IS_L6470)
   extern L6470 stepperE2;
   #define E2_ENABLE_INIT NOOP
   #define E2_ENABLE_WRITE(STATE) do{ if (STATE) stepperE2.Step_Clock(stepperE2.getStatus() & STATUS_HIZ); else stepperE2.softFree(); }while(0)
@@ -361,9 +364,9 @@
     #define E2_ENABLE_WRITE(STATE) stepperE2.setEnabled(STATE)
     #define E2_ENABLE_READ stepperE2.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E2_IS_TMC2130)
+    #if ENABLED(E2_IS_TMC2130)
       extern TMC2130Stepper stepperE2;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E2_IS_TMC2208)
+    #elif ENABLED(E2_IS_TMC2208)
       extern TMC2208Stepper stepperE2;
     #endif
     #define E2_ENABLE_INIT SET_OUTPUT(E2_ENABLE_PIN)
@@ -379,7 +382,7 @@
 #define E2_STEP_READ READ(E2_STEP_PIN)
 
 // E3 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E3_IS_L6470)
+#if ENABLED(E3_IS_L6470)
   extern L6470 stepperE3;
   #define E3_ENABLE_INIT NOOP
   #define E3_ENABLE_WRITE(STATE) do{ if (STATE) stepperE3.Step_Clock(stepperE3.getStatus() & STATUS_HIZ); else stepperE3.softFree(); }while(0)
@@ -394,9 +397,9 @@
     #define E3_ENABLE_WRITE(STATE) stepperE3.setEnabled(STATE)
     #define E3_ENABLE_READ stepperE3.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E3_IS_TMC2130)
+    #if ENABLED(E3_IS_TMC2130)
       extern TMC2130Stepper stepperE3;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E3_IS_TMC2208)
+    #elif ENABLED(E3_IS_TMC2208)
       extern TMC2208Stepper stepperE3;
     #endif
     #define E3_ENABLE_INIT SET_OUTPUT(E3_ENABLE_PIN)
@@ -412,7 +415,7 @@
 #define E3_STEP_READ READ(E3_STEP_PIN)
 
 // E4 Stepper
-#if ENABLED(HAVE_L6470DRIVER) && ENABLED(E4_IS_L6470)
+#if ENABLED(E4_IS_L6470)
   extern L6470 stepperE4;
   #define E4_ENABLE_INIT NOOP
   #define E4_ENABLE_WRITE(STATE) do{ if (STATE) stepperE4.Step_Clock(stepperE4.getStatus() & STATUS_HIZ); else stepperE4.softFree(); }while(0)
@@ -427,9 +430,9 @@
     #define E4_ENABLE_WRITE(STATE) stepperE4.setEnabled(STATE)
     #define E4_ENABLE_READ stepperE4.isEnabled()
   #else
-    #if ENABLED(HAVE_TMC2130) && ENABLED(E4_IS_TMC2130)
+    #if ENABLED(E4_IS_TMC2130)
       extern TMC2130Stepper stepperE4;
-    #elif ENABLED(HAVE_TMC2208) && ENABLED(E4_IS_TMC2208)
+    #elif ENABLED(E4_IS_TMC2208)
       extern TMC2208Stepper stepperE4;
     #endif
     #define E4_ENABLE_INIT SET_OUTPUT(E4_ENABLE_PIN)


### PR DESCRIPTION
Addressing #10087

- Add EEPROM Init, Load, Save, Report for `M913` Hybrid Threshold.
- Bump EEPROM to V53.
- Reorder `TMC_AxisEnum` to match EEPROM storage.
- Reduce PROGMEM string usage with small functions.
- Add `T` parameter to `M906`/`M913` to specific which extruder.
- Add `I` (index) parameter to `M906`/`M913`/`M914` to specify which dual axis stepper.

[Concise Diff](10102/files?w=1)
Counterpart to #10101