### PR TITLE
[1.1.x] Use M_PI instead of PI

### DIFF
--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -773,7 +773,7 @@
 
         #if ENABLED(ARC_SUPPORT)
 
-          #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * 3.141592654 * (quarters) / 2)
+          #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * M_PI * (quarters) / 2)
           float sx = circle_x + INTERSECTION_CIRCLE_RADIUS,   // default to full circle
                 ex = circle_x + INTERSECTION_CIRCLE_RADIUS,
                 sy = circle_y, ey = circle_y,

--- a/Marlin/G26_Mesh_Validation_Tool.cpp
+++ b/Marlin/G26_Mesh_Validation_Tool.cpp
@@ -773,7 +773,7 @@
 
         #if ENABLED(ARC_SUPPORT)
 
-          #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * PI * (quarters) / 2)
+          #define ARC_LENGTH(quarters)  (INTERSECTION_CIRCLE_RADIUS * 3.141592654 * (quarters) / 2)
           float sx = circle_x + INTERSECTION_CIRCLE_RADIUS,   // default to full circle
                 ex = circle_x + INTERSECTION_CIRCLE_RADIUS,
                 sy = circle_y, ey = circle_y,


### PR DESCRIPTION
### Description
Remove dependency on PI preprocessor symbol.
### Benefits
Fixes possible compilation error. Counterpart of #10701.
### Related Issues
#10698