### PR TITLE
[1.1.x] bq Hephestos2: Allow bed leveling

### DIFF
--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
@@ -700,7 +700,7 @@
  */
 #define X_PROBE_OFFSET_FROM_EXTRUDER 34  // X offset: -left  +right  [of the nozzle]
 #define Y_PROBE_OFFSET_FROM_EXTRUDER 15  // Y offset: -front +behind [the nozzle]
-#define Z_PROBE_OFFSET_FROM_EXTRUDER  0  // Z offset: -below +above  [the nozzle]
+#define Z_PROBE_OFFSET_FROM_EXTRUDER -4  // Z offset: -below +above  [the nozzle]
 
 // Certain types of probes need to stay away from edges
 #define MIN_PROBE_EDGE 10
@@ -738,8 +738,8 @@
 //#define Z_AFTER_PROBING          2 // Z position after probing is done
 
 // For M851 give a range for adjusting the Z probe offset
-#define Z_PROBE_OFFSET_RANGE_MIN -2
-#define Z_PROBE_OFFSET_RANGE_MAX  0
+#define Z_PROBE_OFFSET_RANGE_MIN -5.5
+#define Z_PROBE_OFFSET_RANGE_MAX -3
 
 // Enable the M48 repeatability test to test probe accuracy
 #define Z_MIN_PROBE_REPEATABILITY_TEST


### PR DESCRIPTION
### Requirements

* Click and merge :wink: 

### Description

* Increases the offset, which needs to be set to let the nozzle touch the buildplate
* By default uses an offset of -4. This one is minimally far way from the buildplate and therefore only finetuning is needed to set the correct distance.

### Benefits

You can finally use Marlin with the bq BH2

### Related Issues

I preferred to fix it on my own before adding an issue ticket. Could be that there are open tickets already.