### PR TITLE
Fix datasize error when FWRETRACT is disabled

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1314,7 +1314,8 @@ void MarlinSettings::postprocess() {
         #if ENABLED(FWRETRACT)
           EEPROM_READ(fwretract.settings);
         #else
-          for (uint8_t q = sizeof(fwretract_settings_t); q--;) EEPROM_READ(dummyb);
+          fwretract_settings_t fwretract_settings;
+          EEPROM_READ(fwretract_settings);
         #endif
         #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_AUTORETRACT)
           EEPROM_READ(fwretract.autoretract_enabled);

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1313,6 +1313,8 @@ void MarlinSettings::postprocess() {
 
         #if ENABLED(FWRETRACT)
           EEPROM_READ(fwretract.settings);
+        #else
+          for (uint8_t q = sizeof(fwretract_settings_t); q--;) EEPROM_READ(dummyb);
         #endif
         #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_AUTORETRACT)
           EEPROM_READ(fwretract.autoretract_enabled);


### PR DESCRIPTION
When `FWRETRACT` is disabled the dummy `autoretract_defaults` stored are not being read back from storage, causing a datasize error:

```
Error:Field parser_volumetric_enabled mismatch.
Error:EEPROM datasize error.
```

### Benefits

Fixes EEPROM datasize error.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
#12085 #12068 #12048
