### PR TITLE
[bugfix-2.0.x] Updates for the Anycubic Kossel example config

### DIFF
--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -583,9 +583,6 @@
   // and processor overload (too many expensive sqrt calls).
   #define DELTA_SEGMENTS_PER_SECOND 80
 
-  // Convert feedrates to apply to the Effector instead of the Carriages
-  //#define DELTA_FEEDRATE_SCALING
-
   // After homing move down to a height where XY movement is unconstrained
   #define DELTA_HOME_TO_SAFE_ZONE
 


### PR DESCRIPTION
### Description

Remove unused option in Anycubic Kossel config

### Benefits

Remove the DELTA_FEEDRATE_SCALING option. Seems like it has no effect since commit c437bb08f12f1c0535cc78a761b49a18f2dc2a12.
