### PR TITLE
[1.1.x] Unify "I" parameter for M906,M912 etc.

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -10979,26 +10979,26 @@ inline void gcode_M502() {
       switch (i) {
         case X_AXIS:
           #if X_IS_TRINAMIC
-            if (index == 0) TMC_SET_CURRENT(X);
+            if (index < 2) TMC_SET_CURRENT(X);
           #endif
           #if X2_IS_TRINAMIC
-            if (index == 1) TMC_SET_CURRENT(X2);
+            if (!(index & 1)) TMC_SET_CURRENT(X2);
           #endif
           break;
         case Y_AXIS:
           #if Y_IS_TRINAMIC
-            if (index == 0) TMC_SET_CURRENT(Y);
+            if (index < 2) TMC_SET_CURRENT(Y);
           #endif
           #if Y2_IS_TRINAMIC
-            if (index == 1) TMC_SET_CURRENT(Y2);
+            if (!(index & 1)) TMC_SET_CURRENT(Y2);
           #endif
           break;
         case Z_AXIS:
           #if Z_IS_TRINAMIC
-            if (index == 0) TMC_SET_CURRENT(Z);
+            if (index < 2) TMC_SET_CURRENT(Z);
           #endif
           #if Z2_IS_TRINAMIC
-            if (index == 1) TMC_SET_CURRENT(Z2);
+            if (!(index & 1)) TMC_SET_CURRENT(Z2);
           #endif
           break;
         case E_AXIS: {
@@ -11024,48 +11024,40 @@ inline void gcode_M502() {
       }
     }
 
-    if (report) LOOP_XYZE(i) switch (i) {
-      case X_AXIS:
-        #if X_IS_TRINAMIC
-          TMC_SAY_CURRENT(X);
-        #endif
-        #if X2_IS_TRINAMIC
-          TMC_SAY_CURRENT(X2);
-        #endif
-        break;
-      case Y_AXIS:
-        #if Y_IS_TRINAMIC
-          TMC_SAY_CURRENT(Y);
-        #endif
-        #if Y2_IS_TRINAMIC
-          TMC_SAY_CURRENT(Y2);
-        #endif
-        break;
-      case Z_AXIS:
-        #if Z_IS_TRINAMIC
-          TMC_SAY_CURRENT(Z);
-        #endif
-        #if Z2_IS_TRINAMIC
-          TMC_SAY_CURRENT(Z2);
-        #endif
-        break;
-      case E_AXIS:
-        #if E0_IS_TRINAMIC
-          TMC_SAY_CURRENT(E0);
-        #endif
-        #if E1_IS_TRINAMIC
-          TMC_SAY_CURRENT(E1);
-        #endif
-        #if E2_IS_TRINAMIC
-          TMC_SAY_CURRENT(E2);
-        #endif
-        #if E3_IS_TRINAMIC
-          TMC_SAY_CURRENT(E3);
-        #endif
-        #if E4_IS_TRINAMIC
-          TMC_SAY_CURRENT(E4);
-        #endif
-        break;
+    if (report) {
+      #if X_IS_TRINAMIC
+        TMC_SAY_CURRENT(X);
+      #endif
+      #if X2_IS_TRINAMIC
+        TMC_SAY_CURRENT(X2);
+      #endif
+      #if Y_IS_TRINAMIC
+        TMC_SAY_CURRENT(Y);
+      #endif
+      #if Y2_IS_TRINAMIC
+        TMC_SAY_CURRENT(Y2);
+      #endif
+      #if Z_IS_TRINAMIC
+        TMC_SAY_CURRENT(Z);
+      #endif
+      #if Z2_IS_TRINAMIC
+        TMC_SAY_CURRENT(Z2);
+      #endif
+      #if E0_IS_TRINAMIC
+        TMC_SAY_CURRENT(E0);
+      #endif
+      #if E1_IS_TRINAMIC
+        TMC_SAY_CURRENT(E1);
+      #endif
+      #if E2_IS_TRINAMIC
+        TMC_SAY_CURRENT(E2);
+      #endif
+      #if E3_IS_TRINAMIC
+        TMC_SAY_CURRENT(E3);
+      #endif
+      #if E4_IS_TRINAMIC
+        TMC_SAY_CURRENT(E4);
+      #endif
     }
   }
 
@@ -11202,26 +11194,26 @@ inline void gcode_M502() {
         switch (i) {
           case X_AXIS:
             #if X_IS_TRINAMIC
-              if (index == 0) TMC_SET_PWMTHRS(X,X);
+              if (index < 2) TMC_SET_PWMTHRS(X,X);
             #endif
             #if X2_IS_TRINAMIC
-              if (index == 1) TMC_SET_PWMTHRS(X,X2);
+              if (!(index & 1)) TMC_SET_PWMTHRS(X,X2);
             #endif
             break;
           case Y_AXIS:
             #if Y_IS_TRINAMIC
-              if (index == 0) TMC_SET_PWMTHRS(Y,Y);
+              if (index < 2) TMC_SET_PWMTHRS(Y,Y);
             #endif
             #if Y2_IS_TRINAMIC
-              if (index == 1) TMC_SET_PWMTHRS(Y,Y2);
+              if (!(index & 1)) TMC_SET_PWMTHRS(Y,Y2);
             #endif
             break;
           case Z_AXIS:
             #if Z_IS_TRINAMIC
-              if (index == 0) TMC_SET_PWMTHRS(Z,Z);
+              if (index < 2) TMC_SET_PWMTHRS(Z,Z);
             #endif
             #if Z2_IS_TRINAMIC
-              if (index == 1) TMC_SET_PWMTHRS(Z,Z2);
+              if (!(index & 1)) TMC_SET_PWMTHRS(Z,Z2);
             #endif
             break;
           case E_AXIS: {
@@ -11247,48 +11239,40 @@ inline void gcode_M502() {
         }
       }
 
-      if (report) LOOP_XYZE(i) switch (i) {
-        case X_AXIS:
-          #if X_IS_TRINAMIC
-            TMC_SAY_PWMTHRS(X,X);
-          #endif
-          #if X2_IS_TRINAMIC
-            TMC_SAY_PWMTHRS(X,X2);
-          #endif
-          break;
-        case Y_AXIS:
-          #if Y_IS_TRINAMIC
-            TMC_SAY_PWMTHRS(Y,Y);
-          #endif
-          #if Y2_IS_TRINAMIC
-            TMC_SAY_PWMTHRS(Y,Y2);
-          #endif
-          break;
-        case Z_AXIS:
-          #if Z_IS_TRINAMIC
-            TMC_SAY_PWMTHRS(Z,Z);
-          #endif
-          #if Z2_IS_TRINAMIC
-            TMC_SAY_PWMTHRS(Z,Z2);
-          #endif
-          break;
-        case E_AXIS:
-          #if E0_IS_TRINAMIC
-            TMC_SAY_PWMTHRS_E(0);
-          #endif
-          #if E_STEPPERS > 1 && E1_IS_TRINAMIC
-            TMC_SAY_PWMTHRS_E(1);
-          #endif
-          #if E_STEPPERS > 2 && E2_IS_TRINAMIC
-            TMC_SAY_PWMTHRS_E(2);
-          #endif
-          #if E_STEPPERS > 3 && E3_IS_TRINAMIC
-            TMC_SAY_PWMTHRS_E(3);
-          #endif
-          #if E_STEPPERS > 4 && E4_IS_TRINAMIC
-            TMC_SAY_PWMTHRS_E(4);
-          #endif
-          break;
+      if (report) {
+        #if X_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(X,X);
+        #endif
+        #if X2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(X,X2);
+        #endif
+        #if Y_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Y,Y);
+        #endif
+        #if Y2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Y,Y2);
+        #endif
+        #if Z_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Z,Z);
+        #endif
+        #if Z2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS(Z,Z2);
+        #endif
+        #if E0_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(0);
+        #endif
+        #if E_STEPPERS > 1 && E1_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(1);
+        #endif
+        #if E_STEPPERS > 2 && E2_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(2);
+        #endif
+        #if E_STEPPERS > 3 && E3_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(3);
+        #endif
+        #if E_STEPPERS > 4 && E4_IS_TRINAMIC
+          TMC_SAY_PWMTHRS_E(4);
+        #endif
       }
     }
   #endif // HYBRID_THRESHOLD
@@ -11310,66 +11294,60 @@ inline void gcode_M502() {
           #if X_SENSORLESS
             case X_AXIS:
               #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-                if (index == 0) TMC_SET_SGT(X);
+                if (index < 2) TMC_SET_SGT(X);
               #endif
               #if ENABLED(X2_IS_TMC2130)
-                if (index == 1) TMC_SET_SGT(X2);
+                if (!(index & 1)) TMC_SET_SGT(X2);
               #endif
               break;
           #endif
           #if Y_SENSORLESS
             case Y_AXIS:
               #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-                if (index == 0) TMC_SET_SGT(Y);
+                if (index < 2) TMC_SET_SGT(Y);
               #endif
               #if ENABLED(Y2_IS_TMC2130)
-                if (index == 1) TMC_SET_SGT(Y2);
+                if (!(index & 1)) TMC_SET_SGT(Y2);
               #endif
               break;
           #endif
           #if Z_SENSORLESS
             case Z_AXIS:
               #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-                if (index == 0) TMC_SET_SGT(Z);
+                if (index < 2) TMC_SET_SGT(Z);
               #endif
               #if ENABLED(Z2_IS_TMC2130)
-                if (index == 1) TMC_SET_SGT(Z2);
+                if (!(index & 1)) TMC_SET_SGT(Z2);
               #endif
               break;
           #endif
         }
       }
 
-      if (report) LOOP_XYZ(i) switch (i) {
+      if (report) {
         #if X_SENSORLESS
-          case X_AXIS:
-            #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
-              TMC_SAY_SGT(X);
-            #endif
-            #if ENABLED(X2_IS_TMC2130)
-              TMC_SAY_SGT(X2);
-            #endif
-            break;
+          #if ENABLED(X_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(X);
+          #endif
+          #if ENABLED(X2_IS_TMC2130)
+            TMC_SAY_SGT(X2);
+          #endif
         #endif
         #if Y_SENSORLESS
-          case Y_AXIS:
-            #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
-              TMC_SAY_SGT(Y);
-            #endif
-            #if ENABLED(Y2_IS_TMC2130)
-              TMC_SAY_SGT(Y2);
-            #endif
-            break;
+          #if ENABLED(Y_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(Y);
+          #endif
+          #if ENABLED(Y2_IS_TMC2130)
+            TMC_SAY_SGT(Y2);
+          #endif
         #endif
         #if Z_SENSORLESS
-          case Z_AXIS:
-            #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
-              TMC_SAY_SGT(Z);
-            #endif
-            #if ENABLED(Z2_IS_TMC2130)
-              TMC_SAY_SGT(Z2);
-            #endif
-            break;
+          #if ENABLED(Z_IS_TMC2130) || ENABLED(IS_TRAMS)
+            TMC_SAY_SGT(Z);
+          #endif
+          #if ENABLED(Z2_IS_TMC2130)
+            TMC_SAY_SGT(Z2);
+          #endif
         #endif
       }
     }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -14757,6 +14757,6 @@ void loop() {
       if (++cmd_queue_index_r >= BUFSIZE) cmd_queue_index_r = 0;
     }
   }
-  endstops.report_state();
+  endstops.event_handler();
   idle();
 }

--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -189,7 +189,7 @@ void Endstops::init() {
 
 } // Endstops::init
 
-// Called from ISR: Poll endstop state if required
+// Called at ~1KHz from Temperature ISR: Poll endstop state if required
 void Endstops::poll() {
 
   #if ENABLED(PINS_DEBUGGING)
@@ -231,8 +231,8 @@ void Endstops::not_homing() {
 
 // If the last move failed to trigger an endstop, call kill
 void Endstops::validate_homing_move() {
-  if (!trigger_state()) kill(PSTR(MSG_ERR_HOMING_FAILED));
-  hit_on_purpose();
+  if (trigger_state()) hit_on_purpose();
+  else kill(PSTR(MSG_ERR_HOMING_FAILED));
 }
 
 // Enable / disable endstop z-probe checking
@@ -256,8 +256,9 @@ void Endstops::validate_homing_move() {
   }
 #endif
 
-void Endstops::report_state() {
-  if (hit_state) {
+void Endstops::event_handler() {
+  static uint8_t prev_hit_state; // = 0
+  if (hit_state && hit_state != prev_hit_state) {
     #if ENABLED(ULTRA_LCD)
       char chrX = ' ', chrY = ' ', chrZ = ' ', chrP = ' ';
       #define _SET_STOP_CHAR(A,C) (chr## A = C)
@@ -293,8 +294,6 @@ void Endstops::report_state() {
       lcd_status_printf_P(0, PSTR(MSG_LCD_ENDSTOPS " %c %c %c %c"), chrX, chrY, chrZ, chrP);
     #endif
 
-    hit_on_purpose();
-
     #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED) && ENABLED(SDSUPPORT)
       if (planner.abort_on_endstop_hit) {
         card.sdprinting = false;
@@ -304,6 +303,7 @@ void Endstops::report_state() {
       }
     #endif
   }
+  prev_hit_state = hit_state;
 } // Endstops::report_state
 
 void Endstops::M119() {
@@ -365,7 +365,7 @@ void Endstops::M119() {
 #define _ENDSTOP_PIN(AXIS, MINMAX) AXIS ##_## MINMAX ##_PIN
 #define _ENDSTOP_INVERTING(AXIS, MINMAX) AXIS ##_## MINMAX ##_ENDSTOP_INVERTING
 
-// Check endstops - Could be called from ISR!
+// Check endstops - Could be called from Temperature ISR!
 void Endstops::update() {
 
   #if DISABLED(ENDSTOP_NOISE_FILTER)
@@ -540,7 +540,7 @@ void Endstops::update() {
     if (dual_hit) { \
       _ENDSTOP_HIT(AXIS1, MINMAX); \
       /* if not performing home or if both endstops were trigged during homing... */ \
-      if (!stepper.homing_dual_axis || dual_hit == 0x3) \
+      if (!stepper.homing_dual_axis || dual_hit == 0b11) \
         planner.endstop_triggered(_AXIS(AXIS1)); \
     } \
   }while(0)

--- a/Marlin/endstops.h
+++ b/Marlin/endstops.h
@@ -127,7 +127,7 @@ class Endstops {
     /**
      * Report endstop hits to serial. Called from loop().
      */
-    static void report_state();
+    static void event_handler();
 
     /**
      * Report endstop positions in response to M119


### PR DESCRIPTION
Have the "I" parameter mean the same thing in all TMC-oriented M9xx commands.

For `M906 In Xv` the "I" parameter can be:
- No "I" parameter, no value, or I0: both X and X2
- `I1` and `I2` for only the first or second stepper driver
