### PR TITLE
[1.1.x] Add new capability to report if Thermal Protection is enabled

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8783,6 +8783,13 @@ inline void gcode_M115() {
       #endif
     );
 
+    // Thermal Protection capability
+    #if ENABLED(THERMAL_PROTECTION_HOTENDS) && ENABLED(THERMAL_PROTECTION_BED)
+    cap_line(PSTR("THERMAL_PROTECTION"), true);
+    #else
+    cap_line(PSTR("THERMAL_PROTECTION"), false);
+    #endif
+
   #endif // EXTENDED_CAPABILITIES_REPORT
 }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8783,12 +8783,12 @@ inline void gcode_M115() {
       #endif
     );
 
-    // Thermal Protection capability
-    #if ENABLED(THERMAL_PROTECTION_HOTENDS) && ENABLED(THERMAL_PROTECTION_BED)
-    cap_line(PSTR("THERMAL_PROTECTION"), true);
-    #else
-    cap_line(PSTR("THERMAL_PROTECTION"), false);
-    #endif
+    // THERMAL_PROTECTION
+    cap_line(PSTR("THERMAL_PROTECTION")
+      #if ENABLED(THERMAL_PROTECTION_HOTENDS) && ENABLED(THERMAL_PROTECTION_BED)
+        , true
+      #endif
+    );
 
   #endif // EXTENDED_CAPABILITIES_REPORT
 }


### PR DESCRIPTION
### Description

This code add a new capability to report if Thermal Protection is enabled (value 1) or not (value 0). Capabilities are reported by the M115 command. Thermal Protection is a feature of Marlin and is enabled with `THERMAL_PROTECTION_HOTENDS` and `THERMAL_PROTECTION_BED` macros.

The idea behind this new capability is to increase the awareness of users regarding Thermal Protection and the danger to disable it. Thanks to this new capability, software such as OctoPrint (more precisely the [Printer Safety Check plugin](http://docs.octoprint.org/en/devel/bundledplugins/printer_safety_check.html)) will be able to warn users when Thermal Protection is not enabled in the firmware.

### Benefits

It is a very minor and simple modification and it can increase the awareness of users regarding Thermal Protection and the danger to disable it.

### Related Issues

* A PR will be submitted to OctoPrint to detect this new capability and warn users.
* A PR will be submitted to a firmware based on Marlin: [ADVi3++](https://github.com/andrivet/ADVi3pp-Marlin) (I am the author).
