### PR TITLE
[2.0.x] Ender-4 small improvements in Configuration

### DIFF
--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
@@ -74,7 +74,7 @@
 // User-specified version info of this build to display in [Pronterface, etc] terminal window during
 // startup. Implementation of an idea by Prof Braino to inform user that any changes made to this
 // build by the user have been successfully uploaded into firmware.
-#define STRING_CONFIG_H_AUTHOR "Skorpi, Creality Ender-4)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Skorpi, Creality Ender-4, brandstaetter)" // Who made the changes.
 #define SHOW_BOOTSCREEN
 #define STRING_SPLASH_LINE1 SHORT_BUILD_VERSION // will be shown during bootup in line 1
 #define STRING_SPLASH_LINE2 WEBSITE_URL         // will be shown during bootup in line 2

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -260,13 +260,13 @@
 /**
  * M355 Case Light on-off / brightness
  */
-//#define CASE_LIGHT_ENABLE
+#define CASE_LIGHT_ENABLE
 #if ENABLED(CASE_LIGHT_ENABLE)
-  //#define CASE_LIGHT_PIN 4                  // Override the default pin if needed
+  #define CASE_LIGHT_PIN ENDER4_FAN_PIN      // Override the default pin if needed
   #define INVERT_CASE_LIGHT false             // Set true if Case Light is ON when pin is LOW
-  #define CASE_LIGHT_DEFAULT_ON true          // Set default power-up state on
+  #define CASE_LIGHT_DEFAULT_ON false         // Set default power-up state on
   #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // Set default power-up brightness (0-255, requires PWM pin)
-  //#define MENU_ITEM_CASE_LIGHT              // Add a Case Light option to the LCD main menu
+  #define MENU_ITEM_CASE_LIGHT                // Add a Case Light option to the LCD main menu
   //#define CASE_LIGHT_USE_NEOPIXEL           // Use Neopixel LED as case light, requires NEOPIXEL_LED.
   #if ENABLED(CASE_LIGHT_USE_NEOPIXEL)
     #define CASE_LIGHT_NEOPIXEL_COLOR { 255, 255, 255, 255 } // { Red, Green, Blue, White }

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1185,6 +1185,15 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
 #endif
 
 /**
+ * Test case light not using the same pin as the fan
+ */
+#if ENABLED(CASE_LIGHT_ENABLE)
+  #if CASE_LIGHT_PIN == FAN_PIN
+    #error "You cannot set CASE_LIGHT_PIN equal to FAN_PIN."
+  #endif
+#endif
+
+/**
  * Test Heater, Temp Sensor, and Extruder Pins; Sensor Type must also be set.
  */
 #if !HAS_HEATER_0

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1185,15 +1185,6 @@ static_assert(X_MAX_LENGTH >= X_BED_SIZE && Y_MAX_LENGTH >= Y_BED_SIZE,
 #endif
 
 /**
- * Test case light not using the same pin as the fan
- */
-#if ENABLED(CASE_LIGHT_ENABLE)
-  #if CASE_LIGHT_PIN == FAN_PIN
-    #error "You cannot set CASE_LIGHT_PIN equal to FAN_PIN."
-  #endif
-#endif
-
-/**
  * Test Heater, Temp Sensor, and Extruder Pins; Sensor Type must also be set.
  */
 #if !HAS_HEATER_0

--- a/Marlin/src/pins/pins_RAMPS_ENDER_4.h
+++ b/Marlin/src/pins/pins_RAMPS_ENDER_4.h
@@ -26,4 +26,10 @@
 
 #define BOARD_NAME "Ender-4"
 
+// The board only has one controllable fan connector, the others are just plain 12V connectors
+// in the default configuration, this is used to control the brightness of the LED band
+// hotend and controller fan are therefore always-on
+#define ENDER4_FAN_PIN RAMPS_D9_PIN
+#define FAN_PIN -1
+
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/pins_RAMPS_ENDER_4.h
+++ b/Marlin/src/pins/pins_RAMPS_ENDER_4.h
@@ -26,10 +26,10 @@
 
 #define BOARD_NAME "Ender-4"
 
+#include "pins_RAMPS.h"
+
 // The board only has one controllable fan connector, the others are just plain 12V connectors
 // in the default configuration, this is used to control the brightness of the LED band
 // hotend and controller fan are therefore always-on
 #define ENDER4_FAN_PIN RAMPS_D9_PIN
-#define FAN_PIN -1
-
-#include "pins_RAMPS.h"
+#undef FAN_PIN


### PR DESCRIPTION
### Description

The normal Ender-4 configuration uses a board that has only one user-controllable "FAN" pin, the hotend fan as well as the controller fan are always-on and connected to 12V pins on the board.

Previously, the LED lighting band was connected to the FAN pins and therefore the fan speed controlled the LED brightness.

Now, the case light controls are used to control the LEDs and the FAN has been defined as -1, not available.

* removed the FAN_PIN, because there is no user-controllable fan
* activated CASE_LIGHT_ENABLE and configured pins so that the LED can be controlled by M355 instead of using the FAN controls

### Benefits

Less confusion in the UI

### Related Issues

N/A
