### PR TITLE
[2.0.x] Add Viki support to RAMPS_FD_V1 (DUE)

### DIFF
--- a/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
@@ -28,8 +28,6 @@
   uint8_t u8g_com_arduino_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
   #define U8G_COM_HAL_SW_SPI_FN  u8g_com_arduino_sw_spi_fn
 
-
-
   #ifdef __SAM3X8E__
     uint8_t u8g_com_HAL_DUE_shared_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_HW_SPI_FN u8g_com_HAL_DUE_shared_hw_spi_fn

--- a/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
@@ -28,13 +28,18 @@
   uint8_t u8g_com_arduino_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
   #define U8G_COM_HAL_SW_SPI_FN  u8g_com_arduino_sw_spi_fn
 
-  uint8_t u8g_com_arduino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
-  #define U8G_COM_HAL_HW_SPI_FN u8g_com_arduino_hw_spi_fn
+
 
   #ifdef __SAM3X8E__
+    uint8_t u8g_com_HAL_DUE_shared_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+    #define U8G_COM_HAL_HW_SPI_FN u8g_com_HAL_DUE_shared_hw_spi_fn
+
     uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_HAL_DUE_ST7920_sw_spi_fn
   #else
+    uint8_t u8g_com_arduino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+    #define U8G_COM_HAL_HW_SPI_FN u8g_com_arduino_hw_spi_fn
+
     uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_arduino_st7920_spi_fn
   #endif

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -161,6 +161,19 @@
     #define DOGLCD_CS      25
     #define DOGLCD_A0      27
   #endif
+
+  #if ENABLED(VIKI2) || ENABLED(miniVIKI)
+    #define DOGLCD_A0           16
+    #define KILL_PIN            51
+    #define STAT_LED_BLUE_PIN   29
+    #define STAT_LED_RED_PIN    23
+    #define DOGLCD_CS           17
+    #define DOGLCD_SCK          76 //SCK_PIN   - required so that the DUE hardware SPI will be used
+    #define DOGLCD_MOSI         75 //MOSI_PIN  - required so that the DUE hardware SPI will be used
+    #define DOGLCD_MISO         74 //MISO_PIN
+  #endif
+
+
 #endif // ULTRA_LCD
 
 #if ENABLED(HAVE_TMC2208)


### PR DESCRIPTION
Just adding support for VIKI displays to the RAMPS_FD_V1 shield for DUE.

I was surprised when my initial attempt resulted in a boot loop.  Turned out it was trying to use the Arduino hardware SPI which was hanging.  The solution was to use DUE's shared hardware SPI.  This required a change to the **HAL_LCD_com_defines.h** file and setting pin defines so that **ultralcd_impl_DOGM.h** knew this was a shared SPI LCD.

