### PR TITLE
[2.0.x] Creality Stock LCD EXP3 single cable support for Re-Arm

### DIFF
--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -257,47 +257,26 @@
 
 #if ENABLED(ULTRA_LCD)
 
-  #define BEEPER_PIN          P1_30   // (37) not 5V tolerant
+  #if ENABLED(CR10_STOCKDISPLAY)
 
-  #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
-  #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
-  #define BTN_ENC             P2_11   // (35) J3-3 & AUX-4
+    // Re-Arm can support Creality stock display without SD card reader and single cable on EXP3.
+    // Re-Arm J3 pins 1 (p1.31) & 2 (P3.26) are not used. Stock cable will need to have one
+    // 10-pin IDC connector trimmed or replaced with a 12-pin IDC connector to fit J3.
+    // Requires REVERSE_ENCODER_DIRECTION in Configuration.h
 
-  #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
-  #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
-  #define LCD_PINS_RS         P0_16   // (16) J3-7 & AUX-4
-  #define LCD_SDSS            P0_16   // (16) J3-7 & AUX-4
-  #define LCD_BACKLIGHT_PIN   P0_16   // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
-  #define LCD_PINS_ENABLE     P0_18   // (51) (MOSI) J3-10 & AUX-3
-  #define LCD_PINS_D4         P0_15   // (52) (SCK)  J3-9 & AUX-3
+    #define BEEPER_PIN          P2_11   // J3-3 & AUX-4
 
-  #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
-  #define DOGLCD_CS           P0_26   // (63) J5-3 & AUX-2
+    #define BTN_EN1             P0_16   // J3-7 & AUX-4
+    #define BTN_EN2             P1_23   // J3-5 & AUX-4
+    #define BTN_ENC             P3_25   // J3-4 & AUX-4
 
-  #ifdef ULTIPANEL
-    #define LCD_PINS_D5       P1_17   // (71) ENET_MDIO
-    #define LCD_PINS_D6       P1_14   // (73) ENET_RX_ER
-    #define LCD_PINS_D7       P1_10   // (75) ENET_RXD1
-  #endif
+    #define LCD_PINS_RS         P0_15   // J3-9 & AUX-4 (CS)
+    #define LCD_PINS_ENABLE     P0_18   // J3-10 & AUX-3 (SID, MOSI)
+    #define LCD_PINS_D4         P2_06   // J3-8 & AUX-3 (SCK, CLK)
 
-  #if ENABLED(NEWPANEL)
-    #if ENABLED(REPRAPWORLD_KEYPAD)
-      #define SHIFT_OUT         P0_18   // (51)  (MOSI) J3-10 & AUX-3
-      #define SHIFT_CLK         P0_15   // (52)  (SCK)  J3-9 & AUX-3
-      #define SHIFT_LD          P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
-    #endif
   #else
-    //#define SHIFT_CLK           P3_26   // (31)  J3-2 & AUX-4
-    //#define SHIFT_LD            P3_25   // (33)  J3-4 & AUX-4
-    //#define SHIFT_OUT           P2_11   // (35)  J3-3 & AUX-4
-    //#define SHIFT_EN            P1_22   // (41)  J5-4 & AUX-4
-  #endif
 
-  #if ENABLED(VIKI2) || ENABLED(miniVIKI)
-    // #define LCD_SCREEN_ROT_180
-
-    #undef  BEEPER_PIN
-    #define BEEPER_PIN          P1_30   // (37) may change if cable changes
+    #define BEEPER_PIN          P1_30   // (37) not 5V tolerant
 
     #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
     #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
@@ -305,56 +284,81 @@
 
     #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
     #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
+    #define LCD_PINS_RS         P0_16   // (16) J3-7 & AUX-4
+    #define LCD_SDSS            P0_16   // (16) J3-7 & AUX-4
+    #define LCD_BACKLIGHT_PIN   P0_16   // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
+    #define LCD_PINS_ENABLE     P0_18   // (51) (MOSI) J3-10 & AUX-3
+    #define LCD_PINS_D4         P0_15   // (52) (SCK)  J3-9 & AUX-3
 
