### PR TITLE
[1.1.x] Easier FAN_PIN override, pins cleanup

### DIFF
--- a/Marlin/pins_5DPRINT.h
+++ b/Marlin/pins_5DPRINT.h
@@ -132,7 +132,9 @@
 #define HEATER_0_PIN       15   // C5
 #define HEATER_BED_PIN     14   // C4
 
-#define FAN_PIN            16   // C6  PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6  PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -133,7 +133,10 @@
 //
 #define HEATER_0_PIN       13   // (extruder)
 #define HEATER_BED_PIN     12   // (bed)
-#define FAN_PIN             4
+
+#ifndef FAN_PIN
+  #define FAN_PIN           4
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/pins_AZTEEG_X3_PRO.h
@@ -24,21 +24,28 @@
  * AZTEEG_X3_PRO (Arduino Mega) pin assignments
  */
 
+#ifndef __AVR_ATmega2560__
+  #error "Oops! Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu."
+#endif
+
 #if HOTENDS > 5 || E_STEPPERS > 5
   #error "Azteeg X3 Pro supports up to 5 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT)
-  #define CASE_LIGHT_PIN 44     // Define before RAMPS pins include
-#endif
-
 #define BOARD_NAME "Azteeg X3 Pro"
 
-#include "pins_RAMPS.h"
-
-#ifndef __AVR_ATmega2560__
-  #error "Oops! Make sure you have 'Arduino Mega 2560' selected from the 'Tools -> Boards' menu."
+//
+// RAMPS pins overrides
+//
+#if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT)
+  #define CASE_LIGHT_PIN   44
 #endif
+
+#ifndef FAN_PIN
+  #define FAN_PIN           6
+#endif
+
+#include "pins_RAMPS.h"
 
 // DIGIPOT slave addresses
 #define DIGIPOT_I2C_ADDRESS_A 0x2C   // unshifted slave address for first DIGIPOT 0x2C (0x58 <- 0x2C << 1)
@@ -115,9 +122,6 @@
 #define HEATER_5_PIN        5
 #define HEATER_6_PIN        6
 #define HEATER_7_PIN       11
-
-#undef FAN_PIN
-#define FAN_PIN             6   // Part Cooling System
 
 #ifndef CONTROLLER_FAN_PIN
   #define CONTROLLER_FAN_PIN 4   // Pin used for the fan to cool motherboard (-1 to disable)

--- a/Marlin/pins_BRAINWAVE.h
+++ b/Marlin/pins_BRAINWAVE.h
@@ -115,7 +115,9 @@
 #define HEATER_0_PIN       32   // A4 Extruder
 #define HEATER_BED_PIN     18   // E6 Bed
 
-#define FAN_PIN            31   // A3 Fan
+#ifndef FAN_PIN
+  #define FAN_PIN          31   // A3 Fan
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_BRAINWAVE_PRO.h
+++ b/Marlin/pins_BRAINWAVE_PRO.h
@@ -125,7 +125,9 @@
 //
 #define HEATER_0_PIN       27   // B7
 #define HEATER_BED_PIN     26   // B6  Bed
-#define FAN_PIN            16   // C6  Fan, PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6  Fan, PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_CHEAPTRONIC.h
+++ b/Marlin/pins_CHEAPTRONIC.h
@@ -69,8 +69,8 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN       19 // EXTRUDER 1
-#define HEATER_1_PIN       23 // EXTRUDER 2
+#define HEATER_0_PIN       19   // EXTRUDER 1
+#define HEATER_1_PIN       23   // EXTRUDER 2
 #define HEATER_BED_PIN     22
 
 //

--- a/Marlin/pins_CHEAPTRONICv2.h
+++ b/Marlin/pins_CHEAPTRONICv2.h
@@ -31,6 +31,7 @@
 #endif
 
 #define BOARD_NAME         "Cheaptronic v2.0"
+
 //
 // Limit Switches
 //
@@ -80,10 +81,32 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN       6
-#define HEATER_1_PIN       7
-#define HEATER_2_PIN       8
-#define HEATER_BED_PIN     9
+#define HEATER_0_PIN        6
+#define HEATER_1_PIN        7
+#define HEATER_2_PIN        8
+#define HEATER_BED_PIN      9
+#ifndef FAN_PIN
+  #define FAN_PIN           3
+#endif
+#define FAN2_PIN           58   // additional fan or light control output
+
+//
+// Other board specific pins
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN   37   // board input labeled as F-DET
+#endif
+#define Z_MIN_PROBE_PIN    36   // additional external board input labeled as E-SENS (should be used for Z-probe)
+#define LED_PIN            13
+#define SPINDLE_ENABLE_PIN  4   // additional PWM pin 1 at JP1 connector - should be used for laser control too
+#define EXT_2               5   // additional PWM pin 2 at JP1 connector
+#define EXT_3               2   // additional PWM pin 3 at JP1 connector
+#define PS_ON_PIN          45
+#define KILL_PIN           46
+
+#ifndef FILWIDTH_PIN
+  #define FILWIDTH_PIN     11   // shared with TEMP_3 analog input
+#endif
 
 //
 // LCD
@@ -105,23 +128,3 @@
 #define BTN_EN1            11
 #define BTN_EN2            12
 #define BTN_ENC            43
