### PR TITLE
[1.1.x] DRAFT: Fix/Improve junction deviation

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -278,7 +278,9 @@
 #elif defined(JUNCTION_DEVIATION_FACTOR)
   #error "JUNCTION_DEVIATION_FACTOR is now JUNCTION_DEVIATION_MM. Please update your configuration."
 #elif defined(JUNCTION_ACCELERATION_FACTOR)
-  #error "JUNCTION_ACCELERATION_FACTOR is now JUNCTION_ACCELERATION. Please update your configuration."
+  #error "JUNCTION_ACCELERATION_FACTOR is obsolete. Delete it from Configuration_adv.h."
+#elif defined(JUNCTION_ACCELERATION)
+  #error "JUNCTION_ACCELERATION is obsolete. Delete it from Configuration_adv.h."
 #endif
 
 #define BOARD_MKS_13     -47

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
@@ -450,7 +450,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -454,7 +454,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -2148,11 +2148,22 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       }
       else {
         NOLESS(junction_cos_theta, -0.999999); // Check for numerical round-off to avoid divide by zero.
-        const float sin_theta_d2 = SQRT(0.5 * (1.0 - junction_cos_theta)); // Trig half angle identity. Always positive.
 
-        // TODO: Technically, the acceleration used in calculation needs to be limited by the minimum of the
-        // two junctions. However, this shouldn't be a significant problem except in extreme circumstances.
-        vmax_junction_sqr = (JUNCTION_ACCELERATION * JUNCTION_DEVIATION_MM * sin_theta_d2) / (1.0 - sin_theta_d2);
+        float junction_unit_vec[JD_AXES] = {
+          unit_vec[X_AXIS] - previous_unit_vec[X_AXIS],
+          unit_vec[Y_AXIS] - previous_unit_vec[Y_AXIS],
+          unit_vec[Z_AXIS] - previous_unit_vec[Z_AXIS]
+          #if ENABLED(JUNCTION_DEVIATION_INCLUDE_E)
+            , unit_vec[E_AXIS] - previous_unit_vec[E_AXIS]
+          #endif
+        };
+        // Convert delta vector to unit vector
+        normalize_junction_vector(junction_unit_vec);
+
+        const float junction_acceleration = limit_value_by_axis_maximum(block->acceleration, junction_unit_vec),
+                    sin_theta_d2 = SQRT(0.5 * (1.0 - junction_cos_theta)); // Trig half angle identity. Always positive.
+
+        vmax_junction_sqr = (junction_acceleration * JUNCTION_DEVIATION_MM * sin_theta_d2) / (1.0 - sin_theta_d2);
         if (block->millimeters < 1.0) {
 
           // Fast acos approximation, minus the error bar to be safe
@@ -2160,7 +2171,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
           // If angle is greater than 135 degrees (octagon), find speed for approximate arc
           if (junction_theta > RADIANS(135)) {
-            const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * JUNCTION_ACCELERATION;
+            const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
             NOMORE(vmax_junction_sqr, limit_sqr);
           }
         }

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -788,6 +788,30 @@ class Planner {
     static void recalculate_trapezoids();
 
     static void recalculate();
+
+    #if ENABLED(JUNCTION_DEVIATION)
+
+      #if ENABLED(JUNCTION_DEVIATION_INCLUDE_E)
+        #define JD_AXES XYZE
+      #else
+        #define JD_AXES XYZ
+      #endif
+
+      FORCE_INLINE static void normalize_junction_vector(float (&vector)[JD_AXES]) {
+        float magnitude_sq = 0.0;
+        for (uint8_t idx = 0; idx < JD_AXES; idx++) if (vector[idx]) magnitude_sq += sq(vector[idx]);
+        const float inv_magnitude = 1.0 / SQRT(magnitude_sq);
+        for (uint8_t idx = 0; idx < JD_AXES; idx++) vector[idx] *= inv_magnitude;
+      }
+
+      FORCE_INLINE static float limit_value_by_axis_maximum(const float &max_value, float (&unit_vec)[JD_AXES]) {
+        float limit_value = max_value;
+        for (uint8_t idx = 0; idx < JD_AXES; idx++) if (unit_vec[idx]) // Avoid divide by zero
+          NOMORE(limit_value, ABS(max_acceleration_mm_per_s2[idx] / unit_vec[idx]));
+        return limit_value;
+      }
+
+    #endif // JUNCTION_DEVIATION
 };
 
 #define PLANNER_XY_FEEDRATE() (MIN(planner.max_feedrate_mm_s[X_AXIS], planner.max_feedrate_mm_s[Y_AXIS]))


### PR DESCRIPTION
This is a quick but fully working draft to fix the issue that junction deviation code is ignoring heavy or slow axis limitations.

Due to `junction_unit_vec`, it also solves the long-standing issue that (for example on Z-hops), the exit speed of the move is forced to the much too high jerk speed value of the next travel move.

One other point has to be discussed. By default, this code excludes the E-axis from the vector calculations, but on the other hand it's part is always included in values like `inverse_millimeters`. Also E-only moves has to be handled by this code. Therefore, my vote would be to remove the `JUNCTION_DEVIATION_INCLUDE_E` option completely, always enabling it. For printing moves, the effect is negligible as the e portion is tiny.

See #9917 for details. This is based on the latest GRBL code 1.1 (https://github.com/gnea/grbl).
Mentioning @thinkyhead, @Squid116.

Counterpart to #10910