### PR TITLE
[1.1.9] Fix jumping progress bar when ENABLED(LIGHTWEIGHT_UI) and DISABLED(LCD_SET_PROGRESS_MANUALLY)

### DIFF
--- a/Marlin/status_screen_lite_ST7920.h
+++ b/Marlin/status_screen_lite_ST7920.h
@@ -877,11 +877,11 @@ void ST7920_Lite_Status_Screen::update_status_or_position(bool forceUpdate) {
 
 void ST7920_Lite_Status_Screen::update_progress(const bool forceUpdate) {
   #if DISABLED(LCD_SET_PROGRESS_MANUALLY)
-    uint8_t progress_bar_percent;
+    uint8_t progress_bar_percent = 0;
   #endif
 
   // Set current percentage from SD when actively printing
-  #if ENABLED(SDSUPPORT)
+  #if ENABLED(LCD_SET_PROGRESS_MANUALLY) && ENABLED(SDSUPPORT) && (ENABLED(LCD_PROGRESS_BAR) || ENABLED(DOGLCD))
     if (IS_SD_PRINTING) progress_bar_percent = card.percentDone();
   #endif
 


### PR DESCRIPTION
- When LCD_SET_PROGRESS_MANUALLY was disabled and an SD print was not
  active (i.e. the printer was idle), progress_bar_percent would be initialized to random
  memory from stack and cause progress bar to jump wildly.
- Also updated conditions in #ifdef to match ultralcd.cpp