-
-//
-// Other board specific pins
-//
-#ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN   37   // board input labeled as F-DET
-#endif
-#define Z_MIN_PROBE_PIN    36   // additional external board input labeled as E-SENS (should be used for Z-probe)
-#define LED_PIN            13
-#define SPINDLE_ENABLE_PIN  4   // additional PWM pin 1 at JP1 connector - should be used for laser control too
-#define EXT_2               5   // additional PWM pin 2 at JP1 connector
-#define EXT_3               2   // additional PWM pin 3 at JP1 connector
-#define FAN_PIN             3
-#define FAN2_PIN           58   // additional fan or light control output
-#define PS_ON_PIN          45
-#define KILL_PIN           46
-
-#ifndef FILWIDTH_PIN
-  #define FILWIDTH_PIN     11   // shared with TEMP_3 analog input
-#endif

--- a/Marlin/pins_CNCONTROLS_11.h
+++ b/Marlin/pins_CNCONTROLS_11.h
@@ -65,7 +65,9 @@
 #define HEATER_3_PIN       46
 #define HEATER_BED_PIN      2
 
-//#define FAN_PIN           7   // common PWM pin for all tools
+#ifndef FAN_PIN
+  //#define FAN_PIN         7   // common PWM pin for all tools
+#endif
 
 #define ORIG_E0_AUTO_FAN_PIN 7
 #define ORIG_E1_AUTO_FAN_PIN 7

--- a/Marlin/pins_CNCONTROLS_12.h
+++ b/Marlin/pins_CNCONTROLS_12.h
@@ -65,7 +65,9 @@
 #define HEATER_3_PIN        3
 #define HEATER_BED_PIN     24
 
-#define FAN_PIN             5   // 5 is PWMtool3 -> 7 is common PWM pin for all tools
+#ifndef FAN_PIN
+  #define FAN_PIN           5   // 5 is PWMtool3 -> 7 is common PWM pin for all tools
+#endif
 
 #define ORIG_E0_AUTO_FAN_PIN 7
 #define ORIG_E1_AUTO_FAN_PIN 7
@@ -124,4 +126,4 @@
 //#define UI2              37
 
 #define STAT_LED_BLUE_PIN  -1
-#define STAT_LED_RED_PIN   10 // TOOL_0_PWM_PIN
+#define STAT_LED_RED_PIN   10   // TOOL_0_PWM_PIN

--- a/Marlin/pins_EINSY_RAMBO.h
+++ b/Marlin/pins_EINSY_RAMBO.h
@@ -117,7 +117,9 @@
 #define HEATER_0_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/pins_EINSY_RETRO.h
+++ b/Marlin/pins_EINSY_RETRO.h
@@ -134,7 +134,9 @@
 #define HEATER_0_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/pins_ELEFU_3.h
+++ b/Marlin/pins_ELEFU_3.h
@@ -90,7 +90,9 @@
 #define HEATER_2_PIN       17   // 12V PWM3
 #define HEATER_BED_PIN     44   // DOUBLE 12V PWM
 
-#define FAN_PIN            16   // 5V PWM
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // 5V PWM
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_GEN3_MONOLITHIC.h
+++ b/Marlin/pins_GEN3_MONOLITHIC.h
@@ -68,11 +68,11 @@
 //
 #define X_STEP_PIN         15
 #define X_DIR_PIN          18
-#define X_ENABLE_PIN       24 // actually uses Y_enable_pin
+#define X_ENABLE_PIN       24   // actually uses Y_enable_pin
 
 #define Y_STEP_PIN         23
 #define Y_DIR_PIN          22
-#define Y_ENABLE_PIN       24 // shared with X_enable_pin
+#define Y_ENABLE_PIN       24   // shared with X_enable_pin
 
 #define Z_STEP_PIN         27
 #define Z_DIR_PIN          28
@@ -95,7 +95,6 @@
 //
 // Misc. Functions
 //
-#define PS_ON_PIN          14 // Alex, does this work on the card?
+#define PS_ON_PIN          14   // Alex, does this work on the card?
 
 // Alex extras from Gen3+
-

--- a/Marlin/pins_GEN7_12.h
+++ b/Marlin/pins_GEN7_12.h
@@ -112,8 +112,8 @@
 #define HEATER_0_PIN        4
 #define HEATER_BED_PIN      3
 
-#if GEN7_VERSION < 13   // Gen7 v1.3 removed the fan pin
-  #define FAN_PIN          31
+#if !defined(FAN_PIN) && GEN7_VERSION < 13   // Gen7 v1.3 removed the fan pin
+  #define FAN_PIN        31
 #endif
 
 //

--- a/Marlin/pins_GT2560_REV_A.h
+++ b/Marlin/pins_GT2560_REV_A.h
@@ -81,7 +81,9 @@
 #define HEATER_0_PIN        2
 #define HEATER_1_PIN        3
 #define HEATER_BED_PIN      4
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_LEAPFROG.h
+++ b/Marlin/pins_LEAPFROG.h
@@ -47,21 +47,21 @@
 #define X_DIR_PIN          63
 #define X_ENABLE_PIN       29
 
