### PR TITLE
Update fan pins to match online documentation.

### DIFF
--- a/Marlin/pins_EINSY_RAMBO.h
+++ b/Marlin/pins_EINSY_RAMBO.h
@@ -115,10 +115,10 @@
 #define HEATER_0_PIN        3
 #define HEATER_BED_PIN      4
 
-#ifndef FAN_PIN
-  #define FAN_PIN           8
+#ifndef FAN1_PIN
+  #define FAN1_PIN          6
 #endif
-#define FAN1_PIN            6
+#define FAN_PIN             8
 
 //
 // Misc. Functions


### PR DESCRIPTION
Changes made to match online board documentation on Reprap.org and Prusa mk3 manual.

### Description
As the pins had been defined you had to connect the parts cooling fan to the hotend fan connector and vice versa.  
See step 30: [Prusa Mk3 Manual](https://manual.prusa3d.com/Guide/8.+Electronics+assembly/513?lang=en)

### Benefits
This change will help to avoid confusion when connecting the hotend fan and parts cooling fan. 