### PR TITLE
Change SDSS for the Printrboard to the correct pin

### DIFF
--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -74,11 +74,7 @@
 // Limit Switches
 //
 #define X_STOP_PIN         47   // E3
-#if ENABLED(SDSUPPORT)
-  #define Y_STOP_PIN       37   // E5 - Move Ystop to Estop socket
-#else
-  #define Y_STOP_PIN       20   // B0 SS - Ystop in Ystop socket
-#endif
+#define Y_STOP_PIN         20   // B0 SS
 #define Z_STOP_PIN         36   // E4
 
 //
@@ -120,7 +116,7 @@
 //
 // Misc. Functions
 //
-#define SDSS               20   // B0 SS
+#define SDSS               26   // B6
 #define FILWIDTH_PIN        2   // Analog Input
 
 //


### PR DESCRIPTION
This also eliminates the need to remap the y-endstop to the e-endstop pin if using the SD card. See the Printrboard schematic: The SDCS pin is clearly marked on the block diagram as pin B6, not B0/SS

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The Printrboard uses the B0/SS pin (Arduino pin 20) as the y-endstop pin. In addition, according to the block diagram, the Printrboard actually has a SDCS pin on B6 (Arduino pin 26). When the original SDSS define in the header file was added, it was mistakenly added as the B0/SS pin number (Arduino pin 20), leading to a conflict between the y-endstop and the SDSS pin. This change fixes that conflict and assigns the SDSS define to the correct pin (26).

### Benefits

Consistent y-endstop pin. No need to move the y-endstop connector to the e-endstop header if using an SD card. In addition, the SD card controller's SDCS pin will be pulled low when selected instead of being left floating. It seemed to work fine anyway, i.e., interpret a floating input as low, but that's generally a bad idea.

### Related Issues

None.
