### PR TITLE
STM32F1: Fix SD card persistent store API

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
@@ -43,10 +43,10 @@ namespace HAL {
 namespace PersistentStore {
 
 namespace {
-// Store settings in the last two pages
-// Flash pages must be erased before writing, so keep track.
-bool firstWrite = false;
-uint32_t pageBase = EEPROM_START_ADDRESS;
+  // Store settings in the last two pages
+  // Flash pages must be erased before writing, so keep track.
+  bool firstWrite = false;
+  uint32_t pageBase = EEPROM_START_ADDRESS;
 }
 
 bool access_start() {

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
@@ -42,10 +42,12 @@
 namespace HAL {
 namespace PersistentStore {
 
+namespace {
 // Store settings in the last two pages
 // Flash pages must be erased before writing, so keep track.
 bool firstWrite = false;
 uint32_t pageBase = EEPROM_START_ADDRESS;
+}
 
 bool access_start() {
   firstWrite = true;
@@ -64,9 +66,9 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   if (firstWrite) {
     FLASH_Unlock();
     status = FLASH_ErasePage(EEPROM_PAGE0_BASE);
-    if (status != FLASH_COMPLETE) return false;
+    if (status != FLASH_COMPLETE) return true;
     status = FLASH_ErasePage(EEPROM_PAGE1_BASE);
-    if (status != FLASH_COMPLETE) return false;
+    if (status != FLASH_COMPLETE) return true;
     firstWrite = false;
   }
 
@@ -76,7 +78,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   uint16_t* wordBuffer = (uint16_t *)value;
   while (wordsToWrite) {
     status = FLASH_ProgramHalfWord(pageBase + pos + (i * 2), wordBuffer[i]);
-    if (status != FLASH_COMPLETE) return false;
+    if (status != FLASH_COMPLETE) return true;
     wordsToWrite--;
     i++;
   }
@@ -85,15 +87,15 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   if (size & 1) {
     uint16_t temp = value[size - 1];
     status = FLASH_ProgramHalfWord(pageBase + pos + i, temp);
-    if (status != FLASH_COMPLETE) return false;
+    if (status != FLASH_COMPLETE) return true;
   }
 
   crc16(crc, value, size);
   pos += ((size + 1) & ~1);
-  return true;
+  return false;
 }
 
-void read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
+bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
   for (uint16_t i = 0; i < size; i++) {
     byte* accessPoint = (byte*)(pageBase + pos + i);
     uint8_t c = *accessPoint;
@@ -101,6 +103,7 @@ void read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
     crc16(crc, &c, 1);
   }
   pos += ((size + 1) & ~1);
+  return false;
 }
 
 } // PersistentStore


### PR DESCRIPTION
Before commit 572cf0ec the API for persistent store used a `void` return from `read_data()` and also used `true` to indicate success in `write_data()`. Commit 572cf0ec reversed the logic of `write_data()` and converted `read_data()` to `bool` type.

The SD card persistent store API for STM32F1 HAL was however created initially an old template and thus used the old logic for return codes and a `void read_data()`.

That results in build errors due to inconsistency with the common `persistent_store_api.h` header, and also results in wrong reactions to `write_data()` and `read_data()` outcome for STM32F1.

This commit fixes those bugs and also hides the private variables of `HAL::PersistentStore` for STM32F1 from external access.
