### PR TITLE
[2.0.x][HD44780] Remove unused include

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -472,11 +472,12 @@ script:
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}
 
   #############################
-  # STM32F1 default config test
+  # STM32F1 config test
   #############################
 
   - export TEST_PLATFORM="-e STM32F1"
   - restore_configs
   - opt_set MOTHERBOARD BOARD_STM32F1R
   - update_defaults
+  - opt_enable EEPROM_SETTINGS EEPROM_CHITCHAT REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT
   - build_marlin_pio ${TRAVIS_BUILD_DIR} ${TEST_PLATFORM}

--- a/Marlin/src/HAL/HAL_AVR/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_AVR/persistent_store_impl.cpp
@@ -9,13 +9,8 @@
 namespace HAL {
 namespace PersistentStore {
 
-bool access_start() {
-  return true;
-}
-
-bool access_finish(){
-  return true;
-}
+bool access_start() { return true; }
+bool access_finish() { return true; }
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   while (size--) {

--- a/Marlin/src/HAL/HAL_DUE/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_DUE/persistent_store_impl.cpp
@@ -11,14 +11,12 @@ extern void eeprom_flush(void);
 namespace HAL {
 namespace PersistentStore {
 
-bool access_start() {
-  return true;
-}
+bool access_start() { return true; }
 
-bool access_finish(){
-#if DISABLED(I2C_EEPROM) && DISABLED(SPI_EEPROM)
-  eeprom_flush();
-#endif
+bool access_finish() {
+  #if DISABLED(I2C_EEPROM) && DISABLED(SPI_EEPROM)
+    eeprom_flush();
+  #endif
   return true;
 }
 

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
@@ -54,7 +54,7 @@ bool access_start() {
   return true;
 }
 
-bool access_finish(){
+bool access_finish() {
   FLASH_Lock();
   firstWrite = false;
   return true;

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_impl.cpp
@@ -44,37 +44,35 @@
 namespace HAL {
 namespace PersistentStore {
 
-#define CONFIG_FILE_NAME "eeprom.dat"
 #define HAL_STM32F1_EEPROM_SIZE 4096
 char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
+
+char eeprom_filename[] = "eeprom.dat";
 
 bool access_start() {
   if (!card.cardOK) return false;
   int16_t bytes_read = 0;
-  const char eeprom_zero = 0xFF;
-  card.openFile((char *)CONFIG_FILE_NAME,true);
-  bytes_read = card.read (HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
-  if (bytes_read == -1) return false;
-  for (; bytes_read < HAL_STM32F1_EEPROM_SIZE; bytes_read++) {
+  constexpr char eeprom_zero = 0xFF;
+  card.openFile(eeprom_filename, true);
+  bytes_read = card.read(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
+  if (bytes_read < 0) return false;
+  for (; bytes_read < HAL_STM32F1_EEPROM_SIZE; bytes_read++)
     HAL_STM32F1_eeprom_content[bytes_read] = eeprom_zero;
-  }
   card.closefile();
   return true;
 }
 
-bool access_finish(){
+bool access_finish() {
   if (!card.cardOK) return false;
-  int16_t bytes_written = 0;
-  card.openFile((char *)CONFIG_FILE_NAME,true);
-  bytes_written = card.write (HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
+  card.openFile(eeprom_filename, true);
+  int16_t bytes_written = card.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
   card.closefile();
   return (bytes_written == HAL_STM32F1_EEPROM_SIZE);
 }
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
-  for (int i = 0; i < size; i++) {
-    HAL_STM32F1_eeprom_content [pos + i] = value[i];
-  }
+  for (int i = 0; i < size; i++)
+    HAL_STM32F1_eeprom_content[pos + i] = value[i];
   crc16(crc, value, size);
   pos += size;
   return false;

--- a/Marlin/src/HAL/HAL_STM32F4/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/persistent_store_impl.cpp
@@ -33,7 +33,6 @@ namespace HAL {
 namespace PersistentStore {
 
 bool access_start() { return true; }
-
 bool access_finish() { return true; }
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {

--- a/Marlin/src/HAL/HAL_STM32F7/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/persistent_store_impl.cpp
@@ -33,13 +33,8 @@
 namespace HAL {
 namespace PersistentStore {
 
-bool access_start() {
-  return true;
-}
-
-bool access_finish(){
-  return true;
-}
+bool access_start() { return true; }
+bool access_finish() { return true; }
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   while (size--) {

--- a/Marlin/src/HAL/HAL_TEENSY35_36/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/persistent_store_impl.cpp
@@ -9,13 +9,8 @@
 namespace HAL {
 namespace PersistentStore {
 
-bool access_start() {
-  return true;
-}
-
-bool access_finish() {
-  return true;
-}
+bool access_start() { return true; }
+bool access_finish() { return true; }
 
 bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   while (size--) {

--- a/Marlin/src/lcd/ultralcd_common_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_common_HD44780.h
@@ -52,8 +52,6 @@
   #endif
 #endif
 
-#include <binary.h>
-
 extern volatile uint8_t buttons;  //an extended version of the last checked buttons in a bit array.
 
 ////////////////////////////////////
@@ -199,5 +197,3 @@ enum HD44780CharSet : char {
 };
 
 #endif // ULTRALCD_COMMON_HD44780_H
-
-

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -121,6 +121,11 @@ public:
   FORCE_INLINE uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
   FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
 
+  #if defined(__STM32F1__) && ENABLED(EEPROM_SETTINGS) && DISABLED(FLASH_EEPROM_EMULATION)
+    FORCE_INLINE int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
+    FORCE_INLINE int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
+  #endif
+
   Sd2Card& getSd2Card() { return sd2card; }
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)


### PR DESCRIPTION
### Description

The <binary.h> header is not available in STM32 toolchain
and is not used anywhere in ultralcd_common_HD44780.h.
If it is used anywhere in HD44780 support for other platforms,
it must be included in the corresponding .cpp file directly
and put under appropriate conditional compilation directives
for the platform requiring it.

As I was unable to find such code, I consider the file unused
and hence remove the inclusion.

### Benefits

Allow for using HD44780 displays on STM32-based boards

### Related Issues

None
