### PR TITLE
[2.0.x] removed adjacent duplicated 'if enabled'

### DIFF
--- a/Marlin/src/gcode/geometry/G92.cpp
+++ b/Marlin/src/gcode/geometry/G92.cpp
@@ -50,13 +50,11 @@ void GcodeSuite::G92() {
         #endif // Not SCARA
         return;
     }
-  #endif
 
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
     #define IS_G92_0 (parser.subcode == 0)
   #else
     #define IS_G92_0 true
-  #endif
+  #endif // CNC_COORDINATE_SYSTEMS
 
   bool didE = false;
   #if IS_SCARA || !HAS_POSITION_SHIFT


### PR DESCRIPTION
G92 has 2 'if enabled' test one after the other. I think that is better to join them