### PR TITLE
Use uint8_t for all fan speeds

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -170,14 +170,13 @@ uint8_t axis_homed, axis_known_position; // = 0
 #endif
 
 #if FAN_COUNT > 0
-  int16_t fanSpeeds[FAN_COUNT] = { 0 };
+  uint8_t fan_speed[FAN_COUNT] = { 0 };
   #if ENABLED(EXTRA_FAN_SPEED)
-    int16_t old_fanSpeeds[FAN_COUNT],
-            new_fanSpeeds[FAN_COUNT];
+    uint8_t old_fan_speed[FAN_COUNT], new_fan_speed[FAN_COUNT];
   #endif
   #if ENABLED(PROBING_FANS_OFF)
     bool fans_paused; // = false;
-    int16_t paused_fanSpeeds[FAN_COUNT] = { 0 };
+    uint8_t paused_fan_speed[FAN_COUNT] = { 0 };
   #endif
 #endif
 
@@ -972,7 +971,7 @@ void loop() {
         print_job_timer.stop();
         thermalManager.disable_all_heaters();
         #if FAN_COUNT > 0
-          for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+          for (uint8_t i = 0; i < FAN_COUNT; i++) fan_speed[i] = 0;
         #endif
         wait_for_heatup = false;
         #if ENABLED(POWER_LOSS_RECOVERY)

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -208,19 +208,18 @@ extern volatile bool wait_for_heatup;
 extern millis_t max_inactive_time, stepper_inactive_time;
 
 #if FAN_COUNT > 0
-  extern int16_t fanSpeeds[FAN_COUNT];
+  extern uint8_t fan_speed[FAN_COUNT];
   #if ENABLED(EXTRA_FAN_SPEED)
-    extern int16_t old_fanSpeeds[FAN_COUNT],
-                   new_fanSpeeds[FAN_COUNT];
+    extern uint8_t old_fan_speed[FAN_COUNT], new_fan_speed[FAN_COUNT];
   #endif
   #if ENABLED(PROBING_FANS_OFF)
     extern bool fans_paused;
-    extern int16_t paused_fanSpeeds[FAN_COUNT];
+    extern uint8_t paused_fan_speed[FAN_COUNT];
   #endif
 #endif
 
 #if ENABLED(USE_CONTROLLER_FAN)
-  extern uint8_t controllerFanSpeed;
+  extern uint8_t controllerfan_speed;
 #endif
 
 #if HAS_POWER_SWITCH

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -27,7 +27,7 @@
 #include "../module/stepper_indirection.h"
 #include "../module/temperature.h"
 
-uint8_t controllerFanSpeed;
+uint8_t controllerfan_speed;
 
 void controllerfan_update() {
   static millis_t lastMotorOn = 0, // Last time a motor was turned on
@@ -75,7 +75,7 @@ void controllerfan_update() {
 
     // Fan off if no steppers have been enabled for CONTROLLERFAN_SECS seconds
     uint8_t speed = (!lastMotorOn || ELAPSED(ms, lastMotorOn + (CONTROLLERFAN_SECS) * 1000UL)) ? 0 : CONTROLLERFAN_SPEED;
-    controllerFanSpeed = speed;
+    controllerfan_speed = speed;
 
     // allows digital or PWM fan output to be used (see M42 handling)
     WRITE(CONTROLLER_FAN_PIN, speed);

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -39,15 +39,15 @@ millis_t Power::lastPowerOn;
 
 bool Power::is_power_needed() {
   #if ENABLED(AUTO_POWER_FANS)
-    for (uint8_t i = 0; i < FAN_COUNT; i++) if (fanSpeeds[i] > 0) return true;
+    for (uint8_t i = 0; i < FAN_COUNT; i++) if (fan_speed[i]) return true;
   #endif
 
   #if ENABLED(AUTO_POWER_E_FANS)
-    HOTEND_LOOP() if (thermalManager.autofan_speed[e] > 0) return true;
+    HOTEND_LOOP() if (thermalManager.autofan_speed[e]) return true;
   #endif
 
   #if ENABLED(AUTO_POWER_CONTROLLERFAN) && HAS_CONTROLLER_FAN && ENABLED(USE_CONTROLLER_FAN)
-    if (controllerFanSpeed > 0) return true;
+    if (controllerfan_speed) return true;
   #endif
 
   // If any of the drivers or the bed are enabled...

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -82,9 +82,9 @@ extern uint8_t commands_in_queue, cmd_queue_index_r;
         #endif
 
         #if FAN_COUNT
-          SERIAL_PROTOCOLPGM("fanSpeeds: ");
+          SERIAL_PROTOCOLPGM("fan_speed: ");
           for (int8_t i = 0; i < FAN_COUNT; i++) {
-            SERIAL_PROTOCOL(job_recovery_info.fanSpeeds[i]);
+            SERIAL_PROTOCOL(job_recovery_info.fan_speed[i]);
             if (i < FAN_COUNT - 1) SERIAL_CHAR(',');
           }
           SERIAL_EOL();
@@ -264,7 +264,7 @@ void save_job_recovery_info() {
     #endif
 
     #if FAN_COUNT
-      COPY(job_recovery_info.fanSpeeds, fanSpeeds);
+      COPY(job_recovery_info.fan_speed, fan_speed);
     #endif
 
     #if HAS_LEVELING

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -52,7 +52,7 @@ typedef struct {
   #endif
 
   #if FAN_COUNT
-    int16_t fanSpeeds[FAN_COUNT];
+    uint8_t fan_speed[FAN_COUNT];
   #endif
 
   #if HAS_LEVELING

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -52,13 +52,13 @@ void GcodeSuite::M42() {
   #if FAN_COUNT > 0
     switch (pin) {
       #if HAS_FAN0
-        case FAN_PIN: fanSpeeds[0] = pin_status; break;
+        case FAN_PIN: fan_speed[0] = pin_status; break;
       #endif
       #if HAS_FAN1
-        case FAN1_PIN: fanSpeeds[1] = pin_status; break;
+        case FAN1_PIN: fan_speed[1] = pin_status; break;
       #endif
       #if HAS_FAN2
-        case FAN2_PIN: fanSpeeds[2] = pin_status; break;
+        case FAN2_PIN: fan_speed[2] = pin_status; break;
       #endif
     }
   #endif

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -98,10 +98,10 @@ void GcodeSuite::M81() {
   planner.finish_and_disable();
 
   #if FAN_COUNT > 0
-    for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+    for (uint8_t i = 0; i < FAN_COUNT; i++) fan_speed[i] = 0;
     #if ENABLED(PROBING_FANS_OFF)
       fans_paused = false;
-      ZERO(paused_fanSpeeds);
+      ZERO(paused_fan_speed);
     #endif
   #endif
 

--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -49,7 +49,7 @@ void GcodeSuite::M145() {
     }
     if (parser.seenval('F')) {
       v = parser.value_int();
-      lcd_preheat_fan_speed[material] = constrain(v, 0, 255);
+      lcd_preheat_fan_speed[material] = (uint8_t)constrain(v, 0, 255);
     }
     #if TEMP_SENSOR_BED != 0
       if (parser.seenval('B')) {

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -325,8 +325,8 @@ public:
   FORCE_INLINE static uint16_t ushortval(const char c, const uint16_t dval=0) { return seenval(c) ? value_ushort()       : dval; }
   FORCE_INLINE static int32_t  longval(const char c, const int32_t dval=0)    { return seenval(c) ? value_long()         : dval; }
   FORCE_INLINE static uint32_t ulongval(const char c, const uint32_t dval=0)  { return seenval(c) ? value_ulong()        : dval; }
-  FORCE_INLINE static float    linearval(const char c, const float dval=0) { return seenval(c) ? value_linear_units() : dval; }
-  FORCE_INLINE static float    celsiusval(const char c, const float dval=0){ return seenval(c) ? value_celsius()      : dval; }
+  FORCE_INLINE static float    linearval(const char c, const float dval=0)    { return seenval(c) ? value_linear_units() : dval; }
+  FORCE_INLINE static float    celsiusval(const char c, const float dval=0)   { return seenval(c) ? value_celsius()      : dval; }
 
 };
 

--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -25,7 +25,7 @@
 #if FAN_COUNT > 0
 
 #include "../gcode.h"
-#include "../../Marlin.h" // for fanSpeeds — should move those to Planner
+#include "../../Marlin.h" // for fan_speed — should move those to Planner
 
 /**
  * M106: Set Fan Speed
@@ -48,21 +48,22 @@ void GcodeSuite::M106() {
       if (t > 0) {
         switch (t) {
           case 1:
-            fanSpeeds[p] = old_fanSpeeds[p];
+            fan_speed[p] = old_fan_speed[p];
             break;
           case 2:
-            old_fanSpeeds[p] = fanSpeeds[p];
-            fanSpeeds[p] = new_fanSpeeds[p];
+            old_fan_speed[p] = fan_speed[p];
+            fan_speed[p] = new_fan_speed[p];
             break;
           default:
-            new_fanSpeeds[p] = MIN(t, 255);
+            new_fan_speed[p] = MIN(t, 255);
             break;
         }
         return;
+
       }
     #endif // EXTRA_FAN_SPEED
     const uint16_t s = parser.ushortval('S', 255);
-    fanSpeeds[p] = MIN(s, 255U);
+    fan_speed[p] = MIN(s, 255U);
   }
 }
 
@@ -71,7 +72,7 @@ void GcodeSuite::M106() {
  */
 void GcodeSuite::M107() {
   const uint16_t p = parser.ushortval('P');
-  if (p < FAN_COUNT) fanSpeeds[p] = 0;
+  if (p < FAN_COUNT) fan_speed[p] = 0;
 }
 
 #endif // FAN_COUNT > 0

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.h
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.h
@@ -207,7 +207,7 @@ static void lcd_implementation_status_screen() {
     static uint8_t fan_frame;
     if (old_blink != blink) {
       old_blink = blink;
-      if (!fanSpeeds[0] || ++fan_frame >= FAN_ANIM_FRAMES) fan_frame = 0;
+      if (!fan_speed[0] || ++fan_frame >= FAN_ANIM_FRAMES) fan_frame = 0;
     }
   #endif
 
@@ -245,7 +245,7 @@ static void lcd_implementation_status_screen() {
             fan_frame == 3 ? status_screen3_bmp :
           #endif
         #else
-          blink && fanSpeeds[0] ? status_screen1_bmp :
+          blink && fan_speed[0] ? status_screen1_bmp :
         #endif
       #endif
       status_screen0_bmp
@@ -269,7 +269,7 @@ static void lcd_implementation_status_screen() {
     #if HAS_FAN0
       if (PAGE_CONTAINS(STATUS_SCREEN_FAN_TEXT_Y - 7, STATUS_SCREEN_FAN_TEXT_Y)) {
         // Fan
-        const int16_t per = ((fanSpeeds[0] + 1) * 100) / 256;
+        const uint16_t per = (((uint16_t)fan_speed[0] + 1) * 100) / 256;
         if (per) {
           lcd_moveto(STATUS_SCREEN_FAN_TEXT_X, STATUS_SCREEN_FAN_TEXT_Y);
           lcd_put_u8str(itostr3(per));

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -710,7 +710,7 @@ bool ST7920_Lite_Status_Screen::indicators_changed() {
   // them only during blinks we gain a bit of stability.
   const bool       blink             = lcd_blink();
   const uint16_t   feedrate_perc     = feedrate_percentage;
-  const uint8_t    fan_speed         = ((fanSpeeds[0] + 1) * 100) / 256;
+  const uint8_t    fs                = (((uint16_t)fan_speed[0] + 1) * 100) / 256;
   const int16_t    extruder_1_target = thermalManager.degTargetHotend(0);
   #if HOTENDS > 1
     const int16_t  extruder_2_target = thermalManager.degTargetHotend(1);
@@ -719,7 +719,7 @@ bool ST7920_Lite_Status_Screen::indicators_changed() {
     const int16_t  bed_target        = thermalManager.degTargetBed();
   #endif
   static uint16_t last_checksum = 0;
-  const uint16_t checksum = blink ^ feedrate_perc ^ fan_speed ^ extruder_1_target
+  const uint16_t checksum = blink ^ feedrate_perc ^ fs ^ extruder_1_target
     #if HOTENDS > 1
       ^ extruder_2_target
     #endif
@@ -737,7 +737,7 @@ void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
     const bool       blink             = lcd_blink();
     const duration_t elapsed           = print_job_timer.duration();
     const uint16_t   feedrate_perc     = feedrate_percentage;
-    const uint8_t    fan_speed         = ((fanSpeeds[0] + 1) * 100) / 256;
+    const uint8_t    fs                = (((uint16_t)fan_speed[0] + 1) * 100) / 256;
     const int16_t    extruder_1_temp   = thermalManager.degHotend(0),
                      extruder_1_target = thermalManager.degTargetHotend(0);
     #if HOTENDS > 1
@@ -756,12 +756,12 @@ void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
     #if HAS_HEATED_BED
       draw_bed_temp(bed_temp, bed_target, forceUpdate);
     #endif
-    draw_fan_speed(fan_speed);
+    draw_fan_speed(fs);
     draw_print_time(elapsed);
     draw_feedrate_percentage(feedrate_perc);
 
     // Update the fan and bed animations
-    if (fan_speed > 0) draw_fan_icon(blink);
+    if (fs) draw_fan_icon(blink);
     #if HAS_HEATED_BED
       if (bed_target > 0)
         draw_heat_icon(blink, true);

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -85,7 +85,7 @@ static const uint8_t u8g_dev_st7920_128x64_HAL_init_seq[] PROGMEM = {
   U8G_ESC_END         // end of sequence
 };
 
-void clear_graphics_DRAM(u8g_t *u8g, u8g_dev_t *dev){
+void clear_graphics_DRAM(u8g_t *u8g, u8g_dev_t *dev) {
   u8g_SetChipSelect(u8g, dev, 1);
   u8g_Delay(1);
   u8g_SetAddress(u8g, dev, 0);         // cmd mode

--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -255,7 +255,7 @@ void process_lcd_p_command(const char* command) {
         print_job_timer.stop();
         thermalManager.disable_all_heaters();
         #if FAN_COUNT > 0
-          for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+          for (uint8_t i = 0; i < FAN_COUNT; i++) fan_speed[i] = 0;
         #endif
         wait_for_heatup = false;
         write_to_lcd_P(PSTR("{SYS:STARTED}"));

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -159,7 +159,8 @@ millis_t next_lcd_update_ms;
   constexpr int8_t menu_bottom = LCD_HEIGHT - (TALL_FONT_CORRECTION);
 
   // Initialized by settings.load()
-  int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
+  int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2];
+  uint8_t lcd_preheat_fan_speed[2];
 
   #if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(G26_MESH_VALIDATION)
     bool lcd_external_control; // = false
@@ -945,7 +946,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
       // Restore print cooling fan speeds
       for (uint8_t i = 0; i < FAN_COUNT; i++) {
-        int16_t f = job_recovery_info.fanSpeeds[i];
+        uint8_t f = job_recovery_info.fan_speed[i];
         if (f) {
           sprintf_P(cmd, PSTR("M106 P%i S%i"), i, f);
           enqueue_and_echo_command(cmd);
@@ -1553,21 +1554,21 @@ void lcd_quick_feedback(const bool clear_buttons) {
     //
     #if FAN_COUNT > 0
       #if HAS_FAN0
-        MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &fanSpeeds[0], 0, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &fan_speed[0], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
-          MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &new_fanSpeeds[0], 3, 255);
+          MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &new_fan_speed[0], 3, 255);
         #endif
       #endif
       #if HAS_FAN1
-        MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 2", &fanSpeeds[1], 0, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_FAN_SPEED " 2", &fan_speed[1], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
-          MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 2", &new_fanSpeeds[1], 3, 255);
+          MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 2", &new_fan_speed[1], 3, 255);
         #endif
       #endif
       #if HAS_FAN2
-        MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 3", &fanSpeeds[2], 0, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_FAN_SPEED " 3", &fan_speed[2], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
-          MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 3", &new_fanSpeeds[2], 3, 255);
+          MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 3", &new_fan_speed[2], 3, 255);
         #endif
       #endif
     #endif // FAN_COUNT > 0
@@ -1669,7 +1670,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
    * "Temperature" submenu items
    *
    */
-  void _lcd_preheat(const int16_t endnum, const int16_t temph, const int16_t tempb, const int16_t fan) {
+  void _lcd_preheat(const int16_t endnum, const int16_t temph, const int16_t tempb, const uint8_t fan) {
     if (temph > 0) thermalManager.setTargetHotend(MIN(heater_maxtemp[endnum], temph), endnum);
     #if HAS_HEATED_BED
       if (tempb >= 0) thermalManager.setTargetBed(tempb);
@@ -1678,9 +1679,9 @@ void lcd_quick_feedback(const bool clear_buttons) {
     #endif
     #if FAN_COUNT > 0
       #if FAN_COUNT > 1
-        fanSpeeds[active_extruder < FAN_COUNT ? active_extruder : 0] = fan;
+        fan_speed[active_extruder < FAN_COUNT ? active_extruder : 0] = fan;
       #else
-        fanSpeeds[0] = fan;
+        fan_speed[0] = fan;
       #endif
     #else
       UNUSED(fan);
@@ -1915,7 +1916,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
   void lcd_cooldown() {
     #if FAN_COUNT > 0
-      for (uint8_t i = 0; i < FAN_COUNT; i++) fanSpeeds[i] = 0;
+      for (uint8_t i = 0; i < FAN_COUNT; i++) fan_speed[i] = 0;
     #endif
     thermalManager.disable_all_heaters();
     lcd_return_to_status();
@@ -3609,21 +3610,21 @@ void lcd_quick_feedback(const bool clear_buttons) {
     //
     #if FAN_COUNT > 0
       #if HAS_FAN0
-        MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &fanSpeeds[0], 0, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &fan_speed[0], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
-          MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &new_fanSpeeds[0], 3, 255);
+          MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &new_fan_speed[0], 3, 255);
         #endif
       #endif
       #if HAS_FAN1
-        MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 2", &fanSpeeds[1], 0, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_FAN_SPEED " 2", &fan_speed[1], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
-          MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 2", &new_fanSpeeds[1], 3, 255);
+          MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 2", &new_fan_speed[1], 3, 255);
         #endif
       #endif
       #if HAS_FAN2
-        MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_FAN_SPEED " 3", &fanSpeeds[2], 0, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_FAN_SPEED " 3", &fan_speed[2], 0, 255);
         #if ENABLED(EXTRA_FAN_SPEED)
-          MENU_MULTIPLIER_ITEM_EDIT(int3, MSG_EXTRA_FAN_SPEED " 3", &new_fanSpeeds[2], 3, 255);
+          MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 3", &new_fan_speed[2], 3, 255);
         #endif
       #endif
     #endif // FAN_COUNT > 0
@@ -3755,7 +3756,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       #endif
       START_MENU();
       MENU_BACK(MSG_CONFIGURATION);
-      MENU_ITEM_EDIT(int3, MSG_FAN_SPEED, &lcd_preheat_fan_speed[material], 0, 255);
+      MENU_ITEM_EDIT(int8, MSG_FAN_SPEED, &lcd_preheat_fan_speed[material], 0, 255);
       #if HAS_TEMP_HOTEND
         MENU_ITEM_EDIT(int3, MSG_NOZZLE, &lcd_preheat_hotend_temp[material], MINTEMP_ALL, MAXTEMP_ALL - 15);
       #endif

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -107,7 +107,8 @@
     typedef void (*screenFunc_t)();
     typedef void (*menuAction_t)();
 
-    extern int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
+    extern int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2];
+    extern uint8_t lcd_preheat_fan_speed[2];
 
     #if ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(G26_MESH_VALIDATION)
       extern bool lcd_external_control;

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -1008,13 +1008,13 @@ static void lcd_implementation_status_screen() {
       #if FAN_COUNT > 0
         if (0
           #if HAS_FAN0
-            || fanSpeeds[0]
+            || fan_speed[0]
           #endif
           #if HAS_FAN1
-            || fanSpeeds[1]
+            || fan_speed[1]
           #endif
           #if HAS_FAN2
-            || fanSpeeds[2]
+            || fan_speed[2]
           #endif
         ) leds |= LED_C;
       #endif // FAN_COUNT > 0

--- a/Marlin/src/libs/softspi.h
+++ b/Marlin/src/libs/softspi.h
@@ -31,7 +31,7 @@ void fastDigitalWrite(uint8_t pin, bool value) {
  * @return value read
  */
 static inline __attribute__((always_inline))
-bool fastDigitalRead(uint8_t pin){
+bool fastDigitalRead(uint8_t pin) {
   return g_APinDescription[pin].pPort->PIO_PDSR & g_APinDescription[pin].ulPin;
 }
 //------------------------------------------------------------------------------
@@ -40,7 +40,7 @@ bool fastDigitalRead(uint8_t pin){
  * @param[in] level value to write
  */
 static inline __attribute__((always_inline))
-void fastDigitalWrite(uint8_t pin, bool value){
+void fastDigitalWrite(uint8_t pin, bool value) {
   if (value)
     g_APinDescription[pin].pPort->PIO_SODR = g_APinDescription[pin].ulPin;
   else

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V59"
+#define EEPROM_VERSION "V60"
 #define EEPROM_OFFSET 0
 
 // Check the integrity of data offsets.
@@ -214,8 +214,8 @@ typedef struct SettingsDataStruct {
   // ULTIPANEL
   //
   int16_t lcd_preheat_hotend_temp[2],                   // M145 S0 H
-          lcd_preheat_bed_temp[2],                      // M145 S0 B
-          lcd_preheat_fan_speed[2];                     // M145 S0 F
+          lcd_preheat_bed_temp[2];                      // M145 S0 B
+  uint8_t lcd_preheat_fan_speed[2];                     // M145 S0 F
 
   //
   // PIDTEMP
@@ -630,8 +630,8 @@ void MarlinSettings::postprocess() {
 
     #if DISABLED(ULTIPANEL)
       constexpr int16_t lcd_preheat_hotend_temp[2] = { PREHEAT_1_TEMP_HOTEND, PREHEAT_2_TEMP_HOTEND },
-                        lcd_preheat_bed_temp[2] = { PREHEAT_1_TEMP_BED, PREHEAT_2_TEMP_BED },
-                        lcd_preheat_fan_speed[2] = { PREHEAT_1_FAN_SPEED, PREHEAT_2_FAN_SPEED };
+                        lcd_preheat_bed_temp[2] = { PREHEAT_1_TEMP_BED, PREHEAT_2_TEMP_BED };
+      constexpr uint8_t lcd_preheat_fan_speed[2] = { PREHEAT_1_FAN_SPEED, PREHEAT_2_FAN_SPEED };
     #endif
 
     EEPROM_WRITE(lcd_preheat_hotend_temp);
@@ -1238,16 +1238,12 @@ void MarlinSettings::postprocess() {
       _FIELD_TEST(lcd_preheat_hotend_temp);
 
       #if DISABLED(ULTIPANEL)
-        int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2], lcd_preheat_fan_speed[2];
+        int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2];
+        uint8_t lcd_preheat_fan_speed[2];
       #endif
       EEPROM_READ(lcd_preheat_hotend_temp); // 2 floats
       EEPROM_READ(lcd_preheat_bed_temp);    // 2 floats
       EEPROM_READ(lcd_preheat_fan_speed);   // 2 floats
-
-      //EEPROM_ASSERT(
-      //  WITHIN(lcd_preheat_fan_speed, 0, 255),
-      //  "lcd_preheat_fan_speed out of range"
-      //);
 
       //
       // Hotend PID
@@ -2489,7 +2485,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         SERIAL_ECHOPAIR_P(port, "  M145 S", (int)i);
         SERIAL_ECHOPAIR_P(port, " H", TEMP_UNIT(lcd_preheat_hotend_temp[i]));
         SERIAL_ECHOPAIR_P(port, " B", TEMP_UNIT(lcd_preheat_bed_temp[i]));
-        SERIAL_ECHOLNPAIR_P(port, " F", lcd_preheat_fan_speed[i]);
+        SERIAL_ECHOLNPAIR_P(port, " F", int(lcd_preheat_fan_speed[i]));
       }
     #endif // ULTIPANEL
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1187,8 +1187,8 @@ void Planner::recalculate() {
  * Maintain fans, paste extruder pressure,
  */
 void Planner::check_axes_activity() {
-  unsigned char axis_active[NUM_AXIS] = { 0 },
-                tail_fan_speed[FAN_COUNT];
+  uint8_t axis_active[NUM_AXIS] = { 0 },
+          tail_fan_speed[FAN_COUNT];
 
   #if ENABLED(BARICUDA)
     #if HAS_HEATER_1
@@ -1225,7 +1225,7 @@ void Planner::check_axes_activity() {
   }
   else {
     #if FAN_COUNT > 0
-      for (uint8_t i = 0; i < FAN_COUNT; i++) tail_fan_speed[i] = fanSpeeds[i];
+      for (uint8_t i = 0; i < FAN_COUNT; i++) tail_fan_speed[i] = fan_speed[i];
     #endif
 
     #if ENABLED(BARICUDA)
@@ -1774,7 +1774,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   #endif
 
   #if FAN_COUNT > 0
-    for (uint8_t i = 0; i < FAN_COUNT; i++) block->fan_speed[i] = fanSpeeds[i];
+    for (uint8_t i = 0; i < FAN_COUNT; i++) block->fan_speed[i] = fan_speed[i];
   #endif
 
   #if ENABLED(BARICUDA)

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -144,7 +144,7 @@ typedef struct {
            acceleration_steps_per_s2;       // acceleration steps/sec^2
 
   #if FAN_COUNT > 0
-    uint16_t fan_speed[FAN_COUNT];
+    uint8_t fan_speed[FAN_COUNT];
   #endif
 
   #if ENABLED(BARICUDA)

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -273,12 +273,12 @@ float zprobe_zoffset; // Initialized by settings.load()
       fans_paused = p;
       if (p)
         for (uint8_t x = 0; x < FAN_COUNT; x++) {
-          paused_fanSpeeds[x] = fanSpeeds[x];
-          fanSpeeds[x] = 0;
+          paused_fan_speed[x] = fan_speed[x];
+          fan_speed[x] = 0;
         }
       else
         for (uint8_t x = 0; x < FAN_COUNT; x++)
-          fanSpeeds[x] = paused_fanSpeeds[x];
+          fan_speed[x] = paused_fan_speed[x];
     }
   }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -97,7 +97,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
         Temperature::target_temperature[HOTENDS] = { 0 };
 
 #if ENABLED(AUTO_POWER_E_FANS)
-  int16_t Temperature::autofan_speed[HOTENDS] = { 0 };
+  uint8_t Temperature::autofan_speed[HOTENDS] = { 0 };
 #endif
 
 #if HAS_HEATED_BED

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -123,7 +123,7 @@ class Temperature {
     static uint8_t soft_pwm_amount[HOTENDS];
 
     #if ENABLED(AUTO_POWER_E_FANS)
-      static int16_t autofan_speed[HOTENDS];
+      static uint8_t autofan_speed[HOTENDS];
     #endif
 
     #if ENABLED(FAN_SOFT_PWM)


### PR DESCRIPTION
Fan speeds don't need to be 16 bits, but have probably been `int16_t` to facilitate their use in some calculations. This PR changes all fan speed variables to `uint8_t` and uses type coercion where more bits are likely needed. This saves a few bytes of SRAM.

- Also uses `fan_speed` in place of `fanSpeeds` in keeping with array style.