### PR TITLE
[2.0.x] Fix / improve junction deviation

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/TheBorg/Configuration_adv.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -450,7 +450,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -454,7 +454,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -449,7 +449,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -447,7 +447,6 @@
 //#define JUNCTION_DEVIATION
 #if ENABLED(JUNCTION_DEVIATION)
   #define JUNCTION_DEVIATION_MM 0.02  // (mm) Distance from real junction edge
-  #define JUNCTION_ACCELERATION 1000  // (mm/s²) Maximum centripetal acceleration
   //#define JUNCTION_DEVIATION_INCLUDE_E
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -278,7 +278,9 @@
 #elif defined(JUNCTION_DEVIATION_FACTOR)
   #error "JUNCTION_DEVIATION_FACTOR is now JUNCTION_DEVIATION_MM. Please update your configuration."
 #elif defined(JUNCTION_ACCELERATION_FACTOR)
-  #error "JUNCTION_ACCELERATION_FACTOR is now JUNCTION_ACCELERATION. Please update your configuration."
+  #error "JUNCTION_ACCELERATION_FACTOR is obsolete. Delete it from Configuration_adv.h."
+#elif defined(JUNCTION_ACCELERATION)
+  #error "JUNCTION_ACCELERATION is obsolete. Delete it from Configuration_adv.h."
 #endif
 
 #define BOARD_MKS_13     -47

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2166,11 +2166,22 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       }
       else {
         NOLESS(junction_cos_theta, -0.999999); // Check for numerical round-off to avoid divide by zero.
-        const float sin_theta_d2 = SQRT(0.5 * (1.0 - junction_cos_theta)); // Trig half angle identity. Always positive.
 
-        // TODO: Technically, the acceleration used in calculation needs to be limited by the minimum of the
-        // two junctions. However, this shouldn't be a significant problem except in extreme circumstances.
-        vmax_junction_sqr = (JUNCTION_ACCELERATION * JUNCTION_DEVIATION_MM * sin_theta_d2) / (1.0 - sin_theta_d2);
+        float junction_unit_vec[JD_AXES] = {
+          unit_vec[X_AXIS] - previous_unit_vec[X_AXIS],
+          unit_vec[Y_AXIS] - previous_unit_vec[Y_AXIS],
+          unit_vec[Z_AXIS] - previous_unit_vec[Z_AXIS]
+          #if ENABLED(JUNCTION_DEVIATION_INCLUDE_E)
+            , unit_vec[E_AXIS] - previous_unit_vec[E_AXIS]
+          #endif
+        };
+        // Convert delta vector to unit vector
+        normalize_junction_vector(junction_unit_vec);
+
+        const float junction_acceleration = limit_value_by_axis_maximum(block->acceleration, junction_unit_vec),
+                    sin_theta_d2 = SQRT(0.5 * (1.0 - junction_cos_theta)); // Trig half angle identity. Always positive.
+
+        vmax_junction_sqr = (junction_acceleration * JUNCTION_DEVIATION_MM * sin_theta_d2) / (1.0 - sin_theta_d2);
         if (block->millimeters < 1.0) {
 
           // Fast acos approximation, minus the error bar to be safe
@@ -2178,7 +2189,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
           // If angle is greater than 135 degrees (octagon), find speed for approximate arc
           if (junction_theta > RADIANS(135)) {
-            const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * JUNCTION_ACCELERATION;
+            const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
             NOMORE(vmax_junction_sqr, limit_sqr);
           }
         }

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -802,6 +802,29 @@ class Planner {
 
     static void recalculate();
 
+    #if ENABLED(JUNCTION_DEVIATION)
+
+      #if ENABLED(JUNCTION_DEVIATION_INCLUDE_E)
+        #define JD_AXES XYZE
+      #else
+        #define JD_AXES XYZ
+      #endif
+
+      FORCE_INLINE static void normalize_junction_vector(float (&vector)[JD_AXES]) {
+        float magnitude_sq = 0.0;
+        for (uint8_t idx = 0; idx < JD_AXES; idx++) if (vector[idx]) magnitude_sq += sq(vector[idx]);
+        const float inv_magnitude = 1.0 / SQRT(magnitude_sq);
+        for (uint8_t idx = 0; idx < JD_AXES; idx++) vector[idx] *= inv_magnitude;
+      }
+
+      FORCE_INLINE static float limit_value_by_axis_maximum(const float &max_value, float (&unit_vec)[JD_AXES]) {
+        float limit_value = max_value;
+        for (uint8_t idx = 0; idx < JD_AXES; idx++) if (unit_vec[idx]) // Avoid divide by zero
+          NOMORE(limit_value, ABS(max_acceleration_mm_per_s2[idx] / unit_vec[idx]));
+        return limit_value;
+      }
+
+    #endif // JUNCTION_DEVIATION
 };
 
 #define PLANNER_XY_FEEDRATE() (MIN(planner.max_feedrate_mm_s[X_AXIS], planner.max_feedrate_mm_s[Y_AXIS]))


### PR DESCRIPTION
Based on #10906 by @Sebastianv650 

---
This is a quick but fully working draft to fix the issue that junction deviation code is ignoring heavy or slow axis limitations.
Due to `junction_unit_vec`, it also solves the long-standing issue that (for example on Z-hops), the exit speed of the move is forced to the much too high jerk speed value of the next travel move.

One other point has to be discussed. By default, this code excludes the E-axis from the vector calculations, but on the other hand it's part is always included in values like `inverse_millimeters`. Also E-only moves has to be handled by this code. Therefore, my vote would be to remove the `JUNCTION_DEVIATION_INCLUDE_E` option completely, always enabling it. For printing moves, the effect is negligible as the e portion is tiny.

See #9917 for details. This is based on the latest GRBL code 1.1 (https://github.com/gnea/grbl).