### PR TITLE
Various Small Fixes to F4/7 HALs

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -124,6 +124,8 @@
 #define ISRS_ENABLED() (!__get_PRIMASK())
 #define ENABLE_ISRS()  __enable_irq()
 #define DISABLE_ISRS() __disable_irq()
+#define cli() __disable_irq()
+#define sei() __enable_irq()
 
 // On AVR this is in math.h?
 #define square(x) ((x)*(x))
@@ -162,12 +164,6 @@ extern uint16_t HAL_adc_result;
 // --------------------------------------------------------------------------
 // Public functions
 // --------------------------------------------------------------------------
-
-// Disable interrupts
-#define cli() do {  DISABLE_TEMPERATURE_INTERRUPT(); DISABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
-
-// Enable interrupts
-#define sei() do {  ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
 
 // Memory related
 #define __bss_end __bss_end__
@@ -208,7 +204,6 @@ void spiSend(uint32_t chan, byte b);
 void spiSend(uint32_t chan, const uint8_t* buf, size_t n);
 /** Read single byte from specified SPI channel */
 uint8_t spiRec(uint32_t chan);
-
 
 // EEPROM
 

--- a/Marlin/src/HAL/HAL_STM32F7/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL.h
@@ -114,6 +114,8 @@
 #define ISRS_ENABLED() (!__get_PRIMASK())
 #define ENABLE_ISRS()  __enable_irq()
 #define DISABLE_ISRS() __disable_irq()
+#define cli() __disable_irq()
+#define sei() __enable_irq()
 
 // On AVR this is in math.h?
 #define square(x) ((x)*(x))
@@ -151,11 +153,7 @@ extern uint16_t HAL_adc_result;
 // Public functions
 // --------------------------------------------------------------------------
 
-// Disable interrupts
-#define cli() do {  DISABLE_TEMPERATURE_INTERRUPT(); DISABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
 
-// Enable interrupts
-#define sei() do {  ENABLE_TEMPERATURE_INTERRUPT(); ENABLE_STEPPER_DRIVER_INTERRUPT(); } while(0)
 
 // Memory related
 #define __bss_end __bss_end__

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_spi_STM32F7.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_spi_STM32F7.cpp
@@ -41,7 +41,7 @@
 #include "pins_arduino.h"
 #include "spi_pins.h"
 #include "../../core/macros.h"
-
+#include <SPI.h>
 
 // --------------------------------------------------------------------------
 // Public Variables

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.cpp
@@ -148,4 +148,9 @@ void HAL_timer_isr_prologue(const uint8_t timer_num) {
   }
 }
 
+bool HAL_timer_interrupt_enabled(const uint8_t timer_num) {
+  const uint32_t IRQ_Id = uint32_t(timerConfig[timer_num].IRQ_Id);
+  return NVIC->ISER[IRQ_Id >> 5] & _BV32(IRQ_Id & 0x1F);
+}
+
 #endif // STM32F7

--- a/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL_timers_STM32F7.h
@@ -61,6 +61,8 @@
 #define ENABLE_TEMPERATURE_INTERRUPT() HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
+#define STEPPER_ISR_ENABLED() HAL_timer_interrupt_enabled(STEP_TIMER_NUM)
+#define TEMP_ISR_ENABLED() HAL_timer_interrupt_enabled(TEMP_TIMER_NUM)
 // TODO change this
 
 
@@ -92,6 +94,7 @@ typedef struct {
 void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency);
 void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
+bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
 void HAL_timer_set_compare(const uint8_t timer_num, const uint32_t compare);
 hal_timer_t HAL_timer_get_compare(const uint8_t timer_num);

--- a/Marlin/src/HAL/HAL_STM32F7/TMC2660.cpp
+++ b/Marlin/src/HAL/HAL_STM32F7/TMC2660.cpp
@@ -33,7 +33,7 @@
 #include <SPI.h>
 #include "TMC2660.h"
 
-#include "../../HAL/HAL_STM32F7/HAL_STM32F7.h"
+#include "../../HAL/HAL_STM32F7/HAL.h"
 #include "../../core/serial.h"
 #include "../../inc/MarlinConfig.h"
 #include "../../Marlin.h"
@@ -448,7 +448,7 @@ void TMC26XStepper::setMicrosteps(int number_of_steps) {
 /**
  * returns the effective number of microsteps at the moment
  */
-int TMC26XStepper::getMicrosteps(void) { return microsteps }
+int TMC26XStepper::getMicrosteps(void) { return microsteps; }
 
 /**
  * constant_off_time: The off time setting controls the minimum chopper frequency.


### PR DESCRIPTION
### Description

This is one in a series of PRs that will be the foundation of a work in progress 32 bit controller. A few fixes needed to be made so it would compile though namely the ISR enablers and disablers in the F4/7 HALs, as well as a few small typos here and there. 

### Benefits

Now compiles on STM32F4 and F7.



First public contribution, suggestions and comments would be lovely, as well as tips for the future. 
