### PR TITLE
[2.0.x] Change MKS SBase default serial port

### DIFF
--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -105,7 +105,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Select a secondary serial port on the board to use for communication with the host.
@@ -114,7 +114,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define SERIAL_PORT_2 -1
+//#define SERIAL_PORT_2 0
 
 /**
  * This setting determines the communication speed of the printer.


### PR DESCRIPTION
### Description
The MKS SBase board has an example config (against the rules but it's mostly to explain all the wiring issues I think), this changes it from using Hardware Serial Port 0 to the USB Serial as it was causing confusion.

### Related Issues
#11292