### PR TITLE
[2.0.x] Fixed redefinition warnings of MSG_HOTEND_TOO_COLD.

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -200,7 +200,7 @@
 #define MSG_ENDSTOPS_HIT                    "endstops hit: "
 #define MSG_ERR_COLD_EXTRUDE_STOP           " cold extrusion prevented"
 #define MSG_ERR_LONG_EXTRUDE_STOP           " too long extrusion prevented"
-#define MSG_HOTEND_TOO_COLD                 "Hotend too cold"
+#define MSG_ERR_HOTEND_TOO_COLD             "Hotend too cold"
 
 #define MSG_FILAMENT_CHANGE_HEAT            "Press button (or M108) to heat nozzle"
 #define MSG_FILAMENT_CHANGE_INSERT          "Insert filament and press button (or M108)"

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -97,7 +97,7 @@ static bool ensure_safe_temperature(const AdvancedPauseMode mode=ADVANCED_PAUSE_
   #if ENABLED(PREVENT_COLD_EXTRUSION)
     if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder)) {
       SERIAL_ERROR_START();
-      SERIAL_ERRORLNPGM(MSG_HOTEND_TOO_COLD);
+      SERIAL_ERRORLNPGM(MSG_ERR_HOTEND_TOO_COLD);
       return false;
     }
   #endif
@@ -349,7 +349,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
 
   if (!DEBUGGING(DRYRUN) && unload_length && thermalManager.targetTooColdToExtrude(active_extruder)) {
     SERIAL_ERROR_START();
-    SERIAL_ERRORLNPGM(MSG_HOTEND_TOO_COLD);
+    SERIAL_ERRORLNPGM(MSG_ERR_HOTEND_TOO_COLD);
 
     #if ENABLED(ULTIPANEL)
       if (show_lcd) { // Show status screen

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -642,7 +642,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         #if ENABLED(PREVENT_COLD_EXTRUSION)
           if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder) && toolchange_settings.swap_length) {
             SERIAL_ERROR_START();
-            SERIAL_ERRORLNPGM(MSG_HOTEND_TOO_COLD);
+            SERIAL_ERRORLNPGM(MSG_ERR_HOTEND_TOO_COLD);
             active_extruder = tmp_extruder;
             return;
           }


### PR DESCRIPTION
The compiler started complaining about redefinition of string MSG_HOTEND_TOO_COLD after I added a slovak translation of MSG_HOTEND_TOO_COLD to language_sk.h.

So, if we don't want to have a localized string on serial, it's better to rename MSG_HOTEND_TOO_COLD in Marlin/src/core/language.h to something like MSG_ERR_HOTEND_TOO_COLD.