### PR TITLE
[2.0.x] Fix TMC2130 DIAG1 active high, Einsy Retro

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -277,6 +277,9 @@ MCU              ?= atmega2560
 else ifeq  ($(HARDWARE_MOTHERBOARD),304)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560
+else ifeq  ($(HARDWARE_MOTHERBOARD),305)
+HARDWARE_VARIANT ?= arduino
+MCU              ?= atmega2560
 else ifeq  ($(HARDWARE_MOTHERBOARD),21)
 HARDWARE_VARIANT ?= arduino
 MCU              ?= atmega2560

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -95,6 +95,7 @@
 #define BOARD_MINIRAMBO         302   // Mini-Rambo
 #define BOARD_MINIRAMBO_10A     303   // Mini-Rambo 1.0a
 #define BOARD_EINSY_RAMBO       304   // Einsy Rambo
+#define BOARD_EINSY_RETRO       305   // Einsy Retro
 #define BOARD_ELEFU_3           21    // Elefu Ra Board (v3)
 #define BOARD_LEAPFROG          999   // Leapfrog
 #define BOARD_MEGACONTROLLER    310   // Mega controller

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1457,12 +1457,22 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
     #error "E4_CS_PIN is required for E4_IS_TMC2130. Define E4_CS_PIN in Configuration_adv.h."
   #endif
 
-  // Require STEALTHCHOP for SENSORLESS_HOMING on DELTA as the transition from spreadCycle to stealthChop
-  // is necessary in order to reset the stallGuard indication between the initial movement of all three
-  // towers to +Z and the individual homing of each tower. This restriction can be removed once a means of
-  // clearing the stallGuard activated status is found.
-  #if ENABLED(SENSORLESS_HOMING) && ENABLED(DELTA) && !ENABLED(STEALTHCHOP)
-    #error "SENSORLESS_HOMING on DELTA currently requires STEALTHCHOP."
+  #if ENABLED(SENSORLESS_HOMING)
+    // Require STEALTHCHOP for SENSORLESS_HOMING on DELTA as the transition from spreadCycle to stealthChop
+    // is necessary in order to reset the stallGuard indication between the initial movement of all three
+    // towers to +Z and the individual homing of each tower. This restriction can be removed once a means of
+    // clearing the stallGuard activated status is found.
+    #if ENABLED(DELTA) && !ENABLED(STEALTHCHOP)
+      #error "SENSORLESS_HOMING on DELTA currently requires STEALTHCHOP."
+    #elif X_HOME_DIR == -1 && DISABLED(X_MIN_ENDSTOP_INVERTING)
+      #error "SENSORLESS_HOMING requires X_MIN_ENDSTOP_INVERTING when homing to X_MIN."
+    #elif X_HOME_DIR ==  1 && DISABLED(X_MAX_ENDSTOP_INVERTING)
+      #error "SENSORLESS_HOMING requires X_MAX_ENDSTOP_INVERTING when homing to X_MAX."
+    #elif Y_HOME_DIR == -1 && DISABLED(Y_MIN_ENDSTOP_INVERTING)
+      #error "SENSORLESS_HOMING requires Y_MIN_ENDSTOP_INVERTING when homing to Y_MIN."
+    #elif Y_HOME_DIR ==  1 && DISABLED(Y_MAX_ENDSTOP_INVERTING)
+      #error "SENSORLESS_HOMING requires Y_MAX_ENDSTOP_INVERTING when homing to Y_MAX."
+    #endif
   #endif
 
   // Sensorless homing is required for both combined steppers in an H-bot

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -193,7 +193,6 @@
     st.power_down_delay(128); // ~2s until driver lowers to hold current
     st.hysteresis_start(3);
     st.hysteresis_end(2);
-    st.diag1_active_high(1); // For sensorless homing
     #if ENABLED(STEALTHCHOP)
       st.stealth_freq(1); // f_pwm = 2/683 f_clk
       st.stealth_autoscale(1);

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -163,6 +163,8 @@
   #include "pins_MINIRAMBO.h"         // ATmega2560
 #elif MB(EINSY_RAMBO)
   #include "pins_EINSY_RAMBO.h"       // ATmega2560
+#elif MB(EINSY_RETRO)
+  #include "pins_EINSY_RETRO.h"       // ATmega2560
 #elif MB(ELEFU_3)
   #include "pins_ELEFU_3.h"           // ATmega2560
 #elif MB(LEAPFROG)

