### PR TITLE
[1.1.x] Clean up and consolidate SD-related code

### DIFF
--- a/Marlin/SdBaseFile.cpp
+++ b/Marlin/SdBaseFile.cpp
@@ -368,7 +368,7 @@ int8_t SdBaseFile::lsPrintNext(uint8_t flags, uint8_t indent) {
   // print size if requested
   if (!DIR_IS_SUBDIR(&dir) && (flags & LS_SIZE)) {
     SERIAL_CHAR(' ');
-    SERIAL_PROTOCOL(dir.fileSize);
+    SERIAL_ECHO(dir.fileSize);
   }
   SERIAL_EOL();
   return DIR_IS_FILE(&dir) ? 1 : 2;
@@ -601,7 +601,7 @@ bool SdBaseFile::open(SdBaseFile* dirFile, const uint8_t dname[11], uint8_t ofla
   // search for file
 
   while (dirFile->curPosition_ < dirFile->fileSize_) {
-    index = 0XF & (dirFile->curPosition_ >> 5);
+    index = 0xF & (dirFile->curPosition_ >> 5);
     p = dirFile->readDirCache();
     if (!p) return false;
 
@@ -705,7 +705,7 @@ bool SdBaseFile::open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag) {
     return false;
   }
   // open cached entry
-  return openCachedEntry(index & 0XF, oflag);
+  return openCachedEntry(index & 0xF, oflag);
 }
 
 // open a cached directory entry. Assumes vol_ is initialized
@@ -775,7 +775,7 @@ bool SdBaseFile::openNext(SdBaseFile* dirFile, uint8_t oflag) {
   vol_ = dirFile->vol_;
 
   while (1) {
-    index = 0XF & (dirFile->curPosition_ >> 5);
+    index = 0xF & (dirFile->curPosition_ >> 5);
 
     // read entry into cache
     p = dirFile->readDirCache();
@@ -902,11 +902,10 @@ int SdBaseFile::peek() {
   return c;
 }
 
-
 // print uint8_t with width 2
-static void print2u(uint8_t v) {
+static void print2u(const uint8_t v) {
   if (v < 10) SERIAL_CHAR('0');
-  SERIAL_PRINT(v, DEC);
+  SERIAL_ECHO_F(v, DEC);
 }
 
 /**
@@ -927,7 +926,7 @@ static void print2u(uint8_t v) {
  * \param[in] fatDate The date field from a directory entry.
  */
 void SdBaseFile::printFatDate(uint16_t fatDate) {
-  SERIAL_PROTOCOL(FAT_YEAR(fatDate));
+  SERIAL_ECHO(FAT_YEAR(fatDate));
   SERIAL_CHAR('-');
   print2u(FAT_MONTH(fatDate));
   SERIAL_CHAR('-');
@@ -959,7 +958,7 @@ void SdBaseFile::printFatTime(uint16_t fatTime) {
 bool SdBaseFile::printName() {
   char name[FILENAME_LENGTH];
   if (!getFilename(name)) return false;
-  SERIAL_PROTOCOL(name);
+  SERIAL_ECHO(name);
   return true;
 }
 
@@ -1104,7 +1103,7 @@ dir_t* SdBaseFile::readDirCache() {
   if (!isDir()) return 0;
 
   // index of entry in cache
-  i = (curPosition_ >> 5) & 0XF;
+  i = (curPosition_ >> 5) & 0xF;
 
   // use read to locate and cache block
   if (read() < 0) return 0;
@@ -1725,9 +1724,5 @@ int16_t SdBaseFile::write(const void* buf, uint16_t nbyte) {
   writeError = true;
   return -1;
 }
-
-#if ALLOW_DEPRECATED_FUNCTIONS
-  void (*SdBaseFile::oldDateTime_)(uint16_t &date, uint16_t &time) = 0;
-#endif
 
 #endif // SDSUPPORT

--- a/Marlin/SdBaseFile.h
+++ b/Marlin/SdBaseFile.h
@@ -37,6 +37,8 @@
 #include "SdFatConfig.h"
 #include "SdVolume.h"
 
+#include <stdint.h>
+
 /**
  * \struct filepos_t
  * \brief internal type for istream
@@ -383,119 +385,6 @@ class SdBaseFile {
   bool open(SdBaseFile* dirFile, const uint8_t dname[11], uint8_t oflag);
   bool openCachedEntry(uint8_t cacheIndex, uint8_t oflags);
   dir_t* readDirCache();
-
-// Deprecated functions
-#if ALLOW_DEPRECATED_FUNCTIONS
- public:
-
-  /**
-   * \deprecated Use:
-   * bool contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock);
-   * \param[out] bgnBlock the first block address for the file.
-   * \param[out] endBlock the last  block address for the file.
-   * \return true for success or false for failure.
-   */
-  bool contiguousRange(uint32_t& bgnBlock, uint32_t& endBlock) {
-    return contiguousRange(&bgnBlock, &endBlock);
-  }
-
-  /**
-   * \deprecated Use:
-   * bool createContiguous(SdBaseFile* dirFile, const char* path, uint32_t size)
-   * \param[in] dirFile The directory where the file will be created.
-   * \param[in] path A path with a valid DOS 8.3 file name.
-   * \param[in] size The desired file size.
-   * \return true for success or false for failure.
-   */
-  bool createContiguous(SdBaseFile& dirFile, const char* path, uint32_t size) {
-    return createContiguous(&dirFile, path, size);
-  }
-
-  /**
-   * \deprecated Use:
-   * static void dateTimeCallback(
-   *   void (*dateTime)(uint16_t* date, uint16_t* time));
-   * \param[in] dateTime The user's call back function.
-   */
-  static void dateTimeCallback(
-    void (*dateTime)(uint16_t &date, uint16_t &time)) {
-    oldDateTime_ = dateTime;
-    dateTime_ = dateTime ? oldToNew : 0;
-  }
-
-  /**
-   * \deprecated Use:
-   * bool open(SdBaseFile* dirFile, const char* path, uint8_t oflag);
-   * \param[in] dirFile An open SdFat instance for the directory containing the
-   * file to be opened.
-   * \param[in] path A path with a valid 8.3 DOS name for the file.
-   * \param[in] oflag Values for \a oflag are constructed by a bitwise-inclusive
-   * OR of flags O_READ, O_WRITE, O_TRUNC, and O_SYNC.
-   * \return true for success or false for failure.
-   */
-  bool open(SdBaseFile& dirFile, const char* path, uint8_t oflag) {
-    return open(&dirFile, path, oflag);
-  }
-
-  /**
-   * \deprecated  Do not use in new apps
-   * \param[in] dirFile An open SdFat instance for the directory containing the
-   * file to be opened.
-   * \param[in] path A path with a valid 8.3 DOS name for a file to be opened.
-   * \return true for success or false for failure.
-   */
-  bool open(SdBaseFile& dirFile, const char* path) {
-    return open(dirFile, path, O_RDWR);
-  }
-
-  /**
-   * \deprecated Use:
-   * bool open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag);
-   * \param[in] dirFile An open SdFat instance for the directory.
-   * \param[in] index The \a index of the directory entry for the file to be
-   * opened.  The value for \a index is (directory file position)/32.
-   * \param[in] oflag Values for \a oflag are constructed by a bitwise-inclusive
-   * OR of flags O_READ, O_WRITE, O_TRUNC, and O_SYNC.
-   * \return true for success or false for failure.
-   */
-  bool open(SdBaseFile& dirFile, uint16_t index, uint8_t oflag) {
-    return open(&dirFile, index, oflag);
-  }
-
-  /**
-   * \deprecated Use: bool openRoot(SdVolume* vol);
-   * \param[in] vol The FAT volume containing the root directory to be opened.
-   * \return true for success or false for failure.
-   */
-  bool openRoot(SdVolume& vol) { return openRoot(&vol); }
-
-  /**
-   * \deprecated Use: int8_t readDir(dir_t* dir);
-   * \param[out] dir The dir_t struct that will receive the data.
-   * \return bytes read for success zero for eof or -1 for failure.
-   */
-  int8_t readDir(dir_t& dir, char* longFilename) {
-    return readDir(&dir, longFilename);
-  }
-
-  /**
-   * \deprecated Use:
-   * static uint8_t remove(SdBaseFile* dirFile, const char* path);
-   * \param[in] dirFile The directory that contains the file.
-   * \param[in] path The name of the file to be removed.
-   * \return true for success or false for failure.
-   */
-  static bool remove(SdBaseFile& dirFile, const char* path) { return remove(&dirFile, path); }
-
- private:
-  static void (*oldDateTime_)(uint16_t &date, uint16_t &time);
-  static void oldToNew(uint16_t * const date, uint16_t * const time) {
-    uint16_t d, t;
-    oldDateTime_(d, t);
-    *date = d;
-    *time = t;
-  }
-#endif  // ALLOW_DEPRECATED_FUNCTIONS
 };
 
 #endif // _SDBASEFILE_H_

--- a/Marlin/SdFatConfig.h
+++ b/Marlin/SdFatConfig.h
@@ -62,11 +62,6 @@
 #define ENDL_CALLS_FLUSH 0
 
 /**
- * Allow use of deprecated functions if ALLOW_DEPRECATED_FUNCTIONS is nonzero
- */
-#define ALLOW_DEPRECATED_FUNCTIONS 1
-
-/**
  * Allow FAT12 volumes if FAT12_SUPPORT is nonzero.
  * FAT12 has not been well tested.
  */

--- a/Marlin/SdVolume.cpp
+++ b/Marlin/SdVolume.cpp
@@ -204,7 +204,7 @@ bool SdVolume::fatPut(uint32_t cluster, uint32_t value) {
     index &= 0x1FF;
     uint8_t tmp = value;
     if (cluster & 1) {
-      tmp = (cacheBuffer_.data[index] & 0XF) | tmp << 4;
+      tmp = (cacheBuffer_.data[index] & 0xF) | tmp << 4;
     }
     cacheBuffer_.data[index] = tmp;
     index++;

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -88,25 +88,25 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
   uint8_t cnt = 0;
 
   // Read the next entry from a directory
-  while (parent.readDir(p, longFilename) > 0) {
+  while (parent.readDir(&p, longFilename) > 0) {
 
     // If the entry is a directory and the action is LS_SerialPrint
     if (DIR_IS_SUBDIR(&p) && lsAction != LS_Count && lsAction != LS_GetFilename) {
 
       // Get the short name for the item, which we know is a folder
-      char lfilename[FILENAME_LENGTH];
-      createFilename(lfilename, p);
+      char dosFilename[FILENAME_LENGTH];
+      createFilename(dosFilename, p);
 
       // Allocate enough stack space for the full path to a folder, trailing slash, and nul
       bool prepend_is_empty = (prepend[0] == '\0');
-      int len = (prepend_is_empty ? 1 : strlen(prepend)) + strlen(lfilename) + 1 + 1;
+      int len = (prepend_is_empty ? 1 : strlen(prepend)) + strlen(dosFilename) + 1 + 1;
       char path[len];
 
       // Append the FOLDERNAME12/ to the passed string.
       // It contains the full path to the "parent" argument.
       // We now have the full path to the item in this folder.
       strcpy(path, prepend_is_empty ? "/" : prepend); // root slash if prepend is empty
-      strcat(path, lfilename); // FILENAME_LENGTH-1 characters maximum
+      strcat(path, dosFilename); // FILENAME_LENGTH-1 characters maximum
       strcat(path, "/");       // 1 character
 
       // Serial.print(path);
@@ -114,11 +114,11 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
       // Get a new directory object using the full path
       // and dive recursively into it.
       SdFile dir;
-      if (!dir.open(parent, lfilename, O_READ)) {
+      if (!dir.open(&parent, dosFilename, O_READ)) {
         if (lsAction == LS_SerialPrint) {
           SERIAL_ECHO_START();
           SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
-          SERIAL_ECHOLN(lfilename);
+          SERIAL_ECHOLN(dosFilename);
         }
       }
       lsDive(path, dir);
@@ -214,7 +214,7 @@ void CardReader::ls() {
 
       // Open the sub-item as the new dive parent
       SdFile dir;
-      if (!dir.open(diveDir, segment, O_READ)) {
+      if (!dir.open(&diveDir, segment, O_READ)) {
         SERIAL_EOL();
         SERIAL_ECHO_START();
         SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
@@ -237,11 +237,11 @@ void CardReader::ls() {
  */
 void CardReader::printFilename() {
   if (file.isOpen()) {
-    char lfilename[FILENAME_LENGTH];
-    file.getFilename(lfilename);
-    SERIAL_ECHO(lfilename);
+    char dosFilename[FILENAME_LENGTH];
+    file.getFilename(dosFilename);
+    SERIAL_ECHO(dosFilename);
     #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
-      getfilename(0, lfilename);
+      getfilename(0, dosFilename);
       if (longFilename[0]) {
         SERIAL_ECHO(' ');
         SERIAL_ECHO(longFilename);
@@ -262,16 +262,16 @@ void CardReader::initsd() {
     #define SPI_SPEED SPI_FULL_SPEED
   #endif
 
-  if (!card.init(SPI_SPEED, SDSS)
+  if (!sd2card.init(SPI_SPEED, SDSS)
     #if defined(LCD_SDSS) && (LCD_SDSS != SDSS)
-      && !card.init(SPI_SPEED, LCD_SDSS)
+      && !sd2card.init(SPI_SPEED, LCD_SDSS)
     #endif
   ) {
-    //if (!card.init(SPI_HALF_SPEED,SDSS))
+    //if (!sd2card.init(SPI_HALF_SPEED,SDSS))
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM(MSG_SD_INIT_FAIL);
   }
-  else if (!volume.init(&card)) {
+  else if (!volume.init(&sd2card)) {
     SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_SD_VOL_INIT_FAIL);
   }
@@ -285,17 +285,6 @@ void CardReader::initsd() {
     SERIAL_ECHOLNPGM(MSG_SD_CARD_OK);
   }
   setroot();
-}
-
-void CardReader::setroot() {
-  /*if (!workDir.openRoot(&volume)) {
-    SERIAL_ECHOLNPGM(MSG_SD_WORKDIR_FAIL);
-  }*/
-  workDir = root;
-  curDir = &workDir;
-  #if ENABLED(SDCARD_SORT_ALPHA)
-    presort();
-  #endif
 }
 
 void CardReader::release() {
@@ -335,9 +324,9 @@ void CardReader::stopSDPrint(
   #endif
 }
 
-void CardReader::openLogFile(char* name) {
+void CardReader::openLogFile(char * const path) {
   logging = true;
-  openFile(name, false);
+  openFile(path, false);
 }
 
 void appendAtom(SdFile &file, char *& dst, uint8_t &cnt) {
@@ -360,7 +349,7 @@ void CardReader::getAbsFilename(char *t) {
   *t = '\0';
 }
 
-void CardReader::openFile(char* name, const bool read, const bool subcall/*=false*/) {
+void CardReader::openFile(char * const path, const bool read, const bool subcall/*=false*/) {
 
   if (!cardOK) return;
 
@@ -380,7 +369,7 @@ void CardReader::openFile(char* name, const bool read, const bool subcall/*=fals
       filespos[file_subcall_ctr] = sdpos;
 
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR("SUBROUTINE CALL target:\"", name);
+      SERIAL_ECHOPAIR("SUBROUTINE CALL target:\"", path);
       SERIAL_ECHOPAIR("\" parent:\"", proc_filenames[file_subcall_ctr]);
       SERIAL_ECHOLNPAIR("\" pos", sdpos);
       file_subcall_ctr++;
@@ -401,48 +390,14 @@ void CardReader::openFile(char* name, const bool read, const bool subcall/*=fals
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Now ");
     serialprintPGM(doing == 1 ? PSTR("doing") : PSTR("fresh"));
-    SERIAL_ECHOLNPAIR(" file: ", name);
+    SERIAL_ECHOLNPAIR(" file: ", path);
   }
 
   stopSDPrint();
 
-  SdFile myDir;
-  curDir = &root;
-  char *fname = name;
-  char *dirname_start, *dirname_end;
-
-  if (name[0] == '/') {
-    dirname_start = &name[1];
-    while (dirname_start != NULL) {
-      dirname_end = strchr(dirname_start, '/');
-      //SERIAL_ECHOPGM("start:");SERIAL_ECHOLN((int)(dirname_start - name));
-      //SERIAL_ECHOPGM("end  :");SERIAL_ECHOLN((int)(dirname_end - name));
-      if (dirname_end != NULL && dirname_end > dirname_start) {
-        char subdirname[FILENAME_LENGTH];
-        strncpy(subdirname, dirname_start, dirname_end - dirname_start);
-        subdirname[dirname_end - dirname_start] = '\0';
-        if (!myDir.open(curDir, subdirname, O_READ)) {
-          SERIAL_PROTOCOLPAIR(MSG_SD_OPEN_FILE_FAIL, subdirname);
-          SERIAL_PROTOCOLCHAR('.');
-          return;
-        }
-        else {
-          //SERIAL_ECHOLNPGM("dive ok");
-        }
-
-        curDir = &myDir;
-        dirname_start = dirname_end + 1;
-      }
-      else { // the remainder after all /fsa/fdsa/ is the filename
-        fname = dirname_start;
-        //SERIAL_ECHOLNPGM("remainder");
-        //SERIAL_ECHOLN(fname);
-        break;
-      }
-    }
-  }
-  else
-    curDir = &workDir; // Relative paths start in current directory
+  SdFile *curDir;
+  const char * const fname = diveToFile(curDir, path, false);
+  if (!fname) return;
 
   if (read) {
     if (file.open(curDir, fname, O_READ)) {
@@ -472,7 +427,7 @@ void CardReader::openFile(char* name, const bool read, const bool subcall/*=fals
     }
     else {
       saving = true;
-      SERIAL_PROTOCOLLNPAIR(MSG_SD_WRITE_TO_FILE, name);
+      SERIAL_PROTOCOLLNPAIR(MSG_SD_WRITE_TO_FILE, path);
       lcd_setstatus(fname);
     }
   }
@@ -483,40 +438,9 @@ void CardReader::removeFile(const char * const name) {
 
   stopSDPrint();
 
-  SdFile myDir;
-  curDir = &root;
-  const char *fname = name;
-
-  char *dirname_start, *dirname_end;
-  if (name[0] == '/') {
-    dirname_start = strchr(name, '/') + 1;
-    while (dirname_start != NULL) {
-      dirname_end = strchr(dirname_start, '/');
-      //SERIAL_ECHOPGM("start:");SERIAL_ECHOLN((int)(dirname_start - name));
-      //SERIAL_ECHOPGM("end  :");SERIAL_ECHOLN((int)(dirname_end - name));
-      if (dirname_end != NULL && dirname_end > dirname_start) {
-        char subdirname[FILENAME_LENGTH];
-        strncpy(subdirname, dirname_start, dirname_end - dirname_start);
-        subdirname[dirname_end - dirname_start] = 0;
-        SERIAL_ECHOLN(subdirname);
-        if (!myDir.open(curDir, subdirname, O_READ)) {
-          SERIAL_PROTOCOLPAIR(MSG_SD_OPEN_FILE_FAIL, subdirname);
-          SERIAL_PROTOCOLCHAR('.');
-          SERIAL_EOL();
-          return;
-        }
-
-        curDir = &myDir;
-        dirname_start = dirname_end + 1;
-      }
-      else {
-        fname = dirname_start;
-        break;
-      }
-    }
-  }
-  else // Relative paths are rooted in the current directory
-    curDir = &workDir;
+  SdFile *curDir;
+  const char * const fname = diveToFile(curDir, name, false);
+  if (!fname) return;
 
   if (file.remove(curDir, fname)) {
     SERIAL_PROTOCOLPGM("File deleted:");
@@ -582,7 +506,7 @@ void CardReader::checkautostart() {
     sprintf_P(autoname, PSTR("auto%i.g"), autostart_index);
     dir_t p;
     root.rewind();
-    while (root.readDir(p, NULL) > 0) {
+    while (root.readDir(&p, NULL) > 0) {
       for (int8_t i = (int8_t)strlen((char*)p.name); i--;) p.name[i] = tolower(p.name[i]);
       if (p.name[9] != '~' && strncmp((char*)p.name, autoname, 5) == 0) {
         openAndPrintFile(autoname);
@@ -612,6 +536,7 @@ void CardReader::closefile(const bool store_location) {
 
 /**
  * Get the name of a file in the current directory by index
+ * with optional name to match.
  */
 void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/) {
   #if ENABLED(SDSORT_CACHE_NAMES)
@@ -628,41 +553,71 @@ void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/) {
       return;
     }
   #endif // SDSORT_CACHE_NAMES
-  curDir = &workDir;
   lsAction = LS_GetFilename;
   nrFile_index = nr;
-  curDir->rewind();
-  lsDive(NULL, *curDir, match);
+  workDir.rewind();
+  lsDive(NULL, workDir, match);
 }
 
 uint16_t CardReader::getnrfilenames() {
-  curDir = &workDir;
   lsAction = LS_Count;
   nrFiles = 0;
-  curDir->rewind();
-  lsDive(NULL, *curDir);
+  workDir.rewind();
+  lsDive(NULL, workDir);
   //SERIAL_ECHOLN(nrFiles);
   return nrFiles;
 }
 
+/**
+ * Dive to the given file path, with optional echo.
+ * On exit set curDir and return the name part of the path.
+ * A NULL result indicates an unrecoverable error.
+ */
+const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, const bool echo) {
+  SdFile myDir;
+  if (path[0] != '/') { curDir = &workDir; return path; }
+
+  curDir = &root;
+  const char *dirname_start = &path[1];
+  while (dirname_start) {
+    char * const dirname_end = strchr(dirname_start, '/');
+    if (dirname_end <= dirname_start) break;
+
+    char dosSubdirname[FILENAME_LENGTH];
+    const uint8_t len = dirname_end - dirname_start;
+    strncpy(dosSubdirname, dirname_start, len);
+    dosSubdirname[len] = 0;
+
+    if (echo) SERIAL_ECHOLN(dosSubdirname);
+
+    if (!myDir.open(curDir, dosSubdirname, O_READ)) {
+      SERIAL_PROTOCOLPAIR(MSG_SD_OPEN_FILE_FAIL, dosSubdirname);
+      SERIAL_PROTOCOLCHAR('.');
+      SERIAL_EOL();
+      return NULL;
+    }
+    curDir = &myDir;
+    dirname_start = dirname_end + 1;
+  }
+  return dirname_start;
+}
+
 void CardReader::chdir(const char * relpath) {
   SdFile newDir;
-  SdFile *parent = &root;
+  SdFile *parent = workDir.isOpen() ? &workDir : &root;
 
-  if (workDir.isOpen()) parent = &workDir;
-
-  if (!newDir.open(*parent, relpath, O_READ)) {
-    SERIAL_ECHO_START();
-    SERIAL_ECHOPGM(MSG_SD_CANT_ENTER_SUBDIR);
-    SERIAL_ECHOLN(relpath);
-  }
-  else {
+  if (newDir.open(parent, relpath, O_READ)) {
     workDir = newDir;
     if (workDirDepth < MAX_DIR_DEPTH)
       workDirParents[workDirDepth++] = workDir;
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif
+  }
+  else {
+    SERIAL_ECHO_START();
+    SERIAL_ECHOPGM(MSG_SD_CANT_ENTER_SUBDIR);
+    SERIAL_ECHOLN(relpath);
   }
 }
 
@@ -674,6 +629,16 @@ int8_t CardReader::updir() {
     #endif
   }
   return workDirDepth;
+}
+
+void CardReader::setroot() {
+  /*if (!workDir.openRoot(&volume)) {
+    SERIAL_ECHOLNPGM(MSG_SD_WORKDIR_FAIL);
+  }*/
+  workDir = root;
+  #if ENABLED(SDCARD_SORT_ALPHA)
+    presort();
+  #endif
 }
 
 #if ENABLED(SDCARD_SORT_ALPHA)

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -32,8 +32,6 @@
 #define MAX_DIR_DEPTH 10          // Maximum folder depth
 
 #include "SdFile.h"
-#include "types.h"
-#include "enum.h"
 
 class CardReader {
 public:
@@ -45,8 +43,8 @@ public:
   void beginautostart();
   void checkautostart();
 
-  void openFile(char* name, const bool read, const bool subcall=false);
-  void openLogFile(char* name);
+  void openFile(char * const path, const bool read, const bool subcall=false);
+  void openLogFile(char * const path);
   void removeFile(const char * const name);
   void closefile(const bool store_location=false);
   void release();
@@ -74,6 +72,8 @@ public:
   void chdir(const char *relpath);
   int8_t updir();
   void setroot();
+
+  const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo);
 
   uint16_t get_num_Files();
 
@@ -114,12 +114,12 @@ public:
     }
   #endif
 
+public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   int autostart_index;
-
 private:
-  SdFile root, *curDir, workDir, workDirParents[MAX_DIR_DEPTH];
+  SdFile root, workDir, workDirParents[MAX_DIR_DEPTH];
   uint8_t workDirDepth;
 
   // Sort files and folders alphabetically.
@@ -172,7 +172,7 @@ private:
 
   #endif // SDCARD_SORT_ALPHA
 
-  Sd2Card card;
+  Sd2Card sd2card;
   SdVolume volume;
   SdFile file;
 


### PR DESCRIPTION
Reduce SD code by dropping deprecated methods and combining common code in `diveToFile`.