### PR TITLE
Make M125 work with SDSUPPORT

### DIFF
--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -28,10 +28,8 @@
 #include "../../parser.h"
 #include "../../../feature/pause.h"
 #include "../../../module/motion.h"
-
-#if DISABLED(SDSUPPORT)
-  #include "../../../module/printcounter.h"
-#endif
+#include "../../../sd/cardreader.h"
+#include "../../../module/printcounter.h"
 
 /**
  * M125: Store current position and move to filament change position.
@@ -70,21 +68,14 @@ void GcodeSuite::M125() {
     park_point.y += (active_extruder ? hotend_offset[Y_AXIS][active_extruder] : 0);
   #endif
 
-  #if DISABLED(SDSUPPORT)
-    const bool job_running = print_job_timer.isRunning();
-  #endif
+  const bool job_running = print_job_timer.isRunning();
 
-  if (pause_print(retract, park_point)) {
-    #if DISABLED(SDSUPPORT)
-      // Wait for lcd click or M108
-      wait_for_filament_reload();
-
-      // Return to print position and continue
-      resume_print();
-
-      if (job_running) print_job_timer.start();
-    #endif
+  if (pause_print(retract, park_point) && !IS_SD_PRINTING()) {
+    wait_for_filament_reload(); // Wait for lcd click or M108
+    resume_print();             // Return to print position and continue
   }
+
+  if (job_running) print_job_timer.start();
 }
 
 #endif // PARK_HEAD_ON_PAUSE

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -19,9 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-#ifndef _CARDREADER_H_
-#define _CARDREADER_H_
+#pragma once
 
 #include "../inc/MarlinConfig.h"
 
@@ -265,16 +263,14 @@ private:
   #define IS_SD_INSERTED() true
 #endif
 
+#define IS_SD_PRINTING()  card.sdprinting
+#define IS_SD_FILE_OPEN() card.isFileOpen()
+
 extern CardReader card;
 
-#endif // SDSUPPORT
+#else // !SDSUPPORT
 
-#if ENABLED(SDSUPPORT)
-  #define IS_SD_PRINTING()  card.sdprinting
-  #define IS_SD_FILE_OPEN() card.isFileOpen()
-#else
-  #define IS_SD_PRINTING()  false
-  #define IS_SD_FILE_OPEN() false
-#endif
+#define IS_SD_PRINTING()  false
+#define IS_SD_FILE_OPEN() false
 
-#endif // _CARDREADER_H_
+#endif // !SDSUPPORT


### PR DESCRIPTION
In response to #11428…

`M125` was designed to work without SD card support, as a way to pause from the host. But if printing from a host with `SDSUPPORT` compiled in, `M125` performs a pause but then continues without waiting for confirmation or doing the `resume` moves.

This PR alters `M125` to simply check whether an SD print is in progress. If so, it assumes the usual `M25` pause was used from the LCD. If not, it assumes the pause was initiated from the host and proceeds to wait for confirmation and do the `resume` moves.