### PR TITLE
Revive SCARA home offset (not fully implemented)

### DIFF
--- a/Marlin/src/gcode/calibrate/M665.cpp
+++ b/Marlin/src/gcode/calibrate/M665.cpp
@@ -66,32 +66,43 @@
    *   S[segments-per-second] - Segments-per-second
    *   P[theta-psi-offset]    - Theta-Psi offset, added to the shoulder (A/X) angle
    *   T[theta-offset]        - Theta     offset, added to the elbow    (B/Y) angle
+   *   Z[z-offset]            - Z offset, added to Z
    *
    *   A, P, and X are all aliases for the shoulder angle
    *   B, T, and Y are all aliases for the elbow angle
    */
   void GcodeSuite::M665() {
-    if (parser.seen('S')) delta_segments_per_second = parser.value_float();
+    if (parser.seenval('S')) delta_segments_per_second = parser.value_float();
 
-    const bool hasA = parser.seen('A'), hasP = parser.seen('P'), hasX = parser.seen('X');
-    const uint8_t sumAPX = hasA + hasP + hasX;
-    if (sumAPX == 1)
-      home_offset[A_AXIS] = parser.value_float();
-    else if (sumAPX > 1) {
-      SERIAL_ERROR_START();
-      SERIAL_ERRORLNPGM("Only one of A, P, or X is allowed.");
-      return;
-    }
+    #if HAS_SCARA_OFFSET
 
-    const bool hasB = parser.seen('B'), hasT = parser.seen('T'), hasY = parser.seen('Y');
-    const uint8_t sumBTY = hasB + hasT + hasY;
-    if (sumBTY == 1)
-      home_offset[B_AXIS] = parser.value_float();
-    else if (sumBTY > 1) {
-      SERIAL_ERROR_START();
-      SERIAL_ERRORLNPGM("Only one of B, T, or Y is allowed.");
-      return;
-    }
+      if (parser.seenval('Z')) scara_home_offset[Z_AXIS] = parser.value_linear_units();
+
+      const bool hasA = parser.seenval('A'), hasP = parser.seenval('P'), hasX = parser.seenval('X');
+      const uint8_t sumAPX = hasA + hasP + hasX;
+      if (sumAPX) {
+        if (sumAPX == 1)
+          scara_home_offset[A_AXIS] = parser.value_float();
+        else {
+          SERIAL_ERROR_START();
+          SERIAL_ERRORLNPGM("Only one of A, P, or X is allowed.");
+          return;
+        }
+      }
+
+      const bool hasB = parser.seenval('B'), hasT = parser.seenval('T'), hasY = parser.seenval('Y');
+      const uint8_t sumBTY = hasB + hasT + hasY;
+      if (sumBTY) {
+        if (sumBTY == 1)
+          scara_home_offset[B_AXIS] = parser.value_float();
+        else {
+          SERIAL_ERROR_START();
+          SERIAL_ERRORLNPGM("Only one of B, T, or Y is allowed.");
+          return;
+        }
+      }
+
+    #endif // HAS_SCARA_OFFSET
   }
 
 #endif

--- a/Marlin/src/gcode/control/M211.cpp
+++ b/Marlin/src/gcode/control/M211.cpp
@@ -20,6 +20,10 @@
  *
  */
 
+#include "../../inc/MarlinConfigPre.h"
+
+#if HAS_SOFTWARE_ENDSTOPS
+
 #include "../gcode.h"
 #include "../../module/motion.h"
 
@@ -46,3 +50,5 @@ void GcodeSuite::M211() {
   SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_max[Y_AXIS]));
   SERIAL_ECHOLNPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_max[Z_AXIS]));
 }
