### PR TITLE
[2.0.x] Add Bigtreetech/BIQU KFB 2.0 board

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -63,6 +63,7 @@
 #define BOARD_MKS_BASE_HEROIC   41    // MKS BASE 1.0 with Heroic HR4982 stepper drivers
 #define BOARD_MKS_GEN_13        47    // MKS GEN v1.3 or 1.4
 #define BOARD_MKS_GEN_L         53    // MKS GEN L
+#define BOARD_KFB_2             136   // Bigtreetech or BIQU KFB2.0
 #define BOARD_ZRIB_V20          504   // zrib V2.0 control board (Chinese knock off RAMPS replica)
 #define BOARD_FELIX2            37    // Felix 2.0+ Electronics Board (RAMPS like)
 #define BOARD_RIGIDBOARD        42    // Invent-A-Part RigidBoard

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -110,6 +110,8 @@
   #include "pins_MKS_GEN_13.h"        // ATmega1280, ATmega2560                     env:megaatmega1280 env:megaatmega2560
 #elif MB(MKS_GEN_L)
   #include "pins_MKS_GEN_L.h"         // ATmega1280, ATmega2560                     env:megaatmega1280 env:megaatmega2560
+#elif MB(KFB_2)
+  #include "pins_KFB_2.h"             // ATmega2560                                 env:megaatmega2560
 #elif MB(ZRIB_V20)
   #include "pins_ZRIB_V20.h"          // ATmega1280, ATmega2560                     env:megaatmega1280 env:megaatmega2560 (MKS_GEN_13)
 #elif MB(FELIX2)

--- a/Marlin/src/pins/pins_BIQU_KFB_2.h
+++ b/Marlin/src/pins/pins_BIQU_KFB_2.h
@@ -1,0 +1,39 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * KFB 2.0 – Arduino Mega2560 with RAMPS v1.4 pin assignments
+ */
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "KFB 2.0 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_NAME "KFB 2.0"
+
+//
+// Heaters / Fans
+//
+// Power outputs BEEF or BEFF
+#define MOSFET_D_PIN        7
+
+#include "pins_RAMPS.h"


### PR DESCRIPTION
As requested and specified in #10647. A minor variant of RAMPS 1.4.