### PR TITLE
Make compile with platformio for stm32

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_Stm32f1.cpp
@@ -41,7 +41,7 @@
 #include "pins_arduino.h"
 #include "spi_pins.h"
 #include "../../core/macros.h"
-#include <spi.h>
+#include <SPI.h>
 
 // --------------------------------------------------------------------------
 // Public Variables

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -1159,7 +1159,7 @@
 // M501 - reads parameters from EEPROM (if you need reset them after you changed them temporarily).
 // M502 - reverts to the default "factory settings".  You still need to store them in EEPROM afterwards if you want to.
 //
-#define EEPROM_SETTINGS // Enable for M500 and M501 commands
+//#define EEPROM_SETTINGS // Enable for M500 and M501 commands
 //#define DISABLE_M503    // Saves ~2700 bytes of PROGMEM. Disable for release!
 //#define EEPROM_CHITCHAT   // Give feedback on EEPROM commands. Disable to save PROGMEM.
 
@@ -1176,7 +1176,7 @@
 //
 // M100 Free Memory Watcher
 //
-#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
+//#define M100_FREE_MEMORY_WATCHER // uncomment to add the M100 Free Memory Watcher for debug purpose
 
 //
 // G20/G21 Inch mode support

--- a/platformio.ini
+++ b/platformio.ini
@@ -235,6 +235,15 @@ board        = genericSTM32F103RE
 build_flags  = !python Marlin/src/HAL/HAL_STM32F1/stm32f1_flag_script.py
   ${common.build_flags}
 lib_deps     = ${common.lib_deps}
+lib_ignore   = U8glib-HAL
+  c1921b4
+  libf3c
+  lib066
+  Adafruit NeoPixel_ID28
+  Adafruit NeoPixel
+  libf3e
+  TMC26XStepper
+lib_ldf_mode = 1
 src_filter   = ${common.default_src_filter}
 monitor_baud = 250000
 


### PR DESCRIPTION
This pull makes Marlin compile with pio and config from Marlin/src/config/examples/stm32f103ret6/Configuration.h

#8796 #8585 
also fixes #10244