### PR TITLE
[2.0.x] Cleanup/refactoring of EXTENSIBLE_UI

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -281,7 +281,7 @@ namespace UI {
   }
 
   extruder_t getActiveTool() {
-    switch(active_extruder) {
+    switch (active_extruder) {
       case 5:  return E6;
       case 4:  return E5;
       case 3:  return E4;
@@ -291,10 +291,10 @@ namespace UI {
     }
   }
 
-  bool isMoving()                         { return planner.has_blocks_queued(); }
+  bool isMoving() { return planner.has_blocks_queued(); }
 
   bool canMove(const axis_t axis) {
-    switch(axis) {
+    switch (axis) {
       #if IS_KINEMATIC || ENABLED(NO_MOTION_BEFORE_HOMING)
       case X: return TEST(axis_homed, X_AXIS);
       case Y: return TEST(axis_homed, Y_AXIS);
@@ -477,16 +477,16 @@ namespace UI {
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
-    float getAxisBacklash_mm(const axis_t axis)       {return backlash_distance_mm[axis];}
+    float getAxisBacklash_mm(const axis_t axis)       { return backlash_distance_mm[axis]; }
     void setAxisBacklash_mm(const float value, const axis_t axis)
-                                                      {backlash_distance_mm[axis] = clamp(value,0,5);}
+                                                      { backlash_distance_mm[axis] = clamp(value,0,5); }
 
-    float getBacklashCorrection_percent()             {return backlash_correction*100;}
-    void setBacklashCorrection_percent(const float value) {backlash_correction = clamp(value, 0, 100)/100;}
+    float getBacklashCorrection_percent()             { return backlash_correction * 100; }
+    void setBacklashCorrection_percent(const float value) { backlash_correction = clamp(value, 0, 100) / 100; }
 
     #ifdef BACKLASH_SMOOTHING_MM
-      float getBacklashSmoothing_mm()                 {return backlash_smoothing_mm;}
-      void setBacklashSmoothing_mm(const float value) {backlash_smoothing_mm = clamp(value,0,999);}
+      float getBacklashSmoothing_mm()                 { return backlash_smoothing_mm; }
+      void setBacklashSmoothing_mm(const float value) { backlash_smoothing_mm = clamp(value, 0, 999); }
     #endif
   #endif
 
@@ -530,11 +530,11 @@ namespace UI {
     if (heater == BED)
       thermalManager.setTargetBed(clamp(value,0,200));
     #endif
-      thermalManager.setTargetHotend(clamp(value,0,500), heater-H1);
+      thermalManager.setTargetHotend(clamp(value,0,500), heater - H1);
   }
 
   void setTargetTemp_celsius(float value, const extruder_t extruder) {
-    thermalManager.setTargetHotend(clamp(value,0,500), extruder-E1);
+    thermalManager.setTargetHotend(clamp(value,0,500), extruder - E1);
   }
 
   void setFan_percent(float value, const fan_t fan) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -195,7 +195,7 @@ namespace UI {
   }
 
   void setAxisPosition_mm(const float position, const axis_t axis, const float _feedrate_mm_s) {
-    if(!flags.deferred_motion)
+    if (!flags.deferred_motion)
       set_destination_from_current();
 
     // Start with no limits to movement
@@ -247,7 +247,7 @@ namespace UI {
 
     // We don't want to stack up moves, so wait until the
     // machine has stopped moving before sending another.
-    if(isMoving())
+    if (isMoving())
       flags.deferred_motion = true;
     else
       prepare_move_to_destination();
@@ -256,7 +256,7 @@ namespace UI {
   void setAxisPosition_mm(const float position, const extruder_t extruder, const float _feedrate_mm_s) {
     setActiveTool(extruder, true);
 
-    if(!flags.deferred_motion)
+    if (!flags.deferred_motion)
       set_destination_from_current();
 
     destination[E_AXIS] = position;
@@ -265,7 +265,7 @@ namespace UI {
 
     // We don't want to stack up moves, so wait until the
     // machine has stopped moving before sending another.
-    if(isMoving())
+    if (isMoving())
       flags.deferred_motion = true;
     else
       prepare_move_to_destination();
@@ -311,51 +311,51 @@ namespace UI {
   }
 
   float getAxisSteps_per_mm(const axis_t axis) {
-      return planner.settings.axis_steps_per_mm[axis];
+    return planner.settings.axis_steps_per_mm[axis];
   }
 
   float getAxisSteps_per_mm(const extruder_t extruder) {
-      return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E1)];
+    return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E1)];
   }
 
   void setAxisSteps_per_mm(const float value, const axis_t axis) {
-      planner.settings.axis_steps_per_mm[axis] = value;
+    planner.settings.axis_steps_per_mm[axis] = value;
   }
 
   void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
-      planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E1)] = value;
+    planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E1)] = value;
   }
 
   float getAxisMaxFeedrate_mm_s(const axis_t axis) {
-      return planner.settings.max_feedrate_mm_s[axis];
+    return planner.settings.max_feedrate_mm_s[axis];
   }
 
   float getAxisMaxFeedrate_mm_s(const extruder_t extruder) {
-      return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E1)];
+    return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E1)];
   }
 
   void setAxisMaxFeedrate_mm_s(const float value, const axis_t axis) {
-      planner.settings.max_feedrate_mm_s[axis] = value;
+    planner.settings.max_feedrate_mm_s[axis] = value;
   }
 
   void setAxisMaxFeedrate_mm_s(const float value, const extruder_t extruder) {
-      planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E1)] = value;
+    planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E1)] = value;
   }
 
   float getAxisMaxAcceleration_mm_s2(const axis_t axis) {
-      return planner.settings.max_acceleration_mm_per_s2[axis];
+    return planner.settings.max_acceleration_mm_per_s2[axis];
   }
 
   float getAxisMaxAcceleration_mm_s2(const extruder_t extruder) {
-      return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E1)];
+    return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E1)];
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const axis_t axis) {
-      planner.settings.max_acceleration_mm_per_s2[axis] = value;
+    planner.settings.max_acceleration_mm_per_s2[axis] = value;
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
-      planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E1)] = value;
+    planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E1)] = value;
   }
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
@@ -511,9 +511,7 @@ namespace UI {
     }
   #endif
 
