### PR TITLE
[2.0.x] No M914 or SGT with non-sensorless axes

### DIFF
--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -522,23 +522,23 @@
 // Specify here all the endstop connectors that are connected to any endstop or probe.
 // Almost all printers will be using one per axis. Probes will use one or more of the
 // extra connectors. Leave undefined any used for non-endstop and non-probe purposes.
-#define USE_XMIN_PLUG
-#define USE_YMIN_PLUG
+//#define USE_XMIN_PLUG
+//#define USE_YMIN_PLUG
 #define USE_ZMIN_PLUG
-//#define USE_XMAX_PLUG
-//#define USE_YMAX_PLUG
+#define USE_XMAX_PLUG
+#define USE_YMAX_PLUG
 //#define USE_ZMAX_PLUG
 
 // Enable pullup for all endstops to prevent a floating state
 //#define ENDSTOPPULLUPS
 #if DISABLED(ENDSTOPPULLUPS)
   // Disable ENDSTOPPULLUPS to set pullups individually
-  //#define ENDSTOPPULLUP_XMAX
-  //#define ENDSTOPPULLUP_YMAX
-  #define ENDSTOPPULLUP_ZMAX  // open pin, inverted
-  #define ENDSTOPPULLUP_XMIN  // open pin, inverted
-  #define ENDSTOPPULLUP_YMIN  // open pin, inverted
-  //#define ENDSTOPPULLUP_ZMIN
+  #define ENDSTOPPULLUP_XMAX
+  #define ENDSTOPPULLUP_YMAX
+  //#define ENDSTOPPULLUP_ZMAX  // open pin, inverted
+  //#define ENDSTOPPULLUP_XMIN  // open pin, inverted
+  //#define ENDSTOPPULLUP_YMIN  // open pin, inverted
+  #define ENDSTOPPULLUP_ZMIN
   //#define ENDSTOPPULLUP_ZMIN_PROBE
 #endif
 

--- a/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
@@ -268,58 +268,70 @@ void GcodeSuite::M912() {
       const int8_t value = (int8_t)constrain(parser.value_int(), -64, 63);
       report = false;
       switch (i) {
-        case X_AXIS:
-          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-            if (index == 0) TMC_SET_SGT(X);
-          #endif
-          #if ENABLED(X2_IS_TMC2130)
-            if (index == 1) TMC_SET_SGT(X2);
-          #endif
-          break;
-        case Y_AXIS:
-          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-            if (index == 0) TMC_SET_SGT(Y);
-          #endif
-          #if ENABLED(Y2_IS_TMC2130)
-            if (index == 1) TMC_SET_SGT(Y2);
-          #endif
-          break;
-        case Z_AXIS:
-          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-            if (index == 0) TMC_SET_SGT(Z);
-          #endif
-          #if ENABLED(Z2_IS_TMC2130)
-            if (index == 1) TMC_SET_SGT(Z2);
-          #endif
-          break;
+        #if X_SENSORLESS
+          case X_AXIS:
+            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+              if (index == 0) TMC_SET_SGT(X);
+            #endif
+            #if ENABLED(X2_IS_TMC2130)
+              if (index == 1) TMC_SET_SGT(X2);
+            #endif
+            break;
+        #endif
+        #if Y_SENSORLESS
+          case Y_AXIS:
+            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+              if (index == 0) TMC_SET_SGT(Y);
+            #endif
+            #if ENABLED(Y2_IS_TMC2130)
+              if (index == 1) TMC_SET_SGT(Y2);
+            #endif
+            break;
+        #endif
+        #if Z_SENSORLESS
+          case Z_AXIS:
+            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+              if (index == 0) TMC_SET_SGT(Z);
+            #endif
+            #if ENABLED(Z2_IS_TMC2130)
+              if (index == 1) TMC_SET_SGT(Z2);
+            #endif
+            break;
+        #endif
       }
     }
 
     if (report) LOOP_XYZ(i) switch (i) {
-      case X_AXIS:
-        #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-          TMC_SAY_SGT(X);
-        #endif
-        #if ENABLED(X2_IS_TMC2130)
-          TMC_SAY_SGT(X2);
-        #endif
-        break;
-      case Y_AXIS:
-        #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-          TMC_SAY_SGT(Y);
-        #endif
-        #if ENABLED(Y2_IS_TMC2130)
-          TMC_SAY_SGT(Y2);
-        #endif
-        break;
-      case Z_AXIS:
-        #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-          TMC_SAY_SGT(Z);
-        #endif
-        #if ENABLED(Z2_IS_TMC2130)
-          TMC_SAY_SGT(Z2);
-        #endif
-        break;
+      #if X_SENSORLESS
+        case X_AXIS:
+          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(X);
+          #endif
+          #if ENABLED(X2_IS_TMC2130)
+            TMC_SAY_SGT(X2);
+          #endif
+          break;
+      #endif
+      #if Y_SENSORLESS
+        case Y_AXIS:
+          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(Y);
+          #endif
+          #if ENABLED(Y2_IS_TMC2130)
+            TMC_SAY_SGT(Y2);
+          #endif
+          break;
+      #endif
+      #if Z_SENSORLESS
+        case Z_AXIS:
+          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(Z);
+          #endif
+          #if ENABLED(Z2_IS_TMC2130)
+            TMC_SAY_SGT(Z2);
+          #endif
+          break;
+      #endif
     }
   }
 #endif // SENSORLESS_HOMING

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -249,7 +249,7 @@
 
     #if ENABLED(SENSORLESS_HOMING)
       #define TMC_INIT_SGT(P,Q) stepper##Q.sgt(P##_HOMING_SENSITIVITY);
-      #ifdef X_HOMING_SENSITIVITY
+      #if X_SENSORLESS
         #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
           stepperX.sgt(X_HOMING_SENSITIVITY);
         #endif
@@ -257,7 +257,7 @@
           stepperX2.sgt(X_HOMING_SENSITIVITY);
         #endif
       #endif
-      #ifdef Y_HOMING_SENSITIVITY
+      #if Y_SENSORLESS
         #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
           stepperY.sgt(Y_HOMING_SENSITIVITY);
         #endif
@@ -265,7 +265,7 @@
           stepperY2.sgt(Y_HOMING_SENSITIVITY);
         #endif
       #endif
-      #ifdef Z_HOMING_SENSITIVITY
+      #if Z_SENSORLESS
         #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
           stepperZ.sgt(Z_HOMING_SENSITIVITY);
         #endif


### PR DESCRIPTION
Don't apply M914 or SGT settings unless axes are set to use sensorless homing.

Counterpart to #11197