### PR TITLE
[2.0.x] Send "G33 S P1" for Delta Height Calibration

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -2846,7 +2846,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_BACK(MSG_MAIN);
       #if ENABLED(DELTA_AUTO_CALIBRATION)
         MENU_ITEM(gcode, MSG_DELTA_AUTO_CALIBRATE, PSTR("G33"));
-        MENU_ITEM(gcode, MSG_DELTA_HEIGHT_CALIBRATE, PSTR("G33 P1"));
+        MENU_ITEM(gcode, MSG_DELTA_HEIGHT_CALIBRATE, PSTR("G33 S P1"));
         MENU_ITEM(gcode, MSG_DELTA_Z_OFFSET_CALIBRATE, PSTR("G33 P-1"));
         #if ENABLED(EEPROM_SETTINGS)
           MENU_ITEM(function, MSG_STORE_EEPROM, lcd_store_settings);


### PR DESCRIPTION
### Description

On some Delta kits, the DELTA_HEIGHT in the firmware does not match the real hight, but might be set intentionally higher to avoid damage to the nozzle or probe due to user error.

G33 supports ignoring the built-in DELTA_HEIGHT for the setup calibration, but this parameter "S" is not used when coming from the menu.

So I added it. Objections or things I overlooked?

### Benefits

Avoids:
* disable soft endstops
* manually move the nozzle down to measure real DELTA_HEIGHT
* probably miscalculating the difference (I do that all the time, weird...)
* manually setting the delta height in the menu (which is slow, see #11779)
* _then_ being able to run the delta height measurement from the menu

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
