### PR TITLE
[2.0.x] Easier FAN_PIN override, pins cleanup

### DIFF
--- a/Marlin/src/pins/pins_5DPRINT.h
+++ b/Marlin/src/pins/pins_5DPRINT.h
@@ -132,7 +132,9 @@
 #define HEATER_0_PIN       15   // C5
 #define HEATER_BED_PIN     14   // C4
 
-#define FAN_PIN            16   // C6  PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6  PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_ALLIGATOR_R2.h
+++ b/Marlin/src/pins/pins_ALLIGATOR_R2.h
@@ -107,7 +107,9 @@
 #define HEATER_3_PIN          97   // PC20 on piggy
 #define HEATER_BED_PIN        69   // PA0
 
-#define FAN_PIN               92   // PA5
+#ifndef FAN_PIN
+  #define FAN_PIN             92   // PA5
+#endif
 #define FAN1_PIN              31   // PA7
 
 //

--- a/Marlin/src/pins/pins_ANET_10.h
+++ b/Marlin/src/pins/pins_ANET_10.h
@@ -133,7 +133,10 @@
 //
 #define HEATER_0_PIN       13   // (extruder)
 #define HEATER_BED_PIN     12   // (bed)
-#define FAN_PIN             4
+
+#ifndef FAN_PIN
+  #define FAN_PIN           4
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_ARCHIM2.h
+++ b/Marlin/src/pins/pins_ARCHIM2.h
@@ -148,7 +148,9 @@
 //
 // Heaters / Fans
 //
-#define FAN_PIN             4   // D4 PC26 FET_PWM1
+#ifndef FAN_PIN
+  #define FAN_PIN           4   // D4 PC26 FET_PWM1
+#endif
 #define FAN1_PIN            5   // D5 PC25 FET_PWM2
 
 #define HEATER_0_PIN        6   // D6 PC24 FET_PWM3

--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -82,7 +82,9 @@
 // EFB
 #define HEATER_0_PIN       P2_04
 #define HEATER_BED_PIN     P2_05
-#define FAN_PIN            P2_07
+#ifndef FAN_PIN
+  #define FAN_PIN          P2_07
+#endif
 #define FAN1_PIN           P0_26
 
 #if ENABLED(AZSMZ_12864)

--- a/Marlin/src/pins/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/src/pins/pins_AZTEEG_X3_PRO.h
@@ -24,21 +24,28 @@
  * AZTEEG_X3_PRO (Arduino Mega) pin assignments
  */
 
+#ifndef __AVR_ATmega2560__
+  #error "Oops! Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu."
+#endif
+
 #if HOTENDS > 5 || E_STEPPERS > 5
   #error "Azteeg X3 Pro supports up to 5 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT)
-  #define CASE_LIGHT_PIN 44     // Define before RAMPS pins include
-#endif
-
 #define BOARD_NAME "Azteeg X3 Pro"
 
-#include "pins_RAMPS.h"
-
-#ifndef __AVR_ATmega2560__
-  #error "Oops! Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu."
+//
+// RAMPS pins overrides
+//
+#if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT)
+  #define CASE_LIGHT_PIN   44
 #endif
+
+#ifndef FAN_PIN
+  #define FAN_PIN           6
+#endif
+
+#include "pins_RAMPS.h"
 
 // DIGIPOT slave addresses
 #define DIGIPOT_I2C_ADDRESS_A 0x2C   // unshifted slave address for first DIGIPOT 0x2C (0x58 <- 0x2C << 1)
@@ -115,9 +122,6 @@
 #define HEATER_5_PIN        5
 #define HEATER_6_PIN        6
 #define HEATER_7_PIN       11
-
-#undef FAN_PIN
-#define FAN_PIN             6   // Part Cooling System
 
 #ifndef CONTROLLER_FAN_PIN
   #define CONTROLLER_FAN_PIN 4   // Pin used for the fan to cool motherboard (-1 to disable)

--- a/Marlin/src/pins/pins_AZTEEG_X5_GT.h
+++ b/Marlin/src/pins/pins_AZTEEG_X5_GT.h
@@ -85,7 +85,9 @@
 #define HEATER_BED_PIN     P2_07
 #define HEATER_0_PIN       P2_04
 #define HEATER_1_PIN       P2_05
-#define FAN_PIN            P0_26
+#ifndef FAN_PIN
+  #define FAN_PIN          P0_26
+#endif
 #define FAN1_PIN           P1_22
 
 //

--- a/Marlin/src/pins/pins_BEAST.h
+++ b/Marlin/src/pins/pins_BEAST.h
@@ -103,7 +103,9 @@
 #define HEATER_BED2_PIN    -1    // BED2
 #define HEATER_BED3_PIN    -1    // BED3
 
-#define FAN_PIN            PB10
+#ifndef FAN_PIN
+  #define FAN_PIN          PB10
+#endif
 
 #define FAN_SOFT_PWM
 

--- a/Marlin/src/pins/pins_BIQU_BQ111_A4.h
+++ b/Marlin/src/pins/pins_BIQU_BQ111_A4.h
@@ -82,7 +82,9 @@
 //
 #define HEATER_0_PIN       P2_7
 #define HEATER_BED_PIN     P2_5
-#define FAN_PIN            P2_4
+#ifndef FAN_PIN
+  #define FAN_PIN          P2_4
+#endif
 
 //
 // Unused

--- a/Marlin/src/pins/pins_BRAINWAVE.h
+++ b/Marlin/src/pins/pins_BRAINWAVE.h
@@ -115,7 +115,9 @@
 #define HEATER_0_PIN       32   // A4 Extruder
 #define HEATER_BED_PIN     18   // E6 Bed
 
-#define FAN_PIN            31   // A3 Fan
+#ifndef FAN_PIN
+  #define FAN_PIN          31   // A3 Fan
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_BRAINWAVE_PRO.h
+++ b/Marlin/src/pins/pins_BRAINWAVE_PRO.h
@@ -125,7 +125,9 @@
 //
 #define HEATER_0_PIN       27   // B7
 #define HEATER_BED_PIN     26   // B6  Bed
