### PR TITLE
[2.0.x] Reset stepper direction pins when drivers are reset

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -468,6 +468,9 @@ class Stepper {
 
   private:
 
+    // Allow reset_stepper_drivers to access the internal set_directions method.
+    friend void reset_stepper_drivers();
+
     // Set the current position in steps
     static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
 

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -35,6 +35,8 @@
 
 #include "../inc/MarlinConfig.h"
 
+#include "stepper.h"
+
 //
 // TMC26X Driver objects and inits
 //
@@ -580,6 +582,10 @@ void reset_stepper_drivers() {
   #if HAS_DRIVER(L6470)
     L6470_init_to_defaults();
   #endif
+
+  // Initializing the drivers resets the direction pins, so we need to
+  // reset their values.
+  stepper.set_directions();
 }
 
 //


### PR DESCRIPTION
Fixes the issue of the TMC steppers moving in the wrong direction after `M502` as described in https://github.com/MarlinFirmware/Marlin/issues/11103#issuecomment-421387611.
