### PR TITLE
[2.0.x] EEprom code cleanup

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -954,7 +954,6 @@ void MarlinSettings::postprocess() {
         SERIAL_ECHOPAIR_P(port, "(EEPROM=", stored_ver);
         SERIAL_ECHOLNPGM_P(port, " Marlin=" EEPROM_VERSION ")");
       #endif
-      if (!validating) reset();
       eeprom_error = true;
     }
     else {
@@ -1511,15 +1510,13 @@ void MarlinSettings::postprocess() {
         #endif
       }
 
-      if (!validating) {
-        if (eeprom_error) reset(); else postprocess();
-      }
+      if (!validating && !eeprom_error) postprocess();
 
       #if ENABLED(AUTO_BED_LEVELING_UBL)
-        ubl.report_state();
-
         if (!validating) {
-          if (!ubl.sanity_check()) {
+            ubl.report_state();
+
+            if (!ubl.sanity_check()) {
             SERIAL_EOL_P(port);
             #if ENABLED(EEPROM_CHITCHAT)
               ubl.echo_name();

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -45,15 +45,17 @@ class MarlinSettings {
     static bool save(PORTINIT_SOLO);    // Return 'true' if data was saved
 
     FORCE_INLINE static bool init_eeprom() {
-      bool success = true;
       reset();
       #if ENABLED(EEPROM_SETTINGS)
-        success = save();
+        bool success = save();
         #if ENABLED(EEPROM_CHITCHAT)
           if (success) report();
         #endif
+
+        return success;
+      #else
+        return true;
       #endif
-      return success;
     }
 
     #if ENABLED(EEPROM_SETTINGS)

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -47,11 +47,10 @@ class MarlinSettings {
     FORCE_INLINE static bool init_eeprom() {
       reset();
       #if ENABLED(EEPROM_SETTINGS)
-        bool success = save();
+        const bool success = save();
         #if ENABLED(EEPROM_CHITCHAT)
           if (success) report();
         #endif
-
         return success;
       #else
         return true;


### PR DESCRIPTION
My purpose was to remove double "bed level system" message and looking into code I thought to "fix" also something other

1) init_eeprom: removed unnecessary bool when "EEPROM_SETTINGS" is not defined;
2) MarlinSettings::_load: removed 'reset' call since it is already called inside 'MarlinSettings::load' when something goes wrong