### PR TITLE
STM32F4xx modifications for HAL_STM32

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/watchdog.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/watchdog.cpp
@@ -45,7 +45,7 @@ uint8_t HAL_get_reset_source(void) {
 
 void watchdog_reset() {
   WDT_Feed();
-  #if PIN_EXISTS(LED)
+  #if !defined(PINS_DEBUGGING) && PIN_EXISTS(LED)
     TOGGLE(LED_PIN);  // heart beat indicator
   #endif
 }

--- a/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.cpp
@@ -79,7 +79,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
         TimerHandle[timer_num].timer = STEP_TIMER_DEV;
         TimerHandle[timer_num].irqHandle = Step_Handler;
         TimerHandleInit(&TimerHandle[timer_num], (((HAL_TIMER_RATE) / step_prescaler) / frequency) - 1, step_prescaler);
-        HAL_NVIC_SetPriority(STEP_TIMER_IRQ_NAME, 6, 0);
+        HAL_NVIC_SetPriority(STEP_TIMER_IRQ_NAME, STEP_TIMER_IRQ_PRIO, 0);
         break;
 
       case TEMP_TIMER_NUM:
@@ -87,7 +87,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
         TimerHandle[timer_num].timer = TEMP_TIMER_DEV;
         TimerHandle[timer_num].irqHandle = Temp_Handler;
         TimerHandleInit(&TimerHandle[timer_num], (((HAL_TIMER_RATE) / temp_prescaler) / frequency) - 1, temp_prescaler);
-        HAL_NVIC_SetPriority(TEMP_TIMER_IRQ_NAME, 2, 0);
+        HAL_NVIC_SetPriority(TEMP_TIMER_IRQ_NAME, TEMP_TIMER_IRQ_PRIO, 0);
         break;
     }
     timers_initialised[timer_num] = true;

--- a/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.h
@@ -38,7 +38,7 @@
 
 #ifdef STM32F0xx
 
-  #define HAL_TIMER_RATE (HAL_RCC_GetSysClockFreq()) // frequency of timer peripherals
+  #define HAL_TIMER_RATE (F_CPU) // frequency of timer peripherals
 
   #ifndef STEP_TIMER
     #define STEP_TIMER 16
@@ -50,7 +50,7 @@
 
 #elif defined STM32F1xx
 
-  #define HAL_TIMER_RATE (HAL_RCC_GetPCLK2Freq()) // frequency of timer peripherals
+  #define HAL_TIMER_RATE (F_CPU) // frequency of timer peripherals
 
   #ifndef STEP_TIMER
     #define STEP_TIMER 4
@@ -74,7 +74,7 @@
 
 #elif defined STM32F7xx
 
-  #define HAL_TIMER_RATE (HAL_RCC_GetSysClockFreq()/2) // frequency of timer peripherals
+  #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
 
   #ifndef STEP_TIMER
     #define STEP_TIMER 5

--- a/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.h
@@ -34,40 +34,64 @@
 #define FORCE_INLINE __attribute__((always_inline)) inline
 
 #define hal_timer_t uint32_t
-#define HAL_TIMER_TYPE_MAX 0xFFFF
+#define HAL_TIMER_TYPE_MAX 0xFFFFFFFF // Timers can be 16 or 32 bit
 
 #ifdef STM32F0xx
 
   #define HAL_TIMER_RATE (HAL_RCC_GetSysClockFreq()) // frequency of timer peripherals
 
-  #define STEP_TIMER 16
-  #define TEMP_TIMER 17
+  #ifndef STEP_TIMER
+    #define STEP_TIMER 16
+  #endif
+
+  #ifndef TEMP_TIMER
+    #define TEMP_TIMER 17
+  #endif
 
 #elif defined STM32F1xx
 
   #define HAL_TIMER_RATE (HAL_RCC_GetPCLK2Freq()) // frequency of timer peripherals
 
