### PR TITLE
[2.0.x] Prevent compilation of unused u8g-oriented code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
   - opt_set TEMP_SENSOR_BED 1
   - opt_set POWER_SUPPLY 1
   - opt_enable PIDTEMPBED FIX_MOUNTED_PROBE Z_SAFE_HOMING
-  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT EEPROM_SETTINGS
+  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT EEPROM_SETTINGS PINS_DEBUGGING
   - opt_enable BLINKM PCA9632 RGB_LED NEOPIXEL_LED AUTO_POWER_CONTROL NOZZLE_PARK_FEATURE FILAMENT_RUNOUT_SENSOR
   - opt_enable AUTO_BED_LEVELING_LINEAR Z_MIN_PROBE_REPEATABILITY_TEST DEBUG_LEVELING_FEATURE SKEW_CORRECTION SKEW_CORRECTION_FOR_Z SKEW_CORRECTION_GCODE
   - opt_enable_adv ARC_P_CIRCLES ADVANCED_PAUSE_FEATURE CNC_WORKSPACE_PLANES CNC_COORDINATE_SYSTEMS POWER_LOSS_RECOVERY
@@ -83,13 +83,15 @@ script:
   - opt_set TEMP_SENSOR_3 20
   - opt_set TEMP_SENSOR_4 999
   - opt_set TEMP_SENSOR_BED 1
-  - opt_enable AUTO_BED_LEVELING_UBL RESTORE_LEVELING_AFTER_G28 DEBUG_LEVELING_FEATURE G26_MESH_EDITING ENABLE_LEVELING_FADE_HEIGHT EEPROM_SETTINGS EEPROM_CHITCHAT G3D_PANEL SKEW_CORRECTION
+  - opt_enable AUTO_BED_LEVELING_UBL RESTORE_LEVELING_AFTER_G28 DEBUG_LEVELING_FEATURE G26_MESH_EDITING ENABLE_LEVELING_FADE_HEIGHT SKEW_CORRECTION
+  - opt_enable EEPROM_SETTINGS EEPROM_CHITCHAT REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
   - opt_enable_adv CUSTOM_USER_MENUS I2C_POSITION_ENCODERS BABYSTEPPING BABYSTEP_XY LIN_ADVANCE NANODLP_Z_SYNC QUICK_HOME JUNCTION_DEVIATION
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # Add a Sled Z Probe, use UBL Cartesian moves, use Japanese language
   #
   - opt_enable Z_PROBE_SLED SKEW_CORRECTION SKEW_CORRECTION_FOR_Z SKEW_CORRECTION_GCODE
+  - opt_set LCD_LANGUAGE jp-kana
   - opt_disable SEGMENT_LEVELED_MOVES
   - opt_enable_adv BABYSTEP_ZPROBE_OFFSET DOUBLECLICK_FOR_Z_BABYSTEPPING
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
@@ -131,13 +133,13 @@ script:
   - opt_set_adv I2C_SLAVE_ADDRESS 63
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
-  # Mixing Extruder with 5 steppers
+  # Mixing Extruder with 5 steppers, Cyrillic
   #
   - restore_configs
   - opt_set MOTHERBOARD BOARD_AZTEEG_X3_PRO
   - opt_enable MIXING_EXTRUDER CR10_STOCKDISPLAY
   - opt_set MIXING_STEPPERS 5
-  - opt_set LCD_LANGUAGE jp-kana
+  - opt_set LCD_LANGUAGE ru
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # Test DUAL_X_CARRIAGE
@@ -152,11 +154,11 @@ script:
   #
   # Test SPEAKER with BOARD_BQ_ZUM_MEGA_3D and BQ_LCD_SMART_CONTROLLER
   #
-  - restore_configs
-  - opt_set MOTHERBOARD BOARD_BQ_ZUM_MEGA_3D
-  - opt_set LCD_FEEDBACK_FREQUENCY_DURATION_MS 10
-  - opt_set LCD_FEEDBACK_FREQUENCY_HZ 100
-  - opt_enable BQ_LCD_SMART_CONTROLLER SPEAKER
+  #- restore_configs
+  #- opt_set MOTHERBOARD BOARD_BQ_ZUM_MEGA_3D
+  #- opt_set LCD_FEEDBACK_FREQUENCY_DURATION_MS 10
+  #- opt_set LCD_FEEDBACK_FREQUENCY_HZ 100
+  #- opt_enable BQ_LCD_SMART_CONTROLLER SPEAKER
   #
   # Test SWITCHING_EXTRUDER
   #
