### PR TITLE
[2.0.x, RFC] Allow #defined TYPE arg to ultralcd menu macros

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -376,14 +376,14 @@ millis_t next_lcd_update_ms;
   #endif // !ENCODER_RATE_MULTIPLIER
 
   #define MENU_ITEM_DUMMY() do { _thisItemNr++; }while(0)
-  #define MENU_ITEM_EDIT(TYPE, LABEL, ...) MENU_ITEM(setting_edit_ ## TYPE, LABEL, PSTR(LABEL), ## __VA_ARGS__)
-  #define MENU_ITEM_EDIT_CALLBACK(TYPE, LABEL, ...) MENU_ITEM(setting_edit_callback_ ## TYPE, LABEL, PSTR(LABEL), ## __VA_ARGS__)
+  #define MENU_ITEM_EDIT(TYPE, LABEL, ...) MENU_ITEM(_CAT(setting_edit_,TYPE), LABEL, PSTR(LABEL), ## __VA_ARGS__)
+  #define MENU_ITEM_EDIT_CALLBACK(TYPE, LABEL, ...) MENU_ITEM(_CAT(setting_edit_callback_,TYPE), LABEL, PSTR(LABEL), ## __VA_ARGS__)
   #if ENABLED(ENCODER_RATE_MULTIPLIER)
-    #define MENU_MULTIPLIER_ITEM_EDIT(TYPE, LABEL, ...) MENU_MULTIPLIER_ITEM(setting_edit_ ## TYPE, LABEL, PSTR(LABEL), ## __VA_ARGS__)
-    #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(TYPE, LABEL, ...) MENU_MULTIPLIER_ITEM(setting_edit_callback_ ## TYPE, LABEL, PSTR(LABEL), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT(TYPE, LABEL, ...) MENU_MULTIPLIER_ITEM(_CAT(setting_edit_,TYPE), LABEL, PSTR(LABEL), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(TYPE, LABEL, ...) MENU_MULTIPLIER_ITEM(_CAT(setting_edit_callback_,TYPE), LABEL, PSTR(LABEL), ## __VA_ARGS__)
   #else // !ENCODER_RATE_MULTIPLIER
-    #define MENU_MULTIPLIER_ITEM_EDIT(TYPE, LABEL, ...) MENU_ITEM(setting_edit_ ## TYPE, LABEL, PSTR(LABEL), ## __VA_ARGS__)
-    #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(TYPE, LABEL, ...) MENU_ITEM(setting_edit_callback_ ## TYPE, LABEL, PSTR(LABEL), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT(TYPE, LABEL, ...) MENU_ITEM(_CAT(setting_edit_,TYPE), LABEL, PSTR(LABEL), ## __VA_ARGS__)
+    #define MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(TYPE, LABEL, ...) MENU_ITEM(_CAT(setting_edit_callback_,TYPE), LABEL, PSTR(LABEL), ## __VA_ARGS__)
   #endif // !ENCODER_RATE_MULTIPLIER
 
   #define SCREEN_OR_MENU_LOOP() \
@@ -986,7 +986,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       END_MENU();
     }
   #endif
-  
+
   #if ENABLED(MENU_ITEM_CASE_LIGHT)
 
     #include "../feature/caselight.h"


### PR DESCRIPTION
Previously, it was not possible for the TYPE argument to ultralcd menu macros to itself be
a #defined value. This made it difficult to create variables to set many related menu items
to a decimal precision that could be easily changed.

In our firmware, I would like to be able to add the following to "Configuration.h":

```
      #define LCD_PRECISION_XYZ_STEPS  float3
      #define LCD_PRECISION_E_STEPS    float3
```

And then modify "ultralcd.cpp" as such:

```
      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_XYZ_STEPS, MSG_ASTEPS, &planner.axis_steps_per_mm[A_AXIS], 5, 9999, _planner_refresh_positioning);
      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_XYZ_STEPS, MSG_BSTEPS, &planner.axis_steps_per_mm[B_AXIS], 5, 9999, _planner_refresh_positioning);
      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_XYZ_STEPS, MSG_CSTEPS, &planner.axis_steps_per_mm[C_AXIS], 5, 9999, _planner_refresh_positioning);

      #if ENABLED(DISTINCT_E_FACTORS)
        MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_ESTEPS, &planner.axis_steps_per_mm[E_AXIS + active_extruder], 5, 9999, _planner_refresh_positioning);
        MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_E1STEPS, &planner.axis_steps_per_mm[E_AXIS], 5, 9999, _planner_refresh_e0_positioning);
        MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_E2STEPS, &planner.axis_steps_per_mm[E_AXIS + 1], 5, 9999, _planner_refresh_e1_positioning);
        #if E_STEPPERS > 2
          MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_E3STEPS, &planner.axis_steps_per_mm[E_AXIS + 2], 5, 9999, _planner_refresh_e2_positioning);
          #if E_STEPPERS > 3
            MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_E4STEPS, &planner.axis_steps_per_mm[E_AXIS + 3], 5, 9999, _planner_refresh_e3_positioning);
            #if E_STEPPERS > 4
              MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_E5STEPS, &planner.axis_steps_per_mm[E_AXIS + 4], 5, 9999, _planner_refresh_e4_positioning);
              #if E_STEPPERS > 5
                MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_E6STEPS, &planner.axis_steps_per_mm[E_AXIS + 5], 5, 9999, _planner_refresh_e5_positioning);
              #endif // E_STEPPERS > 5
            #endif // E_STEPPERS > 4
          #endif // E_STEPPERS > 3
        #endif // E_STEPPERS > 2
      #else
        MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(LCD_PRECISION_E_STEPS, MSG_ESTEPS, &planner.axis_steps_per_mm[E_AXIS], 5, 9999, _planner_refresh_positioning);
      #endif
```

This PR adds indirection to the UltraLCD macros so that this becomes possible to do. I suspect I may not be the only one who would like to be able to customize the display precision more easily.

This PR does have the downside of making the LCD macros a bit more convoluted (by replacing ## with _CAT), so I am requesting feedback whether this change would be acceptable to merge upstream.