### PR TITLE
Add M524 to abort SD printing

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -103,7 +103,6 @@
 
 #if ENABLED(SDSUPPORT)
   CardReader card;
-  bool abort_sd_printing = false;
 #endif
 
 #if ENABLED(G38_PROBE_TARGET)
@@ -974,8 +973,7 @@ void loop() {
     #if ENABLED(SDSUPPORT)
       card.checkautostart();
     
-      if (abort_sd_printing) {
-        abort_sd_printing = false;
+      if (card.abort_sd_printing) {
         card.stopSDPrint(
           #if SD_RESORT
             true

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -103,6 +103,7 @@
 
 #if ENABLED(SDSUPPORT)
   CardReader card;
+  bool abort_sd_printing = false;
 #endif
 
 #if ENABLED(G38_PROBE_TARGET)
@@ -972,9 +973,7 @@ void loop() {
 
     #if ENABLED(SDSUPPORT)
       card.checkautostart();
-    #endif
-
-    #if ENABLED(SDSUPPORT) && (ENABLED(ULTIPANEL) || ENABLED(EXTENSIBLE_UI))
+    
       if (abort_sd_printing) {
         abort_sd_printing = false;
         card.stopSDPrint(
@@ -992,7 +991,7 @@ void loop() {
           card.removeJobRecoveryFile();
         #endif
       }
-    #endif // SDSUPPORT && (ENABLED(ULTIPANEL) || ENABLED(EXTENSIBLE_UI))
+    #endif // SDSUPPORT
 
     if (commands_in_queue < BUFSIZE) get_available_commands();
     advance_command_queue();

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -584,6 +584,10 @@ void GcodeSuite::process_parsed_command(
         case 504: M504(); break;                                  // M504: Validate EEPROM contents
       #endif
 
+      #if ENABLED(SDSUPPORT)
+        case 524: M524(); break;                                   // M524: Abort the current SD print job
+      #endif
+      
       #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
         case 540: M540(); break;                                  // M540: Set abort on endstop hit for SD printing
       #endif

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -202,6 +202,7 @@
  * M501 - Restore parameters from EEPROM. (Requires EEPROM_SETTINGS)
  * M502 - Revert to the default "factory settings". ** Does not write them to EEPROM! **
  * M503 - Print the current settings (in memory): "M503 S<verbose>". S0 specifies compact output.
+ * M524 - Abort the current SD print job (started with M24)
  * M540 - Enable/disable SD card abort on endstop hit: "M540 S<state>". (Requires ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
  * M600 - Pause for filament change: "M600 X<pos> Y<pos> Z<raise> E<first_retract> L<later_retract>". (Requires ADVANCED_PAUSE_FEATURE)
  * M603 - Configure filament change: "M603 T<tool> U<unload_length> L<load_length>". (Requires ADVANCED_PAUSE_FEATURE)
@@ -719,6 +720,10 @@ private:
     static void M504();
   #endif
 
+  #if ENABLED(SDSUPPORT)
+    static void M524();
+  #endif
+    
   #if ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
     static void M540();
   #endif

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -248,7 +248,7 @@ void GcodeSuite::M32() {
  * M524: Abort the current SD print job (started with M24)
  */
 void GcodeSuite::M524() {
-  if (IS_SD_PRINTING()) abort_sd_printing = true;
+  if (IS_SD_PRINTING()) card.abort_sd_printing = true;
 }
 
 /**

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -245,6 +245,13 @@ void GcodeSuite::M32() {
 #endif // SDCARD_SORT_ALPHA && SDSORT_GCODE
 
 /**
+ * M524: Abort the current SD print job (started with M24)
+ */
+void GcodeSuite::M524() {
+  if (IS_SD_PRINTING()) abort_sd_printing = true;
+}
+
+/**
  * M928: Start SD Write
  */
 void GcodeSuite::M928() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -37,10 +37,6 @@
 #if ENABLED(SDSUPPORT)
   #include "../../sd/cardreader.h"
   #include "../../feature/emergency_parser.h"
-
-  bool abort_sd_printing; // =false
-#else
-  constexpr bool abort_sd_printing = false;
 #endif
 
 #if ENABLED(PRINTCOUNTER)

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -472,7 +472,7 @@ namespace UI {
   void stopPrint() {
     #if ENABLED(SDSUPPORT)
       wait_for_heatup = wait_for_user = false;
-      abort_sd_printing = true;
+      card.abort_sd_printing = true;
       UI::onStatusChanged(PSTR(MSG_PRINT_ABORTED));
     #endif
   }

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -895,8 +895,6 @@ void lcd_quick_feedback(const bool clear_buttons) {
       lcd_reset_status();
     }
 
-    bool abort_sd_printing; // =false
-
     void lcd_sdcard_stop() {
       wait_for_heatup = wait_for_user = false;
       abort_sd_printing = true;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -897,7 +897,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
     void lcd_sdcard_stop() {
       wait_for_heatup = wait_for_user = false;
-      abort_sd_printing = true;
+      card.abort_sd_printing = true;
       lcd_setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
       lcd_return_to_status();
     }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -288,10 +288,5 @@
   void lcd_reselect_last_file();
 #endif
 
-#if (ENABLED(EXTENSIBLE_UI) || ENABLED(ULTIPANEL)) && ENABLED(SDSUPPORT)
-  extern bool abort_sd_printing;
-#else
-  constexpr bool abort_sd_printing = false;
-#endif
 
 #endif // ULTRALCD_H

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -351,7 +351,7 @@ void CardReader::stopSDPrint(
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     did_pause_print = 0;
   #endif
-  sdprinting = false;
+  sdprinting = abort_sd_printing = false;
   if (isFileOpen()) file.close();
   #if SD_RESORT
     if (re_sort) presort();

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -257,6 +257,7 @@ private:
 #endif
 
 extern CardReader card;
+extern bool abort_sd_printing;
 
 #endif // SDSUPPORT
 

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -149,7 +149,7 @@ public:
   FORCE_INLINE char* longest_filename() { return longFilename[0] ? longFilename : filename; }
 
 public:
-  bool saving, logging, sdprinting, cardOK, filenameIsDir;
+  bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   int8_t autostart_index;
 private:
@@ -257,7 +257,6 @@ private:
 #endif
 
 extern CardReader card;
-extern bool abort_sd_printing;
 
 #endif // SDSUPPORT
 


### PR DESCRIPTION
This is a port to 2.0.x of  PR #11386 by @zachwelch. 

"It adds the M524 command as "SD abort job", performing the same logical checks that enable the Stop SD Job option in the LCD menu."
