### PR TITLE
[2.0.x] Correct PWM_PIN behavior for STM32 HALs

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -48,7 +48,7 @@ static SPISettings spiConfig;
   // --------------------------------------------------------------------------
   // Software SPI
   // --------------------------------------------------------------------------
-  #error "Software SPI not supported for STM32F7. Use Hardware SPI."
+  #error "Software SPI not supported for STM32. Use Hardware SPI."
 
 #else
 

--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
@@ -23,7 +23,7 @@
 #pragma once
 
 /**
- * Fast I/O interfaces for STM32F7
+ * Fast I/O interfaces for STM32
  * These use GPIO functions instead of Direct Port Manipulation, as on AVR.
  */
 
@@ -50,5 +50,5 @@
 #define GET_OUTPUT(IO)
 #define GET_TIMER(IO)
 
-#define PWM_PIN(p) true
+#define PWM_PIN(p) digitalPinHasPWM(p)
 #define USEABLE_HARDWARE_PWM(p) PWM_PIN(p)

--- a/Marlin/src/HAL/HAL_STM32F1/fastio_Stm32f1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_Stm32f1.h
@@ -50,7 +50,7 @@
 #define GET_OUTPUT(IO)        (_GET_MODE(IO) == GPIO_OUTPUT_PP)
 #define GET_TIMER(IO)         (PIN_MAP[IO].timer_device != NULL)
 
-#define PWM_PIN(p) digitalPinHasPWM(p)
+#define PWM_PIN(p) true
 #define USEABLE_HARDWARE_PWM(p) PWM_PIN(p)
 
 #endif // _FASTIO_STM32F1_H

--- a/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
@@ -53,7 +53,7 @@
 #define GET_OUTPUT(IO)
 #define GET_TIMER(IO)
 
-#define PWM_PIN(p) digitalPinHasPWM(p)
+#define PWM_PIN(p) true
 #define USEABLE_HARDWARE_PWM(p) PWM_PIN(p)
 
 //

--- a/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
@@ -52,7 +52,7 @@
 #define GET_OUTPUT(IO)
 #define GET_TIMER(IO)
 
-#define PWM_PIN(p) digitalPinHasPWM(p)
+#define PWM_PIN(p) true
 #define USEABLE_HARDWARE_PWM(p) PWM_PIN(p)
 
 //


### PR DESCRIPTION
This change will correct the intended behavior of the STM32 HALs (fixes #12016).

The STM32 family specific HALs (F1, F4 and F7) are targeting the STM32GENERIC core, were PWM is  implemented as software PWM and every PIN can output a PWM signal.

The universal HAL ("STM32") is targeting the official STM32 core, stm32duino (https://github.com/stm32duino/Arduino_Core_STM32), which implement PWM using the hardware peripherals and therefore only specific PIN can output a PWM signal.

I also took the liberty and corrected two instances, where we still referenced the "STM32F7" and corrected it to reference the universal "STM32".