### PR TITLE
[2.0.x] Fix 5 mixing steppers

### DIFF
--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -80,7 +80,10 @@ void manage_inactivity(const bool ignore_stepper_queue=false);
   /**
    * Mixing steppers synchronize their enable (and direction) together
    */
-  #if MIXING_STEPPERS > 3
+  #if MIXING_STEPPERS > 4
+    #define  enable_E0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); E3_ENABLE_WRITE( E_ENABLE_ON); E4_ENABLE_WRITE( E_ENABLE_ON); }
+    #define disable_E0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); E2_ENABLE_WRITE(!E_ENABLE_ON); E3_ENABLE_WRITE(!E_ENABLE_ON); E4_ENABLE_WRITE(!E_ENABLE_ON); }
+  #elif MIXING_STEPPERS > 3
     #define  enable_E0() { E0_ENABLE_WRITE( E_ENABLE_ON); E1_ENABLE_WRITE( E_ENABLE_ON); E2_ENABLE_WRITE( E_ENABLE_ON); E3_ENABLE_WRITE( E_ENABLE_ON); }
     #define disable_E0() { E0_ENABLE_WRITE(!E_ENABLE_ON); E1_ENABLE_WRITE(!E_ENABLE_ON); E2_ENABLE_WRITE(!E_ENABLE_ON); E3_ENABLE_WRITE(!E_ENABLE_ON); }
   #elif MIXING_STEPPERS > 2

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -35,26 +35,34 @@ void controllerfan_update() {
   const millis_t ms = millis();
   if (ELAPSED(ms, nextMotorCheck)) {
     nextMotorCheck = ms + 2500UL; // Not a time critical function, so only check every 2.5s
+
+    // If any of the drivers or the bed are enabled...
     if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON
       #if HAS_HEATED_BED
         || thermalManager.soft_pwm_amount_bed > 0
       #endif
-        || E0_ENABLE_READ == E_ENABLE_ON // If any of the drivers are enabled...
+        #if HAS_X2_ENABLE
+          || X2_ENABLE_READ == X_ENABLE_ON
+        #endif
+        #if HAS_Y2_ENABLE
+          || Y2_ENABLE_READ == Y_ENABLE_ON
+        #endif
+        #if HAS_Z2_ENABLE
+          || Z2_ENABLE_READ == Z_ENABLE_ON
+        #endif
+        || E0_ENABLE_READ == E_ENABLE_ON
         #if E_STEPPERS > 1
           || E1_ENABLE_READ == E_ENABLE_ON
-          #if HAS_X2_ENABLE
-            || X2_ENABLE_READ == X_ENABLE_ON
-          #endif
           #if E_STEPPERS > 2
-            || E2_ENABLE_READ == E_ENABLE_ON
+              || E2_ENABLE_READ == E_ENABLE_ON
             #if E_STEPPERS > 3
-              || E3_ENABLE_READ == E_ENABLE_ON
+                || E3_ENABLE_READ == E_ENABLE_ON
               #if E_STEPPERS > 4
-                || E4_ENABLE_READ == E_ENABLE_ON
-              #endif // E_STEPPERS > 4
-            #endif // E_STEPPERS > 3
-          #endif // E_STEPPERS > 2
-        #endif // E_STEPPERS > 1
+                  || E4_ENABLE_READ == E_ENABLE_ON
+              #endif
+            #endif
+          #endif
+        #endif
     ) {
       lastMotorOn = ms; //... set time to NOW so the fan will turn on
     }

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -50,20 +50,30 @@ bool Power::is_power_needed() {
     if (controllerFanSpeed > 0) return true;
   #endif
 
+  // If any of the drivers or the bed are enabled...
   if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON
     #if HAS_HEATED_BED
       || thermalManager.soft_pwm_amount_bed > 0
     #endif
-      || E0_ENABLE_READ == E_ENABLE_ON // If any of the drivers are enabled...
+      #if HAS_X2_ENABLE
+        || X2_ENABLE_READ == X_ENABLE_ON
+      #endif
+      #if HAS_Y2_ENABLE
+        || Y2_ENABLE_READ == Y_ENABLE_ON
+      #endif
+      #if HAS_Z2_ENABLE
+        || Z2_ENABLE_READ == Z_ENABLE_ON
+      #endif
+      || E0_ENABLE_READ == E_ENABLE_ON
       #if E_STEPPERS > 1
         || E1_ENABLE_READ == E_ENABLE_ON
-        #if HAS_X2_ENABLE
-          || X2_ENABLE_READ == X_ENABLE_ON
-        #endif
         #if E_STEPPERS > 2
             || E2_ENABLE_READ == E_ENABLE_ON
           #if E_STEPPERS > 3
               || E3_ENABLE_READ == E_ENABLE_ON
+            #if E_STEPPERS > 4
+                || E4_ENABLE_READ == E_ENABLE_ON
+            #endif
           #endif
         #endif
       #endif


### PR DESCRIPTION
Requirements
There is no requirement

Description
If MIXING_EXTRUDER enabled Marlin.h enable only 4 extruders.
So you can not use 5 color diamond hotend.
This is fix of it

Benefits
Marlin can support 5 color mixing extruder

Related Issues
If you wired 5 extruders and activate MIXING_EXTRUDER option, only 4 extruders will operate