### PR TITLE
[1.1.x] Fan as laser

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1317,6 +1317,12 @@
 // @section extras
 
 /**
+ * Laser connected to a fan pin. Enable and set to the fan index.
+ * M3 or M4 will set the laser power. M5 will turn it off.
+ */
+//#define USE_FAN_FOR_LASER 1
+
+/**
  * Spindle & Laser control
  *
  * Add the M3, M4, and M5 commands to turn the spindle/laser on and off, and

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6421,6 +6421,24 @@ inline void gcode_G92() {
 
 #endif // SPINDLE_LASER_ENABLE
 
+#ifdef USE_FAN_FOR_LASER
+  /**
+   * M3, M4: Laser On
+   */
+  inline void gcode_M3_M4() {
+    stepper.synchronize();
+    fanSpeeds[USE_FAN_FOR_LASER] = parser.byteval('S', 255);
+  }
+
+  /**
+   * M5: Laser Off
+   */
+  inline void gcode_M5() {
+    stepper.synchronize();
+    fanSpeeds[USE_FAN_FOR_LASER] = 0;
+  }
+#endif
+
 /**
  * M17: Enable power on all stepper motors
  */
@@ -11885,6 +11903,11 @@ void process_parsed_command() {
         case 3: gcode_M3_M4(true); break;                         // M3: Laser/CW-Spindle Power
         case 4: gcode_M3_M4(false); break;                        // M4: Laser/CCW-Spindle Power
         case 5: gcode_M5(); break;                                // M5: Laser/Spindle OFF
+      #endif
+
+      #ifdef USE_FAN_FOR_LASER
+        case 3: gcode_M3(); break;                                // M3: Laser Power On
+        case 5: gcode_M5(); break;                                // M5: Laser OFF
       #endif
 
       case 17: gcode_M17(); break;                                // M17: Enable all steppers

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -468,6 +468,12 @@
 #ifndef MSG_EXTRA_FAN_SPEED
   #define MSG_EXTRA_FAN_SPEED                 _UxGT("Extra fan speed")
 #endif
+#ifndef MSG_LASER_ON
+  #define MSG_LASER_ON                       _UxGT("Laser On")
+#endif
+#ifndef MSG_LASER_OFF
+  #define MSG_LASER_OFF                       _UxGT("Laser Off")
+#endif
 #ifndef MSG_FLOW
   #define MSG_FLOW                            _UxGT("Flow")
 #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1357,22 +1357,30 @@ void kill_screen(const char* lcd_msg) {
     #endif
 
     //
+    // Laser ON/OFF:
+    //
+    #ifdef USE_FAN_FOR_LASER
+      MENU_ITEM(gcode, MSG_LASER_ON, PSTR("M3"));
+      MENU_ITEM(gcode, MSG_LASER_OFF, PSTR("M5"));
+    #endif
+
+    //
     // Fan Speed:
     //
     #if FAN_COUNT > 0
-      #if HAS_FAN0
+      #if (HAS_FAN0 && FAN_NUM_AS_LASER!=0)
         MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &fanSpeeds[0], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
           MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &new_fanSpeeds[0], 3, 255);
         #endif
       #endif
-      #if HAS_FAN1
+      #if (HAS_FAN1 && FAN_NUM_AS_LASER!=1)
         MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 2", &fanSpeeds[1], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
           MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 2", &new_fanSpeeds[1], 3, 255);
         #endif
       #endif
-      #if HAS_FAN2
+      #if (HAS_FAN2 && FAN_NUM_AS_LASER!=2)
         MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 3", &fanSpeeds[2], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
           MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 3", &new_fanSpeeds[2], 3, 255);
@@ -3371,23 +3379,28 @@ void kill_screen(const char* lcd_msg) {
       MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int3, MSG_BED, &thermalManager.target_temperature_bed, 0, BED_MAXTEMP - 15, watch_temp_callback_bed);
     #endif
 
+    #ifdef USE_FAN_FOR_LASER
+      MENU_ITEM(gcode, MSG_LASER_ON, PSTR("M3"));
+      MENU_ITEM(gcode, MSG_LASER_OFF, PSTR("M5"));
+    #endif
+
     //
     // Fan Speed:
     //
     #if FAN_COUNT > 0
-      #if HAS_FAN0
+      #if  (HAS_FAN0 && FAN_NUM_AS_LASER!=0)
         MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &fanSpeeds[0], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
           MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &new_fanSpeeds[0], 3, 255);
         #endif
       #endif
-      #if HAS_FAN1
+      #if (HAS_FAN1 && FAN_NUM_AS_LASER!=1)
         MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 2", &fanSpeeds[1], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
           MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 2", &new_fanSpeeds[1], 3, 255);
         #endif
       #endif
-      #if HAS_FAN2
+      #if (HAS_FAN2 && FAN_NUM_AS_LASER!=2)
         MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 3", &fanSpeeds[2], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
           MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 3", &new_fanSpeeds[2], 3, 255);


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Add option to control a fan output as laser for TTL style laser kits as provided from Formbot on the TRex, and Creality on the CR10S

### Benefits

Enables M3 and M5 commands as push back to fan outputs with mapped fan

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
