### PR TITLE
Option for G0 to have a separate feedrate

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -701,6 +701,22 @@
     #define USB_INTR_PIN       SD_DETECT_PIN
   #endif
 
+  /**
+   * When using a bootloader that supports SD-Firmware-Flashing,
+   * add a menu item to activate SD-FW-Update on the next reboot.
+   *
+   * Requires ATMEGA2560 (Arduino Mega)
+   *
+   * Tested with this bootloader:
+   *   https://github.com/FleetProbe/MicroBridge-Arduino-ATMega2560
+   */
+  //#define SD_FIRMWARE_UPDATE
+  #if ENABLED(SD_FIRMWARE_UPDATE)
+    #define SD_FIRMWARE_UPDATE_EEPROM_ADDR    0x1FF
+    #define SD_FIRMWARE_UPDATE_ACTIVE_VALUE   0xF0
+    #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
+  #endif
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -701,22 +701,6 @@
     #define USB_INTR_PIN       SD_DETECT_PIN
   #endif
 
-  /**
-   * When using a bootloader that supports SD-Firmware-Flashing,
-   * add a menu item to activate SD-FW-Update on the next reboot.
-   *
-   * Requires ATMEGA2560 (Arduino Mega)
-   *
-   * Tested with this bootloader:
-   *   https://github.com/FleetProbe/MicroBridge-Arduino-ATMega2560
-   */
-  //#define SD_FIRMWARE_UPDATE
-  #if ENABLED(SD_FIRMWARE_UPDATE)
-    #define SD_FIRMWARE_UPDATE_EEPROM_ADDR    0x1FF
-    #define SD_FIRMWARE_UPDATE_ACTIVE_VALUE   0xF0
-    #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
-  #endif
-
 #endif // SDSUPPORT
 
 /**
@@ -1614,8 +1598,12 @@
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
  */
-//#define PAREN_COMMENTS      // Support for parentheses-delimited comments
-//#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+#define PAREN_COMMENTS      // Support for parentheses-delimited comments
+#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+#define G0_FEEDRATE         // Manages a G0 specific feedrate, and apply it to any G0 move. Any F parameter into a G0 command sets the feedrate for later commands (uses 4bytes of SRAM)
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_MMM_FOR_G0 3000.0
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1598,9 +1598,9 @@
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
  */
-#define PAREN_COMMENTS      // Support for parentheses-delimited comments
-#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
-#define G0_FEEDRATE         // Manages a G0 specific feedrate, and apply it to any G0 move. Any F parameter into a G0 command sets the feedrate for later commands (uses 4bytes of SRAM)
+//#define PAREN_COMMENTS      // Support for parentheses-delimited comments
+//#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Manages a G0 specific feedrate, and apply it to any G0 move. Any F parameter into a G0 command sets the feedrate for later commands (uses 4bytes of SRAM)
 #if ENABLED(G0_FEEDRATE)
   #define DEFAULT_MMM_FOR_G0 3000.0
 #endif 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1613,10 +1613,11 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Please note that G0 feedrates should be used with care (if at all) for 3D printing where high feedrates can be cause of ringing and bad printing quality
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
-//#define G0_FEEDRATE         // Manages a G0 specific feedrate, and apply it to any G0 move. Any F parameter into a G0 command sets the feedrate for later commands (uses 4bytes of SRAM)
+//#define G0_FEEDRATE         // Manages a G0 specific feedrate, and apply it to any G0 move. Any F parameter into a G0 command sets the feedrate for later commands (uses 4bytes of SRAM) 
 #if ENABLED(G0_FEEDRATE)
   #define DEFAULT_MMM_FOR_G0 3000.0
 #endif 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1613,13 +1613,14 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
