### PR TITLE
[2.0.x] Update pins_AZSMZ_MINI.h

### DIFF
--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -82,8 +82,11 @@
 // EFB
 #define HEATER_0_PIN       P2_04
 #define HEATER_BED_PIN     P2_05
-#define FAN_PIN            P2_07
-#define FAN1_PIN           P0_26
+//Swap to correct FAN PIN
+//#define FAN_PIN            P2_07
+//#define FAN1_PIN           P0_26
+#define FAN1_PIN            P2_07
+#define FAN_PIN           P0_26
 
 #if ENABLED(AZSMZ_12864)
   #define BEEPER_PIN       P1_30


### PR DESCRIPTION
the FAN pins are inverted
#define FAN_PIN            P2_07
#define FAN1_PIN           P0_26
are wrong.
you have to change in :
#define FAN1_PIN            P2_07
#define FAN_PIN           P0_26

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
