### PR TITLE
[2.0.x]  kill() - Add ability to generate traceback debug info & misc changes

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -583,19 +583,23 @@ void kill(const char* lcd_msg) {
     UNUSED(lcd_msg);
   #endif
 
-  _delay_ms(600); // Wait a short time (allows messages to get out before shutting down.
-  cli(); // Stop interrupts
-
-  _delay_ms(250); //Wait to ensure all interrupts routines stopped
-  thermalManager.disable_all_heaters(); //turn off heaters again
-
   #ifdef ACTION_ON_KILL
     SERIAL_ECHOLNPGM("//action:" ACTION_ON_KILL);
   #endif
 
+  _delay_ms(850); // Wait a short time (allows messages to get out before shutting down.
+
+  thermalManager.disable_all_heaters(); //turn off heaters again
+
   #if HAS_POWER_SWITCH
     PSU_OFF();
   #endif
+
+  #if defined(__arm__) && defined(WATCHDOG_RESET_MANUAL)
+    while(1){};  // traceback function enabled - cause WDT timeout so debug info will be generated
+  #endif
+
+  cli(); // Stop interrupts
 
   #if HAS_SUICIDE
     suicide();


### PR DESCRIPTION
Add the ability to generate traceback debug info to the kill() function. 

Traceback is available only on the DUE currently.  The other ARM controllers are similar enough that we expect that this function will be ported to them shortly.  It is not available on the AVR controllers.

The "wait for WDT timeout " loop must be placed before the cli() function because the traceback function uses a WDT interrupt.

Other changes:
1. Wanted as much of the kill() functionality to happen so the "wait for WDT timeout " loop  and cli() function were moved to  just before the suicide and wait for reset functions.
2. The  ACTION_ON_KILL function was moved before the cli() function.  Previously it was after the delays and cli() so it was in danger of not getting out before shutting down.
3. Combined the two delays so that the delay to the second attempt to turn off the heaters remains the same.

The items in the "Other changes" section are just a "nice to do" idea.  They can be dropped if they are of concern.
