### PR TITLE
[2.0.x] Do a hard kill for failed homing moves

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -72,7 +72,9 @@
     #endif
 
     do_blocking_move_to_xy(1.5 * mlx * x_axis_home_dir, 1.5 * mly * home_dir(Y_AXIS), fr_mm_s);
-    endstops.hit_on_purpose(); // clear endstop hit flags
+
+    endstops.validate_homing_move();
+
     current_position[X_AXIS] = current_position[Y_AXIS] = 0.0;
 
     #if ENABLED(SENSORLESS_HOMING)

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -72,12 +72,10 @@ enum CalEnum : char {                        // the 7 main calibration points - 
 
 float lcd_probe_pt(const float &rx, const float &ry);
 
-bool ac_home() {
+void ac_home() {
   endstops.enable(true);
-  if (!home_delta())
-    return false;
+  home_delta();
   endstops.not_homing();
-  return true;
 }
 
 void ac_setup(const bool reset_bed) {
@@ -530,8 +528,7 @@ void GcodeSuite::G33() {
 
   ac_setup(!_0p_calibration && !_1p_calibration);
 
-  if (!_0p_calibration)
-    if (!ac_home()) return;
+  if (!_0p_calibration) ac_home();
 
   do { // start iterations
 
@@ -724,7 +721,7 @@ void GcodeSuite::G33() {
         sprintf_P(&mess[15], PSTR("%03i.x"), (int)round(zero_std_dev));
       lcd_setstatus(mess);
     }
-    if (!ac_home()) return;
+    ac_home();
   }
   while (((zero_std_dev < test_precision && iterations < 31) || iterations <= force_iterations) && zero_std_dev > calibration_precision);
 

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -241,7 +241,7 @@ void forward_kinematics_DELTA(float z1, float z2, float z3) {
  * A delta can only safely home all axes at the same time
  * This is like quick_home_xy() but for 3 towers.
  */
-bool home_delta() {
+void home_delta() {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) DEBUG_POS(">>> home_delta", current_position);
   #endif
@@ -265,16 +265,7 @@ bool home_delta() {
     delta_sensorless_homing(false);
   #endif
 
-  // If an endstop was not hit, then damage can occur if homing is continued.
-  // This can occur if the delta height not set correctly.
-  if (!(endstops.trigger_state() & (_BV(X_MAX) | _BV(Y_MAX) | _BV(Z_MAX)))) {
-    LCD_MESSAGEPGM(MSG_ERR_HOMING_FAILED);
-    SERIAL_ERROR_START();
-    SERIAL_ERRORLNPGM(MSG_ERR_HOMING_FAILED);
-    return false;
-  }
-
-  endstops.hit_on_purpose(); // clear endstop hit flags
+  endstops.validate_homing_move();
 
   // At least one carriage has reached the top.
   // Now re-home each carriage separately.
@@ -293,8 +284,6 @@ bool home_delta() {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) DEBUG_POS("<<< home_delta", current_position);
   #endif
-
-  return true;
 }
 
 #endif // DELTA

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -128,6 +128,6 @@ FORCE_INLINE void forward_kinematics_DELTA(float point[ABC]) {
   forward_kinematics_DELTA(point[A_AXIS], point[B_AXIS], point[C_AXIS]);
 }
 
-bool home_delta();
+void home_delta();
 
 #endif // __DELTA_H__

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -256,6 +256,12 @@ void Endstops::not_homing() {
   #endif
 }
 
+// If the last move failed to trigger an endstop, call kill
+void Endstops::validate_homing_move() {
+  if (!trigger_state()) kill(PSTR(MSG_ERR_HOMING_FAILED));
+  hit_on_purpose();
+}
+
 // Enable / disable endstop z-probe checking
 #if HAS_BED_PROBE
   void Endstops::enable_z_probe(const bool onoff) {

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -144,6 +144,9 @@ class Endstops {
     // Disable / Enable endstops based on ENSTOPS_ONLY_FOR_HOMING and global enable
     static void not_homing();
 
+    // If the last move failed to trigger an endstop, call kill
+    static void validate_homing_move();
+
     // Clear endstops (i.e., they were hit intentionally) to suppress the report
     FORCE_INLINE static void hit_on_purpose() { hit_state = 0; }
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1163,7 +1163,7 @@ static void do_homing_move(const AxisEnum axis, const float distance, const floa
       #endif
     }
 
-    endstops.hit_on_purpose();
+    endstops.validate_homing_move();
 
     // Re-enable stealthChop if used. Disable diag1 pin on driver.
     #if ENABLED(SENSORLESS_HOMING)

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -532,7 +532,6 @@ static bool do_probe_move(const float z, const float fr_mm_s) {
     if (probe_triggered && set_bltouch_deployed(false)) return true;
   #endif
 
-  // Clear endstop flags
   endstops.hit_on_purpose();
 
   // Get Z where the steppers were interrupted


### PR DESCRIPTION
In response to #11112

If a homing move fails, it's probably a hardware failure and better not to continue at all, since it may be part of some other procedure. So just call `kill` and force users to fix their setup.

Counterpart to #11160