### PR TITLE
[1.1.x] Make max_e_jerk an array to save CPU

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -9174,7 +9174,7 @@ inline void gcode_M205() {
       const float junc_dev = parser.value_linear_units();
       if (WITHIN(junc_dev, 0.01, 0.3)) {
         planner.junction_deviation_mm = junc_dev;
-        planner.recalculate_max_e_jerk_factor();
+        planner.recalculate_max_e_jerk();
       }
       else {
         SERIAL_ERROR_START();

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -320,7 +320,7 @@ void MarlinSettings::postprocess() {
   #endif
 
   #if ENABLED(JUNCTION_DEVIATION) && ENABLED(LIN_ADVANCE)
-    planner.recalculate_max_e_jerk_factor();
+    planner.recalculate_max_e_jerk();
   #endif
 
   // Refresh steps_to_mm with the reciprocal of axis_steps_per_mm

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -115,7 +115,11 @@ float Planner::max_feedrate_mm_s[XYZE_N],     // (mm/s) M203 XYZE - Max speeds
 #if ENABLED(JUNCTION_DEVIATION)
   float Planner::junction_deviation_mm;       // (mm) M205 J
   #if ENABLED(LIN_ADVANCE)
-    float Planner::max_e_jerk_factor;         // Calculated from junction_deviation_mm
+    #if ENABLED(DISTINCT_E_FACTORS)
+      float Planner::max_e_jerk[EXTRUDERS];   // Calculated from junction_deviation_mm
+    #else
+      float Planner::max_e_jerk;
+    #endif
   #endif
 #else
   float Planner::max_jerk[XYZE];              // (mm/s^2) M205 XYZE - The largest speed change requiring no acceleration.
@@ -2038,7 +2042,11 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
     #if ENABLED(LIN_ADVANCE)
 
       #if ENABLED(JUNCTION_DEVIATION)
-        #define MAX_E_JERK (max_e_jerk_factor * max_acceleration_mm_per_s2[_EINDEX])
+        #if ENABLED(DISTINCT_E_FACTORS)
+          #define MAX_E_JERK max_e_jerk[extruder]
+        #else
+          #define MAX_E_JERK max_e_jerk
+        #endif
       #else
         #define MAX_E_JERK max_jerk[E_AXIS]
       #endif
@@ -2551,6 +2559,9 @@ void Planner::reset_acceleration_rates() {
     if (AXIS_CONDITION) NOLESS(highest_rate, max_acceleration_steps_per_s2[i]);
   }
   cutoff_long = 4294967295UL / highest_rate; // 0xFFFFFFFFUL
+  #if ENABLED(JUNCTION_DEVIATION) && ENABLED(LIN_ADVANCE)
+    recalculate_max_e_jerk();
+  #endif
 }
 
 // Recalculate position, steps_to_mm if axis_steps_per_mm changes!

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -205,7 +205,11 @@ class Planner {
     #if ENABLED(JUNCTION_DEVIATION)
       static float junction_deviation_mm;       // (mm) M205 J
       #if ENABLED(LIN_ADVANCE)
-        static float max_e_jerk_factor;         // Calculated from junction_deviation_mm
+        #if ENABLED(DISTINCT_E_FACTORS)
+          static float max_e_jerk[EXTRUDERS];   // Calculated from junction_deviation_mm
+        #else
+          static float max_e_jerk;
+        #endif
       #endif
     #else
       static float max_jerk[XYZE];              // (mm/s^2) M205 XYZE - The largest speed change requiring no acceleration.
@@ -737,9 +741,15 @@ class Planner {
     #endif
 
     #if ENABLED(JUNCTION_DEVIATION)
-      FORCE_INLINE static void recalculate_max_e_jerk_factor() {
+      FORCE_INLINE static void recalculate_max_e_jerk() {
+        #define GET_MAX_E_JERK(N) SQRT(SQRT(0.5) * junction_deviation_mm * (N) * RECIPROCAL(1.0 - SQRT(0.5)))
         #if ENABLED(LIN_ADVANCE)
-          max_e_jerk_factor = SQRT(SQRT(0.5) * junction_deviation_mm * RECIPROCAL(1.0 - SQRT(0.5)));
+          #if ENABLED(DISTINCT_E_FACTORS)
+            for (uint8_t i = 0; i < EXTRUDERS; i++)
+              max_e_jerk[i] = GET_MAX_E_JERK(max_acceleration_mm_per_s2[E_AXIS + i]);
+          #else
+            max_e_jerk = GET_MAX_E_JERK(max_acceleration_mm_per_s2[E_AXIS]);
+          #endif
         #endif
       }
     #endif

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3741,7 +3741,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_MOTION);
 
       #if ENABLED(JUNCTION_DEVIATION)
-        MENU_ITEM_EDIT_CALLBACK(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.01, 0.3, planner.recalculate_max_e_jerk_factor);
+        MENU_ITEM_EDIT_CALLBACK(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.01, 0.3, planner.recalculate_max_e_jerk);
       #else
         MENU_MULTIPLIER_ITEM_EDIT(float3, MSG_VA_JERK, &planner.max_jerk[A_AXIS], 1, 990);
         MENU_MULTIPLIER_ITEM_EDIT(float3, MSG_VB_JERK, &planner.max_jerk[B_AXIS], 1, 990);


### PR DESCRIPTION
Based on #11118

Make `max_e_jerk` an array to save CPU cycles in the `LIN_ADVANCE` ISR.