### PR TITLE
[2.0.x] DUE - change hardware SPI to mode 0

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_spi_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_spi_Due.cpp
@@ -825,6 +825,11 @@
 
   #else  // U8G compatible hardware SPI
 
+    #define SPI_MODE_0_DUE_HW 2  // DUE CPHA control bit is inverted
+    #define SPI_MODE_1_DUE_HW 3
+    #define SPI_MODE_2_DUE_HW 0
+    #define SPI_MODE_3_DUE_HW 1
+
     void spiInit(uint8_t spiRate = 6 ) {  // default to slowest rate if not specified)
       // 8.4 MHz, 4 MHz, 2 MHz, 1 MHz, 0.5 MHz, 0.329 MHz, 0.329 MHz
       int spiDueDividors[] = { 10, 21, 42, 84, 168, 255, 255 };
@@ -848,7 +853,7 @@
       SPI0->SPI_MR = SPI_MR_MSTR | SPI_MR_PCSDEC | SPI_MR_MODFDIS;
 
       /* SPI mode 0, 8 Bit data transfer, baud rate */
-      SPI0->SPI_CSR[0] = SPI_CSR_SCBR(spiDueDividors[spiRate]) | 1;
+      SPI0->SPI_CSR[0] = SPI_CSR_SCBR(spiDueDividors[spiRate]) | SPI_MODE_0_DUE_HW;
     }
 
     static uint8_t spiTransfer(uint8_t data) {


### PR DESCRIPTION
The current DUE hardware SPI is running in mode 3 despite what the comment says.  This PR changes it to mode 0 which matches all the other Marlin SPIs. 

DUE's software SPI has been checked and it runs in mode 0.

The SAM3X SPI controller's CPHA control bit is inverted which makes setting the mode correctly a bit confusing.
