### PR TITLE
[1.1.x] removed adjacent duplicated 'if enabled'

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6126,13 +6126,11 @@ inline void gcode_G92() {
         #endif // Not SCARA
         return;
     }
-  #endif
 
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
     #define IS_G92_0 (parser.subcode == 0)
   #else
     #define IS_G92_0 true
-  #endif
+  #endif  // CNC_COORDINATE_SYSTEMS
 
   bool didE = false;
   #if IS_SCARA || !HAS_POSITION_SHIFT


### PR DESCRIPTION
G92 has 2 'if enabled' test one after the other. I think that is better to join them

#10134 counterpart