### PR TITLE
Include stdlib in fontutils

### DIFF
--- a/Marlin/src/lcd/fontutils.h
+++ b/Marlin/src/lcd/fontutils.h
@@ -9,6 +9,7 @@
 #ifndef _FONT_UTILS_H
 #define _FONT_UTILS_H
 
+#include <stdlib.h>
 #include <Arduino.h>
 #include "../core/macros.h"
 #include <stddef.h> // wchar_t


### PR DESCRIPTION
When `REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER` is defined and Re-ARM build is attempted, `u8g_fontutf8.cpp` includes `fontutils.h` which uses `abs()`.
    
However, `abs()` is defined in `stdlib.h` which is not included in `fontutils.h`, so compile fails with an error.

Include `stdlib.h` in `fontutils.h` so that `abs()` is defined before `u8g_fontutf8.cpp` needs to use it, resolving the compile error.
    
 Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>

### Additional

The compile error is as follows:

~~~
In file included from Marlin/src/lcd/fontutils.h:12:0,
from Marlin/src/lcd/u8g_fontutf8.cpp:15:
/home/username/.platformio/packages/toolchain-gccarmnoneeabi/arm-none-eabi/include/stdlib.h:70:5: error: expected unqualified-id before 'int'
int _EXFUN(abs,(int));
^
/home/username/.platformio/packages/toolchain-gccarmnoneeabi/arm-none-eabi/include/stdlib.h:70:5: error: expected ')' before 'int'
/home/username/.platformio/packages/toolchain-gccarmnoneeabi/arm-none-eabi/include/stdlib.h:70:5: error: expected ')' before 'int'
Compiling .pioenvs/LPC1768/src/src/libs/stopwatch.o
*** [.pioenvs/LPC1768/src/src/lcd/u8g_fontutf8.o] Error 1
~~~