-#define FAN_PIN            16   // C6  Fan, PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6  Fan, PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_CHEAPTRONICv2.h
+++ b/Marlin/src/pins/pins_CHEAPTRONICv2.h
@@ -31,6 +31,7 @@
 #endif
 
 #define BOARD_NAME         "Cheaptronic v2.0"
+
 //
 // Limit Switches
 //
@@ -80,10 +81,32 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN       6
-#define HEATER_1_PIN       7
-#define HEATER_2_PIN       8
-#define HEATER_BED_PIN     9
+#define HEATER_0_PIN        6
+#define HEATER_1_PIN        7
+#define HEATER_2_PIN        8
+#define HEATER_BED_PIN      9
+#ifndef FAN_PIN
+  #define FAN_PIN           3
+#endif
+#define FAN2_PIN           58   // additional fan or light control output
+
+//
+// Other board specific pins
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN   37   // board input labeled as F-DET
+#endif
+#define Z_MIN_PROBE_PIN    36   // additional external board input labeled as E-SENS (should be used for Z-probe)
+#define LED_PIN            13
+#define SPINDLE_ENABLE_PIN  4   // additional PWM pin 1 at JP1 connector - should be used for laser control too
+#define EXT_2               5   // additional PWM pin 2 at JP1 connector
+#define EXT_3               2   // additional PWM pin 3 at JP1 connector
+#define PS_ON_PIN          45
+#define KILL_PIN           46
+
+#ifndef FILWIDTH_PIN
+  #define FILWIDTH_PIN     11   // shared with TEMP_3 analog input
+#endif
 
 //
 // LCD
@@ -105,23 +128,3 @@
 #define BTN_EN1            11
 #define BTN_EN2            12
 #define BTN_ENC            43
-
-//
-// Other board specific pins
-//
-#ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN   37   // board input labeled as F-DET
-#endif
-#define Z_MIN_PROBE_PIN    36   // additional external board input labeled as E-SENS (should be used for Z-probe)
-#define LED_PIN            13
-#define SPINDLE_ENABLE_PIN  4   // additional PWM pin 1 at JP1 connector - should be used for laser control too
-#define EXT_2               5   // additional PWM pin 2 at JP1 connector
-#define EXT_3               2   // additional PWM pin 3 at JP1 connector
-#define FAN_PIN             3
-#define FAN2_PIN           58   // additional fan or light control output
-#define PS_ON_PIN          45
-#define KILL_PIN           46
-
-#ifndef FILWIDTH_PIN
-  #define FILWIDTH_PIN     11   // shared with TEMP_3 analog input
-#endif

--- a/Marlin/src/pins/pins_CHITU3D.h
+++ b/Marlin/src/pins/pins_CHITU3D.h
@@ -102,7 +102,9 @@
 #define HEATER_BED2_PIN    -1       // BED2
 #define HEATER_BED3_PIN    -1       // BED3
 
-#define FAN_PIN            PG14     // MAIN BOARD FAN
+#ifndef FAN_PIN
+  #define FAN_PIN          PG14     // MAIN BOARD FAN
+#endif
 
 #define FAN_SOFT_PWM
 

--- a/Marlin/src/pins/pins_CNCONTROLS_11.h
+++ b/Marlin/src/pins/pins_CNCONTROLS_11.h
@@ -65,7 +65,9 @@
 #define HEATER_3_PIN       46
 #define HEATER_BED_PIN      2
 
-//#define FAN_PIN           7   // common PWM pin for all tools
+#ifndef FAN_PIN
+  //#define FAN_PIN         7   // common PWM pin for all tools
+#endif
 
 #define ORIG_E0_AUTO_FAN_PIN 7
 #define ORIG_E1_AUTO_FAN_PIN 7

--- a/Marlin/src/pins/pins_CNCONTROLS_12.h
+++ b/Marlin/src/pins/pins_CNCONTROLS_12.h
@@ -65,7 +65,9 @@
 #define HEATER_3_PIN        3
 #define HEATER_BED_PIN     24
 
-#define FAN_PIN             5   // 5 is PWMtool3 -> 7 is common PWM pin for all tools
+#ifndef FAN_PIN
+  #define FAN_PIN           5   // 5 is PWMtool3 -> 7 is common PWM pin for all tools
+#endif
 
 #define ORIG_E0_AUTO_FAN_PIN 7
 #define ORIG_E1_AUTO_FAN_PIN 7

--- a/Marlin/src/pins/pins_COHESION3D_MINI.h
+++ b/Marlin/src/pins/pins_COHESION3D_MINI.h
@@ -98,12 +98,15 @@
 //
 #define HEATER_BED_PIN      P2_05
 #define HEATER_0_PIN        P2_07   // FET 1
-#define AUTO_FAN_PIN        P2_04   // FET 4
-#define FAN_PIN             P2_06   // ReMix FET 4, Mini FET 3
+#ifndef FAN_PIN
+  #define FAN_PIN           P2_06   // ReMix FET 4, Mini FET 3
+#endif
 
 //
 // Auto fans
 //
+#define AUTO_FAN_PIN        P2_04   // FET 4
+
 #define ORIG_E0_AUTO_FAN_PIN  AUTO_FAN_PIN
 #define ORIG_E1_AUTO_FAN_PIN  AUTO_FAN_PIN
 #define ORIG_E2_AUTO_FAN_PIN  AUTO_FAN_PIN

--- a/Marlin/src/pins/pins_COHESION3D_REMIX.h
+++ b/Marlin/src/pins/pins_COHESION3D_REMIX.h
@@ -115,17 +115,19 @@
 #define HEATER_BED_PIN      P2_05
 #define HEATER_0_PIN        P2_07   // FET 1
 #define HEATER_1_PIN        P1_23   // FET 2
-#if HOTENDS == 3
-  #define HEATER_2_PIN      P1_22   // FET 3
-  #define AUTO_FAN_PIN      P1_18   // FET 6
-#else
-  #define AUTO_FAN_PIN      P1_22   // FET 3
+#define HEATER_2_PIN        P1_22   // FET 3
+#ifndef FAN_PIN
+  #define FAN_PIN           P2_06   // ReMix FET 4, Mini FET 3
 #endif
