### PR TITLE
[2.0.x] Fix M301 access to lpq_len

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -204,10 +204,6 @@ millis_t max_inactive_time, // = 0
   bool chdkActive; // = false;
 #endif
 
-#if ENABLED(PID_EXTRUSION_SCALING)
-  int lpq_len = 20;
-#endif
-
 #if ENABLED(I2C_POSITION_ENCODERS)
   I2CPositionEncodersMgr I2CPEM;
 #endif

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -207,10 +207,6 @@ extern millis_t max_inactive_time, stepper_inactive_time;
   extern uint8_t controllerFanSpeed;
 #endif
 
-#if ENABLED(PID_EXTRUSION_SCALING)
-  extern int lpq_len;
-#endif
-
 #if HAS_POWER_SWITCH
   extern bool powersupply_on;
   #define PSU_PIN_ON()  do{ OUT_WRITE(PS_ON_PIN, PS_ON_AWAKE); powersupply_on = true; }while(0)

--- a/Marlin/src/gcode/config/M301.cpp
+++ b/Marlin/src/gcode/config/M301.cpp
@@ -37,7 +37,7 @@
  * With PID_EXTRUSION_SCALING:
  *
  *   C[float] Kc term
- *   L[float] LPQ length
+ *   L[int] LPQ length
  */
 void GcodeSuite::M301() {
 
@@ -51,8 +51,9 @@ void GcodeSuite::M301() {
     if (parser.seen('D')) PID_PARAM(Kd, e) = scalePID_d(parser.value_float());
     #if ENABLED(PID_EXTRUSION_SCALING)
       if (parser.seen('C')) PID_PARAM(Kc, e) = parser.value_float();
-      if (parser.seen('L')) lpq_len = parser.value_float();
-      NOMORE(lpq_len, LPQ_MAX_LEN);
+      if (parser.seenval('L')) thermalManager.lpq_len = parser.value_int();
+      NOMORE(thermalManager.lpq_len, LPQ_MAX_LEN);
+      NOLESS(thermalManager.lpq_len, 0);
     #endif
 
     thermalManager.updatePID();

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -88,6 +88,10 @@
   #include "../feature/pause.h"
 #endif
 
+#if ENABLED(PID_EXTRUSION_SCALING)
+  #define LPQ_LEN thermalManager.lpq_len
+#endif
+
 #pragma pack(push, 1) // No padding between variables
 
 typedef struct PID { float Kp, Ki, Kd; } PID;
@@ -198,7 +202,7 @@ typedef struct SettingsDataStruct {
   //
   PIDC hotendPID[MAX_EXTRUDERS];                        // M301 En PIDC / M303 En U
 
-  int lpq_len;                                          // M301 L
+  int16_t lpq_len;                                      // M301 L
 
   //
   // PIDTEMPBED
@@ -594,9 +598,9 @@ void MarlinSettings::postprocess() {
     _FIELD_TEST(lpq_len);
 
     #if DISABLED(PID_EXTRUSION_SCALING)
-      int lpq_len = 20;
+      const int16_t LPQ_LEN = 20;
     #endif
-    EEPROM_WRITE(lpq_len);
+    EEPROM_WRITE(LPQ_LEN);
 
     #if DISABLED(PIDTEMPBED)
       dummy = DUMMY_PID_VALUE;
@@ -1199,9 +1203,9 @@ void MarlinSettings::postprocess() {
       _FIELD_TEST(lpq_len);
 
       #if DISABLED(PID_EXTRUSION_SCALING)
-        int lpq_len;
+        int16_t LPQ_LEN;
       #endif
-      EEPROM_READ(lpq_len);
+      EEPROM_READ(LPQ_LEN);
 
       //
       // Heated Bed PID
@@ -1812,7 +1816,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       #endif
     }
     #if ENABLED(PID_EXTRUSION_SCALING)
-      lpq_len = 20; // default last-position-queue size
+      thermalManager.lpq_len = 20; // default last-position-queue size
     #endif
   #endif // PIDTEMP
 
@@ -2288,7 +2292,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
               SERIAL_ECHOPAIR_P(port, " D", unscalePID_d(PID_PARAM(Kd, e)));
               #if ENABLED(PID_EXTRUSION_SCALING)
                 SERIAL_ECHOPAIR_P(port, " C", PID_PARAM(Kc, e));
-                if (e == 0) SERIAL_ECHOPAIR_P(port, " L", lpq_len);
+                if (e == 0) SERIAL_ECHOPAIR_P(port, " L", thermalManager.lpq_len);
               #endif
               SERIAL_EOL_P(port);
             }
@@ -2303,7 +2307,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           SERIAL_ECHOPAIR_P(port, " D", unscalePID_d(PID_PARAM(Kd, 0)));
           #if ENABLED(PID_EXTRUSION_SCALING)
             SERIAL_ECHOPAIR_P(port, " C", PID_PARAM(Kc, 0));
-            SERIAL_ECHOPAIR_P(port, " L", lpq_len);
+            SERIAL_ECHOPAIR_P(port, " L", thermalManager.lpq_len);
           #endif
           SERIAL_EOL_P(port);
         }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -244,6 +244,10 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
   uint8_t Temperature::ADCKey_count = 0;
 #endif
 
+#if ENABLED(PID_EXTRUSION_SCALING)
+  int16_t Temperature::lpq_len; // Initialized in configuration_store
+#endif
+
 #if HAS_PID_HEATING
 
   /**

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -299,6 +299,10 @@ class Temperature {
       static uint8_t ADCKey_count;
     #endif
 
+    #if ENABLED(PID_EXTRUSION_SCALING)
+      static int16_t lpq_len;
+    #endif
+
     /**
      * Instance Methods
      */


### PR DESCRIPTION
Fix `M301` compile error by moving `lpq_len` to the `Temperature` class.

Originally from #10688