### PR TITLE
[2.0.x] MKS SBASE - Separate SD_DETECT for LCD and on-board SD cards

### DIFF
--- a/Marlin/src/config/examples/Mks/Sbase/000-README_RepRap_Discount_Full_Graphic_Smart_Controller.txt
+++ b/Marlin/src/config/examples/Mks/Sbase/000-README_RepRap_Discount_Full_Graphic_Smart_Controller.txt
@@ -25,3 +25,14 @@ An octopus cable something like the Adafruit 1199 will simply the construction o
 
 Adafruit 10-pin IDC Socket Rainbow Breakout Cable [1199]
   https://www.adafruit.com/product/1199
+
+
+/////////////////////////////////////////////////////////////////////
+
+27 APR 2018
+
+If you also want a functional SD_DETECT_PIN then you'll need to also move the following pin:
+
+    used to go to P0.27 to J8-5
+
+if you decide to use a different pin then the pins_MKS_SBASE.h file will need to be modified.

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -158,7 +158,6 @@
   #define BTN_ENC          P1_30   // EXP1.2
   #define BTN_EN1          P3_26   // EXP2.5
   #define BTN_EN2          P3_25   // EXP2.3
-  #define SD_DETECT_PIN    P0_27   // EXP2.7
   #define LCD_PINS_RS      P0_16   // EXP1.4
   #define LCD_SDSS         P0_28   // EXP2.4
   #define LCD_PINS_ENABLE  P0_18   // EXP1.3
@@ -194,7 +193,8 @@
 #define MISO_PIN           P1_23   // J8-3 (moved from EXP2 P0.8)
 #define MOSI_PIN           P2_12   // J8-4 (moved from EXP2 P0.5)
 #define SS_PIN             P0_28
-#define SD_DETECT_PIN      P0_27
+#define SD_DETECT_PIN      P2_11   // J8-5 (moved from EXP2 P0.27)  P0.27 is used by
+                                   // the on board SD card so it can't by the LCD's SD card
 #define SDSS               P0_06
 
 /**

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -193,9 +193,13 @@
 #define MISO_PIN           P1_23   // J8-3 (moved from EXP2 P0.8)
 #define MOSI_PIN           P2_12   // J8-4 (moved from EXP2 P0.5)
 #define SS_PIN             P0_28
-#define SD_DETECT_PIN      P2_11   // J8-5 (moved from EXP2 P0.27)  P0.27 is used by
-                                   // the on board SD card so it can't by the LCD's SD card
 #define SDSS               P0_06
+
+// P0.27 is used by the on-board SD card's SD_DETECT so it can't be used as a
+// SD_DETECT for the LCD's SD card.
+// If you can't find a pin to use for the LCD's SD_DETECT then comment out SD_DETECT_PIN.
+#define SD_DETECT_PIN      P2_11   // J8-5 (moved from EXP2 P0.27)
+
 
 /**
  *  PWMs

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -195,9 +195,16 @@
 #define SS_PIN             P0_28
 #define SDSS               P0_06
 
-// P0.27 is used by the on-board SD card's SD_DETECT so it can't be used as a
-// SD_DETECT for the LCD's SD card.
-// If you can't find a pin to use for the LCD's SD_DETECT then comment out SD_DETECT_PIN.
+/**
+ * P0.27 is on EXP2 and the on-board SD card's socket. That means it can't be
+ * used as the SD_DETECT for the LCD's SD card.
+ *
+ * The best solution is to use the custom cable to connect the LCD's SD_DETECT
+ * to a pin NOT on EXP2.
+ *
+ * If you can't find a pin to use for the LCD's SD_DETECT then comment out
+ * SD_DETECT_PIN entirely and remove that wire from the the custom cable.
+ */
 #define SD_DETECT_PIN      P2_11   // J8-5 (moved from EXP2 P0.27)
 
 


### PR DESCRIPTION
This PR attempts to remove the confusion over the SD_DETECT function in the MKS SBASE controller.

P0_27 is used by the on-board SD card's SD_DETECT so it can't be used as a SD_DETECT for the LCD's SD card.  The alternatives are:
1. Leave as is (SD_DETECT_PIN assigned to P0_27 which is on the EXP2 connector for the LCD **AND** on the on-board SD card's sockect).  This results in the SD_DETECT signal being active when either card is inserted.
2. Not define SD_DETECT_PIN at all.  This results in Marlin not knowing when  the LCD's SD card is removed or inserted.
3. Use a custom cable to move the LCD's SD_DETECT_PIN wire to another connector. 

The on-board SD card software doesn't use the SD_DETECT_PIN define so none of this affects how it operates.

The **pins_MKS_SBASE.h** is being modified to implement option 3 as the default.  A custom cable is already required to make the LCD's SD card functional so this isn't a problem.

What could be a problem is finding a free pin to use for the LCD's SD_DETECT.  If this isn't possible then option 2 is preferred. The comments have been modified to reflect this.

The READ_ME file is being updated to reflect the above.