-    #undef  DOGLCD_CS
-    #define DOGLCD_CS           P0_16   // (16)
-    #undef  LCD_BACKLIGHT_PIN   //P0_16   // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
-    #undef  LCD_PINS_ENABLE     //P0_18   // (51) (MOSI) J3-10 & AUX-3
-    #undef  LCD_PINS_D4         //P0_15   // (52) (SCK)  J3-9 & AUX-3
-
-    #undef  LCD_PINS_D5         //P2_06   // (59) J3-8 & AUX-2
     #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
-    #undef  LCD_PINS_D6         //P0_26   // (63) J5-3 & AUX-2
-    #undef  LCD_PINS_D7         //P1_21   // ( 6) (SERVO1) J5-1 & SERVO connector
-    #define DOGLCD_SCK          SCK_PIN
-    #define DOGLCD_MOSI         MOSI_PIN
+    #define DOGLCD_CS           P0_26   // (63) J5-3 & AUX-2
 
-    #define STAT_LED_BLUE_PIN   P0_26   // (63)  may change if cable changes
-    #define STAT_LED_RED_PIN    P1_21   // ( 6)  may change if cable changes
-  #endif
+    #ifdef ULTIPANEL
+      #define LCD_PINS_D5       P1_17   // (71) ENET_MDIO
+      #define LCD_PINS_D6       P1_14   // (73) ENET_RX_ER
+      #define LCD_PINS_D7       P1_10   // (75) ENET_RXD1
+    #endif
 
-  //#define MISO_PIN            P0_17   // (50)  system defined J3-10 & AUX-3
-  //#define MOSI_PIN            P0_18   // (51)  system defined J3-10 & AUX-3
-  //#define SCK_PIN             P0_15   // (52)  system defined J3-9 & AUX-3
-  //#define SS_PIN              P1_23   // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
+    #if ENABLED(NEWPANEL)
+      #if ENABLED(REPRAPWORLD_KEYPAD)
+        #define SHIFT_OUT         P0_18   // (51)  (MOSI) J3-10 & AUX-3
+        #define SHIFT_CLK         P0_15   // (52)  (SCK)  J3-9 & AUX-3
+        #define SHIFT_LD          P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
+      #endif
+    #else
+      //#define SHIFT_CLK           P3_26   // (31)  J3-2 & AUX-4
+      //#define SHIFT_LD            P3_25   // (33)  J3-4 & AUX-4
+      //#define SHIFT_OUT           P2_11   // (35)  J3-3 & AUX-4
+      //#define SHIFT_EN            P1_22   // (41)  J5-4 & AUX-4
+    #endif
 
-  #if ENABLED(MINIPANEL)
-    // GLCD features
-    //#define LCD_CONTRAST   190
-    // Uncomment screen orientation
-    //#define LCD_SCREEN_ROT_90
-    //#define LCD_SCREEN_ROT_180
-    //#define LCD_SCREEN_ROT_270
+    #if ENABLED(VIKI2) || ENABLED(miniVIKI)
+      // #define LCD_SCREEN_ROT_180
+
+      #undef  BEEPER_PIN
+      #define BEEPER_PIN          P1_30   // (37) may change if cable changes
+
+      #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
+      #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
+      #define BTN_ENC             P2_11   // (35) J3-3 & AUX-4
+
+      #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
+      #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
+
+      #undef  DOGLCD_CS
+      #define DOGLCD_CS           P0_16   // (16)
+      #undef  LCD_BACKLIGHT_PIN   //P0_16   // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
+      #undef  LCD_PINS_ENABLE     //P0_18   // (51) (MOSI) J3-10 & AUX-3
+      #undef  LCD_PINS_D4         //P0_15   // (52) (SCK)  J3-9 & AUX-3
+
+      #undef  LCD_PINS_D5         //P2_06   // (59) J3-8 & AUX-2
+      #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
+      #undef  LCD_PINS_D6         //P0_26   // (63) J5-3 & AUX-2
+      #undef  LCD_PINS_D7         //P1_21   // ( 6) (SERVO1) J5-1 & SERVO connector
+      #define DOGLCD_SCK          SCK_PIN
+      #define DOGLCD_MOSI         MOSI_PIN
+
+      #define STAT_LED_BLUE_PIN   P0_26   // (63)  may change if cable changes
+      #define STAT_LED_RED_PIN    P1_21   // ( 6)  may change if cable changes
+    #endif
+
+    //#define MISO_PIN            P0_17   // (50)  system defined J3-10 & AUX-3
+    //#define MOSI_PIN            P0_18   // (51)  system defined J3-10 & AUX-3
+    //#define SCK_PIN             P0_15   // (52)  system defined J3-9 & AUX-3
+    //#define SS_PIN              P1_23   // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
+
+    #if ENABLED(MINIPANEL)
+      // GLCD features
+      //#define LCD_CONTRAST   190
+      // Uncomment screen orientation
+      //#define LCD_SCREEN_ROT_90
+      //#define LCD_SCREEN_ROT_180
+      //#define LCD_SCREEN_ROT_270
+    #endif
+
   #endif
 
 #endif // ULTRA_LCD