-#define Y_STEP_PIN         14 // A6
-#define Y_DIR_PIN          15 // A0
+#define Y_STEP_PIN         14   // A6
+#define Y_DIR_PIN          15   // A0
 #define Y_ENABLE_PIN       39
 
-#define Z_STEP_PIN         31 // A2
-#define Z_DIR_PIN          32 // A6
-#define Z_ENABLE_PIN       30 // A1
+#define Z_STEP_PIN         31   // A2
+#define Z_DIR_PIN          32   // A6
+#define Z_ENABLE_PIN       30   // A1
 
-#define E0_STEP_PIN        34 // 34
-#define E0_DIR_PIN         35 // 35
-#define E0_ENABLE_PIN      33 // 33
+#define E0_STEP_PIN        34   // 34
+#define E0_DIR_PIN         35   // 35
+#define E0_ENABLE_PIN      33   // 33
 
-#define E1_STEP_PIN        37 // 37
-#define E1_DIR_PIN         40 // 40
-#define E1_ENABLE_PIN      36 // 36
+#define E1_STEP_PIN        37   // 37
+#define E1_DIR_PIN         40   // 40
+#define E1_ENABLE_PIN      36   // 36
 
 //
 // Temperature Sensors
@@ -74,9 +74,9 @@
 // Heaters / Fans
 //
 #define HEATER_0_PIN        9
-#define HEATER_1_PIN        8 // 12
-#define HEATER_2_PIN       11 // 13
-#define HEATER_BED_PIN     10 // 14/15
+#define HEATER_1_PIN        8   // 12
+#define HEATER_2_PIN       11   // 13
+#define HEATER_BED_PIN     10   // 14/15
 
 #define FAN_PIN             7
 

--- a/Marlin/pins_MEGACONTROLLER.h
+++ b/Marlin/pins_MEGACONTROLLER.h
@@ -62,17 +62,17 @@
 //
 // Steppers
 //
-#define X_STEP_PIN         62 // A8
-#define X_DIR_PIN          63 // A9
-#define X_ENABLE_PIN       61 // A7
+#define X_STEP_PIN         62   // A8
+#define X_DIR_PIN          63   // A9
+#define X_ENABLE_PIN       61   // A7
 
-#define Y_STEP_PIN         65 // A11
-#define Y_DIR_PIN          66 // A12
-#define Y_ENABLE_PIN       64 // A10
+#define Y_STEP_PIN         65   // A11
+#define Y_DIR_PIN          66   // A12
+#define Y_ENABLE_PIN       64   // A10
 
-#define Z_STEP_PIN         68 // A14
-#define Z_DIR_PIN          69 // A15
-#define Z_ENABLE_PIN       67 // A13
+#define Z_STEP_PIN         68   // A14
+#define Z_DIR_PIN          69   // A15
+#define Z_ENABLE_PIN       67   // A13
 
 #define E0_STEP_PIN        23
 #define E0_DIR_PIN         24
@@ -112,7 +112,9 @@
 #define HEATER_1_PIN       34
 #define HEATER_BED_PIN     28
 
-#define FAN_PIN            39
+#ifndef FAN_PIN
+  #define FAN_PIN          39
+#endif
 #define FAN1_PIN           35
 #define FAN2_PIN           36
 

--- a/Marlin/pins_MEGATRONICS.h
+++ b/Marlin/pins_MEGATRONICS.h
@@ -53,13 +53,13 @@
 #define X_DIR_PIN          28
 #define X_ENABLE_PIN       24
 
-#define Y_STEP_PIN         60 // A6
-#define Y_DIR_PIN          61 // A7
+#define Y_STEP_PIN         60   // A6
+#define Y_DIR_PIN          61   // A7
 #define Y_ENABLE_PIN       22
 
-#define Z_STEP_PIN         54 // A0
-#define Z_DIR_PIN          55 // A1
-#define Z_ENABLE_PIN       56 // A2
+#define Z_STEP_PIN         54   // A0
+#define Z_DIR_PIN          55   // A1
+#define Z_ENABLE_PIN       56   // A2
 
 #define E0_STEP_PIN        31
 #define E0_DIR_PIN         32
@@ -87,7 +87,9 @@
 #define HEATER_1_PIN        8
 #define HEATER_BED_PIN     10
 
-#define FAN_PIN             7   // IO pin. Buffer needed
+#ifndef FAN_PIN
+  #define FAN_PIN           7   // IO pin. Buffer needed
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_MEGATRONICS_2.h
+++ b/Marlin/pins_MEGATRONICS_2.h
@@ -101,7 +101,9 @@
 #define HEATER_1_PIN        8
 #define HEATER_BED_PIN     10
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/pins_MEGATRONICS_3.h
+++ b/Marlin/pins_MEGATRONICS_3.h
@@ -118,7 +118,9 @@
 #define HEATER_2_PIN        8
 #define HEATER_BED_PIN     10
 
-#define FAN_PIN             6
+#ifndef FAN_PIN
+  #define FAN_PIN           6
+#endif
 #define FAN1_PIN            7
 
 //

--- a/Marlin/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/pins_MIGHTYBOARD_REVE.h
@@ -134,14 +134,14 @@
 //  2 E4 CS2
 // 78 E2 SCK
 //
