### PR TITLE
[bugfix-1.1.x] clarify z min probe endstop

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -697,7 +697,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -696,6 +696,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
@@ -710,7 +710,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
@@ -709,6 +709,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
+++ b/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
+++ b/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Anet/A2plus/Configuration.h
+++ b/Marlin/example_configurations/Anet/A2plus/Configuration.h
@@ -729,7 +729,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A2plus/Configuration.h
+++ b/Marlin/example_configurations/Anet/A2plus/Configuration.h
@@ -728,6 +728,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Anet/A6/Configuration.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration.h
@@ -738,7 +738,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A6/Configuration.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration.h
@@ -737,6 +737,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Anet/A8/Configuration.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration.h
@@ -697,7 +697,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A8/Configuration.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration.h
@@ -696,6 +696,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration.h
@@ -677,6 +677,9 @@
  *
  */
 #define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  //#define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration.h
@@ -678,7 +678,7 @@
  */
 #define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  //#define Z_MIN_PROBE_ENDSTOP -1
+  //#define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
@@ -690,6 +690,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
@@ -691,7 +691,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration.h
@@ -678,7 +678,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration.h
@@ -677,6 +677,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -689,7 +689,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -688,6 +688,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/CR-10/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration.h
@@ -699,6 +699,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/CR-10/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration.h
@@ -700,7 +700,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration.h
@@ -694,7 +694,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration.h
@@ -693,6 +693,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
@@ -708,6 +708,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
@@ -709,7 +709,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-8/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration.h
@@ -699,6 +699,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/CR-8/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration.h
@@ -700,7 +700,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration.h
@@ -694,7 +694,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration.h
@@ -693,6 +693,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration.h
@@ -694,7 +694,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration.h
@@ -693,6 +693,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration.h
@@ -699,6 +699,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration.h
@@ -700,7 +700,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -671,6 +671,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -672,7 +672,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -671,6 +671,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -672,7 +672,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
@@ -695,6 +695,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
@@ -696,7 +696,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
@@ -705,7 +705,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
@@ -704,6 +704,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -704,7 +704,9 @@
  *
  */
 #define Z_MIN_PROBE_ENDSTOP
-#define Z_MIN_PROBE_PIN 32
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP 32
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -705,7 +705,7 @@
  */
 #define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP 32
+  #define Z_MIN_PROBE_PIN 32
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -705,7 +705,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -704,6 +704,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
@@ -694,7 +694,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
@@ -693,6 +693,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/JGAurora/A5/Configuration.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration.h
@@ -701,6 +701,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/JGAurora/A5/Configuration.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration.h
@@ -702,7 +702,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Malyan/M150/Configuration.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration.h
@@ -710,7 +710,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Malyan/M150/Configuration.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration.h
@@ -709,6 +709,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
@@ -694,7 +694,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
@@ -693,6 +693,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
@@ -694,7 +694,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
@@ -693,6 +693,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
@@ -730,7 +730,7 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
@@ -729,6 +729,9 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -688,7 +688,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -687,6 +687,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -703,7 +703,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -702,6 +702,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Sanguinololu/Configuration.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration.h
@@ -721,7 +721,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Sanguinololu/Configuration.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration.h
@@ -720,6 +720,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -741,7 +741,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -740,6 +740,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Tronxy/X1/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X1/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X1/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X1/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Tronxy/X3A/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X3A/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X3A/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X3A/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Tronxy/X5S/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X5S/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X5S/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X5S/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Tronxy/XY100/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/XY100/Configuration.h
@@ -701,7 +701,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/XY100/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/XY100/Configuration.h
@@ -700,6 +700,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Velleman/K8200/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration.h
@@ -719,7 +719,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8200/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration.h
@@ -718,6 +718,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Velleman/K8400/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8400/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
@@ -699,6 +699,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
@@ -700,7 +700,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -690,7 +690,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -689,6 +689,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
@@ -824,6 +824,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
@@ -825,7 +825,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
@@ -779,6 +779,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
@@ -780,7 +780,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -765,7 +765,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -764,6 +764,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -765,7 +765,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -764,6 +764,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -757,6 +757,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -758,7 +758,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -768,7 +768,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -767,6 +767,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
@@ -703,7 +703,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
@@ -702,6 +702,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/hangprinter/Configuration.h
+++ b/Marlin/example_configurations/hangprinter/Configuration.h
@@ -828,7 +828,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/hangprinter/Configuration.h
+++ b/Marlin/example_configurations/hangprinter/Configuration.h
@@ -827,6 +827,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -692,6 +692,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -693,7 +693,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -684,6 +684,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -685,7 +685,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -694,6 +694,9 @@
  *
  */
 //#define Z_MIN_PROBE_ENDSTOP
+#if ENABLED(Z_MIN_PROBE_ENDSTOP)
+  #define Z_MIN_PROBE_ENDSTOP -1
+#endif
 
 /**
  * Probe Type

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -695,7 +695,7 @@
  */
 //#define Z_MIN_PROBE_ENDSTOP
 #if ENABLED(Z_MIN_PROBE_ENDSTOP)
-  #define Z_MIN_PROBE_ENDSTOP -1
+  #define Z_MIN_PROBE_PIN -1
 #endif
 
 /**


### PR DESCRIPTION
### Description

#define Z_MIN_PROBE_ENDSTOP

the above example was not following the usual pattern of providing everything as commented out/disabled example that is necessary.

Adding:

#if ENABLED(Z_MIN_PROBE_ENDSTOP)
#define Z_MIN_PROBE_ENDSTOP -1
#endif

to clarify

### Benefits

less confusion, less support questions

### Related Issues

#12140 for bugfix-2.0.x
