### PR TITLE
[2.0.x][LPC176x] Fix binary linking broken by pio update

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
@@ -22,6 +22,7 @@ if __name__ == "__main__":
 
                     # For MarlinFirmware/U8glib-HAL
                     "-IMarlin/src/HAL/HAL_LPC1768/u8g",
+                    "-DU8G_HAL_LINKS",
 
                     "-MMD",
                     "-MP",
@@ -48,11 +49,12 @@ else:
           "-fno-threadsafe-statics"
       ],
       LINKFLAGS=[
+          "-Wl,-Tframeworks/CMSIS/LPC1768/Re-ARM/LPC1768.ld,--gc-sections",
           "-Os",
           "-mcpu=cortex-m3",
           "-mthumb",
           "--specs=nano.specs",
           "--specs=nosys.specs",
-          "-u_printf_float",
+          "-u_printf_float"
       ],
   )

--- a/frameworks/CMSIS/library.json
+++ b/frameworks/CMSIS/library.json
@@ -11,8 +11,7 @@
       "src_filter": "+<LPC1768/*>",
       "flags": [
         "-ILPC1768/include",
-        "-ILPC1768/lib",
-        "-Wl,-Tframeworks/CMSIS/LPC1768/Re-ARM/LPC1768.ld,--gc-sections"
+        "-ILPC1768/lib"
     ]
   }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -150,10 +150,10 @@ monitor_speed = 250000
 platform          = nxplpc
 board             = lpc1768
 board_build.f_cpu = 100000000L
-build_flags       = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py
-  ${common.build_flags}
-  -DU8G_HAL_LINKS
-src_build_flags   = -Wall
+# Override default maximum RAM, LPC1768/9 do have 64k but it is in 3 blocks, 32kb and 2x16kb
+# The first 32k block is used by default, the others need specifically targeted
+board_upload.maximum_ram_size = 32768
+build_flags       = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py ${common.build_flags}
 build_unflags     = -Wall
 lib_ldf_mode      = off
 lib_extra_dirs    = frameworks

--- a/platformio.ini
+++ b/platformio.ini
@@ -150,8 +150,8 @@ monitor_speed = 250000
 platform          = nxplpc
 board             = lpc1768
 board_build.f_cpu = 100000000L
-# Override default maximum RAM, LPC1768/9 do have 64k but it is in 3 blocks, 32kb and 2x16kb
-# The first 32k block is used by default, the others need specifically targeted
+# Override default maximum RAM. LPC1768/9 do have 64k, but in 3 blocks (32K, 16K, 16K).
+# The first 32k block is used by default, while the others must be specifically targeted.
 board_upload.maximum_ram_size = 32768
 build_flags       = !python Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py ${common.build_flags}
 build_unflags     = -Wall


### PR DESCRIPTION
### Description
Move the link options to the main build flags script rather than in the CMSIS library descriptor to fix the link issue causing incompatible binary generation.

### Related Issues
#11008