### PR TITLE
[2.0.x] Fix Z discrepancy with Tool-Change

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -138,30 +138,16 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
 
   void set_z_fade_height(const float zfh, const bool do_report/*=true*/) {
 
-    if (planner.z_fade_height == zfh) return; // do nothing if no change
+    if (planner.z_fade_height == zfh) return;
 
-    const bool level_active = planner.leveling_active;
-
-    #if ENABLED(AUTO_BED_LEVELING_UBL)
-      if (level_active) set_bed_leveling_enabled(false);  // turn off before changing fade height for proper apply/unapply leveling to maintain current_position
-    #endif
+    const bool leveling_was_active = planner.leveling_active;
+    set_bed_leveling_enabled(false);
 
     planner.set_z_fade_height(zfh);
 
-    if (level_active) {
+    if (leveling_was_active) {
       const float oldpos[] = { current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] };
-      #if ENABLED(AUTO_BED_LEVELING_UBL)
-        set_bed_leveling_enabled(true);  // turn back on after changing fade height
-      #else
-        set_current_from_steppers_for_axis(
-          #if ABL_PLANAR
-            ALL_AXES
-          #else
-            Z_AXIS
-          #endif
-        );
-        SYNC_PLAN_POSITION_KINEMATIC();
-      #endif
+      set_bed_leveling_enabled(true);
       if (do_report && memcmp(oldpos, current_position, sizeof(oldpos)))
         report_current_position();
     }

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -179,7 +179,7 @@ void GcodeSuite::G28(const bool always_home_all) {
   // Disable the leveling matrix before homing
   #if HAS_LEVELING
     #if ENABLED(RESTORE_LEVELING_AFTER_G28)
-      const bool leveling_state_at_entry = planner.leveling_active;
+      const bool leveling_was_active = planner.leveling_active;
     #endif
     set_bed_leveling_enabled(false);
   #endif
@@ -326,7 +326,7 @@ void GcodeSuite::G28(const bool always_home_all) {
   #endif
 
   #if ENABLED(RESTORE_LEVELING_AFTER_G28)
-    set_bed_leveling_enabled(leveling_state_at_entry);
+    set_bed_leveling_enabled(leveling_was_active);
   #endif
 
   clean_up_after_endstop_or_probe_move();

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -444,7 +444,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           destination[Z_AXIS] += z_diff;  // Include the Z restore with the "move back"
         #endif
 
+        // Raise, move, and lower again
         if (safe_to_move && !no_move && IsRunning()) {
+          // Do a small lift to avoid the workpiece in the move back (below)
+          current_position[Z_AXIS] += 1.0;
+          planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
           #endif


### PR DESCRIPTION
Addressing #10130, #10200, #10202
[Concise Diff](10257/files?w=1)

**Background:** Some procedures need to either raise and lower Z or make corrections to the current position as part of their operation. This includes tool change when there are hotend offsets, `G10`/`G11` when there's a Z Hop value set, and so on. Under normal circumstances the existing approaches work, but when bed leveling and/or Z Fade are enabled these procedures can lead to discrepancies, which can accumulate to make objects the wrong size and potentially shift XY position.

In the Tool Change procedure we've customarily dealt with the issue by figuring out the discrepancy and then compensating for it. Unfortunately this no longer works in all cases due to differences in implementation applied at the higher level, specifically for UBL.

The Z hop in `G10`/`G11` has a related problem, but this is caused by their use of "spoofing" to do the Z movement while retaining the same logical Z position. When Z fade is enabled, this results in different amounts of adjustment for the raise-up compared to the lower-back-down.

**Tool-change Solution:** While it may be possible to add extra cases in Tool Change for UBL, it makes more sense to simplify the code by taking advantage of the newer `set_bed_leveling_enabled` code to just disable leveling prior to the procedure, then restore bed leveling at the right time at the end of the procedure. So that's what this PR attempts.

**Z Hop Solution:** It might work to disable leveling in `G10` and then restore it in `G11` but with a very tilted plane this would cause obvious problems. It's preferable to keep leveling enabled. So this PR tries making the Z raise symmetric to the Z lower. It still uses spoofing, but it spoofs the position only after the hop for the `G10` and spoofs the position before the lower down for `G11`. Maybe this leads to the same proportion of leveling adjustment being applied in both cases.

Also:
- Split up `tool_change` into smaller functions for different setups

Counterpart to #10243
