### PR TITLE
Ensure MIN/MAX override, reduce STM32F4 build warnings

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -110,6 +110,7 @@
   #define NUM_SERIAL 1
 #endif
 
+#undef _BV
 #define _BV(b) (1 << (b))
 
 /**

--- a/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
@@ -29,6 +29,7 @@
 #ifndef _FASTIO_STM32F4_H
 #define _FASTIO_STM32F4_H
 
+#undef _BV
 #define _BV(b) (1 << (b))
 
 #define USEABLE_HARDWARE_PWM(p) true

--- a/Marlin/src/core/enum.h
+++ b/Marlin/src/core/enum.h
@@ -69,20 +69,4 @@ typedef enum {
   TEMPUNIT_F
 } TempUnit;
 
-/**
- * SD Card
- */
-enum LsAction : char { LS_SerialPrint, LS_Count, LS_GetFilename };
-
-/**
- * Ultra LCD
- */
-enum LCDViewAction : char {
-  LCDVIEW_NONE,
-  LCDVIEW_REDRAW_NOW,
-  LCDVIEW_CALL_REDRAW_NEXT,
-  LCDVIEW_CLEAR_CALL_REDRAW,
-  LCDVIEW_CALL_NO_REDRAW
-};
-
 #endif // __ENUM_H__

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -57,7 +57,7 @@
 #define NANOSECONDS_PER_CYCLE (1000000000.0 / F_CPU)
 
 // Remove compiler warning on an unused variable
-#define UNUSED(x) (void) (x)
+#define UNUSED(x) ((void)(x))
 
 // Macros to make a string from a macro
 #define STRINGIFY_(M) #M

--- a/Marlin/src/core/minmax.h
+++ b/Marlin/src/core/minmax.h
@@ -20,26 +20,29 @@
  *
  */
 
-#pragma once
-
 #undef MIN
 #undef MAX
 
 #ifdef __cplusplus
 
-  extern "C++" {
+  #ifndef _MINMAX_H_
+  #define _MINMAX_H_
 
-    // C++11 solution that is standards compliant. Return type is deduced automatically
-    template <class L, class R> static inline constexpr auto MIN(const L lhs, const R rhs) -> decltype(lhs + rhs) {
-      return lhs < rhs ? lhs : rhs;
-    }
-    template <class L, class R> static inline constexpr auto MAX(const L lhs, const R rhs) -> decltype(lhs + rhs) {
-      return lhs > rhs ? lhs : rhs;
-    }
-    template<class T, class ... Ts> static inline constexpr const T MIN(T V, Ts... Vs) { return MIN(V, MIN(Vs...)); }
-    template<class T, class ... Ts> static inline constexpr const T MAX(T V, Ts... Vs) { return MAX(V, MAX(Vs...)); }
+    extern "C++" {
 
-  }
+      // C++11 solution that is standards compliant. Return type is deduced automatically
+      template <class L, class R> static inline constexpr auto MIN(const L lhs, const R rhs) -> decltype(lhs + rhs) {
+        return lhs < rhs ? lhs : rhs;
+      }
+      template <class L, class R> static inline constexpr auto MAX(const L lhs, const R rhs) -> decltype(lhs + rhs) {
+        return lhs > rhs ? lhs : rhs;
+      }
+      template<class T, class ... Ts> static inline constexpr const T MIN(T V, Ts... Vs) { return MIN(V, MIN(Vs...)); }
+      template<class T, class ... Ts> static inline constexpr const T MAX(T V, Ts... Vs) { return MAX(V, MAX(Vs...)); }
+
+    }
+
+  #endif
 
 #else
 

--- a/Marlin/src/inc/MarlinConfig.h
+++ b/Marlin/src/inc/MarlinConfig.h
@@ -43,5 +43,6 @@
 #include "../core/language.h"
 #include "../core/utility.h"
 #include "../core/serial.h"
+#include "../core/minmax.h"
 
 #endif // _MARLIN_CONFIG_H_

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -117,10 +117,9 @@ uint8_t lcd_status_update_delay = 1, // First update one loop delayed
 // The main status screen
 void lcd_status_screen();
 
-millis_t next_lcd_update_ms;
-
-uint8_t lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; // Set when the LCD needs to draw, decrements after every draw. Set to 2 in LCD routines so the LCD gets at least 1 full redraw (first redraw is partial)
+LCDViewAction lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
 uint16_t max_display_update_time = 0;
+millis_t next_lcd_update_ms;
 
 #if ENABLED(ULTIPANEL)
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -57,7 +57,15 @@
   void lcd_kill_screen();
   void kill_screen(PGM_P lcd_msg);
 
-  extern uint8_t lcdDrawUpdate;
+  enum LCDViewAction : uint8_t {
+    LCDVIEW_NONE,
+    LCDVIEW_REDRAW_NOW,
+    LCDVIEW_CALL_REDRAW_NEXT,
+    LCDVIEW_CLEAR_CALL_REDRAW,
+    LCDVIEW_CALL_NO_REDRAW
+  };
+
+  extern LCDViewAction lcdDrawUpdate;
   inline void lcd_refresh() { lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW; }
 
   #if HAS_BUZZER

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -33,6 +33,8 @@
 
 #include "SdFile.h"
 
+enum LsAction : uint8_t { LS_SerialPrint, LS_Count, LS_GetFilename };
+
 class CardReader {
 public:
   CardReader();

--- a/frameworks/CMSIS/LPC1768/include/lpc_types.h
+++ b/frameworks/CMSIS/LPC1768/include/lpc_types.h
@@ -145,8 +145,6 @@ typedef int32_t(*PFI)();
 /* External data/function define */
 #define EXTERN extern
 
-#include "../../../../src/core/minmax.h"
-
 /**
  * @}
  */


### PR DESCRIPTION
In response to #11968
Followup to #11960

To ensure that the `MIN`/`MAX` variadic macros or functions override the core headers the `minmax.h` header may need to be included more than once, or at least last ahead of any Marlin code. This PR moves the include of `minmax.h` to the end of `MarlinConfig.h` and adds some trickery to avoid defining the template function versions more than once.