### PR TITLE
Remove hidden dependency on destination from plan_arc() and plan_cubic_move()

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -13693,9 +13693,6 @@ void prepare_move_to_destination() {
       planner.buffer_line_kinematic(cart, fr_mm_s, active_extruder);
     #endif
 
-    // As far as the parser is concerned, the position is now == target. In reality the
-    // motion control system might still be processing the action and the real tool position
-    // in any intermediate location.
     COPY(current_position, cart);
   } // plan_arc
 
@@ -13705,10 +13702,6 @@ void prepare_move_to_destination() {
 
   void plan_cubic_move(const float (&cart)[XYZE], const float (&offset)[4]) {
     cubic_b_spline(current_position, cart, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
-
-    // As far as the parser is concerned, the position is now == destination. In reality the
-    // motion control system might still be processing the action and the real tool position
-    // in any intermediate location.
     COPY(current_position, cart);
   }
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -751,7 +751,7 @@ void set_current_from_steppers_for_axis(const AxisEnum axis);
 #endif
 
 #if ENABLED(BEZIER_CURVE_SUPPORT)
-  void plan_cubic_move(const float (&offset)[4]);
+  void plan_cubic_move(const float (&cart)[XYZE], const float (&offset)[4]);
 #endif
 
 void tool_change(const uint8_t tmp_extruder, const float fr_mm_s=0.0, bool no_move=false);
@@ -3520,7 +3520,7 @@ inline void gcode_G4() {
         parser.linearval('Q')
       };
 
-      plan_cubic_move(offset);
+      plan_cubic_move(destination, offset);
     }
   }
 
@@ -13696,20 +13696,20 @@ void prepare_move_to_destination() {
     // As far as the parser is concerned, the position is now == target. In reality the
     // motion control system might still be processing the action and the real tool position
     // in any intermediate location.
-    set_current_from_destination();
+    COPY(current_position, cart);
   } // plan_arc
 
 #endif // ARC_SUPPORT
 
 #if ENABLED(BEZIER_CURVE_SUPPORT)
 
-  void plan_cubic_move(const float (&offset)[4]) {
-    cubic_b_spline(current_position, destination, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
+  void plan_cubic_move(const float (&cart)[XYZE], const float (&offset)[4]) {
+    cubic_b_spline(current_position, cart, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
 
     // As far as the parser is concerned, the position is now == destination. In reality the
     // motion control system might still be processing the action and the real tool position
     // in any intermediate location.
-    set_current_from_destination();
+    COPY(current_position, cart);
   }
 
 #endif // BEZIER_CURVE_SUPPORT


### PR DESCRIPTION
### Description

Although both `plan_arc()` and `plan_cubic_move()` take explicit endpoint parameters, they end with a call to `set_current_from_destination()`. This means that unless `destination` is set to the same position as the passed-in endpoint `current_position` will be wrong when these functions return. This is not a problem in current code since the callers set `destination` and pass it in as the endpoint, but can be confusing for future development (at least, it confused me).

This change removes the hidden dependencies by explicitly setting the `current_position` to the passed-in endpoint.

### Benefits

Reduced confusion.

### Related Issues

Fixes #10686.

