### PR TITLE
[2.0.x] AVR preemptive interrupts, ARM interrupt priorities

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
@@ -61,13 +61,13 @@
 // --------------------------------------------------------------------------
 
 const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
-  { TC0, 0, TC0_IRQn,  0}, // 0 - [servo timer5]
+  { TC0, 0, TC0_IRQn,  3}, // 0 - [servo timer5]
   { TC0, 1, TC1_IRQn,  0}, // 1
   { TC0, 2, TC2_IRQn,  0}, // 2
   { TC1, 0, TC3_IRQn,  2}, // 3 - stepper
   { TC1, 1, TC4_IRQn, 15}, // 4 - temperature
-  { TC1, 2, TC5_IRQn,  0}, // 5 - [servo timer3]
-  { TC2, 0, TC6_IRQn, 15}, // 6 - tone
+  { TC1, 2, TC5_IRQn,  3}, // 5 - [servo timer3]
+  { TC2, 0, TC6_IRQn, 14}, // 6 - tone
   { TC2, 1, TC7_IRQn,  0}, // 7
   { TC2, 2, TC8_IRQn,  0}, // 8
 };

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -62,8 +62,6 @@ typedef uint32_t hal_timer_t;
 #define ENABLE_TEMPERATURE_INTERRUPT()  HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-#define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr) DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
-
 #define HAL_STEP_TIMER_ISR  void TC3_Handler()
 #define HAL_TEMP_TIMER_ISR  void TC4_Handler()
 #define HAL_TONE_TIMER_ISR  void TC6_Handler()
@@ -126,5 +124,7 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
   // Reading the status register clears the interrupt flag
   pConfig->pTimerRegs->TC_CHANNEL[pConfig->channel].TC_SR;
 }
+
+#define HAL_timer_isr_epilogue(TIMER_NUM)
 
 #endif // _HAL_TIMERS_DUE_H

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
@@ -353,6 +353,11 @@
     // Install interrupt handler
     install_isr(HWUART_IRQ, UART_ISR);
 
+    // Configure priority. We need a very high priority to avoid losing characters
+    // and we need to be able to preempt the Stepper ISR and everything else!
+    // (this could probably be fixed by using DMA with the Serial port)
+    NVIC_SetPriority(HWUART_IRQ, 1);
+
     // Enable UART interrupt in NVIC
     NVIC_EnableIRQ(HWUART_IRQ);
 

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.cpp
@@ -90,5 +90,4 @@ void HAL_timer_isr_prologue(const uint8_t timer_num) {
   }
 }
 
-
 #endif // TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL_timers.h
@@ -65,8 +65,6 @@ typedef uint32_t hal_timer_t;
 #define ENABLE_TEMPERATURE_INTERRUPT() HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-#define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr) DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
-
 #define HAL_STEP_TIMER_ISR  extern "C" void TIMER0_IRQHandler(void)
 #define HAL_TEMP_TIMER_ISR  extern "C" void TIMER1_IRQHandler(void)
 
@@ -129,5 +127,6 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 void HAL_timer_isr_prologue(const uint8_t timer_num);
+#define HAL_timer_isr_epilogue(TIMER_NUM)
 
 #endif // _HAL_TIMERS_DUE_H

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_Stm32f1.h
@@ -88,7 +88,6 @@ timer_dev* get_timer_dev(int number);
 
 #define HAL_timer_get_count(timer_num) timer_get_count(TIMER_DEV(timer_num))
 
-#define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr)DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
 // TODO change this
 
 
@@ -174,5 +173,7 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
     return;
   }
 }
+
+#define HAL_timer_isr_epilogue(TIMER_NUM)
 
 #endif // _HAL_TIMERS_STM32F1_H

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.h
@@ -61,7 +61,6 @@
 #define ENABLE_TEMPERATURE_INTERRUPT() HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-#define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr)DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
 // TODO change this
 
 
@@ -101,5 +100,6 @@ uint32_t HAL_timer_get_count(const uint8_t timer_num);
 void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_ticks);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
+#define HAL_timer_isr_epilogue(TIMER_NUM)
 
 #endif // _HAL_TIMERS_STM32F4_H

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
@@ -60,7 +60,6 @@
 #define ENABLE_TEMPERATURE_INTERRUPT() HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-#define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr)DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
 // TODO change this
 
 
@@ -99,5 +98,6 @@ uint32_t HAL_timer_get_count(const uint8_t timer_num);
 void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_ticks);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
+#define HAL_timer_isr_epilogue(TIMER_NUM)
 
 #endif // _HAL_TIMERS_STM32F7_H

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL_timers_Teensy.h
@@ -78,8 +78,6 @@ typedef uint32_t hal_timer_t;
 #define HAL_STEP_TIMER_ISR  extern "C" void ftm0_isr(void) //void TC3_Handler()
 #define HAL_TEMP_TIMER_ISR  extern "C" void ftm1_isr(void) //void TC4_Handler()
 
-#define HAL_ENABLE_ISRs() do { if (thermalManager.in_temp_isr) DISABLE_TEMPERATURE_INTERRUPT(); else ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
-
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 
 FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const hal_timer_t compare) {
@@ -115,5 +113,6 @@ void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
 void HAL_timer_isr_prologue(const uint8_t timer_num);
+#define HAL_timer_isr_epilogue(TIMER_NUM)
 
 #endif // _HAL_TIMERS_TEENSY_H


### PR DESCRIPTION
Clean up preemptive interrupt emulation for AVR.

Also, simplify logic on all ARM based ones. Now, it is REQUIRED to properly configure interrupt priority. USART should have highest priority, followed by Stepper, then all others.

Note that this is theoretical code. I tried it in Arduino Due and works. AVR compiles but have no way to test on actual hardware.

STM32F1xx is using a very strange API to program timers, and is NOT setting the priority of the interrupts.

All the other targets seem to be properly setting priority of timers

The priorities should be set
1st: USART
2nd: Stepper / Limit switches
3rd all the rest (USB, Servos, etc)
last: Temperature 
