### PR TITLE
Expand serial support in DUE HAL.h

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL.h
@@ -41,9 +41,47 @@
 #include "watchdog_Due.h"
 #include "HAL_timers_Due.h"
 
-#define NUM_SERIAL 1
-// Required before the include or compilation fails
-#define MYSERIAL0 customizedSerial
+//
+// Serial ports
+//
+#if !WITHIN(SERIAL_PORT, -1, 3)
+  #error "SERIAL_PORT must be from -1 to 3"
+#endif
+
+// MYSERIAL0 required before MarlinSerial includes!
+#if SERIAL_PORT == -1
+  #define MYSERIAL0 customizedSerial
+#elif SERIAL_PORT == 0
+  #define MYSERIAL0 Serial
+#elif SERIAL_PORT == 1
+  #define MYSERIAL0 Serial1
+#elif SERIAL_PORT == 2
+  #define MYSERIAL0 Serial2
+#elif SERIAL_PORT == 3
+  #define MYSERIAL0 Serial3
+#endif
+
+#ifdef SERIAL_PORT_2
+  #if !WITHIN(SERIAL_PORT_2, -1, 3)
+    #error "SERIAL_PORT_2 must be from -1 to 3"
+  #elif SERIAL_PORT_2 == SERIAL_PORT
+    #error "SERIAL_PORT_2 must be different than SERIAL_PORT"
+  #endif
+  #define NUM_SERIAL 2
+  #if SERIAL_PORT_2 == -1
+    #define MYSERIAL1 customizedSerial
+  #elif SERIAL_PORT_2 == 0
+    #define MYSERIAL1 Serial
+  #elif SERIAL_PORT_2 == 1
+    #define MYSERIAL1 Serial1
+  #elif SERIAL_PORT_2 == 2
+    #define MYSERIAL1 Serial2
+  #elif SERIAL_PORT_2 == 3
+    #define MYSERIAL1 Serial3
+  #endif
+#else
+  #define NUM_SERIAL 1
+#endif
 
 #include "MarlinSerial_Due.h"
 #include "MarlinSerialUSB_Due.h"


### PR DESCRIPTION
- Borrow serial macro definitions from LPC1768 `HAL.h` and apply to DUE's `HAL.h`.

The change proposed in https://github.com/MarlinFirmware/Marlin/issues/11942#issuecomment-425437503 works to address the issue ("Two serial ports for RuRamps V1.3?"). But is this the correct solution or a hack?

I've massaged the original solution a bit, but this probably needs some testing and discussion to determine whether it's the most appropriate solution.