### PR TITLE
[2.0.x] Fix "SD init fail" problem for STM32F1

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_Stm32f1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_Stm32f1.cpp
@@ -81,8 +81,8 @@ void spiBegin() {
   #if !PIN_EXISTS(SS)
     #error "SS_PIN not defined!"
   #endif
-  WRITE(SS_PIN, HIGH);
   SET_OUTPUT(SS_PIN);
+  WRITE(SS_PIN, HIGH);
 }
 
 /**
@@ -104,7 +104,7 @@ void spiInit(uint8_t spiRate) {
     case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
     default:                clock = SPI_CLOCK_DIV2; // Default from the SPI library
   }
-  spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
+  spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE3);
   SPI.begin();
 }
 


### PR DESCRIPTION
### Description

Fix "SD init fail" problem for STM32F1 caused by incorrect SS pin state and incorrect SPI mode.

Code was tested on STM32F103C8T6 'BluePill' board with external SD Card module.

### Benefits

STM32F1-based systems can use SD card for offline printing and other features (like power loss recovery)

### Related Issues
* [2.0.x] Stm32f1 SDCard in SPI mode problem #11225
