### PR TITLE
[2.0.x] Add BOARD_MKS_BASE_15 with digital micro-stepping

### DIFF
--- a/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -138,7 +138,7 @@
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_MKS_13
+  #define MOTHERBOARD BOARD_MKS_GEN_13
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -61,7 +61,7 @@
 #define BOARD_MKS_BASE          40    // MKS BASE v1.0
 #define BOARD_MKS_BASE_15       405   // MKS v1.5 with Allegro A4982 stepper drivers
 #define BOARD_MKS_BASE_HEROIC   41    // MKS BASE 1.0 with Heroic HR4982 stepper drivers
-#define BOARD_MKS_13            47    // MKS v1.3 or 1.4
+#define BOARD_MKS_GEN_13        47    // MKS v1.3 or 1.4
 #define BOARD_MKS_GEN_L         53    // MKS GEN L
 #define BOARD_ZRIB_V20          504   // zrib V2.0 control board (Chinese knock off RAMPS replica)
 #define BOARD_FELIX2            37    // Felix 2.0+ Electronics Board (RAMPS like)

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -58,9 +58,10 @@
 #define BOARD_K8400             79    // Velleman K8400 Controller (derived from 3Drag Controller)
 #define BOARD_BAM_DICE          401   // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE      402   // 2PrintBeta BAM&DICE Due with STK drivers
-#define BOARD_MKS_BASE          40    // MKS BASE 1.0
+#define BOARD_MKS_BASE          40    // MKS BASE v1.0
+#define BOARD_MKS_BASE_15       405   // MKS v1.5 with Allegro A4982 stepper drivers
 #define BOARD_MKS_BASE_HEROIC   41    // MKS BASE 1.0 with Heroic HR4982 stepper drivers
-#define BOARD_MKS_13            47    // MKS v1.3 or 1.4 (maybe higher)
+#define BOARD_MKS_13            47    // MKS v1.3 or 1.4
 #define BOARD_MKS_GEN_L         53    // MKS GEN L
 #define BOARD_ZRIB_V20          504   // zrib V2.0 control board (Chinese knock off RAMPS replica)
 #define BOARD_FELIX2            37    // Felix 2.0+ Electronics Board (RAMPS like)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -272,6 +272,11 @@
   #error "FILAMENT_CHANGE_LOAD_LENGTH is now FILAMENT_CHANGE_FAST_LOAD_LENGTH. Please update your configuration."
 #endif
 
+#define BOARD_MKS_13 -47
+#if MB(MKS_13)
+  #error "BOARD_MKS_13 has been renamed BOARD_MKS_GEN_13. Please update your configuration."
+#endif
+
 /**
  * Marlin release, version and default string
  */

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -102,6 +102,8 @@
   #include "pins_BAM_DICE_DUE.h"      // ATmega1280, ATmega2560
 #elif MB(MKS_BASE)
   #include "pins_MKS_BASE.h"          // ATmega1280, ATmega2560
+#elif MB(MKS_BASE_15)
+  #include "pins_MKS_BASE_15.h"       // ATmega1280, ATmega2560
 #elif MB(MKS_BASE_HEROIC)
   #include "pins_MKS_BASE_HEROIC.h"   // ATmega1280, ATmega2560
 #elif MB(MKS_13)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -106,12 +106,12 @@
   #include "pins_MKS_BASE_15.h"       // ATmega1280, ATmega2560
 #elif MB(MKS_BASE_HEROIC)
   #include "pins_MKS_BASE_HEROIC.h"   // ATmega1280, ATmega2560
-#elif MB(MKS_13)
-  #include "pins_MKS_13.h"            // ATmega1280, ATmega2560
+#elif MB(MKS_GEN_13)
+  #include "pins_MKS_GEN_13.h"        // ATmega1280, ATmega2560
 #elif MB(MKS_GEN_L)
   #include "pins_MKS_GEN_L.h"         // ATmega1280, ATmega2560
 #elif MB(ZRIB_V20)
