### PR TITLE
Remove hidden dependency on destination from plan_arc() and plan_cubic_move()

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -226,7 +226,7 @@ void plan_arc(
   // As far as the parser is concerned, the position is now == target. In reality the
   // motion control system might still be processing the action and the real tool position
   // in any intermediate location.
-  set_current_from_destination();
+  COPY(current_position, cart);
 } // plan_arc
 
 /**

--- a/Marlin/src/gcode/motion/G5.cpp
+++ b/Marlin/src/gcode/motion/G5.cpp
@@ -27,13 +27,13 @@
 #include "../../module/motion.h"
 #include "../../module/planner_bezier.h"
 
-void plan_cubic_move(const float (&offset)[4]) {
-  cubic_b_spline(current_position, destination, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
+void plan_cubic_move(const float (&cart)[XYZE], const float (&offset)[4]) {
+  cubic_b_spline(current_position, cart, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
 
   // As far as the parser is concerned, the position is now == destination. In reality the
   // motion control system might still be processing the action and the real tool position
   // in any intermediate location.
-  set_current_from_destination();
+  COPY(current_position, cart);
 }
 
 /**
@@ -69,7 +69,7 @@ void GcodeSuite::G5() {
       parser.linearval('Q')
     };
 
-    plan_cubic_move(offset);
+    plan_cubic_move(destination, offset);
   }
 }
 


### PR DESCRIPTION
### Description

Although both `plan_arc()` and `plan_cubic_move()` take explicit endpoint parameters, they end with a call to `set_current_from_destination()`. This means that unless `destination` is set to the same position as the passed-in endpoint `current_position` will be wrong when these functions return. This is not a problem in current code since the callers set `destination` and pass it in as the endpoint, but can be confusing for future development (at least, it confused me).

This change removes the hidden dependencies by explicitly setting the `current_position` to the passed-in endpoint. See also PR #10690 for bugfix-1.1.x

### Benefits

Reduced confusion.

### Related Issues

Fixes #10686.