### PR TITLE
Fix filament runout for idex duplication modes

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -167,6 +167,10 @@ class FilamentSensorTypeSwitch : public FilamentSensorTypeBase {
         return runout_bits;                     // A single sensor applying to all extruders
       #else
         #if ENABLED(DUAL_X_CARRIAGE)
+          if ( dual_x_carriage_mode == DXC_DUPLICATION_MODE || dual_x_carriage_mode == DXC_SCALED_DUPLICATION_MODE)
+            return runout_bits;                 // Any extruder
+          else
+        #elif ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
           if (extruder_duplication_enabled)
             return runout_bits;                 // Any extruder
           else

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -167,7 +167,7 @@ class FilamentSensorTypeSwitch : public FilamentSensorTypeBase {
         return runout_bits;                     // A single sensor applying to all extruders
       #else
         #if ENABLED(DUAL_X_CARRIAGE)
-          if ( dual_x_carriage_mode == DXC_DUPLICATION_MODE || dual_x_carriage_mode == DXC_SCALED_DUPLICATION_MODE)
+          if (dual_x_carriage_mode == DXC_DUPLICATION_MODE || dual_x_carriage_mode == DXC_SCALED_DUPLICATION_MODE)
             return runout_bits;                 // Any extruder
           else
         #elif ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)


### PR DESCRIPTION
Fix runout for IDEX modes and basic dual nozzle duplication mode. Originally used variable is for dual nozzle duplicating and set to false in M605 for idex modes.