### PR TITLE
[2.0.x] reset bltouch on home

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -203,6 +203,7 @@ void GcodeSuite::G28(const bool always_home_all) {
   #endif
 
   #if ENABLED(BLTOUCH)
+    bltouch_command(BLTOUCH_RESET);
     set_bltouch_deployed(false);
   #endif
 


### PR DESCRIPTION
Added reset bltouch instead. This ensure properly stow even when in error.