### PR TITLE
fix jump of z when reaching fade height

### DIFF
--- a/Marlin/mesh_bed_leveling.h
+++ b/Marlin/mesh_bed_leveling.h
@@ -107,7 +107,7 @@ public:
                 z2 = calc_z0(x0, index_to_xpos[cx], z_values[cx][cy + 1], index_to_xpos[cx + 1], z_values[cx + 1][cy + 1]),
                 z0 = calc_z0(y0, index_to_ypos[cy], z1, index_to_ypos[cy + 1], z2);
 
-    return z_offset + z0
+    return (z_offset + z0)
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         * factor
       #endif


### PR DESCRIPTION
if z_offset != 0, z was jumping at z_fade_height

### Requirements

* `ENABLE_LEVELING_FADE_HEIGHT`
* `MESH_BED_LEVELING`
* `z_offset != 0` ("Bed Z" in LCD menu)

### Description

I faced the same defect on my prints as reported by #9118. After some investigation I tracked it down to `z_offset` when used with leveling fading feature and mesh bed leveling.

**Reason of the Defect**
While `z < z_fade_height`, `z_offset` is applied to z as correction term (call of `get_z(...)` ).
While `z >= z_fade_height`, `z_offset` is _not_ applied to z as correction term (`get_z(...)` is not called `if(!fade_scaling_factor)` https://github.com/MarlinFirmware/Marlin/blob/de5f69b2852e0e2fadd02f3c5a8d19f41ab2194e/Marlin/planner.cpp#L654)
--> z will jump by amount of `z_offset` during transition from `z < z_fade_height` to `z >= z_fade_height`.

In my setup, i use `z_offset = -0,2`. When reaching `z = z_fade_height`, the extruder is moved 0,2mm higher than intended since the correction term of -0,2 is not applied any more to z. --> looks like layer is skipped
 The scenario goes in the other direction for `z_offset > 0`.

**Fix**
This pull request applies the fading factor to `z_offset` as well so it is fully compensated when `z = z_fade_height` is reached.
(Tested successfully on my printer.)

Alternative solution would be to apply the `z_offset` correction term for the whole z range. This way the fading feature does not have to deal with `z_offset`.

### Benefits

Print movement is as intened when leveling fade height is reached. 
No visual defect of print.

### Related Issues

#9118 
