### PR TITLE
[2.0.x] Implement servo support for STM32F1

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Servo_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Servo_Stm32f1.h
@@ -24,19 +24,34 @@
 #ifndef HAL_SERVO_STM32F1_H
 #define HAL_SERVO_STM32F1_H
 
-// Path needed, otherwise HAL version is used
-#include <../../libraries/Servo/src/Servo.h>
+// Pin number of unattached pins
+#define NOT_ATTACHED                    (-1)
+#define INVALID_SERVO                   255
 
-// Inherit and expand on the official library
-class libServo : public Servo {
-public:
-    int8_t attach(const int pin);
-    int8_t attach(const int pin, const int min, const int max);
-    void move(const int value);
-private:
-    uint16_t min_ticks;
-    uint16_t max_ticks;
+#ifndef MAX_SERVOS
+  #define MAX_SERVOS 3
+#endif
+
+#define SERVO_DEFAULT_MIN_PW            544
+#define SERVO_DEFAULT_MAX_PW            2400
+#define SERVO_DEFAULT_MIN_ANGLE         0
+#define SERVO_DEFAULT_MAX_ANGLE         180
+
+#define HAL_SERVO_LIB libServo
+
+class libServo {
+  public:
+    libServo();
+    bool attach(const int32_t pin, const int32_t minAngle=SERVO_DEFAULT_MIN_ANGLE, const int32_t maxAngle=SERVO_DEFAULT_MAX_ANGLE);
+    bool attached() const { return this->pin != NOT_ATTACHED; }
+    bool detach();
+    void move(const int32_t value);
+    int32_t read() const;
+  private:
     uint8_t servoIndex;               // index into the channel data for this servo
+    int32_t pin = NOT_ATTACHED;
+    int32_t minAngle;
+    int32_t maxAngle;
 };
 
 #endif // HAL_SERVO_STM32F1_H

--- a/Marlin/src/HAL/shared/servo.cpp
+++ b/Marlin/src/HAL/shared/servo.cpp
@@ -53,7 +53,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if HAS_SERVOS && !(IS_32BIT_TEENSY || defined(TARGET_LPC1768) || defined(STM32F4) || defined(STM32F4xx))
+#if HAS_SERVOS && !(IS_32BIT_TEENSY || defined(TARGET_LPC1768) || defined(STM32F1) || defined(STM32F1xx) || defined(STM32F4) || defined(STM32F4xx))
 
 //#include <Arduino.h>
 #include "servo.h"

--- a/Marlin/src/HAL/shared/servo.h
+++ b/Marlin/src/HAL/shared/servo.h
@@ -74,6 +74,8 @@
 
 #elif defined(TARGET_LPC1768)
   #include "../HAL_LPC1768/LPC1768_Servo.h"
+#elif defined(STM32F1) || defined(STM32F1xx)
+  #include "../HAL_STM32F1/HAL_Servo_STM32F1.h"
 #elif defined(STM32F4) || defined(STM32F4xx)
   #include "../HAL_STM32F4/HAL_Servo_STM32F4.h"
 #else


### PR DESCRIPTION
### Description

Implement servo support for STM32F1.

Original code was incomplete and depended on Servo library from stm32duino which conflicts with module/servo.h as both servo.h files are using the same \_SERVO_H_ macro.
```
#ifndef _SERVO_H_
#define _SERVO_H_
...
#endif // _SERVO_H_
```
New code implements functionality used by MarlinFW and does not rely on servo library from stm32duino framework.

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

STM32F1-based systems can use servo.

### Related Issues

None
