### PR TITLE
[2.0.x] Reduce HOMING_FEEDRATE_XY for Ender 3

### DIFF
--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -1206,7 +1206,7 @@
 #endif
 
 // Homing speeds (mm/m)
-#define HOMING_FEEDRATE_XY (50*60)
+#define HOMING_FEEDRATE_XY (20*60)
 #define HOMING_FEEDRATE_Z  (4*60)
 
 // Validate that endstops are triggered on homing moves


### PR DESCRIPTION
### Description

Homing on the Ender 3 with HOMING_FEEDRATE_XY set to 50*60 was shown [1] to cause the end-stop micro-switches to bottom out, causing the carriage for both X and Y axis to physically crash into the micro switch. Reducing the homing speed prevents the switches from bottoming out.

[1] https://github.com/MarlinFirmware/Marlin/issues/12074

### Benefits

This will prevent end stop switches from bottoming out in a violent way, thereby reducing the chance damage may occur when users use the suggested example configuration for the Ender 3. 

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/12074
