### PR TITLE
Fixes G29_with_retry behavior

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -160,7 +160,7 @@ G29_TYPE GcodeSuite::G29() {
     }
     marlin_debug_flags = old_debug_flags;
     #if DISABLED(PROBE_MANUALLY)
-      if (seenQ) G29_RETURN(true);
+      if (seenQ) G29_RETURN(false);
     #endif
   #endif
 
@@ -180,7 +180,7 @@ G29_TYPE GcodeSuite::G29() {
               ;
 
   // Don't allow auto-leveling without homing first
-  if (axis_unhomed_error()) G29_RETURN(true);
+  if (axis_unhomed_error()) G29_RETURN(false);
 
   if (!no_action && planner.leveling_active && parser.boolval('O')) { // Auto-level only if needed
     #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -189,7 +189,7 @@ G29_TYPE GcodeSuite::G29() {
         SERIAL_ECHOLNPGM("<<< G29");
       }
     #endif
-    G29_RETURN(true);
+    G29_RETURN(false);
   }
 
   // Define local vars 'static' for manual probing, 'auto' otherwise
@@ -291,14 +291,14 @@ G29_TYPE GcodeSuite::G29() {
         if (!leveling_is_valid()) {
           SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("No bilinear grid");
-          G29_RETURN(true);
+          G29_RETURN(false);
         }
 
         const float rz = parser.seenval('Z') ? RAW_Z_POSITION(parser.value_linear_units()) : current_position[Z_AXIS];
         if (!WITHIN(rz, -10, 10)) {
           SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("Bad Z value");
-          G29_RETURN(true);
+          G29_RETURN(false);
         }
 
         const float rx = RAW_X_POSITION(parser.linearval('X', NAN)),
@@ -322,7 +322,7 @@ G29_TYPE GcodeSuite::G29() {
           set_bed_leveling_enabled(abl_should_enable);
           if (abl_should_enable) report_current_position();
         }
-        G29_RETURN(true);
+        G29_RETURN(false);
       } // parser.seen('W')
 
     #else
