### PR TITLE
[2.0.x] Fix crash upon repeated calls to process_subcommands_now_P

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -701,8 +701,7 @@ void GcodeSuite::process_next_command() {
    */
   void GcodeSuite::process_subcommands_now_P(const char *pgcode) {
     // Save the parser state
-    char saved_cmd[strlen(parser.command_ptr) + 1];
-    strcpy(saved_cmd, parser.command_ptr);
+    char *saved_cmd = parser.command_ptr;
 
     // Process individual commands in string
     while (pgm_read_byte_near(pgcode)) {

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -701,7 +701,7 @@ void GcodeSuite::process_next_command() {
    */
   void GcodeSuite::process_subcommands_now_P(const char *pgcode) {
     // Save the parser state
-    char *saved_cmd = parser.command_ptr;
+    const char * const saved_cmd = parser.command_ptr;
 
     // Process individual commands in string
     while (pgm_read_byte_near(pgcode)) {


### PR DESCRIPTION
The first call to `process_subcommands_now_P()` would call `parser.parse()` on a buffer that was allocated on the stack. The parser would in turn store this pointer in `parser.command_ptr`, but this pointer would immediately become invalid when this call to `process_subcommands_now_P()` exited. A subsequent call to `process_subcommands_now_P()` would thus call `strlen()` on `parser.command_ptr`, now invalid, and thus crash Marlin.

This fix stores the value `parser.command_ptr` itself and restores it by value upon exit. This ensures that `parser.command_ptr` will not be left pointing to an invalid buffer.

This PR fixes a bug that was introduced in #10450, due to an attempt to make `process_subcommands_now_P()` safer (it did, but only once!)
