### PR TITLE
[2.0.x] stow bltouch before start homing

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -221,7 +221,10 @@ void GcodeSuite::G28(const bool always_home_all) {
                home_all = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
 
     #if ENABLED(BLTOUCH)
-      if (!HOMING_Z_WITH_PROBE || home_all || homeX || homeY) set_bltouch_deployed(false);
+      #if HOMING_Z_WITH_PROBE
+        if (home_all || homeX || homeY)
+      #endif
+          set_bltouch_deployed(false);
     #endif
 
     set_destination_from_current();

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -190,6 +190,10 @@ void GcodeSuite::G28(const bool always_home_all) {
     workspace_plane = PLANE_XY;
   #endif
 
+  #if ENABLED(BLTOUCH)
+    set_bltouch_deployed(false);
+  #endif
+
   // Always home with tool 0 active
   #if HOTENDS > 1
     #if DISABLED(DELTA) || ENABLED(DELTA_HOME_TO_SAFE_ZONE)
@@ -219,13 +223,6 @@ void GcodeSuite::G28(const bool always_home_all) {
                homeY = always_home_all || parser.seen('Y'),
                homeZ = always_home_all || parser.seen('Z'),
                home_all = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
-
-    #if ENABLED(BLTOUCH)
-      #if HOMING_Z_WITH_PROBE
-        if (home_all || homeX || homeY)
-      #endif
-          set_bltouch_deployed(false);
-    #endif
 
     set_destination_from_current();
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -39,7 +39,7 @@
   #include "../../feature/tmc_util.h"
 #endif
 
-#if HOMING_Z_WITH_PROBE
+#if HOMING_Z_WITH_PROBE || ENABLED(BLTOUCH)
   #include "../../module/probe.h"
 #endif
 
@@ -219,6 +219,10 @@ void GcodeSuite::G28(const bool always_home_all) {
                homeY = always_home_all || parser.seen('Y'),
                homeZ = always_home_all || parser.seen('Z'),
                home_all = (!homeX && !homeY && !homeZ) || (homeX && homeY && homeZ);
+
+    #if ENABLED(BLTOUCH)
+      if (!HOMING_Z_WITH_PROBE || home_all || homeX || homeY) set_bltouch_deployed(false);
+    #endif
 
     set_destination_from_current();
 


### PR DESCRIPTION
Be sure to stow bltouch before homing

If not homing only Z axis (or probe not involved during home) be sure to stow bltouch before moving.