-#define FAN_PIN             P2_06   // ReMix FET 4, Mini FET 3
 
 //
 // Auto fans
 //
+#if HOTENDS == 3
+  #define AUTO_FAN_PIN      P1_18   // FET 6
+#else
+  #define AUTO_FAN_PIN      P1_22   // FET 3
+#endif
 #define ORIG_E0_AUTO_FAN_PIN  AUTO_FAN_PIN
 #define ORIG_E1_AUTO_FAN_PIN  AUTO_FAN_PIN
 #define ORIG_E2_AUTO_FAN_PIN  AUTO_FAN_PIN

--- a/Marlin/src/pins/pins_DUE3DOM.h
+++ b/Marlin/src/pins/pins_DUE3DOM.h
@@ -97,7 +97,9 @@
 #define HEATER_1_PIN        8   // HOTEND1 MOSFET
 #define HEATER_BED_PIN     39   // BED MOSFET
 
-#define FAN_PIN            11   // FAN1 header on board - PRINT FAN
+#ifndef FAN_PIN
+  #define FAN_PIN          11   // FAN1 header on board - PRINT FAN
+#endif
 #define FAN1_PIN            9   // FAN2 header on board - CONTROLLER FAN
 #define FAN2_PIN           12   // FAN3 header on board - EXTRUDER0 FAN
 

--- a/Marlin/src/pins/pins_DUE3DOM_MINI.h
+++ b/Marlin/src/pins/pins_DUE3DOM_MINI.h
@@ -88,7 +88,9 @@
 #define HEATER_0_PIN       13   // HOTEND0 MOSFET
 #define HEATER_BED_PIN      7   // BED MOSFET
 
-#define FAN_PIN            11   // FAN1 header on board - PRINT FAN
+#ifndef FAN_PIN
+  #define FAN_PIN          11   // FAN1 header on board - PRINT FAN
+#endif
 #define FAN1_PIN           12   // FAN2 header on board - CONTROLLER FAN
 #define FAN2_PIN            9   // FAN3 header on board - EXTRUDER0 FAN
 //#define FAN3_PIN          8   // FAN0 4-pin header on board

--- a/Marlin/src/pins/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/pins_EINSY_RAMBO.h
@@ -117,7 +117,9 @@
 #define HEATER_0_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/src/pins/pins_EINSY_RETRO.h
+++ b/Marlin/src/pins/pins_EINSY_RETRO.h
@@ -134,7 +134,9 @@
 #define HEATER_0_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/src/pins/pins_ELEFU_3.h
+++ b/Marlin/src/pins/pins_ELEFU_3.h
@@ -90,7 +90,9 @@
 #define HEATER_2_PIN       17   // 12V PWM3
 #define HEATER_BED_PIN     44   // DOUBLE 12V PWM
 
-#define FAN_PIN            16   // 5V PWM
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // 5V PWM
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_GEN7_12.h
+++ b/Marlin/src/pins/pins_GEN7_12.h
@@ -112,8 +112,8 @@
 #define HEATER_0_PIN        4
 #define HEATER_BED_PIN      3
 
-#if GEN7_VERSION < 13   // Gen7 v1.3 removed the fan pin
-  #define FAN_PIN          31
+#if !defined(FAN_PIN) && GEN7_VERSION < 13   // Gen7 v1.3 removed the fan pin
+  #define FAN_PIN        31
 #endif
 
 //

--- a/Marlin/src/pins/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/pins_GT2560_REV_A.h
@@ -81,7 +81,9 @@
 #define HEATER_0_PIN        2
 #define HEATER_1_PIN        3
 #define HEATER_BED_PIN      4
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_GTM32_PRO_VB.h
+++ b/Marlin/src/pins/pins_GTM32_PRO_VB.h
@@ -85,10 +85,11 @@
 #define HEATER_0_PIN       PB4   // EXTRUDER 1
 #define HEATER_1_PIN       PB5   // EXTRUDER 2
 #define HEATER_2_PIN       PB0   // EXTRUDER 3
-
 #define HEATER_BED_PIN     PB1   // BED
 
-#define FAN_PIN            PB7   // (Sprinter config)
+#ifndef FAN_PIN
+  #define FAN_PIN          PB7   // (Sprinter config)
+#endif
 #define FAN1_PIN           PB8
 #define FAN2_PIN           PB9
 

--- a/Marlin/src/pins/pins_MALYAN_M200.h
+++ b/Marlin/src/pins/pins_MALYAN_M200.h
@@ -76,13 +76,16 @@
 #define HEATER_0_PIN       PB6   // HOTEND0 MOSFET
 #define HEATER_BED_PIN     PB7   // BED MOSFET
 
+// FAN_PIN is commented out here because the M200 example
+// Configuration_adv.h does NOT override E0_AUTO_FAN_PIN.
+#ifndef FAN_PIN
+  //#define FAN_PIN        PB8   // FAN1 header on board - PRINT FAN
+#endif
+#define FAN1_PIN           PB3   // FAN2 header on board - CONTROLLER FAN
+#define FAN2_PIN           -1    // FAN3 header on board - EXTRUDER0 FAN
+
 // This board has only the controller fan and the extruder fan
 // If someone hacks to put a direct power fan on the controller, PB3 could
 // be used as a separate print cooling fan.
 #define ORIG_E0_AUTO_FAN_PIN PB8
 
-// FAN_PIN is commented out here because the M200 example
-// Configuration_adv.h does NOT override E0_AUTO_FAN_PIN.
-//#define FAN_PIN            PB8   // FAN1 header on board - PRINT FAN
-#define FAN1_PIN           PB3   // FAN2 header on board - CONTROLLER FAN
-#define FAN2_PIN           -1    // FAN3 header on board - EXTRUDER0 FAN

