### PR TITLE
Change Marlin debug flag names to fix conflicts

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #define CPU_32_BIT
-#undef DEBUG_NONE
 
 #ifndef vsnprintf_P
   #define vsnprintf_P vsnprintf

--- a/Marlin/src/HAL/HAL_STM32F1/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.h
@@ -27,7 +27,6 @@
  */
 
 #define CPU_32_BIT
-#undef DEBUG_NONE
 
 #ifndef vsnprintf_P
   #define vsnprintf_P vsnprintf
@@ -40,15 +39,6 @@
 #include <stdint.h>
 #include <util/atomic.h>
 #include <Arduino.h>
-
-// --------------------------------------------------------------------------
-// Undefine DEBUG_ settings
-// --------------------------------------------------------------------------
-
-
-#undef DEBUG_NONE
-#undef DEBUG_FAULT
-#undef DEBUG_ALL
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_STM32F1/README.md
+++ b/Marlin/src/HAL/HAL_STM32F1/README.md
@@ -13,13 +13,6 @@ After these lines:
 #endif
 <>
 
-Add the following 3 lines:
-<>
-#undef DEBUG_NONE
-#undef DEBUG_FAULT
-#undef DEBUG_ALL
-<>
-
 ### Main developers:
 Victorpv
 xC000005
@@ -30,5 +23,3 @@ https://github.com/victorpv/Marlin/tree/bugfix-2.0.x
 
 PRs should only be sent to Marlin bugfix-2.0.x branch once tested in printing so not to introduce new bugs.
 For testing/dev, you can submit to the above branch
-
-

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #define CPU_32_BIT
-#undef DEBUG_NONE
 
 #ifndef vsnprintf_P
   #define vsnprintf_P vsnprintf

--- a/Marlin/src/HAL/HAL_STM32F7/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL.h
@@ -23,7 +23,6 @@
 #pragma once
 
 #define CPU_32_BIT
-#undef DEBUG_NONE
 
 #ifndef vsnprintf_P
   #define vsnprintf_P vsnprintf

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -22,7 +22,7 @@
 
 #include "serial.h"
 
-uint8_t marlin_debug_flags = DEBUG_NONE;
+uint8_t marlin_debug_flags = MARLIN_DEBUG_NONE;
 
 const char errormagic[] PROGMEM = "Error:";
 const char echomagic[]  PROGMEM = "echo:";

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -27,20 +27,20 @@
 /**
  * Define debug bit-masks
  */
-enum DebugFlags : unsigned char {
-  DEBUG_NONE          = 0,
-  DEBUG_ECHO          = _BV(0), ///< Echo commands in order as they are processed
-  DEBUG_INFO          = _BV(1), ///< Print messages for code that has debug output
-  DEBUG_ERRORS        = _BV(2), ///< Not implemented
-  DEBUG_DRYRUN        = _BV(3), ///< Ignore temperature setting and E movement commands
-  DEBUG_COMMUNICATION = _BV(4), ///< Not implemented
-  DEBUG_LEVELING      = _BV(5), ///< Print detailed output for homing and leveling
-  DEBUG_MESH_ADJUST   = _BV(6), ///< UBL bed leveling
-  DEBUG_ALL           = 0xFF
+enum MarlinDebugFlags : uint8_t {
+  MARLIN_DEBUG_NONE          = 0,
+  MARLIN_DEBUG_ECHO          = _BV(0), ///< Echo commands in order as they are processed
+  MARLIN_DEBUG_INFO          = _BV(1), ///< Print messages for code that has debug output
+  MARLIN_DEBUG_ERRORS        = _BV(2), ///< Not implemented
+  MARLIN_DEBUG_DRYRUN        = _BV(3), ///< Ignore temperature setting and E movement commands
+  MARLIN_DEBUG_COMMUNICATION = _BV(4), ///< Not implemented
+  MARLIN_DEBUG_LEVELING      = _BV(5), ///< Print detailed output for homing and leveling
+  MARLIN_DEBUG_MESH_ADJUST   = _BV(6), ///< UBL bed leveling
+  MARLIN_DEBUG_ALL           = 0xFF
 };
 
 extern uint8_t marlin_debug_flags;
-#define DEBUGGING(F) (marlin_debug_flags & (DEBUG_## F))
+#define DEBUGGING(F) (marlin_debug_flags & (MARLIN_DEBUG_## F))
 
 #if TX_BUFFER_SIZE < 1
   #define SERIAL_FLUSHTX_P(p)

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -157,7 +157,7 @@ G29_TYPE GcodeSuite::G29() {
   // G29 Q is also available if debugging
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     const uint8_t old_debug_flags = marlin_debug_flags;
-    if (seenQ) marlin_debug_flags |= DEBUG_LEVELING;
+    if (seenQ) marlin_debug_flags |= MARLIN_DEBUG_LEVELING;
     if (DEBUGGING(LEVELING)) {
       DEBUG_POS(">>> G29", current_position);
       log_machine_info();


### PR DESCRIPTION
In reference to #11000

Marlin's debug flag names are generic enough to collide with some platform headers. This PR renames them to prevent collision and gets rid of collision workarounds in the HAL headers.