### PR TITLE
[2.0.x] Hide some menu items when busy: fix typo

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -4032,7 +4032,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       // M205 - Max Jerk
       MENU_ITEM(submenu, MSG_JERK, lcd_advanced_jerk_menu);
 
-      if (!printer_busy) {
+      if (!printer_busy()) {
         // M92 - Steps Per mm
         MENU_ITEM(submenu, MSG_STEPS_PER_MM, lcd_advanced_steps_per_mm_menu);
       }


### PR DESCRIPTION
### Description
Fix typo

### Benefits

We get back steps/mm menu item

### Related Issues

50cbca4c55243f34c84ced3f264fdc76f9fcdc93
