### PR TITLE
[2.0.x][LPC176x, STSTM32] Target previous pio platform versions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -150,7 +150,7 @@ monitor_speed = 250000
 # NXP LPC1768 ARM Cortex-M3
 #
 [env:LPC1768]
-platform          = nxplpc
+platform          = nxplpc@<3.4.0
 board             = lpc1768
 board_build.f_cpu = 100000000L
 # Override default maximum RAM. LPC1768/9 do have 64k, but in 3 blocks (32K, 16K, 16K).
@@ -243,7 +243,7 @@ monitor_speed = 250000
 # STM32F103RE
 #
 [env:STM32F1]
-platform      = ststm32
+platform      = ststm32@<4.4.0
 framework     = arduino
 board         = genericSTM32F103RE
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/stm32f1_flag_script.py


### PR DESCRIPTION
### Description

An update to the nxplpc platform removed the F_CPU define, temporary fix by targeting the old version while I decide how to fix this properly.

Update to ststm32 platform broke the built unsure of cause so forcing old version as well to fix build.

@thinkyhead, @Roxy-3D critical fix for builds