### PR TITLE
Revert "[1.1.x] report error on unsupported commands"

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12061,8 +12061,6 @@ void process_parsed_command() {
       #if ENABLED(DEBUG_GCODE_PARSER)
         case 800: parser.debug(); break;                          // G800: GCode Parser Test for G
       #endif
-
-      default: parser.unknown_command_error();
     }
     break;
 
@@ -12420,8 +12418,6 @@ void process_parsed_command() {
       #endif
 
       case 999: gcode_M999(); break;                              // M999: Restart after being Stopped
-      
-      default: parser.unknown_command_error();
     }
     break;
 


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#10554

Oooops!   Sorry Thinkhead!
