### PR TITLE
[1.1.x] Do a hard kill for failed homing moves

### DIFF
--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -229,6 +229,12 @@ void Endstops::not_homing() {
   #endif
 }
 
+// If the last move failed to trigger an endstop, call kill
+void Endstops::validate_homing_move() {
+  if (!trigger_state()) kill(PSTR(MSG_ERR_HOMING_FAILED));
+  hit_on_purpose();
+}
+
 // Enable / disable endstop z-probe checking
 #if HAS_BED_PROBE
   void Endstops::enable_z_probe(const bool onoff) {

--- a/Marlin/endstops.h
+++ b/Marlin/endstops.h
@@ -143,6 +143,9 @@ class Endstops {
     // Disable / Enable endstops based on ENSTOPS_ONLY_FOR_HOMING and global enable
     static void not_homing();
 
+    // If the last move failed to trigger an endstop, call kill
+    static void validate_homing_move();
+
     // Clear endstops (i.e., they were hit intentionally) to suppress the report
     FORCE_INLINE static void hit_on_purpose() { hit_state = 0; }
 


### PR DESCRIPTION
In response to #11112

If a homing move fails, it's probably a hardware failure and better not to continue at all, since it may be part of some other procedure. So just call `kill` and force users to fix their setup.

Counterpart to #11161