### PR TITLE
Fix "garbage" in display

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -45,7 +45,7 @@
 #include <U8glib.h>
 
 //set optimization so ARDUINO optimizes this file
-#pragma GCC optimize (3)
+//#pragma GCC optimize (3)
 
 // If you want you can define your own set of delays in Configuration.h
 //#define ST7920_DELAY_1 DELAY_NS(0)


### PR DESCRIPTION
### Description

Some users experience random garbage when using LCDs like the RepRapDiscount Full Graphic Smart Controller - I, for example, when using a Melzi Tronxy board.
Removing this optimizer line has fixed said garbage in my display.
The change entails a Flash memory usage increase of around 400 bytes (118768 Bytes instead of 118398 with my settings in Arduino IDE 1.9.0., SRAM unaffected), so a solution specific to the affected displays might be preferable.

### Benefits

No more random garbage characters / pixels in aforementioned display / board combinations.

### Related Issues

Possible fix for issues #9902, #12167.
