### PR TITLE
[2.0.x] Fix compilation error for STM32F1 with U8GLIB_SSD1306 or U8GLIB_SH1106 enabled

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/binary.h
+++ b/Marlin/src/HAL/HAL_STM32F1/binary.h
@@ -1,0 +1,1 @@
+#include "bit_constants.h"


### PR DESCRIPTION
### Description

Fix compilation error for STM32F1 with U8GLIB_SSD1306 or U8GLIB_SH1106 enabled.

The binary.h file required by lcd/dogm/dogm_bitmaps.h is not present in stm32duino environment.
Binary macro are defined in bit_constants.h in stm32duino framework.

Updated U8glib-HAL is required.

### Benefits

STM32F1-based systems can use I2C OLED displays based on SSD1306 and SH1106 controllers.

### Related Issues

https://github.com/MarlinFirmware/U8glib-HAL/pull/3

