### PR TITLE
[1.1.x] MKS_12864_OLED code cleanup

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -356,10 +356,8 @@ static void lcd_implementation_init() {
     OUT_WRITE(LCD_BACKLIGHT_PIN, HIGH);
   #endif
 
-  #if ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
-    OUT_WRITE(LCD_PINS_RS, LOW);
-    _delay_ms(500);
-    OUT_WRITE(LCD_PINS_RS, HIGH);
+  #if !defined(LCD_RESET_PIN) && (ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306))
+    #define LCD_RESET_PIN LCD_PINS_RS
   #endif
 
   #if PIN_EXISTS(LCD_RESET)
@@ -369,7 +367,7 @@ static void lcd_implementation_init() {
     _delay_ms(5); // delay to allow the display to initalize
   #endif
 
-  #if PIN_EXISTS(LCD_RESET) || ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
+  #if PIN_EXISTS(LCD_RESET)
     u8g.begin();
   #endif
 


### PR DESCRIPTION
### Description

After a bit of testing, the reset delay 500ms seems a bit too long, 5ms is just enough.
LCD_PIN_RS can also be directly merged into LCD_RESET_PIN

### Benefits

Improved LCD/OLED reset delay. cleaning the code.

