### PR TITLE
Use board-specific or platform SPI pins in HAL_STM32

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -26,11 +26,7 @@
 // Includes
 // --------------------------------------------------------------------------
 
-#include "HAL.h"
-#include "../shared/HAL_SPI.h"
-#include "pins_arduino.h"
-#include "spi_pins.h"
-#include "../../core/macros.h"
+#include "../../inc/MarlinConfig.h"
 
 #include <SPI.h>
 

--- a/Marlin/src/HAL/HAL_STM32/spi_pins.h
+++ b/Marlin/src/HAL/HAL_STM32/spi_pins.h
@@ -22,14 +22,14 @@
  * Define SPI Pins: SCK, MISO, MOSI, SS
  */
 #ifndef SCK_PIN
-  #define SCK_PIN   13
+  #define SCK_PIN   PIN_SPI_SCK
 #endif
 #ifndef MISO_PIN
-  #define MISO_PIN  12
+  #define MISO_PIN  PIN_SPI_MISO
 #endif
 #ifndef MOSI_PIN
-  #define MOSI_PIN  11
+  #define MOSI_PIN  PIN_SPI_MOSI
 #endif
 #ifndef SS_PIN
-  #define SS_PIN    14
+  #define SS_PIN    PIN_SPI_SS
 #endif

--- a/Marlin/src/pins/pins_ARMED.h
+++ b/Marlin/src/pins/pins_ARMED.h
@@ -105,13 +105,6 @@
 #endif
 
 //
-// SPI
-//
-#define SCK_PIN            PA5
-#define MISO_PIN           PA6
-#define MOSI_PIN           PA7
-
-//
 // Temperature Sensors
 //
 #define TEMP_0_PIN         PC0   // Analog Input
@@ -133,7 +126,6 @@
 // Misc functions
 //
 #define SDSS               PE7
-#define SS_PIN             PE7
 #define LED_PIN            PB7   // Heart beat
 #define PS_ON_PIN          PA10
 #define KILL_PIN           PA8


### PR DESCRIPTION
`HAL_STM32_SPI.cpp` doesn't include board pin definitions and this causes the defaults in `spi_pins.h` to be used. In my case the `SS_PIN` was defined in `spi_pins.h` as my `SWCLK` pin causing SWD to fail after SPI initialization.

Should there really be defaults in `spi_pins.h` for **HAL_STM32**? The will most probably differ for every board variant. Instead I think we should have a check there if SPI pins are not defined.

What do you think @hasenbanck, @thinkyhead ?

