### PR TITLE
[2.0.x][LPC176x] Add missing program space function

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
@@ -93,6 +93,7 @@ extern "C" void GpioDisableInt(uint32_t port, uint32_t pin);
 #define strcpy_P strcpy
 #define snprintf_P snprintf
 #define strlen_P strlen
+#define strchr_P strchr
 
 // Time functions
 extern "C" {


### PR DESCRIPTION
### Description
Fixes compilation when the Emergency parser is enabled

### Related Issues
#10769