### PR TITLE
[2.0.x] Fix some PWM declarations

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -995,15 +995,18 @@
   #define FAN_COUNT 0
 #endif
 
+#ifndef FAN_PIN_INVERTING
+  #define FAN_PIN_INVERTING false
+#endif
 #if HAS_FAN0
-  #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+  #define WRITE_FAN(v) WRITE(FAN_PIN, (v) ^ FAN_PIN_INVERTING)
   #define WRITE_FAN0(v) WRITE_FAN(v)
 #endif
 #if HAS_FAN1
-  #define WRITE_FAN1(v) WRITE(FAN1_PIN, v)
+  #define WRITE_FAN1(v) WRITE(FAN1_PIN, (v) ^ FAN_PIN_INVERTING)
 #endif
 #if HAS_FAN2
-  #define WRITE_FAN2(v) WRITE(FAN2_PIN, v)
+  #define WRITE_FAN2(v) WRITE(FAN2_PIN, (v) ^ FAN_PIN_INVERTING)
 #endif
 #define WRITE_FAN_N(n, v) WRITE_FAN##n(v)
 

--- a/Marlin/src/lcd/ultralcd_impl_DOGM.h
+++ b/Marlin/src/lcd/ultralcd_impl_DOGM.h
@@ -118,9 +118,11 @@
 
 #define START_COL              0
 
+#define LCD_SD_SHARED_BUS (DISABLED(SDSUPPORT) && LCD_PINS_D4 == SCK_PIN && LCD_PINS_ENABLE == MOSI_PIN)
+
 // LCD selection
 #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
-  #if DISABLED(SDSUPPORT) && (LCD_PINS_D4 == SCK_PIN) && (LCD_PINS_ENABLE == MOSI_PIN)
+  #if LCD_SD_SHARED_BUS
     U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_RS); // 2 stripes, HW SPI (shared with SD card)
   #else
     U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
@@ -128,10 +130,11 @@
 
 #elif ENABLED(U8GLIB_ST7920)
   // RepRap Discount Full Graphics Smart Controller
-  #if DISABLED(SDSUPPORT) && (LCD_PINS_D4 == SCK_PIN) && (LCD_PINS_ENABLE == MOSI_PIN)
+  #if LCD_SD_SHARED_BUS
     U8GLIB_ST7920_128X64_4X_HAL u8g(LCD_PINS_RS); // 2 stripes, HW SPI (shared with SD card, on AVR does not use standard LCD adapter)
+  #elif defined(__SAM3X8E__)
+    U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
   #else
-    //U8GLIB_ST7920_128X64_4X u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Original u8glib device. 2 stripes, SW SPI
     U8GLIB_ST7920_128X64_RRD u8g(LCD_PINS_D4, LCD_PINS_ENABLE, LCD_PINS_RS); // Number of stripes can be adjusted in ultralcd_st7920_u8glib_rrd.h with PAGE_HEIGHT
                                                                            // AVR version ignores these pin settings
                                                                            // HAL version uses these pin settings

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -35,9 +35,15 @@
   #define BOARD_NAME       "RAMPS-FD"
 #endif
 
-#define INVERTED_HEATER_PINS
-#define INVERTED_BED_PINS
-#define INVERTED_FAN_PINS
+#ifndef HEATER_HOTEND_INVERTING
+  #define HEATER_HOTEND_INVERTING true
+#endif
+#ifndef HEATER_BED_INVERTING
+  #define HEATER_BED_INVERTING true
+#endif
+#ifndef FAN_PIN_INVERTING
+  #define FAN_PIN_INVERTING true
+#endif
 
 //
 // Servos

--- a/Marlin/src/pins/pins_RAMPS_FD_V2.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V2.h
@@ -29,11 +29,11 @@
 
 #define BOARD_NAME         "RAMPS-FD v2"
 
-#include "pins_RAMPS_FD_V1.h"
+#define HEATER_HOTEND_INVERTING false
+#define HEATER_BED_INVERTING    false
+#define FAN_PIN_INVERTING       false
 
-#undef INVERTED_HEATER_PINS
-#undef INVERTED_BED_PINS
-#undef INVERTED_FAN_PINS
+#include "pins_RAMPS_FD_V1.h"
 
 #define I2C_EEPROM
 #define E2END 0xFFFF // 64K in a 24C512


### PR DESCRIPTION
Found this old branch hanging around, which improves some PWM declarations and allows configurations to override the heater / fan pin inverting behavior.

I'm not sure about the last change to the LCD code, so I could use some feedback about that from someone who can remind me why I would've made that change.