### PR TITLE
[2.0.x] Enable local board repository for PIO

### DIFF
--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -412,45 +412,6 @@ def open_file(path):
 # end - open_file
 
 
-#
-# move custom board definitions from project folder to PlatformIO
-#
-def copy_boards_dir():
-
-        temp = os.environ
-        for key in temp:
-          if 0 <=  os.environ[key].find('.platformio'):
-            part = os.environ[key].split(';')
-            for part2 in part:
-              if 0 <=  part2.find('.platformio'):
-                path = part2
-                break
-
-        PIO_path = path[ : path.find('.platformio') + 11]
-
-#         import sys
-#         import subprocess
-#         pio_subprocess = subprocess.Popen(['platformio', 'run', '-t', 'envdump'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-#
-#         # stream output from subprocess and split it into lines
-#         for line in iter(pio_subprocess.stdout.readline, ''):
-#             if 0 <= line.find('PIOHOME_DIR'):
-#               start = line.find(':') + 3
-#               end =  line.find(',') - 1
-#               PIO_path = line[start:end]
-
-
-        PIO_path =  PIO_path.replace("\\", "/")
-        PIO_path =  PIO_path.replace("//", "/") + '/boards'
-
-        board_path = 'buildroot/share/PlatformIO/boards'
-
-        from distutils.dir_util import copy_tree
-        copy_tree(board_path, PIO_path)
-
-# end copy_boards_dir
-
-
 # gets the last build environment
 def get_build_last():
       env_last = ''
@@ -1265,9 +1226,6 @@ def main():
         os.environ["BOARD_NAME"] = board_name
 
         auto_build = output_window()
-        if 0 <= target_env.find('USB1286'):
-            copy_boards_dir()          # copy custom boards over to PlatformIO if using custom board
-                                       #    causes 3-5 second delay in main window appearing
         auto_build.start_thread()  # executes the "run_PIO" function
 
         auto_build.root.mainloop()

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,6 +20,7 @@ src_dir     = Marlin
 build_dir   = .pioenvs
 lib_dir     = .piolib
 libdeps_dir = .piolibdeps
+boards_dir  = buildroot/share/PlatformIO/boards
 env_default = megaatmega2560
 
 [common]
@@ -89,6 +90,7 @@ lib_deps      = ${common.lib_deps}
 lib_ldf_mode  = deep+
 src_filter    = ${common.default_src_filter}
 extra_scripts = pre:buildroot/share/atom/create_custom_upload_command_CDC.py
+monitor_speed = 250000
 
 #
 # AT90USB1286 boards using DFU bootloader
@@ -105,6 +107,7 @@ lib_deps      = ${common.lib_deps}
 lib_ldf_mode  = deep+
 src_filter    = ${common.default_src_filter}
 extra_scripts = pre:buildroot/share/atom/create_custom_upload_command_DFU.py
+monitor_speed = 250000
 
 #
 # Due (Atmel SAM3X8E ARM Cortex-M3)
@@ -270,20 +273,6 @@ lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, c1921b4, TMC2130Stepper
 src_filter    = ${common.default_src_filter}
 monitor_speed = 250000
-
-#
-# Teensy++ 2.0
-#
-[env:teensy20]
-platform          = teensy
-framework         = arduino
-board             = teensy20pp
-build_flags       = ${common.build_flags}
-#board_build.f_cpu = 20000000L     ; Bug in Arduino framework disallows boards running at 20Mhz
-lib_deps          = ${common.lib_deps}
-lib_ldf_mode      = deep+
-src_filter        = ${common.default_src_filter}
-monitor_speed     = 250000
 
 #
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)


### PR DESCRIPTION
-Enable `boards_dir` option in PIO INI
-Remove defunct custom board file operations from PIO auto-build environment
-Remove now-defunct `teensy20` PIO environment entry, replaced by `at90USB1286_CDC` and `at90USB1286_DFU` (using `teensy20` entry always put AT90USB board bootloaders in jeopardy of being overwritten due to the very small size of the official Teensy++ 2.0 bootloader)
-Update monitor_speed for AT90USB boards
-Whitespace