### PR TITLE
[2.0.x] Workaround for a toolchain lacking precompiler trig

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1029,7 +1029,11 @@
 /**
  * XYZ Bed Skew Correction
  */
+
 #if ENABLED(SKEW_CORRECTION)
+  // If the toolchain's precompiler can't do trigonometry...
+  //#define RUNTIME_SKEW_CALCULATION
+
   #define SKEW_FACTOR_MIN -1
   #define SKEW_FACTOR_MAX 1
 
@@ -1038,34 +1042,28 @@
   #define _SKEW_FACTOR(a,b,c) _SKEW_SIDE(float(a),_GET_SIDE(float(a),float(b),float(c)),float(c))
 
   #ifndef XY_SKEW_FACTOR
-    constexpr float XY_SKEW_FACTOR = (
-      #if defined(XY_DIAG_AC) && defined(XY_DIAG_BD) && defined(XY_SIDE_AD)
-        _SKEW_FACTOR(XY_DIAG_AC, XY_DIAG_BD, XY_SIDE_AD)
-      #else
-        0.0
-      #endif
-    );
+    #if defined(XY_DIAG_AC) && defined(XY_DIAG_BD) && defined(XY_SIDE_AD)
+      #define XY_SKEW_FACTOR _SKEW_FACTOR(XY_DIAG_AC, XY_DIAG_BD, XY_SIDE_AD)
+    #else
+      #define XY_SKEW_FACTOR 0.0
+    #endif
   #endif
   #ifndef XZ_SKEW_FACTOR
     #if defined(XY_SIDE_AD) && !defined(XZ_SIDE_AD)
       #define XZ_SIDE_AD XY_SIDE_AD
     #endif
-    constexpr float XZ_SKEW_FACTOR = (
-      #if defined(XZ_DIAG_AC) && defined(XZ_DIAG_BD) && defined(XZ_SIDE_AD)
-        _SKEW_FACTOR(XZ_DIAG_AC, XZ_DIAG_BD, XZ_SIDE_AD)
-      #else
-        0.0
-      #endif
-    );
+    #if defined(XZ_DIAG_AC) && defined(XZ_DIAG_BD) && defined(XZ_SIDE_AD)
+      #define XZ_SKEW_FACTOR _SKEW_FACTOR(XZ_DIAG_AC, XZ_DIAG_BD, XZ_SIDE_AD)
+    #else
+      #define XZ_SKEW_FACTOR 0.0
+    #endif
   #endif
   #ifndef YZ_SKEW_FACTOR
-    constexpr float YZ_SKEW_FACTOR = (
-      #if defined(YZ_DIAG_AC) && defined(YZ_DIAG_BD) && defined(YZ_SIDE_AD)
-        _SKEW_FACTOR(YZ_DIAG_AC, YZ_DIAG_BD, YZ_SIDE_AD)
-      #else
-        0.0
-      #endif
-    );
+    #if defined(YZ_DIAG_AC) && defined(YZ_DIAG_BD) && defined(YZ_SIDE_AD)
+      #define YZ_SKEW_FACTOR _SKEW_FACTOR(YZ_DIAG_AC, YZ_DIAG_BD, YZ_SIDE_AD)
+    #else
+      #define YZ_SKEW_FACTOR 0.0
+    #endif
   #endif
 #endif // SKEW_CORRECTION
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -162,11 +162,15 @@ float Planner::min_feedrate_mm_s,
 #if ENABLED(SKEW_CORRECTION)
   #if ENABLED(SKEW_CORRECTION_GCODE)
     float Planner::xy_skew_factor;
+  #elif ENABLED(RUNTIME_SKEW_CALCULATION)
+    const float Planner::xy_skew_factor = XY_SKEW_FACTOR;
   #else
     constexpr float Planner::xy_skew_factor;
   #endif
   #if ENABLED(SKEW_CORRECTION_FOR_Z) && ENABLED(SKEW_CORRECTION_GCODE)
     float Planner::xz_skew_factor, Planner::yz_skew_factor;
+  #elif ENABLED(RUNTIME_SKEW_CALCULATION)
+    const float Planner::xz_skew_factor = XZ_SKEW_FACTOR, Planner::yz_skew_factor = YZ_SKEW_FACTOR;
   #else
     constexpr float Planner::xz_skew_factor, Planner::yz_skew_factor;
   #endif

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -233,12 +233,16 @@ class Planner {
     #if ENABLED(SKEW_CORRECTION)
       #if ENABLED(SKEW_CORRECTION_GCODE)
         static float xy_skew_factor;
+      #elif ENABLED(RUNTIME_SKEW_CALCULATION)
+        static const float xy_skew_factor;
       #else
         static constexpr float xy_skew_factor = XY_SKEW_FACTOR;
       #endif
       #if ENABLED(SKEW_CORRECTION_FOR_Z)
         #if ENABLED(SKEW_CORRECTION_GCODE)
           static float xz_skew_factor, yz_skew_factor;
+        #elif ENABLED(RUNTIME_SKEW_CALCULATION)
+          static const float xz_skew_factor, yz_skew_factor;
         #else
           static constexpr float xz_skew_factor = XZ_SKEW_FACTOR, yz_skew_factor = YZ_SKEW_FACTOR;
         #endif


### PR DESCRIPTION
Addressing #10859

Some toolchains might use a version of GCC that can't precompute trigonometric functions. This PR adds a flag that defers computation until runtime.