### PR TITLE
[2.0.x] Printcounter improvements

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1635,4 +1635,8 @@ static_assert(COUNT(sanity_arr_3) <= XYZE_N, "DEFAULT_MAX_ACCELERATION has too m
   #error "FAST_PWM_FAN only supported by 8 bit CPUs."
 #endif
 
+#if ENABLED(PRINTCOUNTER) && DISABLED(EEPROM_SETTINGS)
+  #error "PRINTCOUNTER requires EEPROM_SETTINGS. Please update your Configuration."
+#endif
+
 #endif // _SANITYCHECK_H_

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -39,8 +39,6 @@ printStatistics PrintCounter::data;
 
 const PrintCounter::promdress PrintCounter::address = STATS_EEPROM_ADDRESS;
 
-const uint16_t PrintCounter::updateInterval = 10;
-const uint16_t PrintCounter::saveInterval = 3600;
 millis_t PrintCounter::lastDuration;
 bool PrintCounter::loaded = false;
 
@@ -74,7 +72,6 @@ void PrintCounter::initStats() {
   data = { 0, 0, 0, 0, 0.0 };
 
   saveStats();
-
   persistentStore.access_start();
   persistentStore.write_data(address, (uint8_t)0x16);
   persistentStore.access_finish();
@@ -166,27 +163,20 @@ void PrintCounter::showStats() {
 void PrintCounter::tick() {
   if (!isRunning()) return;
 
-  static uint32_t update_last = millis(),
-                  eeprom_last = millis();
-
   millis_t now = millis();
 
-  // Trying to get the amount of calculations down to the bare min
-  const static uint16_t i = updateInterval * 1000;
-
-  if (now - update_last >= i) {
+  static uint32_t update_next; // = 0
+  if (ELAPSED(now, update_next)) {
     #if ENABLED(DEBUG_PRINTCOUNTER)
       debug(PSTR("tick"));
     #endif
-
     data.printTime += deltaDuration();
-    update_last = now;
+    update_next = now + updateInterval * 1000;
   }
 
-  // Trying to get the amount of calculations down to the bare min
-  const static millis_t j = saveInterval * 1000;
-  if (now - eeprom_last >= j) {
-    eeprom_last = now;
+  static uint32_t eeprom_next; // = 0
+  if (ELAPSED(now, eeprom_next)) {
+    eeprom_next = now + saveInterval * 1000;
     saveStats();
   }
 }

--- a/Marlin/src/module/printcounter.h
+++ b/Marlin/src/module/printcounter.h
@@ -72,7 +72,7 @@ class PrintCounter: public Stopwatch {
      * @note The max value for this option is 60(s), otherwise integer
      * overflow will happen.
      */
-    static const uint16_t updateInterval;
+    static constexpr uint16_t updateInterval = 10;
 
     /**
      * @brief Interval in seconds between EEPROM saves
@@ -80,7 +80,7 @@ class PrintCounter: public Stopwatch {
      * EEPROM save cycle, the development team recommends to set this value
      * no lower than 3600 secs (1 hour).
      */
-    static const uint16_t saveInterval;
+    static constexpr uint16_t saveInterval = 3600;
 
     /**
      * @brief Timestamp of the last call to deltaDuration()


### PR DESCRIPTION
In response to #11674…

- Use `ELAPSED` macros and `*_next` time values.
- Sanity-check `EEPROM_SETTINGS` dependency.
- Move `const` "configuration" values to class as `constexpr`.