### PR TITLE
[1.1.x] Fix Ender 4 compilation, add more AVRs to Makefile

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -1,4 +1,4 @@
-# Sprinter Arduino Project Makefile
+# Marlin Firmware Arduino Project Makefile
 #
 # Makefile Based on:
 # Arduino 0011 Makefile
@@ -149,8 +149,136 @@ else ifeq  ($(HARDWARE_MOTHERBOARD),48)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560
 
-# RAMPS equivalent (?) by Creality
+#RAMPS equivalents
+else ifeq  ($(HARDWARE_MOTHERBOARD),143)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),144)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),145)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),146)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),148)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),77)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),78)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),79)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),401)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),402)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),40)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),41)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),47)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),53)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),504)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),37)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),42)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),52)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),49)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),72)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),80)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),503)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),431)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),343)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
 else ifeq  ($(HARDWARE_MOTHERBOARD),243)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+
+#Other ATmega1280, ATmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),111)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),112)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),2)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),21)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),200)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),70)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),701)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),703)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),704)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),302)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),303)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),304)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),21)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),999)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),310)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),321)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),74)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),75)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560
 
@@ -172,6 +300,9 @@ MCU              ?= atmega644p
 else ifeq  ($(HARDWARE_MOTHERBOARD),63)
 HARDWARE_VARIANT ?= Sanguino
 MCU              ?= atmega644p
+else ifeq  ($(HARDWARE_MOTHERBOARD),64)
+HARDWARE_VARIANT ?= Sanguino
+MCU              ?= atmega1284p
 else ifeq  ($(HARDWARE_MOTHERBOARD),65)
 HARDWARE_VARIANT ?= Sanguino
 MCU              ?= atmega1284p
@@ -179,6 +310,15 @@ else ifeq  ($(HARDWARE_MOTHERBOARD),66)
 HARDWARE_VARIANT ?= Sanguino
 MCU              ?= atmega1284p
 else ifeq  ($(HARDWARE_MOTHERBOARD),69)
+HARDWARE_VARIANT ?= Sanguino
+MCU              ?= atmega1284p
+else ifeq  ($(HARDWARE_MOTHERBOARD),89)
+HARDWARE_VARIANT ?= Sanguino
+MCU              ?= atmega1284p
+else ifeq  ($(HARDWARE_MOTHERBOARD),92)
+HARDWARE_VARIANT ?= Sanguino
+MCU              ?= atmega1284p
+else ifeq  ($(HARDWARE_MOTHERBOARD),505)
 HARDWARE_VARIANT ?= Sanguino
 MCU              ?= atmega1284p
 else ifeq  ($(HARDWARE_MOTHERBOARD),601)
@@ -192,6 +332,14 @@ MCU              ?= atmega2560
 else ifeq  ($(HARDWARE_MOTHERBOARD),71)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega1280
+
+#ATmega1281, ATmega2561
+else ifeq  ($(HARDWARE_MOTHERBOARD),702)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega1281
+else ifeq  ($(HARDWARE_MOTHERBOARD),25)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega1281
 
 #Teensylu
 else ifeq  ($(HARDWARE_MOTHERBOARD),8)
@@ -210,6 +358,9 @@ else ifeq  ($(HARDWARE_MOTHERBOARD),83)
 HARDWARE_VARIANT ?= Teensy
 MCU              ?= at90usb1286
 else ifeq  ($(HARDWARE_MOTHERBOARD),84)
+HARDWARE_VARIANT ?= Teensy
+MCU              ?= at90usb1286
+else ifeq  ($(HARDWARE_MOTHERBOARD),88)
 HARDWARE_VARIANT ?= Teensy
 MCU              ?= at90usb1286
 
@@ -238,12 +389,17 @@ else ifeq  ($(HARDWARE_MOTHERBOARD),91)
 HARDWARE_VARIANT ?= Sanguino
 MCU              ?= atmega644p
 
+#Sethi 3D_1
+else ifeq  ($(HARDWARE_MOTHERBOARD),20)
+HARDWARE_VARIANT ?= Sanguino
+MCU              ?= atmega644p
+
 #Rambo
 else ifeq  ($(HARDWARE_MOTHERBOARD),301)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560
 
-# Azteeg
+#Azteeg
 else ifeq  ($(HARDWARE_MOTHERBOARD),67)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560

--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -149,6 +149,11 @@ else ifeq  ($(HARDWARE_MOTHERBOARD),48)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560
 
+# RAMPS equivalent (?) by Creality
+else ifeq  ($(HARDWARE_MOTHERBOARD),243)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
+
 #Gen6
 else ifeq  ($(HARDWARE_MOTHERBOARD),5)
 HARDWARE_VARIANT ?= Gen6

--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -76,6 +76,7 @@
 #define BOARD_BQ_ZUM_MEGA_3D    503   // bq ZUM Mega 3D
 #define BOARD_MAKEBOARD_MINI    431   // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
 #define BOARD_TRIGORILLA        343   // TriGorilla Anycubic version 1.3 based on RAMPS EFB
+#define BOARD_RAMPS_ENDER_4     243   // Creality: Ender-4, CR-8
 
 //
 // Other ATmega1280, ATmega2560

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -173,6 +173,8 @@
   #include "pins_GT2560_REV_A.h"      // ATmega1280, ATmega2560
 #elif MB(GT2560_REV_A_PLUS)
   #include "pins_GT2560_REV_A_PLUS.h" // ATmega1280, ATmega2560
+#elif MB(RAMPS_ENDER_4)
+  #include "pins_RAMPS_ENDER_4.h"     // ATmega2560
 
 //
 // ATmega1281, ATmega2561


### PR DESCRIPTION
### Description

I tried to build Creality Ender-4's configuration for my Creality CR-8, which turned out to have the exact same mainboard, And I failed. After getting my head around Marlin's structure for a while I found out that the board ID referenced in configuration does not exist in `Makefile` or `boards.h`

I picked an unlisted board ID, 49 and added it in.

### Benefits

This makes configuration for Creality Ender-4's board, actually compilable.

### Related Issues

* #9256 is the original discussion on the Ender 4 board

---

I'm not knowledgeable in Marlin and 3D printing electronics. Let me know if I should make any changes 😃

NB: while CR-8 does feature the same board, **the configuration is different**. I'll provide that separately once I'm done with it.