### PR TITLE
[2.0.x] Fixes to kill() and UI

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -42,6 +42,8 @@
 #include "module/printcounter.h" // PrintCounter or Stopwatch
 #include "feature/closedloop.h"
 
+#include "HAL/shared/Delay.h"
+
 #ifdef ARDUINO
   #include <pins_arduino.h>
 #endif
@@ -610,7 +612,6 @@ void idle(
  * After this the machine will need to be reset.
  */
 void kill(PGM_P const lcd_msg/*=NULL*/) {
-
   thermalManager.disable_all_heaters();
 
   SERIAL_ERROR_START();
@@ -633,11 +634,14 @@ void kill(PGM_P const lcd_msg/*=NULL*/) {
 
 void minkill() {
 
-  _delay_ms(600);  // Wait a short time (allows messages to get out before shutting down.
-  cli();           // Stop interrupts
-  _delay_ms(250);  // Wait to ensure all interrupts stopped
+  // Wait a short time (allows messages to get out before shutting down.
+  for (int i=0; i<600; ++i) DELAY_US(1000);
 
-  disable_all_steppers();
+  cli(); // Stop interrupts
+
+  // Wait to ensure all interrupts stopped
+  for (int i=0; i<250; ++i) DELAY_US(1000);
+
   thermalManager.disable_all_heaters(); // turn off heaters again
 
   #if HAS_POWER_SWITCH

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -635,12 +635,12 @@ void kill(PGM_P const lcd_msg/*=NULL*/) {
 void minkill() {
 
   // Wait a short time (allows messages to get out before shutting down.
-  for (int i=0; i<600; ++i) DELAY_US(1000);
+  DELAY_US(600000);
 
   cli(); // Stop interrupts
 
   // Wait to ensure all interrupts stopped
-  for (int i=0; i<250; ++i) DELAY_US(1000);
+  DELAY_US(250000);
 
   thermalManager.disable_all_heaters(); // turn off heaters again
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -37,6 +37,9 @@
 #if ENABLED(SDSUPPORT)
   #include "../../sd/cardreader.h"
   #include "../../feature/emergency_parser.h"
+  #define IFSD(A,B) (A)
+#else
+  #define IFSD(A,B) (B)
 #endif
 
 #if ENABLED(PRINTCOUNTER)
@@ -352,11 +355,7 @@ namespace UI {
   #endif
 
   uint8_t getProgress_percent() {
-    #if ENABLED(SDSUPPORT)
-      return card.percentDone();
-    #else
-      return 0;
-    #endif
+    return IFSD(card.percentDone(), 0);
   }
 
   uint32_t getProgress_seconds_elapsed() {
@@ -415,25 +414,15 @@ namespace UI {
   }
 
   void printFile(const char *filename) {
-    #if ENABLED(SDSUPPORT)
-      card.openAndPrintFile(filename);
-    #endif
+    IFSD(card.openAndPrintFile(filename), NOOP);
   }
 
   bool isPrintingFromMediaPaused() {
-    #if ENABLED(SDSUPPORT)
-      return isPrintingFromMedia() && !card.sdprinting;
-    #else
-      return false;
-    #endif
+    return IFSD(isPrintingFromMedia() && !card.sdprinting, false);
   }
 
   bool isPrintingFromMedia() {
-    #if ENABLED(SDSUPPORT)
-      return card.cardOK && card.isFileOpen();
-    #else
-      return false;
-    #endif
+    return IFSD(card.cardOK && card.isFileOpen(), false);
   }
 
   bool isPrinting() {
@@ -441,11 +430,7 @@ namespace UI {
   }
 
   bool isMediaInserted() {
-    #if ENABLED(SDSUPPORT)
-      return IS_SD_INSERTED() && card.cardOK;
-    #else
-      return false;
-    #endif
+    return IFSD(IS_SD_INSERTED() && card.cardOK, false);
   }
 
   void pausePrint() {
@@ -506,42 +491,23 @@ namespace UI {
   }
 
   const char* FileList::filename() {
-    #if ENABLED(SDSUPPORT)
-      return (card.longFilename && card.longFilename[0]) ? card.longFilename : card.filename;
-    #else
-      return "";
-    #endif
+    return IFSD(card.longFilename && card.longFilename[0]) ? card.longFilename : card.filename, "");
   }
 
   const char* FileList::shortFilename() {
-    #if ENABLED(SDSUPPORT)
-      return card.filename;
-    #else
-      return "";
-    #endif
+    return IFSD(card.filename, "");
   }
 
   const char* FileList::longFilename() {
-    #if ENABLED(SDSUPPORT)
-      return card.longFilename;
-    #else
-      return "";
-    #endif
+    return IFSD(card.longFilename, "");
   }
 
   bool FileList::isDir() {
-    #if ENABLED(SDSUPPORT)
-      return card.filenameIsDir;
-    #else
-      return false;
-    #endif
+    return IFSD(card.filenameIsDir, false);
   }
 
   uint16_t FileList::count() {
-    #if ENABLED(SDSUPPORT)
-      if (num_files == 0xFFFF) num_files = card.get_num_Files();
-      return num_files;
-    #endif
+    return IFSD((num_files = (num_files == 0xFFFF ? card.get_num_Files() : num_files)), 0);
   }
 
   bool FileList::isAtRootDir() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -420,22 +420,24 @@ namespace UI {
     #endif
   }
 
+  bool isPrintingFromMediaPaused() {
+    #if ENABLED(SDSUPPORT)
+      return isPrintingFromMedia() && !card.sdprinting;
+    #else
+      return false;
+    #endif
+  }
+
   bool isPrintingFromMedia() {
     #if ENABLED(SDSUPPORT)
-      return card.cardOK && card.isFileOpen() && card.sdprinting;
+      return card.cardOK && card.isFileOpen();
     #else
       return false;
     #endif
   }
 
   bool isPrinting() {
-    return (planner.movesplanned() || IS_SD_PRINTING() ||
-      #if ENABLED(SDSUPPORT)
-        (card.cardOK && card.isFileOpen())
-      #else
-        false
-      #endif
-    );
+    return (planner.movesplanned() || IS_SD_PRINTING() || isPrintingFromMedia());
   }
 
   bool isMediaInserted() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -133,6 +133,7 @@ namespace UI {
   void enqueueCommands(progmem_str gcode);
 
   void printFile(const char *filename);
+  bool isPrintingFromMediaPaused();
   bool isPrintingFromMedia();
   bool isPrinting();
   void stopPrint();


### PR DESCRIPTION
Don't use _delay_us in minkill (#12145)
- In HAL_DUE, `_delay_us` is simply an alias for `delay`, which causes the board to hang and subsequently reboot due to the watchdog timer. This implements the fix suggested by @ejtagle.

Fixes to EXTENSIBLE_UI:
- UI::isPrintingFromMedia() will now return true even if SD print is paused.
- UI::isPrintingFromMediaPaused() allows UI to determine if the print is paused.