--- a/Marlin/src/pins/pins_EINSY_RETRO.h
+++ b/Marlin/src/pins/pins_EINSY_RETRO.h
@@ -21,22 +21,22 @@
  */
 
 /**
- * Einsy-Rambo pin assignments
+ * Einsy-Retro pin assignments
  */
 
 #ifndef __AVR_ATmega2560__
   #error "Oops!  Make sure you have 'Arduino Mega 2560 or Rambo' selected from the 'Tools -> Boards' menu."
 #endif
 
-#define BOARD_NAME         "Einsy Rambo"
+#define BOARD_NAME         "Einsy Retro"
 
 //
-// TMC2130 Configuration_adv defaults for EinsyRambo
+// TMC2130 Configuration_adv defaults for EinsyRetro
 //
 #if DISABLED(HAVE_TMC2130)
-  #error "You must enable TMC2130 support in Configuration_adv.h for EinsyRambo."
+  #error "You must enable TMC2130 support in Configuration_adv.h for EinsyRetro."
 #elif DISABLED(X_IS_TMC2130) || DISABLED(Y_IS_TMC2130) || DISABLED(Z_IS_TMC2130) || DISABLED(E0_IS_TMC2130)
-  #error "You must enable ([XYZ]|E0)_IS_TMC2130 in Configuration_adv.h for EinsyRambo."
+  #error "You must enable ([XYZ]|E0)_IS_TMC2130 in Configuration_adv.h for EinsyRetro."
 #endif
 
 // TMC2130 Diag Pins (currently just for reference)
@@ -56,23 +56,40 @@
 
 #if DISABLED(SENSORLESS_HOMING)
 
-  #define X_STOP_PIN       12
-  #define Y_STOP_PIN       11
-  #define Z_STOP_PIN       10
+  #define X_MIN_PIN        12
+  #define Y_MIN_PIN        11
+  #define Z_MIN_PIN        10
+  #define X_MAX_PIN        81
+  #define Y_MAX_PIN        57
 
 #else
 
-  #define X_STOP_PIN       X_DIAG_PIN
-  #define Y_STOP_PIN       Y_DIAG_PIN
+  #if X_HOME_DIR == -1
+    #define X_MIN_PIN      X_DIAG_PIN
+    #define X_MAX_PIN      81
+  #else
+    #define X_MIN_PIN      12
+    #define X_MAX_PIN      X_DIAG_PIN
+  #endif
+
+  #if Y_HOME_DIR == -1
+    #define Y_MIN_PIN      Y_DIAG_PIN
+    #define Y_MAX_PIN      57
+  #else
+    #define Y_MIN_PIN      11
+    #define Y_MAX_PIN      Y_DIAG_PIN
+  #endif
 
   #if ENABLED(BLTOUCH)
-    #define Z_STOP_PIN     11   // Y-MIN
+    #define Z_MIN_PIN      11   // Y-MIN
     #define SERVO0_PIN     10   // Z-MIN
   #else
-    #define Z_STOP_PIN     10
+    #define Z_MIN_PIN      10
   #endif
 
 #endif
+
+#define Z_MAX_PIN           7
 
 //
 // Z Probe (when not Z_MIN_PIN)
@@ -123,7 +140,7 @@
 //
 // Misc. Functions
 //
-#define SDSS               77
+#define SDSS               53
 #define LED_PIN            13
 #define CASE_LIGHT_PIN      9
 
@@ -155,12 +172,12 @@
       #define LCD_PINS_RS     85
       #define LCD_PINS_ENABLE 71
       #define LCD_PINS_D4     70
-      #define BTN_EN1         61
-      #define BTN_EN2         59
+      #define BTN_EN1         18
+      #define BTN_EN2         19
     #else
       #define LCD_PINS_RS     82
-      #define LCD_PINS_ENABLE 61
-      #define LCD_PINS_D4     59
+      #define LCD_PINS_ENABLE 18
+      #define LCD_PINS_D4     19
       #define LCD_PINS_D5     70
       #define LCD_PINS_D6     85
       #define LCD_PINS_D7     71


### PR DESCRIPTION
- Removed potentially dangerous toggle of DIAG1 to active high (#10294)
- Added sanity check to require endstop inverting with `SENSORLESS_HOMING`.
- Added support for Einsy Retro from Ultimachine (Einsy Rambo variant with better Mini Rambo compatibility).