### PR TITLE
[2.0.x] Round all floats in string conversion functions

### DIFF
--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -87,7 +87,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed int to rj string with 1234, _123, -123, _-12, or __-1 format
-  char *itostr4sign(const int x) {
+  char* itostr4sign(const int x) {
     const bool neg = x < 0;
     const int xx = neg ? -x : x;
     if (x >= 1000) {
@@ -119,7 +119,7 @@ void safe_delay(millis_t ms) {
 
   // Convert unsigned float to string with 1.23 format
   char* ftostr12ns(const float &x) {
-    const long xx = (x < 0 ? -x : x) * 100;
+    const long xx = ((x < 0 ? -x : x) + 0.001) * 100;
     conv[3] = DIGIMOD(xx, 100);
     conv[4] = '.';
     conv[5] = DIGIMOD(xx, 10);
@@ -128,8 +128,8 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert signed float to fixed-length string with 023.45 / -23.45 format
-  char *ftostr32(const float &x) {
-    long xx = x * 100;
+  char* ftostr32(const float &x) {
+    long xx = FIXFLOAT(x) * 100;
     conv[1] = MINUSOR(xx, DIGIMOD(xx, 10000));
     conv[2] = DIGIMOD(xx, 1000);
     conv[3] = DIGIMOD(xx, 100);
@@ -142,8 +142,8 @@ void safe_delay(millis_t ms) {
   #if ENABLED(LCD_DECIMAL_SMALL_XY)
 
     // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
-    char *ftostr4sign(const float &fx) {
-      const int x = fx * 10;
+    char* ftostr4sign(const float &fx) {
+      const int x = FIXFLOAT(fx) * 10;
       if (!WITHIN(x, -99, 999)) return itostr4sign((int)fx);
       const bool neg = x < 0;
       const int xx = neg ? -x : x;
@@ -158,7 +158,7 @@ void safe_delay(millis_t ms) {
 
   // Convert float to fixed-length string with +123.4 / -123.4 format
   char* ftostr41sign(const float &x) {
-    int xx = x * 10;
+    int xx = FIXFLOAT(x) * 10;
     conv[1] = MINUSOR(xx, '+');
     conv[2] = DIGIMOD(xx, 1000);
     conv[3] = DIGIMOD(xx, 100);
@@ -170,7 +170,7 @@ void safe_delay(millis_t ms) {
 
   // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
   char* ftostr43sign(const float &x, char plus/*=' '*/) {
-    long xx = x * 1000;
+    long xx = FIXFLOAT(x) * 1000;
     conv[1] = xx ? MINUSOR(xx, plus) : ' ';
     conv[2] = DIGIMOD(xx, 1000);
     conv[3] = '.';
@@ -193,7 +193,7 @@ void safe_delay(millis_t ms) {
 
   // Convert signed float to string with +1234.5 format
   char* ftostr51sign(const float &x) {
-    long xx = x * 10;
+    long xx = FIXFLOAT(x) * 10;
     conv[0] = MINUSOR(xx, '+');
     conv[1] = DIGIMOD(xx, 10000);
     conv[2] = DIGIMOD(xx, 1000);
@@ -206,7 +206,7 @@ void safe_delay(millis_t ms) {
 
   // Convert signed float to string with +123.45 format
   char* ftostr52sign(const float &x) {
-    long xx = x * 100;
+    long xx = FIXFLOAT(x) * 100;
     conv[0] = MINUSOR(xx, '+');
     conv[1] = DIGIMOD(xx, 10000);
     conv[2] = DIGIMOD(xx, 1000);
@@ -219,7 +219,7 @@ void safe_delay(millis_t ms) {
 
   // Convert unsigned float to string with 1234.56 format omitting trailing zeros
   char* ftostr62rj(const float &x) {
-    const long xx = (x < 0 ? -x : x) * 100;
+    const long xx = ((x < 0 ? -x : x) + 0.001) * 100;
     conv[0] = RJDIGIT(xx, 100000);
     conv[1] = RJDIGIT(xx, 10000);
     conv[2] = RJDIGIT(xx, 1000);
@@ -232,7 +232,7 @@ void safe_delay(millis_t ms) {
 
   // Convert signed float to space-padded string with -_23.4_ format
   char* ftostr52sp(const float &x) {
-    long xx = x * 100;
+    long xx = FIXFLOAT(x) * 100;
     uint8_t dig;
     conv[1] = MINUSOR(xx, RJDIGIT(xx, 10000));
     conv[2] = RJDIGIT(xx, 1000);

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -57,7 +57,7 @@ void safe_delay(millis_t ms);
   char* itostr3left(const int xx);
 
   // Convert signed int to rj string with _123, -123, _-12, or __-1 format
-  char *itostr4sign(const int x);
+  char* itostr4sign(const int x);
 
   // Convert unsigned float to string with 1.23 format
   char* ftostr12ns(const float &x);
@@ -87,14 +87,14 @@ void safe_delay(millis_t ms);
   char* ftostr62rj(const float &x);
 
   // Convert float to rj string with 123 or -12 format
-  FORCE_INLINE char *ftostr3(const float &x) { return itostr3((int)x); }
+  FORCE_INLINE char* ftostr3(const float &x) { return itostr3(int(FIXFLOAT(x))); }
 
   #if ENABLED(LCD_DECIMAL_SMALL_XY)
     // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
-    char *ftostr4sign(const float &fx);
+    char* ftostr4sign(const float &fx);
   #else
     // Convert float to rj string with 1234, _123, -123, __12, _-12, ___1, or __-1 format
-    FORCE_INLINE char *ftostr4sign(const float &x) { return itostr4sign((int)x); }
+    FORCE_INLINE char* ftostr4sign(const float &x) { return itostr4sign(int(FIXFLOAT(x))); }
   #endif
 
 #endif // ULTRA_LCD

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -55,9 +55,9 @@ void GcodeSuite::G30() {
   const float measured_z = probe_pt(xpos, ypos, raise_after, 1);
 
   if (!isnan(measured_z)) {
-    SERIAL_PROTOCOLPAIR("Bed X: ", FIXFLOAT(xpos));
-    SERIAL_PROTOCOLPAIR(" Y: ", FIXFLOAT(ypos));
-    SERIAL_PROTOCOLLNPAIR(" Z: ", FIXFLOAT(measured_z));
+    SERIAL_PROTOCOLPAIR_F("Bed X: ", xpos);
+    SERIAL_PROTOCOLPAIR_F(" Y: ", ypos);
+    SERIAL_PROTOCOLLNPAIR_F(" Z: ", measured_z);
   }
 
   clean_up_after_endstop_or_probe_move();

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.h
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.h
@@ -343,7 +343,7 @@ static void lcd_implementation_status_screen() {
   if (page.page == 0) {
     strcpy(xstring, ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])));
     strcpy(ystring, ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])));
-    strcpy(zstring, ftostr52sp(FIXFLOAT(LOGICAL_Z_POSITION(current_position[Z_AXIS]))));
+    strcpy(zstring, ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])));
     #if ENABLED(FILAMENT_LCD_DISPLAY)
       strcpy(wstring, ftostr12ns(filament_width_meas));
       strcpy(mstring, itostr3(100.0 * (

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -4829,7 +4829,6 @@ void kill_screen(const char* lcd_msg) {
     } \
     typedef void _name
 
-  DEFINE_MENU_EDIT_TYPE(uint32_t, long5, ftostr5rj, 0.01);
   DEFINE_MENU_EDIT_TYPE(int16_t, int3, itostr3, 1);
   DEFINE_MENU_EDIT_TYPE(uint8_t, int8, i8tostr3, 1);
   DEFINE_MENU_EDIT_TYPE(float, float3, ftostr3, 1.0);
@@ -4839,6 +4838,7 @@ void kill_screen(const char* lcd_msg) {
   DEFINE_MENU_EDIT_TYPE(float, float51, ftostr51sign, 10.0);
   DEFINE_MENU_EDIT_TYPE(float, float52, ftostr52sign, 100.0);
   DEFINE_MENU_EDIT_TYPE(float, float62, ftostr62rj, 100.0);
+  DEFINE_MENU_EDIT_TYPE(uint32_t, long5, ftostr5rj, 0.01);
 
   /**
    *

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -676,7 +676,7 @@ static void lcd_implementation_status_screen() {
 
     lcd_moveto(LCD_WIDTH - 8, 1);
     _draw_axis_label(Z_AXIS, PSTR(MSG_Z), blink);
-    lcd_put_u8str(ftostr52sp(FIXFLOAT(LOGICAL_Z_POSITION(current_position[Z_AXIS]))));
+    lcd_put_u8str(ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])));
 
     #if HAS_LEVELING && !TEMP_SENSOR_BED
       lcd_put_wchar(planner.leveling_active || blink ? '_' : ' ');


### PR DESCRIPTION
Addressing #10420

Because floats are truncated their inherent rounding behavior can cause displayed values to be confusing. This PR applies the `FIXFLOAT` macro to all the fast string conversion functions for floats to round them before display.

Counterpart to #10565