### PR TITLE
Revert "[2.0.x] Switch to PIO managed L6470 library"

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,7 +35,7 @@ lib_deps =
   https://github.com/teemuatlut/TMC2208Stepper/archive/v0.1.1.zip
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
-  Arduino-L6470
+  https://github.com/ameyer/Arduino-L6470/archive/master.zip
   https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
 
 #################################


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#11288