### PR TITLE
[1.1.x] Validate that X/Y_PROBE_OFFSET_FROM_EXTRUDER are integers

### DIFF
--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -792,8 +792,9 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
     #error "Z_PROBE_LOW_POINT must be less than or equal to 0."
   #endif
 
-  static_assert((int)X_PROBE_OFFSET_FROM_EXTRUDER == X_PROBE_OFFSET_FROM_EXTRUDER, "X_PROBE_OFFSET_FROM_EXTRUDER must be an integer value.");
-  static_assert((int)Y_PROBE_OFFSET_FROM_EXTRUDER == Y_PROBE_OFFSET_FROM_EXTRUDER, "Y_PROBE_OFFSET_FROM_EXTRUDER must be an integer value.");
+  static_assert(int(X_PROBE_OFFSET_FROM_EXTRUDER) == (X_PROBE_OFFSET_FROM_EXTRUDER), "X_PROBE_OFFSET_FROM_EXTRUDER must be an integer value.");
+  static_assert(int(Y_PROBE_OFFSET_FROM_EXTRUDER) == (Y_PROBE_OFFSET_FROM_EXTRUDER), "Y_PROBE_OFFSET_FROM_EXTRUDER must be an integer value.");
+
 #else
 
   /**

--- a/Marlin/SanityCheck.h
+++ b/Marlin/SanityCheck.h
@@ -792,6 +792,8 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
     #error "Z_PROBE_LOW_POINT must be less than or equal to 0."
   #endif
 
+  static_assert((int)X_PROBE_OFFSET_FROM_EXTRUDER == X_PROBE_OFFSET_FROM_EXTRUDER, "X_PROBE_OFFSET_FROM_EXTRUDER must be an integer value.");
+  static_assert((int)Y_PROBE_OFFSET_FROM_EXTRUDER == Y_PROBE_OFFSET_FROM_EXTRUDER, "Y_PROBE_OFFSET_FROM_EXTRUDER must be an integer value.");
 #else
 
   /**


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Addition of two static_asserts into SanityCheck.h which validate that the X_PROBE_OFFSET_FROM_EXTRUDER and Y_PROBE_OFFSET_FROM_EXTRUDER values are infact integers, issuing an error in the event that a float our double is provided erroneously.

### Benefits

Without these checks it is possible to compile (without bed level debugging enabled) and the UBL system will mostly run. However any `G29 Jx` commands will fail with the error "Could not complete LSF!".

By adding this error the misconfiguration becomes immediately clear on compilation preventing a user from reaching the point of the error on `G29`.

### Related Issues

Discussed in #11245 
