### PR TITLE
[2.0.x] Fix stepper/planner race condition, Stepper pulse timer

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -758,12 +758,11 @@ void Planner::calculate_trapezoid_for_block(block_t* const block, const float &e
   const bool was_enabled = STEPPER_ISR_ENABLED();
   if (was_enabled) DISABLE_STEPPER_DRIVER_INTERRUPT();
 
-  // Don't update variables if block is busy: It is being interpreted by the planner
-  // If this happens, we have a problem... The block speed is inconsistent - We already
-  // have updated some values, but the Stepper ISR is already using the block. Fortunately,
-  // we didn´t touch the values being used by the Stepper ISR, so we just stop here...
-  // TODO: Maybe there is a way to update a running block, it all depends on the stepper
-  // ISR position...
+  // Don't update variables if block is busy; it is being interpreted by the planner.
+  // If this happens, there's a problem... The block speed is inconsistent. Some values
+  // have already been updated, but the Stepper ISR is already using the block. Fortunately,
+  // the values being used by the Stepper ISR weren't touched, so just stop here...
+  // TODO: There may be a way to update a running block, depending on the stepper ISR position.
   if (!TEST(block->flag, BLOCK_BIT_BUSY)) {
     block->accelerate_until = accelerate_steps;
     block->decelerate_after = accelerate_steps + plateau_steps;
@@ -1029,10 +1028,9 @@ void Planner::recalculate_trapezoids() {
         // Recalculate if current block entry or exit junction speed has changed.
         if (TEST(current->flag, BLOCK_BIT_RECALCULATE) || TEST(next->flag, BLOCK_BIT_RECALCULATE)) {
 
-          // Mark the current block as RECALCULATE, to protect it from the Stepper ISR starting
-          // to execute it. Note that due to the above condition, there is a chance the current
-          // block is not marked as RECALCULATE yet, but the next one. That´s the reason for the
-          // following line.
+          // Mark the current block as RECALCULATE, to protect it from the Stepper ISR running it.
+          // Note that due to the above condition, there's a chance the current block isn't marked as
+          // RECALCULATE yet, but the next one is. That's the reason for the following line.
           SBI(current->flag, BLOCK_BIT_RECALCULATE);
 
           // NOTE: Entry and exit factors always > 0 by all previous logic operations.
@@ -1063,9 +1061,9 @@ void Planner::recalculate_trapezoids() {
   // Last/newest block in buffer. Exit speed is set with MINIMUM_PLANNER_SPEED. Always recalculated.
   if (next) {
 
-    // Mark the next(last) block as RECALCULATE, to protect it from the Stepper ISR starting
-    // to execute it. As the last block is always recalculated here, there is a chance the
-    // block is not marked as RECALCULATE yet. That´s the reason for the following line.
+    // Mark the next(last) block as RECALCULATE, to prevent the Stepper ISR running it.
+    // As the last block is always recalculated here, there is a chance the block isn't
+    // marked as RECALCULATE yet. That's the reason for the following line.
     SBI(next->flag, BLOCK_BIT_RECALCULATE);
 
     const float next_nominal_speed = SQRT(next->nominal_speed_sqr),
@@ -1079,8 +1077,8 @@ void Planner::recalculate_trapezoids() {
       }
     #endif
 
-    // Reset current only to ensure next trapezoid is computed - The
-    // stepper is free to use the block from now on.
+    // Reset next only to ensure its trapezoid is computed - The stepper is free to use
+    // the block from now on.
     CBI(next->flag, BLOCK_BIT_RECALCULATE);
   }
 }


### PR DESCRIPTION
As pointed out by @AnHardt in #11047 , and measured by @p3p , there seems to be something wrong with the Planner, that somehow , when jogging the Pronterface controls, outputs a first movement block that properly accelerates and decelerates, and then a 2nd block that starts at maximum feed rate and then decelerates.

There is an strong suspicion that this is caused by a race condition between the Planner and the Stepper ISR, that goes like this: When there are few blocks queued, the planner starts the forward and backward passes. And, at some point, there is a chance the block entry and exit speed will be modified before tagging it as "RECALCULATE".

That allows the Stepper to "kidnap" the block and mark it as busy after the entry and exit speed was updated by the planner, but before the new stepper parameters of the block are updated in the calc_trapezoids() function.

As the block is marked as BUSY, the planner tries to calculate the new trapezoid parameters, but is unable to update the block.

But, as the block entry and exit speed IS updated, then the planner will use those updated entry and exit speeds to plan the rest of the blocks: The result is a 1st block that decelerates to 0 (but the planner has replanned it and it should NOT decelerate!) and the 2nd block uses that assumption and starts accelerated.

The fix is to mark the block as RECALCULATE before updating its entry and exit speeds, and not after as it was done previously. Marking the block as RECALCULATE inhibits the Stepper ISR using and "kidnappiing" the block, allowing proper update of the trapezoidal form.

@AnHardt pointed out 2 places, and I found out 2 other places where this race condition exists. So, hopefully this PR will fix the "Proterface jog losing steps issue"

The other thing found by @p3p doing actual measurements on hw is that the width of the Stepper pulses is a little bit short compared with the configured value. This was caused by the fact the program takes some time to toggle the STEP line, but the pulse timing is measured from the point the first STEP line is set, to the first STEP line that is reset. 

That makes the last (typically the extruder stepper) to have a pulse shorter than the specified one.

I did disassemble the code to count the cycles that takes to SET the STEPPER line for both ARM and AVR targets, and now that time is also taken into account in the timing calculations, hopefully will ensure all pulse widths are at least the specified time long.