### PR TITLE
[2.0.x] Board specific init macro

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -719,7 +719,7 @@ void setup() {
     tmc2208_serial_begin();
   #endif
 
-  #if ENABLED(HAS_BOARD_INIT)
+  #ifdef BOARD_INIT
     BOARD_INIT();
   #endif
 

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -719,6 +719,10 @@ void setup() {
     tmc2208_serial_begin();
   #endif
 
+  #if ENABLED(HAS_BOARD_INIT)
+    BOARD_INIT();
+  #endif
+
   // Check startup - does nothing if bootloader sets MCUSR to 0
   byte mcu = HAL_get_reset_source();
   if (mcu &  1) SERIAL_ECHOLNPGM(MSG_POWERUP);

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1444,4 +1444,8 @@
   #define USE_EXECUTE_COMMANDS_IMMEDIATE
 #endif
 
+#ifdef BOARD_INIT
+  #define HAS_BOARD_INIT
+#endif
+
 #endif // CONDITIONALS_POST_H

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1444,8 +1444,4 @@
   #define USE_EXECUTE_COMMANDS_IMMEDIATE
 #endif
 
-#ifdef BOARD_INIT
-  #define HAS_BOARD_INIT
-#endif
-
 #endif // CONDITIONALS_POST_H

--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -103,7 +103,7 @@
 // For Extension Board V2
 // http://doku.radds.org/dokumentation/extension-board
 //#define HAS_RADDS_EXTENSION
-#if ENABLED(HAS_RADD_EXTENSION)
+#if ENABLED(HAS_RADDS_EXTENSION)
   #define E3_STEP_PIN        35
   #define E3_DIR_PIN         33
   #define E3_ENABLE_PIN      37

--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -102,27 +102,35 @@
 
 // For Extension Board V2
 // http://doku.radds.org/dokumentation/extension-board
-//#define E3_STEP_PIN        35
-//#define E3_DIR_PIN         33
-//#define E3_ENABLE_PIN      37
-//#ifndef E3_CS_PIN
-//  #define E3_CS_PIN         6
-//#endif
+//#define HAS_RADDS_EXTENSION
+#if ENABLED(HAS_RADD_EXTENSION)
+  #define E3_STEP_PIN        35
+  #define E3_DIR_PIN         33
+  #define E3_ENABLE_PIN      37
+  #ifndef E3_CS_PIN
+   #define E3_CS_PIN         6
+  #endif
 
-//#define Z2_STEP_PIN        29
-//#define Z2_DIR_PIN         27
-//#define Z2_ENABLE_PIN      31
-//#ifndef Z2_CS_PIN
-//  #define Z2_CS_PIN        39
-//#endif
+  #define E3_MS1_PIN         67
+  #define E3_MS2_PIN         68
+  #define E3_MS3_PIN         69
 
-// Microstepping pins - Mapping not from fastio.h (?)
-//#define E3_MS1_PIN         67
-//#define E3_MS2_PIN         68
-//#define E3_MS3_PIN         69
-//#define Z2_MS1_PIN         67   // shared with E3_MS1_PIN
-//#define Z2_MS2_PIN         68   // shared with E3_MS2_PIN
-//#define Z2_MS3_PIN         69   // shared with E3_MS3_PIN
+  #define Z2_STEP_PIN        29
+  #define Z2_DIR_PIN         27
+  #define Z2_ENABLE_PIN      31
+  #ifndef Z2_CS_PIN
+   #define Z2_CS_PIN        39
+  #endif
+
+  #define Z2_MS1_PIN         67   // shared with E3_MS1_PIN
+  #define Z2_MS2_PIN         68   // shared with E3_MS2_PIN
+  #define Z2_MS3_PIN         69   // shared with E3_MS3_PIN
+
+  #define RADDS_EXT_VDD1_PIN 25
+  #define RADDS_EXT_VDD2_PIN 66
+
+  #define BOARD_INIT() OUT_WRITE(RADDS_EXT_VDD1_PIN, HIGH); OUT_WRITE(RADDS_EXT_VDD2_PIN, HIGH)
+#endif
 
 //
 // Temperature Sensors

--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -100,15 +100,17 @@
   #define E2_CS_PIN        35
 #endif
 
-// For Extension Board V2
+//
+// Extension Board V2
 // http://doku.radds.org/dokumentation/extension-board
-//#define HAS_RADDS_EXTENSION
-#if ENABLED(HAS_RADDS_EXTENSION)
+//
+//#define RADDS_EXTENSION
+#if ENABLED(RADDS_EXTENSION)
   #define E3_STEP_PIN        35
   #define E3_DIR_PIN         33
   #define E3_ENABLE_PIN      37
   #ifndef E3_CS_PIN
-   #define E3_CS_PIN         6
+    #define E3_CS_PIN         6
   #endif
 
   #define E3_MS1_PIN         67
@@ -119,7 +121,7 @@
   #define Z2_DIR_PIN         27
   #define Z2_ENABLE_PIN      31
   #ifndef Z2_CS_PIN
-   #define Z2_CS_PIN        39
+    #define Z2_CS_PIN        39
   #endif
 
   #define Z2_MS1_PIN         67   // shared with E3_MS1_PIN


### PR DESCRIPTION
This pull request is proposing a concept to define board specific initialization through a macro definition. I ran into the issue when creating a RADDS past printer using the RADDS extension board. It requires 2 pins to be set to high permanently.

The intention is to keep the init code tied to the board definition and avoid a setup depending modification of e.g. Marlin.cpp

A macro has been chosen, as the pin definitions so far do not have a cpp, but only a header.