### PR TITLE
[1.1.x] Abort SD printing more safely

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -829,20 +829,10 @@ void kill_screen(const char* lcd_msg) {
       lcd_reset_status();
     }
 
+    bool abort_sd_printing; // =false
+
     void lcd_sdcard_stop() {
-      card.stopSDPrint(
-        #if SD_RESORT
-          true
-        #endif
-      );
-      clear_command_queue();
-      quickstop_stepper();
-      print_job_timer.stop();
-      thermalManager.disable_all_heaters();
-      #if FAN_COUNT > 0
-        for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
-      #endif
-      wait_for_heatup = false;
+      abort_sd_printing = true;
       lcd_setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
       lcd_return_to_status();
     }

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -254,4 +254,10 @@ void lcd_reset_status();
   void lcd_reselect_last_file();
 #endif
 
+#if ENABLED(ULTIPANEL) && ENABLED(SDSUPPORT)
+  extern bool abort_sd_printing;
+#else
+  constexpr bool abort_sd_printing = false;
+#endif
+
 #endif // ULTRALCD_H


### PR DESCRIPTION
Addressing #10372, #10396

Allow the current command to complete when aborting an SD print, otherwise some commands (G28, G29, etc.) can cause various troubles. This is preferable to adding a flag that stalls all movement in the ISR or which lengthy commands would have to check during their processes and abort from.

Since this adds a flag `abort_sd_printing`, commands do have the option to abort when it is set.

Counterpart to #10407