### PR TITLE
Use unions instead of arrays for positions

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -475,10 +475,10 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
         }
       #endif // !SWITCHING_EXTRUDER
 
-      const float olde = current_position[E_AXIS];
-      current_position[E_AXIS] += EXTRUDER_RUNOUT_EXTRUDE;
-      planner.buffer_line(current_position, MMM_TO_MMS(EXTRUDER_RUNOUT_SPEED), active_extruder);
-      current_position[E_AXIS] = olde;
+      const float olde = current.e;
+      current.e += EXTRUDER_RUNOUT_EXTRUDE;
+      planner.buffer_line(current, MMM_TO_MMS(EXTRUDER_RUNOUT_SPEED), active_extruder);
+      current.e = olde;
       planner.set_e_position_mm(olde);
       planner.synchronize();
 
@@ -796,12 +796,12 @@ void setup() {
 
   #if HAS_M206_COMMAND
     // Initialize current position based on home_offset
-    COPY(current_position, home_offset);
+    current = home_offset;
   #else
-    ZERO(current_position);
+    ZERO(current);
   #endif
 
-  // Vital to init stepper/planner equivalent for current_position
+  // Vital to init stepper/planner equivalent for current
   sync_plan_position();
 
   thermalManager.init();    // Initialize temperature loop

--- a/Marlin/src/core/dep_types.h
+++ b/Marlin/src/core/dep_types.h
@@ -1,0 +1,186 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef _DEP_TYPES_H_
+  #define _DEP_TYPES_H_
+#else
+  #error "dep_types.h should only be included from MarlinConfig.h"
+#endif
+
+#if ENABLED(DISTINCT_E_FACTORS) && E_STEPPERS > 1
+  #define E_AXIS_N(E) (E_AXIS + E)
+  #define E_FIELDS LIST_N(E_STEPPERS, e, e1, e2, e3, e4, e5)
+#else
+  #undef DISTINCT_E_FACTORS
+  #define E_AXIS_N(E) E_AXIS
+  #define E_FIELDS e
+#endif
+
+// Forward declarations
+template<typename T> union Tabce;
+template<typename T> union Txyze;
+template<typename T> union Tabc;
+template<typename T> union Txyz;
+template<typename T> union Txy;
+
+//
+// Position structures
+// TODO: Parent template taking a type and a templated union
+//
+
+//
+// ABC
+//
+template<typename T>
+union Tabc {
+  T axis[ABC];
+  struct { T a, b, c; };
+  Tabc<T>()                                   { a = b = c = 0; }
+  Tabc<T>(Tabce<T> &s)                        { *this = s; }
+  Tabc<T>& operator=(const Tabce<T> &s)       { memcpy(this, &s, sizeof(Tabc<T>)); return *this; }
+  T& operator[](const AxisEnum a)             { return axis[uint8_t(a)]; }
+  const T& operator[](const AxisEnum a) const { return axis[uint8_t(a)]; }
+};
+
+typedef Tabc<uint32_t> abc32u_t;
+typedef Tabc<uint16_t> abc16u_t;
+typedef Tabc<uint8_t>  abc8u_t;
+typedef Tabc<int32_t>  abc32_t;
+typedef Tabc<int16_t>  abc16_t;
+typedef Tabc<int8_t>   abc8_t;
+typedef Tabc<float>    abc_t;
+typedef Tabc<bool>     abc_bool_t;
+
+typedef Tabc<volatile int32_t>  abc32v_t;
+
+//
+// ABCE
+//
+template<typename T>
+union Tabce {
+  T axis[ABCE];
+  struct { T a, b, c, e; };
+  Tabce<T>()                                  { a = b = c = e = 0; }
+  Tabce<T>(Tabc<T> &s)                        { *this = s; e = 0; }
+  Tabce<T>& operator=(const Tabc<T> &s)       { memcpy(this, &s, sizeof(Tabc<T>)); return *this; }
+  T& operator[](const AxisEnum a)             { return axis[uint8_t(a)]; }
+  const T& operator[](const AxisEnum a) const { return axis[uint8_t(a)]; }
+};
+
+typedef Tabce<uint32_t> abce32u_t;
+typedef Tabce<uint16_t> abce16u_t;
+typedef Tabce<uint8_t>  abce8u_t;
+typedef Tabce<int32_t>  abce32_t;
+typedef Tabce<int16_t>  abce16_t;
+typedef Tabce<int8_t>   abce8_t;
+typedef Tabce<float>    abce_t;
+typedef Tabce<bool>     abce_bool_t;
+
+typedef Tabce<volatile int32_t> abce32v_t;
+
+//
+// XY
+//
+template<typename T>
+union Txy {
+  T axis[2];
+  struct { T x, y; };
+  Txy<T>()                                    { x = y = 0; }
+  Txy<T>(Txyz<T> &s)                          { *this = s; }
+  Txy<T>(Txyze<T> &s)                         { *this = s; }
+  Txy<T>& operator=(const Txyz<T> &s)         { memcpy(this, &s, sizeof(Txy<T>)); return *this; }
+  Txy<T>& operator=(const Txyze<T> &s)        { memcpy(this, &s, sizeof(Txy<T>)); return *this; }
+  T& operator[](const AxisEnum a)             { return axis[uint8_t(a)]; }
+  const T& operator[](const AxisEnum a) const { return axis[uint8_t(a)]; }
+};
+
+typedef Txy<uint32_t> xy32u_t;
+typedef Txy<uint16_t> xy16u_t;
+typedef Txy<uint8_t>  xy8u_t;
+typedef Txy<int32_t>  xy32_t;
+typedef Txy<int16_t>  xy16_t;
+typedef Txy<int8_t>   xy8_t;
+typedef Txy<float>    xy_t;
+typedef Txy<bool>     xy_bool_t;
+
+//
+// XYZ
+//
+template<typename T>
+union Txyz {
+  T axis[XYZ];
+  struct{ T x, y, z; };
+  Txyz<T>()                                   { x = y = z = 0; }
+  Txyz<T>(Txy<T> &s)                          { *this = s; z = 0; }
+  Txyz<T>(Txyze<T> &s)                        { *this = s; }
+  Txyz<T>& operator=(const Txyze<T> &s)       { memcpy(this, &s, sizeof(Txyz<T>)); return *this; }
+  T& operator[](const AxisEnum a)             { return axis[uint8_t(a)]; }
+  const T& operator[](const AxisEnum a) const { return axis[uint8_t(a)]; }
+};
+
+typedef Txyz<uint32_t> xyz32u_t;
+typedef Txyz<uint16_t> xyz16u_t;
+typedef Txyz<uint8_t>  xyz8u_t;
+typedef Txyz<int32_t>  xyz32_t;
+typedef Txyz<int16_t>  xyz16_t;
+typedef Txyz<int8_t>   xyz8_t;
+typedef Txyz<float>    xyz_t;
+typedef Txyz<bool>     xyz_bool_t;
+
+//
+// XYZE
+//
+template<typename T>
+union Txyze {
+  T axis[XYZE];
+  struct { T x, y, z, e; };
+  Txyze<T>()                                  { x = y = z = e = 0; }
+  Txyze<T>(Txy<T> &s)                         { *this = s; z = 0; e = 0; }
+  Txyze<T>(Txyz<T> &s)                        { *this = s; e = 0; }
+  Txyze<T>& operator=(const Txy<T> &s)        { memcpy(this, &s, sizeof(Txy<T>)); return *this; }
+  Txyze<T>& operator=(const Txyz<T> &s)       { memcpy(this, &s, sizeof(Txyz<T>)); return *this; }
+  T& operator[](const AxisEnum a)             { return axis[uint8_t(a)]; }
+  const T& operator[](const AxisEnum a) const { return axis[uint8_t(a)]; }
+};
+
+typedef Txyze<uint32_t> xyze32u_t;
+typedef Txyze<uint16_t> xyze16u_t;
+typedef Txyze<uint8_t>  xyze8u_t;
+typedef Txyze<int32_t>  xyze32_t;
+typedef Txyze<int16_t>  xyze16_t;
+typedef Txyze<int8_t>   xyze8_t;
+typedef Txyze<float>    xyze_t;
+typedef Txyze<bool>     xyze_bool_t;
+
+//
+// XYZE_N
+//
+template<typename T>
+union T_per_axis {
+  T axis[XYZE_N];
+  struct { T a, b, c, E_FIELDS; };
+  T& E(const uint8_t n) { return axis[E_AXIS_N(n)]; }
+  T& operator[](const AxisEnum a)             { return axis[uint8_t(a)]; }
+  const T& operator[](const AxisEnum a) const { return axis[uint8_t(a)]; }
+};
+
+typedef T_per_axis<float> per_axis_t;
+typedef T_per_axis<uint32_t> per_axis32_t;

--- a/Marlin/src/core/enum.h
+++ b/Marlin/src/core/enum.h
@@ -19,9 +19,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
-#ifndef __ENUM_H__
-#define __ENUM_H__
+#include "macros.h"
 
 /**
  * Axis indices as enumerated constants
@@ -58,15 +58,13 @@ enum AxisEnum : unsigned char {
 #define LOOP_ABCE(VAR) LOOP_S_LE_N(VAR, A_AXIS, E_AXIS)
 #define LOOP_ABCE_N(VAR) LOOP_S_L_N(VAR, A_AXIS, XYZE_N)
 
-typedef enum {
+enum LinearUnit : unsigned char {
   LINEARUNIT_MM,
   LINEARUNIT_INCH
-} LinearUnit;
+};
 
-typedef enum {
+enum TempUnit : unsigned char {
   TEMPUNIT_C,
   TEMPUNIT_K,
   TEMPUNIT_F
-} TempUnit;
-
-#endif // __ENUM_H__
+};

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -151,19 +151,20 @@
 #define NUMERIC_SIGNED(a) (NUMERIC(a) || (a) == '-' || (a) == '+')
 #define DECIMAL_SIGNED(a) (DECIMAL(a) || (a) == '-' || (a) == '+')
 #define COUNT(a) (sizeof(a)/sizeof(*a))
-#define ZERO(a) memset(a,0,sizeof(a))
-#define COPY(a,b) memcpy(a,b,MIN(sizeof(a),sizeof(b)))
+#define ZERO(a) memset(&a,0,sizeof(a))
+#define COPY(a,b) memcpy(&a,&b,MIN(sizeof(a),sizeof(b)))
 
 // Macros for initializing arrays
-#define ARRAY_6(v1, v2, v3, v4, v5, v6, ...) { v1, v2, v3, v4, v5, v6 }
-#define ARRAY_5(v1, v2, v3, v4, v5, ...)     { v1, v2, v3, v4, v5 }
-#define ARRAY_4(v1, v2, v3, v4, ...)         { v1, v2, v3, v4 }
-#define ARRAY_3(v1, v2, v3, ...)             { v1, v2, v3 }
-#define ARRAY_2(v1, v2, ...)                 { v1, v2 }
-#define ARRAY_1(v1, ...)                     { v1 }
+#define LIST_6(v1, v2, v3, v4, v5, v6, ...) v1, v2, v3, v4, v5, v6
+#define LIST_5(v1, v2, v3, v4, v5, ...)     v1, v2, v3, v4, v5
+#define LIST_4(v1, v2, v3, v4, ...)         v1, v2, v3, v4
+#define LIST_3(v1, v2, v3, ...)             v1, v2, v3
+#define LIST_2(v1, v2, ...)                 v1, v2
+#define LIST_1(v1, ...)                     v1
 
-#define _ARRAY_N(N, ...) ARRAY_ ##N(__VA_ARGS__)
-#define ARRAY_N(N, ...) _ARRAY_N(N, __VA_ARGS__)
+#define _LIST_N(N, ...) LIST_ ##N(__VA_ARGS__)
+#define  LIST_N(N, ...) _LIST_N(N, __VA_ARGS__)
+#define ARRAY_N(N, ...) { _LIST_N(N, __VA_ARGS__) }
 
 // Macros for adding
 #define INC_0 1

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -67,9 +67,6 @@ void serial_echo_start()  { serialprintPGM(echomagic); }
 void serial_error_start() { serialprintPGM(errormagic); }
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
-
-  #include "enum.h"
-
   void print_xyz(PGM_P prefix, PGM_P suffix, const float x, const float y, const float z) {
     serialprintPGM(prefix);
     SERIAL_CHAR('(');

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -67,7 +67,7 @@ void serial_echo_start()  { serialprintPGM(echomagic); }
 void serial_error_start() { serialprintPGM(errormagic); }
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
-  void print_xyz(PGM_P prefix, PGM_P suffix, const float x, const float y, const float z) {
+  void print_xyz(PGM_P prefix, PGM_P suffix, const float &x, const float &y, const float &z) {
     serialprintPGM(prefix);
     SERIAL_CHAR('(');
     SERIAL_ECHO(x);
@@ -76,9 +76,6 @@ void serial_error_start() { serialprintPGM(errormagic); }
     SERIAL_CHAR(')');
     if (suffix) serialprintPGM(suffix); else SERIAL_EOL();
   }
-
-  void print_xyz(PGM_P prefix, PGM_P suffix, const float xyz[]) {
-    print_xyz(prefix, suffix, xyz[X_AXIS], xyz[Y_AXIS], xyz[Z_AXIS]);
-  }
-
+  void print_xyz(PGM_P prefix, PGM_P suffix, const xyz_t &xyz)  { print_xyz(prefix, suffix, xyz.x, xyz.y, xyz.z); }
+  void print_xyz(PGM_P prefix, PGM_P suffix, const xyze_t &xyze) { print_xyz(prefix, suffix, xyze.x, xyze.y, xyze.z); }
 #endif

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -23,8 +23,7 @@
 #ifndef __SERIAL_H__
 #define __SERIAL_H__
 
-#include "../inc/MarlinConfigPre.h"
-#include HAL_PATH(../HAL, HAL.h)
+#include "../inc/MarlinConfig.h"
 
 /**
  * Define debug bit-masks
@@ -242,8 +241,9 @@ void serial_echo_start();
 void serial_error_start();
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
-  void print_xyz(PGM_P prefix, PGM_P suffix, const float x, const float y, const float z);
-  void print_xyz(PGM_P prefix, PGM_P suffix, const float xyz[]);
+  void print_xyz(PGM_P prefix, PGM_P suffix, const float &x, const float &y, const float &z);
+  void print_xyz(PGM_P prefix, PGM_P suffix, const xyz_t &xyz);
+  void print_xyz(PGM_P prefix, PGM_P suffix, const xyze_t &xyze);
   #define DEBUG_POS(SUFFIX,VAR) do { print_xyz(PSTR("  " STRINGIFY(VAR) "="), PSTR(" : " SUFFIX "\n"), VAR); } while(0)
 #endif
 

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -28,10 +28,16 @@ typedef uint32_t millis_t;
 
 #pragma pack(push, 1) // No padding between fields
 
+//
+// Filament change settings
+//
 typedef struct {
   float unload_length, load_length;
 } fil_change_settings_t;
 
+//
+// FWRETRACT settings
+//
 typedef struct {
   float retract_length,                     // M207 S - G10 Retract length
         retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate

--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -347,32 +347,32 @@ void safe_delay(millis_t ms) {
             SERIAL_ECHOLNPAIR("Z Fade: ", planner.z_fade_height);
         #endif
         #if ABL_PLANAR
-          const float diff[XYZ] = {
-            planner.get_axis_position_mm(X_AXIS) - current_position[X_AXIS],
-            planner.get_axis_position_mm(Y_AXIS) - current_position[Y_AXIS],
-            planner.get_axis_position_mm(Z_AXIS) - current_position[Z_AXIS]
+          const xyz_t diff = {
+            planner.get_axis_position_mm(X_AXIS) - current.x,
+            planner.get_axis_position_mm(Y_AXIS) - current.y,
+            planner.get_axis_position_mm(Z_AXIS) - current.z
           };
           SERIAL_ECHOPGM("ABL Adjustment X");
-          if (diff[X_AXIS] > 0) SERIAL_CHAR('+');
-          SERIAL_ECHO(diff[X_AXIS]);
+          if (diff.x > 0) SERIAL_CHAR('+');
+          SERIAL_ECHO(diff.x);
           SERIAL_ECHOPGM(" Y");
-          if (diff[Y_AXIS] > 0) SERIAL_CHAR('+');
-          SERIAL_ECHO(diff[Y_AXIS]);
+          if (diff.y > 0) SERIAL_CHAR('+');
+          SERIAL_ECHO(diff.y);
           SERIAL_ECHOPGM(" Z");
-          if (diff[Z_AXIS] > 0) SERIAL_CHAR('+');
-          SERIAL_ECHO(diff[Z_AXIS]);
+          if (diff.z > 0) SERIAL_CHAR('+');
+          SERIAL_ECHO(diff.z);
         #else
           #if ENABLED(AUTO_BED_LEVELING_UBL)
             SERIAL_ECHOPGM("UBL Adjustment Z");
-            const float rz = ubl.get_z_correction(current_position[X_AXIS], current_position[Y_AXIS]);
+            const float rz = ubl.get_z_correction(current.x, current.y);
           #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
             SERIAL_ECHOPGM("ABL Adjustment Z");
-            const float rz = bilinear_z_offset(current_position);
+            const float rz = bilinear_z_offset(current);
           #endif
           SERIAL_ECHO(ftostr43sign(rz, '+'));
           #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
             if (planner.z_fade_height) {
-              SERIAL_ECHOPAIR(" (", ftostr43sign(rz * planner.fade_scaling_factor_for_z(current_position[Z_AXIS]), '+'));
+              SERIAL_ECHOPAIR(" (", ftostr43sign(rz * planner.fade_scaling_factor_for_z(current.z), '+'));
               SERIAL_CHAR(')');
             }
           #endif
@@ -388,7 +388,7 @@ void safe_delay(millis_t ms) {
       SERIAL_ECHOPGM("Mesh Bed Leveling");
       if (planner.leveling_active) {
         SERIAL_ECHOLNPGM(" (enabled)");
-        SERIAL_ECHOPAIR("MBL Adjustment Z", ftostr43sign(mbl.get_z(current_position[X_AXIS], current_position[Y_AXIS]
+        SERIAL_ECHOPAIR("MBL Adjustment Z", ftostr43sign(mbl.get_z(current.x, current.y
           #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
             , 1.0
           #endif
@@ -396,7 +396,7 @@ void safe_delay(millis_t ms) {
         #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
           if (planner.z_fade_height) {
             SERIAL_ECHOPAIR(" (", ftostr43sign(
-              mbl.get_z(current_position[X_AXIS], current_position[Y_AXIS], planner.fade_scaling_factor_for_z(current_position[Z_AXIS])), '+'
+              mbl.get_z(current.x, current.y, planner.fade_scaling_factor_for_z(current.z)), '+'
             ));
             SERIAL_CHAR(')');
           }

--- a/Marlin/src/feature/I2CPositionEncoder.cpp
+++ b/Marlin/src/feature/I2CPositionEncoder.cpp
@@ -340,7 +340,7 @@ bool I2CPositionEncoder::test_axis() {
   //only works on XYZ cartesian machines for the time being
   if (!(encoderAxis == X_AXIS || encoderAxis == Y_AXIS || encoderAxis == Z_AXIS)) return false;
 
-  float startCoord[NUM_AXIS] = { 0 }, endCoord[NUM_AXIS] = { 0 };
+  xyze_t startCoord = { 0 }, endCoord = { 0 };
 
   const float startPosition = soft_endstop_min[encoderAxis] + 10,
               endPosition = soft_endstop_max[encoderAxis] - 10,
@@ -358,7 +358,7 @@ bool I2CPositionEncoder::test_axis() {
 
   planner.synchronize();
 
-  planner.buffer_line(startCoord[X_AXIS], startCoord[Y_AXIS], startCoord[Z_AXIS],
+  planner.buffer_line(startCoord.x, startCoord.y, startCoord.z,
                       planner.get_axis_position_mm(E_AXIS), feedrate, 0);
   planner.synchronize();
 
@@ -370,7 +370,7 @@ bool I2CPositionEncoder::test_axis() {
   }
 
   if (trusted) { // if trusted, commence test
-    planner.buffer_line(endCoord[X_AXIS], endCoord[Y_AXIS], endCoord[Z_AXIS],
+    planner.buffer_line(endCoord.x, endCoord.y, endCoord.z,
                         planner.get_axis_position_mm(E_AXIS), feedrate, 0);
     planner.synchronize();
   }
@@ -391,8 +391,8 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
   float old_steps_mm, new_steps_mm,
         startDistance, endDistance,
-        travelDistance, travelledDistance, total = 0,
-        startCoord[NUM_AXIS] = { 0 }, endCoord[NUM_AXIS] = { 0 };
+        travelDistance, travelledDistance, total = 0;
+  xyze_t startCoord = { 0 }, endCoord = { 0 };
 
   float feedrate;
 
@@ -418,16 +418,16 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
   planner.synchronize();
 
   LOOP_L_N(i, iter) {
-    planner.buffer_line(startCoord[X_AXIS], startCoord[Y_AXIS], startCoord[Z_AXIS],
+    planner.buffer_line(startCoord.x, startCoord.y, startCoord.z,
                         planner.get_axis_position_mm(E_AXIS), feedrate, 0);
     planner.synchronize();
 
     delay(250);
     startCount = get_position();
 
-    //do_blocking_move_to(endCoord[X_AXIS],endCoord[Y_AXIS],endCoord[Z_AXIS]);
+    //do_blocking_move_to(endCoord.x,endCoord.y,endCoord.z);
 
-    planner.buffer_line(endCoord[X_AXIS], endCoord[Y_AXIS], endCoord[Z_AXIS],
+    planner.buffer_line(endCoord.x, endCoord.y, endCoord.z,
                         planner.get_axis_position_mm(E_AXIS), feedrate, 0);
     planner.synchronize();
 

--- a/Marlin/src/feature/I2CPositionEncoder.h
+++ b/Marlin/src/feature/I2CPositionEncoder.h
@@ -95,8 +95,6 @@
 #define LOOP_PE(VAR) LOOP_L_N(VAR, I2CPE_ENCODER_CNT)
 #define CHECK_IDX() do{ if (!WITHIN(idx, 0, I2CPE_ENCODER_CNT - 1)) return; }while(0)
 
-extern const char axis_codes[XYZE];
-
 typedef union {
   volatile int32_t val = 0;
   uint8_t          bval[4];

--- a/Marlin/src/feature/bedlevel/abl/abl.h
+++ b/Marlin/src/feature/bedlevel/abl/abl.h
@@ -32,7 +32,7 @@
   extern int bilinear_grid_spacing[2], bilinear_start[2];
   extern float bilinear_grid_factor[2],
                z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-  float bilinear_z_offset(const float raw[XYZ]);
+  float bilinear_z_offset(const xyz_t &raw);
 
   void extrapolate_unprobed_bed_level();
   void print_bilinear_leveling_grid();

--- a/Marlin/src/feature/bedlevel/bedlevel.h
+++ b/Marlin/src/feature/bedlevel/bedlevel.h
@@ -68,8 +68,8 @@ void reset_bed_level();
 #endif
 
 #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-  #define _GET_MESH_X(I) (bilinear_start[X_AXIS] + (I) * bilinear_grid_spacing[X_AXIS])
-  #define _GET_MESH_Y(J) (bilinear_start[Y_AXIS] + (J) * bilinear_grid_spacing[Y_AXIS])
+  #define _GET_MESH_X(I) (bilinear_start.x + (I) * bilinear_grid_spacing.x)
+  #define _GET_MESH_Y(J) (bilinear_start.y + (J) * bilinear_grid_spacing.y)
 #elif ENABLED(AUTO_BED_LEVELING_UBL)
   #define _GET_MESH_X(I) ubl.mesh_index_to_xpos(I)
   #define _GET_MESH_Y(J) ubl.mesh_index_to_ypos(J)

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -84,10 +84,10 @@
   #if ENABLED(UBL_DEVEL_DEBUGGING)
 
     static void debug_echo_axis(const AxisEnum axis) {
-      if (current_position[axis] == destination[axis])
+      if (current[axis] == destination[axis])
         SERIAL_ECHOPGM("-------------");
       else
-        SERIAL_ECHO_F(destination[X_AXIS], 6);
+        SERIAL_ECHO_F(destination.x, 6);
     }
 
     void debug_current_and_destination(PGM_P title) {
@@ -96,12 +96,12 @@
       // ignore the status of the g26_debug_flag
       if (*title != '!' && !g26_debug_flag) return;
 
-      const float de = destination[E_AXIS] - current_position[E_AXIS];
+      const float de = destination.e - current.e;
 
       if (de == 0.0) return; // Printing moves only
 
-      const float dx = destination[X_AXIS] - current_position[X_AXIS],
-                  dy = destination[Y_AXIS] - current_position[Y_AXIS],
+      const float dx = destination.x - current.x,
+                  dy = destination.y - current.y,
                   xy_dist = HYPOT(dx, dy);
 
       if (xy_dist == 0.0) return;
@@ -111,13 +111,13 @@
       SERIAL_ECHO_F(fpmm, 6);
 
       SERIAL_ECHOPGM("    current=( ");
-      SERIAL_ECHO_F(current_position[X_AXIS], 6);
+      SERIAL_ECHO_F(current.x, 6);
       SERIAL_ECHOPGM(", ");
-      SERIAL_ECHO_F(current_position[Y_AXIS], 6);
+      SERIAL_ECHO_F(current.y, 6);
       SERIAL_ECHOPGM(", ");
-      SERIAL_ECHO_F(current_position[Z_AXIS], 6);
+      SERIAL_ECHO_F(current.z, 6);
       SERIAL_ECHOPGM(", ");
-      SERIAL_ECHO_F(current_position[E_AXIS], 6);
+      SERIAL_ECHO_F(current.e, 6);
       SERIAL_ECHOPGM(" )   destination=( ");
       debug_echo_axis(X_AXIS);
       SERIAL_ECHOPGM(", ");
@@ -230,8 +230,8 @@
       serialprintPGM(csv ? PSTR("CSV:\n") : PSTR("LCD:\n"));
     }
 
-    const float current_xi = get_cell_index_x(current_position[X_AXIS] + (MESH_X_DIST) / 2.0),
-                current_yi = get_cell_index_y(current_position[Y_AXIS] + (MESH_Y_DIST) / 2.0);
+    const float current_xi = get_cell_index_x(current.x + (MESH_X_DIST) / 2.0),
+                current_yi = get_cell_index_y(current.y + (MESH_Y_DIST) / 2.0);
 
     if (!lcd) SERIAL_EOL();
     for (int8_t j = GRID_MAX_POINTS_Y - 1; j >= 0; j--) {

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -357,7 +357,7 @@ class unified_bed_leveling {
     }
 
     #if UBL_SEGMENTED
-      static bool prepare_segmented_line_to(const float (&rtarget)[XYZE], const float &feedrate);
+      static bool prepare_segmented_line_to(const xyze_t &rtarget, const float &feedrate);
     #else
       static void line_to_destination_cartesian(const float &fr, const uint8_t e);
     #endif

--- a/Marlin/src/feature/dac/dac_mcp4728.cpp
+++ b/Marlin/src/feature/dac/dac_mcp4728.cpp
@@ -36,7 +36,7 @@
 
 #include "dac_mcp4728.h"
 
-uint16_t mcp4728_values[XYZE];
+xyze16u_t mcp4728_values;
 
 /**
  * Begin I2C, get current values (input register and eeprom) of mcp4728
@@ -122,7 +122,7 @@ uint8_t mcp4728_getDrvPct(uint8_t channel) { return uint8_t(100.0 * mcp4728_valu
  * Receives all Drive strengths as 0-100 percent values, updates
  * DAC Values array and calls fastwrite to update the DAC.
  */
-void mcp4728_setDrvPct(uint8_t pct[XYZE]) {
+void mcp4728_setDrvPct(xyze8u_t pct) {
   LOOP_XYZE(i) mcp4728_values[i] = 0.01 * pct[i] * (DAC_STEPPER_MAX);
   mcp4728_fastWrite();
 }

--- a/Marlin/src/feature/dac/dac_mcp4728.h
+++ b/Marlin/src/feature/dac/dac_mcp4728.h
@@ -56,6 +56,6 @@ uint16_t mcp4728_getValue(uint8_t channel);
 uint8_t mcp4728_fastWrite();
 uint8_t mcp4728_simpleCommand(byte simpleCommand);
 uint8_t mcp4728_getDrvPct(uint8_t channel);
-void mcp4728_setDrvPct(uint8_t pct[XYZE]);
+void mcp4728_setDrvPct(xyze8u_t pct);
 
 #endif // DAC_MCP4728_H

--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -48,8 +48,8 @@
 #include "stepper_dac.h"
 
 bool dac_present = false;
-const uint8_t dac_order[NUM_AXIS] = DAC_STEPPER_ORDER;
-uint8_t dac_channel_pct[XYZE] = DAC_MOTOR_CURRENT_DEFAULT;
+const xyze8u_t dac_order = DAC_STEPPER_ORDER;
+xyze8u_t dac_channel_pct = DAC_MOTOR_CURRENT_DEFAULT;
 
 int dac_init() {
   #if PIN_EXISTS(DAC_DISABLE)
@@ -95,7 +95,7 @@ static float dac_perc(int8_t n) { return 100.0 * mcp4728_getValue(dac_order[n]) 
 static float dac_amps(int8_t n) { return mcp4728_getDrvPct(dac_order[n]) * (DAC_STEPPER_MAX) * 0.125 * (1.0f / (DAC_STEPPER_SENSE)); }
 
 uint8_t dac_current_get_percent(AxisEnum axis) { return mcp4728_getDrvPct(dac_order[axis]); }
-void dac_current_set_percents(const uint8_t pct[XYZE]) {
+void dac_current_set_percents(const xyze8u_t pct) {
   LOOP_XYZE(i) dac_channel_pct[i] = pct[dac_order[i]];
   mcp4728_setDrvPct(dac_channel_pct);
 }

--- a/Marlin/src/feature/dac/stepper_dac.h
+++ b/Marlin/src/feature/dac/stepper_dac.h
@@ -52,6 +52,6 @@ void dac_current_raw(uint8_t channel, uint16_t val);
 void dac_print_values();
 void dac_commit_eeprom();
 uint8_t dac_current_get_percent(AxisEnum axis);
-void dac_current_set_percents(const uint8_t pct[XYZE]);
+void dac_current_set_percents(const xyze8u_t pct);
 
 #endif // STEPPER_DAC_H

--- a/Marlin/src/feature/digipot/digipot_mcp4018.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4018.cpp
@@ -20,11 +20,10 @@
  *
  */
 
-#include "../../inc/MarlinConfig.h"
+#include "../../inc/MarlinConfigPre.h"
 
 #if ENABLED(DIGIPOT_I2C) && ENABLED(DIGIPOT_MCP4018)
 
-#include "../../core/enum.h"
 #include "Stream.h"
 #include "utility/twi.h"
 #include <SlowSoftI2CMaster.h>  //https://github.com/stawel/SlowSoftI2CMaster
@@ -62,13 +61,13 @@ const uint8_t sda_pins[DIGIPOT_I2C_NUM_CHANNELS] = {
 };
 
 static SlowSoftI2CMaster pots[DIGIPOT_I2C_NUM_CHANNELS] = {
-  SlowSoftI2CMaster { sda_pins[X_AXIS], DIGIPOTS_I2C_SCL }
+  SlowSoftI2CMaster { sda_pins.x, DIGIPOTS_I2C_SCL }
   #if DIGIPOT_I2C_NUM_CHANNELS > 1
-    , SlowSoftI2CMaster { sda_pins[Y_AXIS], DIGIPOTS_I2C_SCL }
+    , SlowSoftI2CMaster { sda_pins.y, DIGIPOTS_I2C_SCL }
     #if DIGIPOT_I2C_NUM_CHANNELS > 2
-      , SlowSoftI2CMaster { sda_pins[Z_AXIS], DIGIPOTS_I2C_SCL }
+      , SlowSoftI2CMaster { sda_pins.z, DIGIPOTS_I2C_SCL }
       #if DIGIPOT_I2C_NUM_CHANNELS > 3
-        , SlowSoftI2CMaster { sda_pins[E_AXIS], DIGIPOTS_I2C_SCL }
+        , SlowSoftI2CMaster { sda_pins.e, DIGIPOTS_I2C_SCL }
         #if DIGIPOT_I2C_NUM_CHANNELS > 4
           , SlowSoftI2CMaster { sda_pins[E_AXIS + 1], DIGIPOTS_I2C_SCL }
         #endif

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -123,8 +123,8 @@ void FWRetract::retract(const bool retracting
         SERIAL_ECHOLNPAIR("] ", retracted_swap[i]);
       #endif
     }
-    SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);
-    SERIAL_ECHOLNPAIR("current_position[e] ", current_position[E_AXIS]);
+    SERIAL_ECHOLNPAIR("current.z ", current.z);
+    SERIAL_ECHOLNPAIR("current.e ", current.e);
     SERIAL_ECHOLNPAIR("current_hop ", current_hop);
   //*/
 
@@ -161,7 +161,7 @@ void FWRetract::retract(const bool retracting
     // Is a Z hop set, and has the hop not yet been done?
     if (settings.retract_zraise > 0.01 && !current_hop) {           // Apply hop only once
       current_hop += settings.retract_zraise;                       // Add to the hop total (again, only once)
-      feedrate_mm_s = planner.settings.max_feedrate_mm_s[Z_AXIS] * unscale_fr;  // Maximum Z feedrate
+      feedrate_mm_s = planner.settings.max_feedrate_mm_s.c * unscale_fr;  // Maximum Z feedrate
       prepare_move_to_destination();                      // Raise up, set_current_to_destination
       planner.synchronize();                              // Wait for move to complete
     }
@@ -170,14 +170,14 @@ void FWRetract::retract(const bool retracting
     // If a hop was done and Z hasn't changed, undo the Z hop
     if (current_hop) {
       current_hop = 0.0;
-      feedrate_mm_s = planner.settings.max_feedrate_mm_s[Z_AXIS] * unscale_fr;  // Z feedrate to max
+      feedrate_mm_s = planner.settings.max_feedrate_mm_s.c * unscale_fr;  // Z feedrate to max
       prepare_move_to_destination();                      // Lower Z, set_current_to_destination
       planner.synchronize();                              // Wait for move to complete
     }
 
     const float extra_recover = swapping ? settings.swap_retract_recover_length : settings.retract_recover_length;
     if (extra_recover != 0.0) {
-      current_position[E_AXIS] -= extra_recover;          // Adjust the current E position by the extra amount to recover
+      current.e -= extra_recover;          // Adjust the current E position by the extra amount to recover
       sync_plan_position_e();                             // Sync the planner position so the extra amount is recovered
     }
 
@@ -216,8 +216,8 @@ void FWRetract::retract(const bool retracting
         SERIAL_ECHOLNPAIR("] ", retracted_swap[i]);
       #endif
     }
-    SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);
-    SERIAL_ECHOLNPAIR("current_position[e] ", current_position[E_AXIS]);
+    SERIAL_ECHOLNPAIR("current.z ", current.z);
+    SERIAL_ECHOLNPAIR("current.e ", current.e);
     SERIAL_ECHOLNPAIR("current_hop ", current_hop);
   //*/
 }

--- a/Marlin/src/feature/power.h
+++ b/Marlin/src/feature/power.h
@@ -19,13 +19,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 /**
  * power.h - power control
  */
-
-#ifndef POWER_H
-#define POWER_H
 
 #include "../core/types.h"
 
@@ -40,5 +38,3 @@ class Power {
 };
 
 extern Power powerManager;
-
-#endif // POWER_H

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -58,9 +58,9 @@ extern uint8_t commands_in_queue, cmd_queue_index_r;
     SERIAL_PROTOCOLLNPAIR(" valid_foot:", int(job_recovery_info.valid_foot));
     if (job_recovery_info.valid_head) {
       if (job_recovery_info.valid_head == job_recovery_info.valid_foot) {
-        SERIAL_PROTOCOLPGM("current_position: ");
+        SERIAL_PROTOCOLPGM("current: ");
         LOOP_XYZE(i) {
-          SERIAL_PROTOCOL(job_recovery_info.current_position[i]);
+          SERIAL_PROTOCOL(job_recovery_info.current[i]);
           if (i < E_AXIS) SERIAL_CHAR(',');
         }
         SERIAL_EOL();
@@ -182,8 +182,8 @@ void check_print_job_recovery() {
           fwretract.current_hop = job_recovery_info.retract_hop;
         #endif
 
-        dtostrf(job_recovery_info.current_position[Z_AXIS] + 2, 1, 3, str_1);
-        dtostrf(job_recovery_info.current_position[E_AXIS]
+        dtostrf(job_recovery_info.current.z + 2, 1, 3, str_1);
+        dtostrf(job_recovery_info.current.e
           #if ENABLED(SAVE_EACH_CMD_MODE)
             - 5
           #endif
@@ -238,7 +238,7 @@ void save_job_recovery_info() {
         ELAPSED(ms, next_save_ms) ||
       #endif
       // Save on every new Z height
-      (current_position[Z_AXIS] > 0 && current_position[Z_AXIS] > job_recovery_info.current_position[Z_AXIS])
+      (current.z > 0 && current.z > job_recovery_info.current.z)
     #endif
   ) {
     #if SAVE_INFO_INTERVAL_MS > 0
@@ -250,7 +250,7 @@ void save_job_recovery_info() {
     job_recovery_info.valid_foot = job_recovery_info.valid_head;
 
     // Machine state
-    COPY(job_recovery_info.current_position, current_position);
+    job_recovery_info.current = current;
     job_recovery_info.feedrate = feedrate_mm_s;
 
     #if HOTENDS > 1

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -36,7 +36,8 @@ typedef struct {
   uint8_t valid_head;
 
   // Machine state
-  float current_position[NUM_AXIS], feedrate;
+  xyze_t current;
+  float feedrate;
 
   #if HOTENDS > 1
     uint8_t active_hotend;

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -19,16 +19,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 /**
  * power_loss_recovery.h - Resume an SD print after power-loss
  */
 
-#ifndef _POWER_LOSS_RECOVERY_H_
-#define _POWER_LOSS_RECOVERY_H_
-
 #include "../sd/cardreader.h"
-#include "../core/types.h"
 #include "../inc/MarlinConfigPre.h"
 
 #define SAVE_INFO_INTERVAL_MS 0
@@ -99,5 +96,3 @@ extern uint8_t job_recovery_commands_count;
 
 void check_print_job_recovery();
 void save_job_recovery_info();
-
-#endif // _POWER_LOSS_RECOVERY_H_

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -456,66 +456,46 @@
 
   static void tmc_debug_loop(const TMC_debug_enum i) {
     #if AXIS_IS_TMC(X)
-      tmc_status(stepperX, i, planner.settings.axis_steps_per_mm[X_AXIS]);
+      tmc_status(stepperX, i, planner.settings.axis_steps_per_mm.a);
     #endif
     #if AXIS_IS_TMC(X2)
-      tmc_status(stepperX2, i, planner.settings.axis_steps_per_mm[X_AXIS]);
+      tmc_status(stepperX2, i, planner.settings.axis_steps_per_mm.a);
     #endif
 
     #if AXIS_IS_TMC(Y)
-      tmc_status(stepperY, i, planner.settings.axis_steps_per_mm[Y_AXIS]);
+      tmc_status(stepperY, i, planner.settings.axis_steps_per_mm.b);
     #endif
     #if AXIS_IS_TMC(Y2)
-      tmc_status(stepperY2, i, planner.settings.axis_steps_per_mm[Y_AXIS]);
+      tmc_status(stepperY2, i, planner.settings.axis_steps_per_mm.b);
     #endif
 
     #if AXIS_IS_TMC(Z)
-      tmc_status(stepperZ, i, planner.settings.axis_steps_per_mm[Z_AXIS]);
+      tmc_status(stepperZ, i, planner.settings.axis_steps_per_mm.c);
     #endif
     #if AXIS_IS_TMC(Z2)
-      tmc_status(stepperZ2, i, planner.settings.axis_steps_per_mm[Z_AXIS]);
+      tmc_status(stepperZ2, i, planner.settings.axis_steps_per_mm.c);
     #endif
     #if AXIS_IS_TMC(Z3)
-      tmc_status(stepperZ3, i, planner.settings.axis_steps_per_mm[Z_AXIS]);
+      tmc_status(stepperZ3, i, planner.settings.axis_steps_per_mm.c);
     #endif
 
     #if AXIS_IS_TMC(E0)
-      tmc_status(stepperE0, i, planner.settings.axis_steps_per_mm[E_AXIS]);
+      tmc_status(stepperE0, i, planner.settings.axis_steps_per_mm.E(0));
     #endif
     #if AXIS_IS_TMC(E1)
-      tmc_status(stepperE1, i, planner.settings.axis_steps_per_mm[E_AXIS
-        #if ENABLED(DISTINCT_E_FACTORS)
-          + 1
-        #endif
-      ]);
+      tmc_status(stepperE1, i, planner.settings.axis_steps_per_mm.E(1));
     #endif
     #if AXIS_IS_TMC(E2)
-      tmc_status(stepperE2, i, planner.settings.axis_steps_per_mm[E_AXIS
-        #if ENABLED(DISTINCT_E_FACTORS)
-          + 2
-        #endif
-      ]);
+      tmc_status(stepperE2, i, planner.settings.axis_steps_per_mm.E(2));
     #endif
     #if AXIS_IS_TMC(E3)
-      tmc_status(stepperE3, i, planner.settings.axis_steps_per_mm[E_AXIS
-        #if ENABLED(DISTINCT_E_FACTORS)
-          + 3
-        #endif
-      ]);
+      tmc_status(stepperE3, i, planner.settings.axis_steps_per_mm.E(3));
     #endif
     #if AXIS_IS_TMC(E4)
-      tmc_status(stepperE4, i, planner.settings.axis_steps_per_mm[E_AXIS
-        #if ENABLED(DISTINCT_E_FACTORS)
-          + 4
-        #endif
-      ]);
+      tmc_status(stepperE4, i, planner.settings.axis_steps_per_mm.E(4));
     #endif
     #if AXIS_IS_TMC(E5)
-      tmc_status(stepperE5, i, planner.settings.axis_steps_per_mm[E_AXIS
-        #if ENABLED(DISTINCT_E_FACTORS)
-          + 5
-        #endif
-      ]);
+      tmc_status(stepperE5, i, planner.settings.axis_steps_per_mm.E(5));
     #endif
 
     SERIAL_EOL();

--- a/Marlin/src/gcode/bedlevel/G42.cpp
+++ b/Marlin/src/gcode/bedlevel/G42.cpp
@@ -45,11 +45,11 @@ void GcodeSuite::G42() {
     }
 
     set_destination_from_current();
-    if (hasI) destination[X_AXIS] = _GET_MESH_X(ix);
-    if (hasJ) destination[Y_AXIS] = _GET_MESH_Y(iy);
+    if (hasI) destination.x = _GET_MESH_X(ix);
+    if (hasJ) destination.y = _GET_MESH_Y(iy);
     if (parser.boolval('P')) {
-      if (hasI) destination[X_AXIS] -= X_PROBE_OFFSET_FROM_EXTRUDER;
-      if (hasJ) destination[Y_AXIS] -= Y_PROBE_OFFSET_FROM_EXTRUDER;
+      if (hasI) destination.x -= X_PROBE_OFFSET_FROM_EXTRUDER;
+      if (hasJ) destination.y -= Y_PROBE_OFFSET_FROM_EXTRUDER;
     }
 
     const float fval = parser.linearval('F');

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -58,7 +58,7 @@ void GcodeSuite::M420() {
   // (Don't disable for just M420 or M420 V)
   if (seen_S && !to_enable) set_bed_leveling_enabled(false);
 
-  const float oldpos[] = { current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] };
+  const xyze_t oldpos = current;
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
 
@@ -207,7 +207,7 @@ void GcodeSuite::M420() {
   #endif
 
   // Report change in position
-  if (memcmp(oldpos, current_position, sizeof(oldpos)))
+  if (memcmp(&oldpos, &current, sizeof(oldpos)))
     report_current_position();
 }
 

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -112,7 +112,7 @@ void GcodeSuite::G29() {
       }
       else {
         // Save Z for the previous mesh position
-        mbl.set_zigzag_z(mbl_probe_index - 1, current_position[Z_AXIS]);
+        mbl.set_zigzag_z(mbl_probe_index - 1, current.z);
         #if HAS_SOFTWARE_ENDSTOPS
           soft_endstops_enabled = enable_soft_endstops;
         #endif
@@ -130,7 +130,7 @@ void GcodeSuite::G29() {
       }
       else {
         // One last "return to the bed" (as originally coded) at completion
-        current_position[Z_AXIS] = MANUAL_PROBE_HEIGHT;
+        current.z = MANUAL_PROBE_HEIGHT;
         line_to_current_position();
         planner.synchronize();
 
@@ -144,7 +144,7 @@ void GcodeSuite::G29() {
         set_bed_leveling_enabled(true);
 
         #if ENABLED(MESH_G28_REST_ORIGIN)
-          current_position[Z_AXIS] = 0;
+          current.z = 0;
           set_destination_from_current();
           buffer_line_to_destination(homing_feedrate(Z_AXIS));
           planner.synchronize();

--- a/Marlin/src/gcode/bedlevel/ubl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/M421.cpp
@@ -51,7 +51,7 @@ void GcodeSuite::M421() {
              hasQ = !hasZ && parser.seen('Q');
 
   if (hasC) {
-    const mesh_index_pair location = ubl.find_closest_mesh_point_of_type(REAL, current_position[X_AXIS], current_position[Y_AXIS], USE_NOZZLE_AS_REFERENCE, NULL);
+    const mesh_index_pair location = ubl.find_closest_mesh_point_of_type(REAL, current.x, current.y, USE_NOZZLE_AS_REFERENCE, NULL);
     ix = location.x_index;
     iy = location.y_index;
   }

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -70,8 +70,8 @@ void GcodeSuite::M48() {
 
   const ProbePtRaise raise_after = parser.boolval('E') ? PROBE_PT_STOW : PROBE_PT_RAISE;
 
-  float X_current = current_position[X_AXIS],
-        Y_current = current_position[Y_AXIS];
+  float X_current = current.x,
+        Y_current = current.y;
 
   const float X_probe_location = parser.linearval('X', X_current + X_PROBE_OFFSET_FROM_EXTRUDER),
               Y_probe_location = parser.linearval('Y', Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER);
@@ -181,7 +181,7 @@ void GcodeSuite::M48() {
             SERIAL_PROTOCOLPGM("Going to:");
             SERIAL_ECHOPAIR(" X", X_current);
             SERIAL_ECHOPAIR(" Y", Y_current);
-            SERIAL_ECHOLNPAIR(" Z", current_position[Z_AXIS]);
+            SERIAL_ECHOLNPAIR(" Z", current.z);
           }
           do_blocking_move_to_xy(X_current, Y_current);
         } // n_legs loop

--- a/Marlin/src/gcode/calibrate/M665.cpp
+++ b/Marlin/src/gcode/calibrate/M665.cpp
@@ -48,9 +48,9 @@
     if (parser.seen('R')) delta_radius                   = parser.value_linear_units();
     if (parser.seen('S')) delta_segments_per_second      = parser.value_float();
     if (parser.seen('B')) delta_calibration_radius       = parser.value_float();
-    if (parser.seen('X')) delta_tower_angle_trim[A_AXIS] = parser.value_float();
-    if (parser.seen('Y')) delta_tower_angle_trim[B_AXIS] = parser.value_float();
-    if (parser.seen('Z')) delta_tower_angle_trim[C_AXIS] = parser.value_float();
+    if (parser.seen('X')) delta_tower_angle_trim.a = parser.value_float();
+    if (parser.seen('Y')) delta_tower_angle_trim.b = parser.value_float();
+    if (parser.seen('Z')) delta_tower_angle_trim.c = parser.value_float();
     recalc_delta_settings();
   }
 
@@ -76,7 +76,7 @@
     const bool hasA = parser.seen('A'), hasP = parser.seen('P'), hasX = parser.seen('X');
     const uint8_t sumAPX = hasA + hasP + hasX;
     if (sumAPX == 1)
-      home_offset[A_AXIS] = parser.value_float();
+      home_offset.a = parser.value_float();
     else if (sumAPX > 1) {
       SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM("Only one of A, P, or X is allowed.");
@@ -86,7 +86,7 @@
     const bool hasB = parser.seen('B'), hasT = parser.seen('T'), hasY = parser.seen('Y');
     const uint8_t sumBTY = hasB + hasT + hasY;
     if (sumBTY == 1)
-      home_offset[B_AXIS] = parser.value_float();
+      home_offset.b = parser.value_float();
     else if (sumBTY > 1) {
       SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM("Only one of B, T, or Y is allowed.");

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -59,8 +59,8 @@ void GcodeSuite::M201() {
 
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i])) {
-      const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
-      planner.settings.max_acceleration_mm_per_s2[a] = parser.value_axis_units((AxisEnum)a);
+      const uint8_t a = (i == E_AXIS ? E_AXIS_N(gcode.target_extruder) : i);
+      planner.settings.max_acceleration_mm_per_s2.a = parser.value_axis_units((AxisEnum)a);
     }
   }
   // steps per sq second need to be updated to agree with the units per sq second (as they are what is used in the planner)
@@ -78,8 +78,8 @@ void GcodeSuite::M203() {
 
   LOOP_XYZE(i)
     if (parser.seen(axis_codes[i])) {
-      const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
-      planner.settings.max_feedrate_mm_s[a] = parser.value_axis_units((AxisEnum)a);
+      const uint8_t a = (i == E_AXIS ? E_AXIS_N(gcode.target_extruder) : i);
+      planner.settings.max_feedrate_mm_s.a = parser.value_axis_units((AxisEnum)a);
     }
 }
 
@@ -147,17 +147,17 @@ void GcodeSuite::M205() {
     }
   #endif
   #if HAS_CLASSIC_JERK
-    if (parser.seen('X')) planner.max_jerk[X_AXIS] = parser.value_linear_units();
-    if (parser.seen('Y')) planner.max_jerk[Y_AXIS] = parser.value_linear_units();
+    if (parser.seen('X')) planner.max_jerk.a = parser.value_linear_units();
+    if (parser.seen('Y')) planner.max_jerk.b = parser.value_linear_units();
     if (parser.seen('Z')) {
-      planner.max_jerk[Z_AXIS] = parser.value_linear_units();
+      planner.max_jerk.c = parser.value_linear_units();
       #if HAS_MESH
-        if (planner.max_jerk[Z_AXIS] <= 0.1f)
+        if (planner.max_jerk.c <= 0.1f)
           SERIAL_ECHOLNPGM("WARNING! Low Z Jerk may lead to unwanted pauses.");
       #endif
     }
     #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
-      if (parser.seen('E')) planner.max_jerk[E_AXIS] = parser.value_linear_units();
+      if (parser.seen('E')) planner.max_jerk.e = parser.value_linear_units();
     #endif
   #endif
 }

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -44,15 +44,15 @@ void GcodeSuite::M218() {
 
   bool report = true;
   if (parser.seenval('X')) {
-    hotend_offset[X_AXIS][target_extruder] = parser.value_linear_units();
+    hotend_offset[target_extruder].x = parser.value_linear_units();
     report = false;
   }
   if (parser.seenval('Y')) {
-    hotend_offset[Y_AXIS][target_extruder] = parser.value_linear_units();
+    hotend_offset[target_extruder].y = parser.value_linear_units();
     report = false;
   }
   if (parser.seenval('Z')) {
-    hotend_offset[Z_AXIS][target_extruder] = parser.value_linear_units();
+    hotend_offset[target_extruder].z = parser.value_linear_units();
     report = false;
   }
 
@@ -61,18 +61,18 @@ void GcodeSuite::M218() {
     SERIAL_ECHOPGM(MSG_HOTEND_OFFSET);
     HOTEND_LOOP() {
       SERIAL_CHAR(' ');
-      SERIAL_ECHO(hotend_offset[X_AXIS][e]);
+      SERIAL_ECHO(hotend_offset[e].x);
       SERIAL_CHAR(',');
-      SERIAL_ECHO(hotend_offset[Y_AXIS][e]);
+      SERIAL_ECHO(hotend_offset[e].y);
       SERIAL_CHAR(',');
-      SERIAL_ECHO_F(hotend_offset[Z_AXIS][e], 3);
+      SERIAL_ECHO_F(hotend_offset[e].z, 3);
     }
     SERIAL_EOL();
   }
 
   #if ENABLED(DELTA)
     if (target_extruder == active_extruder)
-      do_blocking_move_to_xy(current_position[X_AXIS], current_position[Y_AXIS], planner.settings.max_feedrate_mm_s[X_AXIS]);
+      do_blocking_move_to_xy(current.x, current.y, planner.settings.max_feedrate_mm_s.a);
   #endif
 }
 

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -36,16 +36,16 @@ void GcodeSuite::M92() {
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i])) {
       if (i == E_AXIS) {
-        const float value = parser.value_per_axis_units((AxisEnum)(E_AXIS + TARGET_EXTRUDER));
+        const float value = parser.value_per_axis_units((AxisEnum)(E_AXIS_N(gcode.target_extruder)));
         if (value < 20) {
-          float factor = planner.settings.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] / value; // increase e constants if M92 E14 is given for netfab.
+          float factor = planner.settings.axis_steps_per_mm[E_AXIS_N(gcode.target_extruder)] / value; // increase e constants if M92 E14 is given for netfab.
           #if HAS_CLASSIC_JERK && (DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE))
-            planner.max_jerk[E_AXIS] *= factor;
+            planner.max_jerk.e *= factor;
           #endif
-          planner.settings.max_feedrate_mm_s[E_AXIS + TARGET_EXTRUDER] *= factor;
-          planner.max_acceleration_steps_per_s2[E_AXIS + TARGET_EXTRUDER] *= factor;
+          planner.settings.max_feedrate_mm_s[E_AXIS_N(gcode.target_extruder)] *= factor;
+          planner.max_acceleration_steps_per_s2[E_AXIS_N(gcode.target_extruder)] *= factor;
         }
-        planner.settings.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] = value;
+        planner.settings.axis_steps_per_mm[E_AXIS_N(gcode.target_extruder)] = value;
       }
       else {
         planner.settings.axis_steps_per_mm[i] = parser.value_per_axis_units((AxisEnum)i);

--- a/Marlin/src/gcode/control/M211.cpp
+++ b/Marlin/src/gcode/control/M211.cpp
@@ -38,11 +38,11 @@ void GcodeSuite::M211() {
     SERIAL_ECHOPGM(MSG_OFF);
   #endif
   SERIAL_ECHOPGM(MSG_SOFT_MIN);
-  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(soft_endstop_min[X_AXIS]));
-  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_min[Y_AXIS]));
-  SERIAL_ECHOPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_min[Z_AXIS]));
+  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(soft_endstop_min.x));
+  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_min.y));
+  SERIAL_ECHOPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_min.z));
   SERIAL_ECHOPGM(MSG_SOFT_MAX);
-  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(soft_endstop_max[X_AXIS]));
-  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_max[Y_AXIS]));
-  SERIAL_ECHOLNPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_max[Z_AXIS]));
+  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(soft_endstop_max.x));
+  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_max.y));
+  SERIAL_ECHOLNPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_max.z));
 }

