### PR TITLE
[1.1.x] Fix G1 behaviour after tool unpark

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11939,7 +11939,9 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #endif
           // Move back to the original (or tweaked) position
           do_blocking_move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]);
-          active_extruder_parked = false;
+          #if ENABLED(DUAL_X_CARRIAGE)
+            active_extruder_parked = false;
+          #endif
         }
         #if ENABLED(SWITCHING_NOZZLE)
           else {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11938,7 +11938,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
           #endif
           // Move back to the original (or tweaked) position
-          do_blocking_move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]);
+          prepare_move_to_destination();
         }
         #if ENABLED(SWITCHING_NOZZLE)
           else {

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11938,7 +11938,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
           #endif
           // Move back to the original (or tweaked) position
-          prepare_move_to_destination();
+          do_blocking_move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]);
+          active_extruder_parked = false;
         }
         #if ENABLED(SWITCHING_NOZZLE)
           else {


### PR DESCRIPTION
### Setup

- DUAL_X_CARRIAGE
- DXC_AUTO_PARK_MODE

### Description

After every tool change, the first G1 that follows (whatever it is, even if not affecting X) results in the carriage going back to its X parking position very slowly, then the actual requested G1 move after that.

Reverting `do_blocking_move_to` back to `prepare_move_to_destination` in `tool_change` seems to completely fix the issue.

### Benefits

Pre-fix:
https://www.youtube.com/watch?v=m4hY3lAxMaw

Post-fix:
https://www.youtube.com/watch?v=2RZavWEiwBY

### Related Issues

Issue 2 from https://github.com/MarlinFirmware/Marlin/issues/10749