### PR TITLE
[2.0.x] Change direct eeprom access to HAL::PersistentStore

### DIFF
--- a/Marlin/src/HAL/persistent_store_api.cpp
+++ b/Marlin/src/HAL/persistent_store_api.cpp
@@ -19,20 +19,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
+#include "../inc/MarlinConfigPre.h"
 
-#include <stddef.h>
-#include <stdint.h>
+#if ENABLED(EEPROM_SETTINGS)
 
-class PersistentStore {
-public:
-  static bool access_start();
-  static bool access_finish();
-  static bool write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc);
-  static bool read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing=true);
-  static bool write_data(const int pos, uint8_t* value, size_t size);
-  static bool read_data(const int pos, uint8_t* value, size_t size);
-  static const size_t capacity();
-};
+  #include "persistent_store_api.h"
+  PersistentStore persistentStore;
 
-extern PersistentStore persistentStore;
+#endif

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -29,6 +29,7 @@
   #include "ubl.h"
 
   #include "../../../Marlin.h"
+  #include "../../../HAL/persistent_store_api.h"
   #include "../../../libs/hex_print_routines.h"
   #include "../../../module/configuration_store.h"
   #include "../../../lcd/ultralcd.h"
@@ -1167,24 +1168,27 @@
    * right now, it is good to have the extra information. Soon... we prune this.
    */
   void unified_bed_leveling::g29_eeprom_dump() {
-    unsigned char cccc;
-    unsigned int  kkkk;  // Needs to be of unspecfied size to compile clean on all platforms
+    uint8_t cccc;
+    int kkkk;
+    uint16_t crc = 0;
 
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM("EEPROM Dump:");
+    persistentStore.access_start();
     for (uint16_t i = 0; i < persistentStore.capacity(); i += 16) {
       if (!(i & 0x3)) idle();
       print_hex_word(i);
       SERIAL_ECHOPGM(": ");
       for (uint16_t j = 0; j < 16; j++) {
         kkkk = i + j;
-        eeprom_read_block(&cccc, (const void *)kkkk, sizeof(unsigned char));
+        persistentStore.read_data(kkkk, &cccc, sizeof(uint8_t), &crc);
         print_hex_byte(cccc);
         SERIAL_ECHO(' ');
       }
       SERIAL_EOL();
     }
     SERIAL_EOL();
+    persistentStore.access_finish();
   }
 
   /**

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -345,7 +345,6 @@ void MarlinSettings::postprocess() {
 
 #if ENABLED(EEPROM_SETTINGS)
   #include "../HAL/persistent_store_api.h"
-  PersistentStore persistentStore;
 
   #define DUMMY_PID_VALUE 3000.0f
   #define EEPROM_START() int eeprom_index = EEPROM_OFFSET; persistentStore.access_start()


### PR DESCRIPTION
### Description

Every HAL seem to provide the HAL::PersistentStore interface. The configuration store does already use this interface, so it seems logical that all other code parts should use it to let the HAL abstract the persistence layer.

This commit changes the last two files that use the eeprom library directly.

### Benefits

Better usage of the HAL abstraction. HAL then could provide persistence options on their discretion (like MCU internal Backup SRAM).

### Notice

My C/C++ skills are limited. If some things can be expressed shorter, please feel free to suggest more elegant solutions. I have a feeling that we could also extend the current HAL::PersistentStore interface to include constant position / non crc methods.