@@ -171,9 +173,9 @@ script:
   #
   # Enable COREXY
   #
-  - restore_configs
-  - opt_enable COREXY
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #- restore_configs
+  #- opt_enable COREXY
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # Test many less common options
   #
@@ -187,7 +189,7 @@ script:
   - opt_enable_adv VOLUMETRIC_DEFAULT_ON NO_WORKSPACE_OFFSETS ACTION_ON_KILL
   - opt_enable_adv EXTRA_FAN_SPEED FWERETRACT Z_DUAL_STEPPER_DRIVERS Z_DUAL_ENDSTOPS
   - opt_enable_adv MENU_ADDAUTOSTART SDCARD_SORT_ALPHA
-  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER
+  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER BABYSTEPPING DAC_MOTOR_CURRENT_DEFAULT
   - opt_enable FILAMENT_LCD_DISPLAY FILAMENT_WIDTH_SENSOR
   - opt_enable ENDSTOP_INTERRUPTS_FEATURE FAN_SOFT_PWM SDSUPPORT
   - opt_enable USE_XMAX_PLUG
@@ -197,15 +199,15 @@ script:
   #
   # ULTRA_LCD
   #
-  - restore_configs
-  - opt_enable ULTRA_LCD
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #- restore_configs
+  #- opt_enable ULTRA_LCD
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # DOGLCD
   #
-  - restore_configs
-  - opt_enable DOGLCD
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #- restore_configs
+  #- opt_enable DOGLCD
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # MAKRPANEL
   # Needs to use Melzi and Sanguino hardware
@@ -216,27 +218,31 @@ script:
   #
   # REPRAP_DISCOUNT_SMART_CONTROLLER, SDSUPPORT, BABYSTEPPING, RIGIDBOARD_V2, and DAC_MOTOR_CURRENT_DEFAULT
   #
-  - restore_configs
-  - opt_set MOTHERBOARD BOARD_RIGIDBOARD_V2
-  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT BABYSTEPPING DAC_MOTOR_CURRENT_DEFAULT
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
-  #
+  #- restore_configs
+  #- opt_set MOTHERBOARD BOARD_RIGIDBOARD_V2
+  #- opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT BABYSTEPPING DAC_MOTOR_CURRENT_DEFAULT
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  # #
   # G3D_PANEL with SDCARD_SORT_ALPHA and STATUS_MESSAGE_SCROLLING
   #
-  - restore_configs
-  - opt_enable G3D_PANEL SDSUPPORT
-  - opt_enable_adv SDCARD_SORT_ALPHA STATUS_MESSAGE_SCROLLING SCROLL_LONG_FILENAMES
-  - opt_set_adv SDSORT_GCODE true
-  - opt_set_adv SDSORT_USES_RAM true
-  - opt_set_adv SDSORT_USES_STACK true
-  - opt_set_adv SDSORT_CACHE_NAMES true
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #- restore_configs
+  #- opt_enable G3D_PANEL SDSUPPORT
+  #- opt_enable_adv SDCARD_SORT_ALPHA STATUS_MESSAGE_SCROLLING SCROLL_LONG_FILENAMES
+  #- opt_set_adv SDSORT_GCODE true
+  #- opt_set_adv SDSORT_USES_RAM true
+  #- opt_set_adv SDSORT_USES_STACK true
+  #- opt_set_adv SDSORT_CACHE_NAMES true
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
-  # REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER with SDCARD_SORT_ALPHA and STATUS_MESSAGE_SCROLLING
+  # REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER with LIGHTWEIGHT_UI
   #
   - restore_configs
   - opt_enable REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER SDSUPPORT
   - opt_enable_adv SDCARD_SORT_ALPHA STATUS_MESSAGE_SCROLLING SCROLL_LONG_FILENAMES LIGHTWEIGHT_UI
+  - opt_set_adv SDSORT_GCODE true
+  - opt_set_adv SDSORT_USES_RAM true
+  - opt_set_adv SDSORT_USES_STACK true
+  - opt_set_adv SDSORT_CACHE_NAMES true
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # REPRAPWORLD_KEYPAD
@@ -248,9 +254,9 @@ script:
   #
   # RA_CONTROL_PANEL
   #
