### PR TITLE
[2.0.x] Fix ambiguous function call (SERIAL_PROTOCOL_F) when using Arduino_Core_STM32

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -233,7 +233,7 @@ void reset_bed_level() {
         const float offset = fn(x, y);
         if (!isnan(offset)) {
           if (offset >= 0) SERIAL_PROTOCOLCHAR('+');
-          SERIAL_PROTOCOL_F(offset, precision);
+          SERIAL_PROTOCOL_F(offset, (int)precision);
         }
         else {
           #ifdef SCAD_MESH_OUTPUT

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -214,7 +214,7 @@ void reset_bed_level() {
       for (uint8_t x = 0; x < sx; x++) {
         for (uint8_t i = 0; i < precision + 2 + (x < 10 ? 1 : 0); i++)
           SERIAL_PROTOCOLCHAR(' ');
-        SERIAL_PROTOCOL((int)x);
+        SERIAL_PROTOCOL(int(x));
       }
       SERIAL_EOL();
     #endif
@@ -226,14 +226,14 @@ void reset_bed_level() {
         SERIAL_PROTOCOLPGM(" [");           // open sub-array
       #else
         if (y < 10) SERIAL_PROTOCOLCHAR(' ');
-        SERIAL_PROTOCOL((int)y);
+        SERIAL_PROTOCOL(int(y));
       #endif
       for (uint8_t x = 0; x < sx; x++) {
         SERIAL_PROTOCOLCHAR(' ');
         const float offset = fn(x, y);
         if (!isnan(offset)) {
           if (offset >= 0) SERIAL_PROTOCOLCHAR('+');
-          SERIAL_PROTOCOL_F(offset, (int)precision);
+          SERIAL_PROTOCOL_F(offset, int(precision));
         }
         else {
           #ifdef SCAD_MESH_OUTPUT


### PR DESCRIPTION
### Description

When building for STM32 using the Arduino_Core_STM32 the compiler returns the following error:

```
In file included from ...\src\inc\marlinconfig.h:45:0,

                 from ...\src\feature\bedlevel\bedlevel.cpp:23:

...\src\feature\bedlevel\bedlevel.cpp: In function 'void print_2d_array(uint8_t, uint8_t, uint8_t, element_2d_fn)':

...\src\core\serial.h:137:58: error: call of overloaded 'print(const float&, const uint8_t&)' is ambiguous

   #define SERIAL_PROTOCOL_F(x,y)      MYSERIAL0.print(x,y)
                                                          
...\src\feature\bedlevel\bedlevel.cpp:236:11: note: in expansion of macro 'SERIAL_PROTOCOL_F'

           SERIAL_PROTOCOL_F(offset, precision);
```
