### PR TITLE
[2.0.x] LPC1768 - automatic selection of upload disk

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
@@ -98,8 +98,8 @@ if current_OS == 'Linux':
     if target_file_found == True or target_drive_found == True:
       Import("env")
       env.Replace(
-  #            UPLOAD_FLAGS = "-P$UPLOAD_PORT",
-  #       UPLOAD_PORT = upload_disk
+        UPLOAD_FLAGS = "-P$UPLOAD_PORT",
+        UPLOAD_PORT = upload_disk
       )
 
 

--- a/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
@@ -1,0 +1,134 @@
+#
+# sets output_port
+#  if target_filename is found then that drive is used
+#  else if target_drive is found then that drive is used
+#
+
+target_filename = "FIRMWARE.CUR"
+target_drive = "REARM"
+
+
+import platform
+current_OS = platform.system()
+
+if current_OS == 'Windows':
+
+    #
+    # platformio.ini will accept this for a Windows upload port designation: 'upload_port = L:'
+    #   Windows - doesn't care about the disk's name, only cares about the drive letter
+    #
+
+    #
+    # get all drives on this computer
+    #
+
+    import subprocess
+
+    driveStr = subprocess.check_output("fsutil fsinfo drives")  # typical result (string): 'Drives: C:\ D:\ E:\ F:\ G:\ H:\ I:\ J:\ K:\ L:\ M:\ Y:\ Z:\'
+    driveStr = driveStr.strip().lstrip('Drives: ')  # typical result (string): 'C:\ D:\ E:\ F:\ G:\ H:\ I:\ J:\ K:\ L:\ M:\ Y:\ Z:\'
+    drives = driveStr.split()  # typical result (array of stings): ['C:\\', 'D:\\', 'E:\\', 'F:\\', 'G:\\', 'H:\\', 'I:\\', 'J:\\', 'K:\\', 'L:\\', 'M:\\', 'Y:\\', 'Z:\\']
+
+    #
+    # scan top directory of each drive for FIRMWARE.CUR
+    #   return first drive found
+    #
+
+    import os
+    target_file_found = False
+    target_drive_found = False
+    for drive in drives:
+      final_drive_name = drive.strip().rstrip('\\')   # typical result (string): 'C:'
+      # modified version of walklevel()
+      level=0
+      some_dir = "/"
+      some_dir = some_dir.rstrip(os.path.sep)
+      assert os.path.isdir(some_dir)
+      num_sep = some_dir.count(os.path.sep)
+      for root, dirs, files in os.walk(final_drive_name):
+        num_sep_this = root.count(os.path.sep)
+        if num_sep + level <= num_sep_this:
+          del dirs[:]
+        volume_info = subprocess.check_output('fsutil fsinfo volumeinfo ' + final_drive_name)
+        if target_drive in volume_info and target_file_found == False:  # set upload if not found target file yet
+          target_drive_found = True
+          upload_disk = root
+        if target_filename in files:
+          if target_file_found == False:
+            upload_disk = root
+          target_file_found = True
+
+    #
+    # set upload_port to drive if found
+    #
+
+    if target_file_found == True or target_drive_found == True:
+      Import("env")
+      env.Replace(
+          UPLOAD_PORT = upload_disk
+      )
+
+
+
+if current_OS == 'Linux':
+
+    #
+    # platformio.ini will accept this for a Linux upload port designation: 'upload_port = /media/media_name/drive'
+    #
+
+    import os
+    target_file_found = False
+    target_drive_found = False
+    medias = os.listdir('/media')  #
+    for media in medias:
+      drives = os.listdir('/media/' + media)  #
+      if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
+        target_drive_found = True
+        upload_disk = '/media/' + media + '/' + target_drive + '/'
+      for drive in drives:
+        files = os.listdir('/media/' + media + '/' + drive )  #
+        if target_filename in files:
+          if target_file_found == False:
+            upload_disk = '/media/' + media + '/' + drive + '/'
+            target_file_found = True
+
+    #
+    # set upload_port to drive if found
+    #
+
+    if target_file_found == True or target_drive_found == True:
+      Import("env")
+      env.Replace(
+  #            UPLOAD_FLAGS = "-P$UPLOAD_PORT",
+  #       UPLOAD_PORT = upload_disk
+      )
+
+
+if current_OS == 'Darwin':  # MAC
+
+    #
+    # platformio.ini will accept this for a OSX upload port designation: 'upload_port = /media/media_name/drive'
+    #
+
+    import os
+    drives = os.listdir('/Volumes')  #  human readable names
+    target_file_found = False
+    target_drive_found = False
+    if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
+      target_drive_found = True
+      upload_disk = '/Volumes/' + drive + '/'
+    for drive in drives:
+      target_file_found = True
+      filenames = os.listdir('/Volumes/' + drive + '/')
+      if target_filename in filenames:
+        if target_file_found == False:
+          upload_disk = '/Volumes/' + drive + '/'
+        target_file_found = True
+    #
+    # set upload_port to drive if found
+    #
+
+    if target_file_found == True or target_drive_found == True:
+      Import("env")
+      env.Replace(
+          UPLOAD_PORT = upload_disk
+      )

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,7 +103,7 @@ platform     = atmelsam
 framework    = arduino
 board        = due
 build_flags  = ${common.build_flags}
-  -funwind-tables 
+  -funwind-tables
   -mpoke-function-name
 lib_deps     = ${common.lib_deps}
 lib_ignore   = c1921b4
@@ -127,10 +127,11 @@ lib_extra_dirs  = frameworks
 lib_deps        = CMSIS-LPC1768
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMC2130Stepper@>=2.2.1
-extra_scripts   = Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+extra_scripts   = Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter      = ${common.default_src_filter}
 monitor_baud    = 250000
-
+#upload_flags    = -P$UPLOAD_PORT
+#upload_port     = /media/bob/REARM
 #
 # LPC1768 (for debugging and development)
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -130,8 +130,7 @@ lib_deps        = CMSIS-LPC1768
 extra_scripts   = Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter      = ${common.default_src_filter}
 monitor_baud    = 250000
-#upload_flags    = -P$UPLOAD_PORT
-#upload_port     = /media/bob/REARM
+
 #
 # LPC1768 (for debugging and development)
 #


### PR DESCRIPTION
This PR automates the task of moving the **firmware.bin** file to the LPC1768's virtual USB disk.

This is done by adding an upload script to the **extra_scripts** list.

This script has been tested on Win10, OSX & Ubuntu.  I wasn't able to test the latest version on OSX so I'm hoping ...

The script scans every drive on the computer.  It makes note of the path if it finds a drive named **REARM**. 
1. If it finds the file **FIRMWARE.CUR** it then sets the upload port to this path.  
2. If **FIRMWARE.CUR** isn't found then it sets the upload port to the **REARM** path.
3. If neither is found then nothing is done.

Win10, OSX & Ubuntu treat disks differently so each has a separate section.

----

**Known issues**

a) Sometimes on Ubuntu, all will succeed but a power cycle doesn't result in **firmware.bin** being used.  Deleting  **firmware.bin** and doing another upload fixes this.

b) Ubuntu is less forgiving of file system errors than Windows and OSX.  If the upload error message includes **"read only file system"** it means that something is wrong with the files system on the SD card.  Running chkdsk() or it's equivalent will fix it.
