### PR TITLE
Stow probe on probing failed

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -745,6 +745,7 @@ float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/
   feedrate_mm_s = old_feedrate_mm_s;
 
   if (isnan(measured_z)) {
+    STOW_PROBE();
     LCD_MESSAGEPGM(MSG_ERR_PROBING_FAILED);
     SERIAL_ERROR_START();
     SERIAL_ERRORLNPGM(MSG_ERR_PROBING_FAILED);


### PR DESCRIPTION
Prevents probe from being left down should probing fail and print job continue

Users reported when the last probe point was outside the correction range, the bltouch probe was left deployed, the probing failed message was displayed, and the print started, breaking the pin on the edge of the bed as it crossed over to do the prime line. This ensures the probe is stowed when check and retry g29 is not enabled.