--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -70,9 +70,9 @@
         }
         scaled_duplication_mode = true;
         stepper.set_directions();
-        float x_jog = current_position[X_AXIS] - .1;
+        float x_jog = current.x - .1;
         for (uint8_t i = 2; --i;) {
-          planner.buffer_line(x_jog, current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], feedrate_mm_s, 0);
+          planner.buffer_line(x_jog, current.y, current.z, current.e, feedrate_mm_s, 0);
           x_jog += .1;
         }
         return;
@@ -111,7 +111,7 @@
       SERIAL_ECHOPAIR("\nActive Ext: ", int(active_extruder));
       if (!active_extruder_parked) SERIAL_ECHOPGM(" NOT ");
       SERIAL_ECHOPGM(" parked.");
-      SERIAL_ECHOPAIR("\nactive_extruder_x_pos: ", current_position[X_AXIS]);
+      SERIAL_ECHOPAIR("\nactive_extruder_x_pos: ", current.x);
       SERIAL_ECHOPAIR("\ninactive_extruder_x_pos: ", inactive_extruder_x_pos);
       SERIAL_ECHOPAIR("\nextruder_duplication_enabled: ", int(extruder_duplication_enabled));
       SERIAL_ECHOPAIR("\nduplicate_extruder_x_offset: ", duplicate_extruder_x_offset);
