### PR TITLE
Save some PROGMEM with constexpr

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -32,6 +32,7 @@
 
 #include "../lcd/ultralcd.h"
 #include "../gcode/queue.h"
+#include "../module/motion.h"
 #include "../module/planner.h"
 #include "../module/printcounter.h"
 #include "../module/temperature.h"
@@ -43,8 +44,8 @@ job_recovery_info_t job_recovery_info;
 JobRecoveryPhase job_recovery_phase = JOB_RECOVERY_IDLE;
 uint8_t job_recovery_commands_count; //=0
 char job_recovery_commands[BUFSIZE + APPEND_CMD_COUNT][MAX_CMD_SIZE];
-// Extern
-extern uint8_t active_extruder, commands_in_queue, cmd_queue_index_r;
+
+extern uint8_t commands_in_queue, cmd_queue_index_r;
 
 #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
   void debug_print_job_recovery(const bool recovery) {

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -43,6 +43,7 @@
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     #include "../feature/pause.h"
+    #include "../module/motion.h" // for active_extruder
   #endif
 
   bool lcd_hasstatus();
@@ -116,7 +117,6 @@
     void lcd_completion_feedback(const bool good=true);
 
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
-      extern uint8_t active_extruder;
       void lcd_advanced_pause_show_message(const AdvancedPauseMessage message,
                                            const AdvancedPauseMode mode=ADVANCED_PAUSE_MODE_PAUSE_PRINT,
                                            const uint8_t extruder=active_extruder);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -87,9 +87,10 @@ float current_position[XYZE] = { 0 };
  */
 float destination[XYZE] = { 0 };
 
-
 // The active extruder (tool). Set with T<extruder> command.
-uint8_t active_extruder; // = 0;
+#if EXTRUDERS > 1
+  uint8_t active_extruder; // = 0
+#endif
 
 // Extruder offsets
 #if HAS_HOTEND_OFFSET

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -76,7 +76,12 @@ extern float feedrate_mm_s;
 extern int16_t feedrate_percentage;
 #define MMS_SCALED(MM_S) ((MM_S)*feedrate_percentage*0.01f)
 
-extern uint8_t active_extruder;
+// The active extruder (tool). Set with T<extruder> command.
+#if EXTRUDERS > 1
+  extern uint8_t active_extruder;
+#else
+  constexpr uint8_t active_extruder = 0;
+#endif
 
 #if HAS_HOTEND_OFFSET
   extern float hotend_offset[XYZ][HOTENDS];

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1759,7 +1759,9 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
     block->e_to_p_pressure = baricuda_e_to_p_pressure;
   #endif
 
-  block->active_extruder = extruder;
+  #if EXTRUDERS > 1
+    block->active_extruder = extruder;
+  #endif
 
   #if ENABLED(AUTO_POWER_CONTROL)
     if (block->steps[X_AXIS] || block->steps[Y_AXIS] || block->steps[Z_AXIS])

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -101,7 +101,9 @@ typedef struct {
   };
   uint32_t step_event_count;                // The number of step events required to complete this block
 
-  uint8_t active_extruder;                  // The extruder to move (if E move)
+  #if EXTRUDERS > 1
+    uint8_t active_extruder;                // The extruder to move (if E move)
+  #endif
 
   #if ENABLED(MIXING_EXTRUDER)
     uint32_t mix_steps[MIXING_STEPPERS];    // Scaled steps[E_AXIS] for the mixing steppers

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -124,7 +124,7 @@ uint8_t Stepper::last_direction_bits = 0,
 
 bool Stepper::abort_current_block;
 
-#if DISABLED(MIXING_EXTRUDER)
+#if DISABLED(MIXING_EXTRUDER) && EXTRUDERS > 1
   uint8_t Stepper::last_moved_extruder = 0xFF;
 #endif
 
@@ -159,8 +159,8 @@ uint32_t Stepper::advance_dividend[XYZE] = { 0 },
   int32_t Stepper::delta_error_m[MIXING_STEPPERS];
   uint32_t Stepper::advance_dividend_m[MIXING_STEPPERS],
            Stepper::advance_divisor_m;
-#else
-  int8_t Stepper::active_extruder;           // Active extruder
+#elif EXTRUDERS > 1
+  uint8_t Stepper::active_extruder;          // Active extruder
 #endif
 
 #if ENABLED(S_CURVE_ACCELERATION)
@@ -1702,7 +1702,7 @@ uint32_t Stepper::stepper_block_phase_isr() {
           advance_dividend_m[i] = current_block->mix_steps[i] << 1;
         }
         advance_divisor_m = e_steps << 1;
-      #else
+      #elif EXTRUDERS > 1
         active_extruder = current_block->active_extruder;
       #endif
 
@@ -1729,7 +1729,7 @@ uint32_t Stepper::stepper_block_phase_isr() {
         #endif
       ) {
         last_direction_bits = current_block->direction_bits;
-        #if DISABLED(MIXING_EXTRUDER)
+        #if DISABLED(MIXING_EXTRUDER) && EXTRUDERS > 1
           last_moved_extruder = active_extruder;
         #endif
         set_directions();

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -254,8 +254,11 @@ class Stepper {
 
     static bool abort_current_block;        // Signals to the stepper that current block should be aborted
 
-    #if DISABLED(MIXING_EXTRUDER)
-      static uint8_t last_moved_extruder;   // Last-moved extruder, as set when the last movement was fetched from planner
+    // Last-moved extruder, as set when the last movement was fetched from planner
+    #if EXTRUDERS < 2
+      static constexpr uint8_t last_moved_extruder = 0;
+    #elif DISABLED(MIXING_EXTRUDER)
+      static uint8_t last_moved_extruder;
     #endif
 
     #if ENABLED(X_DUAL_ENDSTOPS)
@@ -293,8 +296,10 @@ class Stepper {
                       advance_divisor_m;
       #define MIXING_STEPPERS_LOOP(VAR) \
         for (uint8_t VAR = 0; VAR < MIXING_STEPPERS; VAR++)
+    #elif EXTRUDERS > 1
+      static uint8_t active_extruder;
     #else
-      static int8_t active_extruder;      // Active extruder
+      static constexpr uint8_t active_extruder = 0;
     #endif
 
     #if ENABLED(S_CURVE_ACCELERATION)
@@ -385,7 +390,7 @@ class Stepper {
     // The extruder associated to the last movement
     FORCE_INLINE static uint8_t movement_extruder() {
       return
-        #if ENABLED(MIXING_EXTRUDER)
+        #if ENABLED(MIXING_EXTRUDER) || EXTRUDERS < 2
           0
         #else
           last_moved_extruder

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -158,7 +158,7 @@
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(4) Move to position near new extruder");
       #endif
-      current_position[X_AXIS] += (active_extruder == 0 ? 10 : -10); // move 10mm away from parked extruder
+      current_position[X_AXIS] += active_extruder ? -10 : 10; // move 10mm away from parked extruder
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) DEBUG_POS("Move away from parked extruder", current_position);
@@ -177,7 +177,7 @@
       pe_activate_magnet(tmp_extruder);
 
       // STEP 6
-      current_position[X_AXIS] = grabpos + (tmp_extruder == 0 ? (+10) : (-10));
+      current_position[X_AXIS] = grabpos + (tmp_extruder ? -10 : 10);
       planner.buffer_line_kinematic(current_position, planner.max_feedrate_mm_s[X_AXIS], active_extruder);
       current_position[X_AXIS] = grabpos;
       #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -393,9 +393,9 @@ inline void invalid_extruder_error(const uint8_t e) {
       #define CUR_Z current_position[Z_AXIS]
       #define CUR_E current_position[E_AXIS]
 
-      planner.buffer_line( CUR_X, CUR_Y, raised_z, CUR_E, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
-      planner.buffer_line( xhome, CUR_Y, raised_z, CUR_E, planner.max_feedrate_mm_s[X_AXIS], active_extruder);
-      planner.buffer_line( xhome, CUR_Y, CUR_Z,    CUR_E, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
+      planner.buffer_line(CUR_X, CUR_Y, raised_z, CUR_E, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
+      planner.buffer_line(xhome, CUR_Y, raised_z, CUR_E, planner.max_feedrate_mm_s[X_AXIS], active_extruder);
+      planner.buffer_line(xhome, CUR_Y, CUR_Z,    CUR_E, planner.max_feedrate_mm_s[Z_AXIS], active_extruder);
 
       planner.synchronize();
     }
@@ -607,8 +607,10 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         select_multiplexed_stepper(tmp_extruder);
       #endif
 
-      // Set the new active extruder
-      active_extruder = tmp_extruder;
+      #if EXTRUDERS > 1
+        // Set the new active extruder
+        active_extruder = tmp_extruder;
+      #endif
 
     #endif // HOTENDS <= 1
 
@@ -627,7 +629,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
     #endif
 
     SERIAL_ECHO_START();
-    SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, (int)active_extruder);
+    SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, int(active_extruder));
 
   #endif // !MIXING_EXTRUDER || MIXING_VIRTUAL_TOOLS <= 1
 }


### PR DESCRIPTION
When possible, make `active_extruder` a `constexpr` to save some PROGMEM. For a single extruder system with default config this saves about 164 bytes of program memory (and 18 bytes of SRAM!).