-#define THERMO_SCK_PIN      78   // E2
-#define THERMO_DO_PIN        3   // E5
-#define THERMO_CS1           5   // E3
-#define THERMO_CS2           2   // E4
+#define THERMO_SCK_PIN     78   // E2
+#define THERMO_DO_PIN       3   // E5
+#define THERMO_CS1          5   // E3
+#define THERMO_CS2          2   // E4
 
-#define MAX6675_SS          THERMO_CS1
-#define MAX6675_SCK_PIN     THERMO_SCK_PIN
-#define MAX6675_DO_PIN      THERMO_DO_PIN
+#define MAX6675_SS         THERMO_CS1
+#define MAX6675_SCK_PIN    THERMO_SCK_PIN
+#define MAX6675_DO_PIN     THERMO_DO_PIN
 //
 // Augmentation for auto-assigning plugs
 //
@@ -149,10 +149,10 @@
 // 2 extruders or 1 extruder and a heated bed.
 // With no heated bed, an additional 24V fan is possible.
 //
-#define MOSFET_A_PIN         6   // H3
-#define MOSFET_B_PIN        11   // B5 - Rev A of this file had this pin assigned to 9
-#define MOSFET_C_PIN        45   // L4
-#define MOSFET_D_PIN        44   // L5
+#define MOSFET_A_PIN        6   // H3
+#define MOSFET_B_PIN       11   // B5 - Rev A of this file had this pin assigned to 9
+#define MOSFET_C_PIN       45   // L4
+#define MOSFET_D_PIN       44   // L5
 
 #if HOTENDS > 1
   #if TEMP_SENSOR_BED
@@ -172,23 +172,24 @@
 #define HEATER_0_PIN     MOSFET_A_PIN
 
 #if ENABLED(IS_EFB)                            // Hotend, Fan, Bed
-  #define FAN_PIN        MOSFET_B_PIN
-  #define HEATER_BED_PIN MOSFET_C_PIN
+  #define HEATER_BED_PIN   MOSFET_C_PIN
 #elif ENABLED(IS_EEF)                          // Hotend, Hotend, Fan
-  #define HEATER_1_PIN   MOSFET_B_PIN
-  #define FAN_PIN        MOSFET_C_PIN
+  #define HEATER_1_PIN     MOSFET_B_PIN
 #elif ENABLED(IS_EEB)                          // Hotend, Hotend, Bed
-  #define HEATER_1_PIN   MOSFET_B_PIN
-  #define HEATER_BED_PIN MOSFET_C_PIN
+  #define HEATER_1_PIN     MOSFET_B_PIN
+  #define HEATER_BED_PIN   MOSFET_C_PIN
 #elif ENABLED(IS_EFF)                          // Hotend, Fan, Fan
-  #define FAN_PIN        MOSFET_B_PIN
-  #define FAN1_PIN       MOSFET_C_PIN
-#elif ENABLED(IS_SF)                           // Spindle, Fan
-  #define FAN_PIN        MOSFET_C_PIN
+  #define FAN1_PIN         MOSFET_C_PIN
 #endif
 
 #ifndef FAN_PIN
-  #define FAN_PIN MOSFET_D_PIN
+  #if ENABLED(IS_EFB) || ENABLED(IS_EFF)       // Hotend, Fan, Bed or Hotend, Fan, Fan
+    #define FAN_PIN        MOSFET_B_PIN
+  #elif ENABLED(IS_EEF) || ENABLED(IS_SF)      // Hotend, Hotend, Fan or Spindle, Fan
+    #define FAN_PIN        MOSFET_C_PIN
+  #else
+    #define FAN_PIN        MOSFET_D_PIN
+  #endif
 #endif
 
 //
@@ -200,37 +201,37 @@
 //
 // Misc. Functions
 //
-#define LED_PIN             13   // B7
-#define CUTOFF_RESET_PIN    16   // H1
-#define CUTOFF_TEST_PIN     17   // H0
-#define CASE_LIGHT_PIN      44   // L5   MUST BE HARDWARE PWM
+#define LED_PIN            13   // B7
+#define CUTOFF_RESET_PIN   16   // H1
+#define CUTOFF_TEST_PIN    17   // H0
+#define CASE_LIGHT_PIN     44   // L5   MUST BE HARDWARE PWM
 
 //
 // LCD / Controller
 //
 #ifdef REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 
-  #define LCD_PINS_RS       33   // C4: LCD-STROBE
-  #define LCD_PINS_ENABLE   72   // J2: LEFT
-  #define LCD_PINS_D4       35   // C2: LCD-CLK
-  #define LCD_PINS_D5       32   // C5: RLED
-  #define LCD_PINS_D6       34   // C3: LCD-DATA
-  #define LCD_PINS_D7       31   // C6: GLED
+  #define LCD_PINS_RS      33   // C4: LCD-STROBE
+  #define LCD_PINS_ENABLE  72   // J2: LEFT
+  #define LCD_PINS_D4      35   // C2: LCD-CLK
+  #define LCD_PINS_D5      32   // C5: RLED
+  #define LCD_PINS_D6      34   // C3: LCD-DATA
+  #define LCD_PINS_D7      31   // C6: GLED
 
-  #define BTN_EN2           75   // J4, UP
-  #define BTN_EN1           73   // J3, DOWN
+  #define BTN_EN2          75   // J4, UP
+  #define BTN_EN1          73   // J3, DOWN
   //STOP button connected as KILL_PIN
