### PR TITLE
[2.0.x] Fix undefined symbol 'g29_in_progress'

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -207,6 +207,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   // Disable the leveling matrix before homing
   #if HAS_LEVELING
+
     // Cancel the active G29 session
     #if ENABLED(PROBE_MANUALLY)
       extern bool g29_in_progress;

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -205,14 +205,14 @@ void GcodeSuite::G28(const bool always_home_all) {
   // Wait for planner moves to finish!
   planner.synchronize();
 
-  // Cancel the active G29 session
-  #if ENABLED(PROBE_MANUALLY)
-    extern bool g29_in_progress;
-    g29_in_progress = false;
-  #endif
-
   // Disable the leveling matrix before homing
   #if HAS_LEVELING
+    // Cancel the active G29 session
+    #if ENABLED(PROBE_MANUALLY)
+      extern bool g29_in_progress;
+      g29_in_progress = false;
+    #endif
+
     #if ENABLED(RESTORE_LEVELING_AFTER_G28)
       const bool leveling_was_active = planner.leveling_active;
     #endif


### PR DESCRIPTION
With some configurations, compilation could have failed
complaining that `g29_in_progress` is an unknown reference.

This commit moves the responsible code under proper conditional
compilation checks.