### PR TITLE
[2.0.x] Unify Emergency Parser, support LPC1768

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
@@ -80,97 +80,8 @@
   #endif
 
   #if ENABLED(EMERGENCY_PARSER)
-
-    bool killed_by_M112; // = false
-
-    #include "../../module/stepper.h"
-
-    // Currently looking for: M108, M112, M410
-    // If you alter the parser please don't forget to update the capabilities in Conditionals_post.h
-
-    FORCE_INLINE void emergency_parser(const uint8_t c) {
-
-      static e_parser_state state = state_RESET;
-
-      switch (state) {
-        case state_RESET:
-          switch (c) {
-            case ' ': break;
-            case 'N': state = state_N;      break;
-            case 'M': state = state_M;      break;
-            default: state = state_IGNORE;
-          }
-          break;
-
-        case state_N:
-          switch (c) {
-            case '0': case '1': case '2':
-            case '3': case '4': case '5':
-            case '6': case '7': case '8':
-            case '9': case '-': case ' ':   break;
-            case 'M': state = state_M;      break;
-            default:  state = state_IGNORE;
-          }
-          break;
-
-        case state_M:
-          switch (c) {
-            case ' ': break;
-            case '1': state = state_M1;     break;
-            case '4': state = state_M4;     break;
-            default: state = state_IGNORE;
-          }
-          break;
-
-        case state_M1:
-          switch (c) {
-            case '0': state = state_M10;    break;
-            case '1': state = state_M11;    break;
-            default: state = state_IGNORE;
-          }
-          break;
-
-        case state_M10:
-          state = (c == '8') ? state_M108 : state_IGNORE;
-          break;
-
-        case state_M11:
-          state = (c == '2') ? state_M112 : state_IGNORE;
-          break;
-
-        case state_M4:
-          state = (c == '1') ? state_M41 : state_IGNORE;
-          break;
-
-        case state_M41:
-          state = (c == '0') ? state_M410 : state_IGNORE;
-          break;
-
-        case state_IGNORE:
-          if (c == '\n') state = state_RESET;
-          break;
-
-        default:
-          if (c == '\n') {
-            switch (state) {
-              case state_M108:
-                wait_for_user = wait_for_heatup = false;
-                break;
-              case state_M112:
-                killed_by_M112 = true;
-                break;
-              case state_M410:
-                quickstop_stepper();
-                break;
-              default:
-                break;
-            }
-            state = state_RESET;
-          }
-      }
-    }
-
-  #endif // EMERGENCY_PARSER
+    #include "../../feature/emergency_parser.h"
+  #endif
 
   FORCE_INLINE void store_rxd_char() {
 
@@ -249,7 +160,7 @@
     #endif // SERIAL_XON_XOFF
 
     #if ENABLED(EMERGENCY_PARSER)
-      emergency_parser(c);
+      emergency_parser.update(c);
     #endif
   }
 

--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.h
@@ -94,10 +94,6 @@
     extern ring_buffer_pos_t rx_max_enqueued;
   #endif
 
-  #if ENABLED(EMERGENCY_PARSER)
-    extern bool killed_by_M112;
-  #endif
-
   class MarlinSerial { //: public Stream
 
     public:

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
@@ -107,95 +107,8 @@
   #define sw_barrier() asm volatile("": : :"memory");
 
   #if ENABLED(EMERGENCY_PARSER)
-
-    bool killed_by_M112; // = false
-
-    // Currently looking for: M108, M112, M410
-    // If you alter the parser please don't forget to update the capabilities in Conditionals_post.h
-
-    FORCE_INLINE void emergency_parser(const uint8_t c) {
-
-      static e_parser_state state = state_RESET;
-
-      switch (state) {
-        case state_RESET:
-          switch (c) {
-            case ' ': break;
-            case 'N': state = state_N;      break;
-            case 'M': state = state_M;      break;
-            default: state = state_IGNORE;
-          }
-          break;
-
-        case state_N:
-          switch (c) {
-            case '0': case '1': case '2':
-            case '3': case '4': case '5':
-            case '6': case '7': case '8':
-            case '9': case '-': case ' ':   break;
-            case 'M': state = state_M;      break;
-            default:  state = state_IGNORE;
-          }
-          break;
-
-        case state_M:
-          switch (c) {
-            case ' ': break;
-            case '1': state = state_M1;     break;
-            case '4': state = state_M4;     break;
-            default: state = state_IGNORE;
-          }
-          break;
-
-        case state_M1:
-          switch (c) {
-            case '0': state = state_M10;    break;
-            case '1': state = state_M11;    break;
-            default: state = state_IGNORE;
-          }
-          break;
-
-        case state_M10:
-          state = (c == '8') ? state_M108 : state_IGNORE;
-          break;
-
-        case state_M11:
-          state = (c == '2') ? state_M112 : state_IGNORE;
-          break;
-
-        case state_M4:
-          state = (c == '1') ? state_M41 : state_IGNORE;
-          break;
-
-        case state_M41:
-          state = (c == '0') ? state_M410 : state_IGNORE;
-          break;
-
-        case state_IGNORE:
-          if (c == '\n') state = state_RESET;
-          break;
-
-        default:
-          if (c == '\n') {
-            switch (state) {
-              case state_M108:
-                wait_for_user = wait_for_heatup = false;
-                break;
-              case state_M112:
-                killed_by_M112 = true;
-                break;
-              case state_M410:
-                quickstop_stepper();
-                break;
-              default:
-                break;
-            }
-            state = state_RESET;
-          }
-      }
-    }
-
-  #endif // EMERGENCY_PARSER
+    #include "../../feature/emergency_parser.h"
+  #endif
 
   FORCE_INLINE void store_rxd_char() {
 
@@ -269,7 +182,7 @@
     #endif // SERIAL_XON_XOFF
 
     #if ENABLED(EMERGENCY_PARSER)
-      emergency_parser(c);
+      emergency_parser.update(c);
     #endif
   }
 

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
@@ -74,10 +74,6 @@
   extern ring_buffer_pos_t rx_max_enqueued;
 #endif
 
-#if ENABLED(EMERGENCY_PARSER)
-  extern bool killed_by_M112;
-#endif
-
 class MarlinSerial {
 
 public:

--- a/Marlin/src/HAL/HAL_LPC1768/HardwareSerial.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HardwareSerial.cpp
@@ -22,8 +22,13 @@
 
 #ifdef TARGET_LPC1768
 
-#include "../../inc/MarlinConfig.h"
 #include "HardwareSerial.h"
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if ENABLED(EMERGENCY_PARSER)
+  #include "../../feature/emergency_parser.h"
+#endif
 
 #if SERIAL_PORT == 0 || SERIAL_PORT_2 == 0
   HardwareSerial Serial = HardwareSerial(LPC_UART0);
@@ -248,6 +253,9 @@ void HardwareSerial::IRQHandler() {
   if (IIRValue == UART_IIR_INTID_RDA) {
     // Clear the FIFO
     while (UART_Receive(UARTx, &byte, 1, NONE_BLOCKING)) {
+      #if ENABLED(EMERGENCY_PARSER)
+        emergency_parser.update(byte);
+      #endif
       if ((RxQueueWritePos + 1) % RX_BUFFER_SIZE != RxQueueReadPos) {
         RxBuffer[RxQueueWritePos] = byte;
         RxQueueWritePos = (RxQueueWritePos + 1) % RX_BUFFER_SIZE;

--- a/Marlin/src/HAL/HAL_LPC1768/HardwareSerial.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HardwareSerial.h
@@ -32,6 +32,8 @@ extern "C" {
   #include "lpc17xx_pinsel.h"
 }
 
+#include "../../inc/MarlinConfigPre.h"
+
 class HardwareSerial : public Stream {
 private:
   LPC_UART_TypeDef *UARTx;
@@ -137,8 +139,6 @@ public:
   void print(double value, int round = 6) {
     printf("%f" , value );
   }
-
-
 
   void println(const char value[]) {
     printf("%s\n" , value);

--- a/Marlin/src/HAL/HAL_LPC1768/SanityCheck.h
+++ b/Marlin/src/HAL/HAL_LPC1768/SanityCheck.h
@@ -74,7 +74,3 @@
     ||  MB(RAMPS_14_RE_ARM_SF))
   #error "Re-ARM with REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER and TMC2130 require TMC_USE_SW_SPI"
 #endif
-
-#if ENABLED(EMERGENCY_PARSER)
-  #error "EMERGENCY_PARSER is not yet implemented for LPC1768. Disable EMERGENCY_PARSER to continue."
-#endif

--- a/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
@@ -95,6 +95,7 @@ extern "C" void GpioDisableInt(uint32_t port, uint32_t pin);
 #define vsnprintf_P vsnprintf
 #define strcpy_P strcpy
 #define snprintf_P snprintf
+#define strlen_P strlen
 
 // Time functions
 extern "C" {

--- a/Marlin/src/HAL/HAL_LPC1768/include/serial.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/serial.h
@@ -26,10 +26,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-extern "C" {
-#include <debug_frmwrk.h>
-}
-
 /**
  * Generic RingBuffer
  * T type of the buffer array

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -44,23 +44,6 @@ enum DebugFlags : unsigned char {
   DEBUG_ALL           = 0xFF
 };
 
-#if ENABLED(EMERGENCY_PARSER)
-  enum e_parser_state : char {
-    state_RESET,
-    state_N,
-    state_M,
-    state_M1,
-    state_M10,
-    state_M108,
-    state_M11,
-    state_M112,
-    state_M4,
-    state_M41,
-    state_M410,
-    state_IGNORE // to '\n'
-  };
-#endif
-
 extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (DEBUG_## F))
 

--- a/Marlin/src/feature/emergency_parser.cpp
+++ b/Marlin/src/feature/emergency_parser.cpp
@@ -1,0 +1,121 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * emergency_parser.cpp - Intercept special commands directly in the serial stream
+ */
+
+#include "../inc/MarlinConfigPre.h"
+
+#if ENABLED(EMERGENCY_PARSER)
+
+#include "emergency_parser.h"
+
+extern volatile bool wait_for_user, wait_for_heatup;
+void quickstop_stepper();
+
+EmergencyParser::State EmergencyParser::state = EmergencyParser::State::RESET;
+bool EmergencyParser::killed_by_M112; // = false
+
+EmergencyParser emergency_parser;
+
+void EmergencyParser::update(const uint8_t c) {
+
+  switch (state) {
+    case EmergencyParser::State::RESET:
+      switch (c) {
+        case ' ': break;
+        case 'N': state = EmergencyParser::State::N;      break;
+        case 'M': state = EmergencyParser::State::M;      break;
+        default: state  = EmergencyParser::State::IGNORE;
+      }
+      break;
+
+    case EmergencyParser::State::N:
+      switch (c) {
+        case '0': case '1': case '2':
+        case '3': case '4': case '5':
+        case '6': case '7': case '8':
+        case '9': case '-': case ' ':   break;
+        case 'M': state = EmergencyParser::State::M;      break;
+        default:  state = EmergencyParser::State::IGNORE;
+      }
+      break;
+
+    case EmergencyParser::State::M:
+      switch (c) {
+        case ' ': break;
+        case '1': state = EmergencyParser::State::M1;     break;
+        case '4': state = EmergencyParser::State::M4;     break;
+        default: state  = EmergencyParser::State::IGNORE;
+      }
+      break;
+
+    case EmergencyParser::State::M1:
+      switch (c) {
+        case '0': state = EmergencyParser::State::M10;    break;
+        case '1': state = EmergencyParser::State::M11;    break;
+        default: state  = EmergencyParser::State::IGNORE;
+      }
+      break;
+
+    case EmergencyParser::State::M10:
+      state = (c == '8') ? EmergencyParser::State::M108 : EmergencyParser::State::IGNORE;
+      break;
+
+    case EmergencyParser::State::M11:
+      state = (c == '2') ? EmergencyParser::State::M112 : EmergencyParser::State::IGNORE;
+      break;
+
+    case EmergencyParser::State::M4:
+      state = (c == '1') ? EmergencyParser::State::M41 : EmergencyParser::State::IGNORE;
+      break;
+
+    case EmergencyParser::State::M41:
+      state = (c == '0') ? EmergencyParser::State::M410 : EmergencyParser::State::IGNORE;
+      break;
+
+    case EmergencyParser::State::IGNORE:
+      if (c == '\n') state = EmergencyParser::State::RESET;
+      break;
+
+    default:
+      if (c == '\n') {
+        switch (state) {
+          case EmergencyParser::State::M108:
+            wait_for_user = wait_for_heatup = false;
+            break;
+          case EmergencyParser::State::M112:
+            killed_by_M112 = true;
+            break;
+          case EmergencyParser::State::M410:
+            quickstop_stepper();
+            break;
+          default:
+            break;
+        }
+        state = EmergencyParser::State::RESET;
+      }
+  }
+}
+
+#endif // EMERGENCY_PARSER

--- a/Marlin/src/feature/emergency_parser.h
+++ b/Marlin/src/feature/emergency_parser.h
@@ -20,39 +20,42 @@
  *
  */
 
-#ifdef TARGET_LPC1768
+/**
+ * emergency_parser.h - Intercept special commands directly in the serial stream
+ */
 
-#include "../../inc/MarlinConfig.h"
+#ifndef _EMERGENCY_PARSER_H_
+#define _EMERGENCY_PARSER_H_
 
-#if ENABLED(USE_WATCHDOG)
+class EmergencyParser {
 
-#include "lpc17xx_wdt.h"
-#include "watchdog.h"
+  // Currently looking for: M108, M112, M410
+  enum State : char {
+    RESET,
+    N,
+    M,
+    M1,
+    M10,
+    M108,
+    M11,
+    M112,
+    M4,
+    M41,
+    M410,
+    IGNORE // to '\n'
+  };
 
-void watchdog_init(void) {
-  WDT_Init(WDT_CLKSRC_IRC, WDT_MODE_RESET);
-  WDT_Start(WDT_TIMEOUT);
-}
+public:
 
-void HAL_clear_reset_source(void) {
-  WDT_ClrTimeOutFlag();
-}
+  static EmergencyParser::State state;
+  static bool killed_by_M112;
 
-uint8_t HAL_get_reset_source(void) {
-  if (TEST(WDT_ReadTimeOutFlag(), 0)) return RST_WATCHDOG;
-  return RST_POWER_ON;
-}
+  EmergencyParser() {}
 
-void watchdog_reset() {
-  WDT_Feed();
-  #if PIN_EXISTS(LED)
-    TOGGLE(LED_PIN);  // heart beat indicator
-  #endif
-}
+  static void update(const uint8_t c);
 
-#else
-  void HAL_clear_reset_source(void) {}
-  uint8_t HAL_get_reset_source(void) { return RST_POWER_ON; }
-#endif // USE_WATCHDOG
+};
 
-#endif // TARGET_LPC1768
+extern EmergencyParser emergency_parser;
+
+#endif // _EMERGENCY_PARSER_H_

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -49,6 +49,10 @@
   #include "../feature/filwidth.h"
 #endif
 
+#if ENABLED(EMERGENCY_PARSER)
+  #include "../feature/emergency_parser.h"
+#endif
+
 #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
   static void* heater_ttbl_map[2] = { (void*)HEATER_0_TEMPTABLE, (void*)HEATER_1_TEMPTABLE };
   static uint8_t heater_ttbllen_map[2] = { HEATER_0_TEMPTABLE_LEN, HEATER_1_TEMPTABLE_LEN };
@@ -792,7 +796,7 @@ void Temperature::manage_heater() {
   #endif
 
   #if ENABLED(EMERGENCY_PARSER)
-    if (killed_by_M112) kill(PSTR(MSG_KILLED));
+    if (emergency_parser.killed_by_M112) kill(PSTR(MSG_KILLED));
   #endif
 
   if (!temp_meas_ready) return;

--- a/frameworks/CMSIS/LPC1768/lib/usb/cdcuser.cpp
+++ b/frameworks/CMSIS/LPC1768/lib/usb/cdcuser.cpp
@@ -39,6 +39,11 @@ unsigned short CDC_DepInEmpty = 1;                   // Data IN EP is empty
 unsigned short CDC_LineState = 0;
 unsigned short CDC_SerialState = 0;
 
+#include "../../../../../Marlin/src/inc/MarlinConfigPre.h"
+
+#if ENABLED(EMERGENCY_PARSER)
+  #include "../../../../../Marlin/src/feature/emergency_parser.h"
+#endif
 
 extern HalSerial usb_serial;
 /*----------------------------------------------------------------------------
@@ -52,6 +57,9 @@ uint32_t CDC_WrOutBuf(const char *buffer, uint32_t *length) {
   bytesWritten = bytesToWrite;
 
   while (bytesToWrite) {
+    #if ENABLED(EMERGENCY_PARSER)
+      emergency_parser.update(*buffer);
+    #endif
     usb_serial.receive_buffer.write(*buffer++);           // Copy Data to buffer
     bytesToWrite--;
   }


### PR DESCRIPTION
### Description

Adds Emergency Parser capabilities to usb and hardware serial classes, duplicated (well almost I have a thing about scope) the state machine enum as I had difficulty with with order of inclusion, was much cleaner this way but I might have another look at it.

Unrelated bugfixes for character displays (missing strlen_P) and compiling with disabled watchdog.

### Related Issues
#10499 #10514