### PR TITLE
LPC_1768 End Stop Interrupt fix.

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_LPC1768/endstop_interrupts.h
@@ -38,7 +38,7 @@
 #define _ENDSTOP_INTERRUPTS_H_
 
 #include "../../module/endstops.h"
-
+#define LPC1768_PIN_INTERRUPT_M(pin) ((pin >> 0x5 & 0x7) == 0 || (pin >> 0x5 & 0x7) == 2)
 // One ISR for all EXT-Interrupts
 void endstop_ISR(void) { endstops.update(); }
 


### PR DESCRIPTION
Fixes compilation if end stop interrupts is enabled on LPC1768 boards.

Fixes: https://github.com/MarlinFirmware/Marlin/issues/12166
https://github.com/MarlinFirmware/Marlin/issues/12235

I don't think it was merged yet. If it was, let me know.