### PR TITLE
[bugfix-2.0.x] clarify #define Z_MIN_PROBE_ENDSTOP

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/default/Configuration.h
+++ b/Marlin/src/config/default/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/default/Configuration.h
+++ b/Marlin/src/config/default/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -760,7 +760,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -759,6 +759,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
+++ b/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
+++ b/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Anet/A2/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Anet/A2/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Anet/A6/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration.h
@@ -788,7 +788,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Anet/A6/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration.h
@@ -787,6 +787,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Anet/A8/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration.h
@@ -747,7 +747,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Anet/A8/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration.h
@@ -746,6 +746,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
@@ -741,7 +741,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
@@ -740,6 +740,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -727,6 +727,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -728,7 +728,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Cartesio/Configuration.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration.h
@@ -738,6 +738,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Cartesio/Configuration.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration.h
@@ -739,7 +739,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration.h
@@ -750,7 +750,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration.h
@@ -749,6 +749,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -744,7 +744,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -743,6 +743,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
@@ -759,7 +759,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
@@ -758,6 +758,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration.h
@@ -750,7 +750,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration.h
@@ -749,6 +749,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
@@ -744,7 +744,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
@@ -743,6 +743,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -744,7 +744,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -743,6 +743,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
@@ -750,7 +750,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
@@ -749,6 +749,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Einstart-S/Configuration.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration.h
@@ -751,6 +751,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Einstart-S/Configuration.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration.h
@@ -752,7 +752,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Felix/Configuration.h
+++ b/Marlin/src/config/examples/Felix/Configuration.h
@@ -721,6 +721,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Felix/Configuration.h
+++ b/Marlin/src/config/examples/Felix/Configuration.h
@@ -722,7 +722,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Felix/DUAL/Configuration.h
+++ b/Marlin/src/config/examples/Felix/DUAL/Configuration.h
@@ -721,6 +721,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Felix/DUAL/Configuration.h
+++ b/Marlin/src/config/examples/Felix/DUAL/Configuration.h
@@ -722,7 +722,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -746,7 +746,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -745,6 +745,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
@@ -824,7 +824,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
@@ -823,6 +823,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -778,7 +778,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -777,6 +777,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -761,7 +761,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -760,6 +760,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
@@ -754,6 +754,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
@@ -755,7 +755,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -747,7 +747,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -746,6 +746,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -755,7 +755,7 @@
  */
 #define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP 32
+  #define Z_MIN_PROBE_PIN 32
 #endif
 
 /**

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -754,7 +754,9 @@
  *
  */
 #define Z_MIN_PROBE_ENDSTOP
-#define Z_MIN_PROBE_PIN 32
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP 32
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -754,6 +754,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -755,7 +755,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
@@ -744,7 +744,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
@@ -743,6 +743,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration.h
@@ -751,6 +751,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration.h
@@ -752,7 +752,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -760,7 +760,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -759,6 +759,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -760,7 +760,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -759,6 +759,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -738,6 +738,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -739,7 +739,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
@@ -744,7 +744,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
@@ -743,6 +743,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -744,7 +744,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -743,6 +743,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
@@ -780,7 +780,7 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
@@ -779,6 +779,9 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/RigidBot/Configuration.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration.h
@@ -738,7 +738,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/RigidBot/Configuration.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration.h
@@ -737,6 +737,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -752,6 +752,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -753,7 +753,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/STM32F10/Configuration.h
+++ b/Marlin/src/config/examples/STM32F10/Configuration.h
@@ -742,7 +742,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/STM32F10/Configuration.h
+++ b/Marlin/src/config/examples/STM32F10/Configuration.h
@@ -741,6 +741,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/STM32F4/Configuration.h
+++ b/Marlin/src/config/examples/STM32F4/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/STM32F4/Configuration.h
+++ b/Marlin/src/config/examples/STM32F4/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Sanguinololu/Configuration.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration.h
@@ -771,7 +771,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Sanguinololu/Configuration.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration.h
@@ -770,6 +770,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/TheBorg/Configuration.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/TheBorg/Configuration.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/TinyBoy2/Configuration.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration.h
@@ -790,6 +790,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/TinyBoy2/Configuration.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration.h
@@ -791,7 +791,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Tronxy/X1/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X1/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Tronxy/X1/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X1/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
@@ -751,7 +751,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
@@ -750,6 +750,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration.h
@@ -768,6 +768,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration.h
@@ -769,7 +769,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -750,7 +750,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -749,6 +749,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
+++ b/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
@@ -739,6 +739,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
+++ b/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
@@ -740,7 +740,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -875,7 +875,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -874,6 +874,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -826,6 +826,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -827,7 +827,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/generic/Configuration.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration.h
@@ -812,7 +812,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/generic/Configuration.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration.h
@@ -811,6 +811,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
@@ -812,7 +812,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
@@ -811,6 +811,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
@@ -804,6 +804,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
@@ -805,7 +805,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
@@ -815,7 +815,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
@@ -814,6 +814,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -752,6 +752,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -753,7 +753,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/makibox/Configuration.h
+++ b/Marlin/src/config/examples/makibox/Configuration.h
@@ -743,7 +743,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/makibox/Configuration.h
+++ b/Marlin/src/config/examples/makibox/Configuration.h
@@ -742,6 +742,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -742,7 +742,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -741,6 +741,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
@@ -735,7 +735,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
@@ -734,6 +734,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/src/config/examples/wt150/Configuration.h
+++ b/Marlin/src/config/examples/wt150/Configuration.h
@@ -745,7 +745,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/src/config/examples/wt150/Configuration.h
+++ b/Marlin/src/config/examples/wt150/Configuration.h
@@ -744,6 +744,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type


### PR DESCRIPTION
### Description

#define Z_MIN_PROBE_ENDSTOP

the above example was not following the usual pattern of providing everything as commented out/disabled example that is necessary.

Adding:

#if ENABLED(Z_MIN_PROBE_ENDSTOP)
  #define Z_MIN_PROBE_ENDSTOP -1
#endif

to clarify

### Benefits

less confusion, less support questions

### Related Issues

N/A
