### PR TITLE
[2.0.x] Extruder-Distinct Linear Advance K Factors

### DIFF
--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -34,18 +34,30 @@
  *  K<factor>   Set advance K factor
  */
 void GcodeSuite::M900() {
+  int T = active_extruder;
+  if (parser.seenval('T')){
+    T = parser.intval('T');
+    if (!(T<EXTRUDERS)){
+      SERIAL_PROTOCOLLNPGM("?T value out of range.");
+      return;
+    }
+  }
   if (parser.seenval('K')) {
     const float newK = parser.floatval('K');
     if (WITHIN(newK, 0, 10)) {
       planner.synchronize();
-      planner.extruder_advance_K = newK;
+      planner.extruder_advance_K[T] = newK;
     }
     else
       SERIAL_PROTOCOLLNPGM("?K value out of range (0-10).");
   }
   else {
     SERIAL_ECHO_START();
-    SERIAL_ECHOLNPAIR("Advance K=", planner.extruder_advance_K);
+    LOOP_L_N(i, EXTRUDERS) {
+      SERIAL_ECHOPGM("Advance T");
+      SERIAL_ECHO(i);
+      SERIAL_ECHOLNPAIR(" K=", planner.extruder_advance_K[i]);
+    }
   }
 }
 

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -34,11 +34,16 @@
  *  K<factor>   Set advance K factor
  */
 void GcodeSuite::M900() {
-  const uint8_t tmp_extruder = parser.seenval('T') ? parser.value_int() : active_extruder;
-  if (tmp_extruder >= EXTRUDERS) {
-    SERIAL_PROTOCOLLNPGM("?T value out of range.");
-    return;
-  }
+
+  #if EXTRUDERS < 2
+    constexpr uint8_t tmp_extruder = 0;
+  #else
+    const uint8_t tmp_extruder = parser.seenval('T') ? parser.value_int() : active_extruder;
+    if (tmp_extruder >= EXTRUDERS) {
+      SERIAL_PROTOCOLLNPGM("?T value out of range.");
+      return;
+    }
+  #endif
 
   if (parser.seenval('K')) {
     const float newK = parser.floatval('K');
@@ -51,12 +56,16 @@ void GcodeSuite::M900() {
   }
   else {
     SERIAL_ECHO_START();
-    SERIAL_ECHOPGM("Advance K");
-    LOOP_L_N(i, EXTRUDERS) {
-      SERIAL_CHAR(' '); SERIAL_ECHO(int(i));
-      SERIAL_CHAR('='); SERIAL_ECHO(planner.extruder_advance_K[i]);
-    }
-    SERIAL_EOL();
+    #if EXTRUDERS < 2
+      SERIAL_ECHOLNPAIR("Advance K=", planner.extruder_advance_K[0]);
+    #else
+      SERIAL_ECHOPGM("Advance K");
+      LOOP_L_N(i, EXTRUDERS) {
+        SERIAL_CHAR(' '); SERIAL_ECHO(int(i));
+        SERIAL_CHAR('='); SERIAL_ECHO(planner.extruder_advance_K[i]);
+      }
+      SERIAL_EOL();
+    #endif
   }
 }
 

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -37,7 +37,7 @@ void GcodeSuite::M900() {
   int T = active_extruder;
   if (parser.seenval('T')){
     T = parser.intval('T');
-    if (!(T<EXTRUDERS)){
+    if (!(T < EXTRUDERS)){
       SERIAL_PROTOCOLLNPGM("?T value out of range.");
       return;
     }

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -34,30 +34,29 @@
  *  K<factor>   Set advance K factor
  */
 void GcodeSuite::M900() {
-  int T = active_extruder;
-  if (parser.seenval('T')){
-    T = parser.intval('T');
-    if (!(T < EXTRUDERS)){
-      SERIAL_PROTOCOLLNPGM("?T value out of range.");
-      return;
-    }
+  const uint8_t tmp_extruder = parser.seenval('T') ? parser.value_int() : active_extruder;
+  if (tmp_extruder >= EXTRUDERS) {
+    SERIAL_PROTOCOLLNPGM("?T value out of range.");
+    return;
   }
+
   if (parser.seenval('K')) {
     const float newK = parser.floatval('K');
     if (WITHIN(newK, 0, 10)) {
       planner.synchronize();
-      planner.extruder_advance_K[T] = newK;
+      planner.extruder_advance_K[tmp_extruder] = newK;
     }
     else
       SERIAL_PROTOCOLLNPGM("?K value out of range (0-10).");
   }
   else {
     SERIAL_ECHO_START();
+    SERIAL_ECHOPGM("Advance K");
     LOOP_L_N(i, EXTRUDERS) {
-      SERIAL_ECHOPGM("Advance T");
-      SERIAL_ECHO(i);
-      SERIAL_ECHOLNPAIR(" K=", planner.extruder_advance_K[i]);
+      SERIAL_CHAR(' '); SERIAL_ECHO(int(i));
+      SERIAL_CHAR('='); SERIAL_ECHO(planner.extruder_advance_K[i]);
     }
+    SERIAL_EOL();
   }
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3847,18 +3847,19 @@ void lcd_quick_feedback(const bool clear_buttons) {
     #if DISABLED(NO_VOLUMETRICS) || ENABLED(ADVANCED_PAUSE_FEATURE)
       MENU_ITEM(submenu, MSG_FILAMENT, lcd_advanced_filament_menu);
     #elif ENABLED(LIN_ADVANCE)
-      #if EXTRUDERS >= 1
-        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
-      #endif
-      #if EXTRUDERS >= 2
+      MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
+      #if EXTRUDERS > 1
         MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E2, &planner.extruder_advance_K[1], 0, 999);
-      #endif
-      #if EXTRUDERS >= 3
-        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
-      #endif
-      #if EXTRUDERS >= 4
-        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E4, &planner.extruder_advance_K[3], 0, 999);
-      #endif
+        #if EXTRUDERS > 2
+          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
+          #if EXTRUDERS > 3
+            MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E4, &planner.extruder_advance_K[3], 0, 999);
+            #if EXTRUDERS > 4
+              MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E5, &planner.extruder_advance_K[4], 0, 999);
+            #endif // EXTRUDERS > 4
+          #endif // EXTRUDERS > 3
+        #endif // EXTRUDERS > 2
+      #endif // EXTRUDERS > 1
     #endif
 
     // M540 S - Abort on endstop hit when SD printing
@@ -3893,18 +3894,19 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_ADVANCED_SETTINGS);
 
       #if ENABLED(LIN_ADVANCE)
-        #if EXTRUDERS >= 1
-          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
-        #endif
-          #if EXTRUDERS >= 2
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
+        #if EXTRUDERS > 1
           MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E2, &planner.extruder_advance_K[1], 0, 999);
-       #endif
-        #if EXTRUDERS >= 3
-          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
-        #endif
-        #if EXTRUDERS >= 4
-         MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E4, &planner.extruder_advance_K[3], 0, 999);
-        #endif
+          #if EXTRUDERS > 2
+            MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
+            #if EXTRUDERS > 3
+              MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E4, &planner.extruder_advance_K[3], 0, 999);
+              #if EXTRUDERS > 4
+                MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E5, &planner.extruder_advance_K[4], 0, 999);
+              #endif // EXTRUDERS > 4
+            #endif // EXTRUDERS > 3
+          #endif // EXTRUDERS > 2
+        #endif // EXTRUDERS > 1
       #endif
 
       #if DISABLED(NO_VOLUMETRICS)
