### PR TITLE
[2.0.x] More concise M503 output for TMC commands

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1896,12 +1896,12 @@ void MarlinSettings::reset(PORTARG_SOLO) {
   #define CONFIG_ECHO_START do{ if (!forReplay) SERIAL_ECHO_START_P(port); }while(0)
 
   #if HAS_TRINAMIC
-    void say_M906(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M906 "); }
+    void say_M906(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M906"); }
     #if ENABLED(HYBRID_THRESHOLD)
-      void say_M913(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M913 "); }
+      void say_M913(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M913"); }
     #endif
     #if ENABLED(SENSORLESS_HOMING)
-      void say_M914(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M914 "); }
+      void say_M914(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M914"); }
     #endif
   #endif
 
@@ -2409,49 +2409,56 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOLNPGM_P(port, "Stepper driver current:");
       }
       CONFIG_ECHO_START;
-      #if X_IS_TRINAMIC
+      #if X_IS_TRINAMIC || Y_IS_TRINAMIC || Z_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "X", stepperX.getCurrent());
       #endif
-      #if X2_IS_TRINAMIC
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "I1 X", stepperX2.getCurrent());
+      #if X_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " X", stepperX.getCurrent());
       #endif
       #if Y_IS_TRINAMIC
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "Y", stepperY.getCurrent());
-      #endif
-      #if Y2_IS_TRINAMIC
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "I1 Y", stepperY2.getCurrent());
+        SERIAL_ECHOPAIR_P(port, " Y", stepperY.getCurrent());
       #endif
       #if Z_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Z", stepperZ.getCurrent());
+      #endif
+      #if X_IS_TRINAMIC || Y_IS_TRINAMIC || Z_IS_TRINAMIC
+        SERIAL_EOL_P(port);
+      #endif
+      #if X2_IS_TRINAMIC || Y2_IS_TRINAMIC || Z2_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "Z", stepperZ.getCurrent());
+        SERIAL_ECHOPGM_P(port, " I1");
+      #endif
+      #if X2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " X", stepperX2.getCurrent());
+      #endif
+      #if Y2_IS_TRINAMIC
+        SERIAL_ECHOPAIR_P(port, " Y", stepperY2.getCurrent());
       #endif
       #if Z2_IS_TRINAMIC
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "I1 Z", stepperZ2.getCurrent());
+        SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.getCurrent());
+      #endif
+      #if X2_IS_TRINAMIC || Y2_IS_TRINAMIC || Z2_IS_TRINAMIC
+        SERIAL_EOL_P(port);
       #endif
       #if E0_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "T0 E", stepperE0.getCurrent());
+        SERIAL_ECHOLNPAIR_P(port, " T0 E", stepperE0.getCurrent());
       #endif
       #if E_STEPPERS > 1 && E1_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "T1 E", stepperE1.getCurrent());
+        SERIAL_ECHOLNPAIR_P(port, " T1 E", stepperE1.getCurrent());
       #endif
       #if E_STEPPERS > 2 && E2_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "T2 E", stepperE2.getCurrent());
+        SERIAL_ECHOLNPAIR_P(port, " T2 E", stepperE2.getCurrent());
       #endif
       #if E_STEPPERS > 3 && E3_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "T3 E", stepperE3.getCurrent());
+        SERIAL_ECHOLNPAIR_P(port, " T3 E", stepperE3.getCurrent());
       #endif
       #if E_STEPPERS > 4 && E4_IS_TRINAMIC
         say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, "T4 E", stepperE4.getCurrent());
+        SERIAL_ECHOLNPAIR_P(port, " T4 E", stepperE4.getCurrent());
       #endif
       SERIAL_EOL_P(port);
 
@@ -2464,49 +2471,56 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           SERIAL_ECHOLNPGM_P(port, "Hybrid Threshold:");
         }
         CONFIG_ECHO_START;
-        #if X_IS_TRINAMIC
+        #if X_IS_TRINAMIC || Y_IS_TRINAMIC || Z_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "X", TMC_GET_PWMTHRS(X, X));
         #endif
-        #if X2_IS_TRINAMIC
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "I1 X", TMC_GET_PWMTHRS(X, X2));
+        #if X_IS_TRINAMIC
+          SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X));
         #endif
         #if Y_IS_TRINAMIC
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "Y", TMC_GET_PWMTHRS(Y, Y));
-        #endif
-        #if Y2_IS_TRINAMIC
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "I1 Y", TMC_GET_PWMTHRS(Y, Y2));
+          SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y));
         #endif
         #if Z_IS_TRINAMIC
+          SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z));
+        #endif
+        #if X_IS_TRINAMIC || Y_IS_TRINAMIC || Z_IS_TRINAMIC
+          SERIAL_EOL_P(port);
+        #endif
+        #if X2_IS_TRINAMIC || Y2_IS_TRINAMIC || Z2_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "Z", TMC_GET_PWMTHRS(Z, Z));
+          SERIAL_ECHOPGM_P(port, " I1");
+        #endif
+        #if X2_IS_TRINAMIC
+          SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X2));
+        #endif
+        #if Y2_IS_TRINAMIC
+          SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y2));
         #endif
         #if Z2_IS_TRINAMIC
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "I1 Z", TMC_GET_PWMTHRS(Z, Z2));
+          SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z2));
+        #endif
+        #if X2_IS_TRINAMIC || Y2_IS_TRINAMIC || Z2_IS_TRINAMIC
+          SERIAL_EOL_P(port);
         #endif
         #if E0_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "T0 E", TMC_GET_PWMTHRS(E, E0));
