### PR TITLE
[2.0.x] Abort SD printing more safely

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -898,6 +898,26 @@ void loop() {
   #endif
 
   for (;;) {
+
+    #if ENABLED(SDSUPPORT) && ENABLED(ULTIPANEL)
+      if (abort_sd_printing) {
+        abort_sd_printing = false;
+        card.stopSDPrint(
+          #if SD_RESORT
+            true
+          #endif
+        );
+        clear_command_queue();
+        quickstop_stepper();
+        print_job_timer.stop();
+        thermalManager.disable_all_heaters();
+        #if FAN_COUNT > 0
+          for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+        #endif
+        wait_for_heatup = false;
+      }
+    #endif // SDSUPPORT && ULTIPANEL
+
     if (commands_in_queue < BUFSIZE) get_available_commands();
     advance_command_queue();
     endstops.report_state();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -836,20 +836,10 @@ void kill_screen(const char* lcd_msg) {
       lcd_reset_status();
     }
 
+    bool abort_sd_printing; // =false
+
     void lcd_sdcard_stop() {
-      card.stopSDPrint(
-        #if SD_RESORT
-          true
-        #endif
-      );
-      clear_command_queue();
-      quickstop_stepper();
-      print_job_timer.stop();
-      thermalManager.disable_all_heaters();
-      #if FAN_COUNT > 0
-        for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
-      #endif
-      wait_for_heatup = false;
+      abort_sd_printing = true;
       lcd_setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
       lcd_return_to_status();
     }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -261,4 +261,10 @@ void lcd_reset_status();
   void lcd_reselect_last_file();
 #endif
 
+#if ENABLED(ULTIPANEL) && ENABLED(SDSUPPORT)
+  extern bool abort_sd_printing;
+#else
+  constexpr bool abort_sd_printing = false;
+#endif
+
 #endif // ULTRALCD_H


### PR DESCRIPTION
Addressing #10372, #10396

Allow the current command to complete when aborting an SD print, otherwise some commands (G28, G29, etc.) can cause various troubles. This is preferable to adding a flag that stalls all movement in the ISR or which lengthy commands would have to check during their processes and abort from.

Since this adds a flag `abort_sd_printing`, commands do have the option to abort when it is set.

Counterpart to #10405