@@ -5762,5 +5764,3 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 #endif
 
 #endif // ULTRA_LCD
-
-#pragma clang diagnostic pop

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3847,8 +3847,10 @@ void lcd_quick_feedback(const bool clear_buttons) {
     #if DISABLED(NO_VOLUMETRICS) || ENABLED(ADVANCED_PAUSE_FEATURE)
       MENU_ITEM(submenu, MSG_FILAMENT, lcd_advanced_filament_menu);
     #elif ENABLED(LIN_ADVANCE)
-      MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
-      #if EXTRUDERS > 1
+      #if EXTRUDERS == 1
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
+      #elif EXTRUDERS > 1
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
         MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E2, &planner.extruder_advance_K[1], 0, 999);
         #if EXTRUDERS > 2
           MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
@@ -3894,8 +3896,10 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_ADVANCED_SETTINGS);
 
       #if ENABLED(LIN_ADVANCE)
-        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
-        #if EXTRUDERS > 1
+        #if EXTRUDERS == 1
+          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
+        #elif EXTRUDERS > 1
+          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
           MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E2, &planner.extruder_advance_K[1], 0, 999);
           #if EXTRUDERS > 2
             MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3882,7 +3882,9 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_ADVANCED_SETTINGS);
 
       #if ENABLED(LIN_ADVANCE)
