### PR TITLE
[2.0.x] Change pin definition to match final RemRam board design

### DIFF
--- a/Marlin/src/pins/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/pins_REMRAM_V1.h
@@ -106,9 +106,9 @@
 #define SERVO0_PIN         26   // PWM_EXT1
 #define SERVO1_PIN         27   // PWM_EXT2
 
-#define SDSS                9
+#define SDSS               57   // Onboard SD card reader
+//#define SDSS              9   // LCD SD card reader
 #define LED_PIN            21   // STATUS_LED
-#define KILL_PIN           57
 
 //
 // LCD / Controller


### PR DESCRIPTION
This commit will make Marlin compatible with [the final v1.3 design](https://github.com/hasenbanck/remram/releases/tag/v1.3) of the RemRam board. Since only I currently have a pre 1.3 version of this board, this backward incompatible change is fine.

