### PR TITLE
[1.1.x] Blink the value on non-homed axes

### DIFF
--- a/Marlin/status_screen_DOGM.h
+++ b/Marlin/status_screen_DOGM.h
@@ -98,19 +98,24 @@ FORCE_INLINE void _draw_heater_status(const uint8_t x, const int8_t heater, cons
   }
 }
 
-FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink) {
+//
+// Before homing, blink '123' <-> '???'.
+// Homed but unknown... '123' <-> '   '.
+// Homed and known, display constantly.
+//
+FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const bool blink) {
   if (blink)
-    lcd_printPGM(pstr);
+    lcd_print(value);
   else {
     if (!axis_homed[axis])
-      u8g.print('?');
+      while (const char c = *value++) lcd_print(c <= '.' ? c : '?');
     else {
       #if DISABLED(HOME_AFTER_DEACTIVATE) && DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[axis])
-          u8g.print(' ');
+          lcd_printPGM(axis == Z_AXIS ? PSTR("      ") : PSTR("    "));
         else
       #endif
-          lcd_printPGM(pstr);
+          lcd_print(value);
     }
   }
 }
@@ -330,10 +335,6 @@ static void lcd_implementation_status_screen() {
     #define XYZ_FRAME_HEIGHT INFO_FONT_HEIGHT + 1
   #endif
 
-  // Before homing the axis letters are blinking 'X' <-> '?'.
-  // When axis is homed but axis_known_position is false the axis letters are blinking 'X' <-> ' '.
-  // When everything is ok you see a constant 'X'.
-
   static char xstring[5], ystring[5], zstring[7];
   #if ENABLED(FILAMENT_LCD_DISPLAY)
     static char wstring[5], mstring[4];
@@ -370,19 +371,19 @@ static void lcd_implementation_status_screen() {
       #endif
 
       u8g.setPrintPos(0 * XYZ_SPACING + X_LABEL_POS, XYZ_BASELINE);
-      _draw_axis_label(X_AXIS, PSTR(MSG_X), blink);
+      lcd_printPGM(PSTR(MSG_X));
       u8g.setPrintPos(0 * XYZ_SPACING + X_VALUE_POS, XYZ_BASELINE);
-      lcd_print(xstring);
+      _draw_axis_value(X_AXIS, xstring, blink);
 
       u8g.setPrintPos(1 * XYZ_SPACING + X_LABEL_POS, XYZ_BASELINE);
-      _draw_axis_label(Y_AXIS, PSTR(MSG_Y), blink);
+      lcd_printPGM(PSTR(MSG_Y));
       u8g.setPrintPos(1 * XYZ_SPACING + X_VALUE_POS, XYZ_BASELINE);
-      lcd_print(ystring);
+      _draw_axis_value(Y_AXIS, ystring, blink);
 
       u8g.setPrintPos(2 * XYZ_SPACING + X_LABEL_POS, XYZ_BASELINE);
-      _draw_axis_label(Z_AXIS, PSTR(MSG_Z), blink);
+      lcd_printPGM(PSTR(MSG_Z));
       u8g.setPrintPos(2 * XYZ_SPACING + X_VALUE_POS, XYZ_BASELINE);
-      lcd_print(zstring);
+      _draw_axis_value(Z_AXIS, zstring, blink);
 
       #if DISABLED(XYZ_HOLLOW_FRAME)
         u8g.setColorIndex(1); // black on white

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -467,9 +467,7 @@ static void lcd_implementation_init(
 }
 
 void lcd_implementation_clear() { lcd.clear(); }
-
 void lcd_print(const char c) { charset_mapper(c); }
-
 void lcd_print(const char *str) { while (*str) lcd.print(*str++); }
 void lcd_printPGM(const char *str) { while (const char c = pgm_read_byte(str)) lcd.print(c), ++str; }
 
@@ -599,16 +597,22 @@ void lcd_kill_screen() {
   lcd_printPGM_utf(PSTR(MSG_PLEASE_RESET));
 }
 
-FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char* value, const bool blink) {
+//
+// Before homing, blink '123' <-> '???'.
+// Homed but unknown... '123' <-> '   '.
+// Homed and known, display constantly.
+//
+FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const bool blink) {
+  lcd_print('X' + uint8_t(axis));
   if (blink)
     lcd.print(value);
   else {
     if (!axis_homed[axis])
-      lcd.write('?');
+      while (const char c = *value++) lcd_print(c <= '.' ? c : '?');
     else {
       #if DISABLED(HOME_AFTER_DEACTIVATE) && DISABLED(DISABLE_REDUCED_ACCURACY_WARNING)
         if (!axis_known_position[axis])
-          lcd.write(' ');
+          lcd_printPGM(axis == Z_AXIS ? PSTR("      ") : PSTR("    "));
         else
       #endif
           lcd.print(value);
@@ -799,16 +803,11 @@ static void lcd_implementation_status_screen() {
         ), blink);
 
       #else // HOTENDS <= 2 && (HOTENDS <= 1 || !TEMP_SENSOR_BED)
-        // Before homing the axis values are blinking n <-> '?'.
-        // When axis is homed but axis_known_position is false the axis values are blinking n <-> ' '.
-        // When everything is ok you see a constant n.
 
-        lcd_printPGM(PSTR(MSG_X));
         _draw_axis_value(X_AXIS, ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])), blink);
 
         lcd.write(' ');
 