+          SERIAL_ECHOLNPAIR_P(port, " T0 E", TMC_GET_PWMTHRS(E, E0));
         #endif
         #if E_STEPPERS > 1 && E1_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "T1 E", TMC_GET_PWMTHRS(E, E1));
+          SERIAL_ECHOLNPAIR_P(port, " T1 E", TMC_GET_PWMTHRS(E, E1));
         #endif
         #if E_STEPPERS > 2 && E2_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "T2 E", TMC_GET_PWMTHRS(E, E2));
+          SERIAL_ECHOLNPAIR_P(port, " T2 E", TMC_GET_PWMTHRS(E, E2));
         #endif
         #if E_STEPPERS > 3 && E3_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "T3 E", TMC_GET_PWMTHRS(E, E3));
+          SERIAL_ECHOLNPAIR_P(port, " T3 E", TMC_GET_PWMTHRS(E, E3));
         #endif
         #if E_STEPPERS > 4 && E4_IS_TRINAMIC
           say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, "T4 E", TMC_GET_PWMTHRS(E, E4));
+          SERIAL_ECHOLNPAIR_P(port, " T4 E", TMC_GET_PWMTHRS(E, E4));
         #endif
         SERIAL_EOL_P(port);
       #endif // HYBRID_THRESHOLD
@@ -2520,38 +2534,42 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           SERIAL_ECHOLNPGM_P(port, "Sensorless homing threshold:");
         }
         CONFIG_ECHO_START;
-        #ifdef X_HOMING_SENSITIVITY
-          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-            say_M914(PORTVAR_SOLO);
-            SERIAL_ECHOLNPAIR_P(port, "X", stepperX.sgt());
+        #define HAS_X_SENSORLESS (defined(X_HOMING_SENSITIVITY) && (ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)))
+        #define HAS_Y_SENSORLESS (defined(Y_HOMING_SENSITIVITY) && (ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)))
+        #define HAS_Z_SENSORLESS (defined(Z_HOMING_SENSITIVITY) && (ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)))
+        #if HAS_X_SENSORLESS || HAS_Y_SENSORLESS || HAS_Z_SENSORLESS
+          say_M914(PORTVAR_SOLO);
+          #if HAS_X_SENSORLESS
+            SERIAL_ECHOPAIR_P(port, " X", stepperX.sgt());
           #endif
-          #if ENABLED(X2_IS_TMC2130)
-            say_M914(PORTVAR_SOLO);
-            SERIAL_ECHOLNPAIR_P(port, "I1 X", stepperX2.sgt());
+          #if HAS_Y_SENSORLESS
+            SERIAL_ECHOPAIR_P(port, " Y", stepperY.sgt());
           #endif
+          #if HAS_Z_SENSORLESS
+            SERIAL_ECHOPAIR_P(port, " Z", stepperZ.sgt());
+          #endif
+          SERIAL_EOL_P(port);
         #endif
-        #ifdef Y_HOMING_SENSITIVITY
-          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-            say_M914(PORTVAR_SOLO);
-            SERIAL_ECHOLNPAIR_P(port, "Y", stepperY.sgt());
+
+        #define HAS_X2_SENSORLESS (defined(X_HOMING_SENSITIVITY) && ENABLED(X2_IS_TMC2130))
+        #define HAS_Y2_SENSORLESS (defined(Y_HOMING_SENSITIVITY) && ENABLED(Y2_IS_TMC2130))
+        #define HAS_Z2_SENSORLESS (defined(Z_HOMING_SENSITIVITY) && ENABLED(Z2_IS_TMC2130))
+        #if HAS_X2_SENSORLESS || HAS_Y2_SENSORLESS || HAS_Z2_SENSORLESS
+          say_M914(PORTVAR_SOLO);
+          SERIAL_ECHOPGM_P(port, " I1");
+          #if HAS_X2_SENSORLESS
+            SERIAL_ECHOPAIR_P(port, " X", stepperX2.sgt());
           #endif
-          #if ENABLED(Y2_IS_TMC2130)
-            say_M914(PORTVAR_SOLO);
-            SERIAL_ECHOLNPAIR_P(port, "I1 Y", stepperY2.sgt());
+          #if HAS_Y2_SENSORLESS
+            SERIAL_ECHOPAIR_P(port, " Y", stepperY2.sgt());
           #endif
+          #if HAS_Z2_SENSORLESS
+            SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.sgt());
+          #endif
+          SERIAL_EOL_P(port);
         #endif
-        #ifdef Z_HOMING_SENSITIVITY
-          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-            say_M914(PORTVAR_SOLO);
-            SERIAL_ECHOLNPAIR_P(port, "Z", stepperZ.sgt());
-          #endif
-          #if ENABLED(Z2_IS_TMC2130)
-            say_M914(PORTVAR_SOLO);
-            SERIAL_ECHOLNPAIR_P(port, "I1 Z", stepperZ2.sgt());
-          #endif
-        #endif
-        SERIAL_EOL_P(port);
-      #endif
+
+      #endif // SENSORLESS_HOMING
 
     #endif // HAS_TRINAMIC
 


### PR DESCRIPTION
Combine XYZ axes where possible in the `M503` report for `M906`, `M913`, and `M914`.

Counterpart to #10945