### PR TITLE
[2.0.x] Z correction on tool-change for all HAS_MESH

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -446,11 +446,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
               hotend_offset[Y_AXIS][tmp_extruder] - hotend_offset[Y_AXIS][active_extruder]
             };
 
-            #if ENABLED(MESH_BED_LEVELING)
+            #if HAS_MESH
 
               if (planner.leveling_active) {
                 #if ENABLED(DEBUG_LEVELING_FEATURE)
-                  if (DEBUGGING(LEVELING)) SERIAL_ECHOPAIR("Z before MBL: ", current_position[Z_AXIS]);
+                  if (DEBUGGING(LEVELING)) SERIAL_ECHOPAIR("Z before: ", current_position[Z_AXIS]);
                 #endif
                 float x2 = current_position[X_AXIS] + xydiff[X_AXIS],
                       y2 = current_position[Y_AXIS] + xydiff[Y_AXIS],
@@ -464,7 +464,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
                 #endif
               }
 
-            #endif // MESH_BED_LEVELING
+            #endif // HAS_MESH
 
           #endif // !HAS_ABL
 


### PR DESCRIPTION
Addressing #10130

Apply the same Z correction on tool-change for all mesh-based leveling (not just MBL).