### PR TITLE
Add S_CURVE_ACCELERATION to M115 output

### DIFF
--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -153,5 +153,12 @@ void GcodeSuite::M115() {
       #endif
     );
 
+    // S_CURVE_ACCELERATION
+    cap_line(PSTR("S_CURVE_ACCELERATION")
+      #if ENABLED(S_CURVE_ACCELERATION)
+        , true
+      #endif
+    );
+
   #endif // EXTENDED_CAPABILITIES_REPORT
 }


### PR DESCRIPTION
### Requirements

bugfix-2.0.x

### Description

Add S_CURVE_ACCELERATION to M115 output

### Benefits

Programs that process M115 output will able to know with what parameters Marlin was compiled.  This is useful for [simulating Marlin and getting accurate timing estimates](https://github.com/eyal0/Marlin).

### Related Issues

#11303