### PR TITLE
Fix SWITCHING_NOZZLE zdiff

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -433,11 +433,6 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
         #endif // !DUAL_X_CARRIAGE
 
-        #if ENABLED(SWITCHING_NOZZLE)
-          // The newly-selected extruder Z is actually at...
-          current_position[Z_AXIS] -= zdiff;
-        #endif
-
         // Tell the planner the new "current position"
         SYNC_PLAN_POSITION_KINEMATIC();
 


### PR DESCRIPTION
line 436 to 439 should delete since line 429 already add zdiff

old zdiff code
```cpp
const float zdiff = hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
```
new zdiff code
```cpp
zdiff = hotend_offset[Z_AXIS][tmp_extruder] - hotend_offset[Z_AXIS][active_extruder];
```

so `zdiff` is reversed

line 429
```cpp
current_position[Z_AXIS] += zdiff;
```

line 436 to 439
```cpp
#if ENABLED(SWITCHING_NOZZLE)
  // The newly-selected extruder Z is actually at...
  current_position[Z_AXIS] -= zdiff;
#endif
```