### PR TITLE
[1.1.x] Initialize default units

### DIFF
--- a/Marlin/parser.h
+++ b/Marlin/parser.h
@@ -90,7 +90,7 @@ public:
   #endif
 
   #if ENABLED(DEBUG_GCODE_PARSER)
-    void debug();
+    static void debug();
   #endif
 
   GCodeParser() {


### PR DESCRIPTION
When INCH_MODE_SUPPORT is enabled there is no default unit set, this fix it

Fix #11291