### PR TITLE
RADDS: Update Full Graphic Display Pins

### DIFF
--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -206,8 +206,8 @@
 
   #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
 
-    #define LCD_PINS_RS     46
-    #define LCD_PINS_ENABLE 47
+    #define LCD_PINS_RS     42
+    #define LCD_PINS_ENABLE 43
     #define LCD_PINS_D4     44
 
     #define BEEPER_PIN      41


### PR DESCRIPTION
To use the `REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER` you need an adapter like: https://www.thingiverse.com/thing:1740725

This is the most common adapter for the display. So i think we should use this pin layout as standard.

