### PR TITLE
[2.0.x] Added a "Preheat custom" temp choice to "Change Filament" screen

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -154,6 +154,9 @@
 #ifndef MSG_PREHEAT_2_SETTINGS
   #define MSG_PREHEAT_2_SETTINGS              MSG_PREHEAT_2 _UxGT(" conf")
 #endif
+#ifndef MSG_PREHEAT_CUSTOM
+  #define MSG_PREHEAT_CUSTOM                  _UxGT("Preheat Custom")
+#endif
 #ifndef MSG_COOLDOWN
   #define MSG_COOLDOWN                        _UxGT("Cooldown")
 #endif


### PR DESCRIPTION
Adds a numeric "Preheat Custom" option under "Preheat ABS" and "Preheat PLA" in the "Change Filament" screen to allow for a custom temperature to be dialed in for exotic filaments.

This modification is proposed as a more general solution to PR #8214, which proposes adding a 3rd hard-coded preheat option.