### PR TITLE
[2.0.x][LPC176x][Build] Force single precision constants, disable freestanding

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
@@ -9,10 +9,10 @@ if __name__ == "__main__":
                     "-mcpu=cortex-m3",
                     "-mthumb",
 
-                    "-ffreestanding",
                     "-fsigned-char",
                     "-fno-move-loop-invariants",
                     "-fno-strict-aliasing",
+                    "-fsingle-precision-constant",
 
                     "--specs=nano.specs",
                     "--specs=nosys.specs",

--- a/platformio.ini
+++ b/platformio.ini
@@ -160,7 +160,7 @@ lib_extra_dirs    = frameworks
 lib_deps          = CMSIS-LPC1768
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMC2130Stepper@>=2.2.1
-extra_scripts     =  Marlin/src/HAL/HAL_LPC1768/debug_extra_script.py, Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+extra_scripts     = Marlin/src/HAL/HAL_LPC1768/debug_extra_script.py, Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter        = ${common.default_src_filter}
 monitor_speed     = 250000
 debug_tool        = custom

--- a/platformio.ini
+++ b/platformio.ini
@@ -160,28 +160,8 @@ lib_extra_dirs    = frameworks
 lib_deps          = CMSIS-LPC1768
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMC2130Stepper@>=2.2.1
-extra_scripts     = Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+extra_scripts     =  Marlin/src/HAL/HAL_LPC1768/debug_extra_script.py, Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter        = ${common.default_src_filter}
-monitor_speed     = 250000
-
-#
-# LPC1768 (for debugging and development)
-#
-[env:LPC1768_debug_and_upload]
-# Segger JLink
-platform          = nxplpc
-#framework        = mbed
-board             = lpc1768
-board_build.f_cpu = 100000000L
-build_flags       = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
-  ${common.build_flags}
-  -DU8G_HAL_LINKS
-lib_ldf_mode      = off
-lib_extra_dirs    = frameworks
-lib_deps          = CMSIS-LPC1768
-  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
-src_filter        = ${common.default_src_filter}
-extra_scripts     =  Marlin/src/HAL/HAL_LPC1768/debug_extra_script.py, Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
 monitor_speed     = 250000
 debug_tool        = custom
 debug_server      =


### PR DESCRIPTION
### Description
Updates the LPC176x build to force all double constants to be converted to float constants and disables the freestanding flag that disables builtins which are used for compile time evaluation (along with other things).

Also cleaned up platformio.ini to only include once section for LPC176x, removing the redundant LPC1768_debug_and_upload environment.

### Related Issues
#10859