### PR TITLE
Use blink to show more infos by LCD

### DIFF
--- a/Marlin/src/lcd/HD44780/ultralcd_impl_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_impl_HD44780.cpp
@@ -848,18 +848,37 @@ FORCE_INLINE void _draw_status_message(const bool blink) {
       lcd_put_u8str(itostr3(feedrate_percentage));
       lcd_put_wchar('%');
 
-      #if LCD_WIDTH >= 20 && HAS_PRINT_PROGRESS
-        lcd_moveto(7, 2);
-        _draw_print_progress();
-      #endif
-
       char buffer[14];
       duration_t elapsed = print_job_timer.duration();
-      uint8_t len = elapsed.toDigital(buffer);
-
-      lcd_moveto(LCD_WIDTH - len - 1, 2);
+      const uint8_t len = elapsed.toDigital(buffer),
+                    timepos = LCD_WIDTH - len - 1;
+      lcd_moveto(timepos, 2);
       lcd_put_wchar(LCD_CLOCK_CHAR);
       lcd_put_u8str(buffer);
+
+      #if LCD_WIDTH >= 20
+        lcd_moveto(timepos - 7, 2);
+        #if HAS_PRINT_PROGRESS
+          _draw_print_progress();
+        #else
+          #if HAS_FAN0
+            char c;
+            int per;
+            if (blink) {
+              c = 'F';
+              per = ((int(fan_speed[0]) + 1) * 100) / 256;
+            }
+            else
+          #endif
+            {
+              c = 'E';
+              per = planner.flow_percentage[0];
+            }
+          lcd_put_wchar(c);
+          lcd_put_u8str(itostr3(per));
+          lcd_put_wchar('%');
+        #endif
+      #endif
 
     #endif // LCD_HEIGHT > 3
 

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -282,7 +282,7 @@ void lcd_impl_status_screen_0() {
     #if HAS_FAN0
       if (PAGE_CONTAINS(STATUS_SCREEN_FAN_TEXT_Y - 7, STATUS_SCREEN_FAN_TEXT_Y)) {
         // Fan
-        const uint16_t per = (((uint16_t)fan_speed[0] + 1) * 100) / 256;
+        const int per = ((int(fan_speed[0]) + 1) * 100) / 256;
         if (per) {
           lcd_moveto(STATUS_SCREEN_FAN_TEXT_X, STATUS_SCREEN_FAN_TEXT_Y);
           lcd_put_u8str(itostr3(per));


### PR DESCRIPTION
Starting from #7832 I made a new PR with bugfix-2.0.x as target...

@thinkyhead : there is no 44780 free memory to define custom chars for fan speed and extrusion rate.
So I limited to use fixed English abbreviations. Maybe adding an option to enable blink info is enough. What do you think?