### PR TITLE
template struct simplification for serial

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.cpp
@@ -705,35 +705,35 @@
 
   // Hookup ISR handlers
   ISR(SERIAL_REGNAME(USART,SERIAL_PORT,_RX_vect)) {
-    MarlinSerial<MarlinSerialCfg1>::store_rxd_char();
+    MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>::store_rxd_char();
   }
 
   ISR(SERIAL_REGNAME(USART,SERIAL_PORT,_UDRE_vect)) {
-    MarlinSerial<MarlinSerialCfg1>::_tx_udr_empty_irq();
+    MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>::_tx_udr_empty_irq();
   }
 
   // Preinstantiate
-  template class MarlinSerial<MarlinSerialCfg1>;
+  template class MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>;
 
   // Instantiate
-  MarlinSerial<MarlinSerialCfg1> customizedSerial1;
+  MarlinSerial<MarlinSerialCfg<SERIAL_PORT>> customizedSerial1;
 
   #ifdef SERIAL_PORT_2
 
     // Hookup ISR handlers
     ISR(SERIAL_REGNAME(USART,SERIAL_PORT_2,_RX_vect)) {
-      MarlinSerial<MarlinSerialCfg2>::store_rxd_char();
+      MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>>::store_rxd_char();
     }
 
     ISR(SERIAL_REGNAME(USART,SERIAL_PORT_2,_UDRE_vect)) {
-      MarlinSerial<MarlinSerialCfg2>::_tx_udr_empty_irq();
+      MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>>::_tx_udr_empty_irq();
     }
 
     // Preinstantiate
-    template class MarlinSerial<MarlinSerialCfg2>;
+    template class MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>>;
 
     // Instantiate
-    MarlinSerial<MarlinSerialCfg2> customizedSerial2;
+    MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>> customizedSerial2;
 
   #endif
 

--- a/Marlin/src/HAL/HAL_AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/HAL_AVR/MarlinSerial.h
@@ -254,10 +254,10 @@
       static void printNumber(unsigned long, const uint8_t);
       static void printFloat(double, uint8_t);
   };