- * Please note that G0 feedrates should be used with care (if at all) for 3D printing where high feedrates can be cause of ringing and bad printing quality
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
-//#define G0_FEEDRATE         // Manages a G0 specific feedrate, and apply it to any G0 move. Any F parameter into a G0 command sets the feedrate for later commands (uses 4bytes of SRAM) 
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_MMM_FOR_G0 3000.0
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1620,7 +1620,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1620,7 +1620,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -1613,9 +1613,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1627,7 +1627,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1620,9 +1620,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1615,9 +1615,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1622,7 +1622,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -1623,7 +1623,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -1616,9 +1616,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1624,7 +1624,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1617,9 +1617,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1627,7 +1627,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1620,9 +1620,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/TheBorg/Configuration_adv.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/TheBorg/Configuration_adv.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1625,9 +1625,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1632,7 +1632,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1621,7 +1621,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1614,9 +1614,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1612,9 +1612,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1619,7 +1619,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1620,7 +1620,7 @@
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
 //#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
 #if ENABLED(G0_FEEDRATE)
-  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+  #define DEFAULT_G0_FEEDRATE 3000  // (mm/m)
 #endif 
 
 /**

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -1613,9 +1613,15 @@
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.
+ * Note that G0 feedrates should be used with care for 3D printing (if used at all).
+ * High feedrates may cause ringing and harm print quality.
  */
 //#define PAREN_COMMENTS      // Support for parentheses-delimited comments
 //#define GCODE_MOTION_MODES  // Remember the motion mode (G0 G1 G2 G3 G5 G38.X) and apply for X Y Z E F, etc.
