### PR TITLE
Anycubic Kossel: probe closer to the edge

### DIFF
--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -987,7 +987,7 @@
 #endif
 
 // Certain types of probes need to stay away from edges
-#define MIN_PROBE_EDGE 20
+#define MIN_PROBE_EDGE 15
 
 // X and Y axis travel speed (mm/m) between probes
 #define XY_PROBE_SPEED 6000
@@ -1267,7 +1267,7 @@
 
     // Beyond the probed grid, continue the implied tilt?
     // Default is to maintain the height of the nearest edge.
-    #define EXTRAPOLATE_BEYOND_GRID
+    //#define EXTRAPOLATE_BEYOND_GRID
 
     //
     // Experimental Subdivision of the grid by Catmull-Rom method.


### PR DESCRIPTION
### Description

Optimizing probing on the Anycubic Kossel to probe closer to the edge. Also dactivating extrapolation, as it seems to have a negative impact here.

### Benefits

Better leveling on Anycubic Kossel

### Related Issues

N/A
