### PR TITLE
Turn PlatformIO LDF off for LPC176x builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -158,13 +158,14 @@ build_flags       = -DTARGET_LPC1768 -DU8G_HAL_LINKS -IMarlin/src/HAL/HAL_LPC176
 # debug options for backtrace
 #  -funwind-tables
 #  -mpoke-function-name
-lib_ignore        = Adafruit NeoPixel
-lib_ldf_mode      = chain+
+lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_LPC1768>
 monitor_speed     = 250000
-lib_deps          = https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
+lib_deps          = Servo
+  LiquidCrystal
+  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   https://github.com/teemuatlut/TMCStepper.git
 
 [env:LPC1769]
@@ -175,13 +176,14 @@ build_flags       = -DTARGET_LPC1768 -DU8G_HAL_LINKS -IMarlin/src/HAL/HAL_LPC176
 # debug options for backtrace
 #  -funwind-tables
 #  -mpoke-function-name
-lib_ignore        = Adafruit NeoPixel
-lib_ldf_mode      = chain+
+lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_LPC1768>
 monitor_speed     = 250000
-lib_deps          = https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
+lib_deps          = Servo
+  LiquidCrystal
+  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   https://github.com/teemuatlut/TMCStepper.git
 
 #


### PR DESCRIPTION
### Description

The PlatformIO LDF has issues with cross platform builds and library compatibility, as LPC176x supports very few libraries and they are contained in the platform the LDF can be disabled.

I originally turned it back on so it would pick up new libraries as I ported them but it is probably better to leave it off and just add them to the supported list as I go.