### PR TITLE
[2.0.x] MKS SBASE Trinamic examples/support

### DIFF
--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -221,8 +221,8 @@
   #ifndef TMC_SW_SCK
     #define TMC_SW_SCK     P0_26   // TH4
   #endif
+ #endif
 #endif
-
 #if HAS_DRIVER(TMC2208)
   // The shortage of pins becomes apparent.
   // Worst case you may have to give up the LCD
@@ -282,11 +282,11 @@
  /**
   * Serial Ports
   *   P0_00 - Port  3
-  *   P0_01
+  *   P0_01 - SD Card (Onboard)
   *   P0_10 - Port  2
-  *   P0_11
+  *   P0_11 - Y_EN/Y_DIR
   *   P0_15 - Port  1
-  *   P0_16
+  *   P0_16 - EXP1
   *   P0_02 - Port  0
   *   P0_03 - AUX1
   *   P0_29 - Port -1

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -196,6 +196,50 @@
 #define SDSS               P0_06
 
 /**
+ * Example for trinamic drivers using the J8 connector on MKs Sbase.
+ * 2130s need 1 pin for each driver. 2208s need 2 pins for serial control.
+ * This board does not have enough pins to use hardware serial.
+*/
+
+#if HAS_DRIVER(TMC2130)
+  // J8
+   #define X_CS_PIN   P1_22
+   #define Y_CS_PIN   P1_23
+   #define Z_CS_PIN   P2_12
+   #define E0_CS_PIN  P2_11
+   #define E1_CS_PIN  P4_28
+
+//Hardware SPI is in EXP2 see if you can make it work:
+//https://github.com/makerbase-mks/MKS-SBASE/issues/25
+ #define TMC_USE_SW_SPI
+  #if ENABLED(TMC_USE_SW_SPI)
+   #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI    P0_03 // AUX1
+   #endif
+   #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO    P0_02 // AUX1
+   #endif
+   #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK     P0_26 // TH4
+   #endif
+  #endif
+#endif
+
+#if HAS_DRIVER(TMC2208)
+  // The shortage of pins becomes apparent.
+  // Worst case you may have to give up the LCD
+  // RX pins need to be interrupt capable
+   #define X_SERIAL_TX_PIN    P1_22 // J8-2
+   #define X_SERIAL_RX_PIN    P2_12 // J8-4 Interrupt Capable
+   #define Y_SERIAL_TX_PIN    P1_23 // J8-3
+   #define Y_SERIAL_RX_PIN    P2_11 // J8-5 Interrupt Capable
+   #define Z_SERIAL_TX_PIN    P2_12 // J8-4
+   #define Z_SERIAL_RX_PIN    P0_25 // TH3
+   #define E0_SERIAL_TX_PIN   P4_28 // J8-6
+   #define E0_SERIAL_RX_PIN   P0_26 // TH4
+#endif
+
+/**
  * P0.27 is on EXP2 and the on-board SD card's socket. That means it can't be
  * used as the SD_DETECT for the LCD's SD card.
  *

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -117,7 +117,6 @@
 #define PIN_P0_16          P0_16
 #define PIN_P0_15          P0_15
 
-
 //
 // Connector J8
 //
@@ -199,29 +198,28 @@
  * Example for trinamic drivers using the J8 connector on MKs Sbase.
  * 2130s need 1 pin for each driver. 2208s need 2 pins for serial control.
  * This board does not have enough pins to use hardware serial.
-*/
+ */
 
 #if HAS_DRIVER(TMC2130)
   // J8
-   #define X_CS_PIN   P1_22
-   #define Y_CS_PIN   P1_23
-   #define Z_CS_PIN   P2_12
-   #define E0_CS_PIN  P2_11
-   #define E1_CS_PIN  P4_28
+  #define X_CS_PIN         P1_22
+  #define Y_CS_PIN         P1_23
+  #define Z_CS_PIN         P2_12
+  #define E0_CS_PIN        P2_11
+  #define E1_CS_PIN        P4_28
 
-//Hardware SPI is in EXP2 see if you can make it work:
-//https://github.com/makerbase-mks/MKS-SBASE/issues/25
- #define TMC_USE_SW_SPI
-  #if ENABLED(TMC_USE_SW_SPI)
-   #ifndef TMC_SW_MOSI
-    #define TMC_SW_MOSI    P0_03 // AUX1
-   #endif
-   #ifndef TMC_SW_MISO
-    #define TMC_SW_MISO    P0_02 // AUX1
-   #endif
-   #ifndef TMC_SW_SCK
-    #define TMC_SW_SCK     P0_26 // TH4
-   #endif
+// Hardware SPI is on EXP2. See if you can make it work:
+// https://github.com/makerbase-mks/MKS-SBASE/issues/25
+#define TMC_USE_SW_SPI
+#if ENABLED(TMC_USE_SW_SPI)
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI    P0_03   // AUX1
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO    P0_02   // AUX1
+  #endif
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK     P0_26   // TH4
   #endif
 #endif
 
@@ -229,14 +227,14 @@
   // The shortage of pins becomes apparent.
   // Worst case you may have to give up the LCD
   // RX pins need to be interrupt capable
-   #define X_SERIAL_TX_PIN    P1_22 // J8-2
-   #define X_SERIAL_RX_PIN    P2_12 // J8-4 Interrupt Capable
-   #define Y_SERIAL_TX_PIN    P1_23 // J8-3
-   #define Y_SERIAL_RX_PIN    P2_11 // J8-5 Interrupt Capable
-   #define Z_SERIAL_TX_PIN    P2_12 // J8-4
-   #define Z_SERIAL_RX_PIN    P0_25 // TH3
-   #define E0_SERIAL_TX_PIN   P4_28 // J8-6
-   #define E0_SERIAL_RX_PIN   P0_26 // TH4
+  #define X_SERIAL_TX_PIN  P1_22   // J8-2
+  #define X_SERIAL_RX_PIN  P2_12   // J8-4 Interrupt Capable
+  #define Y_SERIAL_TX_PIN  P1_23   // J8-3
+  #define Y_SERIAL_RX_PIN  P2_11   // J8-5 Interrupt Capable
+  #define Z_SERIAL_TX_PIN  P2_12   // J8-4
+  #define Z_SERIAL_RX_PIN  P0_25   // TH3
+  #define E0_SERIAL_TX_PIN P4_28   // J8-6
+  #define E0_SERIAL_RX_PIN P0_26   // TH4
 #endif
 
 /**

--- a/platformio.ini
+++ b/platformio.ini
@@ -163,6 +163,7 @@ lib_extra_dirs    = frameworks
 lib_deps          = CMSIS-LPC1768
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMC2130Stepper@>=2.2.1
+  TMC2208Stepper@>=0.2.1
 extra_scripts     = Marlin/src/HAL/HAL_LPC1768/debug_extra_script.py, Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter        = ${common.default_src_filter}
 monitor_speed     = 250000


### PR DESCRIPTION
### Description
Trinamic steppers are not easy to set up. This might help a few people in the future. Full disclosure I don't have any but read up on what they need.
### Benefits
People using this stepper won't have to suffer as much configuring it.

### Related Issues
Should we pull all stepper libraries for all platforms? eg. this one had 2130s but not 2208s. they are small. Already use a lot of LCD libs everywhere.
