### PR TITLE
Fix G28 resetting DUAL_NOZZLE_DUPLICATION_MODE

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -229,7 +229,7 @@ void GcodeSuite::G28(const bool always_home_all) {
     tool_change(0, 0, true);
   #endif
 
-  #if ENABLED(DUAL_X_CARRIAGE) || ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
+  #if ENABLED(DUAL_X_CARRIAGE)
     extruder_duplication_enabled = false;
   #endif
 


### PR DESCRIPTION
### Description
With this change, G28 no longer cancels single x carriage duplication. Dual x carriages are unaffected by this change.

### Benefits
There's no reason for G28 to reset DUAL_NOZZLE_DUPLICATION_MODE, because it only affects the E stepper, unlike DUAL_X_CARRIAGE which affects the X steppers as well.