### PR TITLE
[2.0.x, RFC] Fix const correctness in gcode parser

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -144,7 +144,7 @@ void GcodeSuite::dwell(millis_t time) {
       #ifdef G29_ACTION_ON_RECOVER
         SERIAL_ECHOLNPGM("//action:" G29_ACTION_ON_RECOVER);
       #endif
-      #ifdef G29_RECOVERY_COMMANDS
+      #ifdef G29_RECOVER_COMMANDS
         process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
       #endif
     }

--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -30,7 +30,7 @@
  */
 void GcodeSuite::M118() {
   bool hasE = false, hasA = false;
-  char *p = parser.string_arg;
+  const char *p = parser.string_arg;
   for (uint8_t i = 2; i--;)
     if ((p[0] == 'A' || p[0] == 'E') && p[1] == '1') {
       if (p[0] == 'A') hasA = true;

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -45,7 +45,7 @@ bool GCodeParser::volumetric_enabled;
   TempUnit GCodeParser::input_temp_units;
 #endif
 
-char *GCodeParser::command_ptr,
+const char *GCodeParser::command_ptr,
      *GCodeParser::string_arg,
      *GCodeParser::value_ptr;
 char GCodeParser::command_letter;
@@ -86,7 +86,7 @@ void GCodeParser::reset() {
 
 // Populate all fields by parsing a single line of GCode
 // 58 bytes of SRAM are used to speed up seen/value
-void GCodeParser::parse(char *p) {
+void GCodeParser::parse(const char * p) {
 
   reset(); // No codes to report
 

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -185,9 +185,9 @@ public:
         const char c = *e;
         if (c == '\0' || c == ' ') break;
         if (c == 'E' || c == 'e') {
-          char tmp[strlen(value_ptr)+1];
-          strcpy(tmp,value_ptr);
-          tmp[e-value_ptr] = '\0';
+          char tmp[strlen(value_ptr) + 1];
+          strcpy(tmp, value_ptr);
+          tmp[e - value_ptr] = '\0';
           return strtod(tmp, NULL);
         }
         ++e;

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -51,7 +51,7 @@
 class GCodeParser {
 
 private:
-  static char *value_ptr;           // Set by seen, used to fetch the value
+  static const char *value_ptr;           // Set by seen, used to fetch the value
 
   #if ENABLED(FASTER_GCODE_PARSER)
     static uint32_t codebits;       // Parameters pre-scanned
@@ -75,7 +75,7 @@ public:
   #endif
 
   // Command line state
-  static char *command_ptr,               // The command, so it can be echoed
+  static const char *command_ptr,         // The command, so it can be echoed
               *string_arg;                // string of command line
 
   static char command_letter;             // G, M, or T
@@ -108,7 +108,7 @@ public:
     }
 
     // Set the flag and pointer for a parameter
-    static void set(const char c, char * const ptr) {
+    static void set(const char c, const char * const ptr) {
       const uint8_t ind = LETTER_BIT(c);
       if (ind >= COUNT(param)) return;           // Only A-Z
       SBI32(codebits, ind);                      // parameter exists
@@ -130,7 +130,7 @@ public:
       if (ind >= COUNT(param)) return false; // Only A-Z
       const bool b = TEST32(codebits, ind);
       if (b) {
-        char * const ptr = command_ptr + param[ind];
+        const char * const ptr = command_ptr + param[ind];
         value_ptr = param[ind] && valid_float(ptr) ? ptr : (char*)NULL;
       }
       return b;
@@ -164,7 +164,7 @@ public:
 
   // Populate all fields by parsing a single line of GCode
   // This uses 54 bytes of SRAM to speed up seen/value
-  static void parse(char * p);
+  static void parse(const char * p);
 
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
     // Parse the next parameter as a new command
@@ -180,15 +180,15 @@ public:
   // Float removes 'E' to prevent scientific notation interpretation
   inline static float value_float() {
     if (value_ptr) {
-      char *e = value_ptr;
+      const char *e = value_ptr;
       for (;;) {
         const char c = *e;
         if (c == '\0' || c == ' ') break;
         if (c == 'E' || c == 'e') {
-          *e = '\0';
-          const float ret = strtod(value_ptr, NULL);
-          *e = c;
-          return ret;
+          char tmp[strlen(value_ptr)+1];
+          strcpy(tmp,value_ptr);
+          tmp[e-value_ptr] = '\0';
+          return strtod(tmp, NULL);
         }
         ++e;
       }

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
@@ -73,16 +73,16 @@ void GcodeSuite::M22() { card.release(); }
  */
 void GcodeSuite::M23() {
   // Simplify3D includes the size, so truncate string at spaces (#7227)
-  const char *space = strchr(parser.string_arg,' ');
-  if(space) {
+  const char *space = strchr(parser.string_arg, ' ');
+  if (space) {
     const size_t len = space - parser.string_arg;
-    char tmp[len+1];
+    char tmp[len + 1];
     strncpy(tmp, parser.string_arg, len);
     tmp[len] = '\0';
     card.openFile(tmp, true);
-   } else {
+  }
+  else
     card.openFile(parser.string_arg, true);
-   }
 }
 
 /**

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
@@ -72,9 +72,17 @@ void GcodeSuite::M22() { card.release(); }
  * M23: Open a file
  */
 void GcodeSuite::M23() {
-  // Simplify3D includes the size, so zero out all spaces (#7227)
-  for (char *fn = parser.string_arg; *fn; ++fn) if (*fn == ' ') *fn = '\0';
-  card.openFile(parser.string_arg, true);
+  // Simplify3D includes the size, so truncate string at spaces (#7227)
+  const char *space = strchr(parser.string_arg,' ');
+  if(space) {
+    const size_t len = space - parser.string_arg;
+    char tmp[len+1];
+    strncpy(tmp, parser.string_arg, len);
+    tmp[len] = '\0';
+    card.openFile(tmp, true);
+   } else {
+    card.openFile(parser.string_arg, true);
+   }
 }
 
 /**

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -373,7 +373,7 @@ void CardReader::stopSDPrint(
   #endif
 }
 
-void CardReader::openLogFile(char* name) {
+void CardReader::openLogFile(const char* name) {
   logging = true;
   openFile(name, false);
 }
@@ -398,7 +398,7 @@ void CardReader::getAbsFilename(char *t) {
   *t = '\0';
 }
 
-void CardReader::openFile(char* name, const bool read, const bool subcall/*=false*/) {
+void CardReader::openFile(const char* name, const bool read, const bool subcall/*=false*/) {
 
   if (!cardOK) return;
 
@@ -446,8 +446,8 @@ void CardReader::openFile(char* name, const bool read, const bool subcall/*=fals
 
   SdFile myDir;
   curDir = &root;
-  char *fname = name;
-  char *dirname_start, *dirname_end;
+  const char *fname = name;
+  const char *dirname_start, *dirname_end;
 
   if (name[0] == '/') {
     dirname_start = &name[1];

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -45,8 +45,8 @@ public:
   // device is available soon after a reset.
 
   void checkautostart(bool x);
-  void openFile(char* name, const bool read, const bool subcall=false);
-  void openLogFile(char* name);
+  void openFile(const char* name, const bool read, const bool subcall=false);
+  void openLogFile(const char* name);
   void removeFile(const char * const name);
   void closefile(bool store_location=false);
   void release();


### PR DESCRIPTION
Currently the method parser.parse() takes a non-constant string. Furthermore, the implementation of the code for parsing floats actually modifies the string temporarily. This is slightly cringe-worthy, as it violates the expectation that parsing code should not modify that thing which it is supposed to parse.

The lack of constness led to the [following line](https://github.com/MarlinFirmware/Marlin/pull/10509/files) generating a compile error:

```
void GcodeSuite::process_subcommands_now_P(const char *pgcode) {
   // Save the parser state
   const char * const saved_cmd = parser.command_ptr;
   ...
}
```

Although it would be easy to remove that `const` from `process_subcommands_now_P`, this PR shows what would have to change to make the parser work on constant strings.

I had to make float parsing slightly less efficient in the case in which gcode lines are written without spaces and an E value follows a decimal, i.e:

`G0X10E10`

The former code would change the "E" to a '\0', call `strtod`, and then revert the change. Now it will copy the string onto the stack in such cases.

This is an entirely optional PR. The arguments for doing it this way is that it is more correct, the argument against it is that it is less efficient (although possibly making things const could allow the compiler to optimize other things).

I just wanted to put this on the table as a possibility.