### PR TITLE
[2.0.x] M3 & M4 Boards.h classification arrangement

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -202,13 +202,17 @@
 #define BOARD_ALLIGATOR        1602   // Alligator Board R2
 
 //
-// ARM Cortex M4
+// STM32 ARM Cortex-M3
 //
-#define BOARD_TEENSY35_36       841   // Teensy3.5 and Teensy3.6
 #define BOARD_STM32F1R         1800   // STM3R Libmaple based STM32F1 controller
 #define BOARD_MALYAN_M200      1801   // STM32C8T6 Libmaple based stm32f1 controller
-#define BOARD_BEAST            1802   // STM32FxxxVxT6 Libmaple based stm32f4 controller
 #define BOARD_STM3R_MINI       1803   // STM32 Libmaple based stm32f1 controller
+
+//
+// STM32 ARM Cortex-M4F
+//
+#define BOARD_TEENSY35_36       841   // Teensy3.5 and Teensy3.6
+#define BOARD_BEAST            1802   // STM32FxxxVxT6 Libmaple based stm32f4 controller
 #define BOARD_STM32F4          1804   // STM32 STM32GENERIC based STM32F4 controller
 
 //


### PR DESCRIPTION
### Requirements
STM32 ARM Cortex-M3 boards were listed as M4

### Description
Rearranged M3 and M4 boards 
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
Better comprehension when selecting 32bit boards, stm32f1 (M3) were listed as M4
<!-- What does this fix or improve? -->

### Related Issues
Nothing
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
