### PR TITLE
auto power control without heated bed

### DIFF
--- a/Marlin/power.cpp
+++ b/Marlin/power.cpp
@@ -69,7 +69,9 @@ bool Power::is_power_needed() {
   ) return true;
 
   HOTEND_LOOP() if (thermalManager.degTargetHotend(e) > 0) return true;
-  if (thermalManager.degTargetBed() > 0) return true;
+  #if HAS_HEATED_BED
+    if (thermalManager.degTargetBed() > 0) return true;
+  #endif
 
   return false;
 }


### PR DESCRIPTION
AUTO_POWER_CONTROL will not work if printer has no heated bed due to degTargetBed() not being defined

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
