### PR TITLE
[2.0.x] Wait before turning off PRINTER_EVENT_LEDS at print end

### DIFF
--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -324,6 +324,10 @@ public:
     #define KEEPALIVE_STATE(n) NOOP
   #endif
 
+  #if ENABLED(PRINTER_EVENT_LEDS) && ENABLED(SDSUPPORT) && HAS_RESUME_CONTINUE
+    static bool lights_off_after_print;
+  #endif
+
   static void dwell(millis_t time);
 
 private:

--- a/Marlin/src/gcode/lcd/M0_M1.cpp
+++ b/Marlin/src/gcode/lcd/M0_M1.cpp
@@ -33,6 +33,11 @@
 
 #include "../../sd/cardreader.h"
 
+#if ENABLED(PRINTER_EVENT_LEDS) && ENABLED(SDSUPPORT)
+  bool GcodeSuite::lights_off_after_print;
+  #include "../../feature/leds/leds.h"
+#endif
+
 /**
  * M0: Unconditional stop - Wait for user button press on LCD
  * M1: Conditional stop   - Wait for user button press on LCD
@@ -90,6 +95,13 @@ void GcodeSuite::M0_M1() {
       while (wait_for_user) idle();
     #endif
   }
+
+  #if ENABLED(PRINTER_EVENT_LEDS) && ENABLED(SDSUPPORT)
+    if (lights_off_after_print) {
+      leds.set_off();
+      lights_off_after_print = false;
+    }
+  #endif
 
   wait_for_user = false;
   KEEPALIVE_STATE(IN_HANDLER);

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -449,12 +449,19 @@ inline void get_serial_commands() {
               LCD_MESSAGEPGM(MSG_INFO_COMPLETED_PRINTS);
               leds.set_green();
               #if HAS_RESUME_CONTINUE
-                enqueue_and_echo_commands_P(PSTR("M0")); // end of the queue!
+                gcode.lights_off_after_print = true;
+                enqueue_and_echo_commands_P(PSTR("M0 S"
+                  #if ENABLED(NEWPANEL)
+                    "1800"
+                  #else
+                    "60"
+                  #endif
+                ));
               #else
-                safe_delay(1000);
+                safe_delay(2000);
+                leds.set_off();
               #endif
-              leds.set_off();
-            #endif
+            #endif // PRINTER_EVENT_LEDS
             card.checkautostart(true);
           }
         }


### PR DESCRIPTION
Addressing #10246

Use a global to indicate that the LEDs should be turned off at the end of `M0`/`M1`.