--- a/Marlin/src/pins/pins_MEGACONTROLLER.h
+++ b/Marlin/src/pins/pins_MEGACONTROLLER.h
@@ -112,7 +112,9 @@
 #define HEATER_1_PIN       34
 #define HEATER_BED_PIN     28
 
-#define FAN_PIN            39
+#ifndef FAN_PIN
+  #define FAN_PIN          39
+#endif
 #define FAN1_PIN           35
 #define FAN2_PIN           36
 

--- a/Marlin/src/pins/pins_MEGATRONICS.h
+++ b/Marlin/src/pins/pins_MEGATRONICS.h
@@ -87,7 +87,9 @@
 #define HEATER_1_PIN        8
 #define HEATER_BED_PIN     10
 
-#define FAN_PIN             7   // IO pin. Buffer needed
+#ifndef FAN_PIN
+  #define FAN_PIN           7   // IO pin. Buffer needed
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_MEGATRONICS_2.h
+++ b/Marlin/src/pins/pins_MEGATRONICS_2.h
@@ -101,7 +101,9 @@
 #define HEATER_1_PIN        8
 #define HEATER_BED_PIN     10
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/src/pins/pins_MEGATRONICS_3.h
+++ b/Marlin/src/pins/pins_MEGATRONICS_3.h
@@ -118,7 +118,9 @@
 #define HEATER_2_PIN        8
 #define HEATER_BED_PIN     10
 
-#define FAN_PIN             6
+#ifndef FAN_PIN
+  #define FAN_PIN           6
+#endif
 #define FAN1_PIN            7
 
 //

--- a/Marlin/src/pins/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/pins_MIGHTYBOARD_REVE.h
@@ -172,23 +172,24 @@
 #define HEATER_0_PIN     MOSFET_A_PIN
 
 #if ENABLED(IS_EFB)                            // Hotend, Fan, Bed
-  #define FAN_PIN        MOSFET_B_PIN
-  #define HEATER_BED_PIN MOSFET_C_PIN
+  #define HEATER_BED_PIN   MOSFET_C_PIN
 #elif ENABLED(IS_EEF)                          // Hotend, Hotend, Fan
-  #define HEATER_1_PIN   MOSFET_B_PIN
-  #define FAN_PIN        MOSFET_C_PIN
+  #define HEATER_1_PIN     MOSFET_B_PIN
 #elif ENABLED(IS_EEB)                          // Hotend, Hotend, Bed
-  #define HEATER_1_PIN   MOSFET_B_PIN
-  #define HEATER_BED_PIN MOSFET_C_PIN
+  #define HEATER_1_PIN     MOSFET_B_PIN
+  #define HEATER_BED_PIN   MOSFET_C_PIN
 #elif ENABLED(IS_EFF)                          // Hotend, Fan, Fan
-  #define FAN_PIN        MOSFET_B_PIN
-  #define FAN1_PIN       MOSFET_C_PIN
-#elif ENABLED(IS_SF)                           // Spindle, Fan
-  #define FAN_PIN        MOSFET_C_PIN
+  #define FAN1_PIN         MOSFET_C_PIN
 #endif
 
 #ifndef FAN_PIN
-  #define FAN_PIN MOSFET_D_PIN
+  #if ENABLED(IS_EFB) || ENABLED(IS_EFF)       // Hotend, Fan, Bed or Hotend, Fan, Fan
+    #define FAN_PIN        MOSFET_B_PIN
+  #elif ENABLED(IS_EEF) || ENABLED(IS_SF)      // Hotend, Hotend, Fan or Spindle, Fan
+    #define FAN_PIN        MOSFET_C_PIN
+  #else
+    #define FAN_PIN        MOSFET_D_PIN
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/pins_MINIRAMBO.h
+++ b/Marlin/src/pins/pins_MINIRAMBO.h
@@ -106,7 +106,9 @@
 #endif
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/src/pins/pins_MINITRONICS.h
+++ b/Marlin/src/pins/pins_MINITRONICS.h
@@ -87,7 +87,9 @@
 #define HEATER_1_PIN        8   // EXTRUDER 2
 #define HEATER_BED_PIN      3   // BED
 
-#define FAN_PIN             9
+#ifndef FAN_PIN
+  #define FAN_PIN           9
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -36,10 +36,9 @@
 
 // unused
 /*
-#define PIN_P0_27         P0_27
-#define PIN_P0_28         P0_28
+#define PIN_P0_27          P0_27
+#define PIN_P0_28          P0_28
 */
-
 
 //
 // Servo pin
@@ -86,25 +85,20 @@
 // Temperature Sensors
 // 3.3V max when defined as an analog input
 //
-
 #define TEMP_BED_PIN        0   // A0 (TH1)
 #define TEMP_0_PIN          1   // A1 (TH2)
 #define TEMP_1_PIN          2   // A2 (TH3)
 #define TEMP_2_PIN          3   // A3 (TH4)
 
-
 //
 // Heaters / Fans
 //
-
 #define HEATER_BED_PIN     P2_05
 #define HEATER_0_PIN       P2_07
 #define HEATER_1_PIN       P2_06
-#define FAN_PIN            P2_04
-
-
-#define PS_ON_PIN          P0_25
-
+#ifndef FAN_PIN
+  #define FAN_PIN          P2_04
+#endif
 
 //
 // Connector J7
@@ -132,13 +126,18 @@
 //
 // Prusa i3 MK2 Multi Material Multiplexer Support
 //
-
 #if ENABLED(MK2_MULTIPLEXER)
   #define E_MUX0_PIN         P1_23   // J8-3
   #define E_MUX1_PIN         P2_12   // J8-4
   #define E_MUX2_PIN         P2_11   // J8-5
 #endif
 
