### PR TITLE
[2.0.x] Add missing SerialUSB definition for STM32 HAL

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -87,7 +87,7 @@
   #endif
   #define NUM_SERIAL 2
   #if SERIAL_PORT_2 == -1
-    #define MYSERIAL1 Serial0 // TODO Once CDC is supported
+    #define MYSERIAL1 SerialUSB
   #elif SERIAL_PORT_2 == 1
     #define MYSERIAL1 Serial1
   #elif SERIAL_PORT_2 == 2


### PR DESCRIPTION
`SERIAL_PORT` was already defined for SerialUSB. But `SERIAL_PORT_2` wasn't defined to the correct value yet.