### PR TITLE
[2.0.x] Fix u8g path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ before_script:
   #
 script:
   #
+  # Fix include path problem in platformio.ini, U8glib-HAL_ID1932/src/lib/u8g.h
+  #
+  - find Marlin/ -name "*.h" | while read a; do sed -e 's|clib/u8g.h|u8g.h|' -i "$a"; done
+  #
   # Backup pins_RAMPS.h
   #
   - cp Marlin/src/pins/pins_RAMPS.h Marlin/src/pins/pins_RAMPS.h.backup

--- a/Marlin/src/lcd/u8g_fontutf8.c
+++ b/Marlin/src/lcd/u8g_fontutf8.c
@@ -8,7 +8,6 @@
  */
 
 #include <string.h>
-#include <clib/u8g.h>
 #include "fontutils.h"
 #include "u8g_fontutf8.h"
 
@@ -216,7 +215,7 @@ unsigned int uxg_DrawWchar(u8g_t *pu8g, unsigned int x, unsigned int y, wchar_t 
   const font_t *fnt_default = uxg_GetFont(pu8g);
 
   if (!uxg_Utf8FontIsInited()) {
-    u8g_DrawStrP(pu8g, x, y, PSTR("Err: utf8 font not initialized."));
+    u8g_DrawStrP(pu8g, x, y, (const u8g_pgm_uint8_t *)PSTR("Err: utf8 font not initialized."));
     return 0;
   }
   data.pu8g = pu8g;
@@ -250,7 +249,7 @@ unsigned int uxg_DrawUtf8Str(u8g_t *pu8g, unsigned int x, unsigned int y, const 
   const font_t *fnt_default = uxg_GetFont(pu8g);
 
   if (!uxg_Utf8FontIsInited()) {
-    u8g_DrawStrP(pu8g, x, y, PSTR("Err: utf8 font not initialized."));
+    u8g_DrawStrP(pu8g, x, y, (const u8g_pgm_uint8_t *)PSTR("Err: utf8 font not initialized."));
     return 0;
   }
   data.pu8g = pu8g;
@@ -285,7 +284,7 @@ unsigned int uxg_DrawUtf8StrP(u8g_t *pu8g, unsigned int x, unsigned int y, const
 
   if (!uxg_Utf8FontIsInited()) {
     TRACE("Error, utf8string not inited!");
-    u8g_DrawStrP(pu8g, x, y, PSTR("Err: utf8 font not initialized."));
+    u8g_DrawStrP(pu8g, x, y, (const u8g_pgm_uint8_t *)PSTR("Err: utf8 font not initialized."));
     return 0;
   }
   data.pu8g = pu8g;

--- a/buildroot/share/fonts/uxggenpages.md
+++ b/buildroot/share/fonts/uxggenpages.md
@@ -3,7 +3,7 @@
 ### Supported hardware
 
 Marlin supports HD44780 character LCD and 128x64 graphical LCD via U8GLIB.
-Because of the limitation of HD44780 hardware, Marlin can only support three
+Because of the limitation of HD44780 hardwares, Marlin can only support three
 character sets for that hardware:
 Japanese (kana_utf8), Russian/Cyrillic (ru), or Western (Roman characters)
 
@@ -61,18 +61,19 @@ ln -s u8glib-master/tools/font/bdf2u8g/bdf2u8g
 ```
 
 The 'genallfont.sh' script will generate the font data for all of the
-language translation files. You may edit the script to change the variable
-LANGS to the list of languages you want to process. For example:
+language translation files.
+
+You may specify the language list you want to process. For example:
 
 ```bash
-LANGS="zh_TW"
+MARLIN_LANGS="zh_CN zh_TW"
 ```
 
-and then run the script to generate the font data (`language_data_xx.h`):
+and run the script to generate the font data (`language_data_xx.h`):
 
 ```bash
 cd marlin-git/Marlin/
-../buildroot/share/fonts/genallfont.sh
+MARLIN_LANGS="zh_CN zh_TW" ../buildroot/share/fonts/genallfont.sh
 ```
 
 3. Change the language settings
@@ -108,6 +109,9 @@ example, your new font file name is `newfont.bdf`, then run the following comman
 ```bash
 cd Marlin/
 ../buildroot/share/fonts/genallfont.sh ./newfont.bdf
+
+# OR if you just want to regenerate the language font data for a specific language:
+MARLIN_LANGS="zh_TW" ../buildroot/share/fonts/genallfont.sh ./newfont.bdf
 ```
 
 ### Suggestions for Maintainers

--- a/buildroot/share/fonts/uxggenpages.sh
+++ b/buildroot/share/fonts/uxggenpages.sh
@@ -143,7 +143,7 @@ grep -Hrn _UxGT . | grep '"' | \
   while read PAGE BEGIN END UTF8BEGIN UTF8END; do \
     if [ ! -f ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h ]; then \
       ${EXEC_BDF2U8G} -u ${PAGE} -b ${BEGIN} -e ${END} ${FN_FONT} fontpage_${PAGE}_${BEGIN}_${END} ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h > /dev/null 2>&1 ;
-      #sed -i 's|#include "u8g.h"|#include "utility/u8g.h"|' ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h ;
+      #sed -i 's|#include "u8g.h"|#include <clib/u8g.h>|' ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h ;
     fi ;\
     grep -A 10000000000 u8g_fntpgm_uint8_t ${DN_DATA}/fontpage_${PAGE}_${BEGIN}_${END}.h >> tmpa ;\
     echo "    FONTDATA_ITEM(${PAGE}, ${BEGIN}, ${END}, fontpage_${PAGE}_${BEGIN}_${END}), // '${UTF8BEGIN}' -- '${UTF8END}'" >> tmpb ;\


### PR DESCRIPTION
### Description
This PR fix the travis compile error introduce by the commit 584735c99436ce29e49716a7b7c3dc266e0e3d69.

It also update the language data script to update all of font data files and supports generating language data file only specified by user.

### Benefits

Fix travis compile problem. support compiled by both "end user" and "travis" 


### Related Issues

#10213
#10408
#10395
#10413
