### PR TITLE
[2.0.x] Implement special delay/millis routines for EXTENSIBLE_UI

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -617,9 +617,7 @@ void kill(PGM_P const lcd_msg/*=NULL*/) {
   SERIAL_ERROR_START();
   SERIAL_ERRORLNPGM(MSG_ERR_KILLED);
 
-  #if ENABLED(EXTENSIBLE_UI)
-    UI::onPrinterKilled(lcd_msg ? lcd_msg : PSTR(MSG_KILLED));
-  #elif ENABLED(ULTRA_LCD)
+  #if ENABLED(ULTRA_LCD) || ENABLED(EXTENSIBLE_UI)
     kill_screen(lcd_msg ? lcd_msg : PSTR(MSG_KILLED));
   #else
     UNUSED(lcd_msg);

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -1,3 +1,25 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 /**************
  * ui_api.cpp *
  **************/
@@ -68,52 +90,51 @@ inline float clamp(const float value, const float minimum, const float maximum) 
 static bool printer_killed = false;
 
 namespace UI {
-  #if defined(__SAM3X8E__)
-    /* Implement a special millis() to allow measurement of
-     * time from within an ISR (such as when the printer
-     * is killed).
+  #ifdef __SAM3X8E__
+    /**
+     * Implement a special millis() to allow time measurement
+     * within an ISR (such as when the printer is killed).
      *
-     * To keep proper time, must be called at least every
-     * 1 second
+     * To keep proper time, must be called at least every 1s.
      */
     uint32_t safe_millis() {
-      /* If not killed, just call the old Arduino code */
-      if (!printer_killed) {
-        return millis();
-      }
+      // Not killed? Just call millis()
+      if (!printer_killed) return millis();
 
       static uint32_t currTimeHI = 0; /* Current time */
 
-      /* Machine was killed, reinit SysTick so we are able to compute time without ISRs */
+      // Machine was killed, reinit SysTick so we are able to compute time without ISRs
       if (currTimeHI == 0) {
-        /* Get the last time the Arduino time computed (from CMSIS) and convert it to SysTicks*/
+        // Get the last time the Arduino time computed (from CMSIS) and convert it to SysTick
         currTimeHI = (uint32_t)((GetTickCount() * (uint64_t)(F_CPU/8000)) >> 24);
 
-        /* Reinit the SysTick timer to maximize its period */
-        SysTick->LOAD  = SysTick_LOAD_RELOAD_Msk;                    /* get the full range for the systick timer */
-        SysTick->VAL   = 0;                                          /* Load the SysTick Counter Value */
-        SysTick->CTRL  = /* MCLK/8 as source */
-                         /* No interrupts */
-                         SysTick_CTRL_ENABLE_Msk;                    /* Enable SysTick Timer */
+        // Reinit the SysTick timer to maximize its period
+        SysTick->LOAD  = SysTick_LOAD_RELOAD_Msk;                    // get the full range for the systick timer
+        SysTick->VAL   = 0;                                          // Load the SysTick Counter Value
+        SysTick->CTRL  = // MCLK/8 as source
+                         // No interrupts
+                         SysTick_CTRL_ENABLE_Msk;                    // Enable SysTick Timer
      }
 
-      /* Check if there was a timer overflow from the last read */
+      // Check if there was a timer overflow from the last read
       if (SysTick->CTRL & SysTick_CTRL_COUNTFLAG_Msk) {
-        /* There was. This means (SysTick_LOAD_RELOAD_Msk * 1000 * 8)/F_CPU milliseconds
-           have elapsed */
+        // There was. This means (SysTick_LOAD_RELOAD_Msk * 1000 * 8)/F_CPU ms has elapsed
         currTimeHI++;
       }
 
-      /* Calculate current time in milliseconds */
+      // Calculate current time in milliseconds
       uint32_t currTimeLO = SysTick_LOAD_RELOAD_Msk - SysTick->VAL; // (in MCLK/8)
       uint64_t currTime = ((uint64_t)currTimeLO) | (((uint64_t)currTimeHI) << 24);
 
-      /* The count of milliseconds is */
-      return (uint32_t)(currTime / (F_CPU/8000));
+      // The ms count is
+      return (uint32_t)(currTime / (F_CPU / 8000));
     }
+
   #else
-    // TODO: Implement this for AVR
-    uint32_t safe_millis() {return millis();}
+
+    // TODO: Implement for AVR
+    uint32_t safe_millis() { return millis(); }
+
   #endif
 
   void delay_us(unsigned long us) {
@@ -121,11 +142,10 @@ namespace UI {
   }
 
   void delay_ms(unsigned long ms) {
-    if (!printer_killed) {
-      safe_delay(ms);
-    } else {
+    if (printer_killed)
       DELAY_US(ms * 1000);
-    }
+    else
+      safe_delay(ms);
   }
 
   void yield() {
@@ -663,7 +683,7 @@ void lcd_status_printf_P(const uint8_t level, const char * const fmt, ...) {
 }
 
 void kill_screen(PGM_P msg) {
-  if(!printer_killed) {
+  if (!printer_killed) {
     printer_killed = true;
     UI::onPrinterKilled(msg);
   }

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -127,6 +127,9 @@ namespace UI {
     #endif
   #endif
 
+  // This safe_millis is safe to use even when printer is killed (as long as called at least every 1 second)
+  uint32_t safe_millis();
+  void delay_us(unsigned long us);
   void delay_ms(unsigned long ms);
   void yield(); // Within lengthy loop, call this periodically
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -1,3 +1,25 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 /************
  * ui_api.h *
  ************/

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -30,6 +30,7 @@
   bool lcd_detected();
   void lcd_update();
   void lcd_setalertstatusPGM(PGM_P message);
+  void kill_screen(PGM_P lcd_msg);
 #else
   inline void lcd_init() {}
   inline bool lcd_detected() { return true; }


### PR DESCRIPTION
- Implement special delay/millis routines for EXTENSIBLE_UI as discussed in #12145.
- Implement flag to keep track of whether the printer was killed.