### PR TITLE
Add fast binary file transfer to SD card option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/default/Configuration_adv.h
+++ b/Marlin/src/config/default/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/ArmEd/Configuration_adv.h
+++ b/Marlin/src/config/examples/ArmEd/Configuration_adv.h
@@ -717,6 +717,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -732,6 +732,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Cartesio/Configuration_adv.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Felix/Configuration_adv.h
+++ b/Marlin/src/config/examples/Felix/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -728,6 +728,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -729,6 +729,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/MakerParts/Configuration_adv.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration_adv.h
@@ -725,6 +725,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/RigidBot/Configuration_adv.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/SCARA/Configuration_adv.h
+++ b/Marlin/src/config/examples/SCARA/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/TheBorg/Configuration_adv.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration_adv.h
@@ -737,6 +737,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/generic/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -726,6 +726,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/makibox/Configuration_adv.h
+++ b/Marlin/src/config/examples/makibox/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -724,6 +724,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/config/examples/wt150/Configuration_adv.h
+++ b/Marlin/src/config/examples/wt150/Configuration_adv.h
@@ -725,6 +725,9 @@
     #define SD_FIRMWARE_UPDATE_INACTIVE_VALUE 0xFF
   #endif
 
+  // Add an optimized binary file transfer mode, initiated with 'M28 B1'
+  //#define FAST_FILE_TRANSFER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/feature/emergency_parser.cpp
+++ b/Marlin/src/feature/emergency_parser.cpp
@@ -32,6 +32,7 @@
 
 // Static data members
 bool EmergencyParser::killed_by_M112; // = false
+bool EmergencyParser::enabled;
 
 // Global instance
 EmergencyParser emergency_parser;

--- a/Marlin/src/feature/emergency_parser.cpp
+++ b/Marlin/src/feature/emergency_parser.cpp
@@ -31,8 +31,8 @@
 #include "emergency_parser.h"
 
 // Static data members
-bool EmergencyParser::killed_by_M112; // = false
-bool EmergencyParser::enabled;
+bool EmergencyParser::killed_by_M112, // = false
+     EmergencyParser::enabled;
 
 // Global instance
 EmergencyParser emergency_parser;

--- a/Marlin/src/feature/emergency_parser.h
+++ b/Marlin/src/feature/emergency_parser.h
@@ -53,11 +53,12 @@ public:
 
   static bool killed_by_M112;
 
