### PR TITLE
Removed "const" to avoid compile error when passing to parser.

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -701,7 +701,7 @@ void GcodeSuite::process_next_command() {
    */
   void GcodeSuite::process_subcommands_now_P(const char *pgcode) {
     // Save the parser state
-    const char * const saved_cmd = parser.command_ptr;
+    char * const saved_cmd = parser.command_ptr;
 
     // Process individual commands in string
     while (pgm_read_byte_near(pgcode)) {


### PR DESCRIPTION
This change is required as `parser.parse()` takes a non-const string.