### PR TITLE
[2.0.x] Fix up Max7219 orientations

### DIFF
--- a/Marlin/src/feature/Max7219_Debug_LEDs.h
+++ b/Marlin/src/feature/Max7219_Debug_LEDs.h
@@ -31,7 +31,7 @@
  *   #define MAX7219_DIN_PIN   78
  *   #define MAX7219_LOAD_PIN  79
  *
- * Max7219_init() is called automatically at startup, and then there are a number of
+ * max7219.init() is called automatically at startup, and then there are a number of
  * support functions available to control the LEDs in the 8x8 grid.
  *
  * If you are using the Max7219 matrix for firmware debug purposes in time sensitive
@@ -47,14 +47,14 @@
 #endif
 #define _ROT ((MAX7219_ROTATE + 360) % 360)
 
-#define MAX7219_ROWS (8 * (MAX7219_NUMBER_UNITS))
+#define MAX7219_LINES (8 * (MAX7219_NUMBER_UNITS))
 
 #if _ROT == 0 || _ROT == 180
   #define MAX7219_Y_LEDS          8
-  #define MAX7219_X_LEDS          MAX7219_ROWS
+  #define MAX7219_X_LEDS          MAX7219_LINES
 #elif _ROT == 90 || _ROT == 270
   #define MAX7219_X_LEDS          8
-  #define MAX7219_Y_LEDS          MAX7219_ROWS
+  #define MAX7219_Y_LEDS          MAX7219_LINES
 #else
   #error "MAX7219_ROTATE must be a multiple of +/- 90°."
 #endif
@@ -80,7 +80,7 @@
 
 class Max7219 {
 public:
-  static uint8_t led_line[MAX7219_ROWS];
+  static uint8_t led_line[MAX7219_LINES];
 
   Max7219() { }
 
@@ -93,13 +93,13 @@ public:
   static void send(const uint8_t reg, const uint8_t data);
 
   // Refresh all units
-  inline static void refresh() { for (uint8_t i = 0; i < 8; i++) all(i); }
+  inline static void refresh() { for (uint8_t i = 0; i < 8; i++) refresh_line(i); }
 
-  // Update a single native row on all units
-  static void all(const uint8_t line);
+  // Update a single native line on all units
+  static void refresh_line(const uint8_t line);
 
-  // Update a single native row on the target unit
-  static void one(const uint8_t line);
+  // Update a single native line on just one unit
+  static void refresh_unit_line(const uint8_t line);
 
   // Set a single LED by XY coordinate
   static void led_set(const uint8_t x, const uint8_t y, const bool on);
@@ -125,6 +125,9 @@ public:
 
   // Quickly clear the whole matrix
   static void clear();
+
+  // Quickly fill the whole matrix
+  static void fill();
 
   // Apply custom code to update the matrix
   static void idle_tasks();

--- a/Marlin/src/gcode/feature/leds/M7219.cpp
+++ b/Marlin/src/gcode/feature/leds/M7219.cpp
@@ -43,13 +43,11 @@
  */
 void GcodeSuite::M7219() {
   if (parser.seen('I')) {
-    max7219.clear();
     max7219.register_setup();
+    max7219.clear();
   }
 
-  if (parser.seen('F'))
-    for (uint8_t x = 0; x < MAX7219_X_LEDS; x++)
-      max7219.set_column(x, 0xFFFFFFFF);
+  if (parser.seen('F')) max7219.fill();
 
   const uint32_t v = parser.ulongval('V');
 
@@ -69,18 +67,18 @@ void GcodeSuite::M7219() {
       max7219.led_toggle(x, y);
   }
   else if (parser.seen('D')) {
-    const uint8_t r = parser.value_byte();
-    if (r < MAX7219_ROWS) {
-      max7219.led_line[r] = v;
-      return max7219.all(r);
+    const uint8_t line = parser.byteval('D') + (parser.byteval('U') << 3);
+    if (line < MAX7219_LINES) {
+      max7219.led_line[line] = v;
+      return max7219.refresh_line(line);
     }
   }
 
   if (parser.seen('P')) {
-    for (uint8_t r = 0; r < MAX7219_ROWS; r++) {
+    for (uint8_t r = 0; r < MAX7219_LINES; r++) {
       SERIAL_ECHOPGM("led_line[");
-      if (r < 10) SERIAL_CHAR('_');
-      SERIAL_ECHO(r);
+      if (r < 10) SERIAL_CHAR(' ');
+      SERIAL_ECHO(int(r));
       SERIAL_ECHO("]=");
       for (uint8_t b = 8; b--;) SERIAL_CHAR('0' + TEST(max7219.led_line[r], b));
       SERIAL_EOL();


### PR DESCRIPTION
Fix up Max7219 code in various ways…
- Wrap macros in `do{...}while(0)` to fix some if-then clauses.
- Clock out the `led_line` array the same way for all orientations.
- Make sure the default rotation of 0° gives the following:
  - The input wires are on the left
  - Cascaded units are arrayed left-to-right
  - Register `max7219_reg_digit0` is at the top of each unit
  - Bits 0-7 go in the natural order from right-to-left
- Fix up other orientations also
- Fix the `error` method output format
- Refer to the hardware lines as "lines" to distinguish from logical "rows"
- Add more delay to the `noop` method
- Add a `fill` method

Counterpart to #11597