### PR TITLE
[2.0.x] Update TMC2208 to v0.2.3

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1527,6 +1527,24 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
   #error "select hardware UART for TMC2208 to use both TMC2208 and ENDSTOP_INTERRUPTS_FEATURE."
 #endif
 
+/**
+ * TMC2208 software UART is only supported on AVR
+ */
+#if HAS_DRIVER(TMC2208) && !defined(__AVR__) && !( \
+       defined(X_HARDWARE_SERIAL ) \
+    || defined(X2_HARDWARE_SERIAL) \
+    || defined(Y_HARDWARE_SERIAL ) \
+    || defined(Y2_HARDWARE_SERIAL) \
+    || defined(Z_HARDWARE_SERIAL ) \
+    || defined(Z2_HARDWARE_SERIAL) \
+    || defined(E0_HARDWARE_SERIAL) \
+    || defined(E1_HARDWARE_SERIAL) \
+    || defined(E2_HARDWARE_SERIAL) \
+    || defined(E3_HARDWARE_SERIAL) \
+    || defined(E4_HARDWARE_SERIAL) )
+  #error "TMC2208 Software Serial is supported only on AVR platforms."
+#endif
+
 #if ENABLED(SENSORLESS_HOMING)
   // Require STEALTHCHOP for SENSORLESS_HOMING on DELTA as the transition from spreadCycle to stealthChop
   // is necessary in order to reset the stallGuard indication between the initial movement of all three

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -281,8 +281,6 @@
 // TMC2208 Driver objects and inits
 //
 #if HAS_DRIVER(TMC2208)
-
-  #include <SoftwareSerial.h>
   #include <HardwareSerial.h>
   #include <TMC2208Stepper.h>
   #include "planner.h"

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ lib_deps =
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   LiquidCrystal@1.3.4
   TMC2130Stepper
-  https://github.com/teemuatlut/TMC2208Stepper/archive/v0.1.1.zip
+  https://github.com/teemuatlut/TMC2208Stepper/archive/v0.2.3.zip
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
   https://github.com/ameyer/Arduino-L6470/archive/master.zip


### PR DESCRIPTION
Update TMC2208Stepper library to version `0.2.3`.
Add sanity check against using SW serial with platforms other than AVR.