### PR TITLE
Don't call __delay_4cycles for 0 cycle delay - takes a really long time.

### DIFF
--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -115,7 +115,10 @@
       #undef MAXNOPS
     }
     else
-      __delay_4cycles(x / 4);
+    {
+        if ((x = (x) / 4))
+            __delay_4cycles(x);
+    }
   }
   #undef nop
 

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -75,8 +75,10 @@
       }
       #undef MAXNOPS
     }
-    else
-      __delay_4cycles(x / 4);
+    else {
+      if ((x = (x) / 4))
+        __delay_4cycles(x / 4);
+    }
   }
   #undef nop
 
@@ -115,10 +117,7 @@
       #undef MAXNOPS
     }
     else
-    {
-        if ((x = (x) / 4))
-            __delay_4cycles(x);
-    }
+      __delay_4cycles(x / 4);
   }
   #undef nop
 

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -75,7 +75,8 @@
       }
       #undef MAXNOPS
     }
-    else {
+    else
+    {
       if ((x = (x) / 4))
         __delay_4cycles(x);
     }

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -75,11 +75,8 @@
       }
       #undef MAXNOPS
     }
-    else
-    {
-      if ((x = (x) / 4))
-        __delay_4cycles(x);
-    }
+    else if ((x >>= 2))
+      __delay_4cycles(x);
   }
   #undef nop
 
@@ -117,8 +114,8 @@
 
       #undef MAXNOPS
     }
-    else
-      __delay_4cycles(x / 4);
+    else if ((x >>= 2))
+      __delay_4cycles(x);
   }
   #undef nop
 

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -77,7 +77,7 @@
     }
     else {
       if ((x = (x) / 4))
-        __delay_4cycles(x / 4);
+        __delay_4cycles(x);
     }
   }
   #undef nop


### PR DESCRIPTION
### Requirements
Calling DELAY_NS for small values takes really long time on ARM cpu.

### Description

Stepper::set_directions was taking forever (more than 20 seconds). I traced the culprit to this line:
    DELAY_NS(MINIMUM_STEPPER_DIR_DELAY);

MINIMUM_STEPPER_DIR_DELAY was set to 20. On my system F_CPU was 180Mhz, this was expanding the macro to DELAY_CYCLES(3).

In turn the ARM implementation was calling __delay_4cycles(x/4) which was computed as __delay_4cycles(0).

The loop in __delay_4cycles decrements first and checks for 0 later, making __delay_4cycles(0) actually run for 2^32 cycles.
### Benefits

__delay_4cycles(0) would return immediately.

### Related Issues


