### PR TITLE
Fix for Stepper::set_directions() compilation error

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -466,13 +466,12 @@ class Stepper {
       #endif
     }
 
-  private:
-
-    // Set the current position in steps
-    static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
-
     // Set direction bits for all steppers
     static void set_directions();
+
+  private:
+    // Set the current position in steps
+    static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
 
     FORCE_INLINE static uint32_t calc_timer_interval(uint32_t step_rate, uint8_t scale, uint8_t* loops) {
       uint32_t timer;


### PR DESCRIPTION
### Description

Compilation failed with message:

```
In file included from Marlin/src/module/stepper_indirection.cpp:38:0:
Marlin/src/module/../module/stepper.h: In function 'void reset_stepper_drivers()':
Marlin/src/module/../module/stepper.h:475:17: error: 'static void Stepper::set_directions()' is private
static void set_directions();
^
Marlin/src/module/stepper_indirection.cpp:585:11: error: within this context
stepper.set_directions();
^
In file included from Marlin/src/module/stepper_indirection.cpp:38:0:
Marlin/src/module/../module/stepper.h:475:17: error: 'static void Stepper::set_directions()' is private
static void set_directions();
^
Marlin/src/module/stepper_indirection.cpp:585:26: error: within this context
stepper.set_directions();
^
*** [.pioenvs/megaatmega2560/src/src/module/stepper_indirection.cpp.o] Error 1
```

This patch fixes that.

### Benefits

It allows firmware to compile without the error above.