+
+#endif

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -483,7 +483,9 @@ void GcodeSuite::process_parsed_command(
         #endif
       #endif
 
-      case 211: M211(); break;                                    // M211: Enable, Disable, and/or Report software endstops
+      #if HAS_SOFTWARE_ENDSTOPS
+        case 211: M211(); break;                                  // M211: Enable, Disable, and/or Report software endstops
+      #endif
 
       #if EXTRUDERS > 1
         case 217: M217(); break;                                  // M217: Set filament swap parameters

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -44,7 +44,7 @@ bool GcodeSuite::select_coordinate_system(const int8_t _new) {
     const float diff = new_offset[i] - old_offset[i];
     if (diff) {
       position_shift[i] += diff;
-      update_software_endstops((AxisEnum)i);
+      update_workspace_offset((AxisEnum)i);
     }
   }
   return true;

--- a/Marlin/src/gcode/geometry/G92.cpp
+++ b/Marlin/src/gcode/geometry/G92.cpp
@@ -42,7 +42,7 @@ void GcodeSuite::G92() {
             const float v = position_shift[i];
             if (v) {
               position_shift[i] = 0;
-              update_software_endstops((AxisEnum)i);
+              update_workspace_offset((AxisEnum)i);
             }
           }
         #endif // Not SCARA
@@ -79,7 +79,7 @@ void GcodeSuite::G92() {
           }
           else {
             position_shift[i] += d;       // Other axes simply offset the coordinate space
-            update_software_endstops((AxisEnum)i);
+            update_workspace_offset((AxisEnum)i);
           }
         #endif
       }

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1527,7 +1527,9 @@
 // Updated G92 behavior shifts the workspace
 #define HAS_POSITION_SHIFT DISABLED(NO_WORKSPACE_OFFSETS)
 // The home offset also shifts the coordinate space
-#define HAS_HOME_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) && (IS_SCARA || IS_CARTESIAN))
+#define HAS_HOME_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) && IS_CARTESIAN)
+// The SCARA home offset applies only on G28
+#define HAS_SCARA_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) && IS_SCARA)
 // Cumulative offset to workspace to save some calculation
 #define HAS_WORKSPACE_OFFSET (HAS_POSITION_SHIFT && HAS_HOME_OFFSET)
 // M206 sets the home offset for Cartesian machines

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1527,11 +1527,11 @@
 // Updated G92 behavior shifts the workspace
 #define HAS_POSITION_SHIFT DISABLED(NO_WORKSPACE_OFFSETS)
 // The home offset also shifts the coordinate space
