### PR TITLE
[2.0.x] LIGHTWEIGHT_UI: Allow feedrate % to exceed 255%

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -601,7 +601,7 @@ void ST7920_Lite_Status_Screen::draw_print_time(const duration_t &elapsed) {
   write_str(str, 6);
 }
 
-void ST7920_Lite_Status_Screen::draw_feedrate_percentage(const uint8_t percentage) {
+void ST7920_Lite_Status_Screen::draw_feedrate_percentage(const uint16_t percentage) {
   // We only have enough room for the feedrate when
   // we have one extruder
   #if EXTRUDERS == 1
@@ -709,7 +709,7 @@ bool ST7920_Lite_Status_Screen::indicators_changed() {
   // because the actual temps fluctuate so by updating
   // them only during blinks we gain a bit of stability.
   const bool       blink             = lcd_blink();
-  const uint8_t    feedrate_perc     = feedrate_percentage;
+  const uint16_t   feedrate_perc     = feedrate_percentage;
   const uint8_t    fan_speed         = ((fanSpeeds[0] + 1) * 100) / 256;
   const int16_t    extruder_1_target = thermalManager.degTargetHotend(0);
   #if EXTRUDERS == 2
@@ -736,7 +736,7 @@ void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
   if (forceUpdate || indicators_changed()) {
     const bool       blink             = lcd_blink();
     const duration_t elapsed           = print_job_timer.duration();
-    const uint8_t    feedrate_perc     = feedrate_percentage;
+    const uint16_t   feedrate_perc     = feedrate_percentage;
     const uint8_t    fan_speed         = ((fanSpeeds[0] + 1) * 100) / 256;
     const int16_t    extruder_1_temp   = thermalManager.degHotend(0),
                      extruder_1_target = thermalManager.degTargetHotend(0);

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920_class.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920_class.h
@@ -87,7 +87,7 @@ class ST7920_Lite_Status_Screen {
     static void draw_bed_temp(const int16_t temp, const int16_t target, bool forceUpdate = false);
     static void draw_fan_speed(const uint8_t value);
     static void draw_print_time(const duration_t &elapsed);
-    static void draw_feedrate_percentage(const uint8_t percentage);
+    static void draw_feedrate_percentage(const uint16_t percentage);
     static void draw_status_message(const char *str);
     static void draw_position(const float x, const float y, const float z, bool position_known = true);
 


### PR DESCRIPTION
- Changed type of integer used for feedrate percentage from uint8_t to uint16_t so lightweight UI can show FR values greater than 255.
