### PR TITLE
Correct ATmega328P macro

### DIFF
--- a/Marlin/fastio.h
+++ b/Marlin/fastio.h
@@ -38,7 +38,7 @@ typedef int8_t pin_t;
 #define AVR_ATmega1284_FAMILY (defined(__AVR_ATmega644__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644PA__) || defined(__AVR_ATmega1284P__))
 #define AVR_ATmega2560_FAMILY (defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__))
 #define AVR_ATmega2561_FAMILY (defined(__AVR_ATmega1281__) || defined(__AVR_ATmega2561__))
-#define AVR_ATmega328_FAMILY (defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328p__))
+#define AVR_ATmega328_FAMILY (defined(__AVR_ATmega168__) || defined(__AVR_ATmega328__) || defined(__AVR_ATmega328P__))
 
 /**
  * Include Ports and Functions


### PR DESCRIPTION
### Description
The correct MCU-specific macro for ATmega328P is [`__AVR_ATmega328P__`](https://www.microchip.com/webdoc/avrlibcreferencemanual/using_tools_1using_avr_gcc_mach_opt.html), rather than `__AVR_ATmega328p__`, as was previously in the code.

### Benefits
This bug caused a misleading error to be displayed when compiling for ATmega328P:
```
fastio.h:57: error: #error "Pins for this chip not defined in Arduino.h! If you have a working pins definition, please contribute!"
```
This would lead someone to believe the problem is that a pins definition for the microcontroller is required when actually a pins definition [already exists](https://github.com/MarlinFirmware/Marlin/blob/bugfix-1.1.x/Marlin/fastio_168.h) but ATmega328P is [still not supported](https://github.com/MarlinFirmware/Marlin/issues/2122#issuecomment-103281739).

After this fix compilation will still fail for ATmega328P, but without the misleading error.