### PR TITLE
Return set_directions() to stepper.cpp

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2088,6 +2088,7 @@ void Stepper::init() {
 
   endstops.enable(true); // Start with endstops active. After homing they can be disabled
   sei();
+  set_directions(); // Init directions to last_direction_bits = 0  Keeps Z from being reversed
 }
 
 /**


### PR DESCRIPTION
Initial manual Z move can be negative if your stepper is inverted. Leads to bad situations for crashed or initially booted printers.

Consider:
Printer watch-dogged while printing, in the case of PWM fan shut off cooling. Hot nozzle is resting on your print.

You hit reset and try to recover. Manually selecting move Z x10 from the menu, the head crashes further with no way to stop it.

Thanks to AnHardt for finding where it came from. If it interferes with something let me know since I assume it was removed for some reason.