### PR TITLE
[2.0.x] AT90USB1286 PIO cleanup and optimization 

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -250,21 +250,21 @@
 //
 
 #elif MB(TEENSYLU)
-  #include "pins_TEENSYLU.h"          // AT90USB1286, AT90USB1286P                  env:at90USB1286_CDC
+  #include "pins_TEENSYLU.h"          // AT90USB1286, AT90USB1286P                  env:at90usb1286_cdc
 #elif MB(PRINTRBOARD)
-  #include "pins_PRINTRBOARD.h"       // AT90USB1286                                env:at90USB1286_DFU
+  #include "pins_PRINTRBOARD.h"       // AT90USB1286                                env:at90usb1286_dfu
 #elif MB(PRINTRBOARD_REVF)
-  #include "pins_PRINTRBOARD_REVF.h"  // AT90USB1286                                env:at90USB1286_DFU
+  #include "pins_PRINTRBOARD_REVF.h"  // AT90USB1286                                env:at90usb1286_dfu
 #elif MB(BRAINWAVE)
-  #include "pins_BRAINWAVE.h"         // AT90USB646                                 env:at90USB1286_CDC
+  #include "pins_BRAINWAVE.h"         // AT90USB646                                 env:at90usb1286_cdc
 #elif MB(BRAINWAVE_PRO)
-  #include "pins_BRAINWAVE_PRO.h"     // AT90USB1286                                env:at90USB1286_CDC
+  #include "pins_BRAINWAVE_PRO.h"     // AT90USB1286                                env:at90usb1286_cdc
 #elif MB(SAV_MKI)
-  #include "pins_SAV_MKI.h"           // AT90USB1286                                env:at90USB1286_CDC
+  #include "pins_SAV_MKI.h"           // AT90USB1286                                env:at90usb1286_cdc
 #elif MB(TEENSY2)
   #include "pins_TEENSY2.h"           // AT90USB1286                                env:teensy20
 #elif MB(5DPRINT)
-  #include "pins_5DPRINT.h"           // AT90USB1286                                ?env:at90USB1286_DFU
+  #include "pins_5DPRINT.h"           // AT90USB1286                                env:at90usb1286_dfu
 
 //
 // LPC1768 ARM Cortex M3

--- a/buildroot/share/PlatformIO/boards/at90usb1286.json
+++ b/buildroot/share/PlatformIO/boards/at90usb1286.json
@@ -1,14 +1,14 @@
 {
   "build": {
     "core": "teensy",
-    "extra_flags": "-DTEENSY2PP",
+    "extra_flags": "-DTEENSY2PP  -fsingle-precision-constant",
     "f_cpu": "16000000L",
     "mcu": "at90usb1286"
   },
   "frameworks": [
     "arduino"
   ],
-  "name": "at90USB1286.json",
+  "name": "Atmel AT90USB1286 based",
   "upload": {
     "maximum_ram_size": 8192,
     "maximum_size": 122880,

--- a/platformio.ini
+++ b/platformio.ini
@@ -81,10 +81,10 @@ monitor_speed     = 250000
 # - SAV_MKI
 # - TEENSYLU
 #
-[env:at90USB1286_CDC]
+[env:at90usb1286_cdc]
 platform      = teensy
 framework     = arduino
-board         = at90USB1286
+board         = at90usb1286
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 lib_ldf_mode  = deep+
@@ -98,10 +98,10 @@ monitor_speed = 250000
 # - PrintrBoard Rev.F
 # - ? 5DPRINT ?
 #
-[env:at90USB1286_DFU]
+[env:at90usb1286_dfu]
 platform      = teensy
 framework     = arduino
-board         = at90USB1286
+board         = at90usb1286
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 lib_ldf_mode  = deep+


### PR DESCRIPTION
-normalize `env` and `board` to lowercase naming convention
-make board `name` follow descriptive convention
-implement `-fsingle-precision-constant` compile optimization per https://github.com/MarlinFirmware/Marlin/pull/11178#issuecomment-401673901
-fix remnant typo in `5DPRINT` entry