### PR TITLE
[bugfix-1.1.x] Yet another auto build update & add Sublime menu support

### DIFF
--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -69,6 +69,13 @@
 import sys
 import os
 
+pwd = os.getcwd()    # make sure we're executing from the correct directory level
+pwd = pwd.replace('\\', '/')
+if 0 <= pwd.find('buildroot/share/atom'):
+  pwd = pwd[ : pwd.find('buildroot/share/atom')]
+  os.chdir(pwd)
+print 'pwd: ', pwd
+
 num_args = len(sys.argv)
 if num_args > 1:
   build_type = str(sys.argv[1])
@@ -204,7 +211,7 @@ def resolve_path(path):
        #get line and column numbers
         line_num = 1
         column_num = 1
-        line_start = path.find(':')
+        line_start = path.find(':', 2)                  # use 2 here so don't eat Windows full path
         column_start = path.find(':', line_start + 1)
         if column_start == -1:
           column_start = len(path)
@@ -218,57 +225,69 @@ def resolve_path(path):
         if not(column_start == column_end):
           column_num = path[ column_start + 1 : column_end]
           if column_num == '':
-            column_num = 1
+            column_num = 0
 
+        index_end = path.find(',')
+        if 0 <= index_end:
+            path = path[ : index_end]  # delete comma and anything after
+        index_end = path.find(':', 2)
+        if 0 <= index_end:
+            path = path[ : path.find(':', 2)]  # delete the line number and anything after
 
-        path = path[ : path.find(':')]  # delete the line number and anything after
         path = path.replace('\\','/')
 
-      # resolve as many '../' as we can
-        while 0 <= path.find('../'):
-          end =  path.find('../') - 1
-          start = path.find('/')
-          while 0 <= path.find('/',start) and end > path.find('/',start):
-            start = path.find('/',start) + 1
-          path = path[0:start] + path[end + 4: ]
+        if 1 == path.find(':') and current_OS == 'Windows':
+          return path, line_num, column_num                    # found a full path - no need for further processing
+        elif 0 == path.find('/') and (current_OS == 'Linux' or current_OS == 'Darwin'):
+          return path, line_num, column_num                    # found a full path - no need for further processing
 
-        # this is an alternative to the above - it just deletes the '../' section
-        # start_temp = path.find('../')
-        # while 0 <= path.find('../',start_temp):
-        #   start = path.find('../',start_temp)
-        #   start_temp = start  + 1
-        # if 0 <= start:
-        #   path = path[start + 2 : ]
-
-
-        start = path.find('/')
-        if not(0 == start):            # make sure path starts with '/'
-          while 0 == path.find(' '):    # eat any spaces at the beginning
-            path = path[ 1 : ]
-          path = '/' + path
-
-        if current_OS == 'Windows':
-          search_path = path.replace('/', '\\')  # os.walk uses '\' in Windows
         else:
-          search_path = path
 
-        start_path = os.path.abspath('')
+          # resolve as many '../' as we can
+            while 0 <= path.find('../'):
+              end =  path.find('../') - 1
+              start = path.find('/')
+              while 0 <= path.find('/',start) and end > path.find('/',start):
+                start = path.find('/',start) + 1
+              path = path[0:start] + path[end + 4: ]
 
-    # search project directory for the selection
-        found = False
-        full_path = ''
-        for root, directories, filenames in os.walk(start_path):
-          for filename in filenames:
-                  if  0 <= root.find('.git'):              # don't bother looking in this directory
-                    break
-                  full_path = os.path.join(root,filename)
-                  if 0 <= full_path.find(search_path):
-                    found = True
-                    break
-          if found:
-            break
+            # this is an alternative to the above - it just deletes the '../' section
+            # start_temp = path.find('../')
+            # while 0 <= path.find('../',start_temp):
+            #   start = path.find('../',start_temp)
+            #   start_temp = start  + 1
+            # if 0 <= start:
+            #   path = path[start + 2 : ]
 
-        return full_path, line_num, column_num
+
+            start = path.find('/')
+            if not(0 == start):            # make sure path starts with '/'
+              while 0 == path.find(' '):    # eat any spaces at the beginning
+                path = path[ 1 : ]
+              path = '/' + path
+
+            if current_OS == 'Windows':
+              search_path = path.replace('/', '\\')  # os.walk uses '\' in Windows
+            else:
+              search_path = path
+
+            start_path = os.path.abspath('')
+
+        # search project directory for the selection
+            found = False
+            full_path = ''
+            for root, directories, filenames in os.walk(start_path):
+              for filename in filenames:
+                      if  0 <= root.find('.git'):              # don't bother looking in this directory
+                        break
+                      full_path = os.path.join(root,filename)
+                      if 0 <= full_path.find(search_path):
+                        found = True
+                        break
+              if found:
+                break
+
+            return full_path, line_num, column_num
 
 # end - resolve_path
 
@@ -324,6 +343,9 @@ def open_file(path):
         elif current_OS == 'Linux':
 
               command = file_path  + ':' + str(line_num) + ':' + str(column_num)
+              index_end = command.find(',')
+              if 0 <= index_end:
+                  command = command[ : index_end]  # sometimes a comma magically appears, don't want it
               running_apps = subprocess.Popen('ps ax -o cmd', stdout=subprocess.PIPE, shell=True)
               (output, err) = running_apps.communicate()
               temp = output.split('\n')
