### PR TITLE
Fix e jerk calculations for linear advance and junction deviation

### DIFF
--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -136,7 +136,7 @@ void GcodeSuite::M205() {
       const float junc_dev = parser.value_linear_units();
       if (WITHIN(junc_dev, 0.01, 0.3)) {
         planner.junction_deviation_mm = junc_dev;
-        planner.recalculate_max_e_jerk_factor();
+        planner.recalculate_max_e_jerk();
       }
       else {
         SERIAL_ERROR_START();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3752,7 +3752,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_MOTION);
 
       #if ENABLED(JUNCTION_DEVIATION)
-        MENU_ITEM_EDIT_CALLBACK(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.01, 0.3, planner.recalculate_max_e_jerk_factor);
+        MENU_ITEM_EDIT_CALLBACK(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.01, 0.3, planner.recalculate_max_e_jerk);
       #else
         MENU_MULTIPLIER_ITEM_EDIT(float3, MSG_VA_JERK, &planner.max_jerk[A_AXIS], 1, 990);
         MENU_MULTIPLIER_ITEM_EDIT(float3, MSG_VB_JERK, &planner.max_jerk[B_AXIS], 1, 990);

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -331,7 +331,7 @@ void MarlinSettings::postprocess() {
   #endif
 
   #if ENABLED(JUNCTION_DEVIATION) && ENABLED(LIN_ADVANCE)
-    planner.recalculate_max_e_jerk_factor();
+    planner.recalculate_max_e_jerk();
   #endif
 
   // Refresh steps_to_mm with the reciprocal of axis_steps_per_mm

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -210,7 +210,11 @@ class Planner {
     #if ENABLED(JUNCTION_DEVIATION)
       static float junction_deviation_mm;       // (mm) M205 J
       #if ENABLED(LIN_ADVANCE)
-        static float max_e_jerk_factor;         // Calculated from junction_deviation_mm
+        #if ENABLED(DISTINCT_E_FACTORS)
+          static float max_e_jerk[EXTRUDERS];   // Calculated from junction_deviation_mm
+        #else
+          static float max_e_jerk;
+        #endif
       #endif
     #else
       static float max_jerk[XYZE];              // (mm/s^2) M205 XYZE - The largest speed change requiring no acceleration.
@@ -750,9 +754,15 @@ class Planner {
     #endif
 
     #if ENABLED(JUNCTION_DEVIATION)
-      FORCE_INLINE static void recalculate_max_e_jerk_factor() {
+      FORCE_INLINE static void recalculate_max_e_jerk() {
+        #define GET_MAX_E_JERK(N) SQRT(SQRT(0.5) * junction_deviation_mm * (N) * RECIPROCAL(1.0 - SQRT(0.5)))
         #if ENABLED(LIN_ADVANCE)
-          max_e_jerk_factor = SQRT(SQRT(0.5) * junction_deviation_mm * RECIPROCAL(1.0 - SQRT(0.5)));
+          #if ENABLED(DISTINCT_E_FACTORS)
+            for (uint8_t i = 0; i < EXTRUDERS; i++)
+              max_e_jerk[i] = GET_MAX_E_JERK(max_acceleration_mm_per_s2[E_AXIS + i]);
+          #else
+            max_e_jerk = GET_MAX_E_JERK(max_acceleration_mm_per_s2[E_AXIS]);
+          #endif
         #endif
       }
     #endif


### PR DESCRIPTION
### Description

This PR fixes errors in the calculation of the max e jerk setting used when linear advance is active along with junction deviation. The previous implementation was based on an incorrect definition. This version has replaced the previous split calculation to avoid calling SQRT (required by the corrected version) repeatedly. Instead it computes the full e jerk value whenever the contributing factors change.

### Benefits

E jerk is now correctly calculated

### Related Issues

See issue: #9917