### PR TITLE
[1.1.x] SECURITYFIX missing max temp error when PID is used

### DIFF
--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1786,11 +1786,9 @@ void Temperature::readings_ready() {
 
   for (uint8_t e = 0; e < COUNT(temp_dir); e++) {
     const int16_t tdir = temp_dir[e], rawtemp = current_temperature_raw[e] * tdir;
-    const bool heater_on = 0 <
+    const bool heater_on = 0 < target_temperature[e]
       #if ENABLED(PIDTEMP)
-        soft_pwm_amount[e]
-      #else
-        target_temperature[e]
+        || 0 < soft_pwm_amount[e]
       #endif
     ;
     if (rawtemp > maxttemp_raw[e] * tdir && heater_on) max_temp_error(e);

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1786,9 +1786,9 @@ void Temperature::readings_ready() {
 
   for (uint8_t e = 0; e < COUNT(temp_dir); e++) {
     const int16_t tdir = temp_dir[e], rawtemp = current_temperature_raw[e] * tdir;
-    const bool heater_on = 0 < target_temperature[e]
+    const bool heater_on = (target_temperature[e] > 0)
       #if ENABLED(PIDTEMP)
-        || 0 < soft_pwm_amount[e]
+        || (soft_pwm_amount[e] > 0)
       #endif
     ;
     if (rawtemp > maxttemp_raw[e] * tdir) max_temp_error(e);
@@ -1810,9 +1810,9 @@ void Temperature::readings_ready() {
     #else
       #define GEBED >=
     #endif
-    const bool bed_on = 0 < target_temperature_bed
+    const bool bed_on = (target_temperature_bed > 0)
       #if ENABLED(PIDTEMPBED)
-        || 0 < soft_pwm_amount_bed
+        || (soft_pwm_amount_bed > 0)
       #endif
     ;
     if (current_temperature_bed_raw GEBED bed_maxttemp_raw) max_temp_error(-1);
@@ -1821,7 +1821,7 @@ void Temperature::readings_ready() {
 }
 
 /**
- * Timer 0 is shared with millies so don't change the prescaler.
+ * Timer 0 is shared with millis so don't change the prescaler.
  *
  * This ISR uses the compare method so it runs at the base
  * frequency (16 MHz / 64 / 256 = 976.5625 Hz), but at the TCNT0 set

--- a/Marlin/temperature.cpp
+++ b/Marlin/temperature.cpp
@@ -1791,7 +1791,7 @@ void Temperature::readings_ready() {
         || 0 < soft_pwm_amount[e]
       #endif
     ;
-    if (rawtemp > maxttemp_raw[e] * tdir && heater_on) max_temp_error(e);
+    if (rawtemp > maxttemp_raw[e] * tdir) max_temp_error(e);
     if (rawtemp < minttemp_raw[e] * tdir && !is_preheating(e) && heater_on) {
       #ifdef MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED
         if (++consecutive_low_temperature_error[e] >= MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED)
@@ -1810,14 +1810,12 @@ void Temperature::readings_ready() {
     #else
       #define GEBED >=
     #endif
-    const bool bed_on = 0 <
+    const bool bed_on = 0 < target_temperature_bed
       #if ENABLED(PIDTEMPBED)
-        soft_pwm_amount_bed
-      #else
-        target_temperature_bed
+        || 0 < soft_pwm_amount_bed
       #endif
     ;
-    if (current_temperature_bed_raw GEBED bed_maxttemp_raw && bed_on) max_temp_error(-1);
+    if (current_temperature_bed_raw GEBED bed_maxttemp_raw) max_temp_error(-1);
     if (bed_minttemp_raw GEBED current_temperature_bed_raw && bed_on) min_temp_error(-1);
   #endif
 }


### PR DESCRIPTION
Adding the ability to get max temp errors while tuning the PID parameters broke the ability to throw these errors during normal use.

Adding the new condition would have been better than replacing the old one.

Related issues:
#11643 "Printer increases temp to 325C when set to 235C on second layer WITH thermal runaway enabled"
caused by
#8126 "Fix M303 thermal protection"
#8103 "Marlin 115 tried to burn my house down during PID tuning"