### PR TITLE
[1.1.x] No M914 or SGT for non-sensorless axes

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -11285,58 +11285,70 @@ inline void gcode_M502() {
         const int8_t value = (int8_t)constrain(parser.value_int(), -64, 63);
         report = false;
         switch (i) {
-          case X_AXIS:
-            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-              if (index == 0) TMC_SET_SGT(X);
-            #endif
-            #if ENABLED(X2_IS_TMC2130)
-              if (index == 1) TMC_SET_SGT(X2);
-            #endif
-            break;
-          case Y_AXIS:
-            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-              if (index == 0) TMC_SET_SGT(Y);
-            #endif
-            #if ENABLED(Y2_IS_TMC2130)
-              if (index == 1) TMC_SET_SGT(Y2);
-            #endif
-            break;
-          case Z_AXIS:
-            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-              if (index == 0) TMC_SET_SGT(Z);
-            #endif
-            #if ENABLED(Z2_IS_TMC2130)
-              if (index == 1) TMC_SET_SGT(Z2);
-            #endif
-            break;
+          #if X_SENSORLESS
+            case X_AXIS:
+              #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+                if (index == 0) TMC_SET_SGT(X);
+              #endif
+              #if ENABLED(X2_IS_TMC2130)
+                if (index == 1) TMC_SET_SGT(X2);
+              #endif
+              break;
+          #endif
+          #if Y_SENSORLESS
+            case Y_AXIS:
+              #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+                if (index == 0) TMC_SET_SGT(Y);
+              #endif
+              #if ENABLED(Y2_IS_TMC2130)
+                if (index == 1) TMC_SET_SGT(Y2);
+              #endif
+              break;
+          #endif
+          #if Z_SENSORLESS
+            case Z_AXIS:
+              #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+                if (index == 0) TMC_SET_SGT(Z);
+              #endif
+              #if ENABLED(Z2_IS_TMC2130)
+                if (index == 1) TMC_SET_SGT(Z2);
+              #endif
+              break;
+          #endif
         }
       }
 
       if (report) LOOP_XYZ(i) switch (i) {
-        case X_AXIS:
-          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-            TMC_SAY_SGT(X);
-          #endif
-          #if ENABLED(X2_IS_TMC2130)
-            TMC_SAY_SGT(X2);
-          #endif
-          break;
-        case Y_AXIS:
-          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-            TMC_SAY_SGT(Y);
-          #endif
-          #if ENABLED(Y2_IS_TMC2130)
-            TMC_SAY_SGT(Y2);
-          #endif
-          break;
-        case Z_AXIS:
-          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-            TMC_SAY_SGT(Z);
-          #endif
-          #if ENABLED(Z2_IS_TMC2130)
-            TMC_SAY_SGT(Z2);
-          #endif
-          break;
+        #if X_SENSORLESS
+          case X_AXIS:
+            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+              TMC_SAY_SGT(X);
+            #endif
+            #if ENABLED(X2_IS_TMC2130)
+              TMC_SAY_SGT(X2);
+            #endif
+            break;
+        #endif
+        #if Y_SENSORLESS
+          case Y_AXIS:
+            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+              TMC_SAY_SGT(Y);
+            #endif
+            #if ENABLED(Y2_IS_TMC2130)
+              TMC_SAY_SGT(Y2);
+            #endif
+            break;
+        #endif
+        #if Z_SENSORLESS
+          case Z_AXIS:
+            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+              TMC_SAY_SGT(Z);
+            #endif
+            #if ENABLED(Z2_IS_TMC2130)
+              TMC_SAY_SGT(Z2);
+            #endif
+            break;
+        #endif
       }
     }
   #endif // SENSORLESS_HOMING

--- a/Marlin/stepper_indirection.cpp
+++ b/Marlin/stepper_indirection.cpp
@@ -244,7 +244,7 @@
 
     #if ENABLED(SENSORLESS_HOMING)
       #define TMC_INIT_SGT(P,Q) stepper##Q.sgt(P##_HOMING_SENSITIVITY);
-      #ifdef X_HOMING_SENSITIVITY
+      #if X_SENSORLESS
         #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
           stepperX.sgt(X_HOMING_SENSITIVITY);
         #endif
@@ -252,7 +252,7 @@
           stepperX2.sgt(X_HOMING_SENSITIVITY);
         #endif
       #endif
-      #ifdef Y_HOMING_SENSITIVITY
+      #if Y_SENSORLESS
         #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
           stepperY.sgt(Y_HOMING_SENSITIVITY);
         #endif
@@ -260,7 +260,7 @@
           stepperY2.sgt(Y_HOMING_SENSITIVITY);
         #endif
       #endif
-      #ifdef Z_HOMING_SENSITIVITY
+      #if Z_SENSORLESS
         #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
           stepperZ.sgt(Z_HOMING_SENSITIVITY);
         #endif


### PR DESCRIPTION
Don't apply M914 or SGT settings unless axes are set to use sensorless homing.

Counterpart to #11196