### PR TITLE
[2.0.x] 32 bit boards env. check and classification on pins.h

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -176,6 +176,7 @@
 //
 // SAM3X8E ARM Cortex M3
 //
+
 #define BOARD_DUE3DOM          1411   // DUE3DOM for Arduino DUE
 #define BOARD_DUE3DOM_MINI     1412   // DUE3DOM MINI for Arduino DUE
 #define BOARD_RADDS            1502   // RADDS
@@ -204,6 +205,7 @@
 //
 // STM32 ARM Cortex-M3
 //
+
 #define BOARD_STM32F1R         1800   // STM3R Libmaple based STM32F1 controller
 #define BOARD_MALYAN_M200      1801   // STM32C8T6 Libmaple based stm32f1 controller
 #define BOARD_STM3R_MINI       1803   // STM32 Libmaple based stm32f1 controller
@@ -211,6 +213,7 @@
 //
 // STM32 ARM Cortex-M4F
 //
+
 #define BOARD_TEENSY35_36       841   // Teensy3.5 and Teensy3.6
 #define BOARD_BEAST            1802   // STM32FxxxVxT6 Libmaple based stm32f4 controller
 #define BOARD_STM32F4          1804   // STM32 STM32GENERIC based STM32F4 controller
@@ -218,6 +221,7 @@
 //
 // ARM Cortex M7
 //
+
 #define BOARD_THE_BORG         1860   // THE-BORG (Power outputs: Hotend0, Hotend1, Bed, Fan)
 
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -269,7 +269,7 @@
   #include "pins_5DPRINT.h"           // AT90USB1286                                ?env:at90USB1286_DFU
 
 //
-// Re-ARM - LPC1768
+// LPC1768 ARM Cortex M3
 //
 
 #elif MB(RAMPS_14_RE_ARM_EFB)
@@ -282,13 +282,26 @@
   #include "pins_RAMPS_RE_ARM.h"      // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
 #elif MB(RAMPS_14_RE_ARM_SF)
   #include "pins_RAMPS_RE_ARM.h"      // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-
+#elif MB(MKS_SBASE)
+  #include "pins_MKS_SBASE.h"         // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+#elif MB(AZSMZ_MINI)
+  #include "pins_AZSMZ_MINI.h"        // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+#elif MB(AZTEEG_X5_GT)
+  #include "pins_AZTEEG_X5_GT.h"      // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+#elif MB(BIQU_BQ111_A4)
+  #include "pins_BIQU_BQ111_A4.h"     // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+#elif MB(SELENA_COMPACT)
+  #include "pins_SELENA_COMPACT.h"    // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+#elif MB(COHESION3D_REMIX)
+  #include "pins_COHESION3D_REMIX.h"  // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+#elif MB(COHESION3D_MINI)
+  #include "pins_COHESION3D_MINI.h"   // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+  
+  
 //
 // Other 32-bit Boards
 //
 
-#elif MB(TEENSY35_36)
-  #include "pins_TEENSY35_36.h"       // TEENSY35_36                                env:teensy35
 #elif MB(DUE3DOM)
   #include "pins_DUE3DOM.h"           // SAM3X8E                                    env:DUE env:DUE_USB env:DUE_debug
 #elif MB(DUE3DOM_MINI)
@@ -337,34 +350,38 @@
   #include "pins_ARCHIM2.h"           // SAM3X8E                                    env:DUE env:DUE_debug
 #elif MB(ALLIGATOR)
   #include "pins_ALLIGATOR_R2.h"      // SAM3X8E                                    env:DUE env:DUE_debug
+
+//
+// STM32 ARM Cortex-M3
+//  
+  
 #elif MB(STM32F1R)
   #include "pins_STM32F1R.h"          // STM32F1                                    env:STM32F1
 #elif MB(STM3R_MINI)
   #include "pins_STM3R_MINI.h"        // STM32F1                                    env:STM32F1
 #elif MB(MALYAN_M200)
   #include "pins_MALYAN_M200.h"       // STM32F1                                    env:malyanm200
-#elif MB(BEAST)
-  #include "pins_BEAST.h"             // STM32F4                                    env:STM32F1
 #elif MB(CHITU3D)
   #include "pins_CHITU3D.h"           // STM32F1                                    env:STM32F1
-#elif MB(MKS_SBASE)
-  #include "pins_MKS_SBASE.h"         // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-#elif MB(AZSMZ_MINI)
-  #include "pins_AZSMZ_MINI.h"        // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-#elif MB(AZTEEG_X5_GT)
-  #include "pins_AZTEEG_X5_GT.h"      // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-#elif MB(BIQU_BQ111_A4)
-  #include "pins_BIQU_BQ111_A4.h"     // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-#elif MB(THE_BORG)
-  #include "pins_THE_BORG.h"          // STM32F7                                    env:STM32F1
-#elif MB(SELENA_COMPACT)
-  #include "pins_SELENA_COMPACT.h"    // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-#elif MB(COHESION3D_REMIX)
-  #include "pins_COHESION3D_REMIX.h"  // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
-#elif MB(COHESION3D_MINI)
-  #include "pins_COHESION3D_MINI.h"   // LPC176x                                    env:LPC1768 env:LPC1768_debug_and_upload
+  
+//
+// STM32 ARM Cortex-M4F
+//  
+
+#elif MB(TEENSY35_36)
+  #include "pins_TEENSY35_36.h"       // TEENSY35_36                                env:teensy35  
+#elif MB(BEAST)
+  #include "pins_BEAST.h"             // STM32F4                                    env:STM32F4
 #elif MB(STM32F4)
-  #include "pins_STM32F4.h"           // STM32F4                                    env:STM32F1
+  #include "pins_STM32F4.h"           // STM32F4                                    env:STM32F4
+
+//
+// ARM Cortex M7
+//  
+  
+#elif MB(THE_BORG)
+  #include "pins_THE_BORG.h"          // STM32F7                                    env:STM32F7  
+  
 #else
   #error "Unknown MOTHERBOARD value set in Configuration.h"
 #endif


### PR DESCRIPTION
Ordering and match classification between boards.h and pins.h
check pins.h enviroments

### Requirements


### Description
Separated STM32 bit boards list 
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
Genral cleanup
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
