### PR TITLE
[2.0.x] Squelch compiler warnings with -Wall, part II

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/EepromEmulation_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/EepromEmulation_Due.cpp
@@ -815,7 +815,7 @@ static bool ee_Write(uint32_t address, uint8_t data) {
           //  Maybe we could coalesce the next block with this block. Let's try to do it!
           uint16_t inext = i + 3 + blen;
           if (inext <= (PageSize - 4) &&
-            (buffer[inext] | (uint16_t(buffer[inext + 1]) << 8)) == (baddr + blen + 1)) {
+            (buffer[inext] | uint16_t(buffer[inext + 1] << 8)) == (baddr + blen + 1)) {
             // YES! ... we can coalesce blocks! . Do it!
 
             // Adjust this block header to include the next one


### PR DESCRIPTION
This is related to #11889. It looks like the warnings had not been completely eliminated. Still needed a small revision to "EepromEmulation_Due.cpp" to silent the error once and for all.

According to promotion rules, bit-shifting an "uint8_t" promotes it to
an "int". This must be cast down to "uint16_t" in order to suppress the
warning due to the LHS of the "==" being "int" and the RHS being "uint16_t"
