### PR TITLE
[1.1.x] Improve sync of planner / stepper position, asynchronous G92

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -204,8 +204,6 @@
       destination[E_AXIS] = current_position[E_AXIS];
 
       G26_line_to_destination(feed_value);
-
-      stepper.synchronize();
       set_destination_from_current();
     }
 
@@ -220,8 +218,6 @@
     destination[E_AXIS] += e_delta;
 
     G26_line_to_destination(feed_value);
-
-    stepper.synchronize();
     set_destination_from_current();
   }
 
@@ -267,13 +263,12 @@
             if (Total_Prime >= EXTRUDE_MAXLENGTH) return G26_ERR;
           #endif
           G26_line_to_destination(planner.max_feedrate_mm_s[E_AXIS] / 15.0);
-
+          set_destination_from_current();
           stepper.synchronize();    // Without this synchronize, the purge is more consistent,
                                     // but because the planner has a buffer, we won't be able
                                     // to stop as quickly. So we put up with the less smooth
                                     // action to give the user a more responsive 'Stop'.
-          set_destination_from_current();
-          idle();
+
           SERIAL_FLUSH(); // Prevent host M105 buffer overrun.
         }
 
@@ -295,7 +290,6 @@
       set_destination_from_current();
       destination[E_AXIS] += g26_prime_length;
       G26_line_to_destination(planner.max_feedrate_mm_s[E_AXIS] / 15.0);
-      stepper.synchronize();
       set_destination_from_current();
       retract_filament(destination);
     }
@@ -703,7 +697,6 @@
 
     if (current_position[Z_AXIS] < Z_CLEARANCE_BETWEEN_PROBES) {
       do_blocking_move_to_z(Z_CLEARANCE_BETWEEN_PROBES);
-      stepper.synchronize();
       set_current_from_destination();
     }
 
@@ -738,7 +731,7 @@
       lcd_external_control = true;
     #endif
 
