### PR TITLE
[1.1.x] TMC: Fix CURRENT_STEP_DOWN

### DIFF
--- a/Marlin/tmc_util.cpp
+++ b/Marlin/tmc_util.cpp
@@ -126,8 +126,8 @@ bool report_tmc_status = false;
       SERIAL_ECHOLNPGM("mA)");
     }
     #if CURRENT_STEP_DOWN > 0
-      // Decrease current if is_otpw is true and driver is enabled and there's been more then 4 warnings
-      if (data.is_otpw && !st.isEnabled() && otpw_cnt > 4) {
+      // Decrease current if is_otpw is true and driver is enabled and there's been more than 4 warnings
+      if (data.is_otpw && st.isEnabled() && otpw_cnt > 4) {
         st.setCurrent(st.getCurrent() - CURRENT_STEP_DOWN, R_SENSE, HOLD_MULTIPLIER);
         #if ENABLED(REPORT_CURRENT_CHANGE)
           _tmc_say_axis(axis);
@@ -140,7 +140,7 @@ bool report_tmc_status = false;
       otpw_cnt++;
       st.flag_otpw = true;
     }
-    else if (otpw_cnt > 0) otpw_cnt--;
+    else if (otpw_cnt > 0) otpw_cnt=0;
 
     if (report_tmc_status) {
       const uint32_t pwm_scale = get_pwm_scale(st);

--- a/Marlin/tmc_util.cpp
+++ b/Marlin/tmc_util.cpp
@@ -140,7 +140,7 @@ bool report_tmc_status = false;
       otpw_cnt++;
       st.flag_otpw = true;
     }
-    else if (otpw_cnt > 0) otpw_cnt=0;
+    else if (otpw_cnt > 0) otpw_cnt = 0;
 
     if (report_tmc_status) {
       const uint32_t pwm_scale = get_pwm_scale(st);


### PR DESCRIPTION
Fix the `CURRENT_STEP_DOWN` logic and give more time for the driver to cool down before applying another decrease.

2.0.x #10170 