### PR TITLE
[2.0.x] DUE - native port hang (USB CDC: Do not send any character if no program on the PC is listening)

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.c
@@ -1012,7 +1012,7 @@ iram_size_t udi_cdc_read_buf(void* buf, iram_size_t size)
 	return udi_cdc_multi_read_buf(0, buf, size);
 }
 
-iram_size_t udi_cdc_multi_get_free_tx_buffer(uint8_t port)
+iram_size_t __attribute__((optimize("O0"))) udi_cdc_multi_get_free_tx_buffer(uint8_t port)
 {
 	irqflags_t flags;
 	iram_size_t buf_sel_nb, retval;
@@ -1097,7 +1097,7 @@ int udi_cdc_putc(int value)
 	return udi_cdc_multi_putc(0, value);
 }
 
-iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t size)
+iram_size_t __attribute__((optimize("O0"))) udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t size)
 {
 	irqflags_t flags;
 	uint8_t buf_sel;

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -52,6 +52,7 @@
 
 static volatile bool main_b_msc_enable = false;
 static volatile bool main_b_cdc_enable = false;
+static volatile bool main_b_dtr_active = false;
 
 void HAL_idletask(void) {
   // Attend SD card access from the USB MSD -- Prioritize access to improve speed
@@ -69,7 +70,7 @@ void usb_task_msc_disable(void)               { main_b_msc_enable = false; }
 bool usb_task_msc_isenabled(void)             { return main_b_msc_enable; }
 
 bool usb_task_cdc_enable(const uint8_t port)  { return ((main_b_cdc_enable = true)); }
-void usb_task_cdc_disable(const uint8_t port) { main_b_cdc_enable = false; }
+void usb_task_cdc_disable(const uint8_t port) { main_b_cdc_enable = false; main_b_dtr_active = false; }
 bool usb_task_cdc_isenabled(void)             { return main_b_cdc_enable; }
 
 /*! \brief Called by CDC interface
@@ -87,12 +88,17 @@ void usb_task_cdc_config(const uint8_t port, usb_cdc_line_coding_t *cfg) {
     dwDTERate = cfg->dwDTERate;
 }
 
+
 void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable) {
+
+  // Keep DTR status
+  main_b_dtr_active = b_enable;
+
   //  Implement Arduino-Compatible kludge to enter programming mode from
   // the native port:
   //  "Auto-reset into the bootloader is triggered when the port, already
   // open at 1200 bps, is closed."
-    
+
   if (1200 == dwDTERate) {
     // We check DTR state to determine if host port is open (bit 0 of lineState).
     if (!b_enable)
@@ -101,6 +107,8 @@ void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable) {
       cancelReset();
   }
 }
+
+bool usb_task_cdc_dtr_active(void)             { return main_b_dtr_active; }
 
 /// Microsoft WCID descriptor
 typedef struct USB_MicrosoftCompatibleDescriptor_Interface {

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.h
@@ -78,6 +78,19 @@ void usb_task_cdc_disable(const uint8_t port);
  */
 void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable);
 
+/*! \brief Check if MSC is enumerated and configured on the PC side
+ */
+bool usb_task_msc_isenabled(void);
+
+/*! \brief Check if CDC is enumerated and configured on the PC side
+ */
+bool usb_task_cdc_isenabled(void);
+
+/*! \brief Check if CDC is actually OPEN by an application on the PC side
+ *  assuming DTR signal means a program is listening to messages
+ */
+bool usb_task_cdc_dtr_active(void);
+
 /*! \brief Called by UDC when USB Host request a extra string different
  * of this specified in USB device descriptor
  */


### PR DESCRIPTION
This solves Issue #10106.
```
  If the host interface is  on the native port (SERIAL_PORT -1):
    1. On power up or reset the boot screen doesn't come up on the LCD until connected via Repetier Host or Pronterface. Once the LCD is up & running then the USB mass storage device comes up on Windows.
    2. When disconnecting in Repetier Host the controller will hang 20-25 seconds later. When disconnecting in Pronterface it continues to run.
```

The solution is to throw away host bound characters until the host program connects.  This avoids Marlin waiting until the user actually opens a program that is able to consume the output of Marlin
