### PR TITLE
STM32F4 HAL compatibility with the official STMicroelectronics Arduino Core STM32

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_Stm32f1.cpp
@@ -54,6 +54,7 @@ static SPISettings spiConfig;
 // --------------------------------------------------------------------------
 
 #if ENABLED(SOFTWARE_SPI)
+
   // --------------------------------------------------------------------------
   // Software SPI
   // --------------------------------------------------------------------------
@@ -95,14 +96,13 @@ void spiBegin() {
 void spiInit(uint8_t spiRate) {
   uint8_t  clock;
   switch (spiRate) {
-  case SPI_FULL_SPEED:    clock = SPI_CLOCK_DIV2 ; break;
-  case SPI_HALF_SPEED:    clock = SPI_CLOCK_DIV4 ; break;
-  case SPI_QUARTER_SPEED: clock = SPI_CLOCK_DIV8 ; break;
-  case SPI_EIGHTH_SPEED:  clock = SPI_CLOCK_DIV16; break;
-  case SPI_SPEED_5:       clock = SPI_CLOCK_DIV32; break;
-  case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
-  default:
-    clock = SPI_CLOCK_DIV2; // Default from the SPI library
+    case SPI_FULL_SPEED:    clock = SPI_CLOCK_DIV2 ; break;
+    case SPI_HALF_SPEED:    clock = SPI_CLOCK_DIV4 ; break;
+    case SPI_QUARTER_SPEED: clock = SPI_CLOCK_DIV8 ; break;
+    case SPI_EIGHTH_SPEED:  clock = SPI_CLOCK_DIV16; break;
+    case SPI_SPEED_5:       clock = SPI_CLOCK_DIV32; break;
+    case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
+    default:                clock = SPI_CLOCK_DIV2; // Default from the SPI library
   }
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
   SPI.begin();
@@ -168,7 +168,6 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
 /** Begin SPI transaction, set clock, bit order, data mode */
 void spiBeginTransaction(uint32_t spiClock, uint8_t bitOrder, uint8_t dataMode) {
   spiConfig = SPISettings(spiClock, (BitOrder)bitOrder, dataMode);
-
   SPI.beginTransaction(spiConfig);
 }
 

--- a/Marlin/src/HAL/HAL_STM32F4/EEPROM_Emul/eeprom_emul.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/EEPROM_Emul/eeprom_emul.cpp
@@ -47,7 +47,7 @@
 /** @addtogroup EEPROM_Emulation
   * @{
   */
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 /* Includes ------------------------------------------------------------------*/
 #include "eeprom_emul.h"
@@ -562,7 +562,7 @@ static uint16_t EE_PageTransfer(uint16_t VirtAddress, uint16_t Data) {
   return FlashStatus;
 }
 
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx
 
 /**
  * @}

--- a/Marlin/src/HAL/HAL_STM32F4/EmulatedEeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/EmulatedEeprom.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 /**
  * Description: functions for I2C connected external EEPROM.
@@ -139,5 +139,5 @@ void eeprom_update_block(const void *__src, void *__dst, size_t __n) {
 }
 
 #endif // ENABLED(EEPROM_SETTINGS) && DISABLED(I2C_EEPROM) && DISABLED(SPI_EEPROM)
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx
 

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
@@ -21,7 +21,6 @@
  *
  */
 
-
 #if defined(STM32F4) || defined(STM32F4xx)
 
 // --------------------------------------------------------------------------
@@ -81,17 +80,11 @@ void sei(void) { interrupts(); }
 void HAL_clear_reset_source(void) { __HAL_RCC_CLEAR_RESET_FLAGS(); }
 
 uint8_t HAL_get_reset_source (void) {
-  if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST) != RESET)
-    return RST_WATCHDOG;
+  if (__HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST) != RESET) return RST_WATCHDOG;
 
