### PR TITLE
[1.1.x] sd abort: expose sd abort code path via new M524

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -8217,7 +8217,7 @@ inline void gcode_M42() {
    *   This has no effect during an SD print job
    */
   inline void gcode_M73() {
-    if (!IS_SD_PRINTING && parser.seen('P')) {
+    if (!IS_SD_PRINTING() && parser.seen('P')) {
       progress_bar_percent = parser.value_byte();
       NOMORE(progress_bar_percent, 100);
     }
@@ -14786,7 +14786,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
     // ---------------------------------------------------------
     static int homeDebounceCount = 0;   // poor man's debouncing count
     const int HOME_DEBOUNCE_DELAY = 2500;
-    if (!IS_SD_PRINTING && !READ(HOME_PIN)) {
+    if (!IS_SD_PRINTING() && !READ(HOME_PIN)) {
       if (!homeDebounceCount) {
         enqueue_and_echo_commands_P(PSTR("G28"));
         LCD_MESSAGEPGM(MSG_AUTO_HOME);

--- a/Marlin/cardreader.cpp
+++ b/Marlin/cardreader.cpp
@@ -315,7 +315,7 @@ void CardReader::stopSDPrint(
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     did_pause_print = 0;
   #endif
-  sdprinting = false;
+  sdprinting = abort_sd_printing = false;
   if (isFileOpen()) file.close();
   #if SD_RESORT
     if (re_sort) presort();

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -117,7 +117,7 @@ public:
   FORCE_INLINE char* longest_filename() { return longFilename[0] ? longFilename : filename; }
 
 public:
-  bool saving, logging, sdprinting, cardOK, filenameIsDir;
+  bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   int8_t autostart_index;
 private:

--- a/Marlin/cardreader.h
+++ b/Marlin/cardreader.h
@@ -206,13 +206,13 @@ private:
 
 #if PIN_EXISTS(SD_DETECT)
   #if ENABLED(SD_DETECT_INVERTED)
-    #define IS_SD_INSERTED (READ(SD_DETECT_PIN) == HIGH)
+    #define IS_SD_INSERTED()  READ(SD_DETECT_PIN)
   #else
-    #define IS_SD_INSERTED (READ(SD_DETECT_PIN) == LOW)
+    #define IS_SD_INSERTED() !READ(SD_DETECT_PIN)
   #endif
 #else
   // No card detect line? Assume the card is inserted.
-  #define IS_SD_INSERTED true
+  #define IS_SD_INSERTED() true
 #endif
 
 extern CardReader card;
@@ -220,11 +220,11 @@ extern CardReader card;
 #endif // SDSUPPORT
 
 #if ENABLED(SDSUPPORT)
-  #define IS_SD_PRINTING (card.sdprinting)
-  #define IS_SD_FILE_OPEN (card.isFileOpen())
+  #define IS_SD_PRINTING()  card.sdprinting
+  #define IS_SD_FILE_OPEN() card.isFileOpen()
 #else
-  #define IS_SD_PRINTING (false)
-  #define IS_SD_FILE_OPEN (false)
+  #define IS_SD_PRINTING()  false
+  #define IS_SD_FILE_OPEN() false
 #endif
 
 #endif // _CARDREADER_H_

--- a/Marlin/status_screen_lite_ST7920.h
+++ b/Marlin/status_screen_lite_ST7920.h
@@ -884,7 +884,7 @@ void ST7920_Lite_Status_Screen::update_progress(const bool forceUpdate) {
 
     #if ENABLED(SDSUPPORT)
       // Progress bar % comes from SD when actively printing
-      if (IS_SD_PRINTING) progress_bar_percent = card.percentDone();
+      if (IS_SD_PRINTING()) progress_bar_percent = card.percentDone();
     #endif
 
     // Since the progress bar involves writing

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -854,11 +854,9 @@ void lcd_quick_feedback(const bool clear_buttons) {
       lcd_reset_status();
     }
 
-    bool abort_sd_printing; // =false
-
     void lcd_sdcard_stop() {
       wait_for_heatup = wait_for_user = false;
-      abort_sd_printing = true;
+      card.abort_sd_printing = true;
       lcd_setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
       lcd_return_to_status();
     }

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -505,7 +505,7 @@ uint16_t max_display_update_time = 0;
           if (currentScreen == lcd_status_screen)
             doubleclick_expire_ms = millis() + DOUBLECLICK_MAX_INTERVAL;
         }
-        else if (screen == lcd_status_screen && currentScreen == lcd_main_menu && PENDING(millis(), doubleclick_expire_ms) && (planner.movesplanned() || IS_SD_PRINTING))
+        else if (screen == lcd_status_screen && currentScreen == lcd_main_menu && PENDING(millis(), doubleclick_expire_ms) && (planner.movesplanned() || IS_SD_PRINTING()))
           screen =
             #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
               lcd_babystep_zoffset
@@ -652,7 +652,7 @@ void lcd_status_screen() {
 
   #if ENABLED(LCD_SET_PROGRESS_MANUALLY) && ENABLED(SDSUPPORT) && (ENABLED(LCD_PROGRESS_BAR) || ENABLED(DOGLCD))
     // Progress bar % comes from SD when actively printing
-    if (IS_SD_PRINTING)
+    if (IS_SD_PRINTING())
       progress_bar_percent = card.percentDone();
   #endif
 
@@ -1109,7 +1109,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
         MENU_ITEM_EDIT_CALLBACK(bool, MSG_CASE_LIGHT, (bool*)&case_light_on, update_case_light);
     #endif
 
-    if (planner.movesplanned() || IS_SD_PRINTING)
+    if (planner.movesplanned() || IS_SD_PRINTING())
       MENU_ITEM(submenu, MSG_TUNE, lcd_tune_menu);
     else
       MENU_ITEM(submenu, MSG_PREPARE, lcd_prepare_menu);
@@ -2732,7 +2732,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
     // Change filament
     //
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
-      if (!IS_SD_FILE_OPEN) {
+      if (!IS_SD_FILE_OPEN()) {
         #if E_STEPPERS == 1 && !ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
           if (thermalManager.targetHotEnoughToExtrude(active_extruder))
             MENU_ITEM(gcode, MSG_FILAMENTCHANGE, PSTR("M600 B0"));
@@ -4411,7 +4411,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
         #endif // E_STEPPERS == 1
 
         #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
-          if (!planner.movesplanned() && !IS_SD_FILE_OPEN) {
+          if (!planner.movesplanned() && !IS_SD_FILE_OPEN()) {
             // Load filament
             #if E_STEPPERS == 1
               PGM_P msg0 = PSTR(MSG_FILAMENTLOAD);
@@ -5158,7 +5158,7 @@ void lcd_update() {
 
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
 
-    const uint8_t sd_status = (uint8_t)IS_SD_INSERTED;
+    const uint8_t sd_status = (uint8_t)IS_SD_INSERTED();
     if (sd_status != lcd_sd_status && lcd_detected()) {
 
       uint8_t old_sd_status = lcd_sd_status; // prevent re-entry to this block!

--- a/Marlin/ultralcd.h
+++ b/Marlin/ultralcd.h
@@ -262,10 +262,4 @@
   void lcd_reselect_last_file();
 #endif
 
-#if ENABLED(ULTIPANEL) && ENABLED(SDSUPPORT)
-  extern bool abort_sd_printing;
-#else
-  constexpr bool abort_sd_printing = false;
-#endif
-
 #endif // ULTRALCD_H

--- a/Marlin/ultralcd_impl_HD44780.h
+++ b/Marlin/ultralcd_impl_HD44780.h
@@ -803,7 +803,7 @@ static void lcd_implementation_status_screen() {
       #if ENABLED(SDSUPPORT)
         lcd.setCursor(0, 2);
         lcd_printPGM(PSTR("SD"));
-        if (IS_SD_PRINTING)
+        if (IS_SD_PRINTING())
           lcd.print(itostr3(card.percentDone()));
         else
           lcd_printPGM(PSTR("---"));
@@ -867,7 +867,7 @@ static void lcd_implementation_status_screen() {
 
       lcd.setCursor(7, 2);
       lcd_printPGM(PSTR("SD"));
-      if (IS_SD_PRINTING)
+      if (IS_SD_PRINTING())
         lcd.print(itostr3(card.percentDone()));
       else
         lcd_printPGM(PSTR("---"));


### PR DESCRIPTION
### Description

This PR implements the Feature Request presented in issue #11377. It adds the M524 command as "SD abort job", performing the same logical checks that enable the Stop SD Job option in the LCD menu.

Why M524?
- It pairs nicely with the M24 Start SD job command.
- It lands adjacent to another SD-related command (M540).
- I have no idea if there is an "official" code requisition process or central registry.

This feature was tested with my custom host software.

### Benefits

Host software can trigger a graceful abort of an SD print job.

### Related Issues

No new output has been added yet. If the command successfully closes the file, the firmware will produce the same output that the display would trigger. If a SD job is not being printed, that might deserve to be reported to the host, requiring a new message. That can be added as a follow-up patch in this PR, if all else looks good.

If the PR is accepted, the website needs to be updated to list the new code. How is that manged?