-  #define KILL_PIN          14   // J1, RIGHT
+  #define KILL_PIN         14   // J1, RIGHT
   //KILL - not connected
 
-  #define BEEPER_PIN         8   // H5, SD_WP
+  #define BEEPER_PIN        8   // H5, SD_WP
 
-  #define BTN_CENTER        15   // J0
-  #define BTN_ENC           BTN_CENTER
+  #define BTN_CENTER       15   // J0
+  #define BTN_ENC          BTN_CENTER
 
   //on board leds
-  #define STAT_LED_RED_LED  SERVO0_PIN // C1 (1280-EX1, DEBUG2)
-  #define STAT_LED_BLUE_PIN SERVO1_PIN // C0 (1280-EX2, DEBUG3)
+  #define STAT_LED_RED_LED  SERVO0_PIN   // C1 (1280-EX1, DEBUG2)
+  #define STAT_LED_BLUE_PIN SERVO1_PIN   // C0 (1280-EX2, DEBUG3)
 
 #else
   // Replicator uses a 3-wire SR controller with HD44780
@@ -238,18 +239,18 @@
   //
 
   #define SAV_3DLCD
-  #define SR_DATA_PIN       34   // C3
-  #define SR_CLK_PIN        35   // C2
-  #define SR_STROBE_PIN     33   // C4
+  #define SR_DATA_PIN      34   // C3
+  #define SR_CLK_PIN       35   // C2
+  #define SR_STROBE_PIN    33   // C4
 
-  #define BTN_UP            75   // J4
-  #define BTN_DOWN          73   // J3
-  #define BTN_LEFT          72   // J2
-  #define BTN_RIGHT         14   // J1
-  #define BTN_CENTER        15   // J0
-  #define BTN_ENC           BTN_CENTER
+  #define BTN_UP           75   // J4
+  #define BTN_DOWN         73   // J3
+  #define BTN_LEFT         72   // J2
+  #define BTN_RIGHT        14   // J1
+  #define BTN_CENTER       15   // J0
+  #define BTN_ENC          BTN_CENTER
 
-  #define BEEPER_PIN         4   // G5
+  #define BEEPER_PIN        4   // G5
 
   #define STAT_LED_RED_PIN  32   // C5
   #define STAT_LED_BLUE_PIN 31   // C6 (Actually green)
@@ -259,8 +260,8 @@
 //
 // SD Card
 //
-#define SDSS                53   // B0
-#define SD_DETECT_PIN        9   // H6
+#define SDSS               53   // B0
+#define SD_DETECT_PIN       9   // H6
 
 #define MAX_PIN             THERMO_SCK_PIN
 
@@ -270,8 +271,6 @@
 #define SPINDLE_LASER_ENABLE_PIN 66   // K4   Pin should have a pullup!
 #define SPINDLE_LASER_PWM_PIN     8   // H5   MUST BE HARDWARE PWM
 #define SPINDLE_DIR_PIN          67   // K5
-
-
 
 
 // Check if all pins are defined in mega/pins_arduino.h

--- a/Marlin/pins_MINIRAMBO.h
+++ b/Marlin/pins_MINIRAMBO.h
@@ -106,7 +106,9 @@
 #endif
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 
 //

--- a/Marlin/pins_MINITRONICS.h
+++ b/Marlin/pins_MINITRONICS.h
@@ -57,13 +57,13 @@
 #define X_DIR_PIN          47
 #define X_ENABLE_PIN       49
 
-#define Y_STEP_PIN         39 // A6
-#define Y_DIR_PIN          40 // A0
+#define Y_STEP_PIN         39   // A6
+#define Y_DIR_PIN          40   // A0
 #define Y_ENABLE_PIN       38
 
-#define Z_STEP_PIN         42 // A2
-#define Z_DIR_PIN          43 // A6
-#define Z_ENABLE_PIN       41 // A1
+#define Z_STEP_PIN         42   // A2
+#define Z_DIR_PIN          43   // A6
+#define Z_ENABLE_PIN       41   // A1
 
 #define E0_STEP_PIN        45
 #define E0_DIR_PIN         44
@@ -83,11 +83,13 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN        7 // EXTRUDER 1
-#define HEATER_1_PIN        8 // EXTRUDER 2
-#define HEATER_BED_PIN      3 // BED
+#define HEATER_0_PIN        7   // EXTRUDER 1
+#define HEATER_1_PIN        8   // EXTRUDER 2
+#define HEATER_BED_PIN      3   // BED
 
-#define FAN_PIN             9
+#ifndef FAN_PIN
+  #define FAN_PIN           9
+#endif
 
 //
 // Misc. Functions
@@ -122,7 +124,7 @@
   #define BTN_EN2          -1
   #define BTN_ENC          -1
 
-  #define SD_DETECT_PIN    -1 // Minitronics doesn't use this
+  #define SD_DETECT_PIN    -1   // Minitronics doesn't use this
 #endif
 
 //

--- a/Marlin/pins_MKS_GEN_13.h
+++ b/Marlin/pins_MKS_GEN_13.h
@@ -33,7 +33,7 @@
   #error "MKS GEN 1.3/1.4 supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_NAME "MKS GEN > v1.3"
