### PR TITLE
Added pulldown to USB interrupt line; enable EXTENSIBLE_UI pins on Archim 2

### DIFF
--- a/Marlin/src/pins/pins_ARCHIM2.h
+++ b/Marlin/src/pins/pins_ARCHIM2.h
@@ -203,7 +203,7 @@
 
   #define SD_DETECT_PIN     2   // D2  PB25_TIOA0
 
-  #if ENABLED(NEWPANEL)
+  #if ENABLED(NEWPANEL) || ENABLED(EXTENSIBLE_UI)
     // Buttons on AUX-2
     #define BTN_EN1        60   // D60 PA3_TIOB1
     #define BTN_EN2        13   // D13 PB27_TIOB0

--- a/Marlin/src/sd/usb_flashdrive/usb_host.cpp
+++ b/Marlin/src/sd/usb_flashdrive/usb_host.cpp
@@ -109,8 +109,8 @@ bool MAX3421e::reset() {
 bool MAX3421e::start() {
   // Initialize pins and SPI bus
 
-  SET_OUTPUT(SDSS);
-  SET_INPUT(USB_INTR_PIN);
+  SET_OUTPUT(USB_CS_PIN);
+  SET_INPUT_PULLUP(USB_INTR_PIN);
   ncs();
   spiBegin();
 


### PR DESCRIPTION
- A pulldown on the INT pin is required when the pin is level-active.
- Allow EXTENSIBLE_UI to share NEWPANEL pins on Archim 2