-  - restore_configs
-  - opt_enable RA_CONTROL_PANEL PINS_DEBUGGING
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #- restore_configs
+  #- opt_enable RA_CONTROL_PANEL PINS_DEBUGGING
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   ######## I2C LCD/PANELS ##############
   #
@@ -278,19 +284,19 @@ script:
   #
   # LCM1602
   #
-  - restore_configs
-  - opt_enable LCM1602
-  - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
+  #- restore_configs
+  #- opt_enable LCM1602
+  #- build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # Language files test with REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
   #
-  - restore_configs
-  - opt_enable REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER SDSUPPORT
-  - for lang in an bg ca zh_CN zh_TW cz da de el el-gr en es eu fi fr gl hr it jp-kana nl pl pt pt-br ru sk tr uk test; do opt_set LCD_LANGUAGE $lang; echo "compile with language $lang ..."; build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}; done
+  #- restore_configs
+  #- opt_enable REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER SDSUPPORT
+  #- for lang in an bg ca zh_CN zh_TW cz da de el el-gr en es eu fi fr gl hr it jp-kana nl pl pt pt-br ru sk tr uk test; do opt_set LCD_LANGUAGE $lang; echo "compile with language $lang ..."; build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}; done
   #
-  - restore_configs
-  - opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT
-  - for lang in an bg ca zh_CN zh_TW cz da de el el-gr en es eu fi fr gl hr it jp-kana nl pl pt pt-br ru sk tr uk test; do opt_set LCD_LANGUAGE $lang; echo "compile with language $lang ..."; build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}; done
+  #- restore_configs
+  #- opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT
+  #- for lang in an bg ca zh_CN zh_TW cz da de el el-gr en es eu fi fr gl hr it jp-kana nl pl pt pt-br ru sk tr uk test; do opt_set LCD_LANGUAGE $lang; echo "compile with language $lang ..."; build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}; done
   #
   #
   ######## Example Configurations ##############
@@ -308,8 +314,8 @@ script:
   # Delta Config (generic) + UBL + ALLEN_KEY + OLED_PANEL_TINYBOY2 + EEPROM_SETTINGS
   #
   - use_example_configs delta/generic
-  - opt_disable DISABLE_MIN_ENDSTOPS
-  - opt_enable AUTO_BED_LEVELING_UBL RESTORE_LEVELING_AFTER_G28 Z_PROBE_ALLEN_KEY EEPROM_SETTINGS EEPROM_CHITCHAT OLED_PANEL_TINYBOY2 MESH_EDIT_GFX_OVERLAY
+  - opt_enable AUTO_BED_LEVELING_UBL RESTORE_LEVELING_AFTER_G28 Z_PROBE_ALLEN_KEY EEPROM_SETTINGS EEPROM_CHITCHAT
+  - opt_enable OLED_PANEL_TINYBOY2 MESH_EDIT_GFX_OVERLAY
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
   #
   # Delta Config (FLSUN AC because it's complex)
@@ -325,7 +331,7 @@ script:
   # SCARA with TMC2130
   #
   - use_example_configs SCARA
-  - opt_enable AUTO_BED_LEVELING_BILINEAR FIX_MOUNTED_PROBE USE_ZMIN_PLUG EEPROM_SETTINGS EEPROM_CHITCHAT ULTIMAKERCONTROLLER SCARA_FEEDRATE_SCALING
+  - opt_enable AUTO_BED_LEVELING_BILINEAR FIX_MOUNTED_PROBE USE_ZMIN_PLUG EEPROM_SETTINGS EEPROM_CHITCHAT ULTIMAKERCONTROLLER
   - opt_enable_adv HAVE_TMC2130 X_IS_TMC2130 Y_IS_TMC2130 Z_IS_TMC2130
   - opt_enable_adv MONITOR_DRIVER_STATUS STEALTHCHOP HYBRID_THRESHOLD SENSORLESS_HOMING
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_shared_hw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_shared_hw_spi.cpp
@@ -56,108 +56,106 @@
 
 */
 
-
 #ifdef __SAM3X8E__
 
