### PR TITLE
Fix show progress bar percent

### DIFF
--- a/Marlin/status_screen_lite_ST7920.h
+++ b/Marlin/status_screen_lite_ST7920.h
@@ -877,7 +877,7 @@ void ST7920_Lite_Status_Screen::update_status_or_position(bool forceUpdate) {
 
 void ST7920_Lite_Status_Screen::update_progress(const bool forceUpdate) {
   #if DISABLED(LCD_SET_PROGRESS_MANUALLY)
-    uint8_t progress_bar_percent = 0;
+    uint8_t progress_bar_percent = card.percentDone();
   #endif
 
   // Set current percentage from SD when actively printing


### PR DESCRIPTION
Fix progress bar not working when LCD_SET_PROGRESS_MANUALLY is disabled
(Same code in [status_screen_DOGM.h#L309](https://github.com/MarlinFirmware/Marlin/blob/1.1.x/Marlin/status_screen_DOGM.h#L309))
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
* *Progress bar not working and always show 0% when LCD_SET_PROGRESS_MANUALLY is disabled*
