### PR TITLE
[2.0.x] Fix extruder stops extruding with LA

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1485,16 +1485,10 @@ uint32_t Stepper::stepper_block_phase_isr() {
 
         #if ENABLED(LIN_ADVANCE)
           if (LA_use_advance_lead) {
-            // Wake up eISR on first acceleration loop and fire ISR if final adv_rate is reached
-            if (step_events_completed == steps_per_isr || (LA_steps && LA_isr_rate != current_block->advance_speed)) {
-              nextAdvanceISR = 0;
-              LA_isr_rate = current_block->advance_speed;
-            }
+            // Fire ISR if final adv_rate is reached
+            if (LA_steps && LA_isr_rate != current_block->advance_speed) nextAdvanceISR = 0;
           }
-          else {
-            LA_isr_rate = LA_ADV_NEVER;
-            if (LA_steps) nextAdvanceISR = 0;
-          }
+          else if (LA_steps) nextAdvanceISR = 0;
         #endif // LIN_ADVANCE
       }
       // Are we in Deceleration phase ?
@@ -1536,17 +1530,13 @@ uint32_t Stepper::stepper_block_phase_isr() {
 
         #if ENABLED(LIN_ADVANCE)
           if (LA_use_advance_lead) {
-            if (step_events_completed <= decelerate_after + steps_per_isr ||
-               (LA_steps && LA_isr_rate != current_block->advance_speed)
-            ) {
-              nextAdvanceISR = 0; // Wake up eISR on first deceleration loop
+            // Wake up eISR on first deceleration loop and fire ISR if final adv_rate is reached
+            if (step_events_completed <= decelerate_after + steps_per_isr || (LA_steps && LA_isr_rate != current_block->advance_speed)) {
+              nextAdvanceISR = 0;
               LA_isr_rate = current_block->advance_speed;
             }
           }
-          else {
-            LA_isr_rate = LA_ADV_NEVER;
-            if (LA_steps) nextAdvanceISR = 0;
-          }
+          else if (LA_steps) nextAdvanceISR = 0;
         #endif // LIN_ADVANCE
       }
       // We must be in cruise phase otherwise
@@ -1726,7 +1716,11 @@ uint32_t Stepper::stepper_block_phase_isr() {
         if ((LA_use_advance_lead = current_block->use_advance_lead)) {
           LA_final_adv_steps = current_block->final_adv_steps;
           LA_max_adv_steps = current_block->max_adv_steps;
+          //Start the ISR
+          nextAdvanceISR = 0;
+          LA_isr_rate = current_block->advance_speed;
         }
+        else LA_isr_rate = LA_ADV_NEVER;
       #endif
 
       if (current_block->direction_bits != last_direction_bits


### PR DESCRIPTION
Fixes #11711 and #9899.

When the advance ISR rate of the current block is identical to the advance ISR rate of the previous block and the current block has no acceleration phase the advance ISR will not be started as it should. The esteps during the cruising phase will then not trigger the advance ISR any longer due to:

```cpp
if (LA_steps && LA_isr_rate != current_block->advance_speed) nextAdvanceISR = 0;
```

The assumption was that each block enters the acceleration planning block at least once so the extruder ISR gets started. As this is false, I now initialise the extruder ISR when the new block is set up. On the other side, we can now remove some code lines as `LA_isr_rate` is always started in a defined state at the beginning of the block.

I tested the change with @Itox001 configuration which is known to cause the issue and it solves it. Also K=0 and my own configuration was tested.

Calling @Itox001, @buchnoun and @SJ-Innovation please give this PR a try before it gets merged. I had a ton of problems with the quite buggy Arduino 1.9 beta which I used for the 2.0.x code and it's quite late now, don't want to get a buggy fix merged due to fatigue!