### PR TITLE
[2.0.x] some eeprom cleanup

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1516,9 +1516,9 @@ void MarlinSettings::postprocess() {
       }
 
       #if ENABLED(AUTO_BED_LEVELING_UBL)
-        ubl.report_state();
-
         if (!validating) {
+          ubl.report_state();
+
           if (!ubl.sanity_check()) {
             SERIAL_EOL_P(port);
             #if ENABLED(EEPROM_CHITCHAT)
@@ -1569,9 +1569,7 @@ void MarlinSettings::postprocess() {
   }
 
   bool MarlinSettings::load(PORTARG_SOLO) {
-    if (validate(PORTVAR_SOLO)) return _load(PORTVAR_SOLO);
-    reset();
-    return true;
+    return !validate(PORTVAR_SOLO) ||_load(PORTVAR_SOLO);
   }
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -45,15 +45,17 @@ class MarlinSettings {
     static bool save(PORTINIT_SOLO);    // Return 'true' if data was saved
 
     FORCE_INLINE static bool init_eeprom() {
-      bool success = true;
       reset();
       #if ENABLED(EEPROM_SETTINGS)
-        success = save();
+        bool success = save();
         #if ENABLED(EEPROM_CHITCHAT)
           if (success) report();
         #endif
+
+        return success;
+      #else
+        return true;
       #endif
-      return success;
     }
 
     #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
My purpose was to solve point 1 but while I was looking at code I though to 'fix' also other points

1) removed double "Unified bed level system" message
2) MarlinSettings::load: 'reset'  call is not needed because is already called inside load when errors are detected
3) init_eeprom: removed not needed bool variable when no EEPROM_SETTINGS defined
