### PR TITLE
[1.1.x] Silently drop M108, M112 and M410 with emergency parser enabled

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12380,10 +12380,8 @@ void process_parsed_command() {
         case 108: gcode_M108(); break;                            // M108: Cancel Waiting
         case 112: gcode_M112(); break;                            // M112: Emergency Stop
         case 410: gcode_M410(); break;                            // M410: Quickstop. Abort all planned moves
-      #else                                                       // Silently drop as handled by emergency parser
-        case 108: break;
-        case 112: break;
-        case 410: break;
+      #else
+        case 108: case 112: case 410: break;                      // Silently drop as handled by emergency parser
       #endif
 
       #if ENABLED(HOST_KEEPALIVE_FEATURE)

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -12380,6 +12380,10 @@ void process_parsed_command() {
         case 108: gcode_M108(); break;                            // M108: Cancel Waiting
         case 112: gcode_M112(); break;                            // M112: Emergency Stop
         case 410: gcode_M410(); break;                            // M410: Quickstop. Abort all planned moves
+      #else                                                       // Silently drop as handled by emergency parser
+        case 108: break;
+        case 112: break;
+        case 410: break;
       #endif
 
       #if ENABLED(HOST_KEEPALIVE_FEATURE)


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Fixes #11654 emergency parser causes M108, M112 and M410 to respond with "unknown command" even though they execute completely fine. This is due to the emergency parser dealing with them and the standard parser not having these codes defined. I simply added their definitions to silently drop them if the emergency parser is enabled.

### Benefits

<!-- What does this fix or improve? -->
No misleading error messages when codes are handled by the emergency parser.