+#define BOARD_NAME "MKS GEN >= v1.3"
 
 //
 // Heaters / Fans

--- a/Marlin/pins_OMCA.h
+++ b/Marlin/pins_OMCA.h
@@ -108,13 +108,13 @@
 #define E0_DIR_PIN         21
 #define E0_ENABLE_PIN      10
 
-#define E1_STEP_PIN        -1 // 21
-#define E1_DIR_PIN         -1 // 20
-#define E1_ENABLE_PIN      -1 // 19
+#define E1_STEP_PIN        -1   // 21
+#define E1_DIR_PIN         -1   // 20
+#define E1_ENABLE_PIN      -1   // 19
 
-#define E2_STEP_PIN        -1 // 21
-#define E2_DIR_PIN         -1 // 20
-#define E2_ENABLE_PIN      -1 // 18
+#define E2_STEP_PIN        -1   // 21
+#define E2_DIR_PIN         -1   // 20
+#define E2_ENABLE_PIN      -1   // 18
 
 //
 // Temperature Sensors
@@ -126,10 +126,12 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN        3 // DONE PWM on RIGHT connector
+#define HEATER_0_PIN        3   // DONE PWM on RIGHT connector
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN            14 // PWM on MIDDLE connector
+#ifndef FAN_PIN
+  #define FAN_PIN          14   // PWM on MIDDLE connector
+#endif
 
 //
 // Misc. Functions
@@ -145,4 +147,4 @@
 #define __GS  18
 #define __GD  13
 
-#define UNUSED_PWM         14 // PWM on LEFT connector
+#define UNUSED_PWM         14   // PWM on LEFT connector

--- a/Marlin/pins_OMCA_A.h
+++ b/Marlin/pins_OMCA_A.h
@@ -107,12 +107,12 @@
 #define E0_DIR_PIN         27
 #define E0_ENABLE_PIN      24
 
-#define E1_STEP_PIN        -1 // 19
-#define E1_DIR_PIN         -1 // 18
+#define E1_STEP_PIN        -1   // 19
+#define E1_DIR_PIN         -1   // 18
 #define E1_ENABLE_PIN      24
 
-#define E2_STEP_PIN        -1 // 17
-#define E2_DIR_PIN         -1 // 16
+#define E2_STEP_PIN        -1   // 17
+#define E2_DIR_PIN         -1   // 16
 #define E2_ENABLE_PIN      24
 
 //
@@ -125,7 +125,9 @@
 //
 #define HEATER_0_PIN        4
 
-#define FAN_PIN             3
+#ifndef FAN_PIN
+  #define FAN_PIN           3
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_PRINTRBOARD.h
+++ b/Marlin/pins_PRINTRBOARD.h
@@ -110,8 +110,9 @@
 #define HEATER_2_PIN       45   // F7
 #define HEATER_BED_PIN     14   // C4 PWM3C
 
-
-#define FAN_PIN            16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/pins_PRINTRBOARD_REVF.h
@@ -190,7 +190,9 @@
 #endif
 #endif
 
-#define FAN_PIN            16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A
+#endif
 
 //
 // LCD / Controller

--- a/Marlin/pins_RAMBO.h
+++ b/Marlin/pins_RAMBO.h
@@ -127,7 +127,9 @@
 #define HEATER_2_PIN        6
 #define HEATER_BED_PIN      3
 
-#define FAN_PIN             8
+#ifndef FAN_PIN
+  #define FAN_PIN           8
+#endif
 #define FAN1_PIN            6
 #define FAN2_PIN            2
 

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -223,46 +223,48 @@
 // Heaters / Fans
 //
 #ifndef MOSFET_D_PIN
-  #define MOSFET_D_PIN  -1
+  #define MOSFET_D_PIN     -1
 #endif
 #ifndef RAMPS_D8_PIN
-  #define RAMPS_D8_PIN   8
+  #define RAMPS_D8_PIN      8
 #endif
 #ifndef RAMPS_D9_PIN
-  #define RAMPS_D9_PIN   9
+  #define RAMPS_D9_PIN      9
 #endif
 #ifndef RAMPS_D10_PIN
-  #define RAMPS_D10_PIN 10
+  #define RAMPS_D10_PIN    10
 #endif
 
-#define HEATER_0_PIN     RAMPS_D10_PIN
+#define HEATER_0_PIN       RAMPS_D10_PIN
 
 #if ENABLED(IS_RAMPS_EFB)                      // Hotend, Fan, Bed
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
 #elif ENABLED(IS_RAMPS_EEF)                    // Hotend, Hotend, Fan
-  #define HEATER_1_PIN   RAMPS_D9_PIN
-  #define FAN_PIN        RAMPS_D8_PIN
+  #define HEATER_1_PIN     RAMPS_D9_PIN
 #elif ENABLED(IS_RAMPS_EEB)                    // Hotend, Hotend, Bed
