### PR TITLE
Enable malyan lcd in M200 example configuration

### DIFF
--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -1779,7 +1779,7 @@
 // LCD for Malyan M200 printers.
 // This requires SDSUPPORT to be enabled
 //
-//#define MALYAN_LCD
+#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on


### PR DESCRIPTION
Malyan LCD Support should be enabled for M200 configuration. This PR also adds a sanity check for enabling MALYAN_LCD without also enabling SDSUPPORT.