### PR TITLE
Respect min/max positions in mesh leveling

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -787,8 +787,8 @@
 #define X_MIN_POS 0
 #define Y_MIN_POS 0
 #define Z_MIN_POS 0
-#define X_MAX_POS X_BED_SIZE
-#define Y_MAX_POS Y_BED_SIZE
+#define X_MAX_POS ((X_MIN_POS) + (X_BED_SIZE))
+#define Y_MAX_POS ((Y_MIN_POS) + (Y_BED_SIZE))
 #define Z_MAX_POS 200
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -719,10 +719,10 @@
 
 #if ENABLED(MESH_BED_LEVELING) || ENABLED(AUTO_BED_LEVELING_UBL)
   // Override the mesh area if the automatic (max) area is too large
-  //#define MESH_MIN_X MESH_INSET
-  //#define MESH_MIN_Y MESH_INSET
-  //#define MESH_MAX_X X_BED_SIZE - (MESH_INSET)
-  //#define MESH_MAX_Y Y_BED_SIZE - (MESH_INSET)
+  //#define MESH_MIN_X ((X_MIN_POS) + (MESH_INSET))
+  //#define MESH_MIN_Y ((Y_MIN_POS) + (MESH_INSET))
+  //#define MESH_MAX_X ((X_MAX_POS) - (MESH_INSET))
+  //#define MESH_MAX_Y ((Y_MAX_POS) - (MESH_INSET))
 #endif
 
 // @section extras


### PR DESCRIPTION
### Description

For example, I have a printer where the bed is smaller than max area. So the existing mesh leveling (if I would just uncomment the current lines here) - would ask me to manually probe the area outside of the bed boundaries.
My changes make it to be respecting the actual area restrictions imposed by MIN/MAX values (actually - the bed placement), instead of just blindly using a bed size without taking into account not used area around the bed...

### Benefits

It will be easier to set up the config with properly working mesh leveling for users who has a printer with max area bigger than the bed size. Without doing these little changes, as I was forced to do.

### Related Issues

I'm having an issue right now with the current 1.1.8 version.;)
After setting the mesh leveling (when using existing macro lines that just use the bed size without respecting where exactly the bed is placed) - the printer just tried to do a probe outside the bed boundaries. Which should not happen.