-
-  // Serial port configuration
-  struct MarlinSerialCfg1 {
-    static constexpr int PORT               = SERIAL_PORT;
+  
+  template <uint8_t serial>
+  struct MarlinSerialCfg {
+    static constexpr int PORT               = serial;
     static constexpr unsigned int RX_SIZE   = RX_BUFFER_SIZE;
     static constexpr unsigned int TX_SIZE   = TX_BUFFER_SIZE;
     static constexpr bool XONOFF            = bSERIAL_XON_XOFF;
@@ -267,28 +267,13 @@
     static constexpr bool RX_FRAMING_ERRORS = bSERIAL_STATS_RX_FRAMING_ERRORS;
     static constexpr bool MAX_RX_QUEUED     = bSERIAL_STATS_MAX_RX_QUEUED;
   };
-
-  extern MarlinSerial<MarlinSerialCfg1> customizedSerial1;
+  extern MarlinSerial<MarlinSerialCfg<SERIAL_PORT>> customizedSerial1;
 
   #ifdef SERIAL_PORT_2
 
-    // Serial port configuration
-    struct MarlinSerialCfg2 {
-      static constexpr int PORT               = SERIAL_PORT_2;
-      static constexpr unsigned int RX_SIZE   = RX_BUFFER_SIZE;
-      static constexpr unsigned int TX_SIZE   = TX_BUFFER_SIZE;
-      static constexpr bool XONOFF            = bSERIAL_XON_XOFF;
-      static constexpr bool EMERGENCYPARSER   = bEMERGENCY_PARSER;
-      static constexpr bool DROPPED_RX        = bSERIAL_STATS_DROPPED_RX;
-      static constexpr bool RX_OVERRUNS       = bSERIAL_STATS_RX_BUFFER_OVERRUNS;
-      static constexpr bool RX_FRAMING_ERRORS = bSERIAL_STATS_RX_FRAMING_ERRORS;
-      static constexpr bool MAX_RX_QUEUED     = bSERIAL_STATS_MAX_RX_QUEUED;
-    };
-
-    extern MarlinSerial<MarlinSerialCfg2> customizedSerial2;
-
+    extern MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>> customizedSerial2;
+    
   #endif
-
 
 #endif // !USBCON
 

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.cpp
@@ -631,20 +631,20 @@ void MarlinSerial<Cfg>::printFloat(double number, uint8_t digits) {
 #if SERIAL_PORT >= 0
 
   // Preinstantiate
-  template class MarlinSerial<MarlinSerialCfg1>;
+  template class MarlinSerial<MarlinSerialCfg<SERIAL_PORT>>;
 
   // Instantiate
-  MarlinSerial<MarlinSerialCfg1> customizedSerial1;
+  MarlinSerial<MarlinSerialCfg<SERIAL_PORT>> customizedSerial1;
 
 #endif
 
 #ifdef SERIAL_PORT_2
 
   // Preinstantiate
-  template class MarlinSerial<MarlinSerialCfg2>;
+  template class MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>>;
 
   // Instantiate
-  MarlinSerial<MarlinSerialCfg2> customizedSerial2;
+  MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>> customizedSerial2;
 
 #endif
 

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
@@ -19,14 +19,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 /**
  * MarlinSerial_Due.h - Hardware serial library for Arduino DUE
  * Copyright (c) 2017 Eduardo José Tagle. All right reserved
  * Based on MarlinSerial for AVR, copyright (c) 2006 Nicholas Zambetti.  All right reserved.
  */
-
-#pragma once
 
 #include "../shared/MarlinSerial.h"
 

--- a/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerial_Due.h
@@ -26,8 +26,7 @@
  * Based on MarlinSerial for AVR, copyright (c) 2006 Nicholas Zambetti.  All right reserved.
  */
 
-#ifndef MARLINSERIAL_DUE_H
-#define MARLINSERIAL_DUE_H
+#pragma once
 
 #include "../shared/MarlinSerial.h"
 
@@ -159,42 +158,29 @@ private:
   static void printFloat(double, uint8_t);
 };
 
+// Serial port configuration
+template <uint8_t serial>
+struct MarlinSerialCfg {
+  static constexpr int PORT               = serial;
+  static constexpr unsigned int RX_SIZE   = RX_BUFFER_SIZE;
+  static constexpr unsigned int TX_SIZE   = TX_BUFFER_SIZE;
+  static constexpr bool XONOFF            = bSERIAL_XON_XOFF;
+  static constexpr bool EMERGENCYPARSER   = bEMERGENCY_PARSER;
+  static constexpr bool DROPPED_RX        = bSERIAL_STATS_DROPPED_RX;
+  static constexpr bool RX_OVERRUNS       = bSERIAL_STATS_RX_BUFFER_OVERRUNS;
+  static constexpr bool RX_FRAMING_ERRORS = bSERIAL_STATS_RX_FRAMING_ERRORS;
+  static constexpr bool MAX_RX_QUEUED     = bSERIAL_STATS_MAX_RX_QUEUED;
+};
+  
 #if SERIAL_PORT >= 0
 
-  // Serial port configuration
-  struct MarlinSerialCfg1 {
-    static constexpr int PORT               = SERIAL_PORT;
-    static constexpr unsigned int RX_SIZE   = RX_BUFFER_SIZE;
-    static constexpr unsigned int TX_SIZE   = TX_BUFFER_SIZE;
-    static constexpr bool XONOFF            = bSERIAL_XON_XOFF;
-    static constexpr bool EMERGENCYPARSER   = bEMERGENCY_PARSER;
-    static constexpr bool DROPPED_RX        = bSERIAL_STATS_DROPPED_RX;
-    static constexpr bool RX_OVERRUNS       = bSERIAL_STATS_RX_BUFFER_OVERRUNS;
-    static constexpr bool RX_FRAMING_ERRORS = bSERIAL_STATS_RX_FRAMING_ERRORS;
-    static constexpr bool MAX_RX_QUEUED     = bSERIAL_STATS_MAX_RX_QUEUED;
-  };
-
-  extern MarlinSerial<MarlinSerialCfg1> customizedSerial1;
-
+  extern MarlinSerial<MarlinSerialCfg<SERIAL_PORT>> customizedSerial1;
+  
 #endif // SERIAL_PORT >= 0
 
 #ifdef SERIAL_PORT_2
 
-  // Serial port configuration
-  struct MarlinSerialCfg2 {
-    static constexpr int PORT               = SERIAL_PORT_2;
-    static constexpr unsigned int RX_SIZE   = RX_BUFFER_SIZE;
-    static constexpr unsigned int TX_SIZE   = TX_BUFFER_SIZE;
-    static constexpr bool XONOFF            = bSERIAL_XON_XOFF;
-    static constexpr bool EMERGENCYPARSER   = bEMERGENCY_PARSER;
-    static constexpr bool DROPPED_RX        = bSERIAL_STATS_DROPPED_RX;
-    static constexpr bool RX_OVERRUNS       = bSERIAL_STATS_RX_BUFFER_OVERRUNS;
-    static constexpr bool RX_FRAMING_ERRORS = bSERIAL_STATS_RX_FRAMING_ERRORS;
-    static constexpr bool MAX_RX_QUEUED     = bSERIAL_STATS_MAX_RX_QUEUED;
-  };
-
-  extern MarlinSerial<MarlinSerialCfg2> customizedSerial2;
-
+  extern MarlinSerial<MarlinSerialCfg<SERIAL_PORT_2>> customizedSerial2;
+  
 #endif
 
-#endif // MARLINSERIAL_DUE_H


### PR DESCRIPTION
@thinkyhead @ejtagle 
There is no need for two MarlinSerialCfg* definitions.