### PR TITLE
Fix get_period_inverse(0) so it doesn't crash

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -694,7 +694,12 @@ void Planner::init() {
     // All other 32-bit MPUs can easily do inverse using hardware division,
     // so we don't need to reduce precision or to use assembly language at all.
     // This routine, for all other archs, returns 0x100000000 / d ~= 0xFFFFFFFF / d
-    static FORCE_INLINE uint32_t get_period_inverse(const uint32_t d) { return 0xFFFFFFFF / d; }
+    static FORCE_INLINE uint32_t get_period_inverse(const uint32_t d) {
+      if (d == 0) {
+        return 0xFFFFFFFF; // This is consistent with the AVR version.
+      }
+      return 0xFFFFFFFF / d;
+    }
   #endif
 #endif
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -695,10 +695,7 @@ void Planner::init() {
     // so we don't need to reduce precision or to use assembly language at all.
     // This routine, for all other archs, returns 0x100000000 / d ~= 0xFFFFFFFF / d
     static FORCE_INLINE uint32_t get_period_inverse(const uint32_t d) {
-      if (d == 0) {
-        return 0xFFFFFFFF; // This is consistent with the AVR version.
-      }
-      return 0xFFFFFFFF / d;
+      return d ? 0xFFFFFFFF / d : 0xFFFFFFFF;
     }
   #endif
 #endif


### PR DESCRIPTION
This fixes https://github.com/MarlinFirmware/Marlin/issues/11314

### Description

This fixes a divide-by-zero crash.  Divide-by-zero is invalid but the result of the divide-by-zero is never used anyway.

### Benefits

Less crashing.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/11314