### PR TITLE
[2.0.x] Z_move_sync feedrate only bugfix

### DIFF
--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -79,7 +79,7 @@ void GcodeSuite::G0_G1(
 
     #if ENABLED(NANODLP_Z_SYNC)
       #if ENABLED(NANODLP_ALL_AXIS)
-        #define _MOVE_SYNC true                 // For any move wait and output sync message
+        #define _MOVE_SYNC parser.seenval('X') || parser.seenval('Y') || parser.seenval('Z')  // For any move wait and output sync message
       #else
         #define _MOVE_SYNC parser.seenval('Z')  // Only for Z move
       #endif


### PR DESCRIPTION
### Description
This PR fixes unepected behavior when send a G1 command with no X,Y or Z (F only) (#10238).
"Move sync" message should only be triggered when moving an axis, not if just sending a feedrate setting.
In the latter case, "Move sync" message could be detected wrongly and mess up the following sync.
Version for 2.0 firmware.

### Benefits

Fixes issue #10238.

### Related Issues

#10238 