-//  #include <inttypes.h>
+#include "../../inc/MarlinConfigPre.h"
 
-//  #include "src/core/macros.h"
-//  #include "Configuration.h"
+#if ENABLED(DOGLCD)
+
+#include <U8glib.h>
+
 #include "../../Marlin.h"
-#include "../../inc/MarlinConfig.h"
 
-  #include <U8glib.h>
+#define SPI_FULL_SPEED 0
+#define SPI_HALF_SPEED 1
+#define SPI_QUARTER_SPEED 2
+#define SPI_EIGHTH_SPEED 3
+#define SPI_SIXTEENTH_SPEED 4
+#define SPI_SPEED_5 5
+#define SPI_SPEED_6 6
 
-  #define SPI_FULL_SPEED 0
-  #define SPI_HALF_SPEED 1
-  #define SPI_QUARTER_SPEED 2
-  #define SPI_EIGHTH_SPEED 3
-  #define SPI_SIXTEENTH_SPEED 4
-  #define SPI_SPEED_5 5
-  #define SPI_SPEED_6 6
+void spiBegin();
+void spiInit(uint8_t spiRate);
+void spiSend(uint8_t b);
+void spiSend(const uint8_t* buf, size_t n);
 
-  void spiBegin();
-  void spiInit(uint8_t spiRate);
-  void spiSend(uint8_t b);
-  void spiSend(const uint8_t* buf, size_t n);
+#include <Arduino.h>
+#include "fastio_Due.h"
 
-  #include <Arduino.h>
-  #include "../../core/macros.h"
-  #include "fastio_Due.h"
+void u8g_SetPIOutput_DUE_hw_spi(u8g_t *u8g, uint8_t pin_index) {
+   PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,
+     g_APinDescription[u8g->pin_list[pin_index]].ulPin, g_APinDescription[u8g->pin_list[pin_index]].ulPinConfiguration);  // OUTPUT
+}
 
+void u8g_SetPILevel_DUE_hw_spi(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
+  volatile Pio* port = g_APinDescription[u8g->pin_list[pin_index]].pPort;
+  uint32_t mask = g_APinDescription[u8g->pin_list[pin_index]].ulPin;
+  if (level) port->PIO_SODR = mask;
+  else port->PIO_CODR = mask;
+}
 
-  void u8g_SetPIOutput_DUE_hw_spi(u8g_t *u8g, uint8_t pin_index) {
-     PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,
-       g_APinDescription[u8g->pin_list[pin_index]].ulPin, g_APinDescription[u8g->pin_list[pin_index]].ulPinConfiguration);  // OUTPUT
-  }
-
-  void u8g_SetPILevel_DUE_hw_spi(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
-    volatile Pio* port = g_APinDescription[u8g->pin_list[pin_index]].pPort;
-    uint32_t mask = g_APinDescription[u8g->pin_list[pin_index]].ulPin;
-    if (level) port->PIO_SODR = mask;
-    else port->PIO_CODR = mask;
-  }
-
-  uint8_t u8g_com_HAL_DUE_shared_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+uint8_t u8g_com_HAL_DUE_shared_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+{
+  switch(msg)
   {
-    switch(msg)
-    {
-      case U8G_COM_MSG_STOP:
-        break;
+    case U8G_COM_MSG_STOP:
+      break;
 
-      case U8G_COM_MSG_INIT:
-        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_CS, 1);
-        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_A0, 1);
+    case U8G_COM_MSG_INIT:
+      u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_CS, 1);
+      u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_A0, 1);
 
-        u8g_SetPIOutput_DUE_hw_spi(u8g, U8G_PI_CS);
-        u8g_SetPIOutput_DUE_hw_spi(u8g, U8G_PI_A0);
+      u8g_SetPIOutput_DUE_hw_spi(u8g, U8G_PI_CS);
+      u8g_SetPIOutput_DUE_hw_spi(u8g, U8G_PI_A0);
 
-        u8g_Delay(5);
+      u8g_Delay(5);
 
-        spiBegin();
+      spiBegin();
 
-        #ifndef SPI_SPEED
-          #define SPI_SPEED SPI_FULL_SPEED  // use same SPI speed as SD card
-        #endif
-        spiInit(2);
+      #ifndef SPI_SPEED
+        #define SPI_SPEED SPI_FULL_SPEED  // use same SPI speed as SD card
+      #endif
+      spiInit(2);
 