+//#define G0_FEEDRATE         // Add a G0-specific sticky feedrate, applied to all subsequent G0 moves.
+#if ENABLED(G0_FEEDRATE)
+  #define DEFAULT_G0_FEEDRATE 3000.0  // (mm/m)
+#endif 
 
 /**
  * User-defined menu items that execute custom GCode

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -188,7 +188,7 @@ void GcodeSuite::process_parsed_command(
     case 'G': switch (parser.codenum) {
 
       case 0: case 1: G0_G1(                                      // G0: Fast Move, G1: Linear Move
-                        #if IS_SCARA
+                        #if IS_SCARA || ENABLED(G0_FEEDRATE)
                           parser.codenum == 0
                         #endif
                       );

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -194,7 +194,7 @@ void GcodeSuite::process_parsed_command(
                       );
                       break;
 
-      #if ENABLED(ARC_SUPPORT) && DISABLED(IS_SCARA)
+      #if ENABLED(ARC_SUPPORT) && DISABLED(SCARA)
         case 2: case 3: G2_G3(parser.codenum == 2); break;        // G2: CW ARC, G3: CCW ARC
       #endif
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -194,7 +194,7 @@ void GcodeSuite::process_parsed_command(
                       );
                       break;
 
-      #if ENABLED(ARC_SUPPORT) && DISABLED(SCARA)
+      #if ENABLED(ARC_SUPPORT) && DISABLED(IS_SCARA)
         case 2: case 3: G2_G3(parser.codenum == 2); break;        // G2: CW ARC, G3: CCW ARC
       #endif
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -341,7 +341,7 @@ public:
 private:
 
   static void G0_G1(
-    #if IS_SCARA
+    #if IS_SCARA || ENABLED(G0_FEEDRATE)
       bool fast_move=false
     #endif
   );

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -37,6 +37,10 @@
 
 extern float destination[XYZE];
 
+#if ENABLED(G0_FEEDRATE)
+float saved_g0_feedrate_mm_s =  MMM_TO_MMS(DEFAULT_MMM_FOR_G0);
+#endif
+
 #if ENABLED(NO_MOTION_BEFORE_HOMING)
   #define G0_G1_CONDITION !axis_unhomed_error(parser.seen('X'), parser.seen('Y'), parser.seen('Z'))
 #else
@@ -47,11 +51,23 @@ extern float destination[XYZE];
  * G0, G1: Coordinated movement of X Y Z E axes
  */
 void GcodeSuite::G0_G1(
-  #if IS_SCARA
+  #if IS_SCARA || ENABLED(G0_FEEDRATE)
     bool fast_move/*=false*/
   #endif
 ) {
+  #if ENABLED(G0_FEEDRATE)
+    float saved_g1_feedrate_mm_s;
+  #endif
+  
   if (IsRunning() && G0_G1_CONDITION) {
+    
+    #if ENABLED(G0_FEEDRATE)
+    if(fast_move) {
+      // Save standard feedrate before setting feedrate to fast/g0
+      saved_g1_feedrate_mm_s = feedrate_mm_s;
+      feedrate_mm_s = saved_g0_feedrate_mm_s;
+    }
+    #endif
     get_destination_from_command(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_AUTORETRACT)
@@ -77,6 +93,14 @@ void GcodeSuite::G0_G1(
       prepare_move_to_destination();
     #endif
 
+    #if ENABLED(G0_FEEDRATE)
+    // save G0 feedrate, and restore standard feedrate as soon as possible 
+    if(fast_move) {
+      saved_g0_feedrate_mm_s = feedrate_mm_s;
+      feedrate_mm_s = saved_g1_feedrate_mm_s;
+    }
+    #endif
+    
     #if ENABLED(NANODLP_Z_SYNC)
       #if ENABLED(NANODLP_ALL_AXIS)
         #define _MOVE_SYNC parser.seenval('X') || parser.seenval('Y') || parser.seenval('Z')  // For any move wait and output sync message

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -38,7 +38,7 @@
 extern float destination[XYZE];
 
 #if ENABLED(G0_FEEDRATE)
-float saved_g0_feedrate_mm_s =  MMM_TO_MMS(DEFAULT_MMM_FOR_G0);
+  float saved_g0_feedrate_mm_s =  MMM_TO_MMS(DEFAULT_G0_FEEDRATE);
 #endif
 
 #if ENABLED(NO_MOTION_BEFORE_HOMING)
@@ -62,12 +62,13 @@ void GcodeSuite::G0_G1(
   if (IsRunning() && G0_G1_CONDITION) {
     
     #if ENABLED(G0_FEEDRATE)
-    if(fast_move) {
-      // Save standard feedrate before setting feedrate to fast/g0
-      saved_g1_feedrate_mm_s = feedrate_mm_s;
-      feedrate_mm_s = saved_g0_feedrate_mm_s;
-    }
+      if (fast_move) {
+        // Save standard feedrate before setting feedrate to fast/g0
+        saved_g1_feedrate_mm_s = feedrate_mm_s;
+        feedrate_mm_s = saved_g0_feedrate_mm_s;
+      }
     #endif
+
     get_destination_from_command(); // For X Y Z E F
 
     #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_AUTORETRACT)
@@ -94,11 +95,11 @@ void GcodeSuite::G0_G1(
     #endif
 
     #if ENABLED(G0_FEEDRATE)
-    // save G0 feedrate, and restore standard feedrate as soon as possible 
-    if(fast_move) {
-      saved_g0_feedrate_mm_s = feedrate_mm_s;
-      feedrate_mm_s = saved_g1_feedrate_mm_s;
-    }
+      // save G0 feedrate, and restore standard feedrate as soon as possible 
+      if (fast_move) {
+        saved_g0_feedrate_mm_s = feedrate_mm_s;
+        feedrate_mm_s = saved_g1_feedrate_mm_s;
+      }
     #endif
     
     #if ENABLED(NANODLP_Z_SYNC)


### PR DESCRIPTION


### Description

This PR manages a second "feedrate" applied only to G0 moves. It saves/restores the primary feedrate upon evaluation, and likewise restores/saves G0 feedrate.

### Benefits

This increases compatiblity with CNC produced GCode, and can speed up CNC gcode execution where faster G0 is implied. and F is not respecified at each command.

### Related Issues

Would answer to Feature Request #12047  