-  #define STEP_TIMER 4
-  #define TEMP_TIMER 2
+  #ifndef STEP_TIMER
+    #define STEP_TIMER 4
+  #endif
+
+  #ifndef TEMP_TIMER
+    #define TEMP_TIMER 2
+  #endif
 
 #elif defined STM32F4xx
 
-  #define HAL_TIMER_RATE (HAL_RCC_GetPCLK2Freq()) // frequency of timer peripherals
+  #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
 
-  #define STEP_TIMER 4
-  #define TEMP_TIMER 5
+  #ifndef STEP_TIMER
+    #define STEP_TIMER 5
+  #endif
+
+  #ifndef TEMP_TIMER
+    #define TEMP_TIMER 7
+  #endif
 
 #elif defined STM32F7xx
 
   #define HAL_TIMER_RATE (HAL_RCC_GetSysClockFreq()/2) // frequency of timer peripherals
 
-  #define STEP_TIMER 5
-  #define TEMP_TIMER 7
-
-  #if MB(REMRAM_V1)
-  #define STEP_TIMER 2
+  #ifndef STEP_TIMER
+    #define STEP_TIMER 5
   #endif
 
+  #ifndef TEMP_TIMER
+    #define TEMP_TIMER 7
+  #endif
+
+#endif
+
+#ifndef STEP_TIMER_IRQ_PRIO
+  #define STEP_TIMER_IRQ_PRIO 1
+#endif
+
+#ifndef TEMP_TIMER_IRQ_PRIO
+  #define TEMP_TIMER_IRQ_PRIO 2
 #endif
 
 #define STEP_TIMER_NUM 0  // index of timer to use for stepper
@@ -110,9 +134,6 @@
 #define ENABLE_TEMPERATURE_INTERRUPT() HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-#define STEPPER_ISR_ENABLED() HAL_timer_interrupt_enabled(STEP_TIMER_NUM)
-#define TEMP_ISR_ENABLED() HAL_timer_interrupt_enabled(TEMP_TIMER_NUM)
-
 extern void Step_Handler(stimer_t *htim);
 extern void Temp_Handler(stimer_t *htim);
 #define HAL_STEP_TIMER_ISR void Step_Handler(stimer_t *htim)
@@ -151,12 +172,6 @@ FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const ui
 
 FORCE_INLINE static hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
   return __HAL_TIM_GET_AUTORELOAD(&TimerHandle[timer_num].handle);
-}
-
-FORCE_INLINE static void HAL_timer_restrain(const uint8_t timer_num, const uint16_t interval_ticks) {
-  const hal_timer_t mincmp = HAL_timer_get_count(timer_num) + interval_ticks;
-  if (HAL_timer_get_compare(timer_num) < mincmp)
-    HAL_timer_set_compare(timer_num, mincmp);
 }
 
 #define HAL_timer_isr_prologue(TIMER_NUM)