-        break;
+      break;
 
-      case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
-        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_A0, arg_val);
-        break;
+    case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
+      u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_A0, arg_val);
+      break;
 
-      case U8G_COM_MSG_CHIP_SELECT:
-        u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_CS, (arg_val ? 0 : 1));
-        break;
+    case U8G_COM_MSG_CHIP_SELECT:
+      u8g_SetPILevel_DUE_hw_spi(u8g, U8G_PI_CS, (arg_val ? 0 : 1));
+      break;
 
-      case U8G_COM_MSG_RESET:
-        break;
+    case U8G_COM_MSG_RESET:
+      break;
 
-      case U8G_COM_MSG_WRITE_BYTE:
+    case U8G_COM_MSG_WRITE_BYTE:
 
-        spiSend((uint8_t)arg_val);
-        break;
+      spiSend((uint8_t)arg_val);
+      break;
 
-      case U8G_COM_MSG_WRITE_SEQ: {
-          uint8_t *ptr = (uint8_t*) arg_ptr;
-          while (arg_val > 0) {
-            spiSend(*ptr++);
-            arg_val--;
-          }
+    case U8G_COM_MSG_WRITE_SEQ: {
+        uint8_t *ptr = (uint8_t*) arg_ptr;
+        while (arg_val > 0) {
+          spiSend(*ptr++);
+          arg_val--;
         }
-        break;
+      }
+      break;
 
-      case U8G_COM_MSG_WRITE_SEQ_P: {
-          uint8_t *ptr = (uint8_t*) arg_ptr;
-          while (arg_val > 0) {
-            spiSend(*ptr++);
-            arg_val--;
-          }
+    case U8G_COM_MSG_WRITE_SEQ_P: {
+        uint8_t *ptr = (uint8_t*) arg_ptr;
+        while (arg_val > 0) {
+          spiSend(*ptr++);
+          arg_val--;
         }
-        break;
-    }
-    return 1;
+      }
+      break;
   }
+  return 1;
+}
+
+#endif  // DOGLCD
 
 #endif  //__SAM3X8E__

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -55,9 +55,12 @@
 
 #ifdef ARDUINO_ARCH_SAM
 
+#include "../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DOGLCD)
+
 #include <U8glib.h>
 #include <Arduino.h>
-#include "../../core/macros.h"
 #include "../Delay.h"
 
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index) {
@@ -177,4 +180,6 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
   return 1;
 }
 
-#endif  //ARDUINO_ARCH_SAM
+#endif // DOGLCD
+
+#endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_hw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_hw_spi.cpp
@@ -55,11 +55,11 @@
 
 #ifdef TARGET_LPC1768
 
+#include "../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DOGLCD)
+
 //#include <inttypes.h>
-
-//#include "src/core/macros.h"
-//#include "Configuration.h"
-
 #include <U8glib.h>
 
 #define SPI_FULL_SPEED 0
@@ -132,4 +132,6 @@ uint8_t u8g_com_HAL_LPC1768_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif  //TARGET_LPC1768
+#endif // DOGLCD
+
+#endif // TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_ssd_sw_i2c.cpp  under construction
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_ssd_sw_i2c.cpp  under construction
@@ -61,16 +61,20 @@
 
 #ifdef TARGET_LPC1768
 
-  #include <U8glib.h>
+#include "../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DOGLCD)
+
+#include <U8glib.h>
 
 //void pinMode(int16_t pin, uint8_t mode);
 //void digitalWrite(int16_t pin, uint8_t pin_status);
 
 
-  #define I2C_SLA         (0x3C*2)
-  //#define I2C_CMD_MODE  0x080
-  #define I2C_CMD_MODE    0x000
-  #define I2C_DATA_MODE   0x040
+#define I2C_SLA         (0x3C*2)
+//#define I2C_CMD_MODE  0x080
+#define I2C_CMD_MODE    0x000
+#define I2C_DATA_MODE   0x040
 
 //static uint8_t I2C_speed; // 3 - 400KHz, 13 - 100KHz
 //#define SPEED_400KHz 3
@@ -245,4 +249,6 @@ uint8_t u8g_com_HAL_LPC1768_ssd_sw_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_v
   return 1;
 }
 
