### PR TITLE
Eliminate extra tool-change park moves

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -379,7 +379,7 @@ inline void invalid_extruder_error(const uint8_t e) {
     const float xhome = x_home_pos(active_extruder);
     if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE
         && IsRunning()
-        && (delayed_move_time || current_position[X_AXIS] != xhome)
+        && (delayed_move_time || current_position[X_AXIS] != xhome) && !no_move
     ) {
       float raised_z = current_position[Z_AXIS] + toolchange_settings.z_raise;
       #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
@@ -401,7 +401,6 @@ inline void invalid_extruder_error(const uint8_t e) {
 
       planner.buffer_line(CUR_X, CUR_Y, raised_z, CUR_E, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
       planner.buffer_line(xhome, CUR_Y, raised_z, CUR_E, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
-      planner.buffer_line(xhome, CUR_Y, CUR_Z,    CUR_E, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
 
       planner.synchronize();
     }
@@ -409,6 +408,7 @@ inline void invalid_extruder_error(const uint8_t e) {
     // Apply Y & Z extruder offset (X offset is used as home pos with Dual X)
     current_position[Y_AXIS] -= hotend_offset[Y_AXIS][active_extruder] - hotend_offset[Y_AXIS][tmp_extruder];
     current_position[Z_AXIS] -= hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
+    current_position[Z_AXIS] += TOOLCHANGE_ZRAISE;
 
     // Activate the new extruder ahead of calling set_axis_is_at_home!
     active_extruder = tmp_extruder;
@@ -431,12 +431,8 @@ inline void invalid_extruder_error(const uint8_t e) {
         inactive_extruder_x_pos = destination[X_AXIS];
         break;
       case DXC_AUTO_PARK_MODE:
-        // record raised toolhead position for use by unpark
+        // record current raised toolhead position for use by unpark
         COPY(raised_parked_position, current_position);
-        raised_parked_position[Z_AXIS] += toolchange_settings.z_raise;
-        #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
-          NOMORE(raised_parked_position[Z_AXIS], soft_endstop_max[Z_AXIS]);
-        #endif
         active_extruder_parked = true;
         delayed_move_time = 0;
         break;
@@ -448,8 +444,6 @@ inline void invalid_extruder_error(const uint8_t e) {
         DEBUG_POS("New extruder (parked)", current_position);
       }
     #endif
-
-    // No extra case for HAS_ABL in DUAL_X_CARRIAGE. Does that mean they don't work together?
   }
 
 #endif // DUAL_X_CARRIAGE
@@ -585,7 +579,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
         // Raise, move, and lower again
         if (safe_to_move && !no_move && IsRunning()) {
-          #if DISABLED(SWITCHING_NOZZLE)
+          #if DISABLED(SWITCHING_NOZZLE) && DISABLED(DUAL_X_CARRIAGE)
             // Do a small lift to avoid the workpiece in the move back (below)
             current_position[Z_AXIS] += toolchange_settings.z_raise;
             planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);


### PR DESCRIPTION
### Requirements

Dual X Carriage enabled

### Description

Eliminate Unpark z raise variable
Eliminate duplicated moves
Ensure dual x carriage tool change function honors no move variable
Remove redundant logic

If this looks good, please let me know before merging and I will update all of the default / example configs today.