### PR TITLE
[2.0.x] Update to TMC2208Stepper 0.2.5

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1568,7 +1568,7 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
 /**
  * TMC2208 software UART is only supported on AVR
  */
-#if HAS_DRIVER(TMC2208) && !defined(__AVR__) && !( \
+#if HAS_DRIVER(TMC2208) && !defined(__AVR__) && !defined(TARGET_LPC1768) && !( \
        defined(X_HARDWARE_SERIAL ) \
     || defined(X2_HARDWARE_SERIAL) \
     || defined(Y_HARDWARE_SERIAL ) \
@@ -1580,7 +1580,7 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
     || defined(E2_HARDWARE_SERIAL) \
     || defined(E3_HARDWARE_SERIAL) \
     || defined(E4_HARDWARE_SERIAL) )
-  #error "TMC2208 Software Serial is supported only on AVR platforms."
+  #error "TMC2208 Software Serial is supported only on AVR and LPC1768 platforms."
 #endif
 
 #if ENABLED(SENSORLESS_HOMING)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1034,9 +1034,9 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
   #endif // HAS_DEBUG_MENU
 
-   /**
-    * IDEX submenu
-    */
+  /**
+   * IDEX submenu
+   */
   #if ENABLED(DUAL_X_CARRIAGE)
     static void IDEX_menu() {
       START_MENU();

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,7 +32,7 @@ lib_deps =
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   LiquidCrystal@1.3.4
   TMC2130Stepper
-  https://github.com/teemuatlut/TMC2208Stepper/archive/v0.2.3.zip
+  https://github.com/teemuatlut/TMC2208Stepper/archive/v0.2.5.zip
   Adafruit NeoPixel@1.1.3
   https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
   https://github.com/ameyer/Arduino-L6470/archive/master.zip
@@ -163,7 +163,6 @@ lib_extra_dirs    = frameworks
 lib_deps          = CMSIS-LPC1768
   https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMC2130Stepper@>=2.2.1
-  TMC2208Stepper@=0.2.1
 extra_scripts     = Marlin/src/HAL/HAL_LPC1768/debug_extra_script.py, Marlin/src/HAL/HAL_LPC1768/lpc1768_flag_script.py, Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_LPC1768>
 monitor_speed     = 250000


### PR DESCRIPTION
The TCM2208Stepper library has been updated to 0.2.5, with support for software serial on the LPC1768 platform.