-  if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST) != RESET)
-    return RST_SOFTWARE;
-
-  if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST) != RESET)
-    return RST_EXTERNAL;
-
-  if (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST) != RESET)
-    return RST_POWER_ON;
+  if (__HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST) != RESET)  return RST_SOFTWARE;
+  if (__HAL_RCC_GET_FLAG(RCC_FLAG_PINRST) != RESET)  return RST_EXTERNAL;
+  if (__HAL_RCC_GET_FLAG(RCC_FLAG_PORRST) != RESET)  return RST_POWER_ON;
   return 0;
 }
 

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
@@ -22,7 +22,7 @@
  */
 
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 // --------------------------------------------------------------------------
 // Includes
@@ -137,4 +137,4 @@ uint16_t HAL_adc_get_result(void) {
   return HAL_adc_result;
 }
 
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -41,13 +41,16 @@
 
 #include "Arduino.h"
 
+#if defined(USBCON)
+#include <USBSerial.h>
+#endif
+
 #include "../math_32bit.h"
 #include "../HAL_SPI.h"
 #include "fastio_STM32F4.h"
 #include "watchdog_STM32F4.h"
 
 #include "HAL_timers_STM32F4.h"
-
 
 // --------------------------------------------------------------------------
 // Defines

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -21,8 +21,6 @@
  *
  */
 
-
-
 #ifndef _HAL_STM32F4_H
 #define _HAL_STM32F4_H
 
@@ -41,8 +39,8 @@
 
 #include "Arduino.h"
 
-#if defined(USBCON)
-#include <USBSerial.h>
+#ifdef USBCON
+  #include <USBSerial.h>
 #endif
 
 #include "../math_32bit.h"