-//  debug_current_and_destination(PSTR("Starting G26 Mesh Validation Pattern."));
+    //debug_current_and_destination(PSTR("Starting G26 Mesh Validation Pattern."));
 
     /**
      * Pre-generate radius offset values at 30 degree intervals to reduce CPU load.

--- a/Marlin/I2CPositionEncoder.cpp
+++ b/Marlin/I2CPositionEncoder.cpp
@@ -358,7 +358,7 @@
 
     stepper.synchronize();
 
-    planner.buffer_line(startCoord[X_AXIS],startCoord[Y_AXIS],startCoord[Z_AXIS],
+    planner.buffer_line(startCoord[X_AXIS], startCoord[Y_AXIS], startCoord[Z_AXIS],
                         stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
     stepper.synchronize();
 
@@ -415,10 +415,10 @@
     startCoord[encoderAxis] = startDistance;
     endCoord[encoderAxis] = endDistance;
 
-    LOOP_L_N(i, iter) {
-      stepper.synchronize();
+    stepper.synchronize();
 
-      planner.buffer_line(startCoord[X_AXIS],startCoord[Y_AXIS],startCoord[Z_AXIS],
+    LOOP_L_N(i, iter) {
+      planner.buffer_line(startCoord[X_AXIS], startCoord[Y_AXIS], startCoord[Z_AXIS],
                           stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
       stepper.synchronize();
 
@@ -427,7 +427,7 @@
 
       //do_blocking_move_to(endCoord[X_AXIS],endCoord[Y_AXIS],endCoord[Z_AXIS]);
 
-      planner.buffer_line(endCoord[X_AXIS],endCoord[Y_AXIS],endCoord[Z_AXIS],
+      planner.buffer_line(endCoord[X_AXIS], endCoord[Y_AXIS], endCoord[Z_AXIS],
                           stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
       stepper.synchronize();
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2984,7 +2984,7 @@ static void do_homing_move(const AxisEnum axis, const float distance, const floa
     planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], current_position[E_AXIS], fr_mm_s ? fr_mm_s : homing_feedrate(axis), active_extruder);
   #else
     sync_plan_position();
-    current_position[axis] = distance;
+    current_position[axis] = distance; // Set delta/cartesian axes directly
     planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], fr_mm_s ? fr_mm_s : homing_feedrate(axis), active_extruder);
   #endif
 
@@ -5337,8 +5337,8 @@ void home_all_axes() { gcode_G28(true); }
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
         #endif
-        enqueue_and_echo_commands_P(PSTR(Z_PROBE_END_SCRIPT));
         stepper.synchronize();
+        enqueue_and_echo_commands_P(PSTR(Z_PROBE_END_SCRIPT));
       #endif
 
       // Auto Bed Leveling is complete! Enable if possible.
@@ -6134,9 +6134,8 @@ void home_all_axes() { gcode_G28(true); }
       }
     #endif
 
-    stepper.synchronize();  // wait until the machine is idle
-
     // Move until destination reached or target hit
+    stepper.synchronize();
     endstops.enable(true);
     G38_move = true;
     G38_endstop_hit = false;
@@ -6158,13 +6157,13 @@ void home_all_axes() { gcode_G28(true); }
         LOOP_XYZ(i) destination[i] += retract_mm[i];
         endstops.enable(false);
         prepare_move_to_destination();
-        stepper.synchronize();
 
         feedrate_mm_s /= 4;
 
         // Bump the target more slowly
         LOOP_XYZ(i) destination[i] -= retract_mm[i] * 2;
 
+        stepper.synchronize();
         endstops.enable(true);
         G38_move = true;
         prepare_move_to_destination();
@@ -6346,6 +6345,8 @@ inline void gcode_G92() {
 
     const bool has_message = !hasP && !hasS && args && *args;
 
+    stepper.synchronize();
+
     #if ENABLED(ULTIPANEL)
 
       if (has_message)
@@ -6368,8 +6369,6 @@ inline void gcode_G92() {
 
     KEEPALIVE_STATE(PAUSED_FOR_USER);
     wait_for_user = true;
-
-    stepper.synchronize();
 
     if (ms > 0) {
       ms += millis();  // wait until this time for a click
@@ -6521,8 +6520,8 @@ inline void gcode_M17() {
     set_destination_from_current();
     destination[E_AXIS] += length / planner.e_factor[active_extruder];
     planner.buffer_line_kinematic(destination, fr, active_extruder);
-    stepper.synchronize();
     set_current_from_destination();
+    stepper.synchronize();
   }
 
   static float resume_position[XYZE];
@@ -6810,11 +6809,11 @@ inline void gcode_M17() {
     #endif
     print_job_timer.pause();
 
-    // Wait for synchronize steppers
-    stepper.synchronize();
-
     // Save current position
     COPY(resume_position, current_position);
+
+    // Wait for synchronize steppers
+    stepper.synchronize();
 
     // Initial retract before move to filament change position
     if (retract && thermalManager.hotEnoughToExtrude(active_extruder))
@@ -8505,7 +8504,6 @@ inline void gcode_M81() {
   safe_delay(1000); // Wait 1 second before switching off
 
   #if HAS_SUICIDE
-    stepper.synchronize();
     suicide();
   #elif HAS_POWER_SWITCH
     PSU_OFF();
@@ -8641,8 +8639,6 @@ void report_current_position() {
 
   void report_current_position_detail() {
 
-    stepper.synchronize();
-
     SERIAL_PROTOCOLPGM("\nLogical:");
     const float logical[XYZ] = {
       LOGICAL_X_POSITION(current_position[X_AXIS]),
@@ -8676,6 +8672,8 @@ void report_current_position() {
       inverse_kinematics(leveled);  // writes delta[]
       report_xyz(delta);
     #endif
+
+    stepper.synchronize();
 
     SERIAL_PROTOCOLPGM("Stepper:");
     LOOP_XYZE(i) {
@@ -13366,8 +13364,8 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
               current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS],
               planner.max_feedrate_mm_s[X_AXIS], 1
             );
-            SYNC_PLAN_POSITION_KINEMATIC();
             stepper.synchronize();
+            SYNC_PLAN_POSITION_KINEMATIC();
             extruder_duplication_enabled = true;
             active_extruder_parked = false;
             #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -13975,6 +13973,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
       planner.buffer_line_kinematic(current_position, MMM_TO_MMS(EXTRUDER_RUNOUT_SPEED), active_extruder);
       current_position[E_AXIS] = olde;
       planner.set_e_position_mm(olde);
+
       stepper.synchronize();
       #if ENABLED(SWITCHING_EXTRUDER)
         E0_ENABLE_WRITE(oldstatus);

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -6258,8 +6258,6 @@ void home_all_axes() { gcode_G28(true); }
  */
 inline void gcode_G92() {
 
-  stepper.synchronize();
-
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
     switch (parser.subcode) {
       case 1:
@@ -6319,10 +6317,9 @@ inline void gcode_G92() {
       COPY(coordinate_system[active_coordinate_system], position_shift);
   #endif
 
-  if (didXYZ)
-    SYNC_PLAN_POSITION_KINEMATIC();
-  else if (didE)
-    sync_plan_position_e();
+  // Update planner/steppers only if the native coordinates changed
+  if    (didXYZ) SYNC_PLAN_POSITION_KINEMATIC();
+  else if (didE) sync_plan_position_e();
 
   report_current_position();
 }

--- a/Marlin/fwretract.cpp
+++ b/Marlin/fwretract.cpp
@@ -107,7 +107,7 @@ void FWRetract::retract(const bool retracting
     // G11 priority to recover the long retract if activated
     if (!retracting) swapping = retracted_swap[active_extruder];
   #else
-    const bool swapping = false;
+    constexpr bool swapping = false;
   #endif
 
   /* // debugging
@@ -127,54 +127,47 @@ void FWRetract::retract(const bool retracting
     SERIAL_ECHOLNPAIR("hop_amount ", hop_amount);
   //*/
 
-  const float old_feedrate_mm_s = feedrate_mm_s;
+  const float old_feedrate_mm_s = feedrate_mm_s,
+              renormalize = RECIPROCAL(planner.e_factor[active_extruder]),
+              base_retract = swapping ? swap_retract_length : retract_length,
+              old_z = current_position[Z_AXIS],
+              old_e = current_position[E_AXIS];
 
   // The current position will be the destination for E and Z moves
   set_destination_from_current();
-  stepper.synchronize();  // Wait for buffered moves to complete
-
-  const float renormalize = 1.0 / planner.e_factor[active_extruder];
 
   if (retracting) {
     // Retract by moving from a faux E position back to the current E position
     feedrate_mm_s = retract_feedrate_mm_s;
-    current_position[E_AXIS] += (swapping ? swap_retract_length : retract_length) * renormalize;
-    sync_plan_position_e();
-    prepare_move_to_destination();  // set_current_to_destination
+    destination[E_AXIS] -= base_retract * renormalize;
+    prepare_move_to_destination();                        // set_current_to_destination
 
     // Is a Z hop set, and has the hop not yet been done?
-    // No double zlifting
-    // Feedrate to the max
     if (retract_zlift > 0.01 && !hop_amount) {            // Apply hop only once
-      const float old_z = current_position[Z_AXIS];
       hop_amount += retract_zlift;                        // Add to the hop total (again, only once)
       destination[Z_AXIS] += retract_zlift;               // Raise Z by the zlift (M207 Z) amount
       feedrate_mm_s = planner.max_feedrate_mm_s[Z_AXIS];  // Maximum Z feedrate
       prepare_move_to_destination();                      // Raise up, set_current_to_destination
-      current_position[Z_AXIS] = old_z;                   // Spoof the Z position in the planner
-      SYNC_PLAN_POSITION_KINEMATIC();
     }
   }
   else {
     // If a hop was done and Z hasn't changed, undo the Z hop
     if (hop_amount) {
-      current_position[Z_AXIS] += hop_amount;             // Set actual Z (due to the prior hop)
-      SYNC_PLAN_POSITION_KINEMATIC();                     // Spoof the Z position in the planner
+      destination[Z_AXIS] -= hop_amount;                  // Move back down by the total hop amount
       feedrate_mm_s = planner.max_feedrate_mm_s[Z_AXIS];  // Z feedrate to max
       prepare_move_to_destination();                      // Lower Z, set_current_to_destination
       hop_amount = 0.0;                                   // Clear the hop amount
     }
 
-    // A retract multiplier has been added here to get faster swap recovery
+    destination[E_AXIS] += (base_retract + (swapping ? swap_retract_recover_length : retract_recover_length)) * renormalize;
     feedrate_mm_s = swapping ? swap_retract_recover_feedrate_mm_s : retract_recover_feedrate_mm_s;
-
-    current_position[E_AXIS] -= (swapping ? swap_retract_length + swap_retract_recover_length
-                                          : retract_length + retract_recover_length) * renormalize;
-    sync_plan_position_e();
     prepare_move_to_destination();                        // Recover E, set_current_to_destination
   }
 
   feedrate_mm_s = old_feedrate_mm_s;                      // Restore original feedrate
+  current_position[Z_AXIS] = old_z;                       // Restore Z and E positions
+  current_position[E_AXIS] = old_e;
+  SYNC_PLAN_POSITION_KINEMATIC();                         // As if the move never took place
 
   retracted[active_extruder] = retracting;                // Active extruder now retracted / recovered
 

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -53,14 +53,18 @@ enum BlockFlagBit : char {
   BLOCK_BIT_BUSY,
 
   // The block is segment 2+ of a longer move
-  BLOCK_BIT_CONTINUED
+  BLOCK_BIT_CONTINUED,
+
+  // Sync the stepper counts from the block
+  BLOCK_BIT_SYNC_POSITION
 };
 
 enum BlockFlag : char {
   BLOCK_FLAG_RECALCULATE          = _BV(BLOCK_BIT_RECALCULATE),
   BLOCK_FLAG_NOMINAL_LENGTH       = _BV(BLOCK_BIT_NOMINAL_LENGTH),
   BLOCK_FLAG_BUSY                 = _BV(BLOCK_BIT_BUSY),
-  BLOCK_FLAG_CONTINUED            = _BV(BLOCK_BIT_CONTINUED)
+  BLOCK_FLAG_CONTINUED            = _BV(BLOCK_BIT_CONTINUED),
+  BLOCK_FLAG_SYNC_POSITION        = _BV(BLOCK_BIT_SYNC_POSITION)
 };
 
 /**
@@ -409,6 +413,20 @@ class Planner {
 
     #endif
 
+
+    /**
+     * Planner::get_next_free_block
+     *
+     * - Get the next head index (passed by reference)
+     * - Wait for a space to open up in the planner
+     * - Return the head block
+     */
+    FORCE_INLINE static block_t* get_next_free_block(uint8_t &next_buffer_head) {
+      next_buffer_head = next_block_index(block_buffer_head);
+      while (block_buffer_tail == next_buffer_head) idle(); // while (is_full)
+      return &block_buffer[block_buffer_head];
+    }
+
     /**
      * Planner::_buffer_steps
      *
@@ -425,6 +443,12 @@ class Planner {
       #endif
       , float fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
     );
+
+    /**
+     * Planner::buffer_sync_block
+     * Add a block to the buffer that just updates the position
+     */
+    static void buffer_sync_block();
 
     /**
      * Planner::buffer_segment
@@ -505,7 +529,7 @@ class Planner {
     static void set_position_mm_kinematic(const float (&cart)[XYZE]);
     static void set_position_mm(const AxisEnum axis, const float &v);
     FORCE_INLINE static void set_z_position_mm(const float &z) { set_position_mm(Z_AXIS, z); }
-    FORCE_INLINE static void set_e_position_mm(const float &e) { set_position_mm(AxisEnum(E_AXIS), e); }
+    FORCE_INLINE static void set_e_position_mm(const float &e) { set_position_mm(E_AXIS, e); }
 
     /**
      * Sync from the stepper positions. (e.g., after an interrupted move)
@@ -515,7 +539,7 @@ class Planner {
     /**
      * Does the buffer have any blocks queued?
      */
-    static inline bool has_blocks_queued() { return (block_buffer_head != block_buffer_tail); }
+    FORCE_INLINE static bool has_blocks_queued() { return (block_buffer_head != block_buffer_tail); }
 
     /**
      * "Discard" the block and "release" the memory.

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -91,10 +91,10 @@ int16_t Stepper::cleaning_buffer_counter = 0;
   bool Stepper::locked_z_motor = false, Stepper::locked_z2_motor = false;
 #endif
 
-long Stepper::counter_X = 0,
-     Stepper::counter_Y = 0,
-     Stepper::counter_Z = 0,
-     Stepper::counter_E = 0;
+int32_t Stepper::counter_X = 0,
+        Stepper::counter_Y = 0,
+        Stepper::counter_Z = 0,
+        Stepper::counter_E = 0;
 
 volatile uint32_t Stepper::step_events_completed = 0; // The number of step events executed in the current block
 
@@ -123,13 +123,13 @@ volatile uint32_t Stepper::step_events_completed = 0; // The number of step even
 
 #endif // LIN_ADVANCE
 
-long Stepper::acceleration_time, Stepper::deceleration_time;
+int32_t Stepper::acceleration_time, Stepper::deceleration_time;
 
-volatile long Stepper::count_position[NUM_AXIS] = { 0 };
+volatile int32_t Stepper::count_position[NUM_AXIS] = { 0 };
 volatile signed char Stepper::count_direction[NUM_AXIS] = { 1, 1, 1, 1 };
 
 #if ENABLED(MIXING_EXTRUDER)
-  long Stepper::counter_m[MIXING_STEPPERS];
+  int32_t Stepper::counter_m[MIXING_STEPPERS];
 #endif
 
 uint8_t Stepper::step_loops, Stepper::step_loops_nominal;
@@ -137,7 +137,7 @@ uint8_t Stepper::step_loops, Stepper::step_loops_nominal;
 uint16_t Stepper::OCR1A_nominal,
          Stepper::acc_step_rate; // needed for deceleration start point
 
-volatile long Stepper::endstops_trigsteps[XYZ];
+volatile int32_t Stepper::endstops_trigsteps[XYZ];
 
 #if ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
   #define LOCKED_X_MOTOR  locked_x_motor
@@ -1120,7 +1120,7 @@ void Stepper::synchronize() { while (planner.has_blocks_queued() || cleaning_buf
  * This allows get_axis_position_mm to correctly
  * derive the current XYZ position later on.
  */
-void Stepper::set_position(const long &a, const long &b, const long &c, const long &e) {
+void Stepper::set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e) {
 
   synchronize(); // Bad to set stepper counts in the middle of a move
 
@@ -1153,13 +1153,13 @@ void Stepper::set_position(const long &a, const long &b, const long &c, const lo
   CRITICAL_SECTION_END;
 }
 
-void Stepper::set_position(const AxisEnum &axis, const long &v) {
+void Stepper::set_position(const AxisEnum &axis, const int32_t &v) {
   CRITICAL_SECTION_START;
   count_position[axis] = v;
   CRITICAL_SECTION_END;
 }
 
-void Stepper::set_e_position(const long &e) {
+void Stepper::set_e_position(const int32_t &e) {
   CRITICAL_SECTION_START;
   count_position[E_AXIS] = e;
   CRITICAL_SECTION_END;
@@ -1168,9 +1168,9 @@ void Stepper::set_e_position(const long &e) {
 /**
  * Get a stepper's position in steps.
  */
-long Stepper::position(const AxisEnum axis) {
+int32_t Stepper::position(const AxisEnum axis) {
   CRITICAL_SECTION_START;
-  const long count_pos = count_position[axis];
+  const int32_t count_pos = count_position[axis];
   CRITICAL_SECTION_END;
   return count_pos;
 }
@@ -1239,9 +1239,9 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
 
 void Stepper::report_positions() {
   CRITICAL_SECTION_START;
-  const long xpos = count_position[X_AXIS],
-             ypos = count_position[Y_AXIS],
-             zpos = count_position[Z_AXIS];
+  const int32_t xpos = count_position[X_AXIS],
+                ypos = count_position[Y_AXIS],
+                zpos = count_position[Z_AXIS];
   CRITICAL_SECTION_END;
 
   #if CORE_IS_XY || CORE_IS_XZ || IS_DELTA || IS_SCARA

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -119,7 +119,7 @@ class Stepper {
     #endif
 
     // Counter variables for the Bresenham line tracer
-    static long counter_X, counter_Y, counter_Z, counter_E;
+    static int32_t counter_X, counter_Y, counter_Z, counter_E;
     static volatile uint32_t step_events_completed; // The number of step events executed in the current block
 
     #if ENABLED(LIN_ADVANCE)
@@ -142,19 +142,19 @@ class Stepper {
 
     #endif // !LIN_ADVANCE
 
-    static long acceleration_time, deceleration_time;
+    static int32_t acceleration_time, deceleration_time;
     static uint8_t step_loops, step_loops_nominal;
 
     static uint16_t OCR1A_nominal,
                     acc_step_rate; // needed for deceleration start point
 
-    static volatile long endstops_trigsteps[XYZ];
-    static volatile long endstops_stepsTotal, endstops_stepsDone;
+    static volatile int32_t endstops_trigsteps[XYZ];
+    static volatile int32_t endstops_stepsTotal, endstops_stepsDone;
 
     //
     // Positions of stepper motors, in step units
     //
-    static volatile long count_position[NUM_AXIS];
+    static volatile int32_t count_position[NUM_AXIS];
 
     //
     // Current direction of stepper motors (+1 or -1)
@@ -165,7 +165,7 @@ class Stepper {
     // Mixing extruder mix counters
     //
     #if ENABLED(MIXING_EXTRUDER)
-      static long counter_m[MIXING_STEPPERS];
+      static int32_t counter_m[MIXING_STEPPERS];
       #define MIXING_STEPPERS_LOOP(VAR) \
         for (uint8_t VAR = 0; VAR < MIXING_STEPPERS; VAR++) \
           if (current_block->mix_event_count[VAR])
@@ -202,9 +202,9 @@ class Stepper {
     //
     // Set the current position in steps
     //
-    static void set_position(const long &a, const long &b, const long &c, const long &e);
-    static void set_position(const AxisEnum &a, const long &v);
-    static void set_e_position(const long &e);
+    static void set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
+    static void set_position(const AxisEnum &a, const int32_t &v);
+    static void set_e_position(const int32_t &e);
 
     //
     // Set direction bits for all steppers
@@ -214,7 +214,7 @@ class Stepper {
     //
     // Get the position of a stepper, in steps
     //
-    static long position(const AxisEnum axis);
+    static int32_t position(const AxisEnum axis);
 
     //
     // Report the positions of the steppers, in steps

--- a/Marlin/stepper.h
+++ b/Marlin/stepper.h
@@ -202,9 +202,32 @@ class Stepper {
     //
     // Set the current position in steps
     //
-    static void set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
-    static void set_position(const AxisEnum &a, const int32_t &v);
-    static void set_e_position(const int32_t &e);
+    static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
+
+    FORCE_INLINE static void _set_position(const AxisEnum a, const int32_t &v) { count_position[a] = v; }
+
+    FORCE_INLINE static void set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e) {
+      synchronize();
+      CRITICAL_SECTION_START;
+      _set_position(a, b, c, e);
+      CRITICAL_SECTION_END;
+    }
+
+    static void set_position(const AxisEnum a, const int32_t &v) {
+      synchronize();
+      CRITICAL_SECTION_START;
+      count_position[a] = v;
+      CRITICAL_SECTION_END;
+    }
+
+    FORCE_INLINE static void _set_e_position(const int32_t &e) { count_position[E_AXIS] = e; }
+
+    static void set_e_position(const int32_t &e) {
+      synchronize();
+      CRITICAL_SECTION_START;
+      count_position[E_AXIS] = e;
+      CRITICAL_SECTION_END;
+    }
 
     //
     // Set direction bits for all steppers


### PR DESCRIPTION
In relation to #10611…

**Background**: Currently if we set the planner position directly, as with `G92`, we have to call `stepper.synchronize` so the stepper positions aren't updated in the middle of stepping, which would lead to the stepper counts being out of phase. The rationale for this is that setting the stepper positions in the middle of a move breaks forward kinematics, which need to be relied upon to accurately get the high-level position from the steppers.

- **Problem 1**: It's still possible for steps to get out of sync with the planner, in spite of best intentions. The stepper method to set the position _does_ turn off the stepper interrupt, but this comes too late. It's remotely possible that the stepper ISR could start processing the next block in-between the `stepper.synchronize` at the start of `G92` and the call to `stepper.set_position_mm` at the end of `G92`.

- **Problem 2**: Many slicers insert `G92 E0` at the start of each layer, presumably to keep the G-code smaller and to avoid the E coordinate growing too large to fit in a `float` (or to maintain its precision).
  
  (_This concern is overblown. With 500 Esteps/mm, you could go through ~4.3km of filament before the stepper E value will grow too large to fit into an `int32_t`._)

  The bigger problem is that `G92 E` also invokes `stepper.synchronize`, and this has been found to produce seams in the print due to the extra pause between layers. Some slicers may even use `G92 E` after every meter of filament, giving even more strange pauses. To make all axes recoverable, including E, the synchronize is necessary even for `G92 E`. The most simple solution is to be loose about E and only synchronize for XYZ, but there may be good reason that the synchronize was added for E.

If `G92` didn't require a call to `stepper.synchronize` then both problems would be solved. 

**Solution**: Instead of requiring the `stepper.count_position` to be set at the same time as `planner.position`, it makes more sense to let the stepper ISR do this at the best moment. This PR accomplishes this by adding a block flag that instructs the ISR to copy the block `steps` values directly to the `step_count` then throw away the block. This allows `G92` to work without needing to call `stepper.synchronize`.

---
Also:
- Audit code that calls `stepper.synchronize` and, where possible, either move the call to a later point to use up some cycles in code that needs to run anyway, or remove the call if it is superfluous.
- Fix `fwretract.retract` (finally?) by taking advantage of this updated method to set the planner position.

---
Counterpart to #10614