### PR TITLE
[1.1.x] Easier to disable homing validation

### DIFF
--- a/Marlin/endstops.cpp
+++ b/Marlin/endstops.cpp
@@ -229,11 +229,13 @@ void Endstops::not_homing() {
   #endif
 }
 
-// If the last move failed to trigger an endstop, call kill
-void Endstops::validate_homing_move() {
-  if (trigger_state()) hit_on_purpose();
-  else kill(PSTR(MSG_ERR_HOMING_FAILED));
-}
+#if ENABLED(VALIDATE_HOMING_ENDSTOPS)
+  // If the last move failed to trigger an endstop, call kill
+  void Endstops::validate_homing_move() {
+    if (trigger_state()) hit_on_purpose();
+    else kill(PSTR(MSG_ERR_HOMING_FAILED));
+  }
+#endif
 
 // Enable / disable endstop z-probe checking
 #if HAS_BED_PROBE

--- a/Marlin/endstops.h
+++ b/Marlin/endstops.h
@@ -29,6 +29,8 @@
 
 #include "MarlinConfig.h"
 
+#define VALIDATE_HOMING_ENDSTOPS
+
 enum EndstopEnum : char {
   X_MIN,
   Y_MIN,
@@ -143,8 +145,12 @@ class Endstops {
     // Disable / Enable endstops based on ENSTOPS_ONLY_FOR_HOMING and global enable
     static void not_homing();
 
-    // If the last move failed to trigger an endstop, call kill
-    static void validate_homing_move();
+    #if ENABLED(VALIDATE_HOMING_ENDSTOPS)
+      // If the last move failed to trigger an endstop, call kill
+      static void validate_homing_move();
+    #else
+      FORCE_INLINE static void validate_homing_move() { hit_on_purpose(); }
+    #endif
 
     // Clear endstops (i.e., they were hit intentionally) to suppress the report
     FORCE_INLINE static void hit_on_purpose() { hit_state = 0; }


### PR DESCRIPTION
Add a hidden option to disable homing validation, to relieve users who get false "homing failed" messages.

Counterpart to #11458