-  #include "pins_ZRIB_V20.h"          // ATmega1280, ATmega2560 (MKS_13)
+  #include "pins_ZRIB_V20.h"          // ATmega1280, ATmega2560 (MKS_GEN_13)
 #elif MB(FELIX2)
   #include "pins_FELIX2.h"            // ATmega1280, ATmega2560
 #elif MB(RIGIDBOARD)

--- a/Marlin/src/pins/pins_MKS_BASE_15.h
+++ b/Marlin/src/pins/pins_MKS_BASE_15.h
@@ -21,15 +21,21 @@
  */
 
 /**
- * MKS BASE with Heroic HR4982 stepper drivers
+ * MKS BASE v1.5 with A4982 stepper drivers and digital micro-stepping
  */
 
-#include "pins_MKS_BASE_15.h"
+#include "pins_MKS_BASE.h"
 
 /**
- * Some new boards use HR4982 (Heroic) instead of the A4982 (Allegro) stepper drivers.
- * Most the functionality is similar, the HR variant obviously doesn't work with diode
- * smoothers (no fast decay). And the Heroic has a 128 µStepping mode where the A4982
- * is doing quarter steps (MS1=0, MS2=1).
+ * Microstepping pins
  */
-#define HEROIC_STEPPER_DRIVERS
+#define X_MS1_PIN            5   // Digital 3  / Pin 5   / PE3  / SERVO2_PIN
+#define X_MS2_PIN            6   // Digital 6  / Pin 14  / PH3  / SERVO1_PIN
+#define Y_MS1_PIN           59   // Analog 5   / Pin 92  / PF5
+#define Y_MS2_PIN           58   // Analog 4   / Pin 93  / PF4
+#define Z_MS1_PIN           22   // Digital 22 / Pin 78  / PA0
+#define Z_MS2_PIN           39   // Digital 39 / Pin 70  / PG2
+#define E0_MS1_PIN          63   // Analog 9   / Pin 86  / PK1
+#define E0_MS2_PIN          64   // Analog 10  / Pin 87  / PK2
+#define E1_MS1_PIN          57   // Analog 3   / Pin 93  / PF3
+#define E1_MS2_PIN           4   // Digital 4  / Pin 1   / PG5  / SERVO3_PIN

--- a/Marlin/src/pins/pins_MKS_GEN_13.h
+++ b/Marlin/src/pins/pins_MKS_GEN_13.h
@@ -23,17 +23,17 @@
 /**
  * Arduino Mega with RAMPS v1.4 adjusted pin assignments
  *
- *  MKS v1.3  (Extruder, Fan, Bed)
- *  MKS v1.3  (Extruder, Extruder, Fan, Bed)
- *  MKS v1.4  (Extruder, Fan, Bed)
- *  MKS v1.4  (Extruder, Extruder, Fan, Bed)
+ *  MKS GEN v1.3  (Extruder, Fan, Bed)
+ *  MKS GEN v1.3  (Extruder, Extruder, Fan, Bed)
+ *  MKS GEN v1.4  (Extruder, Fan, Bed)
+ *  MKS GEN v1.4  (Extruder, Extruder, Fan, Bed)
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS 1.3/1.4 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS GEN 1.3/1.4 supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_NAME "MKS > v1.3"
+#define BOARD_NAME "MKS GEN >= v1.3"
 
 //
 // Heaters / Fans

--- a/Marlin/src/pins/pins_ZRIB_V20.h
+++ b/Marlin/src/pins/pins_ZRIB_V20.h
@@ -36,4 +36,4 @@
   #define FILWIDTH_PIN 11   // Analog Input
 #endif
 
-#include "pins_MKS_13.h"
+#include "pins_MKS_GEN_13.h"


### PR DESCRIPTION
From discussion in #6456…

Recent MKS BASE boards have digital micro-stepping control. Some have Allegro A4982 drivers, while others have Heroic HR4982. It's not entirely clear whether there's a variant of MKS_BASE v1.4 with digital micro-stepping, but MKS BASE v1.5 certainly does.

- Also rename `BOARD_MKS_13` to `BOARD_MKS_GEN_13`.

Counterpart to #10452