-  #define HEATER_1_PIN   RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define HEATER_1_PIN     RAMPS_D9_PIN
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
 #elif ENABLED(IS_RAMPS_EFF)                    // Hotend, Fan, Fan
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define FAN1_PIN       RAMPS_D8_PIN
-#elif ENABLED(IS_RAMPS_SF)                     // Spindle, Fan
-  #define FAN_PIN        RAMPS_D8_PIN
-#else                                          // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
-  #define FAN_PIN        RAMPS_D9_PIN
-  #define HEATER_BED_PIN RAMPS_D8_PIN
+  #define FAN1_PIN         RAMPS_D8_PIN
+#elif DISABLED(IS_RAMPS_SF)                    // Not Spindle, Fan (i.e., "EFBF" or "EFBE")
+  #define HEATER_BED_PIN   RAMPS_D8_PIN
   #if HOTENDS == 1
-    #define FAN1_PIN     MOSFET_D_PIN
+    #define FAN1_PIN       MOSFET_D_PIN
   #else
-    #define HEATER_1_PIN MOSFET_D_PIN
+    #define HEATER_1_PIN   MOSFET_D_PIN
   #endif
 #endif
 
 #ifndef FAN_PIN
-  #define FAN_PIN           4   // IO pin. Buffer needed
+  #if ENABLED(IS_RAMPS_EFB) || ENABLED(IS_RAMPS_EFF)  // Hotend, Fan, Bed or Hotend, Fan, Fan
+    #define FAN_PIN        RAMPS_D9_PIN
+  #elif ENABLED(IS_RAMPS_EEF) || ENABLED(IS_RAMPS_SF) // Hotend, Hotend, Fan or Spindle, Fan
+    #define FAN_PIN        RAMPS_D8_PIN
+  #elif ENABLED(IS_RAMPS_EEB)                         // Hotend, Hotend, Bed
+    #define FAN_PIN         4   // IO pin. Buffer needed
+  #else                                               // Non-specific are "EFB" (i.e., "EFBF" or "EFBE")
+    #define FAN_PIN        RAMPS_D9_PIN
+  #endif
 #endif
 
 //

--- a/Marlin/pins_RAMPS_OLD.h
+++ b/Marlin/pins_RAMPS_OLD.h
@@ -88,11 +88,15 @@
 #if ENABLED(RAMPS_V_1_0)
   #define HEATER_0_PIN     12
   #define HEATER_BED_PIN   -1
-  #define FAN_PIN          11
+  #ifndef FAN_PIN
+    #define FAN_PIN        11
+  #endif
 #else // RAMPS_V_1_1 or RAMPS_V_1_2
   #define HEATER_0_PIN     10
   #define HEATER_BED_PIN    8
-  #define FAN_PIN           9
+  #ifndef FAN_PIN
+    #define FAN_PIN         9
+  #endif
 #endif
 
 //

--- a/Marlin/pins_RIGIDBOARD.h
+++ b/Marlin/pins_RIGIDBOARD.h
@@ -36,8 +36,8 @@
 //
 // MOSFET changes
 //
-#define RAMPS_D10_PIN       9 // EXTRUDER 1
-#define MOSFET_D_PIN       12 // EXTRUDER 2 or FAN
+#define RAMPS_D10_PIN       9   // EXTRUDER 1
+#define MOSFET_D_PIN       12   // EXTRUDER 2 or FAN
 
 #include "pins_RAMPS.h"
 
@@ -74,9 +74,9 @@
 // SPI for Max6675 or Max31855 Thermocouple
 #undef MAX6675_SS
 #if DISABLED(SDSUPPORT)
-  #define MAX6675_SS       53 // Don't use pin 53 if there is even the remote possibility of using Display/SD card
+  #define MAX6675_SS       53   // Don't use pin 53 if there is even the remote possibility of using Display/SD card
 #else
-  #define MAX6675_SS       49 // Don't use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
+  #define MAX6675_SS       49   // Don't use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
 #endif
 
 //
@@ -85,8 +85,9 @@
 #undef HEATER_BED_PIN
 #define HEATER_BED_PIN     10
 
-#undef FAN_PIN
-#define FAN_PIN             8 // Same as RAMPS_13_EEF
+#ifndef FAN_PIN
+  #define FAN_PIN           8   // Same as RAMPS_13_EEF
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_RIGIDBOARD_V2.h
+++ b/Marlin/pins_RIGIDBOARD_V2.h
@@ -39,12 +39,12 @@
 // Channels available for DAC, For Rigidboard there are 4
 #define DAC_STEPPER_ORDER { 0, 1, 2, 3 }
 
-#define DAC_STEPPER_SENSE    0.05 // sense resistors on rigidboard stepper chips are .05 value
+#define DAC_STEPPER_SENSE    0.05   // sense resistors on rigidboard stepper chips are .05 value
 #define DAC_STEPPER_ADDRESS  0
-#define DAC_STEPPER_MAX   4096 // was 5000 but max allowable value is actually 4096
-#define DAC_STEPPER_VREF     1 // internal Vref, gain 2x = 4.096V
-#define DAC_STEPPER_GAIN     1 // value of 1 here sets gain of 2
-#define DAC_DISABLE_PIN     42 // set low to enable DAC
+#define DAC_STEPPER_MAX   4096   // was 5000 but max allowable value is actually 4096
+#define DAC_STEPPER_VREF     1   // internal Vref, gain 2x = 4.096V
+#define DAC_STEPPER_GAIN     1   // value of 1 here sets gain of 2
+#define DAC_DISABLE_PIN     42   // set low to enable DAC
 #define DAC_OR_ADDRESS    0x01
 
 #ifndef DAC_MOTOR_CURRENT_DEFAULT

