### PR TITLE
Compatibility with Arduino IDE 1.8.6

### DIFF
--- a/Marlin/Sd2Card.h
+++ b/Marlin/Sd2Card.h
@@ -94,16 +94,24 @@ uint8_t const SD_CARD_TYPE_SD1  = 1,                    // Standard capacity V1 
 // SPI pin definitions - do not edit here - change in SdFatConfig.h
 #if DISABLED(SOFTWARE_SPI)
   // hardware pin defs
-  #define SD_CHIP_SELECT_PIN SS_PIN   // The default chip select pin for the SD card is SS.
+  // The default chip select pin for the SD card is SS.
+  #define SD_CHIP_SELECT_PIN SS_PIN
   // The following three pins must not be redefined for hardware SPI.
-  #define SPI_MOSI_PIN MOSI_PIN       // SPI Master Out Slave In pin
-  #define SPI_MISO_PIN MISO_PIN       // SPI Master In Slave Out pin
-  #define SPI_SCK_PIN SCK_PIN         // SPI Clock pin
+  // SPI Master Out Slave In pin
+  #define SPI_MOSI_PIN MOSI_PIN
+  // SPI Master In Slave Out pin
+  #define SPI_MISO_PIN MISO_PIN
+  // SPI Clock pin
+  #define SPI_SCK_PIN SCK_PIN
 #else  // SOFTWARE_SPI
-  #define SD_CHIP_SELECT_PIN SOFT_SPI_CS_PIN  // SPI chip select pin
-  #define SPI_MOSI_PIN SOFT_SPI_MOSI_PIN      // SPI Master Out Slave In pin
-  #define SPI_MISO_PIN SOFT_SPI_MISO_PIN      // SPI Master In Slave Out pin
-  #define SPI_SCK_PIN SOFT_SPI_SCK_PIN        // SPI Clock pin
+  // SPI chip select pin
+  #define SD_CHIP_SELECT_PIN SOFT_SPI_CS_PIN
+  // SPI Master Out Slave In pin
+  #define SPI_MOSI_PIN SOFT_SPI_MOSI_PIN
+  // SPI Master In Slave Out pin
+  #define SPI_MISO_PIN SOFT_SPI_MISO_PIN
+  // SPI Clock pin
+  #define SPI_SCK_PIN SOFT_SPI_SCK_PIN
 #endif  // SOFTWARE_SPI
 
 /**


### PR DESCRIPTION
### Description
After upgrading Arduino IDE to the latest version (1.8.6), it's no longer possible to compile Marlin (replicated on 2 computers) - it fails with an error: `/* SPI Master In Slave Out pin*/" and "_DDR" does not give a valid preprocessing token`. It seems that there is a problem with the C preprocessor. So I moved directive comments in the `Sd2Card.h` file to separate lines and now it works also with Arduino IDE 1.8.6.

### Benefits
Make Marlin compatible with Arduino IDE 1.8.6

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/10862