### PR TITLE
Support Darwin environment on buildroot/bin

### DIFF
--- a/buildroot/bin/opt_disable
+++ b/buildroot/bin/opt_disable
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	for opt in "$@" ; do
-	  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
-	done
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	for opt in "$@" ; do
-	  eval "gsed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
-	done
-fi
+for opt in "$@" ; do
+  eval "${SED} -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
+done

--- a/buildroot/bin/opt_disable
+++ b/buildroot/bin/opt_disable
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
-for opt in "$@" ; do
-  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
-done
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	for opt in "$@" ; do
+	  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
+	done
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	for opt in "$@" ; do
+	  eval "gsed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
+	done
+fi

--- a/buildroot/bin/opt_disable_adv
+++ b/buildroot/bin/opt_disable_adv
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	for opt in "$@" ; do
-	  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
-	done
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	for opt in "$@" ; do
-	  eval "gsed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
-	done
-fi
+for opt in "$@" ; do
+  eval "${SED} -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
+done

--- a/buildroot/bin/opt_disable_adv
+++ b/buildroot/bin/opt_disable_adv
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
-for opt in "$@" ; do
-  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
-done
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	for opt in "$@" ; do
+	  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
+	done
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	for opt in "$@" ; do
+	  eval "gsed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
+	done
+fi

--- a/buildroot/bin/opt_enable
+++ b/buildroot/bin/opt_enable
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	for opt in "$@" ; do
-	  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
-	done
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	for opt in "$@" ; do
-	  eval "gsed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
-	done
-fi
+for opt in "$@" ; do
+  eval "${SED} -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
+done

--- a/buildroot/bin/opt_enable
+++ b/buildroot/bin/opt_enable
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
-for opt in "$@" ; do
-  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
-done
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	for opt in "$@" ; do
+	  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
+	done
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	for opt in "$@" ; do
+	  eval "gsed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
+	done
+fi

--- a/buildroot/bin/opt_enable_adv
+++ b/buildroot/bin/opt_enable_adv
@@ -1,13 +1,7 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	for opt in "$@" ; do
-	  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
-	done
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	for opt in "$@" ; do
-	  eval "gsed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
-	done
-fi
+for opt in "$@" ; do
+  eval "${SED} -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
+done

--- a/buildroot/bin/opt_enable_adv
+++ b/buildroot/bin/opt_enable_adv
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
-for opt in "$@" ; do
-  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
-done
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	for opt in "$@" ; do
+	  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
+	done
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	for opt in "$@" ; do
+	  eval "gsed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
+	done
+fi

--- a/buildroot/bin/opt_set
+++ b/buildroot/bin/opt_set
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	eval "gsed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"
+fi

--- a/buildroot/bin/opt_set
+++ b/buildroot/bin/opt_set
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	eval "gsed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"
-fi
+eval "${SED} -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"

--- a/buildroot/bin/opt_set_adv
+++ b/buildroot/bin/opt_set_adv
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	eval "gsed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"
+fi

--- a/buildroot/bin/opt_set_adv
+++ b/buildroot/bin/opt_set_adv
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	eval "gsed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"
-fi
+eval "${SED} -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"

--- a/buildroot/bin/pins_set
+++ b/buildroot/bin/pins_set
@@ -1,3 +1,9 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"
+unamestr=`uname`
+
+if [[ "$unamestr" == 'Linux' ]]; then
+	eval "sed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"
+elif [[ "$unamestr" == 'Darwin' ]]; then
+	eval "gsed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"
+fi

--- a/buildroot/bin/pins_set
+++ b/buildroot/bin/pins_set
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-unamestr=`uname`
+SED=$(which gsed || which sed)
 
-if [[ "$unamestr" == 'Linux' ]]; then
-	eval "sed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"
-elif [[ "$unamestr" == 'Darwin' ]]; then
-	eval "gsed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"
-fi
+eval "${SED} -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"


### PR DESCRIPTION
### Requirements

For OSX(Darwin): GNU-Sed from HomeBrew or self-built gsed binary.
For Linux: Nothing

### Description
Basically support Darwin environment for opt_* command in buildroot/bin, as well as pins_set

### Benefits
Fixes "sed: 1: "Marlin/Configuration.h": invalid command code M" after executing opt_* command
Its a problem of osx's sed, so changing to gsed will sort the problem out.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
