### PR TITLE
Update Ender-2 BED_MAXTEMP

### DIFF
--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
@@ -390,7 +390,7 @@
 #define HEATER_3_MAXTEMP 275
 #define HEATER_4_MAXTEMP 275
 #define HEATER_5_MAXTEMP 275
-#define BED_MAXTEMP 125
+#define BED_MAXTEMP 75
 
 //===========================================================================
 //============================= PID Settings ================================

--- a/Marlin/src/config/examples/Creality/Ender-2/README.md
+++ b/Marlin/src/config/examples/Creality/Ender-2/README.md
@@ -16,3 +16,18 @@ For U8Glib, at least version 1.14 and at most 1.17 is used, because
 ## Bitmaps
 
 The bootscreen and custom status screens come from Creality's firmware.
+
+## Creality Ender-2 firmware status
+
+The firmware source code has been published on 2018/07/10.
+It is based on Marlin 1.1. The source code and .hex binaries for all printers (including Ender-2) can be obtained from:
+https://www.creality3d.cn/download/firmware_c0001
+
+And repositories for CR-10S and Ender-3 can be found here:
+https://github.com/Creality3DPrinting
+
+The configuration files have been verified to match the original configuration, but further investigation is needed to ensure there aren't any extra changes in the source code.
+
+## Ender-2 specific changelog:
+
+* 2018/10/08 - Updated BED_MAXTEMP to 75 to match the original Creality Ender-2 Firmware (which is now open source)


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Update Ender-2 BED_MAXTEMP to reflect the original firmware settings. I took the settings directly from the Ender-2 source code, which has been released a few months ago. It was Marlin so it was easy to compare. Also added details to the README to make sure the Ender-2 status is properly documented.

### Benefits

While the BED_MAXTEMP set to 125 may work, it may be dangerous to set it so high, considering the original manufacturer didn't intend for it to run so hot. I downgraded the MAXTEMP to 75, to make sure it's safe to use. I don't know if the PSU that comes with the Ender-2 can handle it either, so, even though the bed can handle 100ºC, I'd rather stick with the original settings.

### Related Issues

-- No related issues --
