### PR TITLE
Fix LEVEL_BED_CORNERS menu not found

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -160,17 +160,6 @@
 
 bool Running = true;
 
-/**
- * axis_homed
- *   Flags that each linear axis was homed.
- *   XYZ on cartesian, ABC on delta, ABZ on SCARA.
- *
- * axis_known_position
- *   Flags that the position is known in each linear axis. Set when homed.
- *   Cleared whenever a stepper powers off, potentially losing its position.
- */
-uint8_t axis_homed, axis_known_position; // = 0
-
 #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
   TempUnit input_temp_units = TEMPUNIT_C;
 #endif

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -189,12 +189,6 @@ extern bool Running;
 inline bool IsRunning() { return  Running; }
 inline bool IsStopped() { return !Running; }
 
-extern uint8_t axis_homed, axis_known_position;
-
-constexpr uint8_t xyz_bits = _BV(X_AXIS) | _BV(Y_AXIS) | _BV(Z_AXIS);
-FORCE_INLINE bool all_axes_homed() { return (axis_homed & xyz_bits) == xyz_bits; }
-FORCE_INLINE bool all_axes_known() { return (axis_known_position & xyz_bits) == xyz_bits; }
-
 extern volatile bool wait_for_heatup;
 
 #if HAS_RESUME_CONTINUE

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -28,7 +28,6 @@
 #include "../../module/motion.h"
 #include "../../lcd/ultralcd.h"
 #include "../../libs/buzzer.h"
-#include "../../Marlin.h" // for axis_homed
 
 /**
  * M206: Set Additional Homing Offset (X Y Z). SCARA aliases T=X, P=Y

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -41,7 +41,7 @@
  *   location: <http://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#include "../../Marlin.h"
+#include "../../inc/MarlinConfigPre.h"
 
 #if ENABLED(EXTENSIBLE_UI)
 
@@ -109,7 +109,7 @@ namespace UI {
       // Machine was killed, reinit SysTick so we are able to compute time without ISRs
       if (currTimeHI == 0) {
         // Get the last time the Arduino time computed (from CMSIS) and convert it to SysTick
-        currTimeHI = (uint32_t)((GetTickCount() * (uint64_t)(F_CPU/8000)) >> 24);
+        currTimeHI = (uint32_t)((GetTickCount() * (uint64_t)(F_CPU / 8000)) >> 24);
 
         // Reinit the SysTick timer to maximize its period
         SysTick->LOAD  = SysTick_LOAD_RELOAD_Msk;                    // get the full range for the systick timer
@@ -136,7 +136,7 @@ namespace UI {
   #else
 
     // TODO: Implement for AVR
-    uint32_t safe_millis() { return millis(); }
+    FORCE_INLINE uint32_t safe_millis() { return millis(); }
 
   #endif
 
@@ -399,6 +399,7 @@ namespace UI {
   #endif
 
   #if ENABLED(JUNCTION_DEVIATION)
+
     float getJunctionDeviation_mm() {
       return planner.junction_deviation_mm;
     }
@@ -407,13 +408,15 @@ namespace UI {
       planner.junction_deviation_mm = clamp(value, 0.01, 0.3);
       planner.recalculate_max_e_jerk();
     }
+
   #else
+
     float getAxisMaxJerk_mm_s(const axis_t axis) {
-        return planner.max_jerk[axis];
+      return planner.max_jerk[axis];
     }
 
     float getAxisMaxJerk_mm_s(const extruder_t extruder) {
-        return planner.max_jerk[E_AXIS];
+      return planner.max_jerk[E_AXIS];
     }
 
     void setAxisMaxJerk_mm_s(const float value, const axis_t axis) {

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -1,0 +1,102 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+//
+// Level Bed Corners menu
+//
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if HAS_LCD_MENU && ENABLED(LEVEL_BED_CORNERS)
+
+#include "menu.h"
+#include "../../module/motion.h"
+#include "../../module/planner.h"
+
+/**
+ * Level corners, starting in the front-left corner.
+ */
+static int8_t bed_corner;
+void _lcd_goto_next_corner() {
+  line_to_z(4.0);
+  switch (bed_corner) {
+    case 0:
+      current_position[X_AXIS] = X_MIN_BED + LEVEL_CORNERS_INSET;
+      current_position[Y_AXIS] = Y_MIN_BED + LEVEL_CORNERS_INSET;
+      break;
+    case 1:
+      current_position[X_AXIS] = X_MAX_BED - LEVEL_CORNERS_INSET;
+      break;
+    case 2:
+      current_position[Y_AXIS] = Y_MAX_BED - LEVEL_CORNERS_INSET;
+      break;
+    case 3:
+      current_position[X_AXIS] = X_MIN_BED + LEVEL_CORNERS_INSET;
+      break;
+    #if ENABLED(LEVEL_CENTER_TOO)
+      case 4:
+        current_position[X_AXIS] = X_CENTER;
+        current_position[Y_AXIS] = Y_CENTER;
+        break;
+    #endif
+  }
+  planner.buffer_line(current_position, MMM_TO_MMS(manual_feedrate_mm_m[X_AXIS]), active_extruder);
+  line_to_z(0.0);
+  if (++bed_corner > 3
+    #if ENABLED(LEVEL_CENTER_TOO)
+      + 1
+    #endif
+  ) bed_corner = 0;
+}
+
+void menu_level_bed_corners() {
+  START_MENU();
+  MENU_ITEM(function,
+    #if ENABLED(LEVEL_CENTER_TOO)
+      MSG_LEVEL_BED_NEXT_POINT
+    #else
+      MSG_NEXT_CORNER
+    #endif
+    , _lcd_goto_next_corner);
+  MENU_ITEM(function, MSG_BACK, lcd_goto_previous_menu_no_defer);
+  END_MENU();
+}
+
+void _lcd_level_bed_corners_homing() {
+  _lcd_draw_homing();
+  if (all_axes_homed()) {
+    bed_corner = 0;
+    lcd_goto_screen(menu_level_bed_corners);
+    _lcd_goto_next_corner();
+  }
+}
+
+void _lcd_level_bed_corners() {
+  defer_return_to_status = true;
+  if (!all_axes_known()) {
+    set_all_unhomed();
+    enqueue_and_echo_commands_P(PSTR("G28"));
+  }
+  lcd_goto_screen(_lcd_level_bed_corners_homing);
+}
+
+#endif // HAS_LCD_MENU && LEVEL_BED_CORNERS