@@ -137,7 +137,7 @@
           SERIAL_ECHOPGM("    hotend_offset[");
           SERIAL_CHAR(axis_codes[j]);
           SERIAL_ECHOPAIR("_AXIS][", int(i));
-          SERIAL_ECHOPAIR("]=", hotend_offset[j][i]);
+          SERIAL_ECHOPAIR("]=", hotend_offset[i][j]);
         }
         SERIAL_EOL();
       }

--- a/Marlin/src/gcode/control/T.cpp
+++ b/Marlin/src/gcode/control/T.cpp
@@ -40,7 +40,7 @@ void GcodeSuite::T(const uint8_t tmp_extruder) {
       SERIAL_ECHOPAIR(">>> T(", tmp_extruder);
       SERIAL_CHAR(')');
       SERIAL_EOL();
-      DEBUG_POS("BEFORE", current_position);
+      DEBUG_POS("BEFORE", current);
     }
   #endif
 
@@ -60,7 +60,7 @@ void GcodeSuite::T(const uint8_t tmp_extruder) {
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
-      DEBUG_POS("AFTER", current_position);
+      DEBUG_POS("AFTER", current);
       SERIAL_ECHOLNPGM("<<< T()");
     }
   #endif

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -66,8 +66,8 @@ void GcodeSuite::M125() {
   if (parser.seenval('Z')) park_point.z = parser.linearval('Z');
 
   #if HAS_HOTEND_OFFSET && DISABLED(DUAL_X_CARRIAGE) && DISABLED(DELTA)
-    park_point.x += (active_extruder ? hotend_offset[X_AXIS][active_extruder] : 0);
-    park_point.y += (active_extruder ? hotend_offset[Y_AXIS][active_extruder] : 0);
+    park_point.x += (active_extruder ? hotend_offset[active_extruder].x : 0);
+    park_point.y += (active_extruder ? hotend_offset[active_extruder].y : 0);
   #endif
 
   #if DISABLED(SDSUPPORT)

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -105,8 +105,8 @@ void GcodeSuite::M600() {
   if (parser.seenval('Y')) park_point.y = parser.linearval('Y');
 
   #if HAS_HOTEND_OFFSET && DISABLED(DUAL_X_CARRIAGE) && DISABLED(DELTA)
-    park_point.x += (active_extruder ? hotend_offset[X_AXIS][active_extruder] : 0);
-    park_point.y += (active_extruder ? hotend_offset[Y_AXIS][active_extruder] : 0);
+    park_point.x += (active_extruder ? hotend_offset[active_extruder].x : 0);
+    park_point.y += (active_extruder ? hotend_offset[active_extruder].y : 0);
   #endif
 
   // Unload filament

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -74,7 +74,7 @@ void GcodeSuite::M701() {
 
   // Lift Z axis
   if (park_point.z > 0)
-    do_blocking_move_to_z(MIN(current_position[Z_AXIS] + park_point.z, Z_MAX_POS), NOZZLE_PARK_Z_FEEDRATE);
+    do_blocking_move_to_z(MIN(current.z + park_point.z, Z_MAX_POS), NOZZLE_PARK_Z_FEEDRATE);
 
   // Load filament
   constexpr float slow_load_length = FILAMENT_CHANGE_SLOW_LOAD_LENGTH;
@@ -89,7 +89,7 @@ void GcodeSuite::M701() {
 
   // Restore Z axis
   if (park_point.z > 0)
-    do_blocking_move_to_z(MAX(current_position[Z_AXIS] - park_point.z, 0), NOZZLE_PARK_Z_FEEDRATE);
+    do_blocking_move_to_z(MAX(current.z - park_point.z, 0), NOZZLE_PARK_Z_FEEDRATE);
 
   #if EXTRUDERS > 1
     // Restore toolhead if it was changed
@@ -140,7 +140,7 @@ void GcodeSuite::M702() {
 
   // Lift Z axis
   if (park_point.z > 0)
-    do_blocking_move_to_z(MIN(current_position[Z_AXIS] + park_point.z, Z_MAX_POS), NOZZLE_PARK_Z_FEEDRATE);
+    do_blocking_move_to_z(MIN(current.z + park_point.z, Z_MAX_POS), NOZZLE_PARK_Z_FEEDRATE);
 
   // Unload filament
   #if EXTRUDERS > 1 && ENABLED(FILAMENT_UNLOAD_ALL_EXTRUDERS)
@@ -162,7 +162,7 @@ void GcodeSuite::M702() {
 
   // Restore Z axis
   if (park_point.z > 0)
-    do_blocking_move_to_z(MAX(current_position[Z_AXIS] - park_point.z, 0), NOZZLE_PARK_Z_FEEDRATE);
+    do_blocking_move_to_z(MAX(current.z - park_point.z, 0), NOZZLE_PARK_Z_FEEDRATE);
 
   #if EXTRUDERS > 1
     // Restore toolhead if it was changed

--- a/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
@@ -93,14 +93,14 @@
    *       M912 E1  ; clear E1 only
    */
   void GcodeSuite::M912() {
-      const bool hasX = parser.seen(axis_codes[X_AXIS]),
-                 hasY = parser.seen(axis_codes[Y_AXIS]),
-                 hasZ = parser.seen(axis_codes[Z_AXIS]),
-                 hasE = parser.seen(axis_codes[E_AXIS]),
+      const bool hasX = parser.seen(axis_codes.x),
+                 hasY = parser.seen(axis_codes.y),
+                 hasZ = parser.seen(axis_codes.z),
+                 hasE = parser.seen(axis_codes.e),
                  hasNone = !hasX && !hasY && !hasZ && !hasE;
 
       #if M91x_USE(X) || M91x_USE(X2)
-        const int8_t xval = int8_t(parser.byteval(axis_codes[X_AXIS], 0xFF));
+        const int8_t xval = int8_t(parser.byteval(axis_codes.x, 0xFF));
         #if M91x_USE(X)
           if (hasNone || xval == 1 || (hasX && xval < 0)) tmc_clear_otpw(stepperX);
         #endif
@@ -110,7 +110,7 @@
       #endif
 
       #if M91x_USE(Y) || M91x_USE(Y2)
-        const int8_t yval = int8_t(parser.byteval(axis_codes[Y_AXIS], 0xFF));
+        const int8_t yval = int8_t(parser.byteval(axis_codes.y, 0xFF));
         #if M91x_USE(Y)
           if (hasNone || yval == 1 || (hasY && yval < 0)) tmc_clear_otpw(stepperY);
         #endif
@@ -120,7 +120,7 @@
       #endif
 
       #if M91x_USE(Z) || M91x_USE(Z2) || M91x_USE(Z3)
-        const int8_t zval = int8_t(parser.byteval(axis_codes[Z_AXIS], 0xFF));
+        const int8_t zval = int8_t(parser.byteval(axis_codes.z, 0xFF));
         #if M91x_USE(Z)
           if (hasNone || zval == 1 || (hasZ && zval < 0)) tmc_clear_otpw(stepperZ);
         #endif
@@ -133,7 +133,7 @@
       #endif
 
       #if M91x_USE_E(0) || M91x_USE_E(1) || M91x_USE_E(2) || M91x_USE_E(3) || M91x_USE_E(4) || M91x_USE_E(5)
-        const int8_t eval = int8_t(parser.byteval(axis_codes[E_AXIS], 0xFF));
+        const int8_t eval = int8_t(parser.byteval(axis_codes.e, 0xFF));
         #if M91x_USE_E(0)
           if (hasNone || eval == 0 || (hasE && eval < 0)) tmc_clear_otpw(stepperE0);
         #endif
@@ -163,8 +163,8 @@
   void GcodeSuite::M913() {
     #define TMC_SAY_PWMTHRS(A,Q) tmc_get_pwmthrs(stepper##Q, planner.settings.axis_steps_per_mm[_AXIS(A)])
     #define TMC_SET_PWMTHRS(A,Q) tmc_set_pwmthrs(stepper##Q, value, planner.settings.axis_steps_per_mm[_AXIS(A)])
-    #define TMC_SAY_PWMTHRS_E(E) tmc_get_pwmthrs(stepperE##E, planner.settings.axis_steps_per_mm[E_AXIS_N(E)])
-    #define TMC_SET_PWMTHRS_E(E) tmc_set_pwmthrs(stepperE##E, value, planner.settings.axis_steps_per_mm[E_AXIS_N(E)])
+    #define TMC_SAY_PWMTHRS_E(N) tmc_get_pwmthrs(stepperE##N, planner.settings.axis_steps_per_mm.E(N))
+    #define TMC_SET_PWMTHRS_E(N) tmc_set_pwmthrs(stepperE##N, value, planner.settings.axis_steps_per_mm.E(N))
 
     bool report = true;
     const uint8_t index = parser.byteval('I');

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -197,7 +197,7 @@
  * M410 - Quickstop. Abort all planned moves.
  * M420 - Enable/Disable Leveling (with current values) S1=enable S0=disable (Requires MESH_BED_LEVELING or ABL)
  * M421 - Set a single Z coordinate in the Mesh Leveling grid. X<units> Y<units> Z<units> (Requires MESH_BED_LEVELING, AUTO_BED_LEVELING_BILINEAR, or AUTO_BED_LEVELING_UBL)
- * M428 - Set the home_offset based on the current_position. Nearest edge applies. (Disabled by NO_WORKSPACE_OFFSETS or DELTA)
+ * M428 - Set the home_offset based on the current. Nearest edge applies. (Disabled by NO_WORKSPACE_OFFSETS or DELTA)
  * M500 - Store parameters in EEPROM. (Requires EEPROM_SETTINGS)
  * M501 - Restore parameters from EEPROM. (Requires EEPROM_SETTINGS)
  * M502 - Revert to the default "factory settings". ** Does not write them to EEPROM! **
@@ -266,7 +266,7 @@ public:
 
   static uint8_t target_extruder;
 
-  static bool axis_relative_modes[];
+  static xyze_bool_t axis_relative_modes;
 
   #if ENABLED(CNC_WORKSPACE_PLANES)
     /**
@@ -280,7 +280,7 @@ public:
   #define MAX_COORDINATE_SYSTEMS 9
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
     static int8_t active_coordinate_system;
-    static float coordinate_system[MAX_COORDINATE_SYSTEMS][XYZ];
+    static xyz_t coordinate_system[MAX_COORDINATE_SYSTEMS];
     static bool select_coordinate_system(const int8_t _new);
   #endif
 
@@ -306,11 +306,9 @@ public:
    * Multi-stepper support for M92, M201, M203
    */
   #if ENABLED(DISTINCT_E_FACTORS)
-    #define GET_TARGET_EXTRUDER() if (gcode.get_target_extruder_from_command()) return
-    #define TARGET_EXTRUDER gcode.target_extruder
+    #define GET_TARGET_EXTRUDER() do{ if (gcode.get_target_extruder_from_command()) return; }while(0)
   #else
     #define GET_TARGET_EXTRUDER() NOOP
-    #define TARGET_EXTRUDER 0
   #endif
 
   #if ENABLED(HOST_KEEPALIVE_FEATURE)

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -34,7 +34,7 @@
 bool GcodeSuite::select_coordinate_system(const int8_t _new) {
   if (active_coordinate_system == _new) return false;
   planner.synchronize();
-  float old_offset[XYZ] = { 0 }, new_offset[XYZ] = { 0 };
+  xyz_t old_offset = { 0 }, new_offset = { 0 };
   if (WITHIN(active_coordinate_system, 0, MAX_COORDINATE_SYSTEMS - 1))
     COPY(old_offset, coordinate_system[active_coordinate_system]);
   if (WITHIN(_new, 0, MAX_COORDINATE_SYSTEMS - 1))

--- a/Marlin/src/gcode/geometry/G92.cpp
+++ b/Marlin/src/gcode/geometry/G92.cpp
@@ -67,15 +67,15 @@ void GcodeSuite::G92() {
     if (parser.seenval(axis_codes[i])) {
       const float l = parser.value_axis_units((AxisEnum)i),
                   v = i == E_AXIS ? l : LOGICAL_TO_NATIVE(l, i),
-                  d = v - current_position[i];
+                  d = v - current[i];
       if (!NEAR_ZERO(d)) {
         #if IS_SCARA || !HAS_POSITION_SHIFT
           if (i == E_AXIS) didE = true; else didXYZ = true;
-          current_position[i] = v;        // Without workspaces revert to Marlin 1.0 behavior
+          current[i] = v;        // Without workspaces revert to Marlin 1.0 behavior
         #elif HAS_POSITION_SHIFT
           if (i == E_AXIS) {
             didE = true;
-            current_position[E_AXIS] = v; // When using coordinate spaces, only E is set directly
+            current.e = v; // When using coordinate spaces, only E is set directly
           }
           else {
             position_shift[i] += d;       // Other axes simply offset the coordinate space

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -52,7 +52,7 @@ void GcodeSuite::M206() {
 
 /**
  * M428: Set home_offset based on the distance between the
- *       current_position and the nearest "reference point."
+ *       current and the nearest "reference point."
  *       If an axis is past center its endstop position
  *       is the reference-point. Otherwise it uses 0. This allows
  *       the Z offset to be set near the bed when using a max endstop.
@@ -64,11 +64,11 @@ void GcodeSuite::M206() {
 void GcodeSuite::M428() {
   if (axis_unhomed_error()) return;
 
-  float diff[XYZ];
+  xyz_t diff;
   LOOP_XYZ(i) {
-    diff[i] = base_home_pos((AxisEnum)i) - current_position[i];
-    if (!WITHIN(diff[i], -20, 20) && home_dir((AxisEnum)i) > 0)
-      diff[i] = -current_position[i];
+    diff[i] = base_home_pos[i] - current[i];
+    if (!WITHIN(diff[i], -20, 20) && home_dir[i] > 0)
+      diff[i] = -current[i];
     if (!WITHIN(diff[i], -20, 20)) {
       SERIAL_ERROR_START();
       SERIAL_ERRORLNPGM(MSG_ERR_M428_TOO_FAR);

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -44,17 +44,17 @@
   void report_current_position_detail() {
 
     SERIAL_PROTOCOLPGM("\nLogical:");
-    const float logical[XYZ] = {
-      LOGICAL_X_POSITION(current_position[X_AXIS]),
-      LOGICAL_Y_POSITION(current_position[Y_AXIS]),
-      LOGICAL_Z_POSITION(current_position[Z_AXIS])
+    const xyz_t logical = {
+      LOGICAL_X_POSITION(current.x),
+      LOGICAL_Y_POSITION(current.y),
+      LOGICAL_Z_POSITION(current.z)
     };
     report_xyz(logical);
 
     SERIAL_PROTOCOLPGM("Raw:    ");
-    report_xyz(current_position);
+    report_xyz(current);
 
-    float leveled[XYZ] = { current_position[X_AXIS], current_position[Y_AXIS], current_position[Z_AXIS] };
+    xyz_t leveled = current;
 
     #if HAS_LEVELING
       SERIAL_PROTOCOLPGM("Leveled:");
@@ -62,7 +62,7 @@
       report_xyz(leveled);
 
       SERIAL_PROTOCOLPGM("UnLevel:");
-      float unleveled[XYZ] = { leveled[X_AXIS], leveled[Y_AXIS], leveled[Z_AXIS] };
+      xyz_t unleveled = leveled;
       planner.unapply_leveling(unleveled);
       report_xyz(unleveled);
     #endif
@@ -89,7 +89,7 @@
     SERIAL_EOL();
 
     #if IS_SCARA
-      const float deg[XYZ] = {
+      const xyz_t deg = {
         planner.get_axis_position_degrees(A_AXIS),
         planner.get_axis_position_degrees(B_AXIS)
       };
@@ -99,14 +99,14 @@
 
     SERIAL_PROTOCOLPGM("FromStp:");
     get_cartesian_from_steppers();  // writes cartes[XYZ] (with forward kinematics)
-    const float from_steppers[XYZE] = { cartes[X_AXIS], cartes[Y_AXIS], cartes[Z_AXIS], planner.get_axis_position_mm(E_AXIS) };
+    const xyze_t from_steppers = { cartes.x, cartes.y, cartes.z, planner.get_axis_position_mm(E_AXIS) };
     report_xyze(from_steppers);
 
-    const float diff[XYZE] = {
-      from_steppers[X_AXIS] - leveled[X_AXIS],
-      from_steppers[Y_AXIS] - leveled[Y_AXIS],
-      from_steppers[Z_AXIS] - leveled[Z_AXIS],
-      from_steppers[E_AXIS] - current_position[E_AXIS]
+    const xyze_t diff = {
+      from_steppers.x - leveled.x,
+      from_steppers.y - leveled.y,
+      from_steppers.z - leveled.z,
+      from_steppers.e - current.e
     };
     SERIAL_PROTOCOLPGM("Differ: ");
     report_xyze(diff);

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -35,8 +35,6 @@
   #include "../../module/stepper.h"
 #endif
 
-extern float destination[XYZE];
-
 #if ENABLED(G0_FEEDRATE)
   float saved_g0_feedrate_mm_s =  MMM_TO_MMS(DEFAULT_G0_FEEDRATE);
 #endif
@@ -76,10 +74,10 @@ void GcodeSuite::G0_G1(
       if (MIN_AUTORETRACT <= MAX_AUTORETRACT) {
         // When M209 Autoretract is enabled, convert E-only moves to firmware retract/recover moves
         if (fwretract.autoretract_enabled && parser.seen('E') && !(parser.seen('X') || parser.seen('Y') || parser.seen('Z'))) {
-          const float echange = destination[E_AXIS] - current_position[E_AXIS];
+          const float echange = destination.e - current.e;
           // Is this a retract or recover move?
           if (WITHIN(ABS(echange), MIN_AUTORETRACT, MAX_AUTORETRACT) && fwretract.retracted[active_extruder] == (echange > 0.0)) {
-            current_position[E_AXIS] = destination[E_AXIS]; // Hide a G1-based retract/recover from calculations
+            current.e = destination.e; // Hide a G1-based retract/recover from calculations
             sync_plan_position_e();                         // AND from the planner
             return fwretract.retract(echange < 0.0);        // Firmware-based retract/recover (double-retract ignored)
           }

--- a/Marlin/src/gcode/motion/G5.cpp
+++ b/Marlin/src/gcode/motion/G5.cpp
@@ -27,9 +27,9 @@
 #include "../../module/motion.h"
 #include "../../module/planner_bezier.h"
 
-void plan_cubic_move(const float (&cart)[XYZE], const float (&offset)[4]) {
-  cubic_b_spline(current_position, cart, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
-  COPY(current_position, cart);
+void plan_cubic_move(const xyze_t &cart, const float (&offset)[4]) {
+  cubic_b_spline(current, cart, offset, MMS_SCALED(feedrate_mm_s), active_extruder);
+  COPY(current, cart);
 }
 
 /**

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -47,9 +47,9 @@
     }
     #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
       else {
-        hotend_offset[Z_AXIS][active_extruder] -= offs;
+        hotend_offset[active_extruder].z -= offs;
         SERIAL_ECHO_START();
-        SERIAL_ECHOLNPAIR(MSG_IDEX_Z_OFFSET ": ", hotend_offset[Z_AXIS][active_extruder]);
+        SERIAL_ECHOLNPAIR(MSG_IDEX_Z_OFFSET ": ", hotend_offset[active_extruder].z);
       }
     #endif
   }
@@ -72,7 +72,7 @@ void GcodeSuite::M290() {
   #else
     if (parser.seenval('Z') || parser.seenval('S')) {
       const float offs = constrain(parser.value_axis_units(Z_AXIS), -2, 2);
-      thermalManager.babystep_axis(Z_AXIS, offs * planner.settings.axis_steps_per_mm[Z_AXIS]);
+      thermalManager.babystep_axis(Z_AXIS, offs * planner.settings.axis_steps_per_mm.z);
       #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
         if (!parser.seen('P') || parser.value_bool()) mod_zprobe_zoffset(offs);
       #endif

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -39,8 +39,8 @@
  *   E   Engage the probe for each probe (default 1)
  */
 void GcodeSuite::G30() {
-  const float xpos = parser.linearval('X', current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER),
-              ypos = parser.linearval('Y', current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER);
+  const float xpos = parser.linearval('X', current.x + X_PROBE_OFFSET_FROM_EXTRUDER),
+              ypos = parser.linearval('Y', current.y + Y_PROBE_OFFSET_FROM_EXTRUDER);
 
   if (!position_is_reachable_by_probe(xpos, ypos)) return;
 

--- a/Marlin/src/gcode/probe/G38.cpp
+++ b/Marlin/src/gcode/probe/G38.cpp
@@ -37,10 +37,10 @@ static bool G38_run_probe() {
 
   #if MULTIPLE_PROBING > 1
     // Get direction of move and retract
-    float retract_mm[XYZ];
+    xyz_t retract_mm;
     LOOP_XYZ(i) {
-      const float dist = destination[i] - current_position[i];
-      retract_mm[i] = ABS(dist) < G38_MINIMUM_MOVE ? 0 : home_bump_mm((AxisEnum)i) * (dist > 0 ? -1 : 1);
+      const float dist = destination[i] - current[i];
+      retract_mm[i] = ABS(dist) < G38_MINIMUM_MOVE ? 0 : home_bump_mm[i] * (dist > 0 ? -1 : 1);
     }
   #endif
 
@@ -105,7 +105,7 @@ void GcodeSuite::G38(const bool is_38_2) {
 
   // If any axis has enough movement, do the move
   LOOP_XYZ(i)
-    if (ABS(destination[i] - current_position[i]) >= G38_MINIMUM_MOVE) {
+    if (ABS(destination[i] - current[i]) >= G38_MINIMUM_MOVE) {
       if (!parser.seenval('F')) feedrate_mm_s = homing_feedrate((AxisEnum)i);
       // If G38.2 fails throw an error
       if (!G38_run_probe() && is_38_2) {

--- a/Marlin/src/gcode/scara/M360-M364.cpp
+++ b/Marlin/src/gcode/scara/M360-M364.cpp
@@ -32,9 +32,9 @@
 inline bool SCARA_move_to_cal(const uint8_t delta_a, const uint8_t delta_b) {
   if (IsRunning()) {
     forward_kinematics_SCARA(delta_a, delta_b);
-    destination[X_AXIS] = cartes[X_AXIS];
-    destination[Y_AXIS] = cartes[Y_AXIS];
-    destination[Z_AXIS] = current_position[Z_AXIS];
+    destination.x = cartes.x;
+    destination.y = cartes.y;
+    destination.z = current.z;
     prepare_move_to_destination();
     return true;
   }

--- a/Marlin/src/gcode/units/M82_M83.cpp
+++ b/Marlin/src/gcode/units/M82_M83.cpp
@@ -25,9 +25,9 @@
 /**
  * M82: Set E codes absolute (default)
  */
-void GcodeSuite::M82() { axis_relative_modes[E_AXIS] = false; }
+void GcodeSuite::M82() { axis_relative_modes.e = false; }
 
 /**
  * M83: Set E codes relative while in Absolute Coordinates (G90) mode
  */
-void GcodeSuite::M83() { axis_relative_modes[E_AXIS] = true; }
+void GcodeSuite::M83() { axis_relative_modes.e = true; }

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -472,11 +472,9 @@
  */
 #if ENABLED(DISTINCT_E_FACTORS) && E_STEPPERS > 1
   #define XYZE_N (XYZ + E_STEPPERS)
-  #define E_AXIS_N(E) (E_AXIS + E)
 #else
   #undef DISTINCT_E_FACTORS
   #define XYZE_N XYZE
-  #define E_AXIS_N(E) E_AXIS
 #endif
 
 /**

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -19,14 +19,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#ifndef _CONDITIONALS_POST_H_
+  #define _CONDITIONALS_POST_H_
+#else
+  #error "Conditionals_post.h should only be included from MarlinConfig.h"
+#endif
 
 /**
  * Conditionals_post.h
  * Defines that depend on configuration but are not editable.
  */
-
-#ifndef CONDITIONALS_POST_H
-#define CONDITIONALS_POST_H
 
 #define AVR_ATmega2560_FAMILY_PLUS_70 ( \
      MB(BQ_ZUM_MEGA_3D)                 \
@@ -1610,5 +1612,3 @@
 #if ENABLED(G29_RETRY_AND_RECOVER)
   #define USE_EXECUTE_COMMANDS_IMMEDIATE
 #endif
-
-#endif // CONDITIONALS_POST_H

--- a/Marlin/src/inc/MarlinConfig.h
+++ b/Marlin/src/inc/MarlinConfig.h
@@ -44,6 +44,7 @@
 
 // Include all core headers
 #include "../core/enum.h"
+#include "../core/dep_types.h"
 #include "../core/language.h"
 #include "../core/utility.h"
 #include "../core/serial.h"

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.h
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.h
@@ -384,9 +384,9 @@ static void lcd_implementation_status_screen() {
 
   // At the first page, regenerate the XYZ strings
   if (page.page == 0) {
-    strcpy(xstring, ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])));
-    strcpy(ystring, ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])));
-    strcpy(zstring, ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])));
+    strcpy(xstring, ftostr4sign(LOGICAL_X_POSITION(current.x)));
+    strcpy(ystring, ftostr4sign(LOGICAL_Y_POSITION(current.y)));
+    strcpy(zstring, ftostr52sp(LOGICAL_Z_POSITION(current.z)));
     #if ENABLED(FILAMENT_LCD_DISPLAY)
       strcpy(wstring, ftostr12ns(filament_width_meas));
       strcpy(mstring, itostr3(100.0 * (

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -773,9 +773,9 @@ void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
 }
 
 bool ST7920_Lite_Status_Screen::position_changed() {
-  const float x_pos = current_position[X_AXIS],
-              y_pos = current_position[Y_AXIS],
-              z_pos = current_position[Z_AXIS];
+  const float x_pos = current.x,
+              y_pos = current.y,
+              z_pos = current.z;
   const uint8_t checksum = uint8_t(x_pos) ^ uint8_t(y_pos) ^ uint8_t(z_pos);
 
   static uint8_t last_checksum = 0;
@@ -863,9 +863,9 @@ void ST7920_Lite_Status_Screen::update_status_or_position(bool forceUpdate) {
       #endif
     )) {
       draw_position(
-        current_position[X_AXIS],
-        current_position[Y_AXIS],
-        current_position[Z_AXIS],
+        current.x,
+        current.y,
+        current.z,
         #if ENABLED(DISABLE_REDUCED_ACCURACY_WARNING)
           true
         #else

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -330,37 +330,38 @@ namespace UI {
   #endif // ENABLED(BABYSTEP_ZPROBE_OFFSET)
 
   #if HOTENDS > 1
-    float getNozzleOffset_mm(const axis_t axis, uint8_t extruder) {
+    float getNozzleOffset_mm(const axis_t axis, const uint8_t extruder) {
       if (extruder >= HOTENDS) return 0;
       return hotend_offset[axis][extruder];
     }
 
-    void setNozzleOffset_mm(const axis_t axis, uint8_t extruder, float offset) {
+    void setNozzleOffset_mm(const axis_t axis, const uint8_t extruder, const float offset) {
       if (extruder >= HOTENDS) return;
       hotend_offset[axis][extruder] = offset;
     }
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
-    float getAxisBacklash_mm(const axis_t axis)       {return backlash_distance_mm[axis];}
-    void setAxisBacklash_mm(const axis_t axis, float distance)
-                                                      {backlash_distance_mm[axis] = clamp(distance,0,5);}
+    float getAxisBacklash_mm(const axis_t axis)                       { return backlash_distance_mm[axis]; }
+    void setAxisBacklash_mm(const axis_t axis, const float distance)  { backlash_distance_mm[axis] = clamp(distance, 0, 5); }
 
-    float getBacklashCorrection_percent()             {return backlash_correction*100;}
-    void setBacklashCorrection_percent(float percent) {backlash_correction = clamp(percent, 0, 100)/100;}
+    float getBacklashCorrection_percent()                             { return backlash_correction * 100; }
+    void setBacklashCorrection_percent(const float percent)           { backlash_correction = clamp(percent, 0, 100) / 100; }
 
     #ifdef BACKLASH_SMOOTHING_MM
-      float getBacklashSmoothing_mm()                 {return backlash_smoothing_mm;}
-      void setBacklashSmoothing_mm(float distance)    {backlash_smoothing_mm = clamp(distance,0,999);}
+      float getBacklashSmoothing_mm()                                 { return backlash_smoothing_mm; }
+      void setBacklashSmoothing_mm(const float distance)              { backlash_smoothing_mm = clamp(distance, 0, 999); }
     #endif
   #endif
 
   uint8_t getProgress_percent() {
-    #if ENABLED(SDSUPPORT)
-      return card.percentDone();
-    #else
-      return 0;
-    #endif
+    return
+      #if ENABLED(SDSUPPORT)
+        card.percentDone()
+      #else
+        0
+      #endif
+    ;
   }
 
   uint32_t getProgress_seconds_elapsed() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -51,7 +51,8 @@
 #include "ui_api.h"
 
 #if ENABLED(BACKLASH_GCODE)
-  extern float backlash_distance_mm[XYZ], backlash_correction;
+  extern xyz_t backlash_distance_mm;
+  extern float backlash_correction;
   #ifdef BACKLASH_SMOOTHING_MM
     extern float backlash_smoothing_mm;
   #endif
@@ -102,9 +103,9 @@ namespace UI {
   float getAxisPosition_mm(const axis_t axis) {
     switch (axis) {
       case X: case Y: case Z:
-        return current_position[axis];
+        return current[axis];
       case E0: case E1: case E2: case E3: case E4: case E5:
-        return current_position[E_AXIS];
+        return current.e;
       default: return 0;
     }
   }
@@ -126,7 +127,7 @@ namespace UI {
         destination[axis] = position;
         break;
       case E0: case E1: case E2: case E3: case E4: case E5:
-        destination[E_AXIS] = position;
+        destination.e = position;
         break;
     }
 
@@ -157,7 +158,7 @@ namespace UI {
       case X: case Y: case Z:
         return planner.settings.axis_steps_per_mm[axis];
       case E0: case E1: case E2: case E3: case E4: case E5:
-        return planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E0)];
+        return planner.settings.axis_steps_per_mm.E(axis - E0);
       default: return 0;
     }
   }
@@ -168,7 +169,7 @@ namespace UI {
         planner.settings.axis_steps_per_mm[axis] = steps_per_mm;
         break;
       case E0: case E1: case E2: case E3: case E4: case E5:
-        planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E0)] = steps_per_mm;
+        planner.settings.axis_steps_per_mm.E(axis - E0) = steps_per_mm;
         break;
     }
   }
@@ -178,7 +179,7 @@ namespace UI {
       case X: case Y: case Z:
         return planner.settings.max_feedrate_mm_s[axis];
       case E0: case E1: case E2: case E3: case E4: case E5:
-        return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)];
+        return planner.settings.max_feedrate_mm_s.E(axis - E0);
       default: return 0;
     }
   }
@@ -189,7 +190,7 @@ namespace UI {
         planner.settings.max_feedrate_mm_s[axis] = max_feedrate_mm_s;
         break;
       case E0: case E1: case E2: case E3: case E4: case E5:
-        planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)] = max_feedrate_mm_s;
+        planner.settings.max_feedrate_mm_s.E(axis - E0) = max_feedrate_mm_s;
         break;
       default: return;
     }
@@ -200,7 +201,7 @@ namespace UI {
       case X: case Y: case Z:
         return planner.settings.max_acceleration_mm_per_s2[axis];
       case E0: case E1: case E2: case E3: case E4: case E5:
-        return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(axis - E0)];
+        return planner.settings.max_acceleration_mm_per_s2.E(axis - E0);
       default: return 0;
     }
   }
@@ -211,7 +212,7 @@ namespace UI {
         planner.settings.max_acceleration_mm_per_s2[axis] = max_acceleration_mm_per_s2;
         break;
       case E0: case E1: case E2: case E3: case E4: case E5:
-        planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(axis - E0)] = max_acceleration_mm_per_s2;
+        planner.settings.max_acceleration_mm_per_s2.E(axis - E0) = max_acceleration_mm_per_s2;
         break;
       default: return;
     }
@@ -256,9 +257,9 @@ namespace UI {
     float getAxisMaxJerk_mm_s(const axis_t axis) {
       switch (axis) {
         case X: case Y: case Z:
-          return planner.max_jerk[axis];
+          return planner.max_jerk.of[axis];
         case E0: case E1: case E2: case E3: case E4: case E5:
-          return planner.max_jerk[E_AXIS];
+          return planner.max_jerk.e;
         default: return 0;
       }
     }
@@ -266,10 +267,10 @@ namespace UI {
     void setAxisMaxJerk_mm_s(const axis_t axis, const float max_jerk) {
       switch (axis) {
         case X: case Y: case Z:
-          planner.max_jerk[axis] = max_jerk;
+          planner.max_jerk.of[axis] = max_jerk;
           break;
         case E0: case E1: case E2: case E3: case E4: case E5:
-          planner.max_jerk[E_AXIS] = max_jerk;
+          planner.max_jerk.e = max_jerk;
           break;
         default: return;
       }
@@ -291,14 +292,14 @@ namespace UI {
     float getZOffset_mm() {
       #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
         if (active_extruder != 0)
-          return hotend_offset[Z_AXIS][active_extruder];
+          return hotend_offset[active_extruder].z;
         else
       #endif
           return zprobe_zoffset;
     }
 
     void setZOffset_mm(const float zoffset_mm) {
-      const float diff = (zoffset_mm - getZOffset_mm()) / planner.steps_to_mm[Z_AXIS];
+      const float diff = (zoffset_mm - getZOffset_mm()) / planner.steps_to_mm.z;
       incrementZOffset_steps(diff > 0 ? ceil(diff) : floor(diff));
     }
 
@@ -308,11 +309,11 @@ namespace UI {
       #else
         constexpr bool do_probe = true;
       #endif
-      const float diff = planner.steps_to_mm[Z_AXIS] * babystep_increment,
+      const float diff = planner.steps_to_mm.z * babystep_increment,
                   new_probe_offset = zprobe_zoffset + diff,
                   new_offs =
                     #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
-                      do_probe ? new_probe_offset : hotend_offset[Z_AXIS][active_extruder] - diff
+                      do_probe ? new_probe_offset : hotend_offset[active_extruder].z - diff
                     #else
                       new_probe_offset
                     #endif
@@ -323,7 +324,7 @@ namespace UI {
 
         if (do_probe) zprobe_zoffset = new_offs;
         #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
-          else hotend_offset[Z_AXIS][active_extruder] = new_offs;
+          else hotend_offset[active_extruder].z = new_offs;
         #endif
       }
     }
@@ -332,12 +333,12 @@ namespace UI {
   #if HOTENDS > 1
     float getNozzleOffset_mm(const axis_t axis, const uint8_t extruder) {
       if (extruder >= HOTENDS) return 0;
-      return hotend_offset[axis][extruder];
+      return hotend_offset[extruder][axis];
     }
 
     void setNozzleOffset_mm(const axis_t axis, const uint8_t extruder, const float offset) {
       if (extruder >= HOTENDS) return;
-      hotend_offset[axis][extruder] = offset;
+      hotend_offset[extruder][axis] = offset;
     }
   #endif
 

--- a/Marlin/src/lcd/ultralcd_impl_HD44780.h
+++ b/Marlin/src/lcd/ultralcd_impl_HD44780.h
@@ -690,18 +690,18 @@ static void lcd_implementation_status_screen() {
 
       #else // HOTENDS <= 2 && (HOTENDS <= 1 || !HAS_HEATED_BED)
 
-        _draw_axis_value(X_AXIS, ftostr4sign(LOGICAL_X_POSITION(current_position[X_AXIS])), blink);
+        _draw_axis_value(X_AXIS, ftostr4sign(LOGICAL_X_POSITION(current.x)), blink);
 
         lcd_put_wchar(' ');
 
-        _draw_axis_value(Y_AXIS, ftostr4sign(LOGICAL_Y_POSITION(current_position[Y_AXIS])), blink);
+        _draw_axis_value(Y_AXIS, ftostr4sign(LOGICAL_Y_POSITION(current.y)), blink);
 
       #endif // HOTENDS <= 2 && (HOTENDS <= 1 || !HAS_HEATED_BED)
 
     #endif // LCD_WIDTH >= 20
 
     lcd_moveto(LCD_WIDTH - 8, 1);
-    _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])), blink);
+    _draw_axis_value(Z_AXIS, ftostr52sp(LOGICAL_Z_POSITION(current.z)), blink);
 
     #if HAS_LEVELING && !HAS_HEATED_BED
       lcd_put_wchar(planner.leveling_active || blink ? '_' : ' ');

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -42,7 +42,7 @@
    */
   void Nozzle::stroke(const point_t &start, const point_t &end, const uint8_t &strokes) {
     #if ENABLED(NOZZLE_CLEAN_GOBACK)
-      const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
+      const float ix = current.x, iy = current.y, iz = current.z;
     #endif
 
     // Move to the starting point
@@ -73,7 +73,7 @@
     if (!diffx || !diffy) return;
 
     #if ENABLED(NOZZLE_CLEAN_GOBACK)
-      const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
+      const float ix = current.x, iy = current.y, iz = current.z;
     #endif
 
     do_blocking_move_to(start.x, start.y, start.z);
@@ -116,7 +116,7 @@
     if (strokes == 0) return;
 
     #if ENABLED(NOZZLE_CLEAN_GOBACK)
-      const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
+      const float ix = current.x, iy = current.y, iz = current.z;
     #endif
 
     do_blocking_move_to(start.x, start.y, start.z);
@@ -172,11 +172,11 @@
         break;
 
       case 2: // Raise by Z-park height
-        do_blocking_move_to_z(MIN(current_position[Z_AXIS] + park.z, Z_MAX_POS), fr_z);
+        do_blocking_move_to_z(MIN(current.z + park.z, Z_MAX_POS), fr_z);
         break;
 
       default: // Raise to at least the Z-park height
-        do_blocking_move_to_z(MAX(park.z, current_position[Z_AXIS]), fr_z);
+        do_blocking_move_to_z(MAX(park.z, current.z), fr_z);
     }
 
     do_blocking_move_to_xy(park.x, park.y, fr_xy);

--- a/Marlin/src/libs/stopwatch.h
+++ b/Marlin/src/libs/stopwatch.h
@@ -19,9 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-#ifndef STOPWATCH_H
-#define STOPWATCH_H
+#pragma once
 
 // Print debug messages with M111 S2 (Uses 156 bytes of PROGMEM)
 //#define DEBUG_STOPWATCH
@@ -116,5 +114,3 @@ class Stopwatch {
 
     #endif
 };
-
-#endif // STOPWATCH_H

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1141,7 +1141,10 @@ void MarlinSettings::postprocess() {
       #if ABL_PLANAR
         EEPROM_READ(planner.bed_level_matrix);
       #else
-        for (uint8_t q = 9; q--;) EEPROM_READ(dummy);
+        {
+          float matrix[9];
+          EEPROM_READ(matrix);
+        }
       #endif
 
       //
@@ -1149,22 +1152,22 @@ void MarlinSettings::postprocess() {
       //
 
       uint8_t grid_max_x, grid_max_y;
-      EEPROM_READ_ALWAYS(grid_max_x);                       // 1 byte
-      EEPROM_READ_ALWAYS(grid_max_y);                       // 1 byte
+      EEPROM_READ_ALWAYS(grid_max_x);
+      EEPROM_READ_ALWAYS(grid_max_y);
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
         if (grid_max_x == GRID_MAX_POINTS_X && grid_max_y == GRID_MAX_POINTS_Y) {
           if (!validating) set_bed_leveling_enabled(false);
-          EEPROM_READ(bilinear_grid_spacing);        // 2 ints
-          EEPROM_READ(bilinear_start);               // 2 ints
-          EEPROM_READ(z_values);                     // 9 to 256 floats
+          EEPROM_READ(bilinear_grid_spacing);
+          EEPROM_READ(bilinear_start);
+          EEPROM_READ(z_values);
         }
         else // EEPROM data is stale
       #endif // AUTO_BED_LEVELING_BILINEAR
         {
           // Skip past disabled (or stale) Bilinear Grid data
-          int bgs[2], bs[2];
-          EEPROM_READ(bgs);
-          EEPROM_READ(bs);
+          int bilinear_grid_spacing[2], bilinear_start[2];
+          EEPROM_READ(bilinear_grid_spacing);
+          EEPROM_READ(bilinear_start);
           for (uint16_t q = grid_max_x * grid_max_y; q--;) EEPROM_READ(dummy);
         }
 
@@ -1186,48 +1189,54 @@ void MarlinSettings::postprocess() {
       //
       // SERVO_ANGLES
       //
-      #if !HAS_SERVOS || DISABLED(EDITABLE_SERVO_ANGLES)
-        uint16_t servo_angles[NUM_SERVOS][2];
-      #endif
-      EEPROM_READ(servo_angles);
-
-      //
-      // DELTA Geometry or Dual Endstops offsets
-      //
+      {
+        #if !HAS_SERVOS || DISABLED(EDITABLE_SERVO_ANGLES)
+          uint16_t servo_angles[NUM_SERVOS][2];
+        #endif
+        EEPROM_READ(servo_angles);
+      }
 
       #if ENABLED(DELTA)
 
+        //
+        // DELTA Geometry
+        //
+
         _FIELD_TEST(delta_height);
 
-        EEPROM_READ(delta_height);              // 1 float
-        EEPROM_READ(delta_endstop_adj);         // 3 floats
-        EEPROM_READ(delta_radius);              // 1 float
-        EEPROM_READ(delta_diagonal_rod);        // 1 float
-        EEPROM_READ(delta_segments_per_second); // 1 float
-        EEPROM_READ(delta_calibration_radius);  // 1 float
-        EEPROM_READ(delta_tower_angle_trim);    // 3 floats
+        EEPROM_READ(delta_height);
+        EEPROM_READ(delta_endstop_adj);
+        EEPROM_READ(delta_radius);
+        EEPROM_READ(delta_diagonal_rod);
+        EEPROM_READ(delta_segments_per_second);
+        EEPROM_READ(delta_calibration_radius);
+        EEPROM_READ(delta_tower_angle_trim);
 
       #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || Z_MULTI_ENDSTOPS
+
+        //
+        // Dual Endstops offsets
+        //
 
         _FIELD_TEST(x2_endstop_adj);
 
         #if ENABLED(X_DUAL_ENDSTOPS)
-          EEPROM_READ(endstops.x2_endstop_adj);  // 1 float
+          EEPROM_READ(endstops.x2_endstop_adj);
         #else
           EEPROM_READ(dummy);
         #endif
         #if ENABLED(Y_DUAL_ENDSTOPS)
-          EEPROM_READ(endstops.y2_endstop_adj);  // 1 float
+          EEPROM_READ(endstops.y2_endstop_adj);
         #else
           EEPROM_READ(dummy);
         #endif
         #if Z_MULTI_ENDSTOPS
-          EEPROM_READ(endstops.z2_endstop_adj); // 1 float
+          EEPROM_READ(endstops.z2_endstop_adj);
         #else
           EEPROM_READ(dummy);
         #endif
         #if ENABLED(Z_TRIPLE_ENDSTOPS)
-          EEPROM_READ(endstops.z3_endstop_adj); // 1 float
+          EEPROM_READ(endstops.z3_endstop_adj);
         #else
           EEPROM_READ(dummy);
         #endif
@@ -1237,16 +1246,17 @@ void MarlinSettings::postprocess() {
       //
       // LCD Preheat settings
       //
+      {
+        _FIELD_TEST(lcd_preheat_hotend_temp);
 
-      _FIELD_TEST(lcd_preheat_hotend_temp);
-
-      #if DISABLED(ULTIPANEL)
-        int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2];
-        uint8_t lcd_preheat_fan_speed[2];
-      #endif
-      EEPROM_READ(lcd_preheat_hotend_temp); // 2 floats
-      EEPROM_READ(lcd_preheat_bed_temp);    // 2 floats
-      EEPROM_READ(lcd_preheat_fan_speed);   // 2 floats
+        #if DISABLED(ULTIPANEL)
+          int16_t lcd_preheat_hotend_temp[2], lcd_preheat_bed_temp[2];
+          uint8_t lcd_preheat_fan_speed[2];
+        #endif
+        EEPROM_READ(lcd_preheat_hotend_temp);
+        EEPROM_READ(lcd_preheat_bed_temp);
+        EEPROM_READ(lcd_preheat_fan_speed);
+      }
 
       //
       // Hotend PID

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -27,16 +27,15 @@
 #pragma once
 
 extern float delta_height,
-             delta_endstop_adj[ABC],
              delta_radius,
              delta_diagonal_rod,
              delta_segments_per_second,
              delta_calibration_radius,
-             delta_tower_angle_trim[ABC];
-
-extern float delta_tower[ABC][2],
-             delta_diagonal_rod_2_tower[ABC],
              delta_clip_start_height;
+extern abc_t delta_endstop_adj,
+             delta_tower_angle_trim,
+             delta_diagonal_rod_2_tower;
+extern xy_t  delta_tower[ABC];
 
 /**
  * Recalculate factors used for delta kinematics whenever
@@ -64,7 +63,7 @@ void recalc_delta_settings();
  */
 
 // Macro to obtain the Z position of an individual tower
-#define DELTA_Z(V,T) V[Z_AXIS] + SQRT(    \
+#define DELTA_Z(V,T) V.z + SQRT(    \
   delta_diagonal_rod_2_tower[T] - HYPOT2( \
       delta_tower[T][X_AXIS] - V[X_AXIS], \
       delta_tower[T][Y_AXIS] - V[Y_AXIS]  \
@@ -72,14 +71,14 @@ void recalc_delta_settings();
   )
 
 #define DELTA_IK(V) do {              \
-  delta[A_AXIS] = DELTA_Z(V, A_AXIS); \
-  delta[B_AXIS] = DELTA_Z(V, B_AXIS); \
-  delta[C_AXIS] = DELTA_Z(V, C_AXIS); \
+  delta.a = DELTA_Z(V, A_AXIS); \
+  delta.b = DELTA_Z(V, B_AXIS); \
+  delta.c = DELTA_Z(V, C_AXIS); \
 }while(0)
 
-void inverse_kinematics(const float (&raw)[XYZ]);
-FORCE_INLINE void inverse_kinematics(const float (&raw)[XYZE]) {
-  const float raw_xyz[XYZ] = { raw[X_AXIS], raw[Y_AXIS], raw[Z_AXIS] };
+void inverse_kinematics(const xyz_t &raw);
+FORCE_INLINE void inverse_kinematics(const xyze_t &raw) {
+  const xyz_t raw_xyz = raw;
   inverse_kinematics(raw_xyz);
 }
 
@@ -116,8 +115,8 @@ float delta_safe_distance_from_top();
  */
 void forward_kinematics_DELTA(const float &z1, const float &z2, const float &z3);
 
-FORCE_INLINE void forward_kinematics_DELTA(const float (&point)[ABC]) {
-  forward_kinematics_DELTA(point[A_AXIS], point[B_AXIS], point[C_AXIS]);
+FORCE_INLINE void forward_kinematics_DELTA(const abc_t &point) {
+  forward_kinematics_DELTA(point.a, point.b, point.c);
 }
 
 void home_delta();

--- a/Marlin/src/module/planner_bezier.cpp
+++ b/Marlin/src/module/planner_bezier.cpp
@@ -107,17 +107,17 @@ static inline float dist1(const float &x1, const float &y1, const float &x2, con
  * the mitigation offered by MIN_STEP and the small computational
  * power available on Arduino, I think it is not wise to implement it.
  */
-void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS], const float offset[4], float fr_mm_s, uint8_t extruder) {
+void cubic_b_spline(const xyze_t &position, const xyze_t &target, const float offset[4], const float fr_mm_s, const uint8_t extruder) {
   // Absolute first and second control points are recovered.
-  const float first0 = position[X_AXIS] + offset[0],
-              first1 = position[Y_AXIS] + offset[1],
-              second0 = target[X_AXIS] + offset[2],
-              second1 = target[Y_AXIS] + offset[3];
+  const float first0 = position.x + offset[0],
+              first1 = position.y + offset[1],
+              second0 = target.x + offset[2],
+              second1 = target.y + offset[3];
   float t = 0;
 
   float bez_target[4];
-  bez_target[X_AXIS] = position[X_AXIS];
-  bez_target[Y_AXIS] = position[Y_AXIS];
+  bez_target.x = position.x;
+  bez_target.y = position.y;
   float step = MAX_STEP;
 
   millis_t next_idle_ms = millis() + 200UL;
@@ -136,15 +136,15 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
     bool did_reduce = false;
     float new_t = t + step;
     NOMORE(new_t, 1);
-    float new_pos0 = eval_bezier(position[X_AXIS], first0, second0, target[X_AXIS], new_t),
-          new_pos1 = eval_bezier(position[Y_AXIS], first1, second1, target[Y_AXIS], new_t);
+    float new_pos0 = eval_bezier(position.x, first0, second0, target.x, new_t),
+          new_pos1 = eval_bezier(position.y, first1, second1, target.y, new_t);
     for (;;) {
       if (new_t - t < (MIN_STEP)) break;
       const float candidate_t = 0.5f * (t + new_t),
-                  candidate_pos0 = eval_bezier(position[X_AXIS], first0, second0, target[X_AXIS], candidate_t),
-                  candidate_pos1 = eval_bezier(position[Y_AXIS], first1, second1, target[Y_AXIS], candidate_t),
-                  interp_pos0 = 0.5f * (bez_target[X_AXIS] + new_pos0),
-                  interp_pos1 = 0.5f * (bez_target[Y_AXIS] + new_pos1);
+                  candidate_pos0 = eval_bezier(position.x, first0, second0, target.x, candidate_t),
+                  candidate_pos1 = eval_bezier(position.y, first1, second1, target.y, candidate_t),
+                  interp_pos0 = 0.5f * (bez_target.x + new_pos0),
+                  interp_pos1 = 0.5f * (bez_target.y + new_pos1);
       if (dist1(candidate_pos0, candidate_pos1, interp_pos0, interp_pos1) <= (SIGMA)) break;
       new_t = candidate_t;
       new_pos0 = candidate_pos0;
@@ -157,10 +157,10 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
       if (new_t - t > MAX_STEP) break;
       const float candidate_t = t + 2 * (new_t - t);
       if (candidate_t >= 1) break;
-      const float candidate_pos0 = eval_bezier(position[X_AXIS], first0, second0, target[X_AXIS], candidate_t),
-                  candidate_pos1 = eval_bezier(position[Y_AXIS], first1, second1, target[Y_AXIS], candidate_t),
-                  interp_pos0 = 0.5f * (bez_target[X_AXIS] + candidate_pos0),
-                  interp_pos1 = 0.5f * (bez_target[Y_AXIS] + candidate_pos1);
+      const float candidate_pos0 = eval_bezier(position.x, first0, second0, target.x, candidate_t),
+                  candidate_pos1 = eval_bezier(position.y, first1, second1, target.y, candidate_t),
+                  interp_pos0 = 0.5f * (bez_target.x + candidate_pos0),
+                  interp_pos1 = 0.5f * (bez_target.y + candidate_pos1);
       if (dist1(new_pos0, new_pos1, interp_pos0, interp_pos1) > (SIGMA)) break;
       new_t = candidate_t;
       new_pos0 = candidate_pos0;
@@ -182,23 +182,22 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
     t = new_t;
 
     // Compute and send new position
-    bez_target[X_AXIS] = new_pos0;
-    bez_target[Y_AXIS] = new_pos1;
+    bez_target.x = new_pos0;
+    bez_target.y = new_pos1;
     // FIXME. The following two are wrong, since the parameter t is
     // not linear in the distance.
-    bez_target[Z_AXIS] = interp(position[Z_AXIS], target[Z_AXIS], t);
-    bez_target[E_AXIS] = interp(position[E_AXIS], target[E_AXIS], t);
+    bez_target.z = interp(position.z, target.z, t);
+    bez_target.e = interp(position.e, target.e, t);
     clamp_to_software_endstops(bez_target);
 
     #if HAS_LEVELING && !PLANNER_LEVELING
-      float pos[XYZE] = { bez_target[X_AXIS], bez_target[Y_AXIS], bez_target[Z_AXIS], bez_target[E_AXIS] };
+      xyze_t pos = bez_target;
       planner.apply_leveling(pos);
     #else
-      const float (&pos)[XYZE] = bez_target;
+      const xyze_t &pos = bez_target;
     #endif
 
-    if (!planner.buffer_line(pos, fr_mm_s, active_extruder, step))
-      break;
+    if (!planner.buffer_line(pos, fr_mm_s, extruder, step)) break;
   }
 }
 

--- a/Marlin/src/module/planner_bezier.h
+++ b/Marlin/src/module/planner_bezier.h
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 /**
  * planner_bezier.h
@@ -26,9 +27,6 @@
  * Compute and buffer movement commands for Bézier curves
  *
  */
-
-#ifndef PLANNER_BEZIER_H
-#define PLANNER_BEZIER_H
 
 #include "../inc/MarlinConfig.h"
 
@@ -39,5 +37,3 @@ void cubic_b_spline(
               float fr_mm_s,
               uint8_t extruder
             );
-
-#endif // PLANNER_BEZIER_H

--- a/Marlin/src/module/planner_bezier.h
+++ b/Marlin/src/module/planner_bezier.h
@@ -30,10 +30,4 @@
 
 #include "../inc/MarlinConfig.h"
 
-void cubic_b_spline(
-              const float position[NUM_AXIS], // current position
-              const float target[NUM_AXIS],   // target position
-              const float offset[4],          // a pair of offsets
-              float fr_mm_s,
-              uint8_t extruder
-            );
+void cubic_b_spline(const xyze_t position, const xyze_t target, const float offset[4], const float fr_mm_s, const uint8_t extruder);

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -97,13 +97,13 @@ float zprobe_zoffset; // Initialized by settings.load()
   void run_deploy_moves_script() {
     #if defined(Z_PROBE_ALLEN_KEY_DEPLOY_1_X) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_1_Y) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_1_Z)
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_1_X
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_1_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_1_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_1_Y
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_1_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_1_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_1_Z
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_1_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_1_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_1_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_DEPLOY_1_FEEDRATE 0.0
@@ -113,13 +113,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_DEPLOY_2_X) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_2_Y) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_2_Z)
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_2_X
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_2_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_2_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_2_Y
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_2_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_2_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_2_Z
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_2_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_2_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_2_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_DEPLOY_2_FEEDRATE 0.0
@@ -129,13 +129,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_DEPLOY_3_X) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_3_Y) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_3_Z)
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_3_X
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_3_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_3_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_3_Y
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_3_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_3_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_3_Z
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_3_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_3_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_3_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_DEPLOY_3_FEEDRATE 0.0
@@ -145,13 +145,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_DEPLOY_4_X) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_4_Y) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_4_Z)
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_4_X
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_4_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_4_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_4_Y
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_4_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_4_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_4_Z
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_4_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_4_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_4_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_DEPLOY_4_FEEDRATE 0.0
@@ -161,13 +161,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_DEPLOY_5_X) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_5_Y) || defined(Z_PROBE_ALLEN_KEY_DEPLOY_5_Z)
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_5_X
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_5_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_5_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_5_Y
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_5_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_5_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_5_Z
-        #define Z_PROBE_ALLEN_KEY_DEPLOY_5_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_DEPLOY_5_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_DEPLOY_5_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_DEPLOY_5_FEEDRATE 0.0
@@ -180,13 +180,13 @@ float zprobe_zoffset; // Initialized by settings.load()
   void run_stow_moves_script() {
     #if defined(Z_PROBE_ALLEN_KEY_STOW_1_X) || defined(Z_PROBE_ALLEN_KEY_STOW_1_Y) || defined(Z_PROBE_ALLEN_KEY_STOW_1_Z)
       #ifndef Z_PROBE_ALLEN_KEY_STOW_1_X
-        #define Z_PROBE_ALLEN_KEY_STOW_1_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_1_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_1_Y
-        #define Z_PROBE_ALLEN_KEY_STOW_1_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_1_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_1_Z
-        #define Z_PROBE_ALLEN_KEY_STOW_1_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_1_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_1_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_STOW_1_FEEDRATE 0.0
@@ -196,13 +196,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_STOW_2_X) || defined(Z_PROBE_ALLEN_KEY_STOW_2_Y) || defined(Z_PROBE_ALLEN_KEY_STOW_2_Z)
       #ifndef Z_PROBE_ALLEN_KEY_STOW_2_X
-        #define Z_PROBE_ALLEN_KEY_STOW_2_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_2_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_2_Y
-        #define Z_PROBE_ALLEN_KEY_STOW_2_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_2_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_2_Z
-        #define Z_PROBE_ALLEN_KEY_STOW_2_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_2_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_2_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_STOW_2_FEEDRATE 0.0
@@ -212,13 +212,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_STOW_3_X) || defined(Z_PROBE_ALLEN_KEY_STOW_3_Y) || defined(Z_PROBE_ALLEN_KEY_STOW_3_Z)
       #ifndef Z_PROBE_ALLEN_KEY_STOW_3_X
-        #define Z_PROBE_ALLEN_KEY_STOW_3_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_3_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_3_Y
-        #define Z_PROBE_ALLEN_KEY_STOW_3_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_3_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_3_Z
-        #define Z_PROBE_ALLEN_KEY_STOW_3_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_3_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_3_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_STOW_3_FEEDRATE 0.0
@@ -228,13 +228,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_STOW_4_X) || defined(Z_PROBE_ALLEN_KEY_STOW_4_Y) || defined(Z_PROBE_ALLEN_KEY_STOW_4_Z)
       #ifndef Z_PROBE_ALLEN_KEY_STOW_4_X
-        #define Z_PROBE_ALLEN_KEY_STOW_4_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_4_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_4_Y
-        #define Z_PROBE_ALLEN_KEY_STOW_4_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_4_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_4_Z
-        #define Z_PROBE_ALLEN_KEY_STOW_4_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_4_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_4_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_STOW_4_FEEDRATE 0.0
@@ -244,13 +244,13 @@ float zprobe_zoffset; // Initialized by settings.load()
     #endif
     #if defined(Z_PROBE_ALLEN_KEY_STOW_5_X) || defined(Z_PROBE_ALLEN_KEY_STOW_5_Y) || defined(Z_PROBE_ALLEN_KEY_STOW_5_Z)
       #ifndef Z_PROBE_ALLEN_KEY_STOW_5_X
-        #define Z_PROBE_ALLEN_KEY_STOW_5_X current_position[X_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_5_X current.x
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_5_Y
-        #define Z_PROBE_ALLEN_KEY_STOW_5_Y current_position[Y_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_5_Y current.y
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_5_Z
-        #define Z_PROBE_ALLEN_KEY_STOW_5_Z current_position[Z_AXIS]
+        #define Z_PROBE_ALLEN_KEY_STOW_5_Z current.z
       #endif
       #ifndef Z_PROBE_ALLEN_KEY_STOW_5_FEEDRATE
         #define Z_PROBE_ALLEN_KEY_STOW_5_FEEDRATE 0.0
@@ -359,7 +359,7 @@ inline void do_probe_raise(const float z_raise) {
 
   NOMORE(z_dest, Z_MAX_POS);
 
-  if (z_dest > current_position[Z_AXIS])
+  if (z_dest > current.z)
     do_blocking_move_to_z(z_dest);
 }
 
@@ -377,7 +377,7 @@ bool set_probe_deployed(const bool deploy) {
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
-      DEBUG_POS("set_probe_deployed", current_position);
+      DEBUG_POS("set_probe_deployed", current);
       SERIAL_ECHOLNPAIR("deploy: ", deploy);
     }
   #endif
@@ -417,8 +417,8 @@ bool set_probe_deployed(const bool deploy) {
     }
   #endif
 
-  const float oldXpos = current_position[X_AXIS],
-              oldYpos = current_position[Y_AXIS];
+  const float oldXpos = current.x,
+              oldYpos = current.y;
 
   #ifdef _TRIGGERED_WHEN_STOWED_TEST
 
@@ -487,7 +487,7 @@ bool set_probe_deployed(const bool deploy) {
 
   #endif
 
-  do_blocking_move_to(oldXpos, oldYpos, current_position[Z_AXIS]); // return to position before deploy
+  do_blocking_move_to(oldXpos, oldYpos, current.z); // return to position before deploy
   endstops.enable_z_probe(deploy);
   return false;
 }
@@ -495,9 +495,9 @@ bool set_probe_deployed(const bool deploy) {
 #ifdef Z_AFTER_PROBING
   // After probing move to a preferred Z position
   void move_z_after_probing() {
-    if (current_position[Z_AXIS] != Z_AFTER_PROBING) {
+    if (current.z != Z_AFTER_PROBING) {
       do_blocking_move_to_z(Z_AFTER_PROBING);
-      current_position[Z_AXIS] = Z_AFTER_PROBING;
+      current.z = Z_AFTER_PROBING;
     }
   }
 #endif
@@ -516,7 +516,7 @@ bool set_probe_deployed(const bool deploy) {
 
 static bool do_probe_move(const float z, const float fr_mm_s) {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> do_probe_move", current_position);
+    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> do_probe_move", current);
   #endif
 
   #if HAS_HEATED_BED && ENABLED(WAIT_FOR_BED_HEATER)
@@ -595,7 +595,7 @@ static bool do_probe_move(const float z, const float fr_mm_s) {
   sync_plan_position();
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< do_probe_move", current_position);
+    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< do_probe_move", current);
   #endif
 
   return !probe_triggered;
@@ -603,14 +603,14 @@ static bool do_probe_move(const float z, const float fr_mm_s) {
 
 /**
  * @details Used by probe_pt to do a single Z probe at the current position.
- *          Leaves current_position[Z_AXIS] at the height where the probe triggered.
+ *          Leaves current.z at the height where the probe triggered.
  *
  * @return The raw Z position where the probe was triggered
  */
 static float run_z_probe() {
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> run_z_probe", current_position);
+    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> run_z_probe", current);
   #endif
 
   // Stop the probe before it goes too low to prevent damage.
@@ -625,30 +625,30 @@ static float run_z_probe() {
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) {
           SERIAL_ECHOLNPGM("FAST Probe fail!");
-          DEBUG_POS("<<< run_z_probe", current_position);
+          DEBUG_POS("<<< run_z_probe", current);
         }
       #endif
       return NAN;
     }
 
-    float first_probe_z = current_position[Z_AXIS];
+    float first_probe_z = current.z;
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("1st Probe Z:", first_probe_z);
     #endif
 
     // move up to make clearance for the probe
-    do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_MULTI_PROBE, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
+    do_blocking_move_to_z(current.z + Z_CLEARANCE_MULTI_PROBE, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
 
   #elif Z_PROBE_SPEED_FAST != Z_PROBE_SPEED_SLOW
 
     // If the nozzle is well over the travel height then
     // move down quickly before doing the slow probe
     const float z = Z_CLEARANCE_DEPLOY_PROBE + 5.0 + (zprobe_zoffset < 0 ? -zprobe_zoffset : 0);
-    if (current_position[Z_AXIS] > z) {
+    if (current.z > z) {
       // If we don't make it to the z position (i.e. the probe triggered), move up to make clearance for the probe
       if (!do_probe_move(z, MMM_TO_MMS(Z_PROBE_SPEED_FAST)))
-        do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_BETWEEN_PROBES, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
+        do_blocking_move_to_z(current.z + Z_CLEARANCE_BETWEEN_PROBES, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
     }
   #endif
 
@@ -662,15 +662,15 @@ static float run_z_probe() {
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOLNPGM("SLOW Probe fail!");
-            DEBUG_POS("<<< run_z_probe", current_position);
+            DEBUG_POS("<<< run_z_probe", current);
           }
         #endif
         return NAN;
       }
 
   #if MULTIPLE_PROBING > 2
-      probes_total += current_position[Z_AXIS];
-      if (p > 1) do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_MULTI_PROBE, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
+      probes_total += current.z;
+      if (p > 1) do_blocking_move_to_z(current.z + Z_CLEARANCE_MULTI_PROBE, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
     }
   #endif
 
@@ -681,7 +681,7 @@ static float run_z_probe() {
 
   #elif MULTIPLE_PROBING == 2
 
-    const float z2 = current_position[Z_AXIS];
+    const float z2 = current.z;
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
@@ -696,12 +696,12 @@ static float run_z_probe() {
   #else
 
     // Return the single probe result
-    const float measured_z = current_position[Z_AXIS];
+    const float measured_z = current.z;
 
   #endif
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< run_z_probe", current_position);
+    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< run_z_probe", current);
   #endif
 
   return measured_z;
@@ -725,7 +725,7 @@ float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/
       SERIAL_ECHOPAIR(", ", int(verbose_level));
       SERIAL_ECHOPAIR(", ", probe_relative ? "probe" : "nozzle");
       SERIAL_ECHOLNPGM("_relative)");
-      DEBUG_POS("", current_position);
+      DEBUG_POS("", current);
     }
   #endif
 
@@ -741,9 +741,9 @@ float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/
   const float nz =
     #if ENABLED(DELTA)
       // Move below clip height or xy move will be aborted by do_blocking_move_to
-      MIN(current_position[Z_AXIS], delta_clip_start_height)
+      MIN(current.z, delta_clip_start_height)
     #else
-      current_position[Z_AXIS]
+      current.z
     #endif
   ;
 
@@ -759,7 +759,7 @@ float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/
 
     const bool big_raise = raise_after == PROBE_PT_BIG_RAISE;
     if (big_raise || raise_after == PROBE_PT_RAISE)
-      do_blocking_move_to_z(current_position[Z_AXIS] + (big_raise ? 25 : Z_CLEARANCE_BETWEEN_PROBES), MMM_TO_MMS(Z_PROBE_SPEED_FAST));
+      do_blocking_move_to_z(current.z + (big_raise ? 25 : Z_CLEARANCE_BETWEEN_PROBES), MMM_TO_MMS(Z_PROBE_SPEED_FAST));
     else if (raise_after == PROBE_PT_STOW)
       if (STOW_PROBE()) measured_z = NAN;
   }

--- a/Marlin/src/module/scara.h
+++ b/Marlin/src/module/scara.h
@@ -37,10 +37,9 @@ float constexpr L1 = SCARA_LINKAGE_1, L2 = SCARA_LINKAGE_2,
 
 void scara_set_axis_is_at_home(const AxisEnum axis);
 
-void inverse_kinematics(const float (&raw)[XYZ]);
-FORCE_INLINE void inverse_kinematics(const float (&raw)[XYZE]) {
-  const float raw_xyz[XYZ] = { raw[X_AXIS], raw[Y_AXIS], raw[Z_AXIS] };
-  inverse_kinematics(raw_xyz);
+void inverse_kinematics(const xyz_t &raw);
+FORCE_INLINE void inverse_kinematics(const xyze_t &raw) {
+  inverse_kinematics(reinterpret_cast<xyz_t>(raw));
 }
 void forward_kinematics_SCARA(const float &a, const float &b);
 

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -294,9 +294,9 @@ class Stepper {
     #endif
 
     // Delta error variables for the Bresenham line tracer
-    static int32_t delta_error[XYZE];
-    static uint32_t advance_dividend[XYZE],
-                    advance_divisor,
+    static xyze32_t delta_error;
+    static xyze32u_t advance_dividend;
+    static uint32_t advance_divisor,
                     step_events_completed,  // The number of step events executed in the current block
                     accelerate_until,       // The point from where we need to stop acceleration
                     decelerate_after,       // The point from where we need to start decelerating
@@ -333,17 +333,17 @@ class Stepper {
       static uint32_t acc_step_rate; // needed for deceleration start point
     #endif
 
-    static volatile int32_t endstops_trigsteps[XYZ];
+    static abc32v_t endstops_trigsteps;
 
     //
     // Positions of stepper motors, in step units
     //
-    static volatile int32_t count_position[NUM_AXIS];
+    static abce32v_t count_position;
 
     //
     // Current direction of stepper motors (+1 or -1)
     //
-    static int8_t count_direction[NUM_AXIS];
+    static abce8_t count_direction;
 
   public:
 
@@ -457,6 +457,8 @@ class Stepper {
       if (was_enabled) ENABLE_STEPPER_DRIVER_INTERRUPT();
     }
 
+    FORCE_INLINE static void set_position(const abce32_t &pos) { set_position(pos.a, pos.b, pos.c, pos.e); }
+
     static inline void set_position(const AxisEnum a, const int32_t &v) {
       planner.synchronize();
 
@@ -482,6 +484,7 @@ class Stepper {
 
     // Set the current position in steps
     static void _set_position(const int32_t &a, const int32_t &b, const int32_t &c, const int32_t &e);
+    FORCE_INLINE static void _set_position(const abce32_t &pos) { _set_position(pos.a, pos.b, pos.c, pos.e); }
 
     FORCE_INLINE static uint32_t calc_timer_interval(uint32_t step_rate, uint8_t scale, uint8_t* loops) {
       uint32_t timer;

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -606,43 +606,43 @@ void reset_stepper_drivers() {
   #endif
 
   #if AXIS_IS_TMC(X)
-    _TMC_INIT(X, planner.settings.axis_steps_per_mm[X_AXIS]);
+    _TMC_INIT(X, planner.settings.axis_steps_per_mm.x);
   #endif
   #if AXIS_IS_TMC(X2)
-    _TMC_INIT(X2, planner.settings.axis_steps_per_mm[X_AXIS]);
+    _TMC_INIT(X2, planner.settings.axis_steps_per_mm.x);
   #endif
   #if AXIS_IS_TMC(Y)
-    _TMC_INIT(Y, planner.settings.axis_steps_per_mm[Y_AXIS]);
+    _TMC_INIT(Y, planner.settings.axis_steps_per_mm.y);
   #endif
   #if AXIS_IS_TMC(Y2)
-    _TMC_INIT(Y2, planner.settings.axis_steps_per_mm[Y_AXIS]);
+    _TMC_INIT(Y2, planner.settings.axis_steps_per_mm.y);
   #endif
   #if AXIS_IS_TMC(Z)
-    _TMC_INIT(Z, planner.settings.axis_steps_per_mm[Z_AXIS]);
+    _TMC_INIT(Z, planner.settings.axis_steps_per_mm.z);
   #endif
   #if AXIS_IS_TMC(Z2)
-    _TMC_INIT(Z2, planner.settings.axis_steps_per_mm[Z_AXIS]);
+    _TMC_INIT(Z2, planner.settings.axis_steps_per_mm.z);
   #endif
   #if AXIS_IS_TMC(Z3)
-    _TMC_INIT(Z3, planner.settings.axis_steps_per_mm[Z_AXIS]);
+    _TMC_INIT(Z3, planner.settings.axis_steps_per_mm.z);
   #endif
   #if AXIS_IS_TMC(E0)
-    _TMC_INIT(E0, planner.settings.axis_steps_per_mm[E_AXIS_N(0)]);
+    _TMC_INIT(E0, planner.settings.axis_steps_per_mm.E(0));
   #endif
   #if AXIS_IS_TMC(E1)
-    _TMC_INIT(E1, planner.settings.axis_steps_per_mm[E_AXIS_N(1)]);
+    _TMC_INIT(E1, planner.settings.axis_steps_per_mm.E(1));
   #endif
   #if AXIS_IS_TMC(E2)
-    _TMC_INIT(E2, planner.settings.axis_steps_per_mm[E_AXIS_N(2)]);
+    _TMC_INIT(E2, planner.settings.axis_steps_per_mm.E(2));
   #endif
   #if AXIS_IS_TMC(E3)
-    _TMC_INIT(E3, planner.settings.axis_steps_per_mm[E_AXIS_N(3)]);
+    _TMC_INIT(E3, planner.settings.axis_steps_per_mm.E(3));
   #endif
   #if AXIS_IS_TMC(E4)
-    _TMC_INIT(E4, planner.settings.axis_steps_per_mm[E_AXIS_N(4)]);
+    _TMC_INIT(E4, planner.settings.axis_steps_per_mm.E(4));
   #endif
   #if AXIS_IS_TMC(E5)
-    _TMC_INIT(E5, planner.settings.axis_steps_per_mm[E_AXIS_N(5)]);
+    _TMC_INIT(E5, planner.settings.axis_steps_per_mm.E(5));
   #endif
 
   #if USE_SENSORLESS

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -139,7 +139,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS] = { 0 },
 #endif
 
 #if ENABLED(BABYSTEPPING)
-  volatile int16_t Temperature::babystepsTodo[XYZ] = { 0 };
+  volatile xyz16_T Temperature::babystepsTodo = { 0 };
 #endif
 
 #if WATCH_HOTENDS
@@ -657,7 +657,7 @@ float Temperature::get_pid_output(const int8_t e) {
                   lpq[lpq_ptr] = 0;
 
                 if (++lpq_ptr >= lpq_len) lpq_ptr = 0;
-                work_pid[HOTEND_INDEX].Kc = (lpq[lpq_ptr] * planner.steps_to_mm[E_AXIS]) * PID_PARAM(Kc, HOTEND_INDEX);
+                work_pid[HOTEND_INDEX].Kc = (lpq[lpq_ptr] * planner.steps_to_mm.e) * PID_PARAM(Kc, HOTEND_INDEX);
                 pid_output += work_pid[HOTEND_INDEX].Kc;
               }
             #endif // PID_EXTRUSION_SCALING

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -174,7 +174,7 @@ class Temperature {
     #endif
 
     #if ENABLED(BABYSTEPPING)
-      static volatile int16_t babystepsTodo[3];
+      static volatile xyz16_t babystepsTodo;
     #endif
 
     #if ENABLED(PREVENT_COLD_EXTRUSION)
@@ -530,7 +530,7 @@ class Temperature {
               babystepsTodo[CORE_AXIS_1] += CORESIGN(distance * 2);
               babystepsTodo[CORE_AXIS_2] -= CORESIGN(distance * 2);
             #else
-              babystepsTodo[Z_AXIS] += distance;
+              babystepsTodo.z += distance;
             #endif
           #else
             babystepsTodo[axis] += distance;

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -125,8 +125,8 @@
     if (!no_move) {
 
       const float parkingposx[] = PARKING_EXTRUDER_PARKING_X,
-                  midpos = (parkingposx[0] + parkingposx[1]) * 0.5 + hotend_offset[X_AXIS][active_extruder],
-                  grabpos = parkingposx[tmp_extruder] + hotend_offset[X_AXIS][active_extruder]
+                  midpos = (parkingposx[0] + parkingposx[1]) * 0.5 + hotend_offset[active_extruder].x,
+                  grabpos = parkingposx[tmp_extruder] + hotend_offset[active_extruder].x
                             + (tmp_extruder == 0 ? -(PARKING_EXTRUDER_GRAB_DISTANCE) : PARKING_EXTRUDER_GRAB_DISTANCE);
       /**
        * 1. Raise Z-Axis to give enough clearance
@@ -140,24 +140,24 @@
 
       // STEP 1
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("Start Autopark", current_position);
+        if (DEBUGGING(LEVELING)) DEBUG_POS("Start Autopark", current);
       #endif
-      current_position[Z_AXIS] += PARKING_EXTRUDER_SECURITY_RAISE;
+      current.z += PARKING_EXTRUDER_SECURITY_RAISE;
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current_position);
+        if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current);
       #endif
-      planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
+      planner.buffer_line(current, planner.settings.max_feedrate_mm_s.c, active_extruder);
       planner.synchronize();
 
       // STEP 2
-      current_position[X_AXIS] = parkingposx[active_extruder] + hotend_offset[X_AXIS][active_extruder];
+      current.x = parkingposx[active_extruder] + hotend_offset[active_extruder].x;
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) {
           SERIAL_ECHOLNPAIR("(2) Park extruder ", int(active_extruder));
-          DEBUG_POS("Moving ParkPos", current_position);
+          DEBUG_POS("Moving ParkPos", current);
         }
       #endif
-      planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
+      planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a, active_extruder);
       planner.synchronize();
 
       // STEP 3
@@ -170,12 +170,12 @@
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(4) Move to position near new extruder");
       #endif
-      current_position[X_AXIS] += active_extruder ? -10 : 10; // move 10mm away from parked extruder
+      current.x += active_extruder ? -10 : 10; // move 10mm away from parked extruder
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("Move away from parked extruder", current_position);
+        if (DEBUGGING(LEVELING)) DEBUG_POS("Move away from parked extruder", current);
       #endif
-      planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
+      planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a, active_extruder);
       planner.synchronize();
 
       // STEP 5
@@ -189,21 +189,21 @@
       pe_activate_magnet(tmp_extruder);
 
       // STEP 6
-      current_position[X_AXIS] = grabpos + (tmp_extruder ? -10 : 10);
-      planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
-      current_position[X_AXIS] = grabpos;
+      current.x = grabpos + (tmp_extruder ? -10 : 10);
+      planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a, active_extruder);
+      current.x = grabpos;
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("(6) Unpark extruder", current_position);
+        if (DEBUGGING(LEVELING)) DEBUG_POS("(6) Unpark extruder", current);
       #endif
-      planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS]/2, active_extruder);
+      planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a/2, active_extruder);
       planner.synchronize();
 
       // Step 7
-      current_position[X_AXIS] = midpos - hotend_offset[X_AXIS][tmp_extruder];
+      current.x = midpos - hotend_offset[tmp_extruder].x;
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("(7) Move midway between hotends", current_position);
+        if (DEBUGGING(LEVELING)) DEBUG_POS("(7) Move midway between hotends", current);
       #endif
-      planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
+      planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a, active_extruder);
       planner.synchronize();
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         SERIAL_ECHOLNPGM("Autopark done.");
@@ -216,10 +216,10 @@
         pe_activate_magnet(active_extruder); // Just save power for inverted magnets
       #endif
     }
-    current_position[Z_AXIS] += hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
+    current.z += hotend_offset[active_extruder].z - hotend_offset[tmp_extruder].z;
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Applying Z-offset", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Applying Z-offset", current);
     #endif
   }
 
@@ -247,31 +247,31 @@
 
     // STEP 1
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Starting Toolhead change", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Starting Toolhead change", current);
     #endif
-    current_position[Z_AXIS] += SWITCHING_TOOLHEAD_SECURITY_RAISE;
+    current.z += SWITCHING_TOOLHEAD_SECURITY_RAISE;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.c, active_extruder);
     planner.synchronize();
 
     // STEP 2
-    current_position[X_AXIS] = placexpos;
+    current.x = placexpos;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOLNPAIR("(2) Place old tool ", int(active_extruder));
-        DEBUG_POS("Move X SwitchPos", current_position);
+        DEBUG_POS("Move X SwitchPos", current);
       }
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a, active_extruder);
     planner.synchronize();
 
-    current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS - SWITCHING_TOOLHEAD_Y_SECURITY;
+    current.y = SWITCHING_TOOLHEAD_Y_POS - SWITCHING_TOOLHEAD_Y_SECURITY;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Y_AXIS], active_extruder);
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.b, active_extruder);
     planner.synchronize();
 
     // STEP 3
@@ -281,64 +281,64 @@
     MOVE_SERVO(SWITCHING_TOOLHEAD_SERVO_NR, angles[1]);
     safe_delay(500);
 
-    current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS;
+    current.y = SWITCHING_TOOLHEAD_Y_POS;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current);
     #endif
-    planner.buffer_line(current_position,(planner.settings.max_feedrate_mm_s[Y_AXIS] * 0.5), active_extruder);
+    planner.buffer_line(current,(planner.settings.max_feedrate_mm_s.b * 0.5), active_extruder);
     planner.synchronize();
     safe_delay(200);
-    current_position[Y_AXIS] -= SWITCHING_TOOLHEAD_Y_CLEAR;
+    current.y -= SWITCHING_TOOLHEAD_Y_CLEAR;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Y_AXIS], active_extruder); // move away from docked toolhead
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.b, active_extruder); // move away from docked toolhead
     planner.synchronize();
 
     // STEP 4
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(4) Move to new toolhead position");
     #endif
-    current_position[X_AXIS] = grabxpos;
+    current.x = grabxpos;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move to new toolhead X", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move to new toolhead X", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.a, active_extruder);
     planner.synchronize();
-    current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS - SWITCHING_TOOLHEAD_Y_SECURITY;
+    current.y = SWITCHING_TOOLHEAD_Y_POS - SWITCHING_TOOLHEAD_Y_SECURITY;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Y_AXIS], active_extruder);
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.b, active_extruder);
     planner.synchronize();
 
     // STEP 5
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(5) Grab and lock new toolhead ");
     #endif
-    current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS;
+    current.y = SWITCHING_TOOLHEAD_Y_POS;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Y_AXIS] * 0.5, active_extruder);
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.b * 0.5, active_extruder);
     planner.synchronize();
 
     safe_delay(200);
     MOVE_SERVO(SWITCHING_TOOLHEAD_SERVO_NR, angles[0]);
     safe_delay(500);
 
-    current_position[Y_AXIS] -= SWITCHING_TOOLHEAD_Y_CLEAR;
+    current.y -= SWITCHING_TOOLHEAD_Y_CLEAR;
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current);
     #endif
-    planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Y_AXIS], active_extruder); // move away from docked toolhead
+    planner.buffer_line(current, planner.settings.max_feedrate_mm_s.b, active_extruder); // move away from docked toolhead
     planner.synchronize();
 
     // STEP 6
-    current_position[Z_AXIS] += hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
+    current.z += hotend_offset[active_extruder].z - hotend_offset[tmp_extruder].z;
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("(6) Apply Z offset", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("(6) Apply Z offset", current);
     #endif
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -374,36 +374,36 @@ inline void invalid_extruder_error(const uint8_t e) {
     const float xhome = x_home_pos(active_extruder);
     if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE
         && IsRunning()
-        && (delayed_move_time || current_position[X_AXIS] != xhome)
+        && (delayed_move_time || current.x != xhome)
     ) {
-      float raised_z = current_position[Z_AXIS] + TOOLCHANGE_PARK_ZLIFT;
+      float raised_z = current.z + TOOLCHANGE_PARK_ZLIFT;
       #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
-        NOMORE(raised_z, soft_endstop_max[Z_AXIS]);
+        NOMORE(raised_z, soft_endstop_max.z);
       #endif
       #if ENABLED(DEBUG_LEVELING_FEATURE)
         if (DEBUGGING(LEVELING)) {
           SERIAL_ECHOLNPAIR("Raise to ", raised_z);
           SERIAL_ECHOLNPAIR("MoveX to ", xhome);
-          SERIAL_ECHOLNPAIR("Lower to ", current_position[Z_AXIS]);
+          SERIAL_ECHOLNPAIR("Lower to ", current.z);
         }
       #endif
       // Park old head: 1) raise 2) move to park position 3) lower
 
-      #define CUR_X current_position[X_AXIS]
-      #define CUR_Y current_position[Y_AXIS]
-      #define CUR_Z current_position[Z_AXIS]
-      #define CUR_E current_position[E_AXIS]
+      #define CUR_X current.x
+      #define CUR_Y current.y
+      #define CUR_Z current.z
+      #define CUR_E current.e
 
-      planner.buffer_line(CUR_X, CUR_Y, raised_z, CUR_E, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
-      planner.buffer_line(xhome, CUR_Y, raised_z, CUR_E, planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
-      planner.buffer_line(xhome, CUR_Y, CUR_Z,    CUR_E, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
+      planner.buffer_line(CUR_X, CUR_Y, raised_z, CUR_E, planner.settings.max_feedrate_mm_s.c, active_extruder);
+      planner.buffer_line(xhome, CUR_Y, raised_z, CUR_E, planner.settings.max_feedrate_mm_s.a, active_extruder);
+      planner.buffer_line(xhome, CUR_Y, CUR_Z,    CUR_E, planner.settings.max_feedrate_mm_s.c, active_extruder);
 
       planner.synchronize();
     }
 
     // Apply Y & Z extruder offset (X offset is used as home pos with Dual X)
-    current_position[Y_AXIS] -= hotend_offset[Y_AXIS][active_extruder] - hotend_offset[Y_AXIS][tmp_extruder];
-    current_position[Z_AXIS] -= hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
+    current.y -= hotend_offset[active_extruder].y - hotend_offset[tmp_extruder].y;
+    current.z -= hotend_offset[active_extruder].z - hotend_offset[tmp_extruder].z;
 
     // Activate the new extruder ahead of calling set_axis_is_at_home!
     active_extruder = tmp_extruder;
@@ -412,7 +412,7 @@ inline void invalid_extruder_error(const uint8_t e) {
     set_axis_is_at_home(X_AXIS);
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("New Extruder", current_position);
+      if (DEBUGGING(LEVELING)) DEBUG_POS("New Extruder", current);
     #endif
 
     // Only when auto-parking are carriages safe to move
@@ -421,16 +421,16 @@ inline void invalid_extruder_error(const uint8_t e) {
     switch (dual_x_carriage_mode) {
       case DXC_FULL_CONTROL_MODE:
         // New current position is the position of the activated extruder
-        current_position[X_AXIS] = inactive_extruder_x_pos;
-        // Save the inactive extruder's position (from the old current_position)
-        inactive_extruder_x_pos = destination[X_AXIS];
+        current.x = inactive_extruder_x_pos;
+        // Save the inactive extruder's position (from the old current)
+        inactive_extruder_x_pos = destination.x;
         break;
       case DXC_AUTO_PARK_MODE:
         // record raised toolhead position for use by unpark
-        COPY(raised_parked_position, current_position);
-        raised_parked_position[Z_AXIS] += TOOLCHANGE_UNPARK_ZLIFT;
+        COPY(raised_parked, current);
+        raised_parked.z += TOOLCHANGE_UNPARK_ZLIFT;
         #if ENABLED(MAX_SOFTWARE_ENDSTOPS)
-          NOMORE(raised_parked_position[Z_AXIS], soft_endstop_max[Z_AXIS]);
+          NOMORE(raised_parked.z, soft_endstop_max.z);
         #endif
         active_extruder_parked = true;
         delayed_move_time = 0;
@@ -440,7 +440,7 @@ inline void invalid_extruder_error(const uint8_t e) {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOLNPAIR("Active extruder parked: ", active_extruder_parked ? "yes" : "no");
-        DEBUG_POS("New extruder (parked)", current_position);
+        DEBUG_POS("New extruder (parked)", current);
       }
     #endif
 
@@ -506,16 +506,16 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             active_extruder = !tmp_extruder;
 
             // Don't move the new extruder out of bounds
-            if (!WITHIN(current_position[X_AXIS], soft_endstop_min[X_AXIS], soft_endstop_max[X_AXIS]))
+            if (!WITHIN(current.x, soft_endstop_min.x, soft_endstop_max.x))
               no_move = true;
 
           #else
               // No software endstops? Use the configured limits
               if (active_extruder == 0) {
-                if (!WITHIN(current_position[X_AXIS], X2_MIN_POS, X2_MAX_POS))
+                if (!WITHIN(current.x, X2_MIN_POS, X2_MAX_POS))
                   no_move = true;
               }
-              else if (!WITHIN(current_position[X_AXIS], X1_MIN_POS, X1_MAX_POS))
+              else if (!WITHIN(current.x, X1_MIN_POS, X1_MAX_POS))
                 no_move = true;
           #endif
 
@@ -530,8 +530,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
           set_destination_from_current();
 
-          const float xdiff = hotend_offset[X_AXIS][tmp_extruder] - hotend_offset[X_AXIS][active_extruder],
-                      ydiff = hotend_offset[Y_AXIS][tmp_extruder] - hotend_offset[Y_AXIS][active_extruder];
+          const float xdiff = hotend_offset[tmp_extruder].x - hotend_offset[active_extruder].x,
+                      ydiff = hotend_offset[tmp_extruder].y - hotend_offset[active_extruder].y;
 
           #if ENABLED(PARKING_EXTRUDER) // Dual Parking extruder
             constexpr float zdiff = 0;
@@ -540,11 +540,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             constexpr float zdiff = 0;
             switching_toolhead_tool_change(tmp_extruder, fr_mm_s, no_move);
           #else
-            const float zdiff = hotend_offset[Z_AXIS][tmp_extruder] - hotend_offset[Z_AXIS][active_extruder];
+            const float zdiff = hotend_offset[tmp_extruder].z - hotend_offset[active_extruder].z;
             #if ENABLED(SWITCHING_NOZZLE)
               // Always raise by at least 1 to avoid workpiece
-              current_position[Z_AXIS] += MAX(-zdiff, 0.0) + 1;
-              planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
+              current.z += MAX(-zdiff, 0.0) + 1;
+              planner.buffer_line(current, planner.settings.max_feedrate_mm_s.c, active_extruder);
               move_nozzle_servo(tmp_extruder);
             #endif
           #endif
@@ -559,9 +559,9 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #endif
 
           // The newly-selected extruder XY is actually at...
-          current_position[X_AXIS] += xdiff;
-          current_position[Y_AXIS] += ydiff;
-          current_position[Z_AXIS] += zdiff;
+          current.x += xdiff;
+          current.y += ydiff;
+          current.z += zdiff;
 
           // Set the new active extruder
           active_extruder = tmp_extruder;
@@ -573,7 +573,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
         #if ENABLED(DELTA)
           //LOOP_XYZ(i) update_software_endstops(i); // or modify the constrain function
-          const bool safe_to_move = current_position[Z_AXIS] < delta_clip_start_height - 1;
+          const bool safe_to_move = current.z < delta_clip_start_height - 1;
         #else
           constexpr bool safe_to_move = true;
         #endif
@@ -582,8 +582,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         if (safe_to_move && !no_move && IsRunning()) {
           #if DISABLED(SWITCHING_NOZZLE)
             // Do a small lift to avoid the workpiece in the move back (below)
-            current_position[Z_AXIS] += 1.0;
-            planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder);
+            current.z += 1.0;
+            planner.buffer_line(current, planner.settings.max_feedrate_mm_s.c, active_extruder);
           #endif
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
@@ -592,11 +592,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
             // Dual x carriage does not properly apply these to current position due to command ordering
             // So we apply the offsets for y and z to the destination here. X cannot have an offset in this mode
             // as it is utilized for X2 home position.
-            destination[Y_AXIS] -= hotend_offset[Y_AXIS][active_extruder] - hotend_offset[Y_AXIS][tmp_extruder];
-            destination[Z_AXIS] -= hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
+            destination.y -= hotend_offset[active_extruder].y - hotend_offset[tmp_extruder].y;
+            destination.z -= hotend_offset[active_extruder].z - hotend_offset[tmp_extruder].z;
           #endif
           // Move back to the original (or tweaked) position
-          do_blocking_move_to(destination[X_AXIS], destination[Y_AXIS], destination[Z_AXIS]);
+          do_blocking_move_to(destination.x, destination.y, destination.z);
           #if ENABLED(DUAL_X_CARRIAGE)
             active_extruder_parked = false;
           #endif
@@ -604,7 +604,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         #if ENABLED(SWITCHING_NOZZLE)
           else {
             // Move back down. (Including when the new tool is higher.)
-            do_blocking_move_to_z(destination[Z_AXIS], planner.settings.max_feedrate_mm_s[Z_AXIS]);
+            do_blocking_move_to_z(destination.z, planner.settings.max_feedrate_mm_s.c);
           }
         #endif
       } // (tmp_extruder != active_extruder)
@@ -652,8 +652,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #if ENABLED(ADVANCED_PAUSE_FEATURE)
             do_pause_e_move(-sn_settings.swap_length, MMM_TO_MMS(sn_settings.retract_speed));
           #else
-            current_position[E_AXIS] -= sn_settings.swap_length / planner.e_factor[active_extruder];
-            planner.buffer_line(current_position, MMM_TO_MMS(sn_settings.retract_speed), active_extruder);
+            current.e -= sn_settings.swap_length / planner.e_factor[active_extruder];
+            planner.buffer_line(current, MMM_TO_MMS(sn_settings.retract_speed), active_extruder);
           #endif
         }
 
@@ -665,16 +665,16 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #endif
         ;
 
-        float old_pos[XYZ];
+        xyz_t old_pos;
 
         if (!no_move) {
           COPY(old_pos, current_position);
 
           #if ENABLED(SINGLENOZZLE_SWAP_PARK)
-            current_position[X_AXIS] = sn_settings.change_point.x;
-            current_position[Y_AXIS] = sn_settings.change_point.y;
+            current.x = sn_settings.change_point.x;
+            current.y = sn_settings.change_point.y;
           #endif
-          current_position[Z_AXIS] += sn_settings.z_raise;
+          current.z += sn_settings.z_raise;
 
           do_blocking_move_to(current_position, snfr);
         }
@@ -694,8 +694,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #if ENABLED(ADVANCED_PAUSE_FEATURE)
             do_pause_e_move(sn_settings.swap_length, sn_settings.prime_speed);
           #else
-            current_position[E_AXIS] += sn_settings.swap_length / planner.e_factor[tmp_extruder];
-            planner.buffer_line(current_position, sn_settings.prime_speed, tmp_extruder);
+            current.e += sn_settings.swap_length / planner.e_factor[tmp_extruder];
+            planner.buffer_line(current, sn_settings.prime_speed, tmp_extruder);
           #endif
         }
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -19,7 +19,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
+#ifndef _PINS_H_
+  #define _PINS_H_
+#else
+  #error "pins.h should only be included from MarlinConfig.h"
+#endif
 
 /**
  * Include pins definitions


### PR DESCRIPTION
Instead of using arrays with `[ABC]`, `[ABCE]`, `[XYZ]`, and `[XYZE]` use smart unions that add some advantageous syntax:
- Axis elements can be referred to by dot notation.
- Axis elements can be referred to by array index.
- Copying doesn't require building in-place initializers or looping.
- The nature of the element (abc, xyz) is enforced by the compiler.
- Code for `DISTINCT_E_FACTORS` is much simplified.

Also:
- Enforce some headers are only included by core config headers for dependencies.
- Apply a few `#pragma once` directives.