### PR TITLE
[2.0.x] include AVR HAL in PIO src_filter for at90usb_dfu

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -105,7 +105,7 @@ board         = at90usb1286
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 lib_ldf_mode  = deep+
-src_filter    = ${common.default_src_filter}
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
 extra_scripts = pre:buildroot/share/atom/create_custom_upload_command_DFU.py
 monitor_speed = 250000
 


### PR DESCRIPTION
I missed this one