### PR TITLE
[2.0.x][LPC176x] Fix Interrupt forward declarations

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
@@ -69,8 +69,8 @@ typedef uint8_t byte;
 //Interrupts
 void cli(void); // Disable
 void sei(void); // Enable
-void attachInterrupt(uint32_t pin, void (*callback)(void), uint32_t mode);
-void detachInterrupt(uint32_t pin);
+void attachInterrupt(const pin_t pin, void (*callback)(void), uint32_t mode);
+void detachInterrupt(const pin_t pin);
 extern "C" void GpioEnableInt(uint32_t port, uint32_t pin, uint32_t mode);
 extern "C" void GpioDisableInt(uint32_t port, uint32_t pin);
 


### PR DESCRIPTION
Fix some Interrupt forward declarations in the Arduino header