### PR TITLE
Fix compilation errors when EXTENSIBLE_UI is enabled

### DIFF
--- a/Marlin/src/lcd/extensible_ui/lib/example.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/example.cpp
@@ -47,9 +47,9 @@ namespace UI {
   }
   void onIdle() {}
   void onPrinterKilled(const char* msg) {}
-  void onMediaInserted();
-  void onMediaError();
-  void onMediaRemoved();
+  void onMediaInserted() {};
+  void onMediaError() {};
+  void onMediaRemoved() {};
   void onPlayTone(const uint16_t frequency, const uint16_t duration) {}
   void onPrintTimerStarted() {}
   void onPrintTimerPaused() {}

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -45,6 +45,9 @@
 #if ENABLED(PRINTCOUNTER)
   #include "../../core/utility.h"
   #include "../../module/printcounter.h"
+  #define IFPC(A,B) (A)
+#else
+  #define IFPC(A,B) (B)  
 #endif
 
 #include "ui_api.h"
@@ -115,7 +118,9 @@ namespace UI {
     switch (axis) {
       case X: case Y: case Z: break;
       case E0: case E1: case E2: case E3: case E4: case E5:
-        active_extruder = axis - E0;
+        #if EXTRUDERS > 1
+          active_extruder = axis - E0;
+        #endif
         break;
       default: return;
     }
@@ -144,7 +149,9 @@ namespace UI {
       if (extruder != active_extruder)
         tool_change(extruder, 0, no_move);
     #endif
-    active_extruder = extruder;
+    #if EXTRUDERS > 1
+      active_extruder = extruder;
+    #endif
   }
 
   uint8_t getActiveTool() { return active_extruder + 1; }
@@ -359,7 +366,7 @@ namespace UI {
   }
 
   uint32_t getProgress_seconds_elapsed() {
-    const duration_t elapsed = print_job_timer.duration();
+    const duration_t elapsed = IFPC(print_job_timer.duration(), 0);
     return elapsed.value;
   }
 
@@ -414,7 +421,11 @@ namespace UI {
   }
 
   void printFile(const char *filename) {
-    IFSD(card.openAndPrintFile(filename), NOOP);
+    #if ENABLED(SDSUPPORT)
+      card.openAndPrintFile(filename);
+    #else
+      NOOP;
+    #endif
   }
 
   bool isPrintingFromMediaPaused() {
@@ -426,7 +437,7 @@ namespace UI {
   }
 
   bool isPrinting() {
-    return (planner.movesplanned() || IS_SD_PRINTING() || isPrintingFromMedia());
+    return (planner.movesplanned() || IFSD(IS_SD_PRINTING(), false) || isPrintingFromMedia());
   }
 
   bool isMediaInserted() {
@@ -436,7 +447,9 @@ namespace UI {
   void pausePrint() {
     #if ENABLED(SDSUPPORT)
       card.pauseSDPrint();
-      print_job_timer.pause();
+      #if ENABLED(PRINTCOUNTER)
+        print_job_timer.pause();
+      #endif
       #if ENABLED(PARK_HEAD_ON_PAUSE)
         enqueue_and_echo_commands_P(PSTR("M125"));
       #endif
@@ -450,7 +463,9 @@ namespace UI {
         enqueue_and_echo_commands_P(PSTR("M24"));
       #else
         card.startFileprint();
-        print_job_timer.start();
+        #if ENABLED(PRINTCOUNTER)
+          print_job_timer.start();
+        #endif
       #endif
       UI::onStatusChanged(PSTR(MSG_PRINTING));
     #endif
@@ -491,7 +506,7 @@ namespace UI {
   }
 
   const char* FileList::filename() {
-    return IFSD(card.longFilename && card.longFilename[0]) ? card.longFilename : card.filename, "");
+    return IFSD(card.longFilename && card.longFilename[0] ? card.longFilename : card.filename, "");
   }
 
   const char* FileList::shortFilename() {
@@ -580,13 +595,13 @@ void lcd_reset_status() {
   static const char printing[] PROGMEM = MSG_PRINTING;
   static const char welcome[] PROGMEM = WELCOME_MSG;
   PGM_P msg;
-  if (print_job_timer.isPaused())
+  if (IFPC(print_job_timer.isPaused(), false))
     msg = paused;
   #if ENABLED(SDSUPPORT)
     else if (card.sdprinting)
       return lcd_setstatus(card.longest_filename(), true);
   #endif
-  else if (print_job_timer.isRunning())
+  else if (IFPC(print_job_timer.isRunning(), false))
     msg = printing;
   else
     msg = welcome;

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -421,11 +421,7 @@ namespace UI {
   }
 
   void printFile(const char *filename) {
-    #if ENABLED(SDSUPPORT)
-      card.openAndPrintFile(filename);
-    #else
-      NOOP;
-    #endif
+    #IFSD(card.openAndPrintFile(filename), 0);    
   }
 
   bool isPrintingFromMediaPaused() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -421,7 +421,7 @@ namespace UI {
   }
 
   void printFile(const char *filename) {
-    #IFSD(card.openAndPrintFile(filename), 0);    
+    IFSD(card.openAndPrintFile(filename), 0);    
   }
 
   bool isPrintingFromMediaPaused() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -421,7 +421,7 @@ namespace UI {
   }
 
   void printFile(const char *filename) {
-    IFSD(card.openAndPrintFile(filename), 0);    
+    IFSD(card.openAndPrintFile(filename), 0);
   }
 
   bool isPrintingFromMediaPaused() {

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -28,7 +28,7 @@
 // Make a buzzer and macro
 #if ENABLED(LCD_USE_I2C_BUZZER)
   // BUZZ() will be defined in ultralcd.h
-#elif PIN_EXISTS(BEEPER) || ENABLED(EXTENSIBLE_UI)
+#elif PIN_EXISTS(BEEPER)
 
 #include "circularqueue.h"
 


### PR DESCRIPTION
While playing and using the new EXTENSIBLE_UI feature on MKS SBASE, I came across several compilation issues related to different combinations of features been enabled or not. I have wrapped up the fixes in this pull request to make the feature work as soon as it is enabled, and any new build errors would / should only then be related to the code changes the person is making.

Fixed compilation errors with different combinations of EXTENSIBLE_UI enabled with SDSUPPORT and PRINTCOUNTER, the feature required these to both be enabled to compile, this dependency has been removed using the different macros available.

Fixed compilation error where buzzer required a pin defined if you enabled EXTENSIBLE_UI, even though there is no dependency on the pin in EXTENSIBLE_UI. The buzzer header file had a conditional compilation statement which even if you do not have a buzzer pin such as on the MKS SBASE when you do not enable an LCD it will include the buzzer code and error as the pin is not defined.

Fixed compilation errors where there was no definition for functions for the EXTENSIBLE_UI methods using the default example. The example was missing the function definitions to allow it to compile by default.

Fixed compilation errors related to only having one extruder, so the active extruder flag was not a changeable variable.