### PR TITLE
[2.0.x][LPC176x] Fix PIO build flags

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
@@ -50,7 +50,6 @@ else:
       LINKFLAGS=[
           "-Os",
           "-mcpu=cortex-m3",
-          "-ffreestanding",
           "-mthumb",
           "--specs=nano.specs",
           "--specs=nosys.specs",


### PR DESCRIPTION
Don't build and link with different flags, the binary may not work.