+//
+// Misc. Functions
+//
+#define PS_ON_PIN          P0_25
+#define LPC_SOFTWARE_SPI  // MKS_SBASE needs a software SPI because the
+                          // selected pins are not on a hardware SPI controller
 
 /**
  * Smart LCD adapter
@@ -179,12 +178,6 @@
 #define ENET_TX_EN         P1_04   // J12-10
 #define ENET_TXD0          P1_00   // J12-11
 #define ENET_TXD1          P1_01   // J12-12
-
-//
-// Misc. Functions
-//
-#define LPC_SOFTWARE_SPI  // MKS_SBASE needs a software SPI because the
-                          // selected pins are not on a hardware SPI controller
 
 // A custom cable is needed. See the README file in the
 // Marlin\src\config\examples\Mks\Sbase directory

--- a/Marlin/src/pins/pins_OMCA.h
+++ b/Marlin/src/pins/pins_OMCA.h
@@ -129,7 +129,9 @@
 #define HEATER_0_PIN        3   // DONE PWM on RIGHT connector
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN            14   // PWM on MIDDLE connector
+#ifndef FAN_PIN
+  #define FAN_PIN          14   // PWM on MIDDLE connector
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_OMCA_A.h
+++ b/Marlin/src/pins/pins_OMCA_A.h
@@ -125,7 +125,9 @@
 //
 #define HEATER_0_PIN        4
 
-#define FAN_PIN             3
+#ifndef FAN_PIN
+  #define FAN_PIN           3
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_PRINTRBOARD.h
+++ b/Marlin/src/pins/pins_PRINTRBOARD.h
@@ -110,8 +110,9 @@
 #define HEATER_2_PIN       45   // F7
 #define HEATER_BED_PIN     14   // C4 PWM3C
 
-
-#define FAN_PIN            16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/src/pins/pins_PRINTRBOARD_REVF.h
@@ -190,7 +190,9 @@
 #endif
 #endif
 
-#define FAN_PIN            16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A
+#endif
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -149,7 +149,9 @@
 #define HEATER_2_PIN       11
 #define HEATER_BED_PIN      7   // BED
 
-#define FAN_PIN             9
+#ifndef FAN_PIN
+  #define FAN_PIN           9
+#endif
 #define FAN1_PIN            8
 
 //

--- a/Marlin/src/pins/pins_RAMBO.h
+++ b/Marlin/src/pins/pins_RAMBO.h
@@ -127,7 +127,9 @@
 #define HEATER_2_PIN        6
 #define HEATER_BED_PIN      3
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 #define FAN2_PIN            2
 

--- a/Marlin/src/pins/pins_RAMPS.h
+++ b/Marlin/src/pins/pins_RAMPS.h
@@ -231,46 +231,48 @@
 // Heaters / Fans
 //
 #ifndef MOSFET_D_PIN
-  #define MOSFET_D_PIN  -1
+  #define MOSFET_D_PIN     -1
 #endif
 #ifndef RAMPS_D8_PIN
-  #define RAMPS_D8_PIN   8
+  #define RAMPS_D8_PIN      8
 #endif
 #ifndef RAMPS_D9_PIN
-  #define RAMPS_D9_PIN   9
+  #define RAMPS_D9_PIN      9
 #endif
 #ifndef RAMPS_D10_PIN
-  #define RAMPS_D10_PIN 10
+  #define RAMPS_D10_PIN    10
 #endif
 
-#define HEATER_0_PIN     RAMPS_D10_PIN
+#define HEATER_0_PIN       RAMPS_D10_PIN
 
 #if ENABLED(IS_RAMPS_EFB)                      // Hotend, Fan, Bed
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
 #elif ENABLED(IS_RAMPS_EEF)                    // Hotend, Hotend, Fan
-  #define HEATER_1_PIN   RAMPS_D9_PIN
-  #define FAN_PIN        RAMPS_D8_PIN
+  #define HEATER_1_PIN     RAMPS_D9_PIN
 #elif ENABLED(IS_RAMPS_EEB)                    // Hotend, Hotend, Bed
-  #define HEATER_1_PIN   RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define HEATER_1_PIN     RAMPS_D9_PIN
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
 #elif ENABLED(IS_RAMPS_EFF)                    // Hotend, Fan, Fan
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define FAN1_PIN       RAMPS_D8_PIN
-#elif ENABLED(IS_RAMPS_SF)                     // Spindle, Fan
-  #define FAN_PIN        RAMPS_D8_PIN
-#else                                          // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define FAN1_PIN         RAMPS_D8_PIN
+#elif DISABLED(IS_RAMPS_SF)                    // Not Spindle, Fan (i.e., "EFBF" or "EFBE")
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
   #if HOTENDS == 1
-    #define FAN1_PIN     MOSFET_D_PIN
+    #define FAN1_PIN       MOSFET_D_PIN
   #else
-    #define HEATER_1_PIN MOSFET_D_PIN
+    #define HEATER_1_PIN   MOSFET_D_PIN
   #endif
 #endif
 
 #ifndef FAN_PIN
-  #define FAN_PIN           4   // IO pin. Buffer needed
+  #if ENABLED(IS_RAMPS_EFB) || ENABLED(IS_RAMPS_EFF)  // Hotend, Fan, Bed or Hotend, Fan, Fan
+    #define FAN_PIN        RAMPS_D9_PIN
+  #elif ENABLED(IS_RAMPS_EEF) || ENABLED(IS_RAMPS_SF) // Hotend, Hotend, Fan or Spindle, Fan
+    #define FAN_PIN        RAMPS_D8_PIN
+  #elif ENABLED(IS_RAMPS_EEB)                         // Hotend, Hotend, Bed
+    #define FAN_PIN         4   // IO pin. Buffer needed
+  #else                                               // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
+    #define FAN_PIN        RAMPS_D9_PIN
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -127,7 +127,9 @@
 #define HEATER_2_PIN       11
 #define HEATER_BED_PIN      8
 
-#define FAN_PIN            12
+#ifndef FAN_PIN
+  #define FAN_PIN          12
+#endif
 #define CONTROLLER_FAN_PIN -1
 
 //

--- a/Marlin/src/pins/pins_RAMPS_OLD.h
+++ b/Marlin/src/pins/pins_RAMPS_OLD.h
@@ -88,11 +88,15 @@
 #if ENABLED(RAMPS_V_1_0)
   #define HEATER_0_PIN     12
   #define HEATER_BED_PIN   -1
-  #define FAN_PIN          11
+  #ifndef FAN_PIN
+    #define FAN_PIN        11
+  #endif
 #else // RAMPS_V_1_1 or RAMPS_V_1_2
   #define HEATER_0_PIN     10
   #define HEATER_BED_PIN    8
-  #define FAN_PIN           9
+  #ifndef FAN_PIN
+    #define FAN_PIN         9
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -150,46 +150,48 @@
 // Heaters / Fans
 //
 #ifndef MOSFET_D_PIN
-  #define MOSFET_D_PIN   -1
+  #define MOSFET_D_PIN     -1
 #endif
 #ifndef RAMPS_D8_PIN
-  #define RAMPS_D8_PIN   P2_07   // (8)
+  #define RAMPS_D8_PIN     P2_07   // (8)
 #endif
 #ifndef RAMPS_D9_PIN
-  #define RAMPS_D9_PIN   P2_04   // (9)
+  #define RAMPS_D9_PIN     P2_04   // (9)
 #endif
 #ifndef RAMPS_D10_PIN
-  #define RAMPS_D10_PIN  P2_05   // (10)
+  #define RAMPS_D10_PIN    P2_05   // (10)
 #endif
 
-#define HEATER_0_PIN     RAMPS_D10_PIN
+#define HEATER_0_PIN       RAMPS_D10_PIN
 
 #if ENABLED(IS_RAMPS_EFB)                      // Hotend, Fan, Bed
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
 #elif ENABLED(IS_RAMPS_EEF)                    // Hotend, Hotend, Fan
-  #define HEATER_1_PIN   RAMPS_D9_PIN
-  #define FAN_PIN        RAMPS_D8_PIN
+  #define HEATER_1_PIN     RAMPS_D9_PIN
 #elif ENABLED(IS_RAMPS_EEB)                    // Hotend, Hotend, Bed
-  #define HEATER_1_PIN   RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define HEATER_1_PIN     RAMPS_D9_PIN
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
 #elif ENABLED(IS_RAMPS_EFF)                    // Hotend, Fan, Fan
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define FAN1_PIN       RAMPS_D8_PIN
-#elif ENABLED(IS_RAMPS_SF)                     // Spindle, Fan
-  #define FAN_PIN        RAMPS_D8_PIN
-#else                                          // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define FAN1_PIN         RAMPS_D8_PIN
+#elif DISABLED(IS_RAMPS_SF)                    // Not Spindle, Fan (i.e., "EFBF" or "EFBE")
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
   #if HOTENDS == 1
-    #define FAN1_PIN     MOSFET_D_PIN
+    #define FAN1_PIN       MOSFET_D_PIN
   #else
-    #define HEATER_1_PIN MOSFET_D_PIN
+    #define HEATER_1_PIN   MOSFET_D_PIN
   #endif
 #endif
 
 #ifndef FAN_PIN
-  #define FAN_PIN         P1_18   // (4) IO pin. Buffer needed
+  #if ENABLED(IS_RAMPS_EFB) || ENABLED(IS_RAMPS_EFF)   // Hotend, Fan, Bed or Hotend, Fan, Fan
+    #define FAN_PIN        RAMPS_D9_PIN
+  #elif ENABLED(IS_RAMPS_EEF) || ENABLED(IS_RAMPS_SF)  // Hotend, Hotend, Fan or Spindle, Fan
+    #define FAN_PIN        RAMPS_D8_PIN
+  #elif ENABLED(IS_RAMPS_EEB)                          // Hotend, Hotend, Bed
+    #define FAN_PIN        P1_18   // (4) IO pin. Buffer needed
+  #else                                                // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
+    #define FAN_PIN        RAMPS_D9_PIN
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/pins_RIGIDBOARD.h
+++ b/Marlin/src/pins/pins_RIGIDBOARD.h
@@ -85,8 +85,9 @@
 #undef HEATER_BED_PIN
 #define HEATER_BED_PIN     10
 
-#undef FAN_PIN
-#define FAN_PIN             8   // Same as RAMPS_13_EEF
+#ifndef FAN_PIN
+  #define FAN_PIN           8   // Same as RAMPS_13_EEF
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_RUMBA.h
+++ b/Marlin/src/pins/pins_RUMBA.h
@@ -124,7 +124,9 @@
 #define HEATER_3_PIN        8
 #define HEATER_BED_PIN      9
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 #define FAN1_PIN            8
 
 //

--- a/Marlin/src/pins/pins_RURAMPS4D.h
+++ b/Marlin/src/pins/pins_RURAMPS4D.h
@@ -122,7 +122,9 @@
 #define HEATER_2_PIN       11
 #define HEATER_BED_PIN      7   // BED H1
 
-#define FAN_PIN             9
+#ifndef FAN_PIN
+  #define FAN_PIN           9
+#endif
 #define FAN1_PIN            8
 #define CONTROLLER_FAN_PIN -1
 

--- a/Marlin/src/pins/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/pins_SANGUINOLOLU_11.h
@@ -100,7 +100,7 @@
   #define Z_ENABLE_PIN     26
   #define E0_ENABLE_PIN    14
 
-  #if ENABLED(LCD_I2C_PANELOLU2)
+  #if !defined(FAN_PIN) && ENABLED(LCD_I2C_PANELOLU2)
     #define FAN_PIN         4   // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
   #endif
 
@@ -114,7 +114,7 @@
 
 #endif
 
-#if MB(AZTEEG_X1) || MB(STB_11) || ENABLED(IS_MELZI)
+#if !defined(FAN_PIN) && (MB(AZTEEG_X1) || MB(STB_11) || ENABLED(IS_MELZI))
   #define FAN_PIN           4   // Works for Panelolu2 too
 #endif
 

--- a/Marlin/src/pins/pins_SAV_MKI.h
+++ b/Marlin/src/pins/pins_SAV_MKI.h
@@ -114,7 +114,9 @@
 #define HEATER_0_PIN       15   // C5 PWM3B - Extruder
 #define HEATER_BED_PIN     14   // C4 PWM3C - Bed
 
-#define FAN_PIN            16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_SCOOVO_X9H.h
+++ b/Marlin/src/pins/pins_SCOOVO_X9H.h
@@ -106,7 +106,9 @@
 #define HEATER_1_PIN         7
 #define HEATER_BED_PIN       3
 
-#define FAN_PIN              8
+#ifndef FAN_PIN
+  #define FAN_PIN            8
+#endif
 #define FAN1_PIN             6
 #define FAN2_PIN             2
 

--- a/Marlin/src/pins/pins_SELENA_COMPACT.h
+++ b/Marlin/src/pins/pins_SELENA_COMPACT.h
@@ -86,7 +86,9 @@
 #define HEATER_BED2_PIN    P2_04
 #define HEATER_0_PIN       P2_07
 #define HEATER_1_PIN       P2_06
-#define FAN_PIN            P1_24
+#ifndef FAN_PIN
+  #define FAN_PIN          P1_24
+#endif
 #define FAN1_PIN           P1_26
 
 //

--- a/Marlin/src/pins/pins_SETHI.h
+++ b/Marlin/src/pins/pins_SETHI.h
@@ -98,12 +98,13 @@
 #define HEATER_0_PIN        4
 #define HEATER_BED_PIN      3
 
-
-#if GEN7_VERSION >= 13
-  // Gen7 v1.3 removed the fan pin
-  #define FAN_PIN          -1
-#else
-  #define FAN_PIN          31
+#ifndef FAN_PIN
+  #if GEN7_VERSION >= 13
+    // Gen7 v1.3 removed the fan pin
+    #define FAN_PIN          -1
+  #else
+    #define FAN_PIN          31
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/pins_SILVER_GATE.h
+++ b/Marlin/src/pins/pins_SILVER_GATE.h
@@ -56,7 +56,9 @@
   #define FIL_RUNOUT_PIN   34   // X_MAX unless overridden
 #endif
 
-#define FAN_PIN             5
+#ifndef FAN_PIN
+  #define FAN_PIN           5
+#endif
 
 #define HEATER_0_PIN        7
 

--- a/Marlin/src/pins/pins_STM32F1R.h
+++ b/Marlin/src/pins/pins_STM32F1R.h
@@ -35,33 +35,29 @@
 #define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
 
 //
+// Limit Switches
+//
+#define U_MIN_PIN          -1
+#define V_MIN_PIN          -1
+#define W_MIN_PIN          -1
+#define X_STOP_PIN         PB3
+#define Y_STOP_PIN         PB4
+#define Z_STOP_PIN         PB5
+
+//
 // Steppers
 //
 #define X_STEP_PIN         PC0
 #define X_DIR_PIN          PC1
 #define X_ENABLE_PIN       PA8
-#define X_MIN_PIN          PB3
-#define X_MAX_PIN          -1
 
 #define Y_STEP_PIN         PC2
 #define Y_DIR_PIN          PC3
 #define Y_ENABLE_PIN       PA8
-#define Y_MIN_PIN          -1
-#define Y_MAX_PIN          PB4
 
 #define Z_STEP_PIN         PC4
 #define Z_DIR_PIN          PC5
 #define Z_ENABLE_PIN       PA8
-#define Z_MIN_PIN          -1
-#define Z_MAX_PIN          PB5
-
-#define Y2_STEP_PIN        -1
-#define Y2_DIR_PIN         -1
-#define Y2_ENABLE_PIN      -1
-
-#define Z2_STEP_PIN        -1
-#define Z2_DIR_PIN         -1
-#define Z2_ENABLE_PIN      -1
 
 #define E0_STEP_PIN        PC6
 #define E0_DIR_PIN         PC7
@@ -82,25 +78,16 @@
 //
 // Misc. Functions
 //
-#define SDPOWER            -1
 #define SDSS               PA4
 #define LED_PIN            PD2
-
-#define PS_ON_PIN          -1
-#define KILL_PIN           -1
 
 //
 // Heaters / Fans
 //
 #define HEATER_0_PIN       PB0   // EXTRUDER 1
 #define HEATER_1_PIN       PB1
-#define HEATER_2_PIN       -1
 
 #define HEATER_BED_PIN     PA3   // BED
-#define HEATER_BED2_PIN    -1    // BED2
-#define HEATER_BED3_PIN    -1    // BED3
-
-#define FAN_PIN            -1   // (Sprinter config)
 
 //
 // Temperature Sensors
@@ -108,7 +95,6 @@
 #define TEMP_BED_PIN       PA0   // ANALOG NUMBERING
 #define TEMP_0_PIN         PA1   // ANALOG NUMBERING
 #define TEMP_1_PIN         PA2   // ANALOG NUMBERING
-#define TEMP_2_PIN         -1   // ANALOG NUMBERING
 
 //
 // LCD Pins
@@ -276,7 +262,3 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-#define U_MIN_PIN          -1
-#define V_MIN_PIN          -1
-#define W_MIN_PIN          -1

--- a/Marlin/src/pins/pins_STM32F4.h
+++ b/Marlin/src/pins/pins_STM32F4.h
@@ -115,7 +115,9 @@
 #define HEATER_1_PIN       PA2
 #define HEATER_BED_PIN     PA0
 
-#define FAN_PIN            PC6
+#ifndef FAN_PIN
+  #define FAN_PIN          PC6
+#endif
 #define FAN1_PIN           PC7
 #define FAN2_PIN           PC8
 

--- a/Marlin/src/pins/pins_STM3R_MINI.h
+++ b/Marlin/src/pins/pins_STM3R_MINI.h
@@ -38,33 +38,29 @@
 #define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
 
 //
+// Limit Switches
+//
+#define U_MIN_PIN          -1
+#define V_MIN_PIN          -1
+#define W_MIN_PIN          -1
+#define X_STOP_PIN         PD0
+#define Y_STOP_PIN         PD1
+#define Z_STOP_PIN         PD4
+
+//
 // Steppers
 //
 #define X_STEP_PIN         PE1
 #define X_DIR_PIN          PE0
 #define X_ENABLE_PIN       PC0
-#define X_MIN_PIN          PD0
-#define X_MAX_PIN          -1
 
 #define Y_STEP_PIN         PE3
 #define Y_DIR_PIN          PE2
 #define Y_ENABLE_PIN       PC1
-#define Y_MIN_PIN          PD1
-#define Y_MAX_PIN
 
 #define Z_STEP_PIN         PE5
 #define Z_DIR_PIN          PE4
 #define Z_ENABLE_PIN       PC2
-#define Z_MIN_PIN          PD4
-#define Z_MAX_PIN          -1
-
-#define Y2_STEP_PIN        -1
-#define Y2_DIR_PIN         -1
-#define Y2_ENABLE_PIN      -1
-
-#define Z2_STEP_PIN        -1
-#define Z2_DIR_PIN         -1
-#define Z2_ENABLE_PIN      -1
 
 #define E0_STEP_PIN        PE7
 #define E0_DIR_PIN         PE6
@@ -81,25 +77,22 @@
 //
 // Misc. Functions
 //
-//#define SDPOWER            -1
 #define SDSS               PA15
 #define LED_PIN            PB2
-
-//#define PS_ON_PIN          -1
-//#define KILL_PIN           -1
 
 //
 // Heaters / Fans
 //
 #define HEATER_0_PIN       PD12   // EXTRUDER 1
 //#define HEATER_1_PIN       PD13
-//#define HEATER_2_PIN       -1
 
 #define HEATER_BED_PIN     PB9   // BED
 //#define HEATER_BED2_PIN    -1   // BED2
 //#define HEATER_BED3_PIN    -1   // BED3
 
-#define FAN_PIN            PD14
+#ifndef FAN_PIN
+  #define FAN_PIN          PD14
+#endif
 #define FAN1_PIN           PD13
 
 #define FAN_SOFT_PWM
@@ -114,8 +107,8 @@
 
 // Laser control
 #if ENABLED(SPINDLE_LASER_ENABLE)
-#define SPINDLE_LASER_PWM_PIN       PB8
-#define SPINDLE_LASER_ENABLE_PIN    PD5
+  #define SPINDLE_LASER_PWM_PIN     PB8
+  #define SPINDLE_LASER_ENABLE_PIN  PD5
 #endif
 
 //
@@ -285,7 +278,3 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-#define U_MIN_PIN          -1
-#define V_MIN_PIN          -1
-#define W_MIN_PIN          -1

--- a/Marlin/src/pins/pins_TEENSY2.h
+++ b/Marlin/src/pins/pins_TEENSY2.h
@@ -149,7 +149,9 @@
 //
 #define HEATER_0_PIN       15   // C5 PWM3B  Extruder
 #define HEATER_BED_PIN     14   // C4 PWM3C
-#define FAN_PIN            16   // C6 PWM3A  Fan
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A  Fan
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_TEENSY35_36.h
+++ b/Marlin/src/pins/pins_TEENSY35_36.h
@@ -79,6 +79,16 @@ D8    HEATER_BED_PIN      CS1     RX4  A12 31 |   46 * * 47   | 34 A15 PWM      
 
 */
 
