### PR TITLE
[2.0.x] No delay in sensorless quick homing

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -78,7 +78,6 @@
     #if ENABLED(SENSORLESS_HOMING)
       sensorless_homing_per_axis(X_AXIS, false);
       sensorless_homing_per_axis(Y_AXIS, false);
-      safe_delay(500); // Short delay needed to settle
     #endif
   }
 


### PR DESCRIPTION
This is a remainder of an unsuccessful try to fix sensorless quickhoming (#9471). A positive effect was never confirmed.
Half a second is not short.
If this would be a fix for anything, the same fix would be needed in delta-homing.
