### PR TITLE
[2.0.x] Fix compile warning

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
@@ -75,7 +75,7 @@
 #define ST7565_V0_RATIO(N)       (0x20 | ((N) & 0x7))
 #define ST7565_CONTRAST(N)       (0x81), (N)
 
-#define ST7565_COLUMN_ADR(N)     (0x10 | (((N) >> 4) & 0xF)), (0x00 | ((N) & 0xF))
+#define ST7565_COLUMN_ADR(N)     (0x10 | (((N) >> 4) & 0xF)), ((N) & 0xF)
 #define ST7565_PAGE_ADR(N)       (0xB0 | (N))
 #define ST7565_START_LINE(N)     (0x40 | (N))
 #define ST7565_SLEEP_MODE()      (0xAC)

--- a/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7565_64128n_HAL.cpp
@@ -75,7 +75,7 @@
 #define ST7565_V0_RATIO(N)       (0x20 | ((N) & 0x7))
 #define ST7565_CONTRAST(N)       (0x81), (N)
 
-#define ST7565_COLUMN_ADR(N)     (0x10 | ((N) >> 4) & 0xF), (0x00 | ((N) & 0xF))
+#define ST7565_COLUMN_ADR(N)     (0x10 | (((N) >> 4) & 0xF)), (0x00 | ((N) & 0xF))
 #define ST7565_PAGE_ADR(N)       (0xB0 | (N))
 #define ST7565_START_LINE(N)     (0x40 | (N))
 #define ST7565_SLEEP_MODE()      (0xAC)


### PR DESCRIPTION
This will fix compile warning:

> suggest parentheses around arithmetic in operand of '|' [-Wparentheses]