### PR TITLE
need to add E2END to pins_RAMPS_FD_V2.h

### DIFF
--- a/Marlin/src/pins/pins_RAMPS_FD_V2.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V2.h
@@ -36,6 +36,7 @@
 #undef INVERTED_FAN_PINS
 
 #define I2C_EEPROM
+#define E2END 0xFFFF // 64K in a 24C512
 
 #ifndef PS_ON_PIN
   #define PS_ON_PIN        12


### PR DESCRIPTION
### Description

Commit 66d2b48b5995a4225029f7fed84a2dfe0ee9300a introduced a change that requires E2END to be declared on platforms that have an external EEPROM.  This change was overlooked for the RAMPS-FD v2 configuration, causing builds to break.  

If built according to the schematic, the RAMPS-FD v2 has 64K of EEPROM.

### Benefits

It enables Marlin 2 to build for RAMPS-FD v2 again.

### Related Issues

See issue #11543.