### PR TITLE
[2.0.x] report error on unsupported commands

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -277,6 +277,8 @@ void GcodeSuite::process_parsed_command(
       #if ENABLED(DEBUG_GCODE_PARSER)
         case 800: parser.debug(); break;                          // G800: GCode Parser Test for G
       #endif
+
+      default: parser.unknown_command_error(); break;
     }
     break;
 
@@ -655,6 +657,8 @@ void GcodeSuite::process_parsed_command(
       #endif
 
       case 999: M999(); break;                                    // M999: Restart after being Stopped
+
+      default: parser.unknown_command_error(); break;
     }
     break;
 


### PR DESCRIPTION
Raise an error when an unknown/unsupported G/M command is called.

This will address #10546