-  EmergencyParser() {}
+  EmergencyParser() { enabled = true; }
+  void enable() { enabled = true; }
+  void disable() { enabled = false; }
 
   __attribute__((always_inline)) inline
   static void update(State &state, const uint8_t c) {
-
     switch (state) {
       case EP_RESET:
         switch (c) {
@@ -118,7 +119,7 @@ public:
 
       default:
         if (c == '\n') {
-          switch (state) {
+          if (enabled) switch (state) {
             case EP_M108:
               wait_for_user = wait_for_heatup = false;
               break;
@@ -136,6 +137,8 @@ public:
     }
   }
 
+private:
+  static bool enabled;
 };
 
 extern EmergencyParser emergency_parser;

--- a/Marlin/src/feature/emergency_parser.h
+++ b/Marlin/src/feature/emergency_parser.h
@@ -19,13 +19,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 /**
  * emergency_parser.h - Intercept special commands directly in the serial stream
  */
 
-#ifndef _EMERGENCY_PARSER_H_
-#define _EMERGENCY_PARSER_H_
+#define FORCE_INLINE __attribute__((always_inline)) inline
 
 // External references
 extern volatile bool wait_for_user, wait_for_heatup;
@@ -53,12 +53,13 @@ public:
 
   static bool killed_by_M112;
 
-  EmergencyParser() { enabled = true; }
-  void enable() { enabled = true; }
-  void disable() { enabled = false; }
+  EmergencyParser() { enable(); }
 
-  __attribute__((always_inline)) inline
-  static void update(State &state, const uint8_t c) {
+  FORCE_INLINE static void enable()  { enabled = true; }
+
+  FORCE_INLINE static void disable() { enabled = false; }
+
+  FORCE_INLINE static void update(State &state, const uint8_t c) {
     switch (state) {
       case EP_RESET:
         switch (c) {
@@ -142,5 +143,3 @@ private:
 };
 
 extern EmergencyParser emergency_parser;
-
-#endif // _EMERGENCY_PARSER_H_

--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -56,7 +56,7 @@ public:
   #if ENABLED(FWRETRACT_AUTORETRACT)
     static bool autoretract_enabled;               // M209 S - Autoretract switch
   #else
-    constexpr static bool autoretract_enabled = false;
+    static constexpr bool autoretract_enabled = false;
   #endif
 
   static bool retracted[EXTRUDERS];                // Which extruders are currently retracted

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -209,7 +209,7 @@ void GCodeParser::parse(char *p) {
   #endif
 
   // Only use string_arg for these M codes
-  if (letter == 'M') switch (codenum) { case 23: case 30: case 117: case 118: case 928: string_arg = p; return; default: break; }
+  if (letter == 'M') switch (codenum) { case 23: case 28: case 30: case 117: case 118: case 928: string_arg = p; return; default: break; }
 
   #if ENABLED(DEBUG_GCODE_PARSER)
     const bool debug = codenum == 800;

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -209,7 +209,7 @@ void GCodeParser::parse(char *p) {
   #endif
 
   // Only use string_arg for these M codes
-  if (letter == 'M') switch (codenum) { case 23: case 28: case 30: case 117: case 118: case 928: string_arg = p; return; default: break; }
+  if (letter == 'M') switch (codenum) { case 23: case 30: case 117: case 118: case 928: string_arg = p; return; default: break; }
 
   #if ENABLED(DEBUG_GCODE_PARSER)
     const bool debug = codenum == 800;

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -268,14 +268,15 @@ void gcode_line_error(PGM_P err, uint8_t port) {
 }
 
 static bool serial_data_available() {
-  return (MYSERIAL0.available() ? true :
+  return false
+    || MYSERIAL0.available()
     #if NUM_SERIAL > 1
-      MYSERIAL1.available() ? true :
+      || MYSERIAL1.available()
     #endif
-    false);
+  ;
 }
 
-static bool serial_data_available(const int index) {
+static bool serial_data_available(const uint8_t index) {
   switch (index) {
     case 0: return MYSERIAL0.available();
     #if NUM_SERIAL > 1
@@ -285,7 +286,7 @@ static bool serial_data_available(const int index) {
   }
 }
 
-static int read_serial(const int index) {
+static int read_serial(const uint8_t index) {
   switch (index) {
     case 0: return MYSERIAL0.read();
     #if NUM_SERIAL > 1

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -42,12 +42,12 @@
 #endif
 
 #if ENABLED(SDSUPPORT)
-  #define CARD_CHAR_P(C) SERIAL_CHAR_P(card.transfer_port, C)
-  #define CARD_ECHO_P(V) SERIAL_ECHO_P(card.transfer_port, V)
+  #define CARD_CHAR_P(C)   SERIAL_CHAR_P(card.transfer_port, C)
+  #define CARD_ECHO_P(V)   SERIAL_ECHO_P(card.transfer_port, V)
   #define CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
 #else
-  #define CARD_CHAR_P(C) NOOP
-  #define CARD_ECHO_P(V) NOOP
+  #define CARD_CHAR_P(C)   NOOP
+  #define CARD_ECHO_P(V)   NOOP
   #define CARD_ECHOLN_P(V) NOOP
 #endif
 
@@ -545,7 +545,6 @@ public:
  * Exit when the buffer is full or when no more characters are
  * left on the serial port.
  */
-
 inline void get_serial_commands() {
   static char serial_line_buffer[NUM_SERIAL][MAX_CMD_SIZE];
   static bool serial_comment_mode[NUM_SERIAL] = { false }
@@ -556,8 +555,11 @@ inline void get_serial_commands() {
 
   #if ENABLED(SDSUPPORT)
     if (card.saving && card.transfer_mode == 1) {
-      // if transfering a file in binary stream mode receive it using serial_line_buffer for the working buffer, this limits the packet size to MAX_CMD_SIZE
-      // the serial receive buffer also limits the packet size for reliable transmission
+      /**
+       * For binary stream file transfer, use serial_line_buffer as the working
+       * receive buffer (which limits the packet size to MAX_CMD_SIZE).
+       * The receive buffer also limits the packet size for reliable transmission.
+       */
       binaryStream.receive(serial_line_buffer[card.transfer_port]);
       return;
     }

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -398,8 +398,8 @@ public:
             CARD_ECHO_P(stream_header.filesize);
             CARD_ECHOLN_P("Bytes expected)");
             CARD_ECHO_P("so"); // confirm active stream and the maximum block size supported
-            CARD_CHAR_P(static_cast<uint8_t>(buffer_size & 0xff));
-            CARD_CHAR_P(static_cast<uint8_t>(buffer_size >> 8 & 0xff));
+            CARD_CHAR_P(static_cast<uint8_t>(buffer_size & 0xFF));
+            CARD_CHAR_P(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
             CARD_CHAR_P('\n');
           }
           else {

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -42,13 +42,13 @@
 #endif
 
 #if ENABLED(SDSUPPORT)
-  CARD_CHAR_P(C) SERIAL_CHAR_P(card.transfer_port, C)
-  CARD_ECHO_P(V) SERIAL_ECHO_P(card.transfer_port, V)
-  CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
+  #define CARD_CHAR_P(C) SERIAL_CHAR_P(card.transfer_port, C)
+  #define CARD_ECHO_P(V) SERIAL_ECHO_P(card.transfer_port, V)
+  #define CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
 #else
-  CARD_CHAR_P(C) NOOP
-  CARD_ECHO_P(V) NOOP
-  CARD_ECHOLN_P(V) NOOP
+  #define CARD_CHAR_P(C) NOOP
+  #define CARD_ECHO_P(V) NOOP
+  #define CARD_ECHOLN_P(V) NOOP
 #endif
 
 /**
@@ -398,8 +398,8 @@ public:
             CARD_ECHO_P(stream_header.filesize);
             CARD_ECHOLN_P("Bytes expected)");
             CARD_ECHO_P("so"); // confirm active stream and the maximum block size supported
-            CARD_CHAR_P(buffer_size & 0xff);
-            CARD_CHAR_P(buffer_size >> 8 & 0xff);
+            CARD_CHAR_P(static_cast<uint8_t>(buffer_size & 0xff));
+            CARD_CHAR_P(static_cast<uint8_t>(buffer_size >> 8 & 0xff));
             CARD_CHAR_P('\n');
           }
           else {

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -41,16 +41,6 @@
   #include "../feature/power_loss_recovery.h"
 #endif
 
-#if ENABLED(SDSUPPORT)
-  #define CARD_CHAR_P(C)   SERIAL_CHAR_P(card.transfer_port, C)
-  #define CARD_ECHO_P(V)   SERIAL_ECHO_P(card.transfer_port, V)
-  #define CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
-#else
-  #define CARD_CHAR_P(C)   NOOP
-  #define CARD_ECHO_P(V)   NOOP
-  #define CARD_ECHOLN_P(V) NOOP
-#endif
-
 /**
  * GCode line number handling. Hosts may opt to include line numbers when
  * sending commands to Marlin, and lines will be checked for sequentiality.
@@ -276,16 +266,6 @@ static bool serial_data_available() {
   ;
 }
 
-static bool serial_data_available(const uint8_t index) {
-  switch (index) {
-    case 0: return MYSERIAL0.available();
-    #if NUM_SERIAL > 1
-      case 1: return MYSERIAL1.available();
-    #endif
-    default: return false;
-  }
-}
-
 static int read_serial(const uint8_t index) {
   switch (index) {
     case 0: return MYSERIAL0.read();
@@ -296,219 +276,232 @@ static int read_serial(const uint8_t index) {
   }
 }
 
-class BinaryStream {
-public:
-  enum class StreamState : uint8_t {
-    STREAM_RESET,
-    PACKET_RESET,
-    STREAM_HEADER,
-    PACKET_HEADER,
-    PACKET_DATA,
-    PACKET_VALIDATE,
-    PACKET_RESEND,
-    PACKET_FLUSHRX,
-    PACKET_TIMEOUT,
-    STREAM_COMPLETE,
-    STREAM_FAILED,
-  };
+#if ENABLED(FAST_FILE_TRANSFER)
 
-#pragma pack(push, 1)
-  struct StreamHeader {
-    uint16_t token;
-    uint32_t filesize;
-  };
-  union {
-    uint8_t stream_header_bytes[sizeof(StreamHeader)];
-    StreamHeader stream_header;
-  };
+  #if ENABLED(SDSUPPORT)
+    #define CARD_CHAR_P(C)   SERIAL_CHAR_P(card.transfer_port, C)
+    #define CARD_ECHO_P(V)   SERIAL_ECHO_P(card.transfer_port, V)
+    #define CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
+  #endif
 
-  struct Packet {
-    struct Header {
-      uint32_t id;
-      uint16_t size, checksum;
-    };
-    union {
-      uint8_t header_bytes[sizeof(Header)];
-      Header header;
-    };
-    uint32_t bytes_received;
-    uint16_t checksum;
-    millis_t timeout;
-  } packet{};
-#pragma pack(pop)
-
-  void packet_reset() {
-    packet.header.id = 0;
-    packet.header.size = 0;
-    packet.header.checksum = 0;
-    packet.bytes_received = 0;
-    packet.checksum = 0x53A2;
-    packet.timeout = millis() + STREAM_MAX_WAIT;
-  }
-
-  void stream_reset() {
-    packets_received = 0;
-    bytes_received = 0;
-    packet_retries = 0;
-    buffer_next_index = 0;
-    stream_header.token = 0;
-    stream_header.filesize = 0;
-  }
-
-  uint32_t checksum(uint32_t seed, uint8_t value) {
-    return ((seed ^ value) ^ (seed << 8)) & 0xFFFF;
-  }
-
-  // read the next byte from the data stream keeping track of
-  // whether the stream times out from data starvation
-  // takes the data variable by reference in order to return status
-  bool stream_read(uint8_t& data) {
-    if (ELAPSED(millis(), packet.timeout)) {
-      stream_state = StreamState::PACKET_TIMEOUT;
-      return false;
+  static bool serial_data_available(const uint8_t index) {
+    switch (index) {
+      case 0: return MYSERIAL0.available();
+      #if NUM_SERIAL > 1
+        case 1: return MYSERIAL1.available();
+      #endif
+      default: return false;
     }
-    #if ENABLED(SDSUPPORT)
+  }
+
+  class BinaryStream {
+  public:
+    enum class StreamState : uint8_t {
+      STREAM_RESET,
+      PACKET_RESET,
+      STREAM_HEADER,
+      PACKET_HEADER,
+      PACKET_DATA,
+      PACKET_VALIDATE,
+      PACKET_RESEND,
+      PACKET_FLUSHRX,
+      PACKET_TIMEOUT,
+      STREAM_COMPLETE,
+      STREAM_FAILED,
+    };
+
+    #pragma pack(push, 1)
+
+      struct StreamHeader {
+        uint16_t token;
+        uint32_t filesize;
+      };
+      union {
+        uint8_t stream_header_bytes[sizeof(StreamHeader)];
+        StreamHeader stream_header;
+      };
+
+      struct Packet {
+        struct Header {
+          uint32_t id;
+          uint16_t size, checksum;
+        };
+        union {
+          uint8_t header_bytes[sizeof(Header)];
+          Header header;
+        };
+        uint32_t bytes_received;
+        uint16_t checksum;
+        millis_t timeout;
+      } packet{};
+
+    #pragma pack(pop)
+
+    void packet_reset() {
+      packet.header.id = 0;
+      packet.header.size = 0;
+      packet.header.checksum = 0;
+      packet.bytes_received = 0;
+      packet.checksum = 0x53A2;
+      packet.timeout = millis() + STREAM_MAX_WAIT;
+    }
+
+    void stream_reset() {
+      packets_received = 0;
+      bytes_received = 0;
+      packet_retries = 0;
+      buffer_next_index = 0;
+      stream_header.token = 0;
+      stream_header.filesize = 0;
+    }
+
+    uint32_t checksum(uint32_t seed, uint8_t value) {
+      return ((seed ^ value) ^ (seed << 8)) & 0xFFFF;
+    }
+
+    // read the next byte from the data stream keeping track of
+    // whether the stream times out from data starvation
+    // takes the data variable by reference in order to return status
+    bool stream_read(uint8_t& data) {
+      if (ELAPSED(millis(), packet.timeout)) {
+        stream_state = StreamState::PACKET_TIMEOUT;
+        return false;
+      }
       if (!serial_data_available(card.transfer_port)) return false;
       data = read_serial(card.transfer_port);
-    #endif
-    packet.timeout = millis() + STREAM_MAX_WAIT;
-    return true;
-  }
+      packet.timeout = millis() + STREAM_MAX_WAIT;
+      return true;
+    }
 
-  template<const size_t buffer_size>
-  void receive(char (&buffer)[buffer_size]) {
-    uint8_t data = 0;
-    millis_t tranfer_timeout = millis() + RX_TIMESLICE;
-    while (PENDING(millis(), tranfer_timeout)) {
-      switch (stream_state) {
-        case StreamState::STREAM_RESET:
-          stream_reset();
-        case StreamState::PACKET_RESET:
-          packet_reset();
-          stream_state = StreamState::PACKET_HEADER;
-          break;
-        case StreamState::STREAM_HEADER: // we could also transfer the filename in this packet, rather than handling it in the gcode
-          for (size_t i = 0; i < sizeof(stream_header); ++i) {
-            stream_header_bytes[i] = buffer[i];
-          }
-          if (stream_header.token == 0x1234) {
-            stream_state = StreamState::PACKET_RESET;
-            bytes_received = 0;
-            time_stream_start = millis();
-            CARD_ECHO_P("echo: Datastream initialised (");
-            CARD_ECHO_P(stream_header.filesize);
-            CARD_ECHOLN_P("Bytes expected)");
-            CARD_ECHO_P("so"); // confirm active stream and the maximum block size supported
-            CARD_CHAR_P(static_cast<uint8_t>(buffer_size & 0xFF));
-            CARD_CHAR_P(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
-            CARD_CHAR_P('\n');
-          }
-          else {
-            CARD_ECHOLN_P("echo: Datastream initialisation error (invalid token)");
-            stream_state = StreamState::STREAM_FAILED;
-          }
-          buffer_next_index = 0;
-          break;
-        case StreamState::PACKET_HEADER:
-          if (!stream_read(data)) break;
-
-          packet.header_bytes[packet.bytes_received++] = data;
-          if (packet.bytes_received == sizeof(Packet::Header)) {
-            if (packet.header.id == packets_received) {
-              buffer_next_index = 0;
-              packet.bytes_received = 0;
-              stream_state = StreamState::PACKET_DATA;
-            }
-            else {
-              CARD_ECHO_P("echo: Datastream packet out of order");
-              stream_state = StreamState::PACKET_FLUSHRX;
-            }
-          }
-          break;
-        case StreamState::PACKET_DATA:
-          if (!stream_read(data)) break;
-
-          if (buffer_next_index < buffer_size) {
-            buffer[buffer_next_index] = data;
-          }
-          else {
-            CARD_ECHO_P("echo: Datastream packet data buffer overrun");
-            stream_state = StreamState::STREAM_FAILED;
+    template<const size_t buffer_size>
+    void receive(char (&buffer)[buffer_size]) {
+      uint8_t data = 0;
+      millis_t tranfer_timeout = millis() + RX_TIMESLICE;
+      while (PENDING(millis(), tranfer_timeout)) {
+        switch (stream_state) {
+          case StreamState::STREAM_RESET:
+            stream_reset();
+          case StreamState::PACKET_RESET:
+            packet_reset();
+            stream_state = StreamState::PACKET_HEADER;
             break;
-          }
-
-          packet.checksum = checksum(packet.checksum, data);
-          packet.bytes_received ++;
-          buffer_next_index ++;
-
-          if (packet.bytes_received == packet.header.size) {
-            stream_state = StreamState::PACKET_VALIDATE;
-          }
-          break;
-        case StreamState::PACKET_VALIDATE:
-          if (packet.header.checksum == packet.checksum) {
-            packet_retries = 0;
-            packets_received ++;
-            bytes_received += packet.header.size;
-
-            if (packet.header.id == 0) {                 // id 0 is always the stream descriptor
-              stream_state = StreamState::STREAM_HEADER; // defer packet confirmation to STREAM_HEADER state
+          case StreamState::STREAM_HEADER: // we could also transfer the filename in this packet, rather than handling it in the gcode
+            for (size_t i = 0; i < sizeof(stream_header); ++i) {
+              stream_header_bytes[i] = buffer[i];
+            }
+            if (stream_header.token == 0x1234) {
+              stream_state = StreamState::PACKET_RESET;
+              bytes_received = 0;
+              time_stream_start = millis();
+              CARD_ECHO_P("echo: Datastream initialized (");
+              CARD_ECHO_P(stream_header.filesize);
+              CARD_ECHOLN_P("Bytes expected)");
+              CARD_ECHO_P("so"); // confirm active stream and the maximum block size supported
+              CARD_CHAR_P(static_cast<uint8_t>(buffer_size & 0xFF));
+              CARD_CHAR_P(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
+              CARD_CHAR_P('\n');
             }
             else {
-              if (bytes_received < stream_header.filesize) {
-                stream_state = StreamState::PACKET_RESET;    // reset and receive next packet
-                CARD_ECHOLN_P("ok");   // transmit confirm packet received and valid token
+              CARD_ECHOLN_P("echo: Datastream initialization error (invalid token)");
+              stream_state = StreamState::STREAM_FAILED;
+            }
+            buffer_next_index = 0;
+            break;
+          case StreamState::PACKET_HEADER:
+            if (!stream_read(data)) break;
+
+            packet.header_bytes[packet.bytes_received++] = data;
+            if (packet.bytes_received == sizeof(Packet::Header)) {
+              if (packet.header.id == packets_received) {
+                buffer_next_index = 0;
+                packet.bytes_received = 0;
+                stream_state = StreamState::PACKET_DATA;
               }
-              else  {
-                stream_state = StreamState::STREAM_COMPLETE; // no more data required
+              else {
+                CARD_ECHO_P("echo: Datastream packet out of order");
+                stream_state = StreamState::PACKET_FLUSHRX;
               }
-              #if ENABLED(SDSUPPORT)
+            }
+            break;
+          case StreamState::PACKET_DATA:
+            if (!stream_read(data)) break;
+
+            if (buffer_next_index < buffer_size) {
+              buffer[buffer_next_index] = data;
+            }
+            else {
+              CARD_ECHO_P("echo: Datastream packet data buffer overrun");
+              stream_state = StreamState::STREAM_FAILED;
+              break;
+            }
+
+            packet.checksum = checksum(packet.checksum, data);
+            packet.bytes_received ++;
+            buffer_next_index ++;
+
+            if (packet.bytes_received == packet.header.size) {
+              stream_state = StreamState::PACKET_VALIDATE;
+            }
+            break;
+          case StreamState::PACKET_VALIDATE:
+            if (packet.header.checksum == packet.checksum) {
+              packet_retries = 0;
+              packets_received ++;
+              bytes_received += packet.header.size;
+
+              if (packet.header.id == 0) {                 // id 0 is always the stream descriptor
+                stream_state = StreamState::STREAM_HEADER; // defer packet confirmation to STREAM_HEADER state
+              }
+              else {
+                if (bytes_received < stream_header.filesize) {
+                  stream_state = StreamState::PACKET_RESET;    // reset and receive next packet
+                  CARD_ECHOLN_P("ok");   // transmit confirm packet received and valid token
+                }
+                else  {
+                  stream_state = StreamState::STREAM_COMPLETE; // no more data required
+                }
                 if (card.write(buffer, buffer_next_index) < 0) {
                   stream_state = StreamState::STREAM_FAILED;
                   CARD_ECHO_P("echo: IO ERROR");
                   break;
                 };
-              #endif
+              }
             }
-          }
-          else {
-            CARD_ECHO_P("echo: Block(");
-            CARD_ECHO_P(packet.header.id);
-            CARD_ECHOLN_P(") Corrupt");
-            stream_state = StreamState::PACKET_FLUSHRX;
-          }
-          break;
-        case StreamState::PACKET_RESEND:
-          if (packet_retries < MAX_RETRIES) {
-            packet_retries ++;
-            stream_state = StreamState::PACKET_RESET;
-            CARD_ECHO_P("echo: Resend request ");
-            CARD_ECHOLN_P(packet_retries);
-            CARD_ECHOLN_P("rs"); // transmit resend packet token
-          }
-          else {
-            stream_state = StreamState::STREAM_FAILED;
-          }
-          break;
-        case StreamState::PACKET_FLUSHRX:
-          if (ELAPSED(millis(), packet.timeout)) {
-            stream_state = StreamState::PACKET_RESEND;
+            else {
+              CARD_ECHO_P("echo: Block(");
+              CARD_ECHO_P(packet.header.id);
+              CARD_ECHOLN_P(") Corrupt");
+              stream_state = StreamState::PACKET_FLUSHRX;
+            }
             break;
-          }
-          #if ENABLED(SDSUPPORT)
+          case StreamState::PACKET_RESEND:
+            if (packet_retries < MAX_RETRIES) {
+              packet_retries ++;
+              stream_state = StreamState::PACKET_RESET;
+              CARD_ECHO_P("echo: Resend request ");
+              CARD_ECHOLN_P(packet_retries);
+              CARD_ECHOLN_P("rs"); // transmit resend packet token
+            }
+            else {
+              stream_state = StreamState::STREAM_FAILED;
+            }
+            break;
+          case StreamState::PACKET_FLUSHRX:
+            if (ELAPSED(millis(), packet.timeout)) {
+              stream_state = StreamState::PACKET_RESEND;
+              break;
+            }
             if (!serial_data_available(card.transfer_port)) break;
             read_serial(card.transfer_port); // throw away data
-          #endif
-          packet.timeout = millis() + STREAM_MAX_WAIT;
-          break;
-        case StreamState::PACKET_TIMEOUT:
-          CARD_ECHOLN_P("echo: Datastream timeout");
-          stream_state = StreamState::PACKET_RESEND;
-          break;
-        case StreamState::STREAM_COMPLETE:
-          stream_state = StreamState::STREAM_RESET;
-          #if ENABLED(SDSUPPORT)
-            card.transfer_mode = 0;
+            packet.timeout = millis() + STREAM_MAX_WAIT;
+            break;
+          case StreamState::PACKET_TIMEOUT:
+            CARD_ECHOLN_P("echo: Datastream timeout");
+            stream_state = StreamState::PACKET_RESEND;
+            break;
+          case StreamState::STREAM_COMPLETE:
+            stream_state = StreamState::STREAM_RESET;
+            card.binary_mode = false;
             card.closefile();
             CARD_ECHO_P("echo: ");
             CARD_ECHO_P(card.filename);
@@ -516,30 +509,29 @@ public:
             CARD_ECHO_P(((bytes_received / (millis() - time_stream_start) * 1000) / 1024 ));
             CARD_ECHOLN_P("KiB/s");
             CARD_ECHOLN_P("sc"); // transmit stream complete token
-          #endif
-          return;
-        case StreamState::STREAM_FAILED:
-          stream_state = StreamState::STREAM_RESET;
-          #if ENABLED(SDSUPPORT)
-            card.transfer_mode = 0;
+            return;
+          case StreamState::STREAM_FAILED:
+            stream_state = StreamState::STREAM_RESET;
+            card.binary_mode = false;
             card.closefile();
             card.removeFile(card.filename);
             CARD_ECHOLN_P("echo: File transfer failed");
             CARD_ECHOLN_P("sf"); // transmit stream failed token
-          #endif
-          return;
+            return;
+        }
       }
     }
-  }
 
-  static const uint16_t STREAM_MAX_WAIT = 500, RX_TIMESLICE = 20, MAX_RETRIES = 3;
-  uint8_t  packet_retries;
-  uint16_t buffer_next_index;
-  uint32_t packets_received,  bytes_received;
-  millis_t time_stream_start;
-  StreamState stream_state = StreamState::STREAM_RESET;
+    static const uint16_t STREAM_MAX_WAIT = 500, RX_TIMESLICE = 20, MAX_RETRIES = 3;
+    uint8_t  packet_retries;
+    uint16_t buffer_next_index;
+    uint32_t packets_received,  bytes_received;
+    millis_t time_stream_start;
+    StreamState stream_state = StreamState::STREAM_RESET;
 
-} binaryStream{};
+  } binaryStream{};
+
+#endif // FAST_FILE_TRANSFER
 
 /**
  * Get all commands waiting on the serial port and queue them.
@@ -554,8 +546,8 @@ inline void get_serial_commands() {
               #endif
             ;
 
-  #if ENABLED(SDSUPPORT)
-    if (card.saving && card.transfer_mode == 1) {
+  #if ENABLED(FAST_FILE_TRANSFER)
+    if (card.saving && card.binary_mode) {
       /**
        * For binary stream file transfer, use serial_line_buffer as the working
        * receive buffer (which limits the packet size to MAX_CMD_SIZE).

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -158,23 +158,24 @@ void GcodeSuite::M27() {
  * M28: Start SD Write
  */
 void GcodeSuite::M28() {
-  const int16_t port
-  #if NUM_SERIAL > 1
-    = command_queue_port[cmd_queue_index_r];
-  #else
-    = 0;
-  #endif
+  const int16_t port =
+    #if NUM_SERIAL > 1
+      command_queue_port[cmd_queue_index_r]
+    #else
+      0
+    #endif
+  ;
 
   //binary transfer mode
-  if (parser.seenval('B')){
+  if (parser.seenval('B')) {
     SERIAL_ECHO_P(port, "echo: prepairing to receive: ");
     SERIAL_ECHOLN_P(port,parser.string_arg);
     card.openFile(parser.string_arg, false);
     card.transfer_mode = 1;
     card.transfer_port = port;
-  } else {
-    card.openFile(parser.string_arg, false);
   }
+  else
+    card.openFile(parser.string_arg, false);
 }
 
 /**

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -167,7 +167,7 @@ void GcodeSuite::M28() {
   ;
 
   // Binary transfer mode
-  if (parser.seenval('B')) {
+  if (parser.byteval('B')) {
     SERIAL_ECHO_START_P(port);
     SERIAL_ECHO_P(port, " preparing to receive: ");
     SERIAL_ECHOLN_P(port, parser.string_arg);

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -166,10 +166,11 @@ void GcodeSuite::M28() {
     #endif
   ;
 
-  //binary transfer mode
+  // Binary transfer mode
   if (parser.seenval('B')) {
-    SERIAL_ECHO_P(port, "echo: prepairing to receive: ");
-    SERIAL_ECHOLN_P(port,parser.string_arg);
+    SERIAL_ECHO_START_P(port);
+    SERIAL_ECHO_P(port, " preparing to receive: ");
+    SERIAL_ECHOLN_P(port, parser.string_arg);
     card.openFile(parser.string_arg, false);
     card.transfer_mode = 1;
     card.transfer_port = port;

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -181,7 +181,9 @@ void GcodeSuite::M28() {
     SERIAL_ECHOLN_P(port, p);
     card.openFile(p, false);
     card.transfer_mode = 1;
-    card.transfer_port = port;
+    #if NUM_SERIAL > 1
+      card.transfer_port = port;
+    #endif
   }
   else
     card.openFile(p, false);

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -166,17 +166,25 @@ void GcodeSuite::M28() {
     #endif
   ;
 
+  bool binary_mode = false;
+  char *p = parser.string_arg;
+  if (p[0] == 'B' && p[1] == '0') {
+    binary_mode = true;
+    p += 2;
+    while (*p == ' ') ++p;
+  }
+
   // Binary transfer mode
-  if (parser.byteval('B')) {
+  if (binary_mode) {
     SERIAL_ECHO_START_P(port);
     SERIAL_ECHO_P(port, " preparing to receive: ");
-    SERIAL_ECHOLN_P(port, parser.string_arg);
-    card.openFile(parser.string_arg, false);
+    SERIAL_ECHOLN_P(port, p);
+    card.openFile(p, false);
     card.transfer_mode = 1;
     card.transfer_port = port;
   }
   else
-    card.openFile(parser.string_arg, false);
+    card.openFile(p, false);
 }
 
 /**

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -158,35 +158,43 @@ void GcodeSuite::M27() {
  * M28: Start SD Write
  */
 void GcodeSuite::M28() {
-  const int16_t port =
-    #if NUM_SERIAL > 1
-      command_queue_port[cmd_queue_index_r]
-    #else
-      0
-    #endif
-  ;
 
-  bool binary_mode = false;
-  char *p = parser.string_arg;
-  if (p[0] == 'B' && p[1] == '0') {
-    binary_mode = true;
-    p += 2;
-    while (*p == ' ') ++p;
-  }
+  #if ENABLED(FAST_FILE_TRANSFER)
 
-  // Binary transfer mode
-  if (binary_mode) {
-    SERIAL_ECHO_START_P(port);
-    SERIAL_ECHO_P(port, " preparing to receive: ");
-    SERIAL_ECHOLN_P(port, p);
-    card.openFile(p, false);
-    card.transfer_mode = 1;
-    #if NUM_SERIAL > 1
-      card.transfer_port = port;
-    #endif
-  }
-  else
-    card.openFile(p, false);
+    const int16_t port =
+      #if NUM_SERIAL > 1
+        command_queue_port[cmd_queue_index_r]
+      #else
+        0
+      #endif
+    ;
+
+    bool binary_mode = false;
+    char *p = parser.string_arg;
+    if (p[0] == 'B' && NUMERIC(p[1])) {
+      binary_mode = p[1] > '0';
+      p += 2;
+      while (*p == ' ') ++p;
+    }
+
+    // Binary transfer mode
+    if ((card.binary_mode = binary_mode)) {
+      SERIAL_ECHO_START_P(port);
+      SERIAL_ECHO_P(port, " preparing to receive: ");
+      SERIAL_ECHOLN_P(port, p);
+      card.openFile(p, false);
+      #if NUM_SERIAL > 1
+        card.transfer_port = port;
+      #endif
+    }
+    else
+      card.openFile(p, false);
+
+  #else
+
+    card.openFile(parser.string_arg, false);
+
+  #endif
 }
 
 /**

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -157,7 +157,25 @@ void GcodeSuite::M27() {
 /**
  * M28: Start SD Write
  */
-void GcodeSuite::M28() { card.openFile(parser.string_arg, false); }
+void GcodeSuite::M28() {
+  const int16_t port
+  #if NUM_SERIAL > 1
+    = command_queue_port[cmd_queue_index_r];
+  #else
+    = 0;
+  #endif
+
+  //binary transfer mode
+  if (parser.seenval('B')){
+    SERIAL_ECHO_P(port, "echo: prepairing to receive: ");
+    SERIAL_ECHOLN_P(port,parser.string_arg);
+    card.openFile(parser.string_arg, false);
+    card.transfer_mode = 1;
+    card.transfer_port = port;
+  } else {
+    card.openFile(parser.string_arg, false);
+  }
+}
 
 /**
  * M29: Stop SD Write

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -33,6 +33,10 @@
 #include "../core/language.h"
 #include "../gcode/queue.h"
 
+#if ENABLED(EMERGENCY_PARSER)
+  #include "../feature/emergency_parser.h"
+#endif
+
 #if ENABLED(POWER_LOSS_RECOVERY)
   #include "../feature/power_loss_recovery.h"
 #endif
@@ -461,7 +465,11 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
     }
     else {
       saving = true;
-      SERIAL_PROTOCOLLNPAIR(MSG_SD_WRITE_TO_FILE, path);
+      getfilename(0, fname);
+      #if ENABLED(EMERGENCY_PARSER)
+        emergency_parser.disable();
+      #endif
+      SERIAL_PROTOCOLLNPAIR(MSG_SD_WRITE_TO_FILE, fname);
       lcd_setstatus(fname);
     }
   }
@@ -569,6 +577,9 @@ void CardReader::closefile(const bool store_location) {
   file.sync();
   file.close();
   saving = logging = false;
+  #if ENABLED(EMERGENCY_PARSER)
+    emergency_parser.enable();
+  #endif
 
   if (store_location) {
     //future: store printer state, filename and position for continuing a stopped print

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -148,12 +148,15 @@ public:
 public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
-  int8_t autostart_index, transfer_mode;
+  int8_t autostart_index;
 
-  #if NUM_SERIAL > 1
-    uint8_t transfer_port;
-  #else
-    static constexpr uint8_t transfer_port = 0;
+  #if ENABLED(FAST_FILE_TRANSFER)
+    bool binary_mode;
+    #if NUM_SERIAL > 1
+      uint8_t transfer_port;
+    #else
+      constexpr uint8_t transfer_port = 0;
+    #endif
   #endif
 
 private:

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -148,7 +148,14 @@ public:
 public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
-  int8_t autostart_index, transfer_mode, transfer_port;
+  int8_t autostart_index, transfer_mode;
+
+  #if NUM_SERIAL > 1
+    uint8_t transfer_port;
+  #else
+    static constexpr uint8_t transfer_port = 0;
+  #endif
+
 private:
   SdFile root, workDir, workDirParents[MAX_DIR_DEPTH];
   uint8_t workDirDepth;

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -122,11 +122,8 @@ public:
   FORCE_INLINE uint32_t getIndex() { return sdpos; }
   FORCE_INLINE uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
   FORCE_INLINE char* getWorkDirName() { workDir.getFilename(filename); return filename; }
-
-  #if defined(__STM32F1__) && ENABLED(EEPROM_SETTINGS) && DISABLED(FLASH_EEPROM_EMULATION)
-    FORCE_INLINE int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
-    FORCE_INLINE int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
-  #endif
+  FORCE_INLINE int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
+  FORCE_INLINE int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
 
   Sd2Card& getSd2Card() { return sd2card; }
 
@@ -151,7 +148,7 @@ public:
 public:
   bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
   char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
-  int8_t autostart_index;
+  int8_t autostart_index, transfer_mode, transfer_port;
 private:
   SdFile root, workDir, workDirParents[MAX_DIR_DEPTH];
   uint8_t workDirDepth;


### PR DESCRIPTION
### Description
Adds support for transferring arbitrary files over the serial connection from host software.

I implemented a simple custom protocol, any input into improvements are welcome, I have written similar things in the past but this wasn't exactly thoroughly designed (there may have been a doodle), its a very simple packet structure and keeps the host side of the communication as ASCII (2 byte command tokens) apart from a 16bit max packet size value transferred as part of the stream initialisation.

The host side of the protocol is implemented in the python example attached.
(superseded)

### Benefits
Ability to transfer binaries over the serial connection on devices that can be flashed from sd card and
due to less overhead and constant maximum packet size it improves transfer rate of gcode files.

Until this has host support it will be of very limited use, and we would need to report its availability.