-
-#if ENABLED(CR10_STOCKDISPLAY)
-// Supports Creality LCD display without SD card reader and single cable on EXP3.
-// Re-Arm J3 pins 1 (p1.31) & 2 (P3.26) are not used.  Stock cable will need to have one
-// 10 pin IDC connector trimmed or replaced with a 12 pin IDC connector to fit J3.
-// Requires REVERSE_ENCODER_DIRECTION in CONFIGURATION_H
-
-  #define BEEPER_PIN          P2_11   // (37) J3-3 & AUX-4
-
-  #define BTN_EN1             P0_16   // (31) J3-7 & AUX-4
-  #define BTN_EN2             P1_23   // (33) J3-5 & AUX-4
-  #define BTN_ENC             P3_25   // (35) J3-4 & AUX-4
-
-  #define LCD_PINS_RS         P0_15   // (16) J3-9 & AUX-4 (CS)
-  #define LCD_PINS_ENABLE     P0_18   // (51) J3-10 & AUX-3 (SID, MOSI)
-  #define LCD_PINS_D4         P2_06   // (52) J3-8 & AUX-3 (SCK, CLK)
-#endif
 
 //
 // Ethernet pins

--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -339,6 +339,23 @@
 
 #endif // ULTRA_LCD
 
+#if ENABLED(CR10_STOCKDISPLAY)
+// Supports Creality LCD display without SD card reader and single cable on EXP3.
+// Re-Arm J3 pins 1 (p1.31) & 2 (P3.26) are not used.  Stock cable will need to have one
+// 10 pin IDC connector trimmed or replaced with a 12 pin IDC connector to fit J3.
+// Requires REVERSE_ENCODER_DIRECTION in CONFIGURATION_H
+
+  #define BEEPER_PIN          P2_11   // (37) J3-3 & AUX-4
+
+  #define BTN_EN1             P0_16   // (31) J3-7 & AUX-4
+  #define BTN_EN2             P1_23   // (33) J3-5 & AUX-4
+  #define BTN_ENC             P3_25   // (35) J3-4 & AUX-4
+
+  #define LCD_PINS_RS         P0_15   // (16) J3-9 & AUX-4 (CS)
+  #define LCD_PINS_ENABLE     P0_18   // (51) J3-10 & AUX-3 (SID, MOSI)
+  #define LCD_PINS_D4         P2_06   // (52) J3-8 & AUX-3 (SCK, CLK)
+#endif
+
 //
 // Ethernet pins
 //


### PR DESCRIPTION
### Requirements

Panucatt Re-Arm Controller

Stock Creality LCD display with EXP3 port - Included cable needs one 10 pin IDC connector trimmed or replaced by 12 pin IDC to fit Re-Arm J3 header

#define REVERSE_ENCODER_DIRECTION in CONFIGURATION_H

### Description

Config allows direct connection of the stock Creality LCD EXP3 to Re-Arm J3 header with single 10 pin IDC cable.

### Benefits

Eliminates the need for the Ramps Smart Adapter and second speciality cable from Panucatt.

### Related Issues