### PR TITLE
Mixer - update descriptions

### DIFF
--- a/Marlin/src/gcode/feature/mixing/M163-M165.cpp
+++ b/Marlin/src/gcode/feature/mixing/M163-M165.cpp
@@ -43,7 +43,7 @@ void GcodeSuite::M163() {
 
 /**
  * M164: Normalize and commit the mix.
- *       If 'S' is given store as a virtual tool. Else in T0.
+ *       If 'S' is given store as a virtual tool. Else in the active v-tool.
  *
  *   S[index]   The virtual tool to store
  */
@@ -55,6 +55,8 @@ void GcodeSuite::M164() {
   #endif
   if (WITHIN(tool_index, 0, MIXING_VIRTUAL_TOOLS - 1))
     mixer.normalize(tool_index);
+  else
+    mixer.normalize(mixer.get_current_v_tool());
 }
 
 #if ENABLED(DIRECT_MIXING_IN_G1)

--- a/Marlin/src/gcode/feature/mixing/M163-M165.cpp
+++ b/Marlin/src/gcode/feature/mixing/M163-M165.cpp
@@ -43,9 +43,9 @@ void GcodeSuite::M163() {
 
 /**
  * M164: Normalize and commit the mix.
- *       If 'S' is given store as a virtual tool. Else in the active v-tool.
  *
  *   S[index]   The virtual tool to store
+ *              If 'S' is omitted update the active virtual tool.
  */
 void GcodeSuite::M164() {
   #if MIXING_VIRTUAL_TOOLS > 1

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -146,8 +146,8 @@
  * M150 - Set Status LED Color as R<red> U<green> B<blue> P<bright>. Values 0-255. (Requires BLINKM, RGB_LED, RGBW_LED, NEOPIXEL_LED, or PCA9632).
  * M155 - Auto-report temperatures with interval of S<seconds>. (Requires AUTO_REPORT_TEMPERATURES)
  * M163 - Set a single proportion for a mixing extruder. (Requires MIXING_EXTRUDER)
- * M164 - Commit the mix (Req. MIXING_EXTRUDER) and optionally save as a virtual tool (Requires MIXING_EXTRUDER)
- * M165 - Set the mix for a mixing extruder with parameters ABCDHI. (Requires MIXING_EXTRUDER and DIRECT_MIXING_IN_G1)
+ * M164 - Commit the mix and save as the specified, or if not set active, virtual tool (Requires MIXING_EXTRUDER)
+ * M165 - Set the mix for the active mixing extruder with parameters ABCDHI. (Requires MIXING_EXTRUDER and DIRECT_MIXING_IN_G1)
  * M190 - Sxxx Wait for bed current temp to reach target temp. ** Waits only when heating! **
  *        Rxxx Wait for bed current temp to reach target temp. ** Waits for heating or cooling. **
  * M200 - Set filament diameter, D<diameter>, setting E axis units to cubic. (Use S0 to revert to linear units.)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -146,7 +146,7 @@
  * M150 - Set Status LED Color as R<red> U<green> B<blue> P<bright>. Values 0-255. (Requires BLINKM, RGB_LED, RGBW_LED, NEOPIXEL_LED, or PCA9632).
  * M155 - Auto-report temperatures with interval of S<seconds>. (Requires AUTO_REPORT_TEMPERATURES)
  * M163 - Set a single proportion for a mixing extruder. (Requires MIXING_EXTRUDER)
- * M164 - Commit the mix and save as the specified, or if not set active, virtual tool (Requires MIXING_EXTRUDER)
+ * M164 - Commit the mix and save to a virtual tool (current, or as specified by 'S'). (Requires MIXING_EXTRUDER)
  * M165 - Set the mix for the active mixing extruder with parameters ABCDHI. (Requires MIXING_EXTRUDER and DIRECT_MIXING_IN_G1)
  * M190 - Sxxx Wait for bed current temp to reach target temp. ** Waits only when heating! **
  *        Rxxx Wait for bed current temp to reach target temp. ** Waits for heating or cooling. **

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -147,7 +147,7 @@
  * M155 - Auto-report temperatures with interval of S<seconds>. (Requires AUTO_REPORT_TEMPERATURES)
  * M163 - Set a single proportion for a mixing extruder. (Requires MIXING_EXTRUDER)
  * M164 - Commit the mix and save to a virtual tool (current, or as specified by 'S'). (Requires MIXING_EXTRUDER)
- * M165 - Set the mix for the active mixing extruder with parameters ABCDHI. (Requires MIXING_EXTRUDER and DIRECT_MIXING_IN_G1)
+ * M165 - Set the mix for the mixing extruder (and current virtual tool) with parameters ABCDHI. (Requires MIXING_EXTRUDER and DIRECT_MIXING_IN_G1)
  * M190 - Sxxx Wait for bed current temp to reach target temp. ** Waits only when heating! **
  *        Rxxx Wait for bed current temp to reach target temp. ** Waits for heating or cooling. **
  * M200 - Set filament diameter, D<diameter>, setting E axis units to cubic. (Use S0 to revert to linear units.)


### PR DESCRIPTION
and change behavior of M164 to commit to the active v-tool, if 'S' is omitted, instead of doing nothing.

Parallel PRs to the wiki.