-        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K, &planner.extruder_advance_K, 0, 999);
+      LOOP_L_N(i,EXTRUDERS) {
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[i], 0, 999);
+      }
       #endif
 
       #if DISABLED(NO_VOLUMETRICS)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3847,7 +3847,18 @@ void lcd_quick_feedback(const bool clear_buttons) {
     #if DISABLED(NO_VOLUMETRICS) || ENABLED(ADVANCED_PAUSE_FEATURE)
       MENU_ITEM(submenu, MSG_FILAMENT, lcd_advanced_filament_menu);
     #elif ENABLED(LIN_ADVANCE)
-      MENU_ITEM_EDIT(float52, MSG_ADVANCE_K, &planner.extruder_advance_K, 0, 999);
+      #if EXTRUDERS >= 1
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
+      #endif
+      #if EXTRUDERS >= 2
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E2, &planner.extruder_advance_K[1], 0, 999);
+      #endif
+      #if EXTRUDERS >= 3
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
+      #endif
+      #if EXTRUDERS >= 4
+        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E4, &planner.extruder_advance_K[3], 0, 999);
+      #endif
     #endif
 
     // M540 S - Abort on endstop hit when SD printing
@@ -3882,9 +3893,18 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_ADVANCED_SETTINGS);
 
       #if ENABLED(LIN_ADVANCE)
-      LOOP_L_N(i,EXTRUDERS) {
-        MENU_ITEM_EDIT(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[i], 0, 999);
-      }
+        #if EXTRUDERS >= 1
+          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E1, &planner.extruder_advance_K[0], 0, 999);
+        #endif
+          #if EXTRUDERS >= 2
+          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E2, &planner.extruder_advance_K[1], 0, 999);
+       #endif
+        #if EXTRUDERS >= 3
+          MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E3, &planner.extruder_advance_K[2], 0, 999);
+        #endif
+        #if EXTRUDERS >= 4
+         MENU_ITEM_EDIT(float52, MSG_ADVANCE_K MSG_E4, &planner.extruder_advance_K[3], 0, 999);
+        #endif
       #endif
 
       #if DISABLED(NO_VOLUMETRICS)
@@ -5742,3 +5762,5 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 #endif
 
 #endif // ULTRA_LCD
+
+#pragma clang diagnostic pop

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -871,17 +871,14 @@ void MarlinSettings::postprocess() {
     //
     // Linear Advance
     //
-    LOOP_L_N(i,EXTRUDERS) {
-      _FIELD_TEST(planner_extruder_advance_K[i]);
-    }
+    LOOP_L_N(i,EXTRUDERS) _FIELD_TEST(planner_extruder_advance_K[i]);
+
     #if ENABLED(LIN_ADVANCE)
-    LOOP_L_N(i,EXTRUDERS) {
-      EEPROM_WRITE(planner.extruder_advance_K[i]);
-    }
+      LOOP_L_N(i,EXTRUDERS) EEPROM_WRITE(planner.extruder_advance_K[i]);
     #else
       LOOP_L_N(i,EXTRUDERS) {
-      dummy = 0;
-      EEPROM_WRITE(dummy);
+        dummy = 0;
+        EEPROM_WRITE(dummy);
       }
     #endif
 
@@ -1475,18 +1472,14 @@ void MarlinSettings::postprocess() {
       //
       // Linear Advance
       //
-      LOOP_L_N(i,EXTRUDERS) {
-        _FIELD_TEST(planner_extruder_advance_K[i]);
-      }
+      LOOP_L_N(i,EXTRUDERS) _FIELD_TEST(planner_extruder_advance_K[i]);
+
 
       #if ENABLED(LIN_ADVANCE)
-      LOOP_L_N(i,EXTRUDERS) {
-        EEPROM_READ(planner.extruder_advance_K[i]);
-      }
+        LOOP_L_N(i,EXTRUDERS) EEPROM_READ(planner.extruder_advance_K[i]);
+
       #else
-      LOOP_L_N(i,EXTRUDERS) {
-        EEPROM_READ(dummy);
-        }
+        LOOP_L_N(i,EXTRUDERS) EEPROM_READ(dummy);
       #endif
 
       //
@@ -1966,7 +1959,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
   reset_stepper_drivers();
 
   #if ENABLED(LIN_ADVANCE)
-  LOOP_L_N(i,EXTRUDERS){planner.extruder_advance_K[i] = LIN_ADVANCE_K;}
+  LOOP_L_N(i,EXTRUDERS) {planner.extruder_advance_K[i] = LIN_ADVANCE_K;}
   #endif
 
   #if HAS_MOTOR_CURRENT_PWM
@@ -2729,8 +2722,9 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         CONFIG_ECHO_START;
         SERIAL_ECHOLNPGM_P(port, "Linear Advance:");
       }
-      CONFIG_ECHO_START;
+
       LOOP_L_N(i,EXTRUDERS){
+        CONFIG_ECHO_START;
         SERIAL_ECHOPGM_P(port,"M900 T");
         SERIAL_ECHO(i);
         SERIAL_ECHOLNPAIR_P(port, " K", planner.extruder_advance_K[i]);

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2721,11 +2721,15 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOLNPGM_P(port, "Linear Advance:");
       }
 
-      LOOP_L_N(i, EXTRUDERS) {
-        CONFIG_ECHO_START;
-        SERIAL_ECHOPAIR_P(port, "M900 T", int(i));
-        SERIAL_ECHOLNPAIR_P(port, " K", planner.extruder_advance_K[i]);
-      }
+      CONFIG_ECHO_START;
+      #if EXTRUDERS < 2
+        SERIAL_ECHOLNPAIR_P(port, "  M900 K", planner.extruder_advance_K[0]);
+      #else
+        LOOP_L_N(i, EXTRUDERS) {
+          SERIAL_ECHOPAIR_P(port, "  M900 T", int(i));
+          SERIAL_ECHOLNPAIR_P(port, " K", planner.extruder_advance_K[i]);
+        }
+      #endif
     #endif
 
     #if HAS_MOTOR_CURRENT_PWM

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V56"
+#define EEPROM_VERSION "V57"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -254,7 +254,7 @@ typedef struct SettingsDataStruct {
   //
   // LIN_ADVANCE
   //
-  float planner_extruder_advance_K[EXTRUDERS];                     // M900 K    planner.extruder_advance_K
+  float planner_extruder_advance_K[EXTRUDERS];          // M900 K  planner.extruder_advance_K
 
   //
   // HAS_MOTOR_CURRENT_PWM
@@ -871,15 +871,13 @@ void MarlinSettings::postprocess() {
     //
     // Linear Advance
     //
-    LOOP_L_N(i,EXTRUDERS) _FIELD_TEST(planner_extruder_advance_K[i]);
+    _FIELD_TEST(planner_extruder_advance_K);
 
     #if ENABLED(LIN_ADVANCE)
-      LOOP_L_N(i,EXTRUDERS) EEPROM_WRITE(planner.extruder_advance_K[i]);
+      LOOP_L_N(i, EXTRUDERS) EEPROM_WRITE(planner.extruder_advance_K[i]);
     #else
-      LOOP_L_N(i,EXTRUDERS) {
-        dummy = 0;
-        EEPROM_WRITE(dummy);
-      }
+      dummy = 0;
+      LOOP_L_N(i, EXTRUDERS) EEPROM_WRITE(dummy);
     #endif
 
     _FIELD_TEST(motor_current_setting);
@@ -1472,15 +1470,15 @@ void MarlinSettings::postprocess() {
       //
       // Linear Advance
       //
-      LOOP_L_N(i,EXTRUDERS) _FIELD_TEST(planner_extruder_advance_K[i]);
+      _FIELD_TEST(planner_extruder_advance_K);
 
-
-      #if ENABLED(LIN_ADVANCE)
-        LOOP_L_N(i,EXTRUDERS) EEPROM_READ(planner.extruder_advance_K[i]);
-
-      #else
-        LOOP_L_N(i,EXTRUDERS) EEPROM_READ(dummy);
-      #endif
+      LOOP_L_N(i, EXTRUDERS) {
+        #if ENABLED(LIN_ADVANCE)
+          EEPROM_READ(planner.extruder_advance_K[i]);
+        #else
+          EEPROM_READ(dummy);
+        #endif
+      }
 
       //
       // Motor Current PWM
@@ -1959,7 +1957,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
   reset_stepper_drivers();
 
   #if ENABLED(LIN_ADVANCE)
-  LOOP_L_N(i,EXTRUDERS) {planner.extruder_advance_K[i] = LIN_ADVANCE_K;}
+    LOOP_L_N(i, EXTRUDERS) planner.extruder_advance_K[i] = LIN_ADVANCE_K;
   #endif
 
   #if HAS_MOTOR_CURRENT_PWM
@@ -2723,13 +2721,11 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOLNPGM_P(port, "Linear Advance:");
       }
 
-      LOOP_L_N(i,EXTRUDERS){
+      LOOP_L_N(i, EXTRUDERS) {
         CONFIG_ECHO_START;
-        SERIAL_ECHOPGM_P(port,"M900 T");
-        SERIAL_ECHO(i);
+        SERIAL_ECHOPAIR_P(port, "M900 T", int(i));
         SERIAL_ECHOLNPAIR_P(port, " K", planner.extruder_advance_K[i]);
       }
-
     #endif
 
     #if HAS_MOTOR_CURRENT_PWM

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -254,7 +254,7 @@ typedef struct SettingsDataStruct {
   //
   // LIN_ADVANCE
   //
-  float planner_extruder_advance_K;                     // M900 K    planner.extruder_advance_K
+  float planner_extruder_advance_K[EXTRUDERS];                     // M900 K    planner.extruder_advance_K
 
   //
   // HAS_MOTOR_CURRENT_PWM
@@ -871,14 +871,18 @@ void MarlinSettings::postprocess() {
     //
     // Linear Advance
     //
-
-    _FIELD_TEST(planner_extruder_advance_K);
-
+    LOOP_L_N(i,EXTRUDERS) {
+      _FIELD_TEST(planner_extruder_advance_K[i]);
+    }
     #if ENABLED(LIN_ADVANCE)
-      EEPROM_WRITE(planner.extruder_advance_K);
+    LOOP_L_N(i,EXTRUDERS) {
+      EEPROM_WRITE(planner.extruder_advance_K[i]);
+    }
     #else
+      LOOP_L_N(i,EXTRUDERS) {
       dummy = 0;
       EEPROM_WRITE(dummy);
+      }
     #endif
 
     _FIELD_TEST(motor_current_setting);
@@ -1471,13 +1475,18 @@ void MarlinSettings::postprocess() {
       //
       // Linear Advance
       //
-
-      _FIELD_TEST(planner_extruder_advance_K);
+      LOOP_L_N(i,EXTRUDERS) {
+        _FIELD_TEST(planner_extruder_advance_K[i]);
+      }
 
       #if ENABLED(LIN_ADVANCE)
-        EEPROM_READ(planner.extruder_advance_K);
+      LOOP_L_N(i,EXTRUDERS) {
+        EEPROM_READ(planner.extruder_advance_K[i]);
+      }
       #else
+      LOOP_L_N(i,EXTRUDERS) {
         EEPROM_READ(dummy);
+        }
       #endif
 
       //
@@ -1957,7 +1966,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
   reset_stepper_drivers();
 
   #if ENABLED(LIN_ADVANCE)
-    planner.extruder_advance_K = LIN_ADVANCE_K;
+  LOOP_L_N(i,EXTRUDERS){planner.extruder_advance_K[i] = LIN_ADVANCE_K;}
   #endif
 
   #if HAS_MOTOR_CURRENT_PWM
@@ -2721,7 +2730,12 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOLNPGM_P(port, "Linear Advance:");
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOLNPAIR_P(port, "  M900 K", planner.extruder_advance_K);
+      LOOP_L_N(i,EXTRUDERS){
+        SERIAL_ECHOPGM_P(port,"M900 T");
+        SERIAL_ECHO(i);
+        SERIAL_ECHOLNPAIR_P(port, " K", planner.extruder_advance_K[i]);
+      }
+
     #endif
 
     #if HAS_MOTOR_CURRENT_PWM

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -213,7 +213,7 @@ float Planner::previous_speed[NUM_AXIS],
 #endif
 
 #if ENABLED(LIN_ADVANCE)
-  float Planner::extruder_advance_K; // Initialized by settings.load()
+  float Planner::extruder_advance_K[EXTRUDERS]; // Initialized by settings.load()
 #endif
 
 #if HAS_POSITION_FLOAT
@@ -1082,7 +1082,7 @@ void Planner::recalculate_trapezoids() {
             calculate_trapezoid_for_block(current, current_entry_speed * nomr, next_entry_speed * nomr);
             #if ENABLED(LIN_ADVANCE)
               if (current->use_advance_lead) {
-                const float comp = current->e_D_ratio * extruder_advance_K * axis_steps_per_mm[E_AXIS];
+                const float comp = current->e_D_ratio * extruder_advance_K[active_extruder] * axis_steps_per_mm[E_AXIS];
                 current->max_adv_steps = current_nominal_speed * comp;
                 current->final_adv_steps = next_entry_speed * comp;
               }
@@ -1121,7 +1121,7 @@ void Planner::recalculate_trapezoids() {
       calculate_trapezoid_for_block(next, next_entry_speed * nomr, float(MINIMUM_PLANNER_SPEED) * nomr);
       #if ENABLED(LIN_ADVANCE)
         if (next->use_advance_lead) {
-          const float comp = next->e_D_ratio * extruder_advance_K * axis_steps_per_mm[E_AXIS];
+          const float comp = next->e_D_ratio * extruder_advance_K[active_extruder] * axis_steps_per_mm[E_AXIS];
           next->max_adv_steps = next_nominal_speed * comp;
           next->final_adv_steps = (MINIMUM_PLANNER_SPEED) * comp;
         }
@@ -2123,12 +2123,12 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
        *
        * esteps             : This is a print move, because we checked for A, B, C steps before.
        *
-       * extruder_advance_K : There is an advance factor set.
+       * extruder_advance_K[active_extruder] : There is an advance factor set for this extruder.
        *
        * de > 0             : Extruder is running forward (e.g., for "Wipe while retracting" (Slic3r) or "Combing" (Cura) moves)
        */
       block->use_advance_lead =  esteps
-                              && extruder_advance_K
+                              && extruder_advance_K[active_extruder]
                               && de > 0;
 
       if (block->use_advance_lead) {
@@ -2147,7 +2147,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         if (block->e_D_ratio > 3.0f)
           block->use_advance_lead = false;
         else {
-          const uint32_t max_accel_steps_per_s2 = MAX_E_JERK / (extruder_advance_K * block->e_D_ratio) * steps_per_mm;
+          const uint32_t max_accel_steps_per_s2 = MAX_E_JERK / (extruder_advance_K[active_extruder] * block->e_D_ratio) * steps_per_mm;
           #if ENABLED(LA_DEBUG)
             if (accel > max_accel_steps_per_s2) SERIAL_ECHOLNPGM("Acceleration limited.");
           #endif
@@ -2183,9 +2183,9 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   #endif
   #if ENABLED(LIN_ADVANCE)
     if (block->use_advance_lead) {
-      block->advance_speed = (STEPPER_TIMER_RATE) / (extruder_advance_K * block->e_D_ratio * block->acceleration * axis_steps_per_mm[E_AXIS_N]);
+      block->advance_speed = (STEPPER_TIMER_RATE) / (extruder_advance_K[active_extruder] * block->e_D_ratio * block->acceleration * axis_steps_per_mm[E_AXIS_N]);
       #if ENABLED(LA_DEBUG)
-        if (extruder_advance_K * block->e_D_ratio * block->acceleration * 2 < SQRT(block->nominal_speed_sqr) * block->e_D_ratio)
+        if (extruder_advance_K[active_extruder] * block->e_D_ratio * block->acceleration * 2 < SQRT(block->nominal_speed_sqr) * block->e_D_ratio)
           SERIAL_ECHOLNPGM("More than 2 steps per eISR loop executed.");
         if (block->advance_speed < 200)
           SERIAL_ECHOLNPGM("eISR running at > 10kHz.");

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -231,7 +231,7 @@ class Planner {
     #endif
 
     #if ENABLED(LIN_ADVANCE)
-      static float extruder_advance_K;
+      static float extruder_advance_K[EXTRUDERS];
     #endif
 
     #if HAS_POSITION_FLOAT


### PR DESCRIPTION
Linear Advance is often used on Multi-Extruder setups where each extruder uses a different material. Obviously the material properties therefore differ so a different K factor will be required for each extruder. 

This also allows the use of LinAdv on one extruder but entirely disabling on others, this is useful for hybrid direct-bowden drives where too high a K factor on the direct drive unit can ruin the print. 

This PR adds individual K factors and their required setters on the LCD menus. 