### PR TITLE
Save PROGMEM on serial prefixes

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
@@ -75,13 +75,13 @@ void HAL_adc_init(void) {
 #include "../../core/language.h"
 
 extern void kill(PGM_P);
-extern const char errormagic[];
 
 void HAL_adc_enable_channel(int ch) {
   pin_t pin = analogInputToDigitalPin(ch);
 
   if (pin == -1) {
-    SERIAL_PRINTF("%sINVALID ANALOG PORT:%d\n", errormagic, ch);
+    serial_error_start();
+    SERIAL_PRINTF("INVALID ANALOG PORT:%d\n", ch);
     kill(MSG_KILLED);
   }
 

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -25,7 +25,7 @@
 uint8_t marlin_debug_flags = DEBUG_NONE;
 
 const char errormagic[] PROGMEM = "Error:";
-const char echomagic[] PROGMEM = "echo:";
+const char echomagic[]  PROGMEM = "echo:";
 
 #if NUM_SERIAL > 1
   void serialprintPGM_P(const int8_t p, const char * str) {
@@ -42,6 +42,10 @@ const char echomagic[] PROGMEM = "echo:";
   void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, unsigned long v) { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
 
   void serial_spaces_P(const int8_t p, uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR_P(p, ' '); }
+
+  void serial_echo_start_P(const int8_t p)  { serialprintPGM_P(p, echomagic); }
+  void serial_error_start_P(const int8_t p) { serialprintPGM_P(p, errormagic); }
+
 #endif
 
 void serialprintPGM(PGM_P str) {
@@ -58,6 +62,9 @@ void serial_echopair_PGM(PGM_P s_P, unsigned int v)  { serialprintPGM(s_P); SERI
 void serial_echopair_PGM(PGM_P s_P, unsigned long v) { serialprintPGM(s_P); SERIAL_ECHO(v); }
 
 void serial_spaces(uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR(' '); }
+
+void serial_echo_start()  { serialprintPGM(echomagic); }
+void serial_error_start() { serialprintPGM(errormagic); }
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
 

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -44,60 +44,57 @@ enum DebugFlags : unsigned char {
 extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (DEBUG_## F))
 
-extern const char echomagic[] PROGMEM;
-extern const char errormagic[] PROGMEM;
-
 #if TX_BUFFER_SIZE < 1
   #define SERIAL_FLUSHTX_P(p)
   #define SERIAL_FLUSHTX()
 #endif
 
 #if NUM_SERIAL > 1
-  #define SERIAL_CHAR_P(p,x)          (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.write(x) : MYSERIAL1.write(x)) : SERIAL_CHAR(x))
-  #define SERIAL_PROTOCOL_P(p,x)      (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x) : MYSERIAL1.print(x)) : SERIAL_PROTOCOL(x))
-  #define SERIAL_PROTOCOL_F_P(p,x,y)  (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x,y) : MYSERIAL1.print(x,y)) : SERIAL_PROTOCOL_F(x,y))
-  #define SERIAL_PROTOCOLLN_P(p,x)    (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.println(x) : MYSERIAL1.println(x)) : SERIAL_PROTOCOLLN(x))
-  #define SERIAL_PRINT_P(p,x,b)       (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x,b) : MYSERIAL1.print(x,b)) : SERIAL_PRINT(x,b))
-  #define SERIAL_PRINTLN_P(p,x,b)     (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.println(x,b) : MYSERIAL1.println(x,b)) : SERIAL_PRINTLN(x,b))
-  #define SERIAL_PRINTF_P(p,args...)  (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.printf(args) : MYSERIAL1.printf(args)) : SERIAL_PRINTF(args))
+  #define SERIAL_CHAR_P(p,x)                        (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.write(x) : MYSERIAL1.write(x)) : SERIAL_CHAR(x))
+  #define SERIAL_PROTOCOL_P(p,x)                    (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x) : MYSERIAL1.print(x)) : SERIAL_PROTOCOL(x))
+  #define SERIAL_PROTOCOL_F_P(p,x,y)                (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x,y) : MYSERIAL1.print(x,y)) : SERIAL_PROTOCOL_F(x,y))
+  #define SERIAL_PROTOCOLLN_P(p,x)                  (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.println(x) : MYSERIAL1.println(x)) : SERIAL_PROTOCOLLN(x))
+  #define SERIAL_PRINT_P(p,x,b)                     (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x,b) : MYSERIAL1.print(x,b)) : SERIAL_PRINT(x,b))
+  #define SERIAL_PRINTLN_P(p,x,b)                   (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.println(x,b) : MYSERIAL1.println(x,b)) : SERIAL_PRINTLN(x,b))
+  #define SERIAL_PRINTF_P(p,args...)                (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.printf(args) : MYSERIAL1.printf(args)) : SERIAL_PRINTF(args))
 
-  #define SERIAL_CHAR(x)              (MYSERIAL0.write(x), MYSERIAL1.write(x))
-  #define SERIAL_PROTOCOL(x)          (MYSERIAL0.print(x), MYSERIAL1.print(x))
-  #define SERIAL_PROTOCOL_F(x,y)      (MYSERIAL0.print(x,y), MYSERIAL1.print(x,y))
-  #define SERIAL_PROTOCOLLN(x)        (MYSERIAL0.println(x), MYSERIAL1.println(x))
-  #define SERIAL_PRINT(x,b)           (MYSERIAL0.print(x,b), MYSERIAL1.print(x,b))
-  #define SERIAL_PRINTLN(x,b)         (MYSERIAL0.println(x,b), MYSERIAL1.println(x,b))
-  #define SERIAL_PRINTF(args...)      (MYSERIAL0.printf(args), MYSERIAL1.printf(args))
+  #define SERIAL_CHAR(x)                            (MYSERIAL0.write(x), MYSERIAL1.write(x))
+  #define SERIAL_PROTOCOL(x)                        (MYSERIAL0.print(x), MYSERIAL1.print(x))
+  #define SERIAL_PROTOCOL_F(x,y)                    (MYSERIAL0.print(x,y), MYSERIAL1.print(x,y))
+  #define SERIAL_PROTOCOLLN(x)                      (MYSERIAL0.println(x), MYSERIAL1.println(x))
+  #define SERIAL_PRINT(x,b)                         (MYSERIAL0.print(x,b), MYSERIAL1.print(x,b))
+  #define SERIAL_PRINTLN(x,b)                       (MYSERIAL0.println(x,b), MYSERIAL1.println(x,b))
+  #define SERIAL_PRINTF(args...)                    (MYSERIAL0.printf(args), MYSERIAL1.printf(args))
 
-  #define SERIAL_FLUSH_P(p)           (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.flush() : MYSERIAL1.flush()) : SERIAL_FLUSH())
-  #define SERIAL_FLUSH()              (MYSERIAL0.flush(), MYSERIAL1.flush())
+  #define SERIAL_FLUSH_P(p)                         (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.flush() : MYSERIAL1.flush()) : SERIAL_FLUSH())
+  #define SERIAL_FLUSH()                            (MYSERIAL0.flush(), MYSERIAL1.flush())
   #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX_P(p)       (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.flushTX() : MYSERIAL1.flushTX()) : SERIAL_FLUSHTX())
-    #define SERIAL_FLUSHTX()          (MYSERIAL0.flushTX(), MYSERIAL1.flushTX())
+    #define SERIAL_FLUSHTX_P(p)                     (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.flushTX() : MYSERIAL1.flushTX()) : SERIAL_FLUSHTX())
+    #define SERIAL_FLUSHTX()                        (MYSERIAL0.flushTX(), MYSERIAL1.flushTX())
   #endif
 
   #define SERIAL_EOL_P(p) SERIAL_CHAR_P(p,'\n')
 
-  #define SERIAL_PROTOCOLCHAR_P(p,x)              SERIAL_CHAR_P(p,x)
-  #define SERIAL_PROTOCOLPGM_P(p,x)               (serialprintPGM_P(p,PSTR(x)))
-  #define SERIAL_PROTOCOLLNPGM_P(p,x)             (serialprintPGM_P(p,PSTR(x "\n")))
-  #define SERIAL_PROTOCOLPAIR_P(p, pre, value)    (serial_echopair_PGM_P(p,PSTR(pre),(value)))
-  #define SERIAL_PROTOCOLLNPAIR_P(p, pre, value)  do { SERIAL_PROTOCOLPAIR_P(p, pre, value); SERIAL_EOL_P(p); } while(0)
+  #define SERIAL_PROTOCOLCHAR_P(p,x)                SERIAL_CHAR_P(p,x)
+  #define SERIAL_PROTOCOLPGM_P(p,x)                 (serialprintPGM_P(p,PSTR(x)))
+  #define SERIAL_PROTOCOLLNPGM_P(p,x)               (serialprintPGM_P(p,PSTR(x "\n")))
+  #define SERIAL_PROTOCOLPAIR_P(p, pre, value)      (serial_echopair_PGM_P(p,PSTR(pre),(value)))
+  #define SERIAL_PROTOCOLLNPAIR_P(p, pre, value)    do{ SERIAL_PROTOCOLPAIR_P(p, pre, value); SERIAL_EOL_P(p); }while(0)
 
-  #define SERIAL_ECHO_START_P(p)             (serialprintPGM_P(p,echomagic))
-  #define SERIAL_ECHO_P(p,x)                 SERIAL_PROTOCOL_P(p,x)
-  #define SERIAL_ECHOPGM_P(p,x)              SERIAL_PROTOCOLPGM_P(p,x)
-  #define SERIAL_ECHOLN_P(p,x)               SERIAL_PROTOCOLLN_P(p,x)
-  #define SERIAL_ECHOLNPGM_P(p,x)            SERIAL_PROTOCOLLNPGM_P(p,x)
-  #define SERIAL_ECHOPAIR_P(p,pre,value)     SERIAL_PROTOCOLPAIR_P(p, pre, value)
-  #define SERIAL_ECHOLNPAIR_P(p,pre, value)  SERIAL_PROTOCOLLNPAIR_P(p, pre, value)
-  #define SERIAL_ECHO_F_P(p,x,y)             SERIAL_PROTOCOL_F_P(p,x,y)
+  #define SERIAL_ECHO_START_P(p)                    serial_echo_start_P(p)
+  #define SERIAL_ECHO_P(p,x)                        SERIAL_PROTOCOL_P(p,x)
+  #define SERIAL_ECHOPGM_P(p,x)                     SERIAL_PROTOCOLPGM_P(p,x)
+  #define SERIAL_ECHOLN_P(p,x)                      SERIAL_PROTOCOLLN_P(p,x)
+  #define SERIAL_ECHOLNPGM_P(p,x)                   SERIAL_PROTOCOLLNPGM_P(p,x)
+  #define SERIAL_ECHOPAIR_P(p,pre,value)            SERIAL_PROTOCOLPAIR_P(p, pre, value)
+  #define SERIAL_ECHOLNPAIR_P(p,pre, value)         SERIAL_PROTOCOLLNPAIR_P(p, pre, value)
+  #define SERIAL_ECHO_F_P(p,x,y)                    SERIAL_PROTOCOL_F_P(p,x,y)
 
-  #define SERIAL_ERROR_START_P(p)            (serialprintPGM_P(p,errormagic))
-  #define SERIAL_ERROR_P(p,x)                SERIAL_PROTOCOL_P(p,x)
-  #define SERIAL_ERRORPGM_P(p,x)             SERIAL_PROTOCOLPGM_P(p,x)
-  #define SERIAL_ERRORLN_P(p,x)              SERIAL_PROTOCOLLN_P(p,x)
-  #define SERIAL_ERRORLNPGM_P(p,x)           SERIAL_PROTOCOLLNPGM_P(p,x)
+  #define SERIAL_ERROR_START_P(p)                   serial_error_start_P(p)
+  #define SERIAL_ERROR_P(p,x)                       SERIAL_PROTOCOL_P(p,x)
+  #define SERIAL_ERRORPGM_P(p,x)                    SERIAL_PROTOCOLPGM_P(p,x)
+  #define SERIAL_ERRORLN_P(p,x)                     SERIAL_PROTOCOLLN_P(p,x)
+  #define SERIAL_ERRORLNPGM_P(p,x)                  SERIAL_PROTOCOLLNPGM_P(p,x)
 
   // These macros compensate for float imprecision
   #define SERIAL_PROTOCOLPAIR_F_P(p, pre, value)    SERIAL_PROTOCOLPAIR_P(p, pre, FIXFLOAT(value))
@@ -114,61 +111,65 @@ extern const char errormagic[] PROGMEM;
   void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, unsigned int v);
   void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, unsigned long v);
   FORCE_INLINE void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, uint8_t v) { serial_echopair_PGM_P(p, s_P, (int)v); }
-  FORCE_INLINE void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, bool v) { serial_echopair_PGM_P(p, s_P, (int)v); }
-  FORCE_INLINE void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, void *v) { serial_echopair_PGM_P(p, s_P, (unsigned long)v); }
+  FORCE_INLINE void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, bool v)    { serial_echopair_PGM_P(p, s_P, (int)v); }
+  FORCE_INLINE void serial_echopair_PGM_P(const int8_t p, PGM_P s_P, void *v)   { serial_echopair_PGM_P(p, s_P, (unsigned long)v); }
 
   void serial_spaces_P(const int8_t p, uint8_t count);
-  #define SERIAL_ECHO_SP_P(p,C)     serial_spaces_P(p,C)
-  #define SERIAL_ERROR_SP_P(p,C)    serial_spaces_P(p,C)
-  #define SERIAL_PROTOCOL_SP_P(p,C) serial_spaces_P(p,C)
+  #define SERIAL_ECHO_SP_P(p,C)                     serial_spaces_P(p,C)
+  #define SERIAL_ERROR_SP_P(p,C)                    serial_spaces_P(p,C)
+  #define SERIAL_PROTOCOL_SP_P(p,C)                 serial_spaces_P(p,C)
 
   void serialprintPGM_P(const int8_t p, PGM_P str);
-#else
-  #define SERIAL_CHAR_P(p,x)          SERIAL_CHAR(x)
-  #define SERIAL_PROTOCOL_P(p,x)      SERIAL_PROTOCOL(x)
-  #define SERIAL_PROTOCOL_F_P(p,x,y)  SERIAL_PROTOCOL_F(x,y)
-  #define SERIAL_PROTOCOLLN_P(p,x)    SERIAL_PROTOCOLLN(x)
-  #define SERIAL_PRINT_P(p,x,b)       SERIAL_PRINT(x,b)
-  #define SERIAL_PRINTLN_P(p,x,b)     SERIAL_PRINTLN(x,b)
-  #define SERIAL_PRINTF_P(p,args...)  SERIAL_PRINTF(args)
+  void serial_echo_start_P(const int8_t p);
+  void serial_error_start_P(const int8_t p);
 
-  #define SERIAL_CHAR(x)              MYSERIAL0.write(x)
-  #define SERIAL_PROTOCOL(x)          MYSERIAL0.print(x)
-  #define SERIAL_PROTOCOL_F(x,y)      MYSERIAL0.print(x,y)
-  #define SERIAL_PROTOCOLLN(x)        MYSERIAL0.println(x)
-  #define SERIAL_PRINT(x,b)           MYSERIAL0.print(x,b)
-  #define SERIAL_PRINTLN(x,b)         MYSERIAL0.println(x,b)
-  #define SERIAL_PRINTF(args...)      MYSERIAL0.printf(args)
+#else // NUM_SERIAL < 2
 
-  #define SERIAL_FLUSH_P(p)           SERIAL_FLUSH()
-  #define SERIAL_FLUSH()              MYSERIAL0.flush()
+  #define SERIAL_CHAR_P(p,x)                        SERIAL_CHAR(x)
+  #define SERIAL_PROTOCOL_P(p,x)                    SERIAL_PROTOCOL(x)
+  #define SERIAL_PROTOCOL_F_P(p,x,y)                SERIAL_PROTOCOL_F(x,y)
+  #define SERIAL_PROTOCOLLN_P(p,x)                  SERIAL_PROTOCOLLN(x)
+  #define SERIAL_PRINT_P(p,x,b)                     SERIAL_PRINT(x,b)
+  #define SERIAL_PRINTLN_P(p,x,b)                   SERIAL_PRINTLN(x,b)
+  #define SERIAL_PRINTF_P(p,args...)                SERIAL_PRINTF(args)
+
+  #define SERIAL_CHAR(x)                            MYSERIAL0.write(x)
+  #define SERIAL_PROTOCOL(x)                        MYSERIAL0.print(x)
+  #define SERIAL_PROTOCOL_F(x,y)                    MYSERIAL0.print(x,y)
+  #define SERIAL_PROTOCOLLN(x)                      MYSERIAL0.println(x)
+  #define SERIAL_PRINT(x,b)                         MYSERIAL0.print(x,b)
+  #define SERIAL_PRINTLN(x,b)                       MYSERIAL0.println(x,b)
+  #define SERIAL_PRINTF(args...)                    MYSERIAL0.printf(args)
+
+  #define SERIAL_FLUSH_P(p)                         SERIAL_FLUSH()
+  #define SERIAL_FLUSH()                            MYSERIAL0.flush()
   #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX_P(p)       SERIAL_FLUSHTX()
-    #define SERIAL_FLUSHTX()          MYSERIAL0.flushTX()
+    #define SERIAL_FLUSHTX_P(p)                     SERIAL_FLUSHTX()
+    #define SERIAL_FLUSHTX()                        MYSERIAL0.flushTX()
   #endif
 
   #define SERIAL_EOL_P(p) SERIAL_EOL()
 
-  #define SERIAL_PROTOCOLCHAR_P(p,x)              SERIAL_PROTOCOLCHAR(x)
-  #define SERIAL_PROTOCOLPGM_P(p,x)               SERIAL_PROTOCOLPGM(x)
-  #define SERIAL_PROTOCOLLNPGM_P(p,x)             SERIAL_PROTOCOLLNPGM(x)
-  #define SERIAL_PROTOCOLPAIR_P(p, pre, value)    SERIAL_PROTOCOLPAIR(pre, value)
-  #define SERIAL_PROTOCOLLNPAIR_P(p, pre, value)  SERIAL_PROTOCOLLNPAIR(pre, value)
+  #define SERIAL_PROTOCOLCHAR_P(p,x)                SERIAL_PROTOCOLCHAR(x)
+  #define SERIAL_PROTOCOLPGM_P(p,x)                 SERIAL_PROTOCOLPGM(x)
+  #define SERIAL_PROTOCOLLNPGM_P(p,x)               SERIAL_PROTOCOLLNPGM(x)
+  #define SERIAL_PROTOCOLPAIR_P(p, pre, value)      SERIAL_PROTOCOLPAIR(pre, value)
+  #define SERIAL_PROTOCOLLNPAIR_P(p, pre, value)    SERIAL_PROTOCOLLNPAIR(pre, value)
 
-  #define SERIAL_ECHO_START_P(p)             SERIAL_ECHO_START()
-  #define SERIAL_ECHO_P(p,x)                 SERIAL_ECHO(x)
-  #define SERIAL_ECHOPGM_P(p,x)              SERIAL_ECHOPGM(x)
-  #define SERIAL_ECHOLN_P(p,x)               SERIAL_ECHOLN(x)
-  #define SERIAL_ECHOLNPGM_P(p,x)            SERIAL_ECHOLNPGM(x)
-  #define SERIAL_ECHOPAIR_P(p,pre,value)     SERIAL_ECHOPAIR(pre, value)
-  #define SERIAL_ECHOLNPAIR_P(p,pre, value)  SERIAL_ECHOLNPAIR(pre, value)
-  #define SERIAL_ECHO_F_P(p,x,y)             SERIAL_ECHO_F(x,y)
-
-  #define SERIAL_ERROR_START_P(p)            SERIAL_ERROR_START()
-  #define SERIAL_ERROR_P(p,x)                SERIAL_ERROR(x)
-  #define SERIAL_ERRORPGM_P(p,x)             SERIAL_ERRORPGM(x)
-  #define SERIAL_ERRORLN_P(p,x)              SERIAL_ERRORLN(x)
-  #define SERIAL_ERRORLNPGM_P(p,x)           SERIAL_ERRORLNPGM(x)
+  #define SERIAL_ECHO_START_P(p)                    SERIAL_ECHO_START()
+  #define SERIAL_ECHO_P(p,x)                        SERIAL_ECHO(x)
+  #define SERIAL_ECHOPGM_P(p,x)                     SERIAL_ECHOPGM(x)
+  #define SERIAL_ECHOLN_P(p,x)                      SERIAL_ECHOLN(x)
+  #define SERIAL_ECHOLNPGM_P(p,x)                   SERIAL_ECHOLNPGM(x)
+  #define SERIAL_ECHOPAIR_P(p,pre,value)            SERIAL_ECHOPAIR(pre, value)
+  #define SERIAL_ECHOLNPAIR_P(p,pre, value)         SERIAL_ECHOLNPAIR(pre, value)
+  #define SERIAL_ECHO_F_P(p,x,y)                    SERIAL_ECHO_F(x,y)
+        
+  #define SERIAL_ERROR_START_P(p)                   SERIAL_ERROR_START()
+  #define SERIAL_ERROR_P(p,x)                       SERIAL_ERROR(x)
+  #define SERIAL_ERRORPGM_P(p,x)                    SERIAL_ERRORPGM(x)
+  #define SERIAL_ERRORLN_P(p,x)                     SERIAL_ERRORLN(x)
+  #define SERIAL_ERRORLNPGM_P(p,x)                  SERIAL_ERRORLNPGM(x)
 
   // These macros compensate for float imprecision
   #define SERIAL_PROTOCOLPAIR_F_P(p, pre, value)    SERIAL_PROTOCOLPAIR_F(pre, value)
@@ -178,42 +179,43 @@ extern const char errormagic[] PROGMEM;
 
   #define serial_echopair_PGM_P(p,s_P,v)            serial_echopair_PGM(s_P, v)
 
-  #define serial_spaces_P(p,c)      serial_spaces(c)
-  #define SERIAL_ECHO_SP_P(p,C)     SERIAL_ECHO_SP(C)
-  #define SERIAL_ERROR_SP_P(p,C)    SERIAL_ERROR_SP(C)
-  #define SERIAL_PROTOCOL_SP_P(p,C) SERIAL_PROTOCOL_SP(C)
+  #define serial_spaces_P(p,c)                      serial_spaces(c)
+  #define SERIAL_ECHO_SP_P(p,C)                     SERIAL_ECHO_SP(C)
+  #define SERIAL_ERROR_SP_P(p,C)                    SERIAL_ERROR_SP(C)
+  #define SERIAL_PROTOCOL_SP_P(p,C)                 SERIAL_PROTOCOL_SP(C)
 
-  #define serialprintPGM_P(p,s)     serialprintPGM(s)
-#endif
+  #define serialprintPGM_P(p,s)                     serialprintPGM(s)
+
+#endif // NUM_SERIAL < 2
 
 #define SERIAL_EOL() SERIAL_CHAR('\n')
 
-#define SERIAL_PROTOCOLCHAR(x)              SERIAL_CHAR(x)
-#define SERIAL_PROTOCOLPGM(x)               (serialprintPGM(PSTR(x)))
-#define SERIAL_PROTOCOLLNPGM(x)             (serialprintPGM(PSTR(x "\n")))
-#define SERIAL_PROTOCOLPAIR(pre, value)     (serial_echopair_PGM(PSTR(pre), value))
-#define SERIAL_PROTOCOLLNPAIR(pre, value)   do { SERIAL_PROTOCOLPAIR(pre, value); SERIAL_EOL(); } while(0)
+#define SERIAL_PROTOCOLCHAR(x)                      SERIAL_CHAR(x)
+#define SERIAL_PROTOCOLPGM(x)                       (serialprintPGM(PSTR(x)))
+#define SERIAL_PROTOCOLLNPGM(x)                     (serialprintPGM(PSTR(x "\n")))
+#define SERIAL_PROTOCOLPAIR(pre, value)             (serial_echopair_PGM(PSTR(pre), value))
+#define SERIAL_PROTOCOLLNPAIR(pre, value)           do { SERIAL_PROTOCOLPAIR(pre, value); SERIAL_EOL(); } while(0)
 
-#define SERIAL_ECHO_START()            (serialprintPGM(echomagic))
-#define SERIAL_ECHO(x)                 SERIAL_PROTOCOL(x)
-#define SERIAL_ECHOPGM(x)              SERIAL_PROTOCOLPGM(x)
-#define SERIAL_ECHOLN(x)               SERIAL_PROTOCOLLN(x)
-#define SERIAL_ECHOLNPGM(x)            SERIAL_PROTOCOLLNPGM(x)
-#define SERIAL_ECHOPAIR(pre,value)     SERIAL_PROTOCOLPAIR(pre, value)
-#define SERIAL_ECHOLNPAIR(pre, value)  SERIAL_PROTOCOLLNPAIR(pre, value)
-#define SERIAL_ECHO_F(x,y)             SERIAL_PROTOCOL_F(x, y)
+#define SERIAL_ECHO_START()                         serial_echo_start()
+#define SERIAL_ECHO(x)                              SERIAL_PROTOCOL(x)
+#define SERIAL_ECHOPGM(x)                           SERIAL_PROTOCOLPGM(x)
+#define SERIAL_ECHOLN(x)                            SERIAL_PROTOCOLLN(x)
+#define SERIAL_ECHOLNPGM(x)                         SERIAL_PROTOCOLLNPGM(x)
+#define SERIAL_ECHOPAIR(pre,value)                  SERIAL_PROTOCOLPAIR(pre, value)
+#define SERIAL_ECHOLNPAIR(pre, value)               SERIAL_PROTOCOLLNPAIR(pre, value)
+#define SERIAL_ECHO_F(x,y)                          SERIAL_PROTOCOL_F(x, y)
 
-#define SERIAL_ERROR_START()           (serialprintPGM(errormagic))
-#define SERIAL_ERROR(x)                SERIAL_PROTOCOL(x)
-#define SERIAL_ERRORPGM(x)             SERIAL_PROTOCOLPGM(x)
-#define SERIAL_ERRORLN(x)              SERIAL_PROTOCOLLN(x)
-#define SERIAL_ERRORLNPGM(x)           SERIAL_PROTOCOLLNPGM(x)
+#define SERIAL_ERROR_START()                        serial_error_start()
+#define SERIAL_ERROR(x)                             SERIAL_PROTOCOL(x)
+#define SERIAL_ERRORPGM(x)                          SERIAL_PROTOCOLPGM(x)
+#define SERIAL_ERRORLN(x)                           SERIAL_PROTOCOLLN(x)
+#define SERIAL_ERRORLNPGM(x)                        SERIAL_PROTOCOLLNPGM(x)
 
 // These macros compensate for float imprecision
-#define SERIAL_PROTOCOLPAIR_F(pre, value)   SERIAL_PROTOCOLPAIR(pre, FIXFLOAT(value))
-#define SERIAL_PROTOCOLLNPAIR_F(pre, value) SERIAL_PROTOCOLLNPAIR(pre, FIXFLOAT(value))
-#define SERIAL_ECHOPAIR_F(pre,value)        SERIAL_ECHOPAIR(pre, FIXFLOAT(value))
-#define SERIAL_ECHOLNPAIR_F(pre, value)     SERIAL_ECHOLNPAIR(pre, FIXFLOAT(value))
+#define SERIAL_PROTOCOLPAIR_F(pre, value)           SERIAL_PROTOCOLPAIR(pre, FIXFLOAT(value))
+#define SERIAL_PROTOCOLLNPAIR_F(pre, value)         SERIAL_PROTOCOLLNPAIR(pre, FIXFLOAT(value))
+#define SERIAL_ECHOPAIR_F(pre,value)                SERIAL_ECHOPAIR(pre, FIXFLOAT(value))
+#define SERIAL_ECHOLNPAIR_F(pre, value)             SERIAL_ECHOLNPAIR(pre, FIXFLOAT(value))
 
 void serial_echopair_PGM(PGM_P s_P, const char *v);
 void serial_echopair_PGM(PGM_P s_P, char v);
@@ -224,18 +226,20 @@ void serial_echopair_PGM(PGM_P s_P, double v);
 void serial_echopair_PGM(PGM_P s_P, unsigned int v);
 void serial_echopair_PGM(PGM_P s_P, unsigned long v);
 FORCE_INLINE void serial_echopair_PGM(PGM_P s_P, uint8_t v) { serial_echopair_PGM(s_P, (int)v); }
-FORCE_INLINE void serial_echopair_PGM(PGM_P s_P, bool v) { serial_echopair_PGM(s_P, (int)v); }
-FORCE_INLINE void serial_echopair_PGM(PGM_P s_P, void *v) { serial_echopair_PGM(s_P, (unsigned long)v); }
+FORCE_INLINE void serial_echopair_PGM(PGM_P s_P, bool v)    { serial_echopair_PGM(s_P, (int)v); }
+FORCE_INLINE void serial_echopair_PGM(PGM_P s_P, void *v)   { serial_echopair_PGM(s_P, (unsigned long)v); }
 
 void serial_spaces(uint8_t count);
-#define SERIAL_ECHO_SP(C)     serial_spaces(C)
-#define SERIAL_ERROR_SP(C)    serial_spaces(C)
-#define SERIAL_PROTOCOL_SP(C) serial_spaces(C)
+#define SERIAL_ECHO_SP(C)                           serial_spaces(C)
+#define SERIAL_ERROR_SP(C)                          serial_spaces(C)
+#define SERIAL_PROTOCOL_SP(C)                       serial_spaces(C)
 
 //
 // Functions for serial printing from PROGMEM. (Saves loads of SRAM.)
 //
 void serialprintPGM(PGM_P str);
+void serial_echo_start();
+void serial_error_start();
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
   void print_xyz(PGM_P prefix, PGM_P suffix, const float x, const float y, const float z);


### PR DESCRIPTION
Replace inline macro printing of `echomagic` and `errormagic` strings with function calls. With the default config plus `EEPROM_SETTINGS` this saves over 200 bytes of PROGMEM.

[Concise Diff](12033/files?w=1)