### PR TITLE
M200 - Remove extra parameter to enqueue.

### DIFF
--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -326,7 +326,7 @@ void process_lcd_s_command(const char* command) {
 
     case 'H':
       // Home all axis
-      enqueue_and_echo_command("G28", false);
+      enqueue_and_echo_command("G28");
       break;
 
     case 'L': {


### PR DESCRIPTION
Removes extra parameter to enqueue_and_echo_command function, which was breaking Malyan LCD compilation.

### Related Issues

#11360 reported this.