### PR TITLE
[2.0.x] Smart Homing and Smart Auto-Level

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -68,6 +68,8 @@
  *
  * Enhanced G29 Auto Bed Leveling Probe Routine
  *
+ *  O  Auto-level only if needed
+ *
  *  D  Dry-Run mode. Just evaluate the bed Topology - Don't apply
  *     or alter the bed level data. Useful to check the topology
  *     after a first run of G29.
@@ -174,6 +176,15 @@ void GcodeSuite::G29() {
   // Don't allow auto-leveling without homing first
   if (axis_unhomed_error()) return;
 
+  if (!no_action && planner.leveling_active && parser.boolval('O')) { // Auto-level only if needed
+    #if ENABLED(DEBUG_LEVELING_FEATURE)
+      if (DEBUGGING(LEVELING)) {
+        SERIAL_ECHOLNPGM("> Auto-level not needed, skip");
+        SERIAL_ECHOLNPGM("<<< G29");
+      }
+    #endif
+    return;
+  }
   // Define local vars 'static' for manual probing, 'auto' otherwise
   #if ENABLED(PROBE_MANUALLY)
     #define ABL_VAR static

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -152,6 +152,8 @@
  *  None  Home to all axes with no parameters.
  *        With QUICK_HOME enabled XY will home together, then Z.
  *
+ *  O   Home only if postion is unknown
+ *
  *  Rn  Raise by n mm/inches before homing
  *
  * Cartesian/SCARA parameters
@@ -170,6 +172,16 @@ void GcodeSuite::G28(const bool always_home_all) {
     }
   #endif
 
+  if ((axis_known_position[X_AXIS] && axis_known_position[Y_AXIS] && axis_known_position[Z_AXIS]) && parser.boolval('O')) { // home only if needed
+    #if ENABLED(DEBUG_LEVELING_FEATURE)
+      if (DEBUGGING(LEVELING)) {
+        SERIAL_ECHOLNPGM("> homing not needed, skip");
+        SERIAL_ECHOLNPGM("<<< G28");
+      }
+    #endif
+    return;
+  }
+  
   // Wait for planner moves to finish!
   planner.synchronize();
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -152,7 +152,7 @@
  *  None  Home to all axes with no parameters.
  *        With QUICK_HOME enabled XY will home together, then Z.
  *
- *  O   Home only if postion is unknown
+ *  O   Home only if position is unknown
  *
  *  Rn  Raise by n mm/inches before homing
  *


### PR DESCRIPTION
The pull request adds new options to the gcode commands G28 and G29.  

New options:
G28 O - Only perform homing if needed.
G29 O - Only perform auto-level if needed.

There is no change to the behavior of G28 and G29 if the new 'O' option is not used.

If the O option is specified for G28 the axis will be homed as usual if any of the axis positions are unknown.  If axis positions are known homing will be skipped.

If the O option is specified for G29 and leveling is deactivated the auto-level routine will be performed as usual.  If leveling is already activated re-leveling of the bed skipped.

The idea behind this is to speed up printing repeated prints or prints that have been canceled and quickly restarted.

Prior discussion on the new feature #10894 
