### PR TITLE
[2.0.x] Add Sublime support for Auto build, minor Auto-build update

### DIFF
--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -69,6 +69,13 @@
 import sys
 import os
 
+pwd = os.getcwd()    # make sure we're executing from the correct directory level
+pwd = pwd.replace('\\', '/')
+if 0 <= pwd.find('buildroot/share/atom'):
+  pwd = pwd[ : pwd.find('buildroot/share/atom')]
+  os.chdir(pwd)
+print 'pwd: ', pwd
+
 num_args = len(sys.argv)
 if num_args > 1:
   build_type = str(sys.argv[1])

--- a/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
+++ b/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
@@ -26,9 +26,8 @@ Sublime with autobuild
        \Users\your_user_name\AppData\Roaming\Sublime Text 3\Packages
       Linux
         /home/your_user_name/.config/sublime-text-3/Packages/User
-
-      macOS (hidden files)
-        /Users/your_user_name//Library/Application Support/Sublime Text 3/Packages/User
+      macOS (Click on the Finder's 'Go' menu and hold down Option to open...)
+        ~/Library/Application Support/Sublime Text 3/Packages/User
 
 The menu should now be visible
 

--- a/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
+++ b/buildroot/share/sublime/auto_build_sublime_menu/000_read_me.txt
@@ -1,0 +1,41 @@
+Overview:
+1) Install Sublime
+2) Install Deviot  (?optional?)
+3) Install WebDevShell (this will execute the auto-build script)
+4) Copy the menu configuration to the proper Sublime directory
+5) Add platformio to your path (usually not needed)
+
+
+Sublime with autobuild
+  Tools
+    Install Package Control
+  Tools
+    Command Palette
+      Package Control: Install Package
+          type in deviot and click on it
+  Tools
+    Command Palette
+      Package Control: Install Package
+          type in WebDevShell and click on it
+
+  in Sublime, open Marlin directory with "platformio.ini" in it
+
+  starting in the top level directory, go to the folder "Buildroot/shared/Sublime"
+    copy the folder "auto_build_sublime_menu" and contents to:
+      Windows
+       \Users\your_user_name\AppData\Roaming\Sublime Text 3\Packages
+      Linux
+        /home/your_user_name/.config/sublime-text-3/Packages/User
+
+      macOS (hidden files)
+        /Users/your_user_name//Library/Application Support/Sublime Text 3/Packages/User
+
+The menu should now be visible
+
+If you get an error message that says "file not found" and  "subprocess.Popen(['platformio' ... "
+then you'll need to add platformio to your path.
+  macOS
+      sudo nano /etc/paths
+        add these to the bottom
+            /Users/bob/.platformio
+            /Users/bob/.platformio/penv/bin

--- a/buildroot/share/sublime/auto_build_sublime_menu/Main.sublime-menu
+++ b/buildroot/share/sublime/auto_build_sublime_menu/Main.sublime-menu
@@ -1,0 +1,66 @@
+[
+
+    {
+        "caption": "Auto Build",
+        "children": [
+            {
+                "caption": "PIO Build",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py build"
+                }
+            },
+            {
+                "caption": "PIO Clean",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py clean"
+                }
+            },
+            {
+                "caption": "PIO Upload",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  upload"
+                }
+            },
+            {
+                "caption": "PIO Upload (traceback)",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  traceback"
+                }
+            },
+            {
+                "caption": "PIO Upload using Programmer",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  program"
+                }
+            },
+            {
+                "caption": "PIO Test",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  test"
+                }
+            },
+            {
+                "caption": "PIO Debug",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  debug"
+                }
+            },
+            {
+                "caption": "PIO Remote",
+                "command": "webdevshell",
+                "args": {
+                    "command": "python buildroot/share/atom/auto_build.py  remote"
+                }
+            }
+        ],
+        "id": "AutoBuild",
+        "mnemonic": "A"
+    }
+]


### PR DESCRIPTION
1) Add support file and rough instructions on adding the Auto-build menu to Sublime. This requires installing the WebDevShell package into Sublime and copying a new menu file to the correct location.

2) Update Auto-build to ensure it's running in the correct directory