### PR TITLE
[1.1.x] Add M420 C to center the mesh

### DIFF
--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -95,7 +95,6 @@ class unified_bed_leveling {
     #endif
 
     static bool g29_parameter_parsing() _O0;
-    static void find_mean_mesh_height();
     static void shift_mesh_height();
     static void probe_entire_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map, const bool stow_probe, bool do_furthest) _O0;
     static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
@@ -118,7 +117,8 @@ class unified_bed_leveling {
     static mesh_index_pair find_furthest_invalid_mesh_point() _O0;
     static void reset();
     static void invalidate();
-    static void set_all_mesh_points_to_value(const float);
+    static void set_all_mesh_points_to_value(const float value);
+    static void adjust_mesh_to_mean(const float value);
     static bool sanity_check();
 
     static void G29() _O0;                          // O0 for no optimization

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -539,7 +539,7 @@
           #endif
           break;
 
-        case 5: find_mean_mesh_height(); break;
+        case 5: adjust_mesh_to_mean(g29_constant); break;
 
         case 6: shift_mesh_height(); break;
       }
@@ -629,7 +629,7 @@
     return;
   }
 
-  void unified_bed_leveling::find_mean_mesh_height() {
+  void unified_bed_leveling::adjust_mesh_to_mean(const float value) {
     float sum = 0.0;
     int n = 0;
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
@@ -664,7 +664,7 @@
       for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
         for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
           if (!isnan(z_values[x][y]))
-            z_values[x][y] -= mean + g29_constant;
+            z_values[x][y] -= mean + value;
   }
 
   void unified_bed_leveling::shift_mesh_height() {
@@ -1076,7 +1076,7 @@
       SERIAL_EOL();
     #endif
 
-    find_mean_mesh_height();
+    adjust_mesh_to_mean(g29_constant);
 
     #if HAS_BED_PROBE
       SERIAL_PROTOCOLPGM("zprobe_zoffset: ");


### PR DESCRIPTION
Extend `M420` with a `C` parameter to center the mesh on some value (0 if no value is given). By default, for ABL and MBL this takes the height between the lowest and highest mesh values rather than taking the mean of all mesh values.

For UBL this is just a synonym for `G29 P6 C`.

Counterpart to #10522