### PR TITLE
[2.0.x] Fix overridden Malyan LCD functions

### DIFF
--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -28,6 +28,13 @@
 #if ENABLED(ULTRA_LCD) || ENABLED(MALYAN_LCD)
   void lcd_init();
   bool lcd_detected();
+  void lcd_update();
+  void lcd_setalertstatusPGM(const char* message);
+#else
+  inline void lcd_init() {}
+  inline bool lcd_detected() { return true; }
+  inline void lcd_update() {}
+  inline void lcd_setalertstatusPGM(const char* message) { UNUSED(message); }
 #endif
 
 #if ENABLED(ULTRA_LCD)
@@ -52,7 +59,6 @@
     constexpr bool lcd_wait_for_move = false;
   #endif
 
-  void lcd_update();
   bool lcd_hasstatus();
   void lcd_setstatus(const char* message, const bool persist=false);
   void lcd_setstatusPGM(const char* message, const int8_t level=0);
@@ -230,20 +236,16 @@
     void wait_for_release();
   #endif
 
-#else // no LCD
+#else // MALYAN_LCD or no LCD
 
   constexpr bool lcd_wait_for_move = false;
 
-  inline void lcd_init() {}
-  inline bool lcd_detected() { return true; }
-  inline void lcd_update() {}
   inline void lcd_refresh() {}
   inline void lcd_buttons_update() {}
   inline bool lcd_hasstatus() { return false; }
   inline void lcd_setstatus(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
   inline void lcd_setstatusPGM(const char* const message, const int8_t level=0) { UNUSED(message); UNUSED(level); }
   inline void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...) { UNUSED(level); UNUSED(fmt); }
-  inline void lcd_setalertstatusPGM(const char* message) { UNUSED(message); }
   inline void lcd_reset_alert_level() {}
   inline void lcd_reset_status() {}
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -282,3 +282,24 @@ lib_deps     = ${common.lib_deps}
 lib_ignore   = Adafruit NeoPixel
 src_filter   = ${common.default_src_filter}
 monitor_baud = 250000
+
+[env:malyanm200]
+platform    = ststm32
+framework   = arduino
+board = malyanM200
+build_flags = !python Marlin/src/HAL/HAL_STM32F1/stm32f1_flag_script.py -DMCU_STM32F103CB -D __STM32F1__=1 -std=c++1y -D MOTHERBOARD="BOARD_MALYAN_M200" -DSERIAL_USB -ffunction-sections -fdata-sections -Wl,--gc-sections
+src_filter = ${common.default_src_filter}
+#-<frameworks>
+lib_ignore =
+  U8glib
+  LiquidCrystal_I2C
+  LiquidCrystal
+  NewliquidCrystal
+  LiquidTWI2
+  Adafruit NeoPixel
+  TMC2130Stepper
+  Servo(STM32F1)
+  TMC26XStepper
+  U8glib-HAL
+  TMC2208Stepper
+  c1921b4


### PR DESCRIPTION
### Benefits

When my malyanlcd code was rebuilt, some #ifdef blocks were combined. The result is that the no lcd #else branch is active when MALYANLCD is defined. The null implementations are chosen by the linker and the result is the LCD doesn't work. Putting the function definitions back in their own #else fixes the problem. An "lcd" class might make some of this simpler, but since most of them use the ultralcd class, it would be overkill at the moment.


### Related Issues