--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -188,7 +188,7 @@
   //
   void _lcd_level_bed_continue() {
     defer_return_to_status = true;
-    axis_homed = 0;
+    set_all_unhomed();
     lcd_goto_screen(_lcd_level_bed_homing);
     enqueue_and_echo_commands_P(PSTR("G28"));
   }

--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -195,77 +195,6 @@
 
 #endif // PROBE_MANUALLY || MESH_BED_LEVELING
 
-#if ENABLED(LEVEL_BED_CORNERS)
-
-  /**
-   * Level corners, starting in the front-left corner.
-   */
-  static int8_t bed_corner;
-  void _lcd_goto_next_corner() {
-    line_to_z(4.0);
-    switch (bed_corner) {
-      case 0:
-        current_position[X_AXIS] = X_MIN_BED + LEVEL_CORNERS_INSET;
-        current_position[Y_AXIS] = Y_MIN_BED + LEVEL_CORNERS_INSET;
-        break;
-      case 1:
-        current_position[X_AXIS] = X_MAX_BED - LEVEL_CORNERS_INSET;
-        break;
-      case 2:
-        current_position[Y_AXIS] = Y_MAX_BED - LEVEL_CORNERS_INSET;
-        break;
-      case 3:
-        current_position[X_AXIS] = X_MIN_BED + LEVEL_CORNERS_INSET;
-        break;
-      #if ENABLED(LEVEL_CENTER_TOO)
-        case 4:
-          current_position[X_AXIS] = X_CENTER;
-          current_position[Y_AXIS] = Y_CENTER;
-          break;
-      #endif
-    }
-    planner.buffer_line(current_position, MMM_TO_MMS(manual_feedrate_mm_m[X_AXIS]), active_extruder);
-    line_to_z(0.0);
-    if (++bed_corner > 3
-      #if ENABLED(LEVEL_CENTER_TOO)
-        + 1
-      #endif
-    ) bed_corner = 0;
-  }
-
-  void _lcd_corner_submenu() {
-    START_MENU();
-    MENU_ITEM(function,
-      #if ENABLED(LEVEL_CENTER_TOO)
-        MSG_LEVEL_BED_NEXT_POINT
-      #else
-        MSG_NEXT_CORNER
-      #endif
-      , _lcd_goto_next_corner);
-    MENU_ITEM(function, MSG_BACK, lcd_goto_previous_menu_no_defer);
-    END_MENU();
-  }
-
-  void _lcd_level_bed_corners_homing() {
-    _lcd_draw_homing();
-    if (all_axes_homed()) {
-      bed_corner = 0;
-      lcd_goto_screen(_lcd_corner_submenu);
-      _lcd_goto_next_corner();
-    }
-  }
-
-  void _lcd_level_bed_corners() {
-    defer_return_to_status = true;
-    if (!all_axes_known()) {
-      axis_homed = 0;
-      enqueue_and_echo_commands_P(PSTR("G28"));
-    }
-    lcd_goto_screen(_lcd_level_bed_corners_homing);
-  }
-
-#endif // LEVEL_BED_CORNERS
-
 /**
  * Step 1: Bed Level entry-point
  *
@@ -325,7 +254,6 @@ void menu_bed_leveling() {
   #endif
 
   #if ENABLED(LEVEL_BED_CORNERS)
-    // Move to the next corner for leveling
     MENU_ITEM(submenu, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
   #endif
 

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -502,7 +502,7 @@ void _lcd_ubl_output_map_lcd() {
  */
 void _lcd_ubl_output_map_lcd_cmd() {
   if (!all_axes_known()) {
-    axis_homed = 0;
+    set_all_unhomed();
     enqueue_and_echo_commands_P(PSTR("G28"));
   }
   lcd_goto_screen(_lcd_ubl_map_homing);

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -73,7 +73,7 @@ void recalc_delta_settings() {
   delta_diagonal_rod_2_tower[B_AXIS] = sq(delta_diagonal_rod + drt[B_AXIS]);
   delta_diagonal_rod_2_tower[C_AXIS] = sq(delta_diagonal_rod + drt[C_AXIS]);
   update_software_endstops(Z_AXIS);
-  axis_homed = 0;
+  set_all_unhomed();
 }
 
 /**

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -68,6 +68,17 @@ XYZ_CONSTS(float, max_length,     MAX_LENGTH);
 XYZ_CONSTS(float, home_bump_mm,   HOME_BUMP_MM);
 XYZ_CONSTS(signed char, home_dir, HOME_DIR);
 
+/**
+ * axis_homed
+ *   Flags that each linear axis was homed.
+ *   XYZ on cartesian, ABC on delta, ABZ on SCARA.
+ *
+ * axis_known_position
+ *   Flags that the position is known in each linear axis. Set when homed.
+ *   Cleared whenever a stepper powers off, potentially losing its position.
+ */
+uint8_t axis_homed, axis_known_position; // = 0
+
 // Relative Mode. Enable with G91, disable with G90.
 bool relative_mode; // = false;
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -26,15 +26,21 @@
  * High-level motion commands to feed the planner
  * Some of these methods may migrate to the planner class.
  */
-
-#ifndef MOTION_H
-#define MOTION_H
+#pragma once
 
 #include "../inc/MarlinConfig.h"
 
 #if IS_SCARA
   #include "../module/scara.h"
 #endif
+
+// Axis homed and known-position states
+extern uint8_t axis_homed, axis_known_position;
+constexpr uint8_t xyz_bits = _BV(X_AXIS) | _BV(Y_AXIS) | _BV(Z_AXIS);
+FORCE_INLINE bool all_axes_homed() { return (axis_homed & xyz_bits) == xyz_bits; }
+FORCE_INLINE bool all_axes_known() { return (axis_known_position & xyz_bits) == xyz_bits; }
+FORCE_INLINE void set_all_unhomed() { axis_homed = 0; }
+FORCE_INLINE void set_all_unknown() { axis_known_position = 0; }
 
 // Error margin to work around float imprecision
 constexpr float slop = 0.0001;
@@ -359,5 +365,3 @@ void homeaxis(const AxisEnum axis);
 #if HAS_M206_COMMAND
   void set_home_offset(const AxisEnum axis, const float v);
 #endif
-
-#endif // MOTION_H


### PR DESCRIPTION
- Make sure level bed corners menu functions get compiled even without `LCD_BED_LEVELING`.
- Move `axis_homed`, `axis_known_position` to `motion.*` as part of the `Marlin.h` exodus.

Reference: #12277