### PR TITLE
[Please Close] M108 "Unknown command" with emergency parser

### DIFF
--- a/Marlin/pins_ULTIMAKER.h
+++ b/Marlin/pins_ULTIMAKER.h
@@ -43,7 +43,7 @@
 //
 // Servos
 //
-#define SERVO0_PIN         13   // UNTESTED
+#define SERVO0_PIN         11
 
 //
 // Limit Switches

--- a/Marlin/status_screen_lite_ST7920.h
+++ b/Marlin/status_screen_lite_ST7920.h
@@ -876,24 +876,32 @@ void ST7920_Lite_Status_Screen::update_status_or_position(bool forceUpdate) {
 }
 
 void ST7920_Lite_Status_Screen::update_progress(const bool forceUpdate) {
-  #if DISABLED(LCD_SET_PROGRESS_MANUALLY)
-    uint8_t progress_bar_percent = 0;
-  #endif
+  #if ENABLED(LCD_SET_PROGRESS_MANUALLY) || ENABLED(SDSUPPORT)
 
-  // Set current percentage from SD when actively printing
-  #if ENABLED(LCD_SET_PROGRESS_MANUALLY) && ENABLED(SDSUPPORT) && (ENABLED(LCD_PROGRESS_BAR) || ENABLED(DOGLCD))
-    if (IS_SD_PRINTING) progress_bar_percent = card.percentDone();
-  #endif
+    #if DISABLED(LCD_SET_PROGRESS_MANUALLY)
+      uint8_t progress_bar_percent; //=0
+    #endif
 
-  // Since the progress bar involves writing
-  // quite a few bytes to GDRAM, only do this
-  // when an update is actually necessary.
+    #if ENABLED(SDSUPPORT)
+      // Progress bar % comes from SD when actively printing
+      if (IS_SD_PRINTING) progress_bar_percent = card.percentDone();
+    #endif
 
-  static uint8_t last_progress = 0;
-  if (!forceUpdate && last_progress == progress_bar_percent) return;
-  last_progress = progress_bar_percent;
+    // Since the progress bar involves writing
+    // quite a few bytes to GDRAM, only do this
+    // when an update is actually necessary.
 
-  draw_progress_bar(progress_bar_percent);
+    static uint8_t last_progress = 0;
+    if (!forceUpdate && last_progress == progress_bar_percent) return;
+    last_progress = progress_bar_percent;
+
+    draw_progress_bar(progress_bar_percent);
+
+  #else
+
+    UNUSED(forceUpdate);
+
+  #endif // LCD_SET_PROGRESS_MANUALLY || SDSUPPORT
 }
 
 void ST7920_Lite_Status_Screen::update(const bool forceUpdate) {


### PR DESCRIPTION
AHHHH I made a pull request from the Marlin repo... Please close this and I'll make the proper one from my fork...

Sorry I'm new to github D:

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Enabling emergency parser causes M108, M112 and M410 to respond with "unknown command" even though they execute completely fine. This is due to the emergency parser dealing with them and the standard parser not having these codes defined. I simply added their definitions to silently drop them if the emergency parser is enabled.

### Benefits

<!-- What does this fix or improve? -->
No misleading error messages when codes are handled by the emergency parser.