@@ -336,7 +358,7 @@ def open_file(path):
                   return False , ''
 
               (success_sublime, editor_path_sublime) = find_editor_linux('sublime_text',temp)
-              (success_atom, editor_path_atom) = find_editor+linux('atom',temp)
+              (success_atom, editor_path_atom) = find_editor_linux('atom',temp)
 
               if success_sublime:
                   subprocess.Popen([editor_path_sublime, command])
@@ -350,6 +372,9 @@ def open_file(path):
         elif current_OS == 'Darwin':  # MAC
 
               command = file_path  + ':' + str(line_num) + ':' + str(column_num)
+              index_end = command.find(',')
+              if 0 <= index_end:
+                  command = command[ : index_end]  # sometimes a comma magically appears, don't want it
               running_apps = subprocess.Popen('ps axwww -o command', stdout=subprocess.PIPE, shell=True)
               (output, err) = running_apps.communicate()
               temp = output.split('\n')
@@ -424,8 +449,11 @@ def get_build_last():
         date_last = 0.0
         DIR__pioenvs = os.listdir('.pioenvs')
         for name in DIR__pioenvs:
+          if 0 <= name.find('.') or 0 <= name.find('-'):   # skip files in listing
+            continue
           DIR_temp = os.listdir('.pioenvs/' + name)
           for names_temp in DIR_temp:
+
             if 0 == names_temp.find('firmware.'):
               date_temp = os.path.getmtime('.pioenvs/' + name + '/' + names_temp)
               if date_temp > date_last:
@@ -941,7 +969,7 @@ class output_window(Text):
         Text.__init__(self, self.frame, borderwidth=3, relief="sunken")
         self.config(tabs=(400,))  # configure Text widget tab stops
         self.config(background = 'black', foreground = 'white', font= ("consolas", 12), wrap = 'word', undo = 'True')
-        self.config(height  = 24, width = 120)
+        self.config(height  = 24, width = 100)
         self.config(insertbackground = 'pale green')  # keyboard insertion point
         self.pack(side='left', fill='both', expand=True)
 

--- a/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
+++ b/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
@@ -26,9 +26,8 @@ Sublime with autobuild
        \Users\your_user_name\AppData\Roaming\Sublime Text 3\Packages
       Linux
         /home/your_user_name/.config/sublime-text-3/Packages/User
-
-      macOS (hidden files)
-        /Users/your_user_name//Library/Application Support/Sublime Text 3/Packages/User
+      macOS (Click on the Finder's 'Go' menu and hold down Option to open...)
+        ~/Library/Application Support/Sublime Text 3/Packages/User
 
 The menu should now be visible
 

--- a/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
+++ b/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
@@ -1,0 +1,41 @@
+Overview:
+1) Install Sublime
+2) Install Deviot  (?optional?)
+3) Install WebDevShell (this will execute the auto-build script)
+4) Copy the menu configuration to the proper Sublime directory
+5) Add platformio to your path (usually not needed)
+
+
+Sublime with autobuild
+  Tools
+    Install Package Control
+  Tools
+    Command Palette
+      Package Control: Install Package
+          type in deviot and click on it
+  Tools
+    Command Palette
+      Package Control: Install Package
+          type in WebDevShell and click on it
+
+  in Sublime, open Marlin directory with "platformio.ini" in it
+
+  starting in the top level directory, go to the folder "Buildroot/shared/Sublime"
+    copy the folder "auto_build_sublime_menu" and contents to:
+      Windows
+       \Users\your_user_name\AppData\Roaming\Sublime Text 3\Packages
+      Linux
+        /home/your_user_name/.config/sublime-text-3/Packages/User
+
+      macOS (hidden files)
+        /Users/your_user_name//Library/Application Support/Sublime Text 3/Packages/User
+
+The menu should now be visible
+
+If you get an error message that says "file not found" and  "subprocess.Popen(['platformio' ... "
+then you'll need to add platformio to your path.
+  macOS
+      sudo nano /etc/paths
+        add these to the bottom
+            /Users/bob/.platformio
+            /Users/bob/.platformio/penv/bin

--- a/buildroot/share/sublime/auto_build_sublime_menu/Main.sublime-menu
+++ b/buildroot/share/sublime/auto_build_sublime_menu/Main.sublime-menu
@@ -1,0 +1,66 @@
+[
+
+    {
+        "caption": "Auto Build",
+        "children": [
+            {
+                "caption": "PIO Build",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py build"
+                }
+            },
+            {
+                "caption": "PIO Clean",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py clean"
+                }
+            },
+            {
+                "caption": "PIO Upload",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  upload"
+                }
+            },
+            {
+                "caption": "PIO Upload (traceback)",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  traceback"
+                }
+            },
+            {
+                "caption": "PIO Upload using Programmer",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  program"
+                }
+            },
+            {
+                "caption": "PIO Test",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  test"
+                }
+            },
+            {
+                "caption": "PIO Debug",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  debug"
+                }
+            },
+            {
+                "caption": "PIO Remote",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  remote"
+                }
+            }
+        ],
+        "id": "AutoBuild",
+        "mnemonic": "A"
+    }
+]


### PR DESCRIPTION
1) Update Auto-build so that it can open the file paths that show up in warnings.

2) Add support file and rough instructions on adding the Auto-build menu to Sublime.  This requires installing the WebDevShell package into Sublime and copying a new menu file to the correct location.