### PR TITLE
[2.0.x] Add pin names, Add TMC SW SPI sanity check for Re_ARM

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/SanityCheck.h
+++ b/Marlin/src/HAL/HAL_LPC1768/SanityCheck.h
@@ -24,10 +24,6 @@
  * Test Re-ARM specific configuration values for errors at compile-time.
  */
 
-/**
- * Require gcc 4.7 or newer (first included with Arduino 1.6.8) for C++11 features.
- */
-
 #if ENABLED(SPINDLE_LASER_ENABLE)
   #if !PIN_EXISTS(SPINDLE_LASER_ENABLE)
     #error "SPINDLE_LASER_ENABLE requires SPINDLE_LASER_ENABLE_PIN."
@@ -69,3 +65,12 @@
     #endif
   #endif
 #endif // SPINDLE_LASER_ENABLE
+
+#if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) && ENABLED(HAVE_TMC2130) && DISABLED(TMC_USE_SW_SPI) \
+    && (MB(RAMPS_14_RE_ARM_EFB) \
+    ||  MB(RAMPS_14_RE_ARM_EEB) \
+    ||  MB(RAMPS_14_RE_ARM_EFF) \
+    ||  MB(RAMPS_14_RE_ARM_EEF) \
+    ||  MB(RAMPS_14_RE_ARM_SF))
+  #error "Re-ARM with REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER and TMC2130 require TMC_USE_SW_SPI"
+#endif

--- a/Marlin/src/pins/pinsDebug_list.h
+++ b/Marlin/src/pins/pinsDebug_list.h
@@ -226,6 +226,15 @@
 #if defined(DOGLCD_SCK) && DOGLCD_SCK >= 0
   REPORT_NAME_DIGITAL(__LINE__, DOGLCD_SCK)
 #endif
+#if defined(TMC_SW_MISO) && TMC_SW_MISO >= 0
+  REPORT_NAME_DIGITAL(__LINE__, TMC_SW_MISO)
+#endif
+#if defined(TMC_SW_MOSI) && TMC_SW_MOSI >= 0
+  REPORT_NAME_DIGITAL(__LINE__, TMC_SW_MOSI)
+#endif
+#if defined(TMC_SW_SCK) && TMC_SW_SCK >= 0
+  REPORT_NAME_DIGITAL(__LINE__, TMC_SW_SCK)
+#endif
 #if PIN_EXISTS(E_MUX0)
   REPORT_NAME_DIGITAL(__LINE__, E_MUX0_PIN)
 #endif


### PR DESCRIPTION
Just a couple of items I ran into when checking out the TMC2130 on a Re_ARM board:
1. **pinsDebug_list.h** - add TMC software SPI pins
2. **HAL\HAL_LPC1768\SanityCheck.h** - throw an error if the TMC software SPI ISN'T used and the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER is used.  TMC2130s and this LCD can't share the same SPI or else will get garbage on the LCD screen.