### PR TITLE
Fix IDEX homing X0 wrong direction

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1746,10 +1746,10 @@ uint32_t Stepper::stepper_block_phase_isr() {
           #endif
       ) {
         last_direction_bits = current_block->direction_bits;
-        set_directions();
         #if EXTRUDERS > 1
           last_moved_extruder = stepper_extruder;
         #endif
+        set_directions();
       }
 
       // At this point, we must ensure the movement about to execute isn't

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -399,7 +399,7 @@ class Stepper {
         #if ENABLED(MIXING_EXTRUDER) || EXTRUDERS < 2
           0
         #else
-          active_extruder
+          last_moved_extruder
         #endif
       ;
     }

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -399,7 +399,7 @@ class Stepper {
         #if ENABLED(MIXING_EXTRUDER) || EXTRUDERS < 2
           0
         #else
-          last_moved_extruder
+          active_extruder
         #endif
       ;
     }


### PR DESCRIPTION
First move gets this defined as 255 since the value is not initialized, and idex gets axis sent the wrong direction. This fixes idex homing X0 in the wrong direction, and potentially other movement issues setting the wrong direction.