### PR TITLE
[2.0.x] Fixed X, Y, Z axis movement via LCD menu.

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3226,7 +3226,8 @@ void lcd_quick_feedback(const bool clear_buttons) {
       }
     }
     #if ENABLED(PREVENT_COLD_EXTRUSION)
-      if (thermalManager.tooColdToExtrude(eindex >= 0 ? eindex : active_extruder))
+      if ((axis == E_AXIS) &&
+          (thermalManager.tooColdToExtrude(eindex >= 0 ? eindex : active_extruder)))
         MENU_BACK(MSG_HOTEND_TOO_COLD);
       else
     #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -3226,8 +3226,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       }
     }
     #if ENABLED(PREVENT_COLD_EXTRUSION)
-      if ((axis == E_AXIS) &&
-          (thermalManager.tooColdToExtrude(eindex >= 0 ? eindex : active_extruder)))
+      if (axis == E_AXIS && thermalManager.tooColdToExtrude(eindex >= 0 ? eindex : active_extruder))
         MENU_BACK(MSG_HOTEND_TOO_COLD);
       else
     #endif


### PR DESCRIPTION
It's not possible to move X, Y and Z axis via LCD menu if hotend is cold.

It's an regression of change https://github.com/MarlinFirmware/Marlin/commit/3a46212dd84697d9b84ce59462f351785aedd3b3.

This PR will fix issue #12193.