### PR TITLE
[2.0.x] Correct PROGMEM on DFU-equiped AT90USB boards

### DIFF
--- a/buildroot/share/PlatformIO/boards/at90USB1286.json
+++ b/buildroot/share/PlatformIO/boards/at90USB1286.json
@@ -11,7 +11,7 @@
   "name": "at90USB1286.json",
   "upload": {
     "maximum_ram_size": 8192,
-    "maximum_size": 130048,
+    "maximum_size": 122880,
     "require_upload_port": true,
     "protocol": ""
   },


### PR DESCRIPTION
Prevents possible overwrite of bootloader on DFU-equipped AT90USB boards.

130048 is available on genuine Teensy2.0++ with Paul's "Halfkay" bootloader.  Atmel DFU-equiped boards have only 122880 available.