### PR TITLE
[2.0.x] Use M_PI instead of PI

### DIFF
--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -773,7 +773,7 @@ void GcodeSuite::G26() {
 
       #if ENABLED(ARC_SUPPORT)
 
-        #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * PI * (quarters) / 2)
+        #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * 3.141592654 * (quarters) / 2)
         float sx = circle_x + INTERSECTION_CIRCLE_RADIUS,   // default to full circle
               ex = circle_x + INTERSECTION_CIRCLE_RADIUS,
               sy = circle_y, ey = circle_y,

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -773,7 +773,7 @@ void GcodeSuite::G26() {
 
       #if ENABLED(ARC_SUPPORT)
 
-        #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * 3.141592654 * (quarters) / 2)
+        #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * M_PI * (quarters) / 2)
         float sx = circle_x + INTERSECTION_CIRCLE_RADIUS,   // default to full circle
               ex = circle_x + INTERSECTION_CIRCLE_RADIUS,
               sy = circle_y, ey = circle_y,


### PR DESCRIPTION
### Description
Remove dependency on PI preprocessor symbol.
### Benefits
Fixes compilation error.
### Related Issues
#10698