--- a/Marlin/src/HAL/HAL_STM32/endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_STM32/endstop_interrupts.h
@@ -52,6 +52,12 @@ void setup_endstop_interrupts(void) {
   #if HAS_Z2_MIN
     attachInterrupt(Z2_MIN_PIN, endstop_ISR, CHANGE);
   #endif
+  #if HAS_Z3_MAX
+    attachInterrupt(Z3_MAX_PIN, endstop_ISR, CHANGE);
+  #endif
+  #if HAS_Z3_MIN
+    attachInterrupt(Z3_MIN_PIN, endstop_ISR, CHANGE);
+  #endif  
   #if HAS_Z_MIN_PROBE_PIN
     attachInterrupt(Z_MIN_PROBE_PIN, endstop_ISR, CHANGE);
   #endif

--- a/Marlin/src/HAL/HAL_STM32/watchdog_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/watchdog_STM32.cpp
@@ -31,7 +31,14 @@
 
   void watchdog_init() { IWatchdog.begin(4000000); } // 4 sec timeout
 
-  void watchdog_reset() { IWatchdog.reload(); }
+  void watchdog_reset() 
+  {
+    IWatchdog.reload(); 
+
+    #if PIN_EXISTS(LED)
+      TOGGLE(LED_PIN);  // heart beat indicator
+    #endif
+  }
 
 #endif // USE_WATCHDOG
 #endif // ARDUINO_ARCH_STM32

--- a/Marlin/src/HAL/HAL_STM32F4/EEPROM_Emul/eeprom_emul.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/EEPROM_Emul/eeprom_emul.cpp
@@ -47,7 +47,7 @@
 /** @addtogroup EEPROM_Emulation
   * @{
   */
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 /* Includes ------------------------------------------------------------------*/
 #include "eeprom_emul.h"

--- a/Marlin/src/HAL/HAL_STM32F4/EmulatedEeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/EmulatedEeprom.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 /**
  * Description: functions for I2C connected external EEPROM.

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_Servo_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_Servo_STM32F4.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
@@ -30,7 +30,7 @@
  * Adapted to the STM32F4 HAL
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 // --------------------------------------------------------------------------
 // Includes
@@ -91,7 +91,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
           TimerHandle[timer_num].irqHandle = TC5_Handler;
           TimerHandleInit(&TimerHandle[timer_num], (((HAL_TIMER_RATE) / step_prescaler) / frequency) - 1, step_prescaler);
         #endif
-        HAL_NVIC_SetPriority(STEP_TIMER_IRQ_ID, 6, 0);
+        HAL_NVIC_SetPriority(STEP_TIMER_IRQ_ID, 1, 0);
         break;
 
       case TEMP_TIMER_NUM:

--- a/Marlin/src/HAL/HAL_STM32F4/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/persistent_store_eeprom.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 #include "../shared/persistent_store_api.h"
 

--- a/Marlin/src/HAL/HAL_STM32F4/watchdog_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/watchdog_STM32F4.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#if defined(STM32F4) || defined(STM32F4xx)
+#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/pins/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/pins_REMRAM_V1.h
@@ -124,3 +124,9 @@
 #define BTN_EN1            54   // BTN_EN1
 #define BTN_EN2            55   // BTN_EN2
 #define BTN_ENC            47   // BTN_ENC
+
+//
+// Timers
+//
+
+#define STEP_TIMER 2

--- a/Marlin/src/pins/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/pins_REMRAM_V1.h
@@ -124,3 +124,10 @@
 #define BTN_EN1            54   // BTN_EN1
 #define BTN_EN2            55   // BTN_EN2
 #define BTN_ENC            47   // BTN_ENC
+
+//
+// Timers
+//
+
+#define STEP_TIMER 2
+#define TEMP_TIMER_IRQ_PRIO 6

--- a/Marlin/src/pins/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/pins_REMRAM_V1.h
@@ -124,10 +124,3 @@
 #define BTN_EN1            54   // BTN_EN1
 #define BTN_EN2            55   // BTN_EN2
 #define BTN_ENC            47   // BTN_ENC
-
-//
-// Timers
-//
-
-#define STEP_TIMER 2
-#define TEMP_TIMER_IRQ_PRIO 6


### PR DESCRIPTION
Since the addition of the **HAL_STM32** HAL for **Arduino Core STM32** the **HAL_STM32F4** no longer builds with that core. This PR contains modifications to make the STM32F4 work with the **HAL_STM32** instead.

This includes:

- Support for external I2C/SPI eeprom
- Optional configuration of timer selection and priorities in pins_XXX.h
- Use timer defaults for STM32F4xx from HAL_STM32F4.
- Exclusion of HAL_STM32F4 files when building for Arduino Core STM32.
- STM32F4xx now uses `HAL_TIMER_RATE` of `F_CPU/2` instead of `HAL_RCC_GetPCLK2Freq()` because it's much faster. `F_CPU` is updated by the core if/when frequency changes.
