### PR TITLE
[2.0.x] Add Morpheus Board support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -216,6 +216,7 @@
 #define BOARD_MALYAN_M200      1801   // STM32C8T6 Libmaple based stm32f1 controller
 #define BOARD_STM3R_MINI       1803   // STM32 Libmaple based stm32f1 controller
 #define BOARD_GTM32_PRO_VB     1805   // STM32f103VET6 controller
+#define BOARD_MORPHEUS         1806   // STM32F103C8/STM32F103CB Libmaple based stm32f1 controller
 
 //
 // STM32 ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -374,6 +374,8 @@
   #include "pins_CHITU3D.h"           // STM32F1                                    env:STM32F1
 #elif MB(GTM32_PRO_VB)
   #include "pins_GTM32_PRO_VB.h"      // STM32F1                                    env:STM32F1
+#elif MB(MORPHEUS)
+  #include "pins_MORPHEUS.h"          // STM32F1                                    env:STM32F1
 
 //
 // STM32 ARM Cortex-M4F

--- a/Marlin/src/pins/pins_MORPHEUS.h
+++ b/Marlin/src/pins/pins_MORPHEUS.h
@@ -1,0 +1,90 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+ /**
+  * 2017 Victor Perez Marlin for stm32f1 test
+  * 2018 Modified by Pablo Crespo for Morpheus Board (https://github.com/pscrespo/Morpheus-STM32)
+  */
+
+/**
+ * MORPHEUS Board pin assignments
+ */
+
+#ifndef __STM32F1__
+  #error "Oops!  Make sure you have an STM32F1 board selected from the 'Tools -> Boards' menu."
+#endif
+
+#define BOARD_NAME "Bluepill based board"
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          PB14
+#define Y_MIN_PIN          PB13
+#define Z_MIN_PIN          PB12
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  PB9
+#endif
+
+//
+// Steppers
+//
+// X & Y enable are the same
+#define X_STEP_PIN         PB7
+#define X_DIR_PIN          PB6
+#define X_ENABLE_PIN       PB8
+
+#define Y_STEP_PIN         PB5
+#define Y_DIR_PIN          PB4
+#define Y_ENABLE_PIN       PB8
+
+#define Z_STEP_PIN         PA15
+#define Z_DIR_PIN          PA10
+#define Z_ENABLE_PIN       PB3
+
+#define E0_STEP_PIN        PA8
+#define E0_DIR_PIN         PB15
+#define E0_ENABLE_PIN      PA9
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PB1   // Analog Input (HOTEND thermistor)
+#define TEMP_BED_PIN       PB0   // Analog Input (BED thermistor)
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       PA2   // HOTEND MOSFET
+#define HEATER_BED_PIN     PA0   // BED MOSFET
+
+#define FAN_PIN            PA1   // FAN1 header on board - PRINT FAN
+
+//
+// Misc.
+//
+#define LED_PIN            PC13
+#define SDSS               PA3


### PR DESCRIPTION
### Requirements

(none)

### Description

Add pinmap for Morpheus Board, a DIY controller board based on the "bluepill" STM32F1 development board (https://github.com/pscrespo/Morpheus-STM32).

### Benefits

Adds support for an open source, easy to make, simple DIY board.

### Related Issues

(none)