-  float getFeedrate_percent() {
-    return feedrate_percentage;
-  }
+  float getFeedrate_percent() { return feedrate_percentage; }
 
   void enqueueCommands(progmem_str gcode) {
     enqueue_and_echo_commands_P((PGM_P)gcode);
@@ -599,13 +597,9 @@ namespace UI {
     #endif
   }
 
-  FileList::FileList() {
-    refresh();
-  }
+  FileList::FileList() { refresh(); }
 
-  void FileList::refresh() {
-    num_files = 0xFFFF;
-  }
+  void FileList::refresh() { num_files = 0xFFFF; }
 
   bool FileList::seek(uint16_t pos, bool skip_range_check) {
     #if ENABLED(SDSUPPORT)
@@ -695,14 +689,13 @@ void lcd_update() {
       else {
         const bool ok = card.cardOK;
         card.release();
-        if (ok)
-          UI::onMediaRemoved();
+        if (ok) UI::onMediaRemoved();
       }
     }
   #endif // SDSUPPORT
 
   // Finish up deferred moves from setAxisPosition_mm
-  if(flags.deferred_motion && !UI::isMoving()) {
+  if (flags.deferred_motion && !UI::isMoving()) {
     flags.deferred_motion = false;
     prepare_move_to_destination();
   }

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -554,7 +554,7 @@ namespace UI {
 
   void setFan_percent(float value, const fan_t fan) {
     if (fan < FAN_COUNT)
-      fan_speed[fan - FAN1] = clamp(round(value * 255 / 100), 0, 255);
+      fan_speed[fan - FAN0] = clamp(round(value * 255 / 100), 0, 255);
   }
 
   void setFeedrate_percent(const float value) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -163,11 +163,11 @@ namespace UI {
       #else
         0
       #endif
-      : thermalManager.degHotend(heater - H1);
+      : thermalManager.degHotend(heater - H0);
   }
 
   float getActualTemp_celsius(const extruder_t extruder) {
-    return thermalManager.degHotend(extruder - E1);
+    return thermalManager.degHotend(extruder - E0);
   }
 
   float getTargetTemp_celsius(const heater_t heater) {
@@ -177,14 +177,14 @@ namespace UI {
       #else
         0
       #endif
-      : thermalManager.degTargetHotend(heater - H1);
+      : thermalManager.degTargetHotend(heater - H0);
   }
 
   float getTargetTemp_celsius(const extruder_t extruder) {
-    return thermalManager.degTargetHotend(extruder - E1);
+    return thermalManager.degTargetHotend(extruder - E0);
   }
 
-  float getFan_percent(const fan_t fan) { return ((float(fan_speed[fan - FAN1]) + 1) * 100) / 256; }
+  float getFan_percent(const fan_t fan) { return ((float(fan_speed[fan - FAN0]) + 1) * 100) / 256; }
 
   float getAxisPosition_mm(const axis_t axis) {
     return flags.manual_motion ? destination[axis] : current_position[axis];
@@ -285,7 +285,7 @@ namespace UI {
   }
 
   void setActiveTool(const extruder_t extruder, bool no_move) {
-    const uint8_t e = extruder - E1;
+    const uint8_t e = extruder - E0;
     #if DO_SWITCH_EXTRUDER || ENABLED(SWITCHING_NOZZLE) || ENABLED(PARKING_EXTRUDER)
       if (e != active_extruder)
         tool_change(e, 0, no_move);
@@ -295,12 +295,12 @@ namespace UI {
 
   extruder_t getActiveTool() {
     switch (active_extruder) {
-      case 5:  return E6;
-      case 4:  return E5;
-      case 3:  return E4;
-      case 2:  return E3;
-      case 1:  return E2;
-      default: return E1;
+      case 5:  return E5;
+      case 4:  return E4;
+      case 3:  return E3;
+      case 2:  return E2;
+      case 1:  return E1;
+      default: return E0;
     }
   }
 
@@ -320,7 +320,7 @@ namespace UI {
   }
 
   bool canMove(const extruder_t extruder) {
-    return !thermalManager.tooColdToExtrude(extruder - E1);
+    return !thermalManager.tooColdToExtrude(extruder - E0);
   }
 
   float getAxisSteps_per_mm(const axis_t axis) {
@@ -328,7 +328,7 @@ namespace UI {
   }
 
   float getAxisSteps_per_mm(const extruder_t extruder) {
-    return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E1)];
+    return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)];
   }
 
   void setAxisSteps_per_mm(const float value, const axis_t axis) {
@@ -336,7 +336,7 @@ namespace UI {
   }
 
   void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
-    planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E1)] = value;
+    planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E0)] = value;
   }
 
   float getAxisMaxFeedrate_mm_s(const axis_t axis) {
@@ -344,7 +344,7 @@ namespace UI {
   }
 
   float getAxisMaxFeedrate_mm_s(const extruder_t extruder) {
-    return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E1)];
+    return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)];
   }
 
   void setAxisMaxFeedrate_mm_s(const float value, const axis_t axis) {
@@ -352,7 +352,7 @@ namespace UI {
   }
 
   void setAxisMaxFeedrate_mm_s(const float value, const extruder_t extruder) {
-    planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E1)] = value;
+    planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)] = value;
   }
 
   float getAxisMaxAcceleration_mm_s2(const axis_t axis) {
@@ -360,7 +360,7 @@ namespace UI {
   }
 
   float getAxisMaxAcceleration_mm_s2(const extruder_t extruder) {
-    return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E1)];
+    return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)];
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const axis_t axis) {
@@ -368,7 +368,7 @@ namespace UI {
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
-    planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E1)] = value;
+    planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)] = value;
   }
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
@@ -388,12 +388,12 @@ namespace UI {
 
   #if ENABLED(LIN_ADVANCE)
     float getLinearAdvance_mm_mm_s(const extruder_t extruder) {
-      return (extruder < EXTRUDERS) ? planner.extruder_advance_K[extruder - E1] : 0;
+      return (extruder < EXTRUDERS) ? planner.extruder_advance_K[extruder - E0] : 0;
     }
 
     void setLinearAdvance_mm_mm_s(const float value, const extruder_t extruder) {
       if (extruder < EXTRUDERS)
-        planner.extruder_advance_K[extruder - E1] = clamp(value, 0, 999);
+        planner.extruder_advance_K[extruder - E0] = clamp(value, 0, 999);
     }
   #endif
 
@@ -481,13 +481,13 @@ namespace UI {
 
   #if HOTENDS > 1
     float getNozzleOffset_mm(const axis_t axis, const extruder_t extruder) {
-      if (extruder >= HOTENDS) return 0;
-      return hotend_offset[axis][extruder - E1];
+      if (extruder - E0 >= HOTENDS) return 0;
+      return hotend_offset[axis][extruder - E0];
     }
 
     void setNozzleOffset_mm(const float value, const axis_t axis, const extruder_t extruder) {
-      if (extruder >= HOTENDS) return;
-      hotend_offset[axis][extruder - E1] = value;
+      if (extruder - E0 >= HOTENDS) return;
+      hotend_offset[axis][extruder - E0] = value;
     }
   #endif
 
@@ -545,11 +545,11 @@ namespace UI {
     if (heater == BED)
       thermalManager.setTargetBed(clamp(value,0,200));
     #endif
-      thermalManager.setTargetHotend(clamp(value,0,500), heater - H1);
+      thermalManager.setTargetHotend(clamp(value,0,500), heater - H0);
   }
 
   void setTargetTemp_celsius(float value, const extruder_t extruder) {
-    thermalManager.setTargetHotend(clamp(value,0,500), extruder - E1);
+    thermalManager.setTargetHotend(clamp(value,0,500), extruder - E0);
   }
 
   void setFan_percent(float value, const fan_t fan) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -498,7 +498,7 @@ namespace UI {
                                                       { backlash_distance_mm[axis] = clamp(value,0,5); }
 
     float getBacklashCorrection_percent()             { return backlash_correction * 100; }
-    void setBacklashCorrection_percent(const float value) { backlash_correction = clamp(value, 0, 100) / 100; }
+    void setBacklashCorrection_percent(const float value) { backlash_correction = clamp(value, 0, 100) / 100.0f; }
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm()                 { return backlash_smoothing_mm; }
@@ -713,10 +713,10 @@ void lcd_update() {
   UI::onIdle();
 }
 
-bool lcd_hasstatus()                                                             { return true; }
-bool lcd_detected()                                                              { return true; }
-void lcd_reset_alert_level()                                                     {}
-void lcd_refresh()                                                               {}
+bool lcd_hasstatus() { return true; }
+bool lcd_detected() { return true; }
+void lcd_reset_alert_level() { }
+void lcd_refresh() { }
 void lcd_setstatus(const char * const message, const bool persist /* = false */) { UI::onStatusChanged(message); }
 void lcd_setstatusPGM(const char * const message, int8_t level /* = 0 */)        { UI::onStatusChanged((progmem_str)message); }
 void lcd_setalertstatusPGM(const char * const message)                           { lcd_setstatusPGM(message, 0); }

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -275,7 +275,8 @@ namespace UI {
         destination[Z_AXIS] = scale * destination[Z_AXIS] + current_position[Z_AXIS];
         prepare_move_to_destination();
         COPY(destination, saved_destination);
-      } else {
+      }
+      else {
         // We are close enough to finish off the move.
         COPY(destination, saved_destination);
         prepare_move_to_destination();
@@ -309,11 +310,11 @@ namespace UI {
   bool canMove(const axis_t axis) {
     switch (axis) {
       #if IS_KINEMATIC || ENABLED(NO_MOTION_BEFORE_HOMING)
-      case X: return TEST(axis_homed, X_AXIS);
-      case Y: return TEST(axis_homed, Y_AXIS);
-      case Z: return TEST(axis_homed, Z_AXIS);
+        case X: return TEST(axis_homed, X_AXIS);
+        case Y: return TEST(axis_homed, Y_AXIS);
+        case Z: return TEST(axis_homed, Z_AXIS);
       #else
-      case X: case Y: case Z: return true;
+        case X: case Y: case Z: return true;
       #endif
       default: return false;
     }

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -49,13 +49,10 @@ typedef const __FlashStringHelper *progmem_str;
 
 namespace UI {
 
-  /* Labels to resolve ambiguity around zero-based vs one-based indexing.
-   * For a user-facing UI, one-based labels are far more natural. */
-
   enum axis_t     : uint8_t { X,    Y,    Z };
-  enum extruder_t : uint8_t { E1,   E2,   E3,   E4,   E5,   E6        };
-  enum heater_t   : uint8_t { H1,   H2,   H3,   H4,   H5,   H6,   BED };
-  enum fan_t      : uint8_t { FAN1, FAN2, FAN3, FAN4, FAN5, FAN6      };
+  enum extruder_t : uint8_t { E0,   E1,   E2,   E3,   E4,   E5        };
+  enum heater_t   : uint8_t { H0,   H1,   H2,   H3,   H4,   H5,   BED };
+  enum fan_t      : uint8_t { FAN0, FAN1, FAN2, FAN3, FAN4, FAN5      };
 
   constexpr uint8_t extruderCount = EXTRUDERS;
   constexpr uint8_t hotendCount   = HOTENDS;
@@ -239,17 +236,17 @@ namespace UI {
 
 /* Helper macros to increment or decrement a value. For example:
  *
- *   UI_INCREMENT_BY(TargetTemp_celsius, 10, E1)
+ *   UI_INCREMENT_BY(TargetTemp_celsius, 10, E0)
  *
  * Expands to:
  *
- *   setTargetTemp_celsius(getTargetTemp_celsius(E1) + 10, E1);
+ *   setTargetTemp_celsius(getTargetTemp_celsius(E0) + 10, E0);
  *
  * Or, in the case where a constant increment is desired:
  *
  *   constexpr float increment = 10;
  *
- *   UI_INCREMENT(TargetTemp_celsius, E1)
+ *   UI_INCREMENT(TargetTemp_celsius, E0)
  *
  */
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -49,10 +49,10 @@ typedef const __FlashStringHelper *progmem_str;
 
 namespace UI {
 
-  enum axis_t     : uint8_t { X,    Y,    Z };
-  enum extruder_t : uint8_t { E0,   E1,   E2,   E3,   E4,   E5        };
-  enum heater_t   : uint8_t { H0,   H1,   H2,   H3,   H4,   H5,   BED };
-  enum fan_t      : uint8_t { FAN0, FAN1, FAN2, FAN3, FAN4, FAN5      };
+  enum axis_t     : uint8_t { X, Y, Z };
+  enum extruder_t : uint8_t { E0, E1, E2, E3, E4, E5 };
+  enum heater_t   : uint8_t { H0, H1, H2, H3, H4, H5, BED };
+  enum fan_t      : uint8_t { FAN0, FAN1, FAN2, FAN3, FAN4, FAN5 };
 
   constexpr uint8_t extruderCount = EXTRUDERS;
   constexpr uint8_t hotendCount   = HOTENDS;
@@ -65,7 +65,7 @@ namespace UI {
   void enqueueCommands(progmem_str);
 
   /**
-   * Getter and setters
+   * Getters and setters
    * Should be used by the EXTENSIBLE_UI to query or change Marlin's state.
    */
   progmem_str getFirmwareName_str();

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -49,161 +49,212 @@ typedef const __FlashStringHelper *progmem_str;
 
 namespace UI {
 
-  enum axis_t : uint8_t { X, Y, Z, E0, E1, E2, E3, E4, E5 };
+  /* Use of labels rather than integers resolves the ambiguity
+   * inherent in zero-based vs one-based indexing. For a user
+   * facing UI, one-based labels are far more natural. */
+
+  enum axis_t     : uint8_t { X,    Y,    Z };
+  enum extruder_t : uint8_t { E1,   E2,   E3,   E4,   E5,   E6        };
+  enum heater_t   : uint8_t { H1,   H2,   H3,   H4,   H5,   H6,   BED };
+  enum fan_t      : uint8_t { FAN1, FAN2, FAN3, FAN4, FAN5, FAN6      };
 
   constexpr uint8_t extruderCount = EXTRUDERS;
+  constexpr uint8_t hotendCount   = HOTENDS;
   constexpr uint8_t fanCount      = FAN_COUNT;
 
-  // The following methods should be used by the extension module to
-  // query or change Marlin's state.
+  bool        isMoving                       ();
+  bool        isAxisPositionKnown            (const axis_t);
+  bool        canMove                        (const axis_t);
+  bool        canMove                        (const extruder_t);
+  void        enqueueCommands                (progmem_str);
 
-  progmem_str getFirmwareName();
+  /* Getter and setters */
+  /* Should be used by the EXTENSIBLE_UI to query or change Marlin's state. */
 
-  bool isAxisPositionKnown(const axis_t axis);
-  bool isMoving();
+  progmem_str getFirmwareName_str            ();
 
-  float getActualTemp_celsius(const uint8_t extruder);
-  float getTargetTemp_celsius(const uint8_t extruder);
-  float getFan_percent(const uint8_t fan);
-  float getAxisPosition_mm(const axis_t axis);
-  float getAxisSteps_per_mm(const axis_t axis);
-  float getAxisMaxFeedrate_mm_s(const axis_t axis);
-  float getAxisMaxAcceleration_mm_s2(const axis_t axis);
-  float getMinFeedrate_mm_s();
-  float getMinTravelFeedrate_mm_s();
-  float getPrintingAcceleration_mm_s2();
-  float getRetractAcceleration_mm_s2();
-  float getTravelAcceleration_mm_s2();
-  float getFeedRate_percent();
-  uint8_t getProgress_percent();
-  uint32_t getProgress_seconds_elapsed();
+  float       getActualTemp_celsius          (const heater_t);
+  float       getActualTemp_celsius          (const extruder_t);
+  float       getTargetTemp_celsius          (const heater_t);
+  float       getTargetTemp_celsius          (const extruder_t);
+  float       getFan_percent                 (const fan_t);
+  float       getAxisPosition_mm             (const axis_t);
+  float       getAxisPosition_mm             (const extruder_t);
+  float       getAxisSteps_per_mm            (const axis_t);
+  float       getAxisSteps_per_mm            (const extruder_t);
+  float       getAxisMaxFeedrate_mm_s        (const axis_t);
+  float       getAxisMaxFeedrate_mm_s        (const extruder_t);
+  float       getAxisMaxAcceleration_mm_s2   (const axis_t);
+  float       getAxisMaxAcceleration_mm_s2   (const extruder_t);
+  float       getMinFeedrate_mm_s            ();
+  float       getMinTravelFeedrate_mm_s      ();
+  float       getPrintingAcceleration_mm_s2  ();
+  float       getRetractAcceleration_mm_s2   ();
+  float       getTravelAcceleration_mm_s2    ();
+  float       getFeedrate_percent            ();
+  uint8_t     getProgress_percent            ();
+  uint32_t    getProgress_seconds_elapsed    ();
 
   #if ENABLED(PRINTCOUNTER)
-    char *getTotalPrints_str(char buffer[21]);
-    char *getFinishedPrints_str(char buffer[21]);
-    char *getTotalPrintTime_str(char buffer[21]);
-    char *getLongestPrint_str(char buffer[21]);
-    char *getFilamentUsed_str(char buffer[21]);
+    char *    getTotalPrints_str             (char buffer[21]);
+    char *    getFinishedPrints_str          (char buffer[21]);
+    char *    getTotalPrintTime_str          (char buffer[21]);
+    char *    getLongestPrint_str            (char buffer[21]);
+    char *    getFilamentUsed_str            (char buffer[21]);
   #endif
 
-  void setTargetTemp_celsius(const uint8_t extruder, float temp);
-  void setFan_percent(const uint8_t fan, const float percent);
-  void setAxisPosition_mm(const axis_t axis, float position, float _feedrate_mm_s);
-  void setAxisSteps_per_mm(const axis_t axis, const float steps_per_mm);
-  void setAxisMaxFeedrate_mm_s(const axis_t axis, const float max_feedrate_mm_s);
-  void setAxisMaxAcceleration_mm_s2(const axis_t axis, const float max_acceleration_mm_per_s2);
-  void setMinFeedrate_mm_s(const float min_feedrate_mm_s);
-  void setMinTravelFeedrate_mm_s(const float min_travel_feedrate_mm_s);
-  void setPrintingAcceleration_mm_s2(const float acceleration);
-  void setRetractAcceleration_mm_s2(const float retract_acceleration);
-  void setTravelAcceleration_mm_s2(const float travel_acceleration);
-  void setFeedrate_percent(const float percent);
+  void        setTargetTemp_celsius          (const float, const heater_t);
+  void        setTargetTemp_celsius          (const float, const extruder_t);
+  void        setFan_percent                 (const float, const fan_t);
+  void        setAxisPosition_mm             (const float, const axis_t,     float _feedrate_mm_s);
+  void        setAxisPosition_mm             (const float, const extruder_t, float _feedrate_mm_s);
+  void        setAxisSteps_per_mm            (const float, const axis_t);
+  void        setAxisSteps_per_mm            (const float, const extruder_t);
+  void        setAxisMaxFeedrate_mm_s        (const float, const axis_t);
+  void        setAxisMaxFeedrate_mm_s        (const float, const extruder_t);
+  void        setAxisMaxAcceleration_mm_s2   (const float, const axis_t);
+  void        setAxisMaxAcceleration_mm_s2   (const float, const extruder_t);
+  void        setMinFeedrate_mm_s            (const float);
+  void        setMinTravelFeedrate_mm_s      (const float);
+  void        setPrintingAcceleration_mm_s2  (const float);
+  void        setRetractAcceleration_mm_s2   (const float);
+  void        setTravelAcceleration_mm_s2    (const float);
+  void        setFeedrate_percent            (const float);
 
   #if ENABLED(LIN_ADVANCE)
-    float getLinearAdvance_mm_mm_s(const uint8_t extruder);
-    void setLinearAdvance_mm_mm_s(const uint8_t extruder, const float k);
+    float     getLinearAdvance_mm_mm_s       (             const extruder_t);
+    void      setLinearAdvance_mm_mm_s       (const float, const extruder_t);
   #endif
 
   #if ENABLED(JUNCTION_DEVIATION)
-    float getJunctionDeviation_mm();
-    void setJunctionDeviation_mm(const float junc_dev);
+    float     getJunctionDeviation_mm        ();
+    void      setJunctionDeviation_mm        (const float);
   #else
-    float getAxisMaxJerk_mm_s(const axis_t axis);
-    void setAxisMaxJerk_mm_s(const axis_t axis, const float max_jerk);
+    float     getAxisMaxJerk_mm_s            (             const axis_t);
+    float     getAxisMaxJerk_mm_s            (             const extruder_t);
+    void      setAxisMaxJerk_mm_s            (const float, const axis_t);
+    void      setAxisMaxJerk_mm_s            (const float, const extruder_t);
   #endif
 
-  void setActiveTool(uint8_t extruder, bool no_move);
-  uint8_t getActiveTool();
+  extruder_t  getActiveTool                  ();
+  void        setActiveTool                  (const extruder_t, bool no_move);
+
 
   #if HOTENDS > 1
-    float getNozzleOffset_mm(const axis_t axis, uint8_t extruder);
-    void setNozzleOffset_mm(const axis_t axis, uint8_t extruder, float offset);
+    float     getNozzleOffset_mm             (             const axis_t, const extruder_t);
+    void      setNozzleOffset_mm             (const float, const axis_t, const extruder_t);
   #endif
 
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-    float getZOffset_mm();
-    void setZOffset_mm(const float zoffset_mm);
-    void incrementZOffset_steps(const int16_t babystep_increment);
+    float     getZOffset_mm                  ();
+    void      setZOffset_mm                  (const float);
+    void      addZOffset_steps               (const int16_t);
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
-    float getAxisBacklash_mm(const axis_t axis);
-    void setAxisBacklash_mm(const axis_t axis, float distance);
+    float     getAxisBacklash_mm             (             const axis_t);
+    void      setAxisBacklash_mm             (const float, const axis_t);
 
-    float getBacklashCorrection_percent();
-    void setBacklashCorrection_percent(float percent);
+    float     getBacklashCorrection_percent  ();
+    void      setBacklashCorrection_percent  (const float);
 
     #ifdef BACKLASH_SMOOTHING_MM
-      float getBacklashSmoothing_mm();
-      void setBacklashSmoothing_mm(float distance);
+      float   getBacklashSmoothing_mm        ();
+      void    setBacklashSmoothing_mm        (const float);
     #endif
   #endif
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    bool isFilamentRunoutEnabled();
-    void toggleFilamentRunout(const bool state);
+    bool      getFilamentRunoutEnabled       ();
+    void      setFilamentRunoutEnabled       (const bool);
 
     #if FILAMENT_RUNOUT_DISTANCE_MM > 0
-      float getFilamentRunoutDistance_mm();
-      void setFilamentRunoutDistance_mm(const float distance);
+      float   getFilamentRunoutDistance_mm   ();
+      void    setFilamentRunoutDistance_mm   (const float);
     #endif
   #endif
 
-  // This safe_millis is safe to use even when printer is killed (as long as called at least every 1 second)
-  uint32_t safe_millis();
-  void delay_us(unsigned long us);
-  void delay_ms(unsigned long ms);
-  void yield(); // Within lengthy loop, call this periodically
+  /* Delay and timing routines */
+  /* Should be used by the EXTENSIBLE_UI to safely pause or measure time */
+  /* safe_millis must be called at least every 1 sec to guarantee time */
+  /* yield should be called within lengthy loops */
+  uint32_t    safe_millis                    ();
+  void        delay_us                       (unsigned long us);
+  void        delay_ms                       (unsigned long ms);
+  void        yield                          ();
 
-  void enqueueCommands(progmem_str gcode);
+  /* Media access routines */
+  /* Should be used by the EXTENSIBLE_UI to operate on files */
 
-  void printFile(const char *filename);
-  bool isPrintingFromMediaPaused();
-  bool isPrintingFromMedia();
-  bool isPrinting();
-  void stopPrint();
-  void pausePrint();
-  void resumePrint();
+  bool        isMediaInserted                ();
+  bool        isPrintingFromMediaPaused      ();
+  bool        isPrintingFromMedia            ();
+  bool        isPrinting                     ();
 
-  bool isMediaInserted();
+  void        printFile                      (const char *filename);
+  void        stopPrint                      ();
+  void        pausePrint                     ();
+  void        resumePrint                    ();
 
   class FileList {
     private:
       uint16_t num_files;
 
     public:
-      FileList();
-      void        refresh();
-      bool        seek(uint16_t, bool skip_range_check = false);
+      FileList                               ();
+      void        refresh                    ();
+      bool        seek                       (uint16_t, bool skip_range_check = false);
 
-      const char *longFilename();
-      const char *shortFilename();
-      const char *filename();
-      bool        isDir();
+      const char *longFilename               ();
+      const char *shortFilename              ();
+      const char *filename                   ();
+      bool        isDir                      ();
 
-      void        changeDir(const char *dirname);
-      void        upDir();
-      bool        isAtRootDir();
-      uint16_t    count();
+      void        changeDir                  (const char *dirname);
+      void        upDir                      ();
+      bool        isAtRootDir                ();
+      uint16_t    count                      ();
   };
 
-  // The following event handlers are to be declared by the extension
-  // module and will be called by Marlin.
+  /* Event callback routines */
+  /* Should be declared by EXTENSIBLE_UI and will be called by Marlin */
 
-  void onStartup();
-  void onIdle();
-  void onMediaInserted();
-  void onMediaError();
-  void onMediaRemoved();
-  void onPlayTone(const uint16_t frequency, const uint16_t duration);
-  void onPrinterKilled(const char* msg);
-  void onPrintTimerStarted();
-  void onPrintTimerPaused();
-  void onPrintTimerStopped();
-  void onFilamentRunout();
-  void onStatusChanged(const char* msg);
-  void onStatusChanged(progmem_str msg);
-  void onFactoryReset();
-  void onStoreSettings();
-  void onLoadSettings();
+  void        onStartup                      ();
+  void        onIdle                         ();
+  void        onMediaInserted                ();
+  void        onMediaError                   ();
+  void        onMediaRemoved                 ();
+  void        onPlayTone                     (const uint16_t frequency, const uint16_t duration);
+  void        onPrinterKilled                (const char* msg);
+  void        onPrintTimerStarted            ();
+  void        onPrintTimerPaused             ();
+  void        onPrintTimerStopped            ();
+  void        onFilamentRunout               ();
+  void        onStatusChanged                (const char* msg);
+  void        onStatusChanged                (progmem_str msg);
+  void        onFactoryReset                 ();
+  void        onStoreSettings                ();
+  void        onLoadSettings                 ();
 };
+
+/* Helper macros to increment or decrement a value. For example:
+ *
+ *   UI_INCREMENT_BY(TargetTemp_celsius, 10, E1)
+ *
+ * Expands to:
+ *
+ *   setTargetTemp_celsius(getTargetTemp_celsius(E1) + 10, E1);
+ *
+ * Or, in the case where a constant increment is desired:
+ *
+ *   constexpr float increment = 10;
+ *
+ *   UI_INCREMENT(TargetTemp_celsius, E1)
+ *
+ */
+
+#define UI_INCREMENT_BY(method, inc, ...) UI::set ## method(UI::get ## method (__VA_ARGS__) + inc, ##__VA_ARGS__)
+#define UI_DECREMENT_BY(method, inc, ...) UI::set ## method(UI::get ## method (__VA_ARGS__) - inc, ##__VA_ARGS__)
+
+#define UI_INCREMENT(method, ...) UI_INCREMENT_BY(method, increment, ##__VA_ARGS__)
+#define UI_DECREMENT(method, ...) UI_DECREMENT_BY(method, increment, ##__VA_ARGS__)

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -49,9 +49,8 @@ typedef const __FlashStringHelper *progmem_str;
 
 namespace UI {
 
-  /* Use of labels rather than integers resolves the ambiguity
-   * inherent in zero-based vs one-based indexing. For a user
-   * facing UI, one-based labels are far more natural. */
+  /* Labels to resolve ambiguity around zero-based vs one-based indexing.
+   * For a user-facing UI, one-based labels are far more natural. */
 
   enum axis_t     : uint8_t { X,    Y,    Z };
   enum extruder_t : uint8_t { E1,   E2,   E3,   E4,   E5,   E6        };

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -64,9 +64,10 @@ namespace UI {
   bool        canMove                        (const extruder_t);
   void        enqueueCommands                (progmem_str);
 
-  /* Getter and setters */
-  /* Should be used by the EXTENSIBLE_UI to query or change Marlin's state. */
-
+  /**
+   * Getter and setters
+   * Should be used by the EXTENSIBLE_UI to query or change Marlin's state.
+   */
   progmem_str getFirmwareName_str            ();
 
   float       getActualTemp_celsius          (const heater_t);
@@ -171,18 +172,22 @@ namespace UI {
     #endif
   #endif
 
-  /* Delay and timing routines */
-  /* Should be used by the EXTENSIBLE_UI to safely pause or measure time */
-  /* safe_millis must be called at least every 1 sec to guarantee time */
-  /* yield should be called within lengthy loops */
+  /**
+   * Delay and timing routines
+   * Should be used by the EXTENSIBLE_UI to safely pause or measure time
+   * safe_millis must be called at least every 1 sec to guarantee time
+   * yield should be called within lengthy loops
+   */
   uint32_t    safe_millis                    ();
   void        delay_us                       (unsigned long us);
   void        delay_ms                       (unsigned long ms);
   void        yield                          ();
 
-  /* Media access routines */
-  /* Should be used by the EXTENSIBLE_UI to operate on files */
-
+  /**
+   * Media access routines
+   *
+   * Should be used by the EXTENSIBLE_UI to operate on files
+   */
   bool        isMediaInserted                ();
   bool        isPrintingFromMediaPaused      ();
   bool        isPrintingFromMedia            ();
@@ -213,9 +218,11 @@ namespace UI {
       uint16_t    count                      ();
   };
 
-  /* Event callback routines */
-  /* Should be declared by EXTENSIBLE_UI and will be called by Marlin */
-
+  /**
+   * Event callback routines
+   *
+   * Should be declared by EXTENSIBLE_UI and will be called by Marlin
+   */
   void        onStartup                      ();
   void        onIdle                         ();
   void        onMediaInserted                ();
@@ -234,7 +241,8 @@ namespace UI {
   void        onLoadSettings                 ();
 };
 
-/* Helper macros to increment or decrement a value. For example:
+/**
+ * Helper macros to increment or decrement a value. For example:
  *
  *   UI_INCREMENT_BY(TargetTemp_celsius, 10, E0)
  *
@@ -249,7 +257,6 @@ namespace UI {
  *   UI_INCREMENT(TargetTemp_celsius, E0)
  *
  */
-
 #define UI_INCREMENT_BY(method, inc, ...) UI::set ## method(UI::get ## method (__VA_ARGS__) + inc, ##__VA_ARGS__)
 #define UI_DECREMENT_BY(method, inc, ...) UI::set ## method(UI::get ## method (__VA_ARGS__) - inc, ##__VA_ARGS__)
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -58,117 +58,117 @@ namespace UI {
   constexpr uint8_t hotendCount   = HOTENDS;
   constexpr uint8_t fanCount      = FAN_COUNT;
 
-  bool        isMoving                       ();
-  bool        isAxisPositionKnown            (const axis_t);
-  bool        canMove                        (const axis_t);
-  bool        canMove                        (const extruder_t);
-  void        enqueueCommands                (progmem_str);
+  bool isMoving();
+  bool isAxisPositionKnown(const axis_t);
+  bool canMove(const axis_t);
+  bool canMove(const extruder_t);
+  void enqueueCommands(progmem_str);
 
   /**
    * Getter and setters
    * Should be used by the EXTENSIBLE_UI to query or change Marlin's state.
    */
-  progmem_str getFirmwareName_str            ();
+  progmem_str getFirmwareName_str();
 
-  float       getActualTemp_celsius          (const heater_t);
-  float       getActualTemp_celsius          (const extruder_t);
-  float       getTargetTemp_celsius          (const heater_t);
-  float       getTargetTemp_celsius          (const extruder_t);
-  float       getFan_percent                 (const fan_t);
-  float       getAxisPosition_mm             (const axis_t);
-  float       getAxisPosition_mm             (const extruder_t);
-  float       getAxisSteps_per_mm            (const axis_t);
-  float       getAxisSteps_per_mm            (const extruder_t);
-  float       getAxisMaxFeedrate_mm_s        (const axis_t);
-  float       getAxisMaxFeedrate_mm_s        (const extruder_t);
-  float       getAxisMaxAcceleration_mm_s2   (const axis_t);
-  float       getAxisMaxAcceleration_mm_s2   (const extruder_t);
-  float       getMinFeedrate_mm_s            ();
-  float       getMinTravelFeedrate_mm_s      ();
-  float       getPrintingAcceleration_mm_s2  ();
-  float       getRetractAcceleration_mm_s2   ();
-  float       getTravelAcceleration_mm_s2    ();
-  float       getFeedrate_percent            ();
-  uint8_t     getProgress_percent            ();
-  uint32_t    getProgress_seconds_elapsed    ();
+  float getActualTemp_celsius(const heater_t);
+  float getActualTemp_celsius(const extruder_t);
+  float getTargetTemp_celsius(const heater_t);
+  float getTargetTemp_celsius(const extruder_t);
+  float getFan_percent(const fan_t);
+  float getAxisPosition_mm(const axis_t);
+  float getAxisPosition_mm(const extruder_t);
+  float getAxisSteps_per_mm(const axis_t);
+  float getAxisSteps_per_mm(const extruder_t);
+  float getAxisMaxFeedrate_mm_s(const axis_t);
+  float getAxisMaxFeedrate_mm_s(const extruder_t);
+  float getAxisMaxAcceleration_mm_s2(const axis_t);
+  float getAxisMaxAcceleration_mm_s2(const extruder_t);
+  float getMinFeedrate_mm_s();
+  float getMinTravelFeedrate_mm_s();
+  float getPrintingAcceleration_mm_s2();
+  float getRetractAcceleration_mm_s2();
+  float getTravelAcceleration_mm_s2();
+  float getFeedrate_percent();
+  uint8_t getProgress_percent();
+  uint32_t getProgress_seconds_elapsed();
 
   #if ENABLED(PRINTCOUNTER)
-    char *    getTotalPrints_str             (char buffer[21]);
-    char *    getFinishedPrints_str          (char buffer[21]);
-    char *    getTotalPrintTime_str          (char buffer[21]);
-    char *    getLongestPrint_str            (char buffer[21]);
-    char *    getFilamentUsed_str            (char buffer[21]);
+    char* getTotalPrints_str(char buffer[21]);
+    char* getFinishedPrints_str(char buffer[21]);
+    char* getTotalPrintTime_str(char buffer[21]);
+    char* getLongestPrint_str(char buffer[21]);
+    char* getFilamentUsed_str(char buffer[21]);
   #endif
 
-  void        setTargetTemp_celsius          (const float, const heater_t);
-  void        setTargetTemp_celsius          (const float, const extruder_t);
-  void        setFan_percent                 (const float, const fan_t);
-  void        setAxisPosition_mm             (const float, const axis_t);
-  void        setAxisPosition_mm             (const float, const extruder_t);
-  void        setAxisSteps_per_mm            (const float, const axis_t);
-  void        setAxisSteps_per_mm            (const float, const extruder_t);
-  void        setAxisMaxFeedrate_mm_s        (const float, const axis_t);
-  void        setAxisMaxFeedrate_mm_s        (const float, const extruder_t);
-  void        setAxisMaxAcceleration_mm_s2   (const float, const axis_t);
-  void        setAxisMaxAcceleration_mm_s2   (const float, const extruder_t);
-  void        setFeedrate_mm_s               (const float);
-  void        setMinFeedrate_mm_s            (const float);
-  void        setMinTravelFeedrate_mm_s      (const float);
-  void        setPrintingAcceleration_mm_s2  (const float);
-  void        setRetractAcceleration_mm_s2   (const float);
-  void        setTravelAcceleration_mm_s2    (const float);
-  void        setFeedrate_percent            (const float);
+  void setTargetTemp_celsius(const float, const heater_t);
+  void setTargetTemp_celsius(const float, const extruder_t);
+  void setFan_percent(const float, const fan_t);
+  void setAxisPosition_mm(const float, const axis_t);
+  void setAxisPosition_mm(const float, const extruder_t);
+  void setAxisSteps_per_mm(const float, const axis_t);
+  void setAxisSteps_per_mm(const float, const extruder_t);
+  void setAxisMaxFeedrate_mm_s(const float, const axis_t);
+  void setAxisMaxFeedrate_mm_s(const float, const extruder_t);
+  void setAxisMaxAcceleration_mm_s2(const float, const axis_t);
+  void setAxisMaxAcceleration_mm_s2(const float, const extruder_t);
+  void setFeedrate_mm_s(const float);
+  void setMinFeedrate_mm_s(const float);
+  void setMinTravelFeedrate_mm_s(const float);
+  void setPrintingAcceleration_mm_s2(const float);
+  void setRetractAcceleration_mm_s2(const float);
+  void setTravelAcceleration_mm_s2(const float);
+  void setFeedrate_percent(const float);
 
   #if ENABLED(LIN_ADVANCE)
-    float     getLinearAdvance_mm_mm_s       (             const extruder_t);
-    void      setLinearAdvance_mm_mm_s       (const float, const extruder_t);
+    float getLinearAdvance_mm_mm_s(const extruder_t);
+    void setLinearAdvance_mm_mm_s(const float, const extruder_t);
   #endif
 
   #if ENABLED(JUNCTION_DEVIATION)
-    float     getJunctionDeviation_mm        ();
-    void      setJunctionDeviation_mm        (const float);
+    float getJunctionDeviation_mm();
+    void setJunctionDeviation_mm(const float);
   #else
-    float     getAxisMaxJerk_mm_s            (             const axis_t);
-    float     getAxisMaxJerk_mm_s            (             const extruder_t);
-    void      setAxisMaxJerk_mm_s            (const float, const axis_t);
-    void      setAxisMaxJerk_mm_s            (const float, const extruder_t);
+    float getAxisMaxJerk_mm_s(const axis_t);
+    float getAxisMaxJerk_mm_s(const extruder_t);
+    void setAxisMaxJerk_mm_s(const float, const axis_t);
+    void setAxisMaxJerk_mm_s(const float, const extruder_t);
   #endif
 
-  extruder_t  getActiveTool                  ();
-  void        setActiveTool                  (const extruder_t, bool no_move);
+  extruder_t getActiveTool();
+  void setActiveTool(const extruder_t, bool no_move);
 
 
   #if HOTENDS > 1
-    float     getNozzleOffset_mm             (             const axis_t, const extruder_t);
-    void      setNozzleOffset_mm             (const float, const axis_t, const extruder_t);
+    float getNozzleOffset_mm(const axis_t, const extruder_t);
+    void setNozzleOffset_mm(const float, const axis_t, const extruder_t);
   #endif
 
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-    float     getZOffset_mm                  ();
-    void      setZOffset_mm                  (const float);
-    void      addZOffset_steps               (const int16_t);
+    float getZOffset_mm();
+    void setZOffset_mm(const float);
+    void addZOffset_steps(const int16_t);
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
-    float     getAxisBacklash_mm             (             const axis_t);
-    void      setAxisBacklash_mm             (const float, const axis_t);
+    float getAxisBacklash_mm(const axis_t);
+    void setAxisBacklash_mm(const float, const axis_t);
 
-    float     getBacklashCorrection_percent  ();
-    void      setBacklashCorrection_percent  (const float);
+    float getBacklashCorrection_percent();
+    void setBacklashCorrection_percent(const float);
 
     #ifdef BACKLASH_SMOOTHING_MM
-      float   getBacklashSmoothing_mm        ();
-      void    setBacklashSmoothing_mm        (const float);
+      float getBacklashSmoothing_mm();
+      void setBacklashSmoothing_mm(const float);
     #endif
   #endif
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    bool      getFilamentRunoutEnabled       ();
-    void      setFilamentRunoutEnabled       (const bool);
+    bool getFilamentRunoutEnabled();
+    void setFilamentRunoutEnabled(const bool);
 
     #if FILAMENT_RUNOUT_DISTANCE_MM > 0
-      float   getFilamentRunoutDistance_mm   ();
-      void    setFilamentRunoutDistance_mm   (const float);
+      float getFilamentRunoutDistance_mm();
+      void setFilamentRunoutDistance_mm(const float);
     #endif
   #endif
 
@@ -178,44 +178,44 @@ namespace UI {
    * safe_millis must be called at least every 1 sec to guarantee time
    * yield should be called within lengthy loops
    */
-  uint32_t    safe_millis                    ();
-  void        delay_us                       (unsigned long us);
-  void        delay_ms                       (unsigned long ms);
-  void        yield                          ();
+  uint32_t safe_millis();
+  void delay_us(unsigned long us);
+  void delay_ms(unsigned long ms);
+  void yield();
 
   /**
    * Media access routines
    *
    * Should be used by the EXTENSIBLE_UI to operate on files
    */
-  bool        isMediaInserted                ();
-  bool        isPrintingFromMediaPaused      ();
-  bool        isPrintingFromMedia            ();
-  bool        isPrinting                     ();
+  bool isMediaInserted();
+  bool isPrintingFromMediaPaused();
+  bool isPrintingFromMedia();
+  bool isPrinting();
 
-  void        printFile                      (const char *filename);
-  void        stopPrint                      ();
-  void        pausePrint                     ();
-  void        resumePrint                    ();
+  void printFile(const char *filename);
+  void stopPrint();
+  void pausePrint();
+  void resumePrint();
 
   class FileList {
     private:
       uint16_t num_files;
 
     public:
-      FileList                               ();
-      void        refresh                    ();
-      bool        seek                       (uint16_t, bool skip_range_check = false);
+      FileList();
+      void refresh();
+      bool seek(uint16_t, bool skip_range_check = false);
 
-      const char *longFilename               ();
-      const char *shortFilename              ();
-      const char *filename                   ();
-      bool        isDir                      ();
+      const char *longFilename();
+      const char *shortFilename();
+      const char *filename();
+      bool isDir();
 
-      void        changeDir                  (const char *dirname);
-      void        upDir                      ();
-      bool        isAtRootDir                ();
-      uint16_t    count                      ();
+      void changeDir(const char *dirname);
+      void upDir();
+      bool isAtRootDir();
+      uint16_t    count();
   };
 
   /**
@@ -223,22 +223,22 @@ namespace UI {
    *
    * Should be declared by EXTENSIBLE_UI and will be called by Marlin
    */
-  void        onStartup                      ();
-  void        onIdle                         ();
-  void        onMediaInserted                ();
-  void        onMediaError                   ();
-  void        onMediaRemoved                 ();
-  void        onPlayTone                     (const uint16_t frequency, const uint16_t duration);
-  void        onPrinterKilled                (const char* msg);
-  void        onPrintTimerStarted            ();
-  void        onPrintTimerPaused             ();
-  void        onPrintTimerStopped            ();
-  void        onFilamentRunout               ();
-  void        onStatusChanged                (const char* msg);
-  void        onStatusChanged                (progmem_str msg);
-  void        onFactoryReset                 ();
-  void        onStoreSettings                ();
-  void        onLoadSettings                 ();
+  void onStartup();
+  void onIdle();
+  void onMediaInserted();
+  void onMediaError();
+  void onMediaRemoved();
+  void onPlayTone(const uint16_t frequency, const uint16_t duration);
+  void onPrinterKilled(const char* msg);
+  void onPrintTimerStarted();
+  void onPrintTimerPaused();
+  void onPrintTimerStopped();
+  void onFilamentRunout();
+  void onStatusChanged(const char* msg);
+  void onStatusChanged(progmem_str msg);
+  void onFactoryReset();
+  void onStoreSettings();
+  void onLoadSettings();
 };
 
 /**

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -105,14 +105,15 @@ namespace UI {
   void        setTargetTemp_celsius          (const float, const heater_t);
   void        setTargetTemp_celsius          (const float, const extruder_t);
   void        setFan_percent                 (const float, const fan_t);
-  void        setAxisPosition_mm             (const float, const axis_t,     float _feedrate_mm_s);
-  void        setAxisPosition_mm             (const float, const extruder_t, float _feedrate_mm_s);
+  void        setAxisPosition_mm             (const float, const axis_t);
+  void        setAxisPosition_mm             (const float, const extruder_t);
   void        setAxisSteps_per_mm            (const float, const axis_t);
   void        setAxisSteps_per_mm            (const float, const extruder_t);
   void        setAxisMaxFeedrate_mm_s        (const float, const axis_t);
   void        setAxisMaxFeedrate_mm_s        (const float, const extruder_t);
   void        setAxisMaxAcceleration_mm_s2   (const float, const axis_t);
   void        setAxisMaxAcceleration_mm_s2   (const float, const extruder_t);
+  void        setFeedrate_mm_s               (const float);
   void        setMinFeedrate_mm_s            (const float);
   void        setMinTravelFeedrate_mm_s      (const float);
   void        setPrintingAcceleration_mm_s2  (const float);


### PR DESCRIPTION
- Added axis_t, extruder_t, heater_t and fan_t to eliminate ambiguity, improve type safety.
- Regularized getter/setter argument order and naming.
- Tabular layout of "ui_api.h" to make it easier to use it as a reference.
- setAxisPosition now will not stack moves in buffer, allowing it to be
  called repeatedly on each touch ui tap.

Unambigous enum labels
----------------------------------
Methods which formerly used integers as arguments now use type-safe enum labels. The uses of labels also allows the use of BED instead of magical values such as zero.

An intentional choice was made to use C style "enums" rather than "class enums" to allow the brevity of writing "E0" rather than "extruder_t::E0"

Type-safety and compile-time checking:
----------------------------------------------------
There are now three new enum types: axis_t, heater_t, extruder_t and fan_t.

- axis_t: X, Y, Z
- extruder_t: E0, E1, E2, E3, E4, E5
- heater_t: H0, H1, H2, H3, H4, H5, BED
- fan_t: FAN0, FAN1, FAN2, FAN3, FAN4, FAN5

"axis_t" refer to a movement axis, but excludes extruders because there are operations which make sense for an extruder but not for a movement axis (such as linear advance). Separating "axis_t" and "extruder_t" allows methods to be written to take only one type while eliminating the need for run-time error checking or switch statements. Operations which apply to "axis_t" as well "extruder_t", such as setting positions, are handled via method overloading.

The additional "heater_t" type overlaps with "extruder_t", but also includes "BED", which has no associated stepper motor. Heaters are designated H0...H5. For convenience, methods which act on heaters also take "extruder_t", therefore "E" labels can be used interchangeably with "H" labels when setting temperatures.

Reordered and standardized getter/setter:
-------------------------------------------------------

The arguments to setter and getter methods have been reordered such that the value the setter is setting is always the first argument. The remaining arguments are modifiers and have been made identical between getter and setters, and the method names have been standardized, differing only by the "set" and "get" prefix. This allows for short-cuts via macros. For example, the standard way of increasing a temperature by 10 degrees looks like this:

```
UI::setTargetTemp_celsius(UI::getTargetTemp_celsius(E0) + 10, E0);
```

However, a variadic macro called UI_INCREMENT_BY has been created which expresses this more concisely as:

```
UI_INCREMENT_BY(TargetTemp_celsius, 10, E0)
```

A way forward for Ultralcd?
-------------------------------------------------------

This standardization of getter/setters also may allow more complex macros to be created, allowing for a possible future migration of the Ultralcd code to an EXTENSIBLE_UI module (if this is desired). This could be done by replacing a macro like this:

```
MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int3, MSG_NOZZLE, &thermalManager.target_temperature[0], 0, HEATER_0_MAXTEMP - 15, watch_temp_callback_E0);
```

With a macro like this:

```
MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int3, MSG_NOZZLE, watch_temp_callback_E0, TargetTemp_celsius, E0);
```

In this case, the temperature limits are removed (because such limits can be enforced by the setter and getters) and the pointer to a memory location is replaced with the setter/getter name (TargetTemp_celsius) and associated modifiers (E0).

Compatibility with earlier EXTENSIBLE_UI:
--------------------------------------------------------

The reordering of the parameters and the introduction of types will break code that formerly relied on the EXTENSIBLE_UI, but at this early stage of API development, I don't think anyone will be affected! The changes are fairly obvious and the added type-safety will ensure that the compiler will flag all code that needs to be modified. Apologies if this PR messes anyone up!