+//
+// Limit Switches
+//
+#define X_STOP_PIN         24
+#define Y_STOP_PIN         26
+#define Z_STOP_PIN         28
+
+//
+// Steppers
+//
 #define X_STEP_PIN         22
 #define X_DIR_PIN          21
 #define X_ENABLE_PIN       39
@@ -102,11 +112,9 @@ D8    HEATER_BED_PIN      CS1     RX4  A12 31 |   46 * * 47   | 34 A15 PWM      
 #define HEATER_0_PIN       30
 #define HEATER_1_PIN       36
 #define HEATER_BED_PIN     31
-#define FAN_PIN             2
-
-#define X_STOP_PIN         24
-#define Y_STOP_PIN         26
-#define Z_STOP_PIN         28
+#ifndef FAN_PIN
+  #define FAN_PIN           2
+#endif
 
 #define TEMP_0_PIN          2   // Extruder / Analog pin numbering: 2 => A2
 #define TEMP_1_PIN          0

--- a/Marlin/src/pins/pins_TEENSYLU.h
+++ b/Marlin/src/pins/pins_TEENSYLU.h
@@ -127,7 +127,9 @@
 #define HEATER_0_PIN            15   // C5 PWM3B - Extruder
 #define HEATER_BED_PIN          14   // C4 PWM3C
 
