### PR TITLE
2.0 add disable jtag for stm32

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL.h
@@ -352,6 +352,10 @@ inline void HAL_adc_init(void) {
 
 #define HAL_SENSITIVE_PINS 0, 1
 
+#ifdef __AVR_AT90USB1286__
+  #define JTAG_DISABLE() do{ MCUCR = 0x80; MCUCR = 0x80; }while(0)
+#endif
+
 // AVR compatibility
 #define strtof strtod
 

--- a/Marlin/src/HAL/HAL_STM32F1/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.h
@@ -249,4 +249,6 @@ void HAL_enable_AdcFreerun(void);
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
 
+#define JTAG_DISABLE() afio_cfg_debug_ports(AFIO_DEBUG_NONE)
+
 #endif // _HAL_STM32F1_H

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -248,4 +248,6 @@ void HAL_enable_AdcFreerun(void);
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
 
+#define JTAG_DISABLE() afio_cfg_debug_ports(AFIO_DEBUG_NONE)
+
 #endif // _HAL_STM32F4_H

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -687,9 +687,12 @@ void setup() {
   #endif
 
   #if ENABLED(DISABLE_JTAG)
-    // Disable JTAG on AT90USB chips to free up pins for IO
-    MCUCR = 0x80;
-    MCUCR = 0x80;
+    // Disable JTAG to free up pins for IO
+    #ifdef JTAG_DISABLE
+      JTAG_DISABLE();
+    #else
+      #error "DISABLE_JTAG is not supported for the selected MCU/Board"
+    #endif
   #endif
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)


### PR DESCRIPTION
### Description

Add support for DISABLE_JTAG option for STM32Fx.

### Benefits

Allow for using multiplexed JTAG pins on STM32Fx boards as IO.

### Related Issues

#10898 