-#endif  // TARGET_LPC1768
+#endif // DOGLCD
+
+#endif // TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -55,6 +55,10 @@
 
 #ifdef TARGET_LPC1768
 
+#include "../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DOGLCD)
+
 #include <U8glib.h>
 #include "SoftwareSPI.h"
 
@@ -119,5 +123,7 @@ uint8_t u8g_com_HAL_LPC1768_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   }
   return 1;
 }
+
+#endif // DOGLCD
 
 #endif // TARGET_LPC1768

--- a/Marlin/src/lcd/dogm/u8g_dev_ssd1306_sh1106_128x64_I2C.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_ssd1306_sh1106_128x64_I2C.cpp
@@ -65,7 +65,7 @@
  * beginning.
  */
 
-#include "../../inc/MarlinConfig.h"
+#include "../../inc/MarlinConfigPre.h"
 
 #if ENABLED(DOGLCD)
 

--- a/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
@@ -67,43 +67,43 @@
 
 /* init sequence from https://github.com/adafruit/ST7565-LCD/blob/master/ST7565/ST7565.cpp */
 static const uint8_t u8g_dev_st7565_64128n_HAL_init_seq[] PROGMEM = {
-   U8G_ESC_CS(0),       // disable chip
-    U8G_ESC_ADR(0),     // instruction mode
-    U8G_ESC_CS(1),      // enable chip
-    U8G_ESC_RST(15),    // do reset low pulse with (15*16)+2 milliseconds (=maximum delay)*/
+  U8G_ESC_CS(0),       // disable chip
+  U8G_ESC_ADR(0),     // instruction mode
+  U8G_ESC_CS(1),      // enable chip
+  U8G_ESC_RST(15),    // do reset low pulse with (15*16)+2 milliseconds (=maximum delay)*/
 
-    0x0A2,              // 0x0A2: LCD bias 1/9 (according to Displaytech 64128N datasheet)
-    0x0A0,              // Normal ADC Select (according to Displaytech 64128N datasheet)
+  0x0A2,              // 0x0A2: LCD bias 1/9 (according to Displaytech 64128N datasheet)
+  0x0A0,              // Normal ADC Select (according to Displaytech 64128N datasheet)
 
-    0x0C8,              // common output mode: set scan direction normal operation/SHL Select, 0x0C0 --> SHL = 0, normal, 0x0C8 --> SHL = 1
-    0x040,              // Display start line for Displaytech 64128N
+  0x0C8,              // common output mode: set scan direction normal operation/SHL Select, 0x0C0 --> SHL = 0, normal, 0x0C8 --> SHL = 1
+  0x040,              // Display start line for Displaytech 64128N
 
-    0x028 | 0x04,       // power control: turn on voltage converter
-    U8G_ESC_DLY(50),    // delay 50 ms
+  0x028 | 0x04,       // power control: turn on voltage converter
+  U8G_ESC_DLY(50),    // delay 50 ms
 
-    0x028 | 0x06,       // power control: turn on voltage regulator
-    U8G_ESC_DLY(50),    // delay 50 ms
+  0x028 | 0x06,       // power control: turn on voltage regulator
+  U8G_ESC_DLY(50),    // delay 50 ms
 
-    0x028 | 0x07,       // power control: turn on voltage follower
-    U8G_ESC_DLY(50),    // delay 50 ms
+  0x028 | 0x07,       // power control: turn on voltage follower
+  U8G_ESC_DLY(50),    // delay 50 ms
 
-    0x010,              // Set V0 voltage resistor ratio. Setting for controlling brightness of Displaytech 64128N
+  0x010,              // Set V0 voltage resistor ratio. Setting for controlling brightness of Displaytech 64128N
 
-    0x0A6,              // display normal, bit val 0: LCD pixel off.
+  0x0A6,              // display normal, bit val 0: LCD pixel off.
 
-    0x081,              // set contrast
-    0x01E,              // Contrast value. Setting for controlling brightness of Displaytech 64128N
+  0x081,              // set contrast
+  0x01E,              // Contrast value. Setting for controlling brightness of Displaytech 64128N
 
 
-    0x0AF,              // display on
+  0x0AF,              // display on
 
-    U8G_ESC_DLY(100),   // delay 100 ms
-    0x0A5,              // display all points, ST7565
-    U8G_ESC_DLY(100),   // delay 100 ms
-    U8G_ESC_DLY(100),   // delay 100 ms
-    0x0A4,              // normal display
-    U8G_ESC_CS(0),      // disable chip
-    U8G_ESC_END         // end of sequence
+  U8G_ESC_DLY(100),   // delay 100 ms
+  0x0A5,              // display all points, ST7565
+  U8G_ESC_DLY(100),   // delay 100 ms
+  U8G_ESC_DLY(100),   // delay 100 ms
+  0x0A4,              // normal display
+  U8G_ESC_CS(0),      // disable chip
+  U8G_ESC_END         // end of sequence
 };
 
 static const uint8_t u8g_dev_st7565_64128n_HAL_data_start[] PROGMEM = {
@@ -210,7 +210,6 @@ uint8_t u8g_dev_st7565_64128n_HAL_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg,
   }
   return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
 }