-#define FAN_PIN                 16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN               16   // C6 PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_THE_BORG.h
+++ b/Marlin/src/pins/pins_THE_BORG.h
@@ -125,7 +125,9 @@
 #define HEATER_1_PIN       PD14
 #define HEATER_BED_PIN     PF6
 
-#define FAN_PIN            PD13
+#ifndef FAN_PIN
+  #define FAN_PIN          PD13
+#endif
 #define FAN1_PIN           PA0
 #define FAN2_PIN           PA1
 

--- a/Marlin/src/pins/pins_ULTIMAIN_2.h
+++ b/Marlin/src/pins/pins_ULTIMAIN_2.h
@@ -93,7 +93,9 @@
 #define HEATER_1_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_ULTIMAKER.h
+++ b/Marlin/src/pins/pins_ULTIMAKER.h
@@ -99,7 +99,9 @@
 #define HEATER_1_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/pins_ULTRATRONICS_PRO.h
+++ b/Marlin/src/pins/pins_ULTRATRONICS_PRO.h
@@ -100,7 +100,9 @@
 #define HEATER_3_PIN        9
 #define HEATER_BED_PIN      2
 
-#define FAN_PIN             6
+#ifndef FAN_PIN
+  #define FAN_PIN           6
+#endif
 #define FAN2_PIN            5
 
 //


### PR DESCRIPTION
- Wrap `FAN_PIN` in `#ifdef` to allow easier override.
- Group `FAN_PIN` defines for RAMPS-like boards.
- Define endstop pins as `[XYZ]_STOP_PIN` when only 3 exist.
- Miscellaneous cleanup of newer pins files.

Counterpart to #10957