### PR TITLE
Add helpers for custom text in menu items

### DIFF
--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -87,9 +87,17 @@
     uint8_t get_ADC_keyValue();
   #endif
 
-  #if ENABLED(DOGLCD)
+  #if HAS_LCD_CONTRAST
     extern int16_t lcd_contrast;
     void set_lcd_contrast(const int16_t value);
+  #endif
+
+  #if ENABLED(DOGLCD)
+    #define SETCURSOR(col, row) lcd_moveto(col * (DOG_CHAR_WIDTH), (row + 1) * row_height)
+    #define SETCURSOR_RJ(len, row) lcd_moveto(LCD_PIXEL_WIDTH - len * (DOG_CHAR_WIDTH), (row + 1) * row_height)
+  #else
+    #define SETCURSOR(col, row) lcd_moveto(col, row)
+    #define SETCURSOR_RJ(len, row) lcd_moveto(LCD_WIDTH - len, row)
   #endif
 
   #if ENABLED(SHOW_BOOTSCREEN)


### PR DESCRIPTION
For some features it may be useful to print custom text in a menu item.
This commit provides helpers to make this easier. See the [Geeetech fork of Marlin](https://github.com/Geeetech3D/Prusa_I3_3Dprinter) for usage examples.

As an alternative (or an adjunct) the menu editing helpers could be given an extra "`suffix`" parameter for appending something like "`mm`" or "`%`" after an item's value, preserving right-alignment for the display item and the logic for moving the value down on the edit screen when the label and value won't fit on a single line. But this makes it easier to do things like print two complementary formatted values or display textual options for something that selects among a set of named options.