### PR TITLE
[2.0.x] Anycubic Kossel Linear Plus: corrected DELTA_DIAGONAL_ROD

### DIFF
--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -605,7 +605,7 @@
     // Print surface diameter/2 minus unreachable space (avoid collisions with vertical towers).
     #define DELTA_PRINTABLE_RADIUS 116.0 // mm
     // Center-to-center distance of the holes in the diagonal push rods.
-    #define DELTA_DIAGONAL_ROD 271.5 // mm
+    #define DELTA_DIAGONAL_ROD 267 // mm
       // Horizontal offset from middle of printer to smooth rod center.
     #define DELTA_SMOOTH_ROD_OFFSET 186 // mm
     // Horizontal offset of the universal joints on the end effector.


### PR DESCRIPTION
### Description

I got undersized prints, so I rechecked the rod length and also got some measurements of other owners. Seems the original Firmware data was wrong.

### Benefits

Correct XY dimensions
