### PR TITLE
M119 Fix garbled output and honor number of  runout sensors enabled

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -430,17 +430,15 @@ void _O2 Endstops::M119() {
         switch (i) {
           default: continue;
           case 1: pin = FIL_RUNOUT_PIN; break;
-          #if NUM_RUNOUT_SENSORS > 1
-            case 2: pin = FIL_RUNOUT2_PIN; break;
-            #if NUM_RUNOUT_SENSORS > 2
-              case 3: pin = FIL_RUNOUT3_PIN; break;
-              #if NUM_RUNOUT_SENSORS > 3
-                case 4: pin = FIL_RUNOUT4_PIN; break;
-                #if NUM_RUNOUT_SENSORS > 4
-                  case 5: pin = FIL_RUNOUT5_PIN; break;
-                  #if NUM_RUNOUT_SENSORS > 5
-                    case 6: pin = FIL_RUNOUT6_PIN; break;
-                  #endif
+          case 2: pin = FIL_RUNOUT2_PIN; break;
+          #if NUM_RUNOUT_SENSORS > 2
+            case 3: pin = FIL_RUNOUT3_PIN; break;
+            #if NUM_RUNOUT_SENSORS > 3
+              case 4: pin = FIL_RUNOUT4_PIN; break;
+              #if NUM_RUNOUT_SENSORS > 4
+                case 5: pin = FIL_RUNOUT5_PIN; break;
+                #if NUM_RUNOUT_SENSORS > 5
+                  case 6: pin = FIL_RUNOUT6_PIN; break;
                 #endif
               #endif
             #endif

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -423,43 +423,30 @@ void _O2 Endstops::M119() {
   #endif
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
     #if NUM_RUNOUT_SENSORS == 1
-      print_es_state((digitalRead(FIL_RUNOUT_PIN) != FIL_RUNOUT_INVERTING), PSTR(MSG_FILAMENT_RUNOUT_SENSOR));
+      print_es_state(READ(FIL_RUNOUT_PIN) != FIL_RUNOUT_INVERTING, PSTR(MSG_FILAMENT_RUNOUT_SENSOR));
     #else
-      for (uint8_t i = 1; i <=
-        #if   NUM_RUNOUT_SENSORS == 6
-          6
-        #elif NUM_RUNOUT_SENSORS == 5
-          5
-        #elif NUM_RUNOUT_SENSORS == 4
-          4
-        #elif NUM_RUNOUT_SENSORS == 3
-          3
-        #elif NUM_RUNOUT_SENSORS == 2
-          2
-        #endif
-        ; i++
-      ) {
+      for (uint8_t i = 1; i <= NUM_RUNOUT_SENSORS; i++) {
         pin_t pin;
         switch (i) {
           default: continue;
           case 1: pin = FIL_RUNOUT_PIN; break;
-          #if PIN_EXISTS(FIL_RUNOUT2)
+          #if NUM_RUNOUT_SENSORS > 1
             case 2: pin = FIL_RUNOUT2_PIN; break;
-          #endif
-          #if PIN_EXISTS(FIL_RUNOUT3)
-            case 3: pin = FIL_RUNOUT3_PIN; break;
-          #endif
-          #if PIN_EXISTS(FIL_RUNOUT4)
-            case 4: pin = FIL_RUNOUT4_PIN; break;
-          #endif
-          #if PIN_EXISTS(FIL_RUNOUT5)
-            case 5: pin = FIL_RUNOUT5_PIN; break;
-          #endif
-          #if PIN_EXISTS(FIL_RUNOUT6)
-            case 6: pin = FIL_RUNOUT6_PIN; break;
+            #if NUM_RUNOUT_SENSORS > 2
+              case 3: pin = FIL_RUNOUT3_PIN; break;
+              #if NUM_RUNOUT_SENSORS > 3
+                case 4: pin = FIL_RUNOUT4_PIN; break;
+                #if NUM_RUNOUT_SENSORS > 4
+                  case 5: pin = FIL_RUNOUT5_PIN; break;
+                  #if NUM_RUNOUT_SENSORS > 5
+                    case 6: pin = FIL_RUNOUT6_PIN; break;
+                  #endif
+                #endif
+              #endif
+            #endif
           #endif
         }
-        SERIAL_PROTOCOLPGM(PSTR(MSG_FILAMENT_RUNOUT_SENSOR));
+        SERIAL_PROTOCOLPGM(MSG_FILAMENT_RUNOUT_SENSOR);
         if (i > 1) { SERIAL_CHAR(' '); SERIAL_CHAR('0' + i); }
         print_es_state(digitalRead(pin) != FIL_RUNOUT_INVERTING);
       }

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -422,20 +422,19 @@ void _O2 Endstops::M119() {
     print_es_state(READ(Z_MIN_PROBE_PIN) != Z_MIN_PROBE_ENDSTOP_INVERTING, PSTR(MSG_Z_PROBE));
   #endif
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    #define FRS_COUNT (1 + PIN_EXISTS(FIL_RUNOUT2) + PIN_EXISTS(FIL_RUNOUT3) + PIN_EXISTS(FIL_RUNOUT4) + PIN_EXISTS(FIL_RUNOUT5) + PIN_EXISTS(FIL_RUNOUT6))
-    #if FRS_COUNT == 1
-      print_es_state(READ(FIL_RUNOUT_PIN) != FIL_RUNOUT_INVERTING, MSG_FILAMENT_RUNOUT_SENSOR);
+    #if NUM_RUNOUT_SENSORS == 1
+      print_es_state((digitalRead(FIL_RUNOUT_PIN) != FIL_RUNOUT_INVERTING), PSTR(MSG_FILAMENT_RUNOUT_SENSOR));
     #else
       for (uint8_t i = 1; i <=
-        #if   FRS_COUNT == 6
+        #if   NUM_RUNOUT_SENSORS == 6
           6
-        #elif FRS_COUNT == 5
+        #elif NUM_RUNOUT_SENSORS == 5
           5
-        #elif FRS_COUNT == 4
+        #elif NUM_RUNOUT_SENSORS == 4
           4
-        #elif FRS_COUNT == 3
+        #elif NUM_RUNOUT_SENSORS == 3
           3
-        #elif FRS_COUNT == 2
+        #elif NUM_RUNOUT_SENSORS == 2
           2
         #endif
         ; i++
@@ -460,7 +459,7 @@ void _O2 Endstops::M119() {
             case 6: pin = FIL_RUNOUT6_PIN; break;
           #endif
         }
-        SERIAL_PROTOCOLPGM(MSG_FILAMENT_RUNOUT_SENSOR);
+        SERIAL_PROTOCOLPGM(PSTR(MSG_FILAMENT_RUNOUT_SENSOR));
         if (i > 1) { SERIAL_CHAR(' '); SERIAL_CHAR('0' + i); }
         print_es_state(digitalRead(pin) != FIL_RUNOUT_INVERTING);
       }


### PR DESCRIPTION
### Requirements

Enable filament runout detection

### Description

Runout detection would output garbled string. Also, by determining just based on pins, would not honor number selected by user in configuration.h

### Benefits

Correctly format string, and honor number of runout sensors enabled
