### PR TITLE
[2.0.x] Enable use of SERIAL_PORT_2 on HAL_STM32

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL.cpp
@@ -29,6 +29,8 @@
 
 #include "HAL.h"
 
+#include "../../inc/MarlinConfig.h"
+
 #if ENABLED(EEPROM_EMULATED_WITH_SRAM)
   #if STM32F7xx
     #include "stm32f7xx_ll_pwr.h"

--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -41,6 +41,7 @@
   #include <USBSerial.h>
 #endif
 
+#include "../../inc/MarlinConfigPre.h"
 #include "../shared/math_32bit.h"
 #include "../shared/HAL_SPI.h"
 #include "fastio_STM32.h"

--- a/Marlin/src/HAL/HAL_STM32/watchdog_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/watchdog_STM32.h
@@ -21,7 +21,5 @@
  */
 #pragma once
 
-#include "../../inc/MarlinConfig.h"
-
 void watchdog_init();
 void watchdog_reset();


### PR DESCRIPTION
### Description

On HAL_STM32, enabling `SERIAL_PORT_2` fails with a compilation error:

`#error "SERIAL_PORT_2 is not supported for your MOTHERBOARD. Disable it to continue."`

This is due to `MarlinConfig.h` being included from `watchdog_STM32.h` which is then being included from `HAL.h`. The error occurs because the `SanityCheck.h` is included before `Configuration.h`.

### Benefits

Enables the use of a second serial port on HAL_STM32.