-
 
 U8G_PB_DEV(u8g_dev_st7565_64128n_HAL_sw_spi, WIDTH, HEIGHT, PAGE_HEIGHT, u8g_dev_st7565_64128n_HAL_fn, U8G_COM_HAL_SW_SPI_FN);
 

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -53,7 +53,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../inc/MarlinConfig.h"
+#include "../../inc/MarlinConfigPre.h"
 
 #if ENABLED(DOGLCD)
 

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -57,7 +57,7 @@
 
 */
 
-#include "../../inc/MarlinConfig.h"
+#include "../../inc/MarlinConfigPre.h"
 
 #if ENABLED(DOGLCD)
 
@@ -108,10 +108,8 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_data_start[] PROGMEM = {
   U8G_ESC_END                /* end of sequence */
 };
 
-uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
-{
-  switch(msg)
-  {
+uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
+  switch(msg) {
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
@@ -140,10 +138,8 @@ uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg,
   return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
 }
 
-uint8_t u8g_dev_uc1701_mini12864_HAL_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
-{
-  switch(msg)
-  {
+uint8_t u8g_dev_uc1701_mini12864_HAL_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
+  switch(msg) {
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -24,11 +24,12 @@
 // file u8g_dev_st7920_128x64_HAL.cpp for the HAL version.
 
 #include "../../inc/MarlinConfig.h"
-#include "../../HAL/Delay.h"
 
 #if ENABLED(U8GLIB_ST7920)
 
 #if !(defined(U8G_HAL_LINKS) || defined(__SAM3X8E__))
+
+#include "../../HAL/Delay.h"
 
 #define ST7920_CLK_PIN  LCD_PINS_D4
 #define ST7920_DAT_PIN  LCD_PINS_ENABLE

--- a/Marlin/src/lcd/lcdprint_u8g.cpp
+++ b/Marlin/src/lcd/lcdprint_u8g.cpp
@@ -8,11 +8,8 @@
  */
 
 #include "../inc/MarlinConfigPre.h"
-#include "../inc/MarlinConfig.h"
 
-#define USE_LCDPRINT_U8G ENABLED(ULTRA_LCD) && ENABLED(DOGLCD)
-
-#if USE_LCDPRINT_U8G
+#if ENABLED(DOGLCD)
 
 #include <U8glib.h>
 extern U8GLIB *pu8g;
@@ -72,9 +69,9 @@ int lcd_put_u8str_max_rom(const char * utf8_str_P, pixel_len_t max_length) {
   return ret;
 }
 
-#else // !USE_LCDPRINT_U8G
+#else // !ULTRA_LCD
 
-#define _lcd_write(a) TRACE("Write LCD: %c (%d)", (a), (int)(a));
-#define _lcd_setcursor(col, row) TRACE("Set cursor LCD: (%d,%d)", (col), (row));
+  #define _lcd_write(a) TRACE("Write LCD: %c (%d)", (a), (int)(a));
+  #define _lcd_setcursor(col, row) TRACE("Set cursor LCD: (%d,%d)", (col), (row));
 
-#endif // !USE_LCDPRINT_U8G
+#endif // !ULTRA_LCD


### PR DESCRIPTION
In response to #10736

Make sure that unused U8glib-oriented `.cpp` files aren't compiled, don't create false dependencies, and don't end up linking Marlin with U8glib unnecessarily.

[Concise Diff](10742/files?w=1)