### PR TITLE
[1.1.x] Modify UBL mesh_is_valid and use in leveling_is_valid

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2448,7 +2448,7 @@ void clean_up_after_endstop_or_probe_move() {
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
         !!bilinear_grid_spacing[X_AXIS]
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
-        true
+        ubl.mesh_is_valid()
       #else // 3POINT, LINEAR
         true
       #endif
@@ -10039,8 +10039,9 @@ void quickstop_stepper() {
       // L or V display the map info
       if (parser.seen('L') || parser.seen('V')) {
         ubl.display_map(parser.byteval('T'));
-        SERIAL_ECHOLNPAIR("ubl.mesh_is_valid = ", ubl.mesh_is_valid());
-        SERIAL_ECHOLNPAIR("ubl.storage_slot = ", ubl.storage_slot);
+        SERIAL_ECHOPGM("Mesh is ");
+        if (!ubl.mesh_is_valid()) SERIAL_ECHOPGM("in");
+        SERIAL_ECHOLNPAIR("valid\nStorage slot: ", ubl.storage_slot);
       }
 
     #endif // AUTO_BED_LEVELING_UBL

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -356,17 +356,11 @@ class unified_bed_leveling {
       static void line_to_destination_cartesian(const float &fr, const uint8_t e);
     #endif
 
-    #define _CMPZ(a,b) (z_values[a][b] == z_values[a][b+1])
-    #define CMPZ(a) (_CMPZ(a, 0) && _CMPZ(a, 1))
-    #define ZZER(a) (z_values[a][0] == 0)
-
-    FORCE_INLINE bool mesh_is_valid() {
-      return !(
-        (    CMPZ(0) && CMPZ(1) && CMPZ(2) // adjacent z values all equal?
-          && ZZER(0) && ZZER(1) && ZZER(2) // all zero at the edge?
-        )
-        || isnan(z_values[0][0])
-      );
+    inline static bool mesh_is_valid() {
+      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
+        for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)
+          if (isnan(z_values[x][y])) return false;
+      return true;
     }
 
 }; // class unified_bed_leveling


### PR DESCRIPTION
Response to #10738

- Have UBL `mesh_is_valid` look at all values and return `false` if any are `NAN`.
- Make `mesh_is_valid` a `static inline` method.
- Consider an all-zeroes mesh to be ok.
- Consider a flat mesh to be ok.
- Tweak `M420` mesh report output.

Counterpart to #10746