### PR TITLE
[2.0.x] Followup: HOTEND_OFFSET_Z always available 

### DIFF
--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -37,7 +37,7 @@
  *   T<tool>
  *   X<xoffset>
  *   Y<yoffset>
- *   Z<zoffset> - Available with DUAL_X_CARRIAGE, SWITCHING_NOZZLE and PARKING_EXTRUDER
+ *   Z<zoffset>
  */
 void GcodeSuite::M218() {
   if (get_target_extruder_from_command() || target_extruder == 0) return;
@@ -51,13 +51,10 @@ void GcodeSuite::M218() {
     hotend_offset[Y_AXIS][target_extruder] = parser.value_linear_units();
     report = false;
   }
-
-  #if HAS_HOTEND_OFFSET_Z
-    if (parser.seenval('Z')) {
-      hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
-      report = false;
-    }
-  #endif
+  if (parser.seenval('Z')) {
+    hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
+    report = false;
+  }
 
   if (report) {
     SERIAL_ECHO_START();
@@ -67,10 +64,8 @@ void GcodeSuite::M218() {
       SERIAL_ECHO(hotend_offset[X_AXIS][e]);
       SERIAL_CHAR(',');
       SERIAL_ECHO(hotend_offset[Y_AXIS][e]);
-      #if HAS_HOTEND_OFFSET_Z
-        SERIAL_CHAR(',');
-        SERIAL_ECHO(hotend_offset[Z_AXIS][e]);
-      #endif
+      SERIAL_CHAR(',');
+      SERIAL_ECHO(hotend_offset[Z_AXIS][e]);
     }
     SERIAL_EOL();
   }

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -413,7 +413,6 @@
 /**
  * Default hotend offsets, if not defined
  */
-#define HAS_HOTEND_OFFSET_Z (HOTENDS > 1 && (ENABLED(DUAL_X_CARRIAGE) || ENABLED(SWITCHING_NOZZLE) || ENABLED(PARKING_EXTRUDER)))
 #if HOTENDS > 1
   #ifndef HOTEND_OFFSET_X
     #define HOTEND_OFFSET_X { 0 } // X offsets for each extruder
@@ -421,8 +420,8 @@
   #ifndef HOTEND_OFFSET_Y
     #define HOTEND_OFFSET_Y { 0 } // Y offsets for each extruder
   #endif
-  #if HAS_HOTEND_OFFSET_Z && !defined(HOTEND_OFFSET_Z)
-    #define HOTEND_OFFSET_Z { 0 }
+  #ifndef HOTEND_OFFSET_Z
+    #define HOTEND_OFFSET_Z { 0 } // Z offsets for each extruder
   #endif
 #endif
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1754,7 +1754,6 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       HOTEND_OFFSET_X,
       HOTEND_OFFSET_Y,
       HOTEND_OFFSET_Z
-      #endif
     };
     static_assert(
       tmp4[X_AXIS][0] == 0 && tmp4[Y_AXIS][0] == 0 && tmp4[Z_AXIS][0] == 0,

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1752,11 +1752,8 @@ void MarlinSettings::reset(PORTARG_SOLO) {
   #if HOTENDS > 1
     constexpr float tmp4[XYZ][HOTENDS] = {
       HOTEND_OFFSET_X,
-      HOTEND_OFFSET_Y
-      #ifdef HOTEND_OFFSET_Z
-        , HOTEND_OFFSET_Z
-      #else
-        , { 0 }
+      HOTEND_OFFSET_Y,
+      HOTEND_OFFSET_Z
       #endif
     };
     static_assert(
@@ -2173,9 +2170,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOPAIR_P(port, "  M218 T", (int)e);
         SERIAL_ECHOPAIR_P(port, " X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
         SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
-        #if HAS_HOTEND_OFFSET_Z
-          SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]));
-        #endif
+        SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]));
         SERIAL_EOL_P(port);
       }
     #endif

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -415,8 +415,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #endif
 
           const float xdiff = hotend_offset[X_AXIS][tmp_extruder] - hotend_offset[X_AXIS][active_extruder],
-                      ydiff = hotend_offset[Y_AXIS][tmp_extruder] - hotend_offset[Y_AXIS][active_extruder],
-                      zdiff = hotend_offset[Z_AXIS][tmp_extruder] - hotend_offset[Z_AXIS][active_extruder];
+                      ydiff = hotend_offset[Y_AXIS][tmp_extruder] - hotend_offset[Y_AXIS][active_extruder];
+        
+          #if !ENABLED(SWITCHING_NOZZLE) && !ENABLED(DUAL_X_CARRIAGE) && !ENABLED(PARKING_EXTRUDER)
+            const float zdiff = hotend_offset[Z_AXIS][tmp_extruder] - hotend_offset[Z_AXIS][active_extruder];
+          #endif
 
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) {
@@ -430,7 +433,10 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           // The newly-selected extruder XY is actually at...
           current_position[X_AXIS] += xdiff;
           current_position[Y_AXIS] += ydiff;
-          current_position[Z_AXIS] += zdiff;
+        
+          #if !ENABLED(SWITCHING_NOZZLE) && !ENABLED(DUAL_X_CARRIAGE) && !ENABLED(PARKING_EXTRUDER)
+            current_position[Z_AXIS] += zdiff;
+          #endif
 
           // Set the new active extruder
           active_extruder = tmp_extruder;


### PR DESCRIPTION
Sorry for breaking some stuff.
This is needed to fix:
https://github.com/MarlinFirmware/Marlin/pull/11603

This includes eeprom, M218 and fixes for other dual extrusion systems