### PR TITLE
[2.0.x] Move Stepper::synchronize to Planner

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -274,7 +274,7 @@ bool pin_is_protected(const pin_t pin) {
 
 void quickstop_stepper() {
   stepper.quick_stop();
-  stepper.synchronize();
+  planner.synchronize();
   set_current_from_steppers_for_axis(ALL_AXES);
   SYNC_PLAN_POSITION_KINEMATIC();
 }
@@ -461,7 +461,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
       planner.buffer_line_kinematic(current_position, MMM_TO_MMS(EXTRUDER_RUNOUT_SPEED), active_extruder);
       current_position[E_AXIS] = olde;
       planner.set_e_position_mm(olde);
-      stepper.synchronize();
+      planner.synchronize();
       #if ENABLED(SWITCHING_EXTRUDER)
         E0_ENABLE_WRITE(oldstatus);
       #else

--- a/Marlin/src/feature/I2CPositionEncoder.cpp
+++ b/Marlin/src/feature/I2CPositionEncoder.cpp
@@ -356,11 +356,11 @@ bool I2CPositionEncoder::test_axis() {
   startCoord[encoderAxis] = startPosition;
   endCoord[encoderAxis] = endPosition;
 
-  stepper.synchronize();
+  planner.synchronize();
 
   planner.buffer_line(startCoord[X_AXIS], startCoord[Y_AXIS], startCoord[Z_AXIS],
                       stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
-  stepper.synchronize();
+  planner.synchronize();
 
   // if the module isn't currently trusted, wait until it is (or until it should be if things are working)
   if (!trusted) {
@@ -372,7 +372,7 @@ bool I2CPositionEncoder::test_axis() {
   if (trusted) { // if trusted, commence test
     planner.buffer_line(endCoord[X_AXIS], endCoord[Y_AXIS], endCoord[Z_AXIS],
                         stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
-    stepper.synchronize();
+    planner.synchronize();
   }
 
   return trusted;
@@ -415,12 +415,12 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
   startCoord[encoderAxis] = startDistance;
   endCoord[encoderAxis] = endDistance;
 
-  stepper.synchronize();
+  planner.synchronize();
 
   LOOP_L_N(i, iter) {
     planner.buffer_line(startCoord[X_AXIS], startCoord[Y_AXIS], startCoord[Z_AXIS],
                         stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
-    stepper.synchronize();
+    planner.synchronize();
 
     delay(250);
     startCount = get_position();
@@ -429,7 +429,7 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
     planner.buffer_line(endCoord[X_AXIS], endCoord[Y_AXIS], endCoord[Z_AXIS],
                         stepper.get_axis_position_mm(E_AXIS), feedrate, 0);
-    stepper.synchronize();
+    planner.synchronize();
 
     //Read encoder distance
     delay(250);

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -797,7 +797,7 @@
 
       do_blocking_move_to(0.5 * (MESH_MAX_X - (MESH_MIN_X)), 0.5 * (MESH_MAX_Y - (MESH_MIN_Y)), in_height);
         //, min(planner.max_feedrate_mm_s[X_AXIS], planner.max_feedrate_mm_s[Y_AXIS]) / 2.0);
-      stepper.synchronize();
+      planner.synchronize();
 
       SERIAL_PROTOCOLPGM("Place shim under nozzle");
       LCD_MESSAGEPGM(MSG_UBL_BC_INSERT);
@@ -806,7 +806,7 @@
 
       const float z1 = measure_point_with_encoder();
       do_blocking_move_to_z(current_position[Z_AXIS] + SIZE_OF_LITTLE_RAISE);
-      stepper.synchronize();
+      planner.synchronize();
 
       SERIAL_PROTOCOLPGM("Remove shim");
       LCD_MESSAGEPGM(MSG_UBL_BC_REMOVE);

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -122,7 +122,7 @@ static void do_pause_e_move(const float &length, const float &fr) {
   destination[E_AXIS] += length / planner.e_factor[active_extruder];
   planner.buffer_line_kinematic(destination, fr, active_extruder);
   set_current_from_destination();
-  stepper.synchronize();
+  planner.synchronize();
 }
 
 /**
@@ -370,7 +370,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
   COPY(resume_position, current_position);
 
   // Wait for buffered blocks to complete
-  stepper.synchronize();
+  planner.synchronize();
 
   // Initial retract before move to filament change position
   if (retract && thermalManager.hotEnoughToExtrude(active_extruder))

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -48,7 +48,7 @@ class FilamentRunoutSensor {
       if ((IS_SD_PRINTING || print_job_timer.isRunning()) && check() && !filament_ran_out) {
         filament_ran_out = true;
         enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
-        stepper.synchronize();
+        planner.synchronize();
       }
     }
   private:

--- a/Marlin/src/feature/snmm.cpp
+++ b/Marlin/src/feature/snmm.cpp
@@ -27,7 +27,7 @@
 #include "../module/stepper.h"
 
 void select_multiplexed_stepper(const uint8_t e) {
-  stepper.synchronize();
+  planner.synchronize();
   disable_e_steppers();
   WRITE(E_MUX0_PIN, TEST(e, 0) ? HIGH : LOW);
   WRITE(E_MUX1_PIN, TEST(e, 1) ? HIGH : LOW);

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -500,7 +500,7 @@ inline bool prime_nozzle() {
         #endif
         G26_line_to_destination(planner.max_feedrate_mm_s[E_AXIS] / 15.0);
         set_destination_from_current();
-        stepper.synchronize();    // Without this synchronize, the purge is more consistent,
+        planner.synchronize();    // Without this synchronize, the purge is more consistent,
                                   // but because the planner has a buffer, we won't be able
                                   // to stop as quickly. So we put up with the less smooth
                                   // action to give the user a more responsive 'Stop'.

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -391,7 +391,7 @@ void GcodeSuite::G29() {
       SERIAL_EOL();
     }
 
-    stepper.synchronize();
+    planner.synchronize();
 
     // Disable auto bed leveling during G29.
     // Be formal so G29 can be done successively without G28.
@@ -949,7 +949,7 @@ void GcodeSuite::G29() {
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
       #endif
-      stepper.synchronize();
+      planner.synchronize();
       enqueue_and_echo_commands_P(PSTR(Z_PROBE_END_SCRIPT));
     #endif
 

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -132,7 +132,7 @@ void GcodeSuite::G29() {
         // One last "return to the bed" (as originally coded) at completion
         current_position[Z_AXIS] = MANUAL_PROBE_HEIGHT;
         line_to_current_position();
-        stepper.synchronize();
+        planner.synchronize();
 
         // After recording the last point, activate home and activate
         mbl_probe_index = -1;
@@ -147,7 +147,7 @@ void GcodeSuite::G29() {
           current_position[Z_AXIS] = 0;
           set_destination_from_current();
           buffer_line_to_destination(homing_feedrate(Z_AXIS));
-          stepper.synchronize();
+          planner.synchronize();
         #endif
 
         #if ENABLED(LCD_BED_LEVELING)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -171,7 +171,7 @@ void GcodeSuite::G28(const bool always_home_all) {
   #endif
 
   // Wait for planner moves to finish!
-  stepper.synchronize();
+  planner.synchronize();
 
   // Cancel the active G29 session
   #if ENABLED(PROBE_MANUALLY)

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -85,7 +85,7 @@ void ac_setup(const bool reset_bed) {
     tool_change(0, 0, true);
   #endif
 
-  stepper.synchronize();
+  planner.synchronize();
   setup_for_endstop_or_probe_move();
 
   #if HAS_LEVELING

--- a/Marlin/src/gcode/control/M17_M18_M84.cpp
+++ b/Marlin/src/gcode/control/M17_M18_M84.cpp
@@ -50,7 +50,7 @@ void GcodeSuite::M18_M84() {
       stepper.finish_and_disable();
     }
     else {
-      stepper.synchronize();
+      planner.synchronize();
       if (parser.seen('X')) disable_X();
       if (parser.seen('Y')) disable_Y();
       if (parser.seen('Z')) disable_Z();

--- a/Marlin/src/gcode/control/M226.cpp
+++ b/Marlin/src/gcode/control/M226.cpp
@@ -37,7 +37,7 @@ void GcodeSuite::M226() {
 
       int target = LOW;
 
-      stepper.synchronize();
+      planner.synchronize();
 
       pinMode(pin, INPUT);
       switch (pin_state) {

--- a/Marlin/src/gcode/control/M3-M5.cpp
+++ b/Marlin/src/gcode/control/M3-M5.cpp
@@ -79,7 +79,7 @@ inline void ocr_val_mode() {
 
 void GcodeSuite::M3_M4(bool is_M3) {
 
-  stepper.synchronize();   // wait until previous movement commands (G0/G0/G2/G3) have completed before playing with the spindle
+  planner.synchronize();   // wait until previous movement commands (G0/G0/G2/G3) have completed before playing with the spindle
   #if SPINDLE_DIR_CHANGE
     const bool rotation_dir = (is_M3 != SPINDLE_INVERT_DIR);
     if (SPINDLE_STOP_ON_DIR_CHANGE \
@@ -129,7 +129,7 @@ void GcodeSuite::M3_M4(bool is_M3) {
  * M5 turn off spindle
  */
 void GcodeSuite::M5() {
-  stepper.synchronize();
+  planner.synchronize();
   WRITE(SPINDLE_LASER_ENABLE_PIN, !SPINDLE_LASER_ENABLE_INVERT);
   #if ENABLED(SPINDLE_LASER_PWM)
     analogWrite(SPINDLE_LASER_PWM_PIN, SPINDLE_LASER_PWM_INVERT ? 255 : 0);

--- a/Marlin/src/gcode/control/M400.cpp
+++ b/Marlin/src/gcode/control/M400.cpp
@@ -28,6 +28,6 @@
  */
 void GcodeSuite::M400() {
 
-  stepper.synchronize();
+  planner.synchronize();
 
 }

--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -43,7 +43,7 @@
    *    Note: the X axis should be homed after changing dual x-carriage mode.
    */
   void GcodeSuite::M605() {
-    stepper.synchronize();
+    planner.synchronize();
     if (parser.seen('S')) dual_x_carriage_mode = (DualXMode)parser.value_byte();
     switch (dual_x_carriage_mode) {
       case DXC_FULL_CONTROL_MODE:
@@ -75,7 +75,7 @@
 #elif ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
 
   void GcodeSuite::M605() {
-    stepper.synchronize();
+    planner.synchronize();
     extruder_duplication_enabled = parser.intval('S') == (int)DXC_DUPLICATION_MODE;
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_DUPLICATION_MODE, extruder_duplication_enabled ? MSG_ON : MSG_OFF);

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -37,7 +37,7 @@ void GcodeSuite::M900() {
   if (parser.seenval('K')) {
     const float newK = parser.floatval('K');
     if (WITHIN(newK, 0, 10)) {
-      stepper.synchronize();
+      planner.synchronize();
       planner.extruder_advance_K = newK;
     }
     else

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -33,7 +33,7 @@
  */
 bool GcodeSuite::select_coordinate_system(const int8_t _new) {
   if (active_coordinate_system == _new) return false;
-  stepper.synchronize();
+  planner.synchronize();
   float old_offset[XYZ] = { 0 }, new_offset[XYZ] = { 0 };
   if (WITHIN(active_coordinate_system, 0, MAX_COORDINATE_SYSTEMS - 1))
     COPY(old_offset, coordinate_system[active_coordinate_system]);

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -77,7 +77,7 @@
       report_xyz(delta);
     #endif
 
-    stepper.synchronize();
+    planner.synchronize();
 
     SERIAL_PROTOCOLPGM("Stepper:");
     LOOP_XYZE(i) {
@@ -126,6 +126,6 @@ void GcodeSuite::M114() {
     }
   #endif
 
-  stepper.synchronize();
+  planner.synchronize();
   report_current_position();
 }

--- a/Marlin/src/gcode/lcd/M0_M1.cpp
+++ b/Marlin/src/gcode/lcd/M0_M1.cpp
@@ -58,7 +58,7 @@ void GcodeSuite::M0_M1() {
 
   const bool has_message = !hasP && !hasS && args && *args;
 
-  stepper.synchronize();
+  planner.synchronize();
 
   #if ENABLED(ULTIPANEL)
 

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -84,7 +84,7 @@ void GcodeSuite::G0_G1(
         #define _MOVE_SYNC parser.seenval('Z')  // Only for Z move
       #endif
       if (_MOVE_SYNC) {
-        stepper.synchronize();
+        planner.synchronize();
         SERIAL_ECHOLNPGM(MSG_Z_MOVE_COMP);
       }
     #endif

--- a/Marlin/src/gcode/motion/G4.cpp
+++ b/Marlin/src/gcode/motion/G4.cpp
@@ -33,7 +33,7 @@ void GcodeSuite::G4() {
   if (parser.seenval('P')) dwell_ms = parser.value_millis(); // milliseconds to wait
   if (parser.seenval('S')) dwell_ms = parser.value_millis_from_seconds(); // seconds to wait
 
-  stepper.synchronize();
+  planner.synchronize();
   #if ENABLED(NANODLP_Z_SYNC)
     SERIAL_ECHOLNPGM(MSG_Z_MOVE_COMP);
   #endif

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -44,14 +44,14 @@ static bool G38_run_probe() {
     }
   #endif
 
-  stepper.synchronize();  // wait until the machine is idle
+  planner.synchronize();  // wait until the machine is idle
 
   // Move until destination reached or target hit
   endstops.enable(true);
   G38_move = true;
   G38_endstop_hit = false;
   prepare_move_to_destination();
-  stepper.synchronize();
+  planner.synchronize();
   G38_move = false;
 
   endstops.hit_on_purpose();
@@ -68,7 +68,7 @@ static bool G38_run_probe() {
       LOOP_XYZ(i) destination[i] += retract_mm[i];
       endstops.enable(false);
       prepare_move_to_destination();
-      stepper.synchronize();
+      planner.synchronize();
 
       feedrate_mm_s /= 4;
 
@@ -78,7 +78,7 @@ static bool G38_run_probe() {
       endstops.enable(true);
       G38_move = true;
       prepare_move_to_destination();
-      stepper.synchronize();
+      planner.synchronize();
       G38_move = false;
 
       set_current_from_steppers_for_axis(ALL_AXES);

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M928.cpp
@@ -179,7 +179,7 @@ void GcodeSuite::M30() {
  *
  */
 void GcodeSuite::M32() {
-  if (card.sdprinting) stepper.synchronize();
+  if (card.sdprinting) planner.synchronize();
 
   if (card.cardOK) {
     const bool call_procedure = parser.boolval('P');

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -570,7 +570,7 @@ uint16_t max_display_update_time = 0;
     no_reentry = true;
     const screenFunc_t old_screen = currentScreen;
     lcd_goto_screen(_lcd_synchronize);
-    stepper.synchronize(); // idle() is called until moves complete
+    planner.synchronize(); // idle() is called until moves complete
     no_reentry = false;
     lcd_goto_screen(old_screen);
   }

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -32,7 +32,7 @@
 #include "motion.h"
 
 // For homing:
-#include "stepper.h"
+#include "planner.h"
 #include "endstops.h"
 #include "../lcd/ultralcd.h"
 #include "../Marlin.h"
@@ -258,7 +258,7 @@ bool home_delta() {
   current_position[X_AXIS] = current_position[Y_AXIS] = current_position[Z_AXIS] = (delta_height + 10);
   feedrate_mm_s = homing_feedrate(X_AXIS);
   line_to_current_position();
-  stepper.synchronize();
+  planner.synchronize();
 
   // Re-enable stealthChop if used. Disable diag1 pin on driver.
   #if ENABLED(SENSORLESS_HOMING)

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -402,7 +402,7 @@ void do_blocking_move_to(const float rx, const float ry, const float rz, const f
     if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< do_blocking_move_to");
   #endif
 
-  stepper.synchronize();
+  planner.synchronize();
 }
 void do_blocking_move_to_x(const float &rx, const float &fr_mm_s/*=0.0*/) {
   do_blocking_move_to(rx, current_position[Y_AXIS], current_position[Z_AXIS], fr_mm_s);
@@ -881,7 +881,7 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
               current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS],
               planner.max_feedrate_mm_s[X_AXIS], 1
             );
-            stepper.synchronize();
+            planner.synchronize();
             SYNC_PLAN_POSITION_KINEMATIC();
             extruder_duplication_enabled = true;
             active_extruder_parked = false;
@@ -1110,7 +1110,7 @@ static void do_homing_move(const AxisEnum axis, const float distance, const floa
     planner.buffer_line(current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], fr_mm_s ? fr_mm_s : homing_feedrate(axis), active_extruder);
   #endif
 
-  stepper.synchronize();
+  planner.synchronize();
 
   if (is_home_dir) {
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1300,6 +1300,11 @@ void Planner::check_axes_activity() {
 #endif // PLANNER_LEVELING
 
 /**
+ * Block until all buffered steps are executed / cleaned
+ */
+void Planner::synchronize() { while (has_blocks_queued() || stepper.cleaning_buffer_counter) idle(); }
+
+/**
  * Planner::_buffer_steps
  *
  * Add a new linear movement to the buffer (in terms of steps).

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -551,6 +551,11 @@ class Planner {
      */
     FORCE_INLINE static bool has_blocks_queued() { return (block_buffer_head != block_buffer_tail); }
 
+    //
+    // Block until all buffered steps are executed
+    //
+    static void synchronize();
+
     /**
      * "Discard" the block and "release" the memory.
      * Called when the current block is no longer needed.

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1977,12 +1977,6 @@ void Stepper::init() {
   set_directions(); // Init directions to last_direction_bits = 0
 }
 
-
-/**
- * Block until all buffered steps are executed / cleaned
- */
-void Stepper::synchronize() { while (planner.has_blocks_queued() || cleaning_buffer_counter) idle(); }
-
 /**
  * Set the stepper positions directly in steps
  *
@@ -2055,7 +2049,7 @@ float Stepper::get_axis_position_mm(const AxisEnum axis) {
 }
 
 void Stepper::finish_and_disable() {
-  synchronize();
+  planner.synchronize();
   disable_all_steppers();
 }
 

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -184,11 +184,6 @@ class Stepper {
     #endif
 
     //
-    // Block until all buffered steps are executed
-    //
-    static void synchronize();
-
-    //
     // Set the current position in steps
     //
     static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
@@ -196,14 +191,14 @@ class Stepper {
     FORCE_INLINE static void _set_position(const AxisEnum a, const int32_t &v) { count_position[a] = v; }
 
     FORCE_INLINE static void set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e) {
-      synchronize();
+      planner.synchronize();
       CRITICAL_SECTION_START;
       _set_position(a, b, c, e);
       CRITICAL_SECTION_END;
     }
 
     static void set_position(const AxisEnum a, const int32_t &v) {
-      synchronize();
+      planner.synchronize();
       CRITICAL_SECTION_START;
       count_position[a] = v;
       CRITICAL_SECTION_END;
@@ -212,7 +207,7 @@ class Stepper {
     FORCE_INLINE static void _set_e_position(const int32_t &e) { count_position[E_AXIS] = e; }
 
     static void set_e_position(const int32_t &e) {
-      synchronize();
+      planner.synchronize();
       CRITICAL_SECTION_START;
       count_position[E_AXIS] = e;
       CRITICAL_SECTION_END;

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -24,7 +24,6 @@
 
 #include "motion.h"
 #include "planner.h"
-#include "stepper.h"
 
 #include "../Marlin.h"
 
@@ -71,7 +70,7 @@
   void move_extruder_servo(const uint8_t e) {
     constexpr int16_t angles[] = SWITCHING_EXTRUDER_SERVO_ANGLES;
     static_assert(COUNT(angles) == REQ_ANGLES, "SWITCHING_EXTRUDER_SERVO_ANGLES needs " STRINGIFY(REQ_ANGLES) " angles.");
-    stepper.synchronize();
+    planner.synchronize();
     #if EXTRUDERS & 1
       if (e < EXTRUDERS - 1)
     #endif
@@ -87,7 +86,7 @@
 
   void move_nozzle_servo(const uint8_t e) {
     const int16_t angles[2] = SWITCHING_NOZZLE_SERVO_ANGLES;
-    stepper.synchronize();
+    planner.synchronize();
     MOVE_SERVO(SWITCHING_NOZZLE_SERVO_NR, angles[e]);
     safe_delay(500);
   }
@@ -144,7 +143,7 @@
         if (DEBUGGING(LEVELING)) DEBUG_POS("Moving to Raised Z-Position", current_position);
       #endif
       planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
-      stepper.synchronize();
+      planner.synchronize();
 
       // STEP 2
       current_position[X_AXIS] = parkingposx[active_extruder] + hotend_offset[X_AXIS][active_extruder];
@@ -153,7 +152,7 @@
         if (DEBUGGING(LEVELING)) DEBUG_POS("Moving ParkPos", current_position);
       #endif
       planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[X_AXIS], active_extruder);
-      stepper.synchronize();
+      planner.synchronize();
 
       // STEP 3
       #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -171,7 +170,7 @@
         if (DEBUGGING(LEVELING)) DEBUG_POS("Moving away from parked extruder", current_position);
       #endif
       planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[X_AXIS], active_extruder);
-      stepper.synchronize();
+      planner.synchronize();
 
       // STEP 5
       #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -192,7 +191,7 @@
         if (DEBUGGING(LEVELING)) DEBUG_POS("Move UnparkPos", current_position);
       #endif
       planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[X_AXIS]/2, active_extruder);
-      stepper.synchronize();
+      planner.synchronize();
 
       // Step 7
       current_position[X_AXIS] = midpos - hotend_offset[X_AXIS][tmp_extruder];
@@ -201,7 +200,7 @@
         if (DEBUGGING(LEVELING)) DEBUG_POS("Move midway to new extruder", current_position);
       #endif
       planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[X_AXIS], active_extruder);
-      stepper.synchronize();
+      planner.synchronize();
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         SERIAL_ECHOLNPGM("Autopark done.");
       #endif
@@ -283,7 +282,7 @@ inline void invalid_extruder_error(const uint8_t e) {
           planner.max_feedrate_mm_s[i == 1 ? X_AXIS : Z_AXIS],
           active_extruder
         );
-      stepper.synchronize();
+      planner.synchronize();
     }
 
     // Apply Y & Z extruder offset (X offset is used as home pos with Dual X)
@@ -466,7 +465,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         #endif
       } // (tmp_extruder != active_extruder)
 
-      stepper.synchronize();
+      planner.synchronize();
 
       #if ENABLED(EXT_SOLENOID) && !ENABLED(PARKING_EXTRUDER)
         disable_all_solenoids();
@@ -493,7 +492,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
     #endif // HOTENDS <= 1
 
     #if DO_SWITCH_EXTRUDER
-      stepper.synchronize();
+      planner.synchronize();
       move_extruder_servo(active_extruder);
     #endif
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -28,6 +28,7 @@
 
 #include "../Marlin.h"
 #include "../lcd/ultralcd.h"
+#include "../module/planner.h"
 #include "../module/stepper.h"
 #include "../module/printcounter.h"
 #include "../core/language.h"
@@ -962,7 +963,7 @@ uint16_t CardReader::get_num_Files() {
 }
 
 void CardReader::printingHasFinished() {
-  stepper.synchronize();
+  planner.synchronize();
   file.close();
   if (file_subcall_ctr > 0) { // Heading up to a parent file that called current as a procedure.
     file_subcall_ctr--;


### PR DESCRIPTION
Move the `Stepper::synchronize` method to the `Planner` class in the most basic fashion. This is done ahead of #10688 to make that PR smaller, and submitted as a PR so it gets full Travis test and review before being committed.