### PR TITLE
[2.0.x] DUE Tone fixes/changes

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
@@ -61,15 +61,15 @@
 // --------------------------------------------------------------------------
 
 const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
-  { TC0, 0, TC0_IRQn, 0},  // 0 - [servo timer5]
-  { TC0, 1, TC1_IRQn, 0},  // 1
-  { TC0, 2, TC2_IRQn, 0},  // 2
-  { TC1, 0, TC3_IRQn, 2},  // 3 - stepper
+  { TC0, 0, TC0_IRQn,  0}, // 0 - [servo timer5]
+  { TC0, 1, TC1_IRQn,  0}, // 1
+  { TC0, 2, TC2_IRQn,  0}, // 2
+  { TC1, 0, TC3_IRQn,  2}, // 3 - stepper
   { TC1, 1, TC4_IRQn, 15}, // 4 - temperature
-  { TC1, 2, TC5_IRQn, 0},  // 5 - [servo timer3]
-  { TC2, 0, TC6_IRQn, 0},  // 6 - tone
-  { TC2, 1, TC7_IRQn, 0},  // 7
-  { TC2, 2, TC8_IRQn, 0},  // 8
+  { TC1, 2, TC5_IRQn,  0}, // 5 - [servo timer3]
+  { TC2, 0, TC6_IRQn, 15}, // 6 - tone
+  { TC2, 1, TC7_IRQn,  0}, // 7
+  { TC2, 2, TC8_IRQn,  0}, // 8
 };
 
 // --------------------------------------------------------------------------
@@ -100,6 +100,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
   pmc_enable_periph_clk((uint32_t)irq);
   NVIC_SetPriority(irq, TimerConfig [timer_num].priority);
 
+  // wave mode, reset counter on match with RC,
   TC_Configure(tc, channel, TC_CMR_WAVE | TC_CMR_WAVSEL_UP_RC | TC_CMR_TCCLKS_TIMER_CLOCK1);
 
   TC_SetRC(tc, channel, VARIANT_MCK / 2 / frequency);

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -109,9 +109,21 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   return pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV;
 }
 
+FORCE_INLINE static void HAL_timer_set_count(const uint8_t timer_num, const hal_timer_t counter) {
+  const tTimerConfig * const pConfig = &TimerConfig[timer_num];
+  pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_CV = counter;
+}
+
+// if counter too high then bump up compare
 FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_ticks) {
   const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_ticks;
   if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_compare(timer_num, mincmp);
+}
+
+// if counter too high then clear it
+FORCE_INLINE static void HAL_timer_restrain_count(const uint8_t timer_num, const uint16_t interval_ticks) {
+  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_ticks;
+  if (HAL_timer_get_compare(timer_num) < mincmp) HAL_timer_set_count(timer_num, 0);
 }
 
 void HAL_timer_enable_interrupt(const uint8_t timer_num);

--- a/Marlin/src/HAL/HAL_DUE/Tone.cpp
+++ b/Marlin/src/HAL/HAL_DUE/Tone.cpp
@@ -34,13 +34,15 @@ static pin_t tone_pin;
 volatile static int32_t toggles;
 
 void toneInit() {
-  HAL_timer_start(TONE_TIMER_NUM, 1); // Lowest frequency possible
+  HAL_timer_start(TONE_TIMER_NUM, 100000);
+  HAL_timer_disable_interrupt(TONE_TIMER_NUM);
 }
 
 void tone(const pin_t _pin, const unsigned int frequency, const unsigned long duration) {
   tone_pin = _pin;
   toggles = 2 * frequency * duration / 1000;
-  HAL_timer_set_compare(TONE_TIMER_NUM, VARIANT_MCK / 2 / frequency); // 84MHz / 2 prescaler / Hz
+  HAL_timer_set_count(TONE_TIMER_NUM, 0);  // ensure first beep is correct (make sure counter is less than the compare value)
+  HAL_timer_set_compare(TONE_TIMER_NUM, VARIANT_MCK / 2 / 2 / frequency); // 84MHz / 2 prescaler / 2 interrupts per cycle /Hz
   HAL_timer_enable_interrupt(TONE_TIMER_NUM);
 }
 
@@ -52,11 +54,13 @@ void noTone(const pin_t _pin) {
 HAL_TONE_TIMER_ISR {
   static uint8_t pin_state = 0;
   HAL_timer_isr_prologue(TONE_TIMER_NUM);
+
   if (toggles) {
     toggles--;
     digitalWrite(tone_pin, (pin_state ^= 1));
   }
-  else noTone(tone_pin);                                  // seems superfluous ?
+  else noTone(tone_pin);                         // turn off interrupt
+  HAL_timer_restrain_count(TONE_TIMER_NUM, 10);  // make sure next ISR isn't delayed by up to 2 minutes
 }
 
 #endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -648,7 +648,7 @@ void setup() {
 
   #ifdef HAL_INIT
     HAL_init();
-    #if defined(ARDUINO_ARCH_SAM) && PIN_EXISTS(BEEPER)
+    #if defined(ARDUINO_ARCH_SAM) && PIN_EXISTS(BEEPER) && ENABLED(SPEAKER)
       toneInit();
     #endif
   #endif


### PR DESCRIPTION
This PR addresses 4 items:
1. Host comm problem work around  (Issue #10116)
2. Tone duration and frequency were wrong (frequency was 1/2 which meant the duration was 2x)
3. Tones had the highest ISR priority which meant that it could interfere with stepper and servo timing.
4. Tones were sometimes delayed.

----

**Host comm problem work around  (Issue #10116)**
1) In Marlin.cpp - added condition to only init the tone counter when SPEAKER was enabled.
2) In Tone.cpp - disabled ISR within toneInit() so that the ISR wouldn't run during startup.

Either of these seem to fix Issue #10116.  Somehow the receive interrupt wasn't working properly which meant the controller couldn't hear the host.  How these changes fixed is not known.  This problem couldn't be duplicated by the testers so **root cause has not been determined**.  Investigation continues.

----

**Tone duration and frequency were wrong (frequency was 1/2 which meant the duration was 2x)**

The ISR was running at the tone rate which meant that the tone pin was being toggled at 1/2 the desired rate. 

In Tone.cpp changed
FROM
```cpp
HAL_timer_set_compare(TONE_TIMER_NUM, VARIANT_MCK / 2  / frequency); // 84MHz / 2 prescaler /Hz
```
TO
```cpp
HAL_timer_set_compare(TONE_TIMER_NUM, VARIANT_MCK / 2 / 2 / frequency); // 84MHz / 2 prescaler / 2 interrupts per cycle /Hz
```

----

**Tones had the highest ISR priority which meant that it could interfere with stepper and servo timing.**

Changed priority from highest (0) to lowest (15) in the TimerConfig structure in HAL_timers_Due.cpp.

____

**Tones were sometimes delayed.**

1. Tone.cpp - changed the frequency in the HAL_timer_start(timer, freq) call from 1 to 100,000 in the toneInit() routine.  This resulted in the first tone not being delayed.
2. HAL_timers_Due.h - added routines to set the timer counter to a value and to clear the counter if it was beyond the compare value (minus a fudge factor).
3. Tone.cpp - in tone(,,,) - set the timer counter to 0 so that the first toggle always occurred at the correct interval.  Currently, if the counter was already past the compare value, the first transition could be delayed up to 50 - 100 seconds
4. Tone.cpp - in ISR - clear the timer counter if the counter will be beyond the compare before the ISR is re-enabled.   If the counter was already past the compare value, the first transition could be delayed up to 50 - 100 seconds.  This is a possibility because the ISR's priority has been dropped so higher priority ISRs could delay this ISR enough to cause a problem.

