### PR TITLE
[1.1.x] Require line number, checksum when card.saving

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -1070,6 +1070,10 @@ inline void get_serial_commands() {
 
         gcode_LastN = gcode_N;
       }
+      else if (card.saving) {
+        gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM));
+        return;
+      }
 
       // Movement commands alert when stopped
       if (IsStopped()) {


### PR DESCRIPTION
### Description

I worked on using XON/XOFF to send files from Octoprint and found that if errors occur (resend commands) some invalid data that is still in the RX buffer will be accepted as commands without checksum and will be written in the file. The problem is that if the data that comes from the RX buffer doesn't start with N it's considered a command and it will be queued and written to the file (commands that don't have the line number, but have the checksum, the '*' and the checksum are written in the file). I haven't tested how these incomplete commands are actually executed, but this could be a problem in the future. One solution for this is to accept only commands with checksum when saving to a file. This is more like a bug report + a possible solution, maybe not the correct one. 

### Benefits

When saving a file to SD with XON/XOFF enabled and RX errors occur, the file will be written without invalid commands.
