### PR TITLE
[2.0.x] TMC2660 followup

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -107,7 +107,7 @@
       constexpr uint8_t OTPW_bp = 2;
       constexpr uint32_t OT_bm = 0x2UL;
       constexpr uint8_t OT_bp = 1;
-      constexpr uint8_t DRIVER_ERROR_bm = 0x1EUL;
+      constexpr uint8_t DRIVER_ERROR_bm = 0x6;
       TMC_driver_data data;
       data.drv_status = st.DRVSTATUS();
       data.is_otpw = (data.drv_status & OTPW_bm) >> OTPW_bp;

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -645,7 +645,7 @@ void reset_stepper_drivers() {
     { constexpr uint8_t extruder = 5; _TMC_INIT(E5, planner.axis_steps_per_mm[E_AXIS_N]); UNUSED(extruder); }
   #endif
 
-  #if ENABLED(SENSORLESS_HOMING)
+  #if USE_SENSORLESS
     #if X_SENSORLESS
       #if AXIS_HAS_STALLGUARD(X)
         stepperX.sgt(X_STALL_SENSITIVITY);


### PR DESCRIPTION
Quick follow up on TMC2660 and the TMCStepper update.
* The TMC2660 seems to experience quite a lot of false positives for short to ground. Marlin will no longer react to the flag but the protection remains enabled driver side.
* With the introduction of sensorless probing, it too is a valid condition for initializing SGT values.