### PR TITLE
[2.0.x] MAX7219: delayMicroseconds cannot be called in critical section

### DIFF
--- a/Marlin/src/feature/Max7219_Debug_LEDs.cpp
+++ b/Marlin/src/feature/Max7219_Debug_LEDs.cpp
@@ -64,7 +64,7 @@
 static uint8_t LEDs[8] = { 0 };
 
 #ifdef CPU_32_BIT
-  #define MS_DELAY() delayMicroseconds(7)  // 32-bit processors need a delay to stabilize the signal
+void MS_DELAY() { DELAY_1US; }  // 32-bit processors need a delay to stabilize the signal
 #else
   #define MS_DELAY() DELAY_3_NOP
 #endif


### PR DESCRIPTION
### Description

`delayMicroseconds()` cannot be called in a critical section on the STM32 platform (probably applies to other 32-bit platforms as well). On the STM32 platform, the `delayMicroseconds()` function is relies on the SysTick interrupt. In a critical section all interrupts are disabled and the delay will never complete.

The `Max7219_PutByte()` and `Max7219()` functions are using critical sections (not sure why) with delay calls inside the critical sections. Instead of `delayMicroseconds()` use the macro `DELAY_1US` on 32-bit platforms. The delay has been reduced from 7us to ~1us as the Max7219 minimum clock period is 100ns.
