### PR TITLE
[1.1.x] Bugfix for buffer-overflow in cardreader

### DIFF
--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -581,10 +581,9 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
   const char *dirname_start = &path[1];
   while (dirname_start) {
     char * const dirname_end = strchr(dirname_start, '/');
-    if (dirname_end <= dirname_start) break;
-
-    char dosSubdirname[FILENAME_LENGTH];
-    const uint8_t len = dirname_end - dirname_start;
+    const int8_t len = dirname_end - dirname_start;
+    if (len <= 0) break;
+    char dosSubdirname[len + 1];
     strncpy(dosSubdirname, dirname_start, len);
     dosSubdirname[len] = 0;
 


### PR DESCRIPTION
### Description

In `CardReader::diveToFile`, the calculated `len` (length of the directory name) is not validated before being used to `strncpy` the directory name to the array of fixed size `dosSubdirname[FILENAME_LENGTH]`. 

For overly long directory names, this results in a buffer-overflow which can be triggered by several SD card related G-Code instructions. 

The same issue applies to the 2.0.x branch of Marlin.

### Benefits

The error can be prevented by checking the resulting length of the directory name.