### PR TITLE
[2.0.x] Update PersistentStore api

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_AVR/persistent_store_eeprom.cpp
@@ -1,18 +1,15 @@
 #ifdef __AVR__
 
-#include "../persistent_store_api.h"
-
 #include "../../inc/MarlinConfig.h"
 
 #if ENABLED(EEPROM_SETTINGS)
 
-namespace HAL {
-namespace PersistentStore {
+#include "../persistent_store_api.h"
 
-bool access_start() { return true; }
-bool access_finish() { return true; }
+bool PersistentStore::access_start() { return true; }
+bool PersistentStore::access_finish() { return true; }
 
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   while (size--) {
     uint8_t * const p = (uint8_t * const)pos;
     uint8_t v = *value;
@@ -33,7 +30,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
   do {
     uint8_t c = eeprom_read_byte((unsigned char*)pos);
     if (writing) *value = c;
@@ -44,7 +41,20 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
   return false;  // always assume success for AVR's
 }
 
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
 }
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return E2END + 1;
 }
 
 #endif // EEPROM_SETTINGS

--- a/Marlin/src/HAL/HAL_DUE/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_DUE/persistent_store_eeprom.cpp
@@ -8,19 +8,16 @@
 
 extern void eeprom_flush(void);
 
-namespace HAL {
-namespace PersistentStore {
+bool PersistentStore::access_start() { return true; }
 
-bool access_start() { return true; }
-
-bool access_finish() {
+bool PersistentStore::access_finish() {
   #if DISABLED(I2C_EEPROM) && DISABLED(SPI_EEPROM)
     eeprom_flush();
   #endif
   return true;
 }
 
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   while (size--) {
     uint8_t * const p = (uint8_t * const)pos;
     uint8_t v = *value;
@@ -41,7 +38,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
   do {
     uint8_t c = eeprom_read_byte((unsigned char*)pos);
     if (writing) *value = c;
@@ -52,8 +49,21 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
   return false;
 }
 
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
 }
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return E2END + 1;
 }
 
 #endif // EEPROM_SETTINGS
-#endif // __AVR__
+#endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/Arduino.h
@@ -43,8 +43,6 @@
 #define FALLING      0x03
 #define RISING       0x04
 
-#define E2END 0xFFF // EEPROM end address
-
 typedef uint8_t byte;
 #define PROGMEM
 #define PSTR(v) (v)

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_flash.cpp
@@ -39,28 +39,23 @@
 #include <flash_stm32.h>
 #include <EEPROM.h>
 
-namespace HAL {
-namespace PersistentStore {
+// Store settings in the last two pages
+// Flash pages must be erased before writing, so keep track.
+bool firstWrite = false;
+uint32_t pageBase = EEPROM_START_ADDRESS;
 
-namespace {
-  // Store settings in the last two pages
-  // Flash pages must be erased before writing, so keep track.
-  bool firstWrite = false;
-  uint32_t pageBase = EEPROM_START_ADDRESS;
-}
-
-bool access_start() {
+bool PersistentStore::access_start() {
   firstWrite = true;
   return true;
 }
 
-bool access_finish() {
+bool PersistentStore::access_finish() {
   FLASH_Lock();
   firstWrite = false;
   return true;
 }
 
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   FLASH_Status status;
 
   if (firstWrite) {
@@ -95,7 +90,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
   for (uint16_t i = 0; i < size; i++) {
     byte* accessPoint = (byte*)(pageBase + pos + i);
     uint8_t c = *accessPoint;
@@ -106,8 +101,22 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
   return false;
 }
 
-} // PersistentStore
-} // HAL
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
+}
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return E2END + 1;
+}
+
 
 #endif // EEPROM_SETTINGS && EEPROM FLASH
 #endif // __STM32F1__

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -32,24 +32,14 @@
 #if ENABLED(EEPROM_SETTINGS) && DISABLED(FLASH_EEPROM_EMULATION)
 
 #include "../persistent_store_api.h"
-
-//#include "../../core/types.h"
-//#include "../../core/language.h"
-//#include "../../core/serial.h"
-//#include "../../core/utility.h"
-
 #include "../../sd/cardreader.h"
-
-
-namespace HAL {
-namespace PersistentStore {
 
 #define HAL_STM32F1_EEPROM_SIZE 4096
 char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
 
 char eeprom_filename[] = "eeprom.dat";
 
-bool access_start() {
+bool PersistentStore::access_start() {
   if (!card.cardOK) return false;
   int16_t bytes_read = 0;
   constexpr char eeprom_zero = 0xFF;
@@ -62,7 +52,7 @@ bool access_start() {
   return true;
 }
 
-bool access_finish() {
+bool PersistentStore::access_finish() {
   if (!card.cardOK) return false;
   card.openFile(eeprom_filename, true);
   int16_t bytes_written = card.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
@@ -70,7 +60,7 @@ bool access_finish() {
   return (bytes_written == HAL_STM32F1_EEPROM_SIZE);
 }
 
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   for (int i = 0; i < size; i++)
     HAL_STM32F1_eeprom_content[pos + i] = value[i];
   crc16(crc, value, size);
@@ -78,7 +68,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
   for (int i = 0; i < size; i++) {
     uint8_t c = HAL_STM32F1_eeprom_content[pos + i];
     if (writing) value[i] = c;
@@ -88,10 +78,22 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
   return false;
 }
 
-} // PersistentStore::
-} // HAL::
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
+}
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return HAL_STM32F1_EEPROM_SIZE;
+}
 
 #endif // EEPROM_SETTINGS
 
 #endif // __STM32F1__
-

--- a/Marlin/src/HAL/HAL_STM32F4/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/persistent_store_eeprom.cpp
@@ -29,13 +29,10 @@
 
 #if ENABLED(EEPROM_SETTINGS)
 
-namespace HAL {
-namespace PersistentStore {
+bool PersistentStore::access_start() { return true; }
+bool PersistentStore::access_finish() { return true; }
 
-bool access_start() { return true; }
-bool access_finish() { return true; }
-
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   while (size--) {
     uint8_t * const p = (uint8_t * const)pos;
     uint8_t v = *value;
@@ -56,7 +53,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing) {
   do {
     uint8_t c = eeprom_read_byte((unsigned char*)pos);
     if (writing) *value = c;
@@ -67,8 +64,21 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
   return false;
 }
 
-} // PersistentStore
-} // HAL
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
+}
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return E2END + 1;
+}
 
 #endif // EEPROM_SETTINGS
 #endif // STM32F4 || STM32F4xx

--- a/Marlin/src/HAL/HAL_STM32F7/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/persistent_store_eeprom.cpp
@@ -24,19 +24,16 @@
 
 #ifdef STM32F7
 
-#include "../persistent_store_api.h"
-
 #include "../../inc/MarlinConfig.h"
 
 #if ENABLED(EEPROM_SETTINGS)
 
-namespace HAL {
-namespace PersistentStore {
+#include "../persistent_store_api.h"
 
-bool access_start() { return true; }
-bool access_finish() { return true; }
+bool PersistentStore::access_start() { return true; }
+bool PersistentStore::access_finish() { return true; }
 
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   while (size--) {
     uint8_t * const p = (uint8_t * const)pos;
     uint8_t v = *value;
@@ -57,7 +54,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc) {
   do {
     uint8_t c = eeprom_read_byte((unsigned char*)pos);
     *value = c;
@@ -68,10 +65,21 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
 }
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return E2END + 1;
 }
 
 #endif // EEPROM_SETTINGS
 #endif // STM32F7
-
-

--- a/Marlin/src/HAL/HAL_TEENSY35_36/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/persistent_store_eeprom.cpp
@@ -5,14 +5,12 @@
 #if ENABLED(EEPROM_SETTINGS)
 
 #include "../persistent_store_api.h"
+#include <avr/eeprom.h>
 
-namespace HAL {
-namespace PersistentStore {
+bool PersistentStore::access_start() { return true; }
+bool PersistentStore::access_finish() { return true; }
 
-bool access_start() { return true; }
-bool access_finish() { return true; }
-
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   while (size--) {
     uint8_t * const p = (uint8_t * const)pos;
     uint8_t v = *value;
@@ -33,7 +31,7 @@ bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc) {
   return false;
 }
 
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing/*=true*/) {
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
   do {
     uint8_t c = eeprom_read_byte((unsigned char*)pos);
     if (writing) *value = c;
@@ -44,8 +42,21 @@ bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const boo
   return false;
 }
 
-} // PersistentStore
-} // HAL
+bool PersistentStore::write_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return write_data(data_pos, value, size, &crc);
+}
+
+bool PersistentStore::read_data(const int pos, uint8_t* value, size_t size) {
+  int data_pos = pos;
+  uint16_t crc = 0;
+  return read_data(data_pos, value, size, &crc);
+}
+
+const size_t PersistentStore::capacity() {
+  return E2END + 1;
+}
 
 #endif // EEPROM_SETTINGS
 #endif // __MK64FX512__ || __MK66FX1M0__

--- a/Marlin/src/HAL/persistent_store_api.h
+++ b/Marlin/src/HAL/persistent_store_api.h
@@ -4,15 +4,17 @@
 #include <stddef.h>
 #include <stdint.h>
 
-namespace HAL {
-namespace PersistentStore {
+class PersistentStore {
+public:
+  static bool access_start();
+  static bool access_finish();
+  static bool write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc);
+  static bool read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing=true);
+  static bool write_data(const int pos, uint8_t* value, size_t size);
+  static bool read_data(const int pos, uint8_t* value, size_t size);
+  static const size_t capacity();
+};
 
-bool access_start();
-bool access_finish();
-bool write_data(int &pos, const uint8_t *value, uint16_t size, uint16_t *crc);
-bool read_data(int &pos, uint8_t* value, uint16_t size, uint16_t *crc, const bool writing=true);
-
-} // PersistentStore
-} // HAL
+extern PersistentStore persistentStore;
 
 #endif // _PERSISTENT_STORE_H_

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -1172,7 +1172,7 @@
 
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPGM("EEPROM Dump:");
-    for (uint16_t i = 0; i <= E2END; i += 16) {
+    for (uint16_t i = 0; i < persistentStore.capacity(); i += 16) {
       if (!(i & 0x3)) idle();
       print_hex_word(i);
       SERIAL_ECHOPGM(": ");

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -345,14 +345,15 @@ void MarlinSettings::postprocess() {
 
 #if ENABLED(EEPROM_SETTINGS)
   #include "../HAL/persistent_store_api.h"
+  PersistentStore persistentStore;
 
   #define DUMMY_PID_VALUE 3000.0f
-  #define EEPROM_START() int eeprom_index = EEPROM_OFFSET; HAL::PersistentStore::access_start()
-  #define EEPROM_FINISH() HAL::PersistentStore::access_finish()
+  #define EEPROM_START() int eeprom_index = EEPROM_OFFSET; persistentStore.access_start()
+  #define EEPROM_FINISH() persistentStore.access_finish()
   #define EEPROM_SKIP(VAR) eeprom_index += sizeof(VAR)
-  #define EEPROM_WRITE(VAR) HAL::PersistentStore::write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
-  #define EEPROM_READ(VAR) HAL::PersistentStore::read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating)
-  #define EEPROM_READ_ALWAYS(VAR) HAL::PersistentStore::read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
+  #define EEPROM_WRITE(VAR) persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
+  #define EEPROM_READ(VAR) persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating)
+  #define EEPROM_READ_ALWAYS(VAR) persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
   #define EEPROM_ASSERT(TST,ERR) if (!(TST)) do{ SERIAL_ERROR_START_P(port); SERIAL_ERRORLNPGM_P(port, ERR); eeprom_error = true; }while(0)
 
   #if ENABLED(DEBUG_EEPROM_READWRITE)
@@ -1607,6 +1608,10 @@ void MarlinSettings::postprocess() {
       }
     #endif
 
+    const uint16_t MarlinSettings::meshes_end = persistentStore.capacity() - 129; // 128 (+1 because of the change to capacity rather than last valid address)
+                                                                                  // is a placeholder for the size of the MAT; the MAT will always
+                                                                                  // live at the very end of the eeprom
+
     uint16_t MarlinSettings::meshes_start_index() {
       return (datasize() + EEPROM_OFFSET + 32) & 0xFFF8;  // Pad the end of configuration data so it can float up
                                                           // or down a little bit without disrupting the mesh data
@@ -1627,7 +1632,7 @@ void MarlinSettings::postprocess() {
         if (!WITHIN(slot, 0, a - 1)) {
           #if ENABLED(EEPROM_CHITCHAT)
             ubl_invalid_slot(a);
-            SERIAL_PROTOCOLPAIR("E2END=", E2END);
+            SERIAL_PROTOCOLPAIR("E2END=", persistentStore.capacity() - 1);
             SERIAL_PROTOCOLPAIR(" meshes_end=", meshes_end);
             SERIAL_PROTOCOLLNPAIR(" slot=", slot);
             SERIAL_EOL();
@@ -1638,9 +1643,9 @@ void MarlinSettings::postprocess() {
         int pos = mesh_slot_offset(slot);
         uint16_t crc = 0;
 
-        HAL::PersistentStore::access_start();
-        const bool status = HAL::PersistentStore::write_data(pos, (uint8_t *)&ubl.z_values, sizeof(ubl.z_values), &crc);
-        HAL::PersistentStore::access_finish();
+        persistentStore.access_start();
+        const bool status = persistentStore.write_data(pos, (uint8_t *)&ubl.z_values, sizeof(ubl.z_values), &crc);
+        persistentStore.access_finish();
 
         if (status)
           SERIAL_PROTOCOLPGM("?Unable to save mesh data.\n");
@@ -1676,9 +1681,9 @@ void MarlinSettings::postprocess() {
         uint16_t crc = 0;
         uint8_t * const dest = into ? (uint8_t*)into : (uint8_t*)&ubl.z_values;
 
-        HAL::PersistentStore::access_start();
-        const uint16_t status = HAL::PersistentStore::read_data(pos, dest, sizeof(ubl.z_values), &crc);
-        HAL::PersistentStore::access_finish();
+        persistentStore.access_start();
+        const uint16_t status = persistentStore.read_data(pos, dest, sizeof(ubl.z_values), &crc);
+        persistentStore.access_finish();
 
         if (status)
           SERIAL_PROTOCOLPGM("?Unable to load mesh data.\n");

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -24,6 +24,9 @@
 #define CONFIGURATION_STORE_H
 
 #include "../inc/MarlinConfig.h"
+#if ENABLED(EEPROM_SETTINGS)
+  #include "../HAL/persistent_store_api.h"
+#endif
 
 #define ADD_PORT_ARG ENABLED(EEPROM_CHITCHAT) && NUM_SERIAL > 1
 
@@ -96,11 +99,10 @@ class MarlinSettings {
 
       static bool eeprom_error, validating;
 
-      #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
-                                         // That can store is enabled
-        static constexpr uint16_t meshes_end = E2END - 128; // 128 is a placeholder for the size of the MAT; the MAT will always
-                                                            // live at the very end of the eeprom
-
+      #if ENABLED(AUTO_BED_LEVELING_UBL)  // Eventually make these available if any leveling system
+                                          // That can store is enabled
+        static const uint16_t meshes_end; // 128 is a placeholder for the size of the MAT; the MAT will always
+                                          // live at the very end of the eeprom
       #endif
 
       static bool _load(PORTINIT_SOLO);


### PR DESCRIPTION
### Description
Clean up the api to use a static class instance to adhere to Marlin convention
Add const position data access for read/write without crc.
Add Storage capacity to the interface, this removes the requirement for E2END to be arbitrarily redefined, this change required me to change a few thing by 1 (or the comparison).

These changes will require updates to #11526 and #11500