@@ -334,13 +334,13 @@ G29_TYPE GcodeSuite::G29() {
     // Jettison bed leveling data
     if (!seen_w && parser.seen('J')) {
       reset_bed_level();
-      G29_RETURN(true);
+      G29_RETURN(false);
     }
 
     verbose_level = parser.intval('V');
     if (!WITHIN(verbose_level, 0, 4)) {
       SERIAL_PROTOCOLLNPGM("?(V)erbose level is implausible (0-4).");
-      G29_RETURN(true);
+      G29_RETURN(false);
     }
 
     dryrun = parser.boolval('D')
@@ -361,11 +361,11 @@ G29_TYPE GcodeSuite::G29() {
 
       if (!WITHIN(abl_grid_points_x, 2, GRID_MAX_POINTS_X)) {
         SERIAL_PROTOCOLLNPGM("?Probe points (X) is implausible (2-" STRINGIFY(GRID_MAX_POINTS_X) ").");
-        G29_RETURN(true);
+        G29_RETURN(false);
       }
       if (!WITHIN(abl_grid_points_y, 2, GRID_MAX_POINTS_Y)) {
         SERIAL_PROTOCOLLNPGM("?Probe points (Y) is implausible (2-" STRINGIFY(GRID_MAX_POINTS_Y) ").");
-        G29_RETURN(true);
+        G29_RETURN(false);
       }
 
       abl_points = abl_grid_points_x * abl_grid_points_y;
@@ -398,7 +398,7 @@ G29_TYPE GcodeSuite::G29() {
         #endif
       ) {
         SERIAL_PROTOCOLLNPGM("? (L,R,F,B) out of bounds.");
-        G29_RETURN(true);
+        G29_RETURN(false);
       }
 
       // probe at the points of a lattice grid
@@ -423,7 +423,7 @@ G29_TYPE GcodeSuite::G29() {
       // Deploy the probe. Probe will raise if needed.
       if (DEPLOY_PROBE()) {
         set_bed_leveling_enabled(abl_should_enable);
-        G29_RETURN(true);
+        G29_RETURN(false);
       }
     #endif
 
@@ -500,7 +500,7 @@ G29_TYPE GcodeSuite::G29() {
         SERIAL_PROTOCOLLNPGM("idle");
     }
 
-    if (no_action) G29_RETURN(true);
+    if (no_action) G29_RETURN(false);
 
     if (abl_probe_index == 0) {
       // For the initial G29 S2 save software endstop state
@@ -590,7 +590,7 @@ G29_TYPE GcodeSuite::G29() {
           // If G29 is not completed, they will not be re-enabled
           soft_endstops_enabled = false;
         #endif
-        G29_RETURN(true);
+        G29_RETURN(false);
       }
       else {
 
@@ -616,7 +616,7 @@ G29_TYPE GcodeSuite::G29() {
           // If G29 is not completed, they will not be re-enabled
           soft_endstops_enabled = false;
         #endif
-        G29_RETURN(true);
+        G29_RETURN(false);
       }
       else {
 
@@ -997,7 +997,7 @@ G29_TYPE GcodeSuite::G29() {
 
   report_current_position();
   
-  G29_RETURN(!isnan(measured_z));
+  G29_RETURN(isnan(measured_z));
 }
 
 #endif // OLDSCHOOL_ABL

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -62,6 +62,12 @@
   #endif
 #endif
 
+#if ENABLED(G29_RETRY_AND_RECOVER)
+  #define G29_RETURN(b) return b;
+#else
+  #define G29_RETURN(b) return;
+#endif 
+
 /**
  * G29: Detailed Z probe, probes the bed at 3 or more points.
  *      Will fail if the printer has not been homed with G28.
@@ -136,7 +142,7 @@
  *     There's no extra effect if you have a fixed Z probe.
  *
  */
-void GcodeSuite::G29() {
+G29_TYPE GcodeSuite::G29() {
 
   #if ENABLED(DEBUG_LEVELING_FEATURE) || ENABLED(PROBE_MANUALLY)
     const bool seenQ = parser.seen('Q');
@@ -154,7 +160,7 @@ void GcodeSuite::G29() {
     }
     marlin_debug_flags = old_debug_flags;
     #if DISABLED(PROBE_MANUALLY)
-      if (seenQ) return;
+      if (seenQ) G29_RETURN(true);
     #endif
   #endif
 
@@ -174,7 +180,7 @@ void GcodeSuite::G29() {
               ;
 
   // Don't allow auto-leveling without homing first
-  if (axis_unhomed_error()) return;
+  if (axis_unhomed_error()) G29_RETURN(true);
 
   if (!no_action && planner.leveling_active && parser.boolval('O')) { // Auto-level only if needed
     #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -183,7 +189,7 @@ void GcodeSuite::G29() {
         SERIAL_ECHOLNPGM("<<< G29");
       }
     #endif
-    return;
+    G29_RETURN(true);
   }
 
   // Define local vars 'static' for manual probing, 'auto' otherwise
@@ -285,14 +291,14 @@ void GcodeSuite::G29() {
         if (!leveling_is_valid()) {
           SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("No bilinear grid");
-          return;
+          G29_RETURN(true);
         }
 
         const float rz = parser.seenval('Z') ? RAW_Z_POSITION(parser.value_linear_units()) : current_position[Z_AXIS];
         if (!WITHIN(rz, -10, 10)) {
           SERIAL_ERROR_START();
           SERIAL_ERRORLNPGM("Bad Z value");
-          return;
+          G29_RETURN(true);
         }
 
         const float rx = RAW_X_POSITION(parser.linearval('X', NAN)),
@@ -316,7 +322,7 @@ void GcodeSuite::G29() {
           set_bed_leveling_enabled(abl_should_enable);
           if (abl_should_enable) report_current_position();
         }
-        return;
+        G29_RETURN(true);
       } // parser.seen('W')
 
     #else
@@ -328,13 +334,13 @@ void GcodeSuite::G29() {
     // Jettison bed leveling data
     if (!seen_w && parser.seen('J')) {
       reset_bed_level();
-      return;
+      G29_RETURN(true);
     }
 
     verbose_level = parser.intval('V');
     if (!WITHIN(verbose_level, 0, 4)) {
       SERIAL_PROTOCOLLNPGM("?(V)erbose level is implausible (0-4).");
-      return;
+      G29_RETURN(true);
     }
 
     dryrun = parser.boolval('D')
@@ -355,11 +361,11 @@ void GcodeSuite::G29() {
 
       if (!WITHIN(abl_grid_points_x, 2, GRID_MAX_POINTS_X)) {
         SERIAL_PROTOCOLLNPGM("?Probe points (X) is implausible (2-" STRINGIFY(GRID_MAX_POINTS_X) ").");
-        return;
+        G29_RETURN(true);
       }
       if (!WITHIN(abl_grid_points_y, 2, GRID_MAX_POINTS_Y)) {
         SERIAL_PROTOCOLLNPGM("?Probe points (Y) is implausible (2-" STRINGIFY(GRID_MAX_POINTS_Y) ").");
-        return;
+        G29_RETURN(true);
       }
 
       abl_points = abl_grid_points_x * abl_grid_points_y;
@@ -392,7 +398,7 @@ void GcodeSuite::G29() {
         #endif
       ) {
         SERIAL_PROTOCOLLNPGM("? (L,R,F,B) out of bounds.");
-        return;
+        G29_RETURN(true);
       }
 
       // probe at the points of a lattice grid
@@ -417,7 +423,7 @@ void GcodeSuite::G29() {
       // Deploy the probe. Probe will raise if needed.
       if (DEPLOY_PROBE()) {
         set_bed_leveling_enabled(abl_should_enable);
-        return;
+        G29_RETURN(true);
       }
     #endif
 
@@ -494,7 +500,7 @@ void GcodeSuite::G29() {
         SERIAL_PROTOCOLLNPGM("idle");
     }
 
-    if (no_action) return;
+    if (no_action) G29_RETURN(true);
 
     if (abl_probe_index == 0) {
       // For the initial G29 S2 save software endstop state
@@ -584,7 +590,7 @@ void GcodeSuite::G29() {
           // If G29 is not completed, they will not be re-enabled
           soft_endstops_enabled = false;
         #endif
-        return;
+        G29_RETURN(true);
       }
       else {
 
@@ -610,7 +616,7 @@ void GcodeSuite::G29() {
           // If G29 is not completed, they will not be re-enabled
           soft_endstops_enabled = false;
         #endif
-        return;
+        G29_RETURN(true);
       }
       else {
 
@@ -990,6 +996,8 @@ void GcodeSuite::G29() {
   #endif
 
   report_current_position();
+  
+  G29_RETURN(!isnan(measured_z));
 }
 
 #endif // OLDSCHOOL_ABL

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -61,11 +61,6 @@ bool GcodeSuite::axis_relative_modes[] = AXIS_RELATIVE_MODES;
   float GcodeSuite::coordinate_system[MAX_COORDINATE_SYSTEMS][XYZ];
 #endif
 
-#if HAS_LEVELING && ENABLED(G29_RETRY_AND_RECOVER)
-  #include "../feature/bedlevel/bedlevel.h"
-  #include "../module/planner.h"
-#endif
-
 /**
  * Set target_extruder from the T parameter or the active_extruder
  *
@@ -135,35 +130,36 @@ void GcodeSuite::dwell(millis_t time) {
  * a loop with recovery and retry handling.
  */
 #if HAS_LEVELING && ENABLED(G29_RETRY_AND_RECOVER)
-
+  #ifndef G29_MAX_RETRIES
+    #define G29_MAX_RETRIES 0
+  #endif
+   
   void GcodeSuite::G29_with_retry() {
-    set_bed_leveling_enabled(false);
-    for (uint8_t retries_left = G29_MAX_RETRIES;;) {
-      G29();
-      if (planner.leveling_active || !retries_left--) break;
-      #ifdef G29_ACTION_ON_RECOVER
-        SERIAL_ECHOLNPGM("//action:" G29_ACTION_ON_RECOVER);
-      #endif
-      #ifdef G29_RECOVER_COMMANDS
-        process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
-      #endif
+    uint8_t retries = G29_MAX_RETRIES;
+    while (!G29()) { //G29 should return false for failed probes ONLY
+      if (retries--) {
+        #ifdef G29_ACTION_ON_RECOVER
+          SERIAL_ECHOLNPGM("//action:" G29_ACTION_ON_RECOVER);
+        #endif
+        #ifdef G29_RECOVER_COMMANDS
+          process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
+        #endif   
+      } else {
+        #ifdef G29_FAILURE_COMMANDS
+          process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
+        #endif
+        #ifdef G29_ACTION_ON_FAILURE
+          SERIAL_ECHOLNPGM("//action:" G29_ACTION_ON_FAILURE);
+        #endif
+        #if ENABLED(G29_HALT_ON_FAILURE)
+          kill(PSTR(MSG_ERR_PROBING_FAILED));
+        #endif
+        return;
+      }
     }
-    if (planner.leveling_active) {
-      #ifdef G29_SUCCESS_COMMANDS
-        process_subcommands_now_P(PSTR(G29_SUCCESS_COMMANDS));
-      #endif
-    }
-    else {
-      #ifdef G29_FAILURE_COMMANDS
-        process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
-      #endif
-      #ifdef G29_ACTION_ON_FAILURE
-        SERIAL_ECHOLNPGM("//action:" G29_ACTION_ON_FAILURE);
-      #endif
-      #if ENABLED(G29_HALT_ON_FAILURE)
-        kill(PSTR(MSG_ERR_PROBING_FAILED));
-      #endif
-    }
+    #ifdef G29_SUCCESS_COMMANDS
+      process_subcommands_now_P(PSTR(G29_SUCCESS_COMMANDS));
+    #endif
   }
 
 #endif // HAS_LEVELING && G29_RETRY_AND_RECOVER

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -130,13 +130,14 @@ void GcodeSuite::dwell(millis_t time) {
  * a loop with recovery and retry handling.
  */
 #if HAS_LEVELING && ENABLED(G29_RETRY_AND_RECOVER)
+
   #ifndef G29_MAX_RETRIES
     #define G29_MAX_RETRIES 0
   #endif
    
   void GcodeSuite::G29_with_retry() {
     uint8_t retries = G29_MAX_RETRIES;
-    while (!G29()) { //G29 should return false for failed probes ONLY
+    while (G29()) { // G29 should return true for failed probes ONLY
       if (retries--) {
         #ifdef G29_ACTION_ON_RECOVER
           SERIAL_ECHOLNPGM("//action:" G29_ACTION_ON_RECOVER);
@@ -144,7 +145,8 @@ void GcodeSuite::dwell(millis_t time) {
         #ifdef G29_RECOVER_COMMANDS
           process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
         #endif   
-      } else {
+      }
+      else {
         #ifdef G29_FAILURE_COMMANDS
           process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
         #endif

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -387,10 +387,13 @@ private:
   static void G28(const bool always_home_all);
 
   #if HAS_LEVELING
-    static void G29();
     #if ENABLED(G29_RETRY_AND_RECOVER)
       static void G29_with_retry();
+      #define G29_TYPE bool
+    #else
+      #define G29_TYPE void
     #endif
+    static G29_TYPE G29();
   #endif
 
   #if HAS_BED_PROBE

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -936,6 +936,10 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
   #error "MESH_EDIT_GFX_OVERLAY requires AUTO_BED_LEVELING_UBL and a Graphical LCD."
 #endif
 
+#if ENABLED(G29_RETRY_AND_RECOVER) && HAS_LEVELING && !OLDSCHOOL_ABL
+  #error "G29_RETRY_AND_RECOVER currently only supports ABL"
+#endif
+
 /**
  * LCD_BED_LEVELING requirements
  */


### PR DESCRIPTION
### Description
As currently implemented, `G29_RETRY_AND_RECOVER` is situated outside all `G29()` code, and attempts reprobe attempts whenever leveling is disabled after running `G29()`. However, there are several reasons `G29()` can leave without enabling bed leveling that have nothing to do with a failed probe (axes not homed, dry run, report, etc.). There are two ways to solve this: to turn `G29()` into a `bool` that indicates whether a probe has failed, or to handle reprobe attempts inside `G29()`. This PR is the second approach, currently for ABL only. Implementing it for UBL shouldn't be too hard, but UBL currently doesn't handle failed probes at all. It might help to encapsulate `probe_pt()` in a helper function that handles retry logic to achieve DRY.

I've thoroughly this code with and without `G29_RETRY_AND_RECOVER`. 

### Benefits
1. `G29_MAX_RETRIES` is now the number of *re*tries, not just tries. It also persists across multiple different probes in the same G29 commands, which is intuitive as well as idiomatic with the original Lulzbot implementation.
2. Extraneous `G29_RECOVER_COMMANDS` are not run without an accompanying call to `G29()`
3. Full G29 functionality is restored

### Related Issues
Fixes #11044.