### PR TITLE
[2.0.x] fix lcd messages for manual deploy/stow feature

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -373,9 +373,6 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     // leave the menu if it is displayed to make LCD messsages visible
     lcd_return_to_status();
     lcd_setstatusPGM(ds_str, 99);
-    #if HAS_LCD_MENU
-      lcd_quick_feedback(true);
-    #endif
     serialprintPGM(ds_str);
     SERIAL_EOL();
 
@@ -383,9 +380,6 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     wait_for_user = true;
     while (wait_for_user) idle();
     lcd_reset_status();
-    #if HAS_LCD_MENU
-      lcd_quick_feedback(true);
-    #endif
     KEEPALIVE_STATE(IN_HANDLER);
 
   #endif // PAUSE_BEFORE_DEPLOY_STOW

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -370,8 +370,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     BUZZ(100, 698);
 
     PGM_P const ds_str = deploy ? PSTR(MSG_MANUAL_DEPLOY) : PSTR(MSG_MANUAL_STOW);
-    // leave the menu if it is displayed to make LCD messsages visible
-    lcd_return_to_status();
+    lcd_return_to_status();       // To display the new status message
     lcd_setstatusPGM(ds_str, 99);
     serialprintPGM(ds_str);
     SERIAL_EOL();

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -370,7 +370,12 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     BUZZ(100, 698);
 
     PGM_P const ds_str = deploy ? PSTR(MSG_MANUAL_DEPLOY) : PSTR(MSG_MANUAL_STOW);
-    lcd_setstatusPGM(ds_str);
+    // leave the menu if it is displayed to make LCD messsages visible
+    lcd_return_to_status();
+    lcd_setstatusPGM(ds_str, 99);
+    #if HAS_LCD_MENU
+      lcd_quick_feedback(true);
+    #endif
     serialprintPGM(ds_str);
     SERIAL_EOL();
 
@@ -378,6 +383,9 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     wait_for_user = true;
     while (wait_for_user) idle();
     lcd_reset_status();
+    #if HAS_LCD_MENU
+      lcd_quick_feedback(true);
+    #endif
     KEEPALIVE_STATE(IN_HANDLER);
 
   #endif // PAUSE_BEFORE_DEPLOY_STOW


### PR DESCRIPTION
This fixes the lcd messages for the manual deploy stow features

when the feature is triggered within the menu, the lcd messages were not shown because the menu was "above" the messages. This simply goes to the status screen first.