### PR TITLE
A possible null exception due to the elasped object been set to a zero

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -445,7 +445,7 @@ namespace UI {
   }
 
   uint32_t getProgress_seconds_elapsed() {
-    const duration_t elapsed = IFPC(print_job_timer.duration(), 0);
+    const duration_t elapsed = IFPC(print_job_timer.duration(), duration_t(0));
     return elapsed.value;
   }
 


### PR DESCRIPTION
In my last pull request when fixing some compilation errors I introduced this possible null exception on the return value as it would access the duration_t.value, but it was set to a 0 for the object. I have not fully tested this as my lcd code does not access this if the counters are not enabled.