### PR TITLE
Fix bed size and max z pos for Ender-2

### DIFF
--- a/Marlin/example_configurations/Creality/Ender-2/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration.h
@@ -818,8 +818,8 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 320
-#define Y_BED_SIZE 320
+#define X_BED_SIZE 150
+#define Y_BED_SIZE 150
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
@@ -827,7 +827,7 @@
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 420
+#define Z_MAX_POS 200
 
 /**
  * Software Endstops


### PR DESCRIPTION
### Description

The Bed Size and max Z-Position in the Ender-2 default configuration is wrong

### Benefits

Correct the bed size and z max position to the actual Ender-2 values