### PR TITLE
Remove duplicated logic in idex homing

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -335,16 +335,16 @@ void GcodeSuite::G28(const bool always_home_all) {
         active_extruder_parked = true;
 
         if (IDEX_saved_mode >= DXC_DUPLICATION_MODE) {
-          enqueue_and_echo_commands_P("M605 S1\nT0");
-          char idexbuffer[20];
-          sprintf_P(idexbuffer, PSTR("M605 S2 X%i"), DEFAULT_DUPLICATION_X_OFFSET);
-          enqueue_and_echo_commands_P(idexbuffer);
-          enqueue_and_echo_commands_P(PSTR("G28 X"));
-          sprintf_P(idexbuffer, PSTR("G1 X%i"), (X_BED_SIZE) / 3);
-          enqueue_and_echo_commands_P(idexbuffer);
+          enqueue_and_echo_commands_now_P(PSTR("M605 S1\nT0"));
+          char cmd[16];
+          sprintf_P(cmd, PSTR("M605 S2 X%i"), DEFAULT_DUPLICATION_X_OFFSET);
+          enqueue_and_echo_command_now(cmd);
+          enqueue_and_echo_commands_now_P(PSTR("G28 X"));
+          sprintf_P(cmd, PSTR("G1 X%i"), (X_BED_SIZE) / 3);
+          enqueue_and_echo_command_now(cmd);
           if (IDEX_saved_mode >= DXC_SCALED_DUPLICATION_MODE) {
-            sprintf_P(idexbuffer, PSTR("M605 S3 X%i"), DEFAULT_DUPLICATION_X_OFFSET);
-            enqueue_and_echo_commands_P(idexbuffer);
+            sprintf_P(cmd, PSTR("M605 S3 X%i"), DEFAULT_DUPLICATION_X_OFFSET);
+            enqueue_and_echo_commands_now_P(cmd);
           }
         }
         else

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -193,7 +193,7 @@ void enqueue_and_echo_commands_P(PGM_P const pgcode) {
   void enqueue_and_echo_command_now(const char* cmd) {
     while (!enqueue_and_echo_command(cmd)) idle();
   }
-  #if HAS_LCD_QUEUE_NOW
+  #if HAS_QUEUE_NOW_P
     /**
      * Enqueue from program memory and return only when commands are actually enqueued
      */

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -97,15 +97,18 @@ void enqueue_and_echo_commands_P(PGM_P const pgcode);
  */
 bool enqueue_and_echo_command(const char* cmd);
 
-#define HAS_LCD_QUEUE_NOW (ENABLED(MALYAN_LCD) || (HAS_LCD_MENU && (ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(PID_AUTOTUNE_MENU) || ENABLED(ADVANCED_PAUSE_FEATURE))))
-#define HAS_QUEUE_NOW (ENABLED(SDSUPPORT) || HAS_LCD_QUEUE_NOW)
+#define HAS_QUEUE_NOW_P (    ENABLED(DUAL_X_CARRIAGE) \
+                          || ENABLED(MALYAN_LCD) \
+                          || (HAS_LCD_MENU && (ENABLED(AUTO_BED_LEVELING_UBL) || ENABLED(PID_AUTOTUNE_MENU) || ENABLED(ADVANCED_PAUSE_FEATURE))) \
+                        )
+#define HAS_QUEUE_NOW (ENABLED(SDSUPPORT) || HAS_QUEUE_NOW_P)
 
 #if HAS_QUEUE_NOW
   /**
    * Enqueue and return only when commands are actually enqueued
    */
   void enqueue_and_echo_command_now(const char* cmd);
-  #if HAS_LCD_QUEUE_NOW
+  #if HAS_QUEUE_NOW_P
     /**
      * Enqueue from program memory and return only when commands are actually enqueued
      */

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -122,17 +122,16 @@ static void lcd_factory_settings() {
   void menu_IDEX() {
     START_MENU();
     MENU_BACK(MSG_MAIN);
-
-    MENU_ITEM(gcode, MSG_IDEX_MODE_AUTOPARK,  PSTR("M605 S1\nG28 X\nG1 X100"));
+    char menu_buffer[65];
+    sprintf_P(menu_buffer, PSTR("M605 S1\nG28 X\nG1 X%i"), int((X_BED_SIZE) / 2));
+    MENU_ITEM(gcode, MSG_IDEX_MODE_AUTOPARK, menu_buffer);
     const bool need_g28 = !(TEST(axis_known_position, Y_AXIS) && TEST(axis_known_position, Z_AXIS));
-    MENU_ITEM(gcode, MSG_IDEX_MODE_DUPLICATE, need_g28
-      ? PSTR("M605 S1\nT0\nG28\nM605 S2 X200\nG28 X\nG1 X100")                // If Y or Z is not homed, do a full G28 first
-      : PSTR("M605 S1\nT0\nM605 S2 X200\nG28 X\nG1 X100")
-    );
-    //MENU_ITEM(gcode, MSG_IDEX_MODE_SCALED_COPY, need_g28
-    //  ? PSTR("M605 S1\nT0\nG28\nM605 S2 X200\nG28 X\nG1 X100\nM605 S3 X200")  // If Y or Z is not homed, do a full G28 first
-    //  : PSTR("M605 S1\nT0\nM605 S2 X200\nG28 X\nG1 X100\nM605 S3 X200")
-    //);
+    const char * const g28 = need_g28 ? "G28\n" : "";
+    sprintf_P(menu_buffer, PSTR("M605 S1\nT0\n%sM605 S2 X%i\nG28 X\nG1 X%i"), g28, DEFAULT_DUPLICATION_X_OFFSET, int((X_BED_SIZE) / 3));
+    MENU_ITEM(gcode, MSG_IDEX_MODE_DUPLICATE, menu_buffer);
+    //sprintf_P(menu_buffer, PSTR("M605 S1\nT0\n%sM605 S2 X%i\nG28 X\nG1 X%i\nM605 S3 X%i"), g28, DEFAULT_DUPLICATION_X_OFFSET, int((X_BED_SIZE) / 3), DEFAULT_DUPLICATION_X_OFFSET);
+    //MENU_ITEM(gcode, MSG_IDEX_MODE_SCALED_COPY, menu_buffer);
+
     MENU_ITEM(gcode, MSG_IDEX_MODE_FULL_CTRL, PSTR("M605 S0\nG28 X"));
     MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float52, MSG_IDEX_X_OFFSET , &hotend_offset[X_AXIS][1], MIN(X2_HOME_POS, X2_MAX_POS) - 25.0, MAX(X2_HOME_POS, X2_MAX_POS) + 25.0, _recalc_IDEX_settings);
     MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float52, MSG_IDEX_Y_OFFSET , &hotend_offset[Y_AXIS][1], -10.0, 10.0, _recalc_IDEX_settings);


### PR DESCRIPTION
Removes some duplicated steps in idex homing if duplicate mode is enabled first.

Duplicate mode restoration seems incomplete still, so next I will look into code to reinitialize this state after homing instead of just sitting at z safe home position as it does now.