### PR TITLE
[LPC176x] Fix USEABLE_HARDWARE_PWM macro, cleanup multiple LED support

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -37,7 +37,7 @@
 
 #include <Arduino.h>
 
-#define USEABLE_HARDWARE_PWM(pin) useable_hardware_PWM(pin)
+#define USEABLE_HARDWARE_PWM(pin) TRUE // all pins are PWM capable
 
 #define LPC_PIN(pin)            gpio_pin(pin)
 #define LPC_GPIO(port)          gpio_port(port)

--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -28,24 +28,30 @@ void SysTick_Callback() {
 }
 
 void HAL_init() {
+
+  // Support the 4 LEDs some LPC176x boards have
   #if PIN_EXISTS(LED)
     SET_DIR_OUTPUT(LED_PIN);
     WRITE_PIN_CLR(LED_PIN);
-
-    // MKS_SBASE has 3 other LEDs the bootloader uses during flashing. Clear them.
-    SET_DIR_OUTPUT(P1_19);
-    WRITE_PIN_CLR(P1_19);
-    SET_DIR_OUTPUT(P1_20);
-    WRITE_PIN_CLR(P1_20);
-    SET_DIR_OUTPUT(P1_21);
-    WRITE_PIN_CLR(P1_21);
-
+    #if PIN_EXISTS(LED2)
+        SET_DIR_OUTPUT(LED2_PIN);
+        WRITE_PIN_CLR(LED2_PIN);
+      #if PIN_EXISTS(LED3)
+          SET_DIR_OUTPUT(LED3_PIN);
+          WRITE_PIN_CLR(LED3_PIN);
+        #if PIN_EXISTS(LED4)
+            SET_DIR_OUTPUT(LED4_PIN);
+            WRITE_PIN_CLR(LED4_PIN);
+        #endif
+      #endif
+    #endif
     // Flash status LED 3 times to indicate Marlin has started booting
     for (uint8_t i = 0; i < 6; ++i) {
       TOGGLE(LED_PIN);
       delay(100);
     }
   #endif
+
   //debug_frmwrk_init();
   //_DBG("\n\nDebug running\n");
   // Initialise the SD card chip select pins as soon as possible

--- a/Marlin/src/HAL/HAL_LPC1768/watchdog.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/watchdog.cpp
@@ -68,7 +68,7 @@ uint8_t HAL_get_reset_source(void) {
 void watchdog_reset() {
   WDT_Feed();
   #if DISABLED(PINS_DEBUGGING) && PIN_EXISTS(LED)
-    TOGGLE(LED_PIN);  // heart beat indicator
+    TOGGLE(LED_PIN);  // heartbeat indicator
   #endif
 }
 

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -42,7 +42,10 @@
 #define PIN_P0_03          P0_03   // AUX1 (Interrupt Capable/ADC/Serial Port 0)
 */
 
-#define LED_PIN            P1_18   // LED2 P1_19, LED3 P1_20, LED4 P1_21
+#define LED_PIN            P1_18   // Used as a status indicator
+#define LED2_PIN           P1_19
+#define LED3_PIN           P1_20
+#define LED4_PIN           P1_21
 
 //
 // Servo pin


### PR DESCRIPTION
### Description
Fix the USEABLE_HARDWARE_PWM to always return true as the platform supports PWM on all pins, cleanup multiple LED support so we don't just configure the smoothieware default LED pins, will require board to set the appropriate pins.

### Related Issues
resolves #12127
