### PR TITLE
[1.1.x] Update X/Y/Z pin assignments for Einsy Rambo

### DIFF
--- a/Marlin/pins_EINSY_RAMBO.h
+++ b/Marlin/pins_EINSY_RAMBO.h
@@ -41,20 +41,39 @@
 #endif
 
 // TMC2130 Diag Pins (currently just for reference)
-#define X_DIAG_PIN      64
-#define Y_DIAG_PIN      69
-#define Z_DIAG_PIN      68
-#define E0_DIAG_PIN     65
+//#define X_DIAG_PIN      64
+//#define Y_DIAG_PIN      69
+//#define Z_DIAG_PIN      68
+//#define E0_DIAG_PIN     65
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN          64 //12
+// Only use Diag Pins when SENSORLESS_HOMING is enabled for the TMC2130 drivers. 
+// Otherwise use a physical endstop based configuration.
+//
+// SERVO0_PIN and Z_MIN_PIN configuration for BLTOUCH sensor when combined with SENSORLESS_HOMING.
+//
+
 #define X_MAX_PIN          -1
-#define Y_MIN_PIN          69 //11
 #define Y_MAX_PIN          -1
-#define Z_MIN_PIN          68 //10
 #define Z_MAX_PIN          -1
+
+#if ENABLED(SENSORLESS_HOMING)
+  #define X_MIN_PIN          64
+  #define Y_MIN_PIN          69
+
+  #if ENABLED(BLTOUCH)
+    #define Z_MIN_PIN        11 //Y-MIN on board
+    #define SERVO0_PIN       10 //Z-MIN on board
+  #else
+    #define Z_MIN_PIN        10 
+  #endif
+#else
+  #define X_MIN_PIN          12
+  #define Y_MIN_PIN          11
+  #define Z_MIN_PIN          10
+#endif
 
 //
 // Z Probe (when not Z_MIN_PIN)

--- a/Marlin/pins_EINSY_RAMBO.h
+++ b/Marlin/pins_EINSY_RAMBO.h
@@ -41,15 +41,15 @@
 #endif
 
 // TMC2130 Diag Pins (currently just for reference)
-//#define X_DIAG_PIN      64
-//#define Y_DIAG_PIN      69
-//#define Z_DIAG_PIN      68
-//#define E0_DIAG_PIN     65
+#define X_DIAG_PIN      64
+#define Y_DIAG_PIN      69
+#define Z_DIAG_PIN      68
+#define E0_DIAG_PIN     65
 
 //
 // Limit Switches
 //
-// Only use Diag Pins when SENSORLESS_HOMING is enabled for the TMC2130 drivers. 
+// Only use Diag Pins when SENSORLESS_HOMING is enabled for the TMC2130 drivers.
 // Otherwise use a physical endstop based configuration.
 //
 // SERVO0_PIN and Z_MIN_PIN configuration for BLTOUCH sensor when combined with SENSORLESS_HOMING.
@@ -59,20 +59,24 @@
 #define Y_MAX_PIN          -1
 #define Z_MAX_PIN          -1
 
-#if ENABLED(SENSORLESS_HOMING)
-  #define X_MIN_PIN          64
-  #define Y_MIN_PIN          69
+#if DISABLED(SENSORLESS_HOMING)
 
-  #if ENABLED(BLTOUCH)
-    #define Z_MIN_PIN        11 //Y-MIN on board
-    #define SERVO0_PIN       10 //Z-MIN on board
-  #else
-    #define Z_MIN_PIN        10 
-  #endif
-#else
   #define X_MIN_PIN          12
   #define Y_MIN_PIN          11
   #define Z_MIN_PIN          10
+
+#else
+
+  #define X_MIN_PIN          X_DIAG_PIN
+  #define Y_MIN_PIN          Y_DIAG_PIN
+
+  #if ENABLED(BLTOUCH)
+    #define Z_MIN_PIN        11 // Y-MIN
+    #define SERVO0_PIN       10 // Z-MIN
+  #else
+    #define Z_MIN_PIN        10
+  #endif
+
 #endif
 
 //


### PR DESCRIPTION
This request is to add a more complete pin assignment for the Einsy Rambo board. The existing settings were using diag pins regardless of setup. This request sets the use of the diag pins for the x and y axis if sensorless homing is turned on for the TMC2130(Validation earlier in the file asserts this is required for the board). If sensorless homing isn't enabled, the board would default to using phyiscal endstop pin assignments. 

Also added is a bltouch pin config for if sensorless homing is enabled because of the freed up pins as defined in ultimachine's servo example branch for the einsy.

This should make things easier for people who buy this board and the complete board kit from Ultimachine to get up and going. I could provider basic config and config_adv as well if requested.

