### PR TITLE
[2.0.x] DUE TMC2130 compatibility improvements & moved card.checkautostart

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_Due.cpp
@@ -1,23 +1,21 @@
-/* **************************************************************************
-
- Marlin 3D Printer Firmware
- Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
-****************************************************************************/
-
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 /**
  * Description: HAL for Arduino Due and compatible (SAM3X8E)
@@ -77,6 +75,9 @@ uint16_t HAL_adc_result;
 // HAL initialization task
 void HAL_init(void) {
   // Initialize the USB stack
+  #if ENABLED(SDSUPPORT)
+    OUT_WRITE(SDSS, HIGH);  // Try to set SDSS inactive before any other SPI users start up
+  #endif
   usb_task_init();
 }
 
@@ -86,10 +87,10 @@ void HAL_idletask(void) {
   usb_task_idle();
 }
 
-// disable interrupts
+// Disable interrupts
 void cli(void) { noInterrupts(); }
 
-// enable interrupts
+// Enable interrupts
 void sei(void) { interrupts(); }
 
 void HAL_clear_reset_source(void) { }
@@ -106,7 +107,7 @@ uint8_t HAL_get_reset_source(void) {
 }
 
 void _delay_ms(const int delay_ms) {
-  // todo: port for Due?
+  // Todo: port for Due?
   delay(delay_ms);
 }
 
@@ -114,7 +115,7 @@ extern "C" {
   extern unsigned int _ebss; // end of bss section
 }
 
-// return free memory between end of heap (or end bss) and whatever is current
+// Return free memory between end of heap (or end bss) and whatever is current
 int freeMemory() {
   int free_memory, heap_end = (int)_sbrk(0);
   return (int)&free_memory - (heap_end ? heap_end : (int)&_ebss);

--- a/Marlin/src/HAL/HAL_DUE/SanityCheck_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/SanityCheck_Due.h
@@ -27,3 +27,11 @@
 /**
  * Require gcc 4.7 or newer (first included with Arduino 1.6.8) for C++11 features.
  */
+
+#if ENABLED(SDSUPPORT) && ENABLED(HAVE_TMC2130)
+  #if ENABLED(DUE_SOFTWARE_SPI) && !ENABLED(TMC_USE_SW_SPI)
+    #error "DUE software SPI is incompatible with TMC2130 hardware SPI. Enable TMC_USE_SW_SPI to fix."
+  #elif !ENABLED(DUE_SOFTWARE_SPI) && ENABLED(TMC_USE_SW_SPI)
+    #error "DUE hardware SPI is incompatible with TMC2130 software SPI. Disable TMC_USE_SW_SPI to fix."
+  #endif
+#endif

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -892,14 +892,15 @@ void setup() {
  *  - Call LCD update
  */
 void loop() {
-  if (commands_in_queue < BUFSIZE) get_available_commands();
 
   #if ENABLED(SDSUPPORT)
     card.checkautostart(false);
   #endif
 
-  advance_command_queue();
-
-  endstops.report_state();
-  idle();
+  for (;;) {
+    if (commands_in_queue < BUFSIZE) get_available_commands();
+    advance_command_queue();
+    endstops.report_state();
+    idle();
+  }
 }

--- a/Marlin/src/sd/Sd2Card.cpp
+++ b/Marlin/src/sd/Sd2Card.cpp
@@ -249,15 +249,16 @@ bool Sd2Card::init(uint8_t sckRateID, pin_t chipSelectPin) {
     watchdog_reset();
   #endif
 
-  // set pin modes
-  pinMode(chipSelectPin_, OUTPUT); // Solution for #8746 by @benlye
+  // Set pin modes
+  digitalWrite(chipSelectPin_, HIGH);  // For some CPUs pinMode can write the wrong data so init desired data value first
+  pinMode(chipSelectPin_, OUTPUT);     // Solution for #8746 by @benlye
   spiBegin();
 
-  // set SCK rate for initialization commands
+  // Set SCK rate for initialization commands
   spiRate_ = SPI_SD_INIT_RATE;
   spiInit(spiRate_);
 
-  // must supply min of 74 clock cycles with CS high.
+  // Must supply min of 74 clock cycles with CS high.
   for (uint8_t i = 0; i < 10; i++) spiSend(0xFF);
 
   // Initialization can cause the watchdog to timeout, so reinit it here
@@ -265,7 +266,7 @@ bool Sd2Card::init(uint8_t sckRateID, pin_t chipSelectPin) {
     watchdog_reset();
   #endif
 
-  // command to go idle in SPI mode
+  // Command to go idle in SPI mode
   while ((status_ = cardCommand(CMD0, 0)) != R1_IDLE_STATE) {
     if (((uint16_t)millis() - t0) > SD_INIT_TIMEOUT) {
       error(SD_CARD_ERROR_CMD0);


### PR DESCRIPTION
The main focus of this PR is to improve the compatibility of DUE with the TMC2130.

Also moved **card.checkautostart** (in **Marlin.cpp**) so it's executed only once rather than every time through the command loop..

----

**TMC2130 compatibility improvements**

1. **HAL_spi_Due.cpp** - for the U8G compatible hardware SPI, a) changed SPI Mode Register (SPI_MR) to allow the PCS field in the data written to the Transmit Data Register SPI_TDR) to select the Chip Select Register, b) switched from CSR[0] to CSR[3], and c) OR'd into the data bytes the PCS bits used by the TMC2130.  The result of this is the SD card's SPI settings and the TMC2130's settings don't interfere with each other.  Previously the SD card left the SPI controller set to mode 0 and 8 MHz.  The TMC2130 max is about 4MHz so sometimes this would cause TMC2130 read/write fails.  
2. **HAL_Due.cpp** - added code to the HAL_INIT routine to init the SD card's SDSS as early as possible.  The TMC2130 library starts writing to the drivers before the SD card software is initialized.  Previously the SDSS line floated before the SD card software was initialized. If it floated low it would select the SD card which resulted in a bus conflict with the driver.  
3. **SanityCheck_Due.h** -  added a section that would error out if one was running a hardware SPI and the other a software SPI.
4. **Sd2Card.cpp** - added a write to the chip select pin immediately before it was set to an output.  On some CPUs **pinMode** can result in to output line going to the wrong state unless the desired state is written first.





