### PR TITLE
[1.1.x][2.0.x] Fix pca9632_set_led_color lost i2c connection

### DIFF
--- a/Marlin/pca9632.cpp
+++ b/Marlin/pca9632.cpp
@@ -100,9 +100,9 @@ static void PCA9632_WriteAllRegisters(const byte addr, const byte regadd, const 
 #endif
 
 void pca9632_set_led_color(const LEDColor &color) {
+  Wire.begin();
   if (!PCA_init) {
     PCA_init = 1;
-    Wire.begin();
     PCA9632_WriteRegister(PCA9632_ADDRESS,PCA9632_MODE1, PCA9632_MODE1_VALUE);
     PCA9632_WriteRegister(PCA9632_ADDRESS,PCA9632_MODE2, PCA9632_MODE2_VALUE);
   }


### PR DESCRIPTION
### Description

When pca9632 led controller sharing i2c bus together with i2c screen (I'm currently working on connecting ultimaker2 ulticontroller which use i2c to communicate with both screen and rgb leds). `pca9632_set_led_color()` will only work on first run ( init phase ). This PR fix this issue.

### Benefits

Can use M150 to control PCA9632 RGB leds as intended.

### Related Issues

Seems very little chance people will use this combination thus no reported issue yet. But pca9632 LED driver is widely used with this issue.
