### PR TITLE
[1.1.x] Add minimum step dir delay option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
@@ -817,8 +817,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
@@ -812,8 +812,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -816,8 +816,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -811,8 +811,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -809,8 +809,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -810,8 +810,21 @@
 #define MIN_STEPS_PER_SEGMENT 6
 
 /**
+ * Minimum delay after setting the stepper DIR (in ns)
+ *    0 : No delay (Expect at least 10µS since one Stepper ISR must transpire)
+ *   20 : Minimum for TMC2xxx drivers
+ *  200 : Minimum for A4988 drivers
+ *  500 : Minimum for LV8729 drivers (guess, no info in datasheet)
+ *  650 : Minimum for DRV8825 drivers
+ * 1500 : Minimum for TB6600 drivers (guess, no info in datasheet)
+ *15000 : Minimum for TB6560 drivers (guess, no info in datasheet)
+ */
+#define MINIMUM_STEPPER_DIR_DELAY 0
+
+/**
  * Minimum stepper driver pulse width (in µs)
  *   0 : Smallest possible width the MCU can produce, compatible with TMC2xxx drivers
+ *   1 : Minimum for A4988 stepper drivers
  *   1 : Minimum for LV8729 stepper drivers
  *   2 : Minimum for DRV8825 stepper drivers
  *   3 : Minimum for TB6600 stepper drivers

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -688,7 +688,7 @@ class Planner {
      */
     FORCE_INLINE static void discard_current_block() {
       if (has_blocks_queued()) { // Discard non-empty buffer.
-        uint8_t block_index = next_block_index( block_buffer_tail );
+        uint8_t block_index = next_block_index(block_buffer_tail);
 
         // Push block_buffer_planned pointer, if encountered.
         if (!has_blocks_queued()) block_buffer_planned = block_index;

--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -379,6 +379,11 @@ void Stepper::set_directions() {
       }
     #endif
   #endif // !LIN_ADVANCE
+
+  // A small delay may be needed after changing direction
+  #if MINIMUM_STEPPER_DIR_DELAY > 0
+    DELAY_NS(MINIMUM_STEPPER_DIR_DELAY);
+  #endif
 }
 
 #if ENABLED(S_CURVE_ACCELERATION)


### PR DESCRIPTION
Add a minimum delay which will be applied after setting all the axis directions and before changing any step pulse pins. Ideally, this delay should only be applied when at least one axis direction changes, but for now it's just a crude delay at the start of each segment.