### PR TITLE
[bugfix-1.1.x] Loosen static assertion guarding overflow in SCAN_THERMISTOR_TABLE

### DIFF
--- a/Marlin/thermistortables.h
+++ b/Marlin/thermistortables.h
@@ -204,8 +204,8 @@
 #endif
 
 // The SCAN_THERMISTOR_TABLE macro needs alteration?
-static_assert(HEATER_0_TEMPTABLE_LEN < 128 && HEATER_1_TEMPTABLE_LEN < 128 && HEATER_2_TEMPTABLE_LEN < 128 && HEATER_3_TEMPTABLE_LEN < 128 && HEATER_4_TEMPTABLE_LEN < 128 && BEDTEMPTABLE_LEN < 128 && CHAMBERTEMPTABLE_LEN < 128,
-  "Temperature conversion tables over 127 entries need special consideration."
+static_assert(HEATER_0_TEMPTABLE_LEN < 256 && HEATER_1_TEMPTABLE_LEN < 256 && HEATER_2_TEMPTABLE_LEN < 256 && HEATER_3_TEMPTABLE_LEN < 256 && HEATER_4_TEMPTABLE_LEN < 256 && BEDTEMPTABLE_LEN < 256 && CHAMBERTEMPTABLE_LEN < 256,
+  "Temperature conversion tables over 255 entries need special consideration."
 );
 
 // Set the high and low raw values for the heaters


### PR DESCRIPTION
### Description

Bisect search merged in #10882 actually works fine for thermistor tables with up to 255 entries with no overflow, due to C++ [integer promotion rules][promo]. Feel free to verify independently with this [simple test program to search for overflows][test].

 [promo]: https://en.cppreference.com/w/cpp/language/implicit_conversion#Integral_promotion
 [test]: https://gist.github.com/agrif/846d8e2e275e9f09b87eea7648be13fc

This PR loosens the static assertion to only prevent compilation if the table is more than 255 entries.

Closes issue #11220.

### Benefits

Thermistor tables with more than 127 entries, like table 71 (#11220) can now be used without a compiler error. As discussed in that issue, table 71 has other unrelated issues that will be addressed in a later PR.
