### PR TITLE
[2.0.x] Anycubic Trigorilla 14 pins tweak

### DIFF
--- a/Marlin/src/pins/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/pins_TRIGORILLA_14.h
@@ -46,9 +46,8 @@
 
 // TODO 1.4 boards do have an E1 stepper driver. However the pin definitions
 // from pins_RAMPS.h are incorrect for this board. e.g., Pin 44 is the Extruder fan.
-// Warn the user if there's a conflict.
-#if defined(E1_CS_PIN) && defined(FAN2_PIN) && (E1_CS_PIN == FAN2_PIN)
-  #warning E1_CS_PIN and FAN2_PIN are the same
+#if PIN_EXISTS(E1_CS) && PIN_EXISTS(FAN2) && E1_CS_PIN == FAN2_PIN
+  #warning "E1_CS_PIN and FAN2_PIN are set to the same pin."
 #endif
 
 //

--- a/Marlin/src/pins/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/pins_TRIGORILLA_14.h
@@ -44,12 +44,6 @@
 
 #include "pins_RAMPS.h"
 
-// TODO 1.4 boards do have an E1 stepper driver. However the pin definitions
-// from pins_RAMPS.h are incorrect for this board. e.g., Pin 44 is the Extruder fan.
-#if PIN_EXISTS(E1_CS) && PIN_EXISTS(FAN2) && E1_CS_PIN == FAN2_PIN
-  #warning "E1_CS_PIN and FAN2_PIN are set to the same pin."
-#endif
-
 //
 // AnyCubic made the following changes to 1.1.0-RC8
 // If these are appropriate for your LCD let us know.

--- a/Marlin/src/pins/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/pins_TRIGORILLA_14.h
@@ -31,13 +31,16 @@
 #define IS_RAMPS_EFB
 
 // FAN0 / D9  - Typically used for the part fan on Anycubic Delta devices
-#define FAN_PIN 9
+#define FAN_PIN               9
 
 // FAN1 / D7  - Typically unused, can be allocated as Case Fan
+#define FAN1_PIN              7
 
 // FAN2 / D44 - Typical Extruder Fan on Anycubic Delta devices
 #define FAN2_PIN              44
 #define ORIG_E0_AUTO_FAN_PIN  44
+
+#define HEATER_1_PIN          45
 
 #include "pins_RAMPS.h"
 

--- a/Marlin/src/pins/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/pins_TRIGORILLA_14.h
@@ -28,19 +28,20 @@
   #define BOARD_NAME "Anycubic RAMPS 1.4"
 #endif
 
-#define IS_RAMPS_EFB
+// Remap MOSFET pins to common usages
+#if HOTENDS > 1
+  #define RAMPS_D9_PIN     45   // EEB, EEF
+  #if !TEMP_SENSOR_BED
+    #define RAMPS_D8_PIN    9   // EEF
+  #endif
+#elif TEMP_SENSOR_BED
+  #define FAN1_PIN          7   // EFB
+#else
+  #define FAN2_PIN         44   // EFF
+#endif
 
-// FAN0 / D9  - Typically used for the part fan on Anycubic Delta devices
-#define FAN_PIN               9
-
-// FAN1 / D7  - Typically unused, can be allocated as Case Fan
-#define FAN1_PIN              7
-
-// FAN2 / D44 - Typical Extruder Fan on Anycubic Delta devices
-#define FAN2_PIN              44
-#define ORIG_E0_AUTO_FAN_PIN  44
-
-#define HEATER_1_PIN          45
+// D44 - Typical Extruder Fan on Anycubic Delta devices
+#define ORIG_E0_AUTO_FAN_PIN 44
 
 #include "pins_RAMPS.h"
 

--- a/Marlin/src/pins/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/pins_TRIGORILLA_14.h
@@ -46,10 +46,10 @@
 
 // TODO 1.4 boards do have an E1 stepper driver. However the pin definitions
 // from pins_RAMPS.h are incorrect for this board. e.g., Pin 44 is the Extruder fan.
-#undef E1_STEP_PIN
-#undef E1_DIR_PIN
-#undef E1_ENABLE_PIN
-#undef E1_CS_PIN
+// Warn the user if there's a conflict.
+#if defined(E1_CS_PIN) && defined(FAN2_PIN) && (E1_CS_PIN == FAN2_PIN)
+  #warning E1_CS_PIN and FAN2_PIN are the same
+#endif
 
 //
 // AnyCubic made the following changes to 1.1.0-RC8


### PR DESCRIPTION
follow up https://github.com/MarlinFirmware/Marlin/pull/11730

1. add missing pin definisions like `FAN2_PIN` and `HEATER_1_PIN`
2. warn the user about the conflict between `E1_CS_PIN` and `FAN2_PIN`, instead of directly `#undef` them altogether.