### PR TITLE
[2.0.x] Fix crashing the probe into the bed during z-Probe offset measurement for Anycubic Kossel example

### DIFF
--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1017,8 +1017,8 @@
  *     But: `M851 Z+1` with a CLEARANCE of 2  =>  2mm from bed to nozzle.
  */
 #define Z_CLEARANCE_DEPLOY_PROBE   10 // Z Clearance for Deploy/Stow
-#define Z_CLEARANCE_BETWEEN_PROBES  5 // Z Clearance between probe points
-#define Z_CLEARANCE_MULTI_PROBE     5 // Z Clearance between multiple probes
+#define Z_CLEARANCE_BETWEEN_PROBES 25 // Z Clearance between probe points
+#define Z_CLEARANCE_MULTI_PROBE    25 // Z Clearance between multiple probes
 #define Z_AFTER_PROBING            30 // Z position after probing is done
 
 #define Z_PROBE_LOW_POINT          -2 // Farthest distance below the trigger-point to go before stopping

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -237,7 +237,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN ORIG_E0_AUTO_FAN_PIN
+//#define E0_AUTO_FAN_PIN -1
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/README.md
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/README.md
@@ -8,13 +8,14 @@ These configurations activate many of the new advanced features of the Marlin fi
 
 **Important**: Before doing anything else after updating the firmware, go to `Configuration > Advanced Settings > Initialize EEPROM` to get rid of old configurations.
 
+Then you should execute `Configuration > Delta Calibration > Set Delta Height` and also run `Configuration > Delta Configuration > Probe Z-offset` to verify the Probe offset.
+
 After that you should connect the Z-Probe and start `Configuration > Delta Calibration > Auto Calibration`. When it's done don't forget to also do `Configuration > Delta Calibration > Store Settings` to make it permanent.
 
 You should also do a `Motion > Bed Leveling > Level bed` followed by `Store Settings` to ensure a perfect leveling.
 
 Please do a manual paper test (moving the nozzle slowly down to Z0 and checking with a piece of paper). If it's not perfect, use `Configuration > Advanced Settings > Probe Z Offset` to correct the difference and execute the calibration again.
 
-**Also Important**: if you value your Z-Probe do NOT execute `Configuration > Delta Configuration > Probe Z-offset` - This can destroy the Z-Probe, see issue [#11337](https://github.com/MarlinFirmware/Marlin/issues/11337).
 
 # Select the Configuration
 


### PR DESCRIPTION
### Description

In the discussion of #11337 @Jvbx suggested a possible fix for the immediate problem of crashing and nearly breaking the manually detachable Z probe during z probe offset measurement.

I still think that there is a deeper problem in G33.cpp though.

### Benefits

Prevents crashing the probe into the bed.

### Related Issues

#11337
