### PR TITLE
[2.0.x] Fix for Teensy 3.5/3.6 ADC access for ADC1

### DIFF
--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL.cpp
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL.cpp
@@ -18,7 +18,6 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ****************************************************************************/
 
-
 /**
  * Description: HAL for Teensy35 (MK64FX512)
  */
@@ -94,23 +93,24 @@ extern "C" {
 
 void HAL_adc_start_conversion(const uint8_t adc_pin) {
   uint16_t pin = pin2sc1a[adc_pin];
-  if (pin == 255) {
+  if (pin == 0xFF) {
     // Digital only
     HAL_adc_select = -1;
-  } else if ((pin & 128) == 128) {
+  }
+  else if (pin & 0x80) {
     HAL_adc_select = 1;
-    ADC1_SC1A = pin - 128;
-  } else {
+    ADC1_SC1A = pin & 0x7F;
+  }
+  else {
     HAL_adc_select = 0;
     ADC0_SC1A = pin;
   }
 }
 
 uint16_t HAL_adc_get_result(void) {
-  if (HAL_adc_select == 0) {
-    return ADC0_RA;
-  } else if (HAL_adc_select == 1) {
-    return ADC1_RA;
+  switch (HAL_adc_select) {
+    case 0: return ADC0_RA;
+    case 1: return ADC1_RA;
   }
   return 0;
 }

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL.cpp
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL.cpp
@@ -30,7 +30,7 @@
 
 #include <Wire.h>
 
-uint16_t HAL_adc_result;
+uint16_t HAL_adc_result, HAL_adc_select;
 
 static const uint8_t pin2sc1a[] = {
   5, 14, 8, 9, 13, 12, 6, 7, 15, 4, 3, 19+128, 14+128, 15+128, // 0-13 -> A0-A13
@@ -59,6 +59,7 @@ static const uint8_t pin2sc1a[] = {
 void HAL_adc_init() {
   analog_init();
   while (ADC0_SC3 & ADC_SC3_CAL) {}; // Wait for calibration to finish
+  while (ADC1_SC3 & ADC_SC3_CAL) {}; // Wait for calibration to finish
   NVIC_ENABLE_IRQ(IRQ_FTM1);
 }
 
@@ -91,8 +92,27 @@ extern "C" {
   }
 }
 
-void HAL_adc_start_conversion(const uint8_t adc_pin) { ADC0_SC1A = pin2sc1a[adc_pin]; }
+void HAL_adc_start_conversion(const uint8_t adc_pin) {
+  uint16_t pin = pin2sc1a[adc_pin];
+  if (pin == 255) {
+    // Digital only
+    HAL_adc_select = -1;
+  } else if ((pin & 128) == 128) {
+    HAL_adc_select = 1;
+    ADC1_SC1A = pin - 128;
+  } else {
+    HAL_adc_select = 0;
+    ADC0_SC1A = pin;
+  }
+}
 
-uint16_t HAL_adc_get_result(void) { return ADC0_RA; }
+uint16_t HAL_adc_get_result(void) {
+  if (HAL_adc_select == 0) {
+    return ADC0_RA;
+  } else if (HAL_adc_select == 1) {
+    return ADC1_RA;
+  }
+  return 0;
+}
 
 #endif // __MK64FX512__ || __MK66FX1M0__


### PR DESCRIPTION
Ive changed the ADC function to check for a ADC1 pin and uses ADC1 instead of ADC0, allowing all of the analog pins to be used. Not tested on a 3.5 but should be the same as 3.6

Possibly fixes #7839