-#define HAS_HOME_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) && DISABLED(DELTA))
-// Either offset yields extra calculations on all moves
-#define HAS_WORKSPACE_OFFSET (HAS_POSITION_SHIFT || HAS_HOME_OFFSET)
-// M206 doesn't apply to DELTA
-#define HAS_M206_COMMAND (HAS_HOME_OFFSET && DISABLED(DELTA))
+#define HAS_HOME_OFFSET (DISABLED(NO_WORKSPACE_OFFSETS) && (IS_SCARA || IS_CARTESIAN))
+// Cumulative offset to workspace to save some calculation
+#define HAS_WORKSPACE_OFFSET (HAS_POSITION_SHIFT && HAS_HOME_OFFSET)
+// M206 sets the home offset for Cartesian machines
+#define HAS_M206_COMMAND (HAS_HOME_OFFSET && !IS_SCARA)
 
 // LCD timeout to status screen default is 15s
 #ifndef LCD_TIMEOUT_TO_STATUS

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -200,7 +200,7 @@ namespace UI {
           max = current_position[axis] + 1000;
 
     // Limit to software endstops, if enabled
-    #if ENABLED(MIN_SOFTWARE_ENDSTOPS) || ENABLED(MAX_SOFTWARE_ENDSTOPS)
+    #if HAS_SOFTWARE_ENDSTOPS
       if (soft_endstops_enabled) switch (axis) {
         case X_AXIS:
           #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
@@ -227,7 +227,7 @@ namespace UI {
           #endif
         default: break;
       }
-    #endif // MIN_SOFTWARE_ENDSTOPS || MAX_SOFTWARE_ENDSTOPS
+    #endif // HAS_SOFTWARE_ENDSTOPS
 
     // Delta limits XY based on the current offset from center
     // This assumes the center is 0,0

--- a/Marlin/src/lcd/language/language_pt-br.h
+++ b/Marlin/src/lcd/language/language_pt-br.h
@@ -200,7 +200,7 @@
   #define MSG_VA_JERK                       _UxGT("jogo VA")
   #define MSG_VB_JERK                       _UxGT("jogo VB")
   #define MSG_VC_JERK                       _UxGT("jogo VZ")
-#elif IS_DELTA
+#elif ENABLED(DELTA)
   #define MSG_VA_JERK                       _UxGT("jogo VA")
   #define MSG_VB_JERK                       _UxGT("jogo VB")
   #define MSG_VC_JERK                       _UxGT("jogo VC")
@@ -222,7 +222,7 @@
   #define MSG_ASTEPS                        _UxGT("Passo A/deg")
   #define MSG_BSTEPS                        _UxGT("Passo B/deg")
   #define MSG_CSTEPS                        _UxGT("Passo Z/mm")
-#elif IS_DELTA
+#elif ENABLED(DELTA)
   #define MSG_ASTEPS                        _UxGT("Passo A/mm")
   #define MSG_BSTEPS                        _UxGT("Passo B/mm")
   #define MSG_CSTEPS                        _UxGT("Passo C/mm")

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -88,7 +88,7 @@ static void _lcd_move_xyz(PGM_P name, AxisEnum axis) {
           max = current_position[axis] + 1000;
 
     // Limit to software endstops, if enabled
-    #if ENABLED(MIN_SOFTWARE_ENDSTOPS) || ENABLED(MAX_SOFTWARE_ENDSTOPS)
+    #if HAS_SOFTWARE_ENDSTOPS
       if (soft_endstops_enabled) switch (axis) {
         case X_AXIS:
           #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
@@ -115,7 +115,7 @@ static void _lcd_move_xyz(PGM_P name, AxisEnum axis) {
           #endif
         default: break;
       }
-    #endif // MIN_SOFTWARE_ENDSTOPS || MAX_SOFTWARE_ENDSTOPS
+    #endif // HAS_SOFTWARE_ENDSTOPS
 
     // Delta limits XY based on the current offset from center
     // This assumes the center is 0,0

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -129,9 +129,12 @@ const float homing_feedrate_mm_s[4] PROGMEM = {
 // Cartesian conversion result goes here:
 float cartes[XYZ];
 
-// Until kinematics.cpp is created, create this here
 #if IS_KINEMATIC
   float delta[ABC];
+#endif
+
+#if HAS_SCARA_OFFSET
+  float scara_home_offset[ABC];
 #endif
 
 /**
@@ -452,14 +455,13 @@ void bracket_probe_move(const bool before) {
 void setup_for_endstop_or_probe_move() { bracket_probe_move(true); }
 void clean_up_after_endstop_or_probe_move() { bracket_probe_move(false); }
 
-// Software Endstops are based on the configured limits.
-float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
-      soft_endstop_max[XYZ] = { X_MAX_BED, Y_MAX_BED, Z_MAX_POS };
-
 #if HAS_SOFTWARE_ENDSTOPS
 
-  // Software Endstops are based on the configured limits.
   bool soft_endstops_enabled = true;
+
+  // Software Endstops are based on the configured limits.
+  float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
+        soft_endstop_max[XYZ] = { X_MAX_BED, Y_MAX_BED, Z_MAX_POS };
 
   #if IS_KINEMATIC
     float soft_endstop_radius, soft_endstop_radius_2;
@@ -499,6 +501,79 @@ float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
     #endif
     #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
       NOMORE(target[Z_AXIS], soft_endstop_max[Z_AXIS]);
+    #endif
+  }
+
+  /**
+   * Software endstops can be used to monitor the open end of
+   * an axis that has a hardware endstop on the other end. Or
+   * they can prevent axes from moving past endstops and grinding.
+   *
+   * To keep doing their job as the coordinate system changes,
+   * the software endstop positions must be refreshed to remain
+   * at the same positions relative to the machine.
+   */
+  void update_software_endstops(const AxisEnum axis) {
+
+    #if ENABLED(DUAL_X_CARRIAGE)
+
+      if (axis == X_AXIS) {
+
+        // In Dual X mode hotend_offset[X] is T1's home position
+        const float dual_max_x = MAX(hotend_offset[X_AXIS][1], X2_MAX_POS);
+
+        if (active_extruder != 0) {
+          // T1 can move from X2_MIN_POS to X2_MAX_POS or X2 home position (whichever is larger)
+          soft_endstop_min[X_AXIS] = X2_MIN_POS;
+          soft_endstop_max[X_AXIS] = dual_max_x;
+        }
+        else if (dxc_is_duplicating()) {
+          // In Duplication Mode, T0 can move as far left as X1_MIN_POS
+          // but not so far to the right that T1 would move past the end
+          soft_endstop_min[X_AXIS] = X1_MIN_POS;
+          soft_endstop_max[X_AXIS] = MIN(X1_MAX_POS, dual_max_x - duplicate_extruder_x_offset);
+        }
+        else {
+          // In other modes, T0 can move from X1_MIN_POS to X1_MAX_POS
+          soft_endstop_min[X_AXIS] = X1_MIN_POS;
+          soft_endstop_max[X_AXIS] = X1_MAX_POS;
+        }
+      }
+
+    #elif ENABLED(DELTA)
+
+      soft_endstop_min[axis] = base_min_pos(axis);
+      soft_endstop_max[axis] = (axis == Z_AXIS ? delta_height
+      #if HAS_BED_PROBE
+        - zprobe_zoffset + Z_PROBE_OFFSET_FROM_EXTRUDER
+      #endif
+      : base_max_pos(axis));
+
+      switch (axis) {
+        case X_AXIS:
+        case Y_AXIS:
+          // Get a minimum radius for clamping
+          soft_endstop_radius = MIN(ABS(MAX(soft_endstop_min[X_AXIS], soft_endstop_min[Y_AXIS])), soft_endstop_max[X_AXIS], soft_endstop_max[Y_AXIS]);
+          soft_endstop_radius_2 = sq(soft_endstop_radius);
+          break;
+        case Z_AXIS:
+          delta_clip_start_height = soft_endstop_max[axis] - delta_safe_distance_from_top();
+        default: break;
+      }
+
+    #else
+
+      soft_endstop_min[axis] = base_min_pos(axis);
+      soft_endstop_max[axis] = base_max_pos(axis);
+
+    #endif
+
+    #if ENABLED(DEBUG_LEVELING_FEATURE)
+      if (DEBUGGING(LEVELING)) {
+        SERIAL_ECHOPAIR("For ", axis_codes[axis]);
+        SERIAL_ECHOPAIR(" axis:\n soft_endstop_min = ", soft_endstop_min[axis]);
+        SERIAL_ECHOLNPAIR("\n soft_endstop_max = ", soft_endstop_max[axis]);
+      }
     #endif
   }
 
@@ -1154,7 +1229,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
 
   #if HAS_POSITION_SHIFT
     position_shift[axis] = 0;
-    update_software_endstops(axis);
+    update_workspace_offset(axis);
   #endif
 
   #if ENABLED(DUAL_X_CARRIAGE)
@@ -1504,89 +1579,18 @@ void homeaxis(const AxisEnum axis) {
   #endif
 } // homeaxis()
 
-#if HAS_WORKSPACE_OFFSET || ENABLED(DUAL_X_CARRIAGE) || ENABLED(DELTA)
-
-  /**
-   * Software endstops can be used to monitor the open end of
-   * an axis that has a hardware endstop on the other end. Or
-   * they can prevent axes from moving past endstops and grinding.
-   *
-   * To keep doing their job as the coordinate system changes,
-   * the software endstop positions must be refreshed to remain
-   * at the same positions relative to the machine.
-   */
-  void update_software_endstops(const AxisEnum axis) {
-    #if HAS_HOME_OFFSET
-      workspace_offset[axis] = home_offset[axis] + position_shift[axis];
-    #endif
-
-    #if ENABLED(DUAL_X_CARRIAGE)
-      if (axis == X_AXIS) {
-
-        // In Dual X mode hotend_offset[X] is T1's home position
-        const float dual_max_x = MAX(hotend_offset[X_AXIS][1], X2_MAX_POS);
-
-        if (active_extruder != 0) {
-          // T1 can move from X2_MIN_POS to X2_MAX_POS or X2 home position (whichever is larger)
-          soft_endstop_min[X_AXIS] = X2_MIN_POS;
-          soft_endstop_max[X_AXIS] = dual_max_x;
-        }
-        else if (dxc_is_duplicating()) {
-          // In Duplication Mode, T0 can move as far left as X1_MIN_POS
-          // but not so far to the right that T1 would move past the end
-          soft_endstop_min[X_AXIS] = X1_MIN_POS;
-          soft_endstop_max[X_AXIS] = MIN(X1_MAX_POS, dual_max_x - duplicate_extruder_x_offset);
-        }
-        else {
-          // In other modes, T0 can move from X1_MIN_POS to X1_MAX_POS
-          soft_endstop_min[X_AXIS] = X1_MIN_POS;
-          soft_endstop_max[X_AXIS] = X1_MAX_POS;
-        }
-      }
-    #elif ENABLED(DELTA)
-      soft_endstop_min[axis] = base_min_pos(axis);
-      soft_endstop_max[axis] = (axis == Z_AXIS ? delta_height
-      #if HAS_BED_PROBE
-        - zprobe_zoffset + Z_PROBE_OFFSET_FROM_EXTRUDER
-      #endif
-      : base_max_pos(axis));
-    #else
-      soft_endstop_min[axis] = base_min_pos(axis);
-      soft_endstop_max[axis] = base_max_pos(axis);
-    #endif
-
+#if HAS_WORKSPACE_OFFSET
+  void update_workspace_offset(const AxisEnum axis) {
+    workspace_offset[axis] = home_offset[axis] + position_shift[axis];
     #if ENABLED(DEBUG_LEVELING_FEATURE)
       if (DEBUGGING(LEVELING)) {
         SERIAL_ECHOPAIR("For ", axis_codes[axis]);
-        #if HAS_HOME_OFFSET
-          SERIAL_ECHOPAIR(" axis:\n home_offset = ", home_offset[axis]);
-        #endif
-        #if HAS_POSITION_SHIFT
-          SERIAL_ECHOPAIR("\n position_shift = ", position_shift[axis]);
-        #endif
-        SERIAL_ECHOPAIR("\n soft_endstop_min = ", soft_endstop_min[axis]);
-        SERIAL_ECHOLNPAIR("\n soft_endstop_max = ", soft_endstop_max[axis]);
-      }
-    #endif
-
-    #if ENABLED(DELTA)
-      switch (axis) {
-        #if HAS_SOFTWARE_ENDSTOPS
-          case X_AXIS:
-          case Y_AXIS:
-            // Get a minimum radius for clamping
-            soft_endstop_radius = MIN(ABS(MAX(soft_endstop_min[X_AXIS], soft_endstop_min[Y_AXIS])), soft_endstop_max[X_AXIS], soft_endstop_max[Y_AXIS]);
-            soft_endstop_radius_2 = sq(soft_endstop_radius);
-            break;
-        #endif
-        case Z_AXIS:
-          delta_clip_start_height = soft_endstop_max[axis] - delta_safe_distance_from_top();
-        default: break;
+        SERIAL_ECHOPAIR(" axis:\n home_offset = ", home_offset[axis]);
+        SERIAL_ECHOLNPAIR("\n position_shift = ", position_shift[axis]);
       }
     #endif
   }
-
-#endif // HAS_WORKSPACE_OFFSET || DUAL_X_CARRIAGE || DELTA
+#endif
 
 #if HAS_M206_COMMAND
   /**
@@ -1595,6 +1599,6 @@ void homeaxis(const AxisEnum axis) {
    */
   void set_home_offset(const AxisEnum axis, const float v) {
     home_offset[axis] = v;
-    update_software_endstops(axis);
+    update_workspace_offset(axis);
   }
 #endif // HAS_M206_COMMAND

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -138,20 +138,18 @@ float cartes[XYZ];
  * The workspace can be offset by some commands, or
  * these offsets may be omitted to save on computation.
  */
-#if HAS_WORKSPACE_OFFSET
-  #if HAS_POSITION_SHIFT
-    // The distance that XYZ has been offset by G92. Reset by G28.
-    float position_shift[XYZ] = { 0 };
-  #endif
-  #if HAS_HOME_OFFSET
-    // This offset is added to the configured home position.
-    // Set by M206, M428, or menu item. Saved to EEPROM.
-    float home_offset[XYZ] = { 0 };
-  #endif
-  #if HAS_HOME_OFFSET && HAS_POSITION_SHIFT
-    // The above two are combined to save on computes
-    float workspace_offset[XYZ] = { 0 };
-  #endif
+#if HAS_POSITION_SHIFT
+  // The distance that XYZ has been offset by G92. Reset by G28.
+  float position_shift[XYZ] = { 0 };
+#endif
+#if HAS_HOME_OFFSET
+  // This offset is added to the configured home position.
+  // Set by M206, M428, or menu item. Saved to EEPROM.
+  float home_offset[XYZ] = { 0 };
+#endif
+#if HAS_HOME_OFFSET && HAS_POSITION_SHIFT
+  // The above two are combined to save on computes
+  float workspace_offset[XYZ] = { 0 };
 #endif
 
 #if OLDSCHOOL_ABL
@@ -1518,7 +1516,7 @@ void homeaxis(const AxisEnum axis) {
    * at the same positions relative to the machine.
    */
   void update_software_endstops(const AxisEnum axis) {
-    #if HAS_HOME_OFFSET && HAS_POSITION_SHIFT
+    #if HAS_HOME_OFFSET
       workspace_offset[axis] = home_offset[axis] + position_shift[axis];
     #endif
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -211,14 +211,10 @@ void homeaxis(const AxisEnum axis);
   void sensorless_homing_per_axis(const AxisEnum axis, const bool enable=true);
 #endif
 
-//
-// Macros
-//
-
 /**
  * Workspace offsets
  */
-#if HAS_WORKSPACE_OFFSET
+#if HAS_HOME_OFFSET || HAS_POSITION_SHIFT
   #if HAS_HOME_OFFSET
     extern float home_offset[XYZ];
   #endif
@@ -230,7 +226,7 @@ void homeaxis(const AxisEnum axis);
     #define WORKSPACE_OFFSET(AXIS) workspace_offset[AXIS]
   #elif HAS_HOME_OFFSET
     #define WORKSPACE_OFFSET(AXIS) home_offset[AXIS]
-  #elif HAS_POSITION_SHIFT
+  #else
     #define WORKSPACE_OFFSET(AXIS) position_shift[AXIS]
   #endif
   #define NATIVE_TO_LOGICAL(POS, AXIS) ((POS) + WORKSPACE_OFFSET(AXIS))

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -93,8 +93,6 @@ extern int16_t feedrate_percentage;
   extern float hotend_offset[XYZ][HOTENDS];
 #endif
 
-extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
-
 FORCE_INLINE float pgm_read_any(const float *p) { return pgm_read_float(p); }
 FORCE_INLINE signed char pgm_read_any(const signed char *p) { return pgm_read_byte(p); }
 
@@ -110,12 +108,23 @@ XYZ_DEFS(float, max_length,     MAX_LENGTH);
 XYZ_DEFS(float, home_bump_mm,   HOME_BUMP_MM);
 XYZ_DEFS(signed char, home_dir, HOME_DIR);
 
+#if HAS_WORKSPACE_OFFSET
+  void update_workspace_offset(const AxisEnum axis);
+#else
+  #define update_workspace_offset(x) NOOP
+#endif
+
 #if HAS_SOFTWARE_ENDSTOPS
   extern bool soft_endstops_enabled;
+  extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
   void clamp_to_software_endstops(float target[XYZ]);
+  void update_software_endstops(const AxisEnum axis);
 #else
   constexpr bool soft_endstops_enabled = false;
+  constexpr float soft_endstop_min[XYZ] = { X_MIN_BED, Y_MIN_BED, Z_MIN_POS },
+                  soft_endstop_max[XYZ] = { X_MAX_BED, Y_MAX_BED, Z_MAX_POS };
   #define clamp_to_software_endstops(x) NOOP
+  #define update_software_endstops(x) NOOP
 #endif
 
 void report_current_position();
@@ -252,6 +261,10 @@ void homeaxis(const AxisEnum axis);
     extern const float L1, L2;
   #endif
 
+  #if HAS_SCARA_OFFSET
+    extern float scara_home_offset[ABC]; // A and B angular offsets, Z mm offset
+  #endif
+
   // Return true if the given point is within the printable area
   inline bool position_is_reachable(const float &rx, const float &ry, const float inset=0) {
     #if ENABLED(DELTA)
@@ -352,10 +365,6 @@ void homeaxis(const AxisEnum axis);
     DXC_DUPLICATION_MODE = 2
   };
 
-#endif
-
-#if HAS_WORKSPACE_OFFSET || ENABLED(DUAL_X_CARRIAGE) || ENABLED(DELTA)
-  void update_software_endstops(const AxisEnum axis);
 #endif
 
 #if HAS_M206_COMMAND

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -60,12 +60,7 @@ void scara_set_axis_is_at_home(const AxisEnum axis) {
 
     current_position[axis] = cartes[axis];
 
-    /**
-     * SCARA home positions are based on configuration since the actual
-     * limits are determined by the inverse kinematic transform.
-     */
-    soft_endstop_min[axis] = base_min_pos(axis); // + (cartes[axis] - base_home_pos(axis));
-    soft_endstop_max[axis] = base_max_pos(axis); // + (cartes[axis] - base_home_pos(axis));
+    update_software_endstops(axis);
   }
 }
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2218,21 +2218,21 @@ void Stepper::report_positions() {
 
   if (was_enabled) ENABLE_STEPPER_DRIVER_INTERRUPT();
 
-  #if CORE_IS_XY || CORE_IS_XZ || IS_DELTA || IS_SCARA
+  #if CORE_IS_XY || CORE_IS_XZ || ENABLED(DELTA) || IS_SCARA
     SERIAL_PROTOCOLPGM(MSG_COUNT_A);
   #else
     SERIAL_PROTOCOLPGM(MSG_COUNT_X);
   #endif
   SERIAL_PROTOCOL(xpos);
 
-  #if CORE_IS_XY || CORE_IS_YZ || IS_DELTA || IS_SCARA
+  #if CORE_IS_XY || CORE_IS_YZ || ENABLED(DELTA) || IS_SCARA
     SERIAL_PROTOCOLPGM(" B:");
   #else
     SERIAL_PROTOCOLPGM(" Y:");
   #endif
   SERIAL_PROTOCOL(ypos);
 
-  #if CORE_IS_XZ || CORE_IS_YZ || IS_DELTA
+  #if CORE_IS_XZ || CORE_IS_YZ || ENABLED(DELTA)
     SERIAL_PROTOCOLPGM(" C:");
   #else
     SERIAL_PROTOCOLPGM(" Z:");

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -623,7 +623,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
       feedrate_mm_s = old_feedrate_mm_s;
 
-      #if HAS_SOFTWARE_ENDSTOPS && ENABLED(DUAL_X_CARRIAGE)
+      #if ENABLED(DUAL_X_CARRIAGE)
         update_software_endstops(X_AXIS);
       #endif
 


### PR DESCRIPTION
The SCARA home offset should be separate from the common `home_offset` to avoid confusion. In SCARA the home offsets only need to be applied during `G28` as corrections to the AB arm angles —expressed in degrees— and the Z position — mm as usual. The actual application of `scara_home_offset` in `G28` is not implemented here, but will be added in a future PR.

This also clarifies and standardizes the meaning of the conditionals pertaining to the home offset, workspace offset, and position shift globals so they directly refer to the need and presence of the variables that share their names.

- `HAS_POSITION_SHIFT` means "needs the `position_shift` global." This array is used to remember any changes applied using `G92` under the updated "native machine space" system.
- `HAS_HOME_OFFSET` means "needs the `home_offset` global." This array is used for setting a home offset that gets applied at the end of `G28`. It's the old-school way of dealing with flaky endstops and/or to provide a saved-to-eeprom offset to Gn motion coordinates.
- `HAS_WORKSPACE_OFFSET` means "needs the `workspace_offset` global," which Marlin just uses to save one add/subtract for every Gn move operation that would otherwise involve an add/subtract of _both_ `position_shift[]` and `home_offset[]`.

Future feature additions should preserve these meanings.

- This also fixes bugs where code used `IS_DELTA` instead of `ENABLED(DELTA)`.
