### PR TITLE
Add creality ramps pin definition

### DIFF
--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -134,10 +134,6 @@
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
   #define MOTHERBOARD BOARD_RAMPS_CREALITY
-  #define PIN_EXP1 65 // A11
-  #define PIN_EXP2 66 // A12
-  #define PIN_EXP3 11 // SERVO0_PIN
-  #define PIN_EXP4 12 // PS_ON_PIN
 #endif
 
 // Optional custom name for your RepStrap or other custom machine

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -133,7 +133,7 @@
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_RAMPS_CREALITY
   #define PIN_EXP1 65 // A11
   #define PIN_EXP2 66 // A12
   #define PIN_EXP3 11 // SERVO0_PIN

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -83,6 +83,7 @@
 #define BOARD_TRIGORILLA_13     343   // TriGorilla Anycubic version 1.3 based on RAMPS EFB
 #define BOARD_TRIGORILLA_14     443   // TriGorilla Anycubic version 1.4 based on RAMPS EFB
 #define BOARD_RAMPS_ENDER_4     243   // Creality: Ender-4, CR-8
+#define BOARD_RAMPS_CREALITY    244   // Creality: CR10S, CR20, CR-X
 #define BOARD_FYSETC_F6_13      541   // Fysetc F6
 
 //

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -148,6 +148,8 @@
   #include "pins_TRIGORILLA_14.h"     // ATmega2560                                 env:megaatmega2560
 #elif MB(RAMPS_ENDER_4)
   #include "pins_RAMPS_ENDER_4.h"     // ATmega2560                                 env:megaatmega2560
+#elif MB(RAMPS_CREALITY)
+  #include "pins_RAMPS_CREALITY.h"     // ATmega2560                                 env:megaatmega2560
 #elif MB(FYSETC_F6_13)
   #include "pins_FYSETC_F6_13.h"      // ATmega2560                                 env:megaatmega2560
 

--- a/Marlin/src/pins/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/pins_MELZI_CREALITY.h
@@ -53,6 +53,10 @@
 #define LCD_PINS_D4        30   // ST9720 CLK
 #define FIL_RUNOUT_PIN     -1   // Uses Beeper/LED Pin Pulled to GND
 
+#if DISABLED(SPEAKER) && ENABLED(BLTOUCH)
+  #define SERVO0_PIN 27
+#endif
+
 // Alter timing for graphical display
 #ifndef ST7920_DELAY_1
   #define ST7920_DELAY_1 DELAY_NS(125)

--- a/Marlin/src/pins/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/pins_RAMPS_CREALITY.h
@@ -36,3 +36,8 @@
 #define FIL_RUNOUT_PIN 2
 
 #include "pins_RAMPS.h"
+
+#define EXP1_PIN 65   // A11
+#define EXP2_PIN 66   // A12
+#define EXP3_PIN 11   // SERVO0_PIN
+#define EXP4_PIN 12   // PS_ON_PIN

--- a/Marlin/src/pins/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/pins_RAMPS_CREALITY.h
@@ -1,0 +1,38 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "Ender-4 supports only 2 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_NAME "Creality"
+
+//
+// Heaters / Fans
+//
+// Power outputs EFBF or EFBE
+#define MOSFET_D_PIN 7
+
+#define FIL_RUNOUT_PIN 2
+
+#include "pins_RAMPS.h"
+

--- a/Marlin/src/pins/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/pins_RAMPS_CREALITY.h
@@ -21,18 +21,18 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Ender-4 supports only 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Creality3D RAMPS supports only 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_NAME "Creality"
+#define BOARD_NAME "Creality3D RAMPS"
 
 //
 // Heaters / Fans
 //
+
 // Power outputs EFBF or EFBE
 #define MOSFET_D_PIN 7
 
 #define FIL_RUNOUT_PIN 2
 
 #include "pins_RAMPS.h"
-


### PR DESCRIPTION
Add pins file for Creality ramps generation boards with definition for filament sensor and heater 1 pins. Update creality melzi to support servo0 definition for bltouch when required. Standard method using TH3D EZOut boards, provided as stock upgrade by Tinymachines3D, and by many users.