--- a/Marlin/pins_RUMBA.h
+++ b/Marlin/pins_RUMBA.h
@@ -124,7 +124,9 @@
 #define HEATER_3_PIN        8
 #define HEATER_BED_PIN      9
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 #define FAN1_PIN            8
 
 //

--- a/Marlin/pins_SANGUINOLOLU_11.h
+++ b/Marlin/pins_SANGUINOLOLU_11.h
@@ -100,7 +100,7 @@
   #define Z_ENABLE_PIN     26
   #define E0_ENABLE_PIN    14
 
-  #if ENABLED(LCD_I2C_PANELOLU2)
+  #if !defined(FAN_PIN) && ENABLED(LCD_I2C_PANELOLU2)
     #define FAN_PIN         4   // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
   #endif
 
@@ -114,7 +114,7 @@
 
 #endif
 
-#if MB(AZTEEG_X1) || MB(STB_11) || ENABLED(IS_MELZI)
+#if !defined(FAN_PIN) && (MB(AZTEEG_X1) || MB(STB_11) || ENABLED(IS_MELZI))
   #define FAN_PIN           4   // Works for Panelolu2 too
 #endif
 

--- a/Marlin/pins_SAV_MKI.h
+++ b/Marlin/pins_SAV_MKI.h
@@ -114,7 +114,9 @@
 #define HEATER_0_PIN       15   // C5 PWM3B - Extruder
 #define HEATER_BED_PIN     14   // C4 PWM3C - Bed
 
-#define FAN_PIN            16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_SCOOVO_X9H.h
+++ b/Marlin/pins_SCOOVO_X9H.h
@@ -91,7 +91,7 @@
 #define E1_MS2_PIN          64
 
 #define DIGIPOTSS_PIN       38
-#define DIGIPOT_CHANNELS {4,5,3,0,1} // X Y Z E0 E1 digipot channels to stepper driver mapping
+#define DIGIPOT_CHANNELS {4,5,3,0,1}   // X Y Z E0 E1 digipot channels to stepper driver mapping
 
 //
 // Temperature Sensors
@@ -106,7 +106,9 @@
 #define HEATER_1_PIN         7
 #define HEATER_BED_PIN       3
 
-#define FAN_PIN              8
+#ifndef FAN_PIN
+  #define FAN_PIN            8
+#endif
 #define FAN1_PIN             6
 #define FAN2_PIN             2
 

--- a/Marlin/pins_SETHI.h
+++ b/Marlin/pins_SETHI.h
@@ -98,12 +98,13 @@
 #define HEATER_0_PIN        4
 #define HEATER_BED_PIN      3
 
-
-#if GEN7_VERSION >= 13
-  // Gen7 v1.3 removed the fan pin
-  #define FAN_PIN          -1
-#else
-  #define FAN_PIN          31
+#ifndef FAN_PIN
+  #if GEN7_VERSION >= 13
+    // Gen7 v1.3 removed the fan pin
+    #define FAN_PIN          -1
+  #else
+    #define FAN_PIN          31
+  #endif
 #endif
 
 //

--- a/Marlin/pins_SILVER_GATE.h
+++ b/Marlin/pins_SILVER_GATE.h
@@ -56,7 +56,9 @@
   #define FIL_RUNOUT_PIN   34   // X_MAX unless overridden
 #endif
 
-#define FAN_PIN             5
+#ifndef FAN_PIN
+  #define FAN_PIN           5
+#endif
 
 #define HEATER_0_PIN        7
 

--- a/Marlin/pins_TEENSY2.h
+++ b/Marlin/pins_TEENSY2.h
@@ -149,7 +149,9 @@
 //
 #define HEATER_0_PIN       15   // C5 PWM3B  Extruder
 #define HEATER_BED_PIN     14   // C4 PWM3C
-#define FAN_PIN            16   // C6 PWM3A  Fan
+#ifndef FAN_PIN
+  #define FAN_PIN          16   // C6 PWM3A  Fan
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_TEENSYLU.h
+++ b/Marlin/pins_TEENSYLU.h
@@ -127,7 +127,9 @@
 #define HEATER_0_PIN            15   // C5 PWM3B - Extruder
 #define HEATER_BED_PIN          14   // C4 PWM3C
 
-#define FAN_PIN                 16   // C6 PWM3A
+#ifndef FAN_PIN
+  #define FAN_PIN               16   // C6 PWM3A
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_ULTIMAIN_2.h
+++ b/Marlin/pins_ULTIMAIN_2.h
@@ -93,7 +93,9 @@
 #define HEATER_1_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -99,7 +99,9 @@
 #define HEATER_1_PIN        3
 #define HEATER_BED_PIN      4
 
-#define FAN_PIN             7
+#ifndef FAN_PIN
+  #define FAN_PIN           7
+#endif
 
 //
 // Misc. Functions


### PR DESCRIPTION
- Wrap `FAN_PIN` in `#ifdef` to allow easier override.
- Group `FAN_PIN` defines for RAMPS-like boards.
- Miscellaneous cleanup of pins files.

Counterpart to #10956