-        lcd_printPGM(PSTR(MSG_Y));
         _draw_axis_value(Y_AXIS, ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])), blink);
 
       #endif // HOTENDS <= 2 && (HOTENDS <= 1 || !TEMP_SENSOR_BED)
@@ -816,7 +815,6 @@ static void lcd_implementation_status_screen() {
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    lcd_printPGM(PSTR(MSG_Z));
     _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])), blink);
 
     #if HAS_LEVELING && !TEMP_SENSOR_BED

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -599,9 +599,9 @@ void lcd_kill_screen() {
   lcd_printPGM_utf(PSTR(MSG_PLEASE_RESET));
 }
 
-FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, const bool blink) {
+FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char* value, const bool blink) {
   if (blink)
-    lcd_printPGM(pstr);
+    lcd.print(value);
   else {
     if (!axis_homed[axis])
       lcd.write('?');
@@ -611,7 +611,7 @@ FORCE_INLINE void _draw_axis_label(const AxisEnum axis, const char* const pstr, 
           lcd.write(' ');
         else
       #endif
-          lcd_printPGM(pstr);
+          lcd.print(value);
     }
   }
 }
@@ -799,25 +799,25 @@ static void lcd_implementation_status_screen() {
         ), blink);
 
       #else // HOTENDS <= 2 && (HOTENDS <= 1 || !TEMP_SENSOR_BED)
-        // Before homing the axis letters are blinking 'X' <-> '?'.
-        // When axis is homed but axis_known_position is false the axis letters are blinking 'X' <-> ' '.
-        // When everything is ok you see a constant 'X'.
+        // Before homing the axis values are blinking n <-> '?'.
+        // When axis is homed but axis_known_position is false the axis values are blinking n <-> ' '.
+        // When everything is ok you see a constant n.
 
-        _draw_axis_label(X_AXIS, PSTR(MSG_X), blink);
-        lcd.print(ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])));
+        lcd_printPGM(PSTR(MSG_X));
+        _draw_axis_value(X_AXIS, ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])), blink);
 
         lcd.write(' ');
 
-        _draw_axis_label(Y_AXIS, PSTR(MSG_Y), blink);
-        lcd.print(ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])));
+        lcd_printPGM(PSTR(MSG_Y));
+        _draw_axis_value(Y_AXIS, ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])), blink);
 
       #endif // HOTENDS <= 2 && (HOTENDS <= 1 || !TEMP_SENSOR_BED)
 
     #endif // LCD_WIDTH >= 20
 
     lcd.setCursor(LCD_WIDTH - 8, 1);
-    _draw_axis_label(Z_AXIS, PSTR(MSG_Z), blink);
-    lcd.print(ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])));
+    lcd_printPGM(PSTR(MSG_Z));
+    _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])), blink);
 
     #if HAS_LEVELING && !TEMP_SENSOR_BED
       lcd.write(planner.leveling_active || blink ? '_' : ' ');


### PR DESCRIPTION
### Description

This kept tripping me up, Blinking a `?` on the label suggests that the firmware isn't sure about the axis itself (such as it doesn't know what steppers is which axis), blinking the value more appropriately suggests that it isn't sure about the value.

### Benefits

Increasing native/intuitive understanding of status messages

### Related Issues

fixes #3737