### PR TITLE
[2.0.x] Fix NOZZLE_PARK_FEATURE for Anycubic Kossel

### DIFF
--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1488,7 +1488,7 @@
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
   // Specify a park position as { X, Y, Z }
-  #define NOZZLE_PARK_POINT { 0, 0, MANUAL_Z_HOME_POS }
+  #define NOZZLE_PARK_POINT { 0, 0, 20 }
   #define NOZZLE_PARK_XY_FEEDRATE 100   // X and Y axes feedrate in mm/s (also used for delta printers Z axis)
   #define NOZZLE_PARK_Z_FEEDRATE 100      // Z axis feedrate in mm/s (not used for delta printers)
 #endif

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1042,7 +1042,7 @@
   #define PAUSE_PARK_NO_STEPPER_TIMEOUT           // Enable for XYZ steppers to stay powered on during filament change.
 
   #define PARK_HEAD_ON_PAUSE                    // Park the nozzle during pause and filament change.
-  //#define HOME_BEFORE_FILAMENT_CHANGE           // Ensure homing has been completed prior to parking for filament change
+  #define HOME_BEFORE_FILAMENT_CHANGE           // Ensure homing has been completed prior to parking for filament change
 
   #define FILAMENT_LOAD_UNLOAD_GCODES           // Add M701/M702 Load/Unload G-codes, plus Load/Unload in the LCD Prepare menu.
   //#define FILAMENT_UNLOAD_ALL_EXTRUDERS         // Allow M702 to unload all extruders above a minimum target temp (as set by M302)


### PR DESCRIPTION
Fix an issue in the nozzle park config that could cause the printer to run into the endstops while parking