### PR TITLE
Rumba support for MKS 128x64 OLED screen

### DIFF
--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -140,15 +140,26 @@
 //
 #define SD_DETECT_PIN      49
 #define BEEPER_PIN         44
-#define LCD_PINS_RS        19
-#define LCD_PINS_ENABLE    42
-#define LCD_PINS_D4        18
-#define LCD_PINS_D5        38
-#define LCD_PINS_D6        41
 #define LCD_PINS_D7        40
 #define BTN_EN1            11
 #define BTN_EN2            12
 #define BTN_ENC            43
+
+#if ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
+  #define LCD_PINS_DC      38 // Set as output on init
+  #define LCD_PINS_RS      41 // Pull low for 1s to init
+  // DOGM SPI LCD Support
+  #define DOGLCD_CS        19
+  #define DOGLCD_MOSI      42
+  #define DOGLCD_SCK       18
+  #define DOGLCD_A0        LCD_PINS_DC
+#else
+  #define LCD_PINS_RS      19
+  #define LCD_PINS_ENABLE  42
+  #define LCD_PINS_D4      18
+  #define LCD_PINS_D5      38
+  #define LCD_PINS_D6      41
+#endif
 
 //
 // M3/M4/M5 - Spindle/Laser Control


### PR DESCRIPTION
### Requirements
RUMBA board and MKS 12864 OLED screen

### Description
It happened to be no chance to use MKS_12864OLED with RUMBA board without modifications in rumba pins file. These changes work for me great. And it would be great if they will help someone else to unstall these parts together in one project.

### Benefits
One can use MKS_12864OLED and RUMBA board together.

### Related Issues
Sometimes picture on screen look cracked or mirrored. It happens when I connect MatterControl to my printer via USB cable. It fixes by pushing reset button on screen board,
