### PR TITLE
[1.1.x] Darwin-compatible buildroot/src scripts

### DIFF
--- a/buildroot/bin/opt_disable
+++ b/buildroot/bin/opt_disable
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SED=$(which gsed || which sed)
+
 for opt in "$@" ; do
-  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
+  eval "${SED} -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration.h"
 done

--- a/buildroot/bin/opt_disable_adv
+++ b/buildroot/bin/opt_disable_adv
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SED=$(which gsed || which sed)
+
 for opt in "$@" ; do
-  eval "sed -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
+  eval "${SED} -i 's/\([[:blank:]]*\)\(#define \b${opt}\b\)/\1\/\/\2/g' Marlin/Configuration_adv.h"
 done

--- a/buildroot/bin/opt_enable
+++ b/buildroot/bin/opt_enable
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SED=$(which gsed || which sed)
+
 for opt in "$@" ; do
-  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
+  eval "${SED} -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration.h"
 done

--- a/buildroot/bin/opt_enable_adv
+++ b/buildroot/bin/opt_enable_adv
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+SED=$(which gsed || which sed)
+
 for opt in "$@" ; do
-  eval "sed -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
+  eval "${SED} -i 's/\/\/[[:blank:]]*\(#define \b${opt}\b\)/\1/g' Marlin/Configuration_adv.h"
 done

--- a/buildroot/bin/opt_set
+++ b/buildroot/bin/opt_set
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"
+SED=$(which gsed || which sed)
+
+eval "${SED} -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration.h"

--- a/buildroot/bin/opt_set_adv
+++ b/buildroot/bin/opt_set_adv
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"
+SED=$(which gsed || which sed)
+
+eval "${SED} -i 's/\(#define \b${1}\b\).*$/\1 ${2}/g' Marlin/Configuration_adv.h"

--- a/buildroot/bin/pins_set
+++ b/buildroot/bin/pins_set
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-eval "sed -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/pins_${1}.h"
+SED=$(which gsed || which sed)
+
+eval "${SED} -i 's/\(#define \b${2}\b\).*$/\1 ${3}/g' Marlin/src/pins/pins_${1}.h"


### PR DESCRIPTION
Based on #10751 by @KangDroid and @thinkyhead

Make `buildroot/bin` scripts (used by Travis CI) compatible with Darwin, so they can be used for testing in local working copies.

- Requires an installation of `gsed` on macOS using Homebrew, MacPorts, or `/usr/local`