@@ -189,6 +187,7 @@ extern "C" {
 */
 
 extern "C" char* _sbrk(int incr);
+
 /*
 static int freeMemory() {
   volatile int top;
@@ -196,6 +195,7 @@ static int freeMemory() {
   return top;
 }
 */
+
 static int freeMemory() {
   volatile char top;
   return &top - reinterpret_cast<char*>(_sbrk(0));

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_Servo_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_Servo_STM32F4.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 #include "../../inc/MarlinConfig.h"
 
@@ -50,4 +50,4 @@ void libServo::move(const int value) {
 }
 #endif // HAS_SERVOS
 
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
@@ -30,7 +30,7 @@
  * Adapted to the STM32F4 HAL
  */
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 // --------------------------------------------------------------------------
 // Includes
@@ -128,7 +128,13 @@ uint8_t spiRec(void) {
  */
 void spiRead(uint8_t* buf, uint16_t nbyte) {
   SPI.beginTransaction(spiConfig);
+
+#if defined(STM32GENERIC)
   SPI.dmaTransfer(0, const_cast<uint8_t*>(buf), nbyte);
+#else
+  SPI.transfer((uint8_t*)buf, nbyte);
+#endif
+
   SPI.endTransaction();
 }
 
@@ -156,10 +162,16 @@ void spiSend(uint8_t b) {
 void spiSendBlock(uint8_t token, const uint8_t* buf) {
   SPI.beginTransaction(spiConfig);
   SPI.transfer(token);
+
+#if defined(STM32GENERIC)
   SPI.dmaSend(const_cast<uint8_t*>(buf), 512);
+#else
+  SPI.transfer((uint8_t*)buf, (uint8_t*)0, 512);
+#endif
+
   SPI.endTransaction();
 }
 
 #endif // SOFTWARE_SPI
 
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
@@ -54,6 +54,7 @@ static SPISettings spiConfig;
 // --------------------------------------------------------------------------
 
 #if ENABLED(SOFTWARE_SPI)
+
   // --------------------------------------------------------------------------
   // Software SPI
   // --------------------------------------------------------------------------
@@ -81,8 +82,7 @@ void spiBegin(void) {
     #error SS_PIN not defined!
   #endif
 
-  SET_OUTPUT(SS_PIN);
-  WRITE(SS_PIN, HIGH);
+  OUT_WRITE(SS_PIN, HIGH);
 }
 
 /** Configure SPI for specified SPI speed */
@@ -90,14 +90,13 @@ void spiInit(uint8_t spiRate) {
   // Use datarates Marlin uses
   uint32_t clock;
   switch (spiRate) {
-  case SPI_FULL_SPEED:    clock = 20000000; break; // 13.9mhz=20000000  6.75mhz=10000000  3.38mhz=5000000  .833mhz=1000000
-  case SPI_HALF_SPEED:    clock =  5000000; break;
-  case SPI_QUARTER_SPEED: clock =  2500000; break;
-  case SPI_EIGHTH_SPEED:  clock =  1250000; break;
-  case SPI_SPEED_5:       clock =   625000; break;
-  case SPI_SPEED_6:       clock =   300000; break;
-  default:
-    clock = 4000000; // Default from the SPI libarary
+    case SPI_FULL_SPEED:    clock = 20000000; break; // 13.9mhz=20000000  6.75mhz=10000000  3.38mhz=5000000  .833mhz=1000000
+    case SPI_HALF_SPEED:    clock =  5000000; break;
+    case SPI_QUARTER_SPEED: clock =  2500000; break;
+    case SPI_EIGHTH_SPEED:  clock =  1250000; break;
+    case SPI_SPEED_5:       clock =   625000; break;
+    case SPI_SPEED_6:       clock =   300000; break;
+    default:                clock =  4000000; // Default from the SPI libarary
   }
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
   SPI.begin();
@@ -129,11 +128,11 @@ uint8_t spiRec(void) {
 void spiRead(uint8_t* buf, uint16_t nbyte) {
   SPI.beginTransaction(spiConfig);
 
-#if defined(STM32GENERIC)
-  SPI.dmaTransfer(0, const_cast<uint8_t*>(buf), nbyte);
-#else
-  SPI.transfer((uint8_t*)buf, nbyte);
-#endif
+  #ifdef STM32GENERIC
+    SPI.dmaTransfer(0, const_cast<uint8_t*>(buf), nbyte);
+  #else
+    SPI.transfer((uint8_t*)buf, nbyte);
+  #endif
 
   SPI.endTransaction();
 }
@@ -163,11 +162,11 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
   SPI.beginTransaction(spiConfig);
   SPI.transfer(token);
 
-#if defined(STM32GENERIC)
-  SPI.dmaSend(const_cast<uint8_t*>(buf), 512);
-#else
-  SPI.transfer((uint8_t*)buf, (uint8_t*)0, 512);
-#endif
+  #ifdef STM32GENERIC
+    SPI.dmaSend(const_cast<uint8_t*>(buf), 512);
+  #else
+    SPI.transfer((uint8_t*)buf, (uint8_t*)0, 512);
+  #endif
 
   SPI.endTransaction();
 }

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.h
@@ -63,39 +63,38 @@
 
 // TODO change this
 
-#if defined(STM32GENERIC)
-extern void TC5_Handler();
-extern void TC7_Handler();
-#define HAL_STEP_TIMER_ISR  void TC5_Handler()
-#define HAL_TEMP_TIMER_ISR  void TC7_Handler()
+#ifdef STM32GENERIC
+  extern void TC5_Handler();
+  extern void TC7_Handler();
+  #define HAL_STEP_TIMER_ISR void TC5_Handler()
+  #define HAL_TEMP_TIMER_ISR void TC7_Handler()
 #else
-extern void TC5_Handler(stimer_t *htim);
-extern void TC7_Handler(stimer_t *htim);
-#define HAL_STEP_TIMER_ISR  void TC5_Handler(stimer_t *htim)
-#define HAL_TEMP_TIMER_ISR  void TC7_Handler(stimer_t *htim)
+  extern void TC5_Handler(stimer_t *htim);
+  extern void TC7_Handler(stimer_t *htim);
+  #define HAL_STEP_TIMER_ISR void TC5_Handler(stimer_t *htim)
+  #define HAL_TEMP_TIMER_ISR void TC7_Handler(stimer_t *htim)
 #endif
 
 
 // --------------------------------------------------------------------------
 // Types
 // --------------------------------------------------------------------------
-#if defined(STM32GENERIC)
-typedef struct {
-  TIM_HandleTypeDef handle;
-  uint32_t callback;
-} tTimerConfig;
+
+#ifdef STM32GENERIC
+  typedef struct {
+    TIM_HandleTypeDef handle;
+    uint32_t callback;
+  } tTimerConfig;
+  typedef tTimerConfig stm32f4_timer_t;
+#else
+  typedef stimer_t stm32f4_timer_t;
 #endif
 
 // --------------------------------------------------------------------------
 // Public Variables
 // --------------------------------------------------------------------------
 
-#if defined(STM32GENERIC)
-extern tTimerConfig TimerHandle[];
-#else
-extern stimer_t TimerHandle[];
-#endif
-
+extern stm32f4_timer_t TimerHandle[];
 
 // --------------------------------------------------------------------------
 // Public functions
@@ -112,10 +111,8 @@ FORCE_INLINE static uint32_t HAL_timer_get_count(const uint8_t timer_num) {
 
 FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare) {
   __HAL_TIM_SET_AUTORELOAD(&TimerHandle[timer_num].handle, compare);
-
-  if(HAL_timer_get_count(timer_num) >= compare) {
+  if (HAL_timer_get_count(timer_num) >= compare)
     TimerHandle[timer_num].handle.Instance->EGR |= TIM_EGR_UG; // Generate an immediate update interrupt
-  }
 }
 
 FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
@@ -124,19 +121,17 @@ FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
 
 FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_ticks) {
   const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_ticks;
-  if (HAL_timer_get_compare(timer_num) < mincmp) {
+  if (HAL_timer_get_compare(timer_num) < mincmp)
     HAL_timer_set_compare(timer_num, mincmp);
-  } 
 }
 
-#if defined(STM32GENERIC)
-FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
-  if (__HAL_TIM_GET_FLAG(&TimerHandle[timer_num].handle, TIM_FLAG_UPDATE) == SET) {
-    __HAL_TIM_CLEAR_FLAG(&TimerHandle[timer_num].handle, TIM_FLAG_UPDATE);    
+#ifdef STM32GENERIC
+  FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
+    if (__HAL_TIM_GET_FLAG(&TimerHandle[timer_num].handle, TIM_FLAG_UPDATE) == SET)
+      __HAL_TIM_CLEAR_FLAG(&TimerHandle[timer_num].handle, TIM_FLAG_UPDATE);
   }
-}
 #else
-#define HAL_timer_isr_prologue(TIMER_NUM)
+  #define HAL_timer_isr_prologue(TIMER_NUM)
 #endif
 
 #define HAL_timer_isr_epilogue(TIMER_NUM)

--- a/Marlin/src/HAL/HAL_STM32F4/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/persistent_store_impl.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 #include "../persistent_store_api.h"
 
@@ -72,4 +72,4 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
 } // HAL
 
 #endif // EEPROM_SETTINGS
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx

--- a/Marlin/src/HAL/HAL_STM32F4/watchdog_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/watchdog_STM32F4.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 
 #include "../../inc/MarlinConfig.h"
 
@@ -54,4 +54,4 @@
 
 #endif // USE_WATCHDOG
 
-#endif // STM32F4
+#endif // STM32F4 || STM32F4xx

--- a/Marlin/src/HAL/backtrace/unwmemaccess.cpp
+++ b/Marlin/src/HAL/backtrace/unwmemaccess.cpp
@@ -62,7 +62,7 @@
 #define END_FLASH_ADDR    0x00080000
 #endif
 
-#ifdef STM32F4
+#if defined(STM32F4) || defined(STM32F4xx)
 // For STM32F407VET
 //  SRAM  (0x20000000 - 0x20030000) (192kb)
 //  FLASH (0x08000000 - 0x08080000) (512kb)

--- a/Marlin/src/HAL/platforms.h
+++ b/Marlin/src/HAL/platforms.h
@@ -15,7 +15,7 @@
   #define HAL_PLATFORM HAL_STM32F1
 #elif defined(STM32F4) || defined(STM32F4xx)
   #define HAL_PLATFORM HAL_STM32F4
-#elif defined(STM32F7) 
+#elif defined(STM32F7)
   #define HAL_PLATFORM HAL_STM32F7
 #else
   #error "Unsupported Platform!"

--- a/Marlin/src/HAL/platforms.h
+++ b/Marlin/src/HAL/platforms.h
@@ -13,9 +13,9 @@
   #define HAL_PLATFORM HAL_LPC1768
 #elif defined(__STM32F1__) || defined(TARGET_STM32F1)
   #define HAL_PLATFORM HAL_STM32F1
-#elif defined(STM32F4)
+#elif defined(STM32F4) || defined(STM32F4xx)
   #define HAL_PLATFORM HAL_STM32F4
-#elif defined(STM32F7)
+#elif defined(STM32F7) 
   #define HAL_PLATFORM HAL_STM32F7
 #else
   #error "Unsupported Platform!"

--- a/Marlin/src/HAL/servo.cpp
+++ b/Marlin/src/HAL/servo.cpp
@@ -53,7 +53,7 @@
 
 #include "../inc/MarlinConfig.h"
 
-#if HAS_SERVOS && !(IS_32BIT_TEENSY || defined(TARGET_LPC1768) || defined(STM32F4))
+#if HAS_SERVOS && !(IS_32BIT_TEENSY || defined(TARGET_LPC1768) || defined(STM32F4) || defined(STM32F4xx))
 
 //#include <Arduino.h>
 #include "servo.h"

--- a/Marlin/src/HAL/servo.h
+++ b/Marlin/src/HAL/servo.h
@@ -74,7 +74,7 @@
 
 #elif defined(TARGET_LPC1768)
   #include "HAL_LPC1768/LPC1768_Servo.h"
-#elif defined(STM32F4)
+#elif defined(STM32F4) || defined(STM32F4xx)
   #include "HAL_STM32F4/HAL_Servo_STM32F4.h"
 #else
   #include <stdint.h>

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -181,7 +181,7 @@ void GcodeSuite::G28(const bool always_home_all) {
     #endif
     return;
   }
-  
+
   // Wait for planner moves to finish!
   planner.synchronize();
 

--- a/Marlin/src/pins/pins_STM32F4.h
+++ b/Marlin/src/pins/pins_STM32F4.h
@@ -20,7 +20,7 @@
  *
  */
 
-#if !defined(STM32F4)
+#if !defined(STM32F4) && !defined(STM32F4xx)
   #error "Oops!  Make sure you have an STM32F4 board selected from the 'Tools -> Boards' menu."
 #endif
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -265,7 +265,7 @@ monitor_speed = 250000
 platform      = ststm32
 framework     = arduino
 board         = disco_f407vg
-build_flags   = ${common.build_flags} -DUSE_STM32GENERIC  -DSTM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
+build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
 lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, c1921b4, TMC2130Stepper
 src_filter    = ${common.default_src_filter}

--- a/platformio.ini
+++ b/platformio.ini
@@ -265,7 +265,7 @@ monitor_speed = 250000
 platform      = ststm32
 framework     = arduino
 board         = disco_f407vg
-build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
+build_flags   = ${common.build_flags} -DUSE_STM32GENERIC  -DSTM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
 lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, c1921b4, TMC2130Stepper
 src_filter    = ${common.default_src_filter}


### PR DESCRIPTION
### Description

STM32F4 HAL compatibility with the official [Arduino Core STM32](https://github.com/stm32duino/Arduino_Core_STM32) from STMicroelectronics.

### Benefits

- The Arduino Core STM32 is supported by STMicroelectronics. 
- Compared to the STM32GENERIC core this core supports hardware PWM. 

Building against the official core is currently not supported in PlatformIO but the PIO team is working on it. See https://github.com/platformio/platform-ststm32/issues/76. Building with the Arduino IDE or Arduino for VS Code works fine.

Please note that the STM32F4 HAL is still compatible with STM32GENERIC. It should certainly be possible to make the same modifications for the STM32F7 HAL as well but I have no F7 hardware to test on.


