### PR TITLE
Show an appropriate message for M125

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -202,10 +202,13 @@
 
 #define MSG_FILAMENT_CHANGE_HEAT            "Press button (or M108) to heat nozzle"
 #define MSG_FILAMENT_CHANGE_INSERT          "Insert filament and press button (or M108)"
+#define MSG_FILAMENT_CHANGE_WAIT            "Press button (or M108) to resume"
 #define MSG_FILAMENT_CHANGE_HEAT_LCD        "Press button to heat nozzle"
 #define MSG_FILAMENT_CHANGE_INSERT_LCD      "Insert filament and press button"
+#define MSG_FILAMENT_CHANGE_WAIT_LCD        "Press button to resume"
 #define MSG_FILAMENT_CHANGE_HEAT_M108       "Send M108 to heat nozzle"
 #define MSG_FILAMENT_CHANGE_INSERT_M108     "Insert filament and send M108"
+#define MSG_FILAMENT_CHANGE_WAIT_M108       "Send M108 to resume"
 
 #define MSG_ERR_EEPROM_WRITE                "Error writing to EEPROM!"
 

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -44,18 +44,20 @@ enum AdvancedPauseMode : char {
 
 enum AdvancedPauseMessage : char {
   ADVANCED_PAUSE_MESSAGE_INIT,
+  ADVANCED_PAUSE_MESSAGE_WAITING,
   ADVANCED_PAUSE_MESSAGE_UNLOAD,
   ADVANCED_PAUSE_MESSAGE_INSERT,
   ADVANCED_PAUSE_MESSAGE_LOAD,
-  ADVANCED_PAUSE_MESSAGE_PURGE,
   #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
     ADVANCED_PAUSE_MESSAGE_CONTINUOUS_PURGE,
+  #else
+    ADVANCED_PAUSE_MESSAGE_PURGE,
   #endif
   ADVANCED_PAUSE_MESSAGE_OPTION,
   ADVANCED_PAUSE_MESSAGE_RESUME,
   ADVANCED_PAUSE_MESSAGE_STATUS,
-  ADVANCED_PAUSE_MESSAGE_CLICK_TO_HEAT_NOZZLE,
-  ADVANCED_PAUSE_MESSAGE_WAIT_FOR_NOZZLES_TO_HEAT
+  ADVANCED_PAUSE_MESSAGE_HEAT,
+  ADVANCED_PAUSE_MESSAGE_HEATING
 };
 
 enum AdvancedPauseMenuResponse : char {
@@ -84,7 +86,7 @@ void do_pause_e_move(const float &length, const float &fr);
 
 bool pause_print(const float &retract, const point_t &park_point, const float &unload_length=0, const bool show_lcd=false DXC_PARAMS);
 
-void wait_for_filament_reload(const int8_t max_beep_count=0 DXC_PARAMS);
+void wait_for_confirmation(const bool is_reload=false, const int8_t max_beep_count=0 DXC_PARAMS);
 
 void resume_print(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=ADVANCED_PAUSE_PURGE_LENGTH, const int8_t max_beep_count=0 DXC_PARAMS);
 

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -71,8 +71,8 @@ void GcodeSuite::M125() {
   const bool job_running = print_job_timer.isRunning();
 
   if (pause_print(retract, park_point) && !IS_SD_PRINTING()) {
-    wait_for_filament_reload(); // Wait for lcd click or M108
-    resume_print();             // Return to print position and continue
+    wait_for_confirmation();  // Wait for lcd click or M108
+    resume_print();           // Return to print position and continue
   }
 
   if (job_running) print_job_timer.start();

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -131,7 +131,7 @@ void GcodeSuite::M600() {
   const bool job_running = print_job_timer.isRunning();
 
   if (pause_print(retract, park_point, unload_length, true DXC_PASS)) {
-    wait_for_filament_reload(beep_count DXC_PASS);
+    wait_for_confirmation(true, beep_count DXC_PASS);
     resume_print(slow_load_length, fast_load_length, ADVANCED_PAUSE_PURGE_LENGTH, beep_count DXC_PASS);
   }
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1097,63 +1097,70 @@
 //                        ...or up to 2 lines on a 3-line display
 //
 #if LCD_HEIGHT >= 4
-  #ifndef MSG_FILAMENT_CHANGE_INIT_1
-    #define MSG_FILAMENT_CHANGE_INIT_1          _UxGT("Wait for start")
-    #define MSG_FILAMENT_CHANGE_INIT_2          _UxGT("of the filament")
-    #define MSG_FILAMENT_CHANGE_INIT_3          _UxGT("change")
+  #ifndef MSG_ADVANCED_PAUSE_WAITING_1
+    #define MSG_ADVANCED_PAUSE_WAITING_1      _UxGT("Press button")
+    #define MSG_ADVANCED_PAUSE_WAITING_2      _UxGT("to resume print")
   #endif
-  #ifndef MSG_FILAMENT_CHANGE_UNLOAD_1
-    #define MSG_FILAMENT_CHANGE_UNLOAD_1        _UxGT("Wait for")
-    #define MSG_FILAMENT_CHANGE_UNLOAD_2        _UxGT("filament unload")
+  #ifndef MSG_FILAMENT_CHANGE_INIT_1
+    #define MSG_FILAMENT_CHANGE_INIT_1        _UxGT("Wait for")
+    #define MSG_FILAMENT_CHANGE_INIT_2        _UxGT("filament change")
+    #define MSG_FILAMENT_CHANGE_INIT_3        _UxGT("to start")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_INSERT_1
-    #define MSG_FILAMENT_CHANGE_INSERT_1        _UxGT("Insert filament")
-    #define MSG_FILAMENT_CHANGE_INSERT_2        _UxGT("and press button")
-    #define MSG_FILAMENT_CHANGE_INSERT_3        _UxGT("to continue...")
+    #define MSG_FILAMENT_CHANGE_INSERT_1      _UxGT("Insert filament")
+    #define MSG_FILAMENT_CHANGE_INSERT_2      _UxGT("and press button")
+    #define MSG_FILAMENT_CHANGE_INSERT_3      _UxGT("to continue")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_HEAT_1
-    #define MSG_FILAMENT_CHANGE_HEAT_1          _UxGT("Press button to")
-    #define MSG_FILAMENT_CHANGE_HEAT_2          _UxGT("heat nozzle.")
+    #define MSG_FILAMENT_CHANGE_HEAT_1        _UxGT("Press button")
+    #define MSG_FILAMENT_CHANGE_HEAT_2        _UxGT("to heat nozzle")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_HEATING_1
-    #define MSG_FILAMENT_CHANGE_HEATING_1       _UxGT("Heating nozzle")
-    #define MSG_FILAMENT_CHANGE_HEATING_2       _UxGT("Please wait...")
+    #define MSG_FILAMENT_CHANGE_HEATING_1     _UxGT("Nozzle heating")
+    #define MSG_FILAMENT_CHANGE_HEATING_2     _UxGT("Please wait...")
+  #endif
+  #ifndef MSG_FILAMENT_CHANGE_UNLOAD_1
+    #define MSG_FILAMENT_CHANGE_UNLOAD_1      _UxGT("Wait for")
+    #define MSG_FILAMENT_CHANGE_UNLOAD_2      _UxGT("filament unload")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_LOAD_1
-    #define MSG_FILAMENT_CHANGE_LOAD_1          _UxGT("Wait for")
-    #define MSG_FILAMENT_CHANGE_LOAD_2          _UxGT("filament load")
+    #define MSG_FILAMENT_CHANGE_LOAD_1        _UxGT("Wait for")
+    #define MSG_FILAMENT_CHANGE_LOAD_2        _UxGT("filament load")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_PURGE_1
-    #define MSG_FILAMENT_CHANGE_PURGE_1         _UxGT("Wait for")
-    #define MSG_FILAMENT_CHANGE_PURGE_2         _UxGT("filament purge")
+    #define MSG_FILAMENT_CHANGE_PURGE_1       _UxGT("Wait for")
+    #define MSG_FILAMENT_CHANGE_PURGE_2       _UxGT("filament purge")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_RESUME_1
-    #define MSG_FILAMENT_CHANGE_RESUME_1        _UxGT("Wait for print")
-    #define MSG_FILAMENT_CHANGE_RESUME_2        _UxGT("to resume")
+    #define MSG_FILAMENT_CHANGE_RESUME_1      _UxGT("Wait for print")
+    #define MSG_FILAMENT_CHANGE_RESUME_2      _UxGT("to resume...")
   #endif
 #else // LCD_HEIGHT < 4
+  #ifndef MSG_ADVANCED_PAUSE_WAITING_1
+    #define MSG_ADVANCED_PAUSE_WAITING_1      _UxGT("Click to continue")
+  #endif
   #ifndef MSG_FILAMENT_CHANGE_INIT_1
-    #define MSG_FILAMENT_CHANGE_INIT_1          _UxGT("Please wait...")
+    #define MSG_FILAMENT_CHANGE_INIT_1        _UxGT("Please wait...")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_UNLOAD_1
-    #define MSG_FILAMENT_CHANGE_UNLOAD_1        _UxGT("Ejecting...")
+    #define MSG_FILAMENT_CHANGE_UNLOAD_1      _UxGT("Ejecting...")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_INSERT_1
-    #define MSG_FILAMENT_CHANGE_INSERT_1        _UxGT("Insert and Click")
+    #define MSG_FILAMENT_CHANGE_INSERT_1      _UxGT("Insert and Click")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_HEAT_1
-    #define MSG_FILAMENT_CHANGE_HEAT_1          _UxGT("Click to heat")
+    #define MSG_FILAMENT_CHANGE_HEAT_1        _UxGT("Click to heat")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_HEATING_1
-    #define MSG_FILAMENT_CHANGE_HEATING_1       _UxGT("Heating...")
+    #define MSG_FILAMENT_CHANGE_HEATING_1     _UxGT("Heating...")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_LOAD_1
-    #define MSG_FILAMENT_CHANGE_LOAD_1          _UxGT("Loading...")
+    #define MSG_FILAMENT_CHANGE_LOAD_1        _UxGT("Loading...")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_PURGE_1
-    #define MSG_FILAMENT_CHANGE_PURGE_1         _UxGT("Purging...")
+    #define MSG_FILAMENT_CHANGE_PURGE_1       _UxGT("Purging...")
   #endif
   #ifndef MSG_FILAMENT_CHANGE_RESUME_1
-    #define MSG_FILAMENT_CHANGE_RESUME_1        _UxGT("Resuming...")
+    #define MSG_FILAMENT_CHANGE_RESUME_1      _UxGT("Resuming...")
   #endif
 #endif // LCD_HEIGHT < 4

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -354,208 +354,151 @@ void menu_advanced_pause_option() {
   END_MENU();
 }
 
-void lcd_advanced_pause_init_message() {
+//
+// ADVANCED_PAUSE_FEATURE message screens
+//
+
+void _lcd_advanced_pause_message(PGM_P const msg1, PGM_P const msg2=NULL, PGM_P const msg3=NULL) {
   START_SCREEN();
   STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_INIT_1);
-  #ifdef MSG_FILAMENT_CHANGE_INIT_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_INIT_2);
-    #define __FC_LINES_A 3
-  #else
-    #define __FC_LINES_A 2
-  #endif
-  #ifdef MSG_FILAMENT_CHANGE_INIT_3
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_INIT_3);
-    #define _FC_LINES_A (__FC_LINES_A + 1)
-  #else
-    #define _FC_LINES_A __FC_LINES_A
-  #endif
-  #if LCD_HEIGHT > _FC_LINES_A + 1
-    STATIC_ITEM(" ");
-  #endif
+  STATIC_ITEM_P(msg1);
+  if (msg2) STATIC_ITEM_P(msg2);
+  if (msg3) STATIC_ITEM_P(msg3);
+  if ((!!msg2) + (!!msg3) + 2 < LCD_HEIGHT - 1) STATIC_ITEM(" ");
   HOTEND_STATUS_ITEM();
   END_SCREEN();
+}
+
+void lcd_advanced_pause_init_message() {
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_INIT_1
+    #ifdef MSG_FILAMENT_CHANGE_INIT_2
+      , MSG_FILAMENT_CHANGE_INIT_2
+      #ifdef MSG_FILAMENT_CHANGE_INIT_3
+        , MSG_FILAMENT_CHANGE_INIT_3
+      #endif
+    #endif
+  );
 }
 
 void lcd_advanced_pause_unload_message() {
-  START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_UNLOAD_1);
-  #ifdef MSG_FILAMENT_CHANGE_UNLOAD_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_UNLOAD_2);
-    #define __FC_LINES_B 3
-  #else
-    #define __FC_LINES_B 2
-  #endif
-  #ifdef MSG_FILAMENT_CHANGE_UNLOAD_3
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_UNLOAD_3);
-    #define _FC_LINES_B (__FC_LINES_B + 1)
-  #else
-    #define _FC_LINES_B __FC_LINES_B
-  #endif
-  #if LCD_HEIGHT > _FC_LINES_B + 1
-    STATIC_ITEM(" ");
-  #endif
-  HOTEND_STATUS_ITEM();
-  END_SCREEN();
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_UNLOAD_1
+    #ifdef MSG_FILAMENT_CHANGE_UNLOAD_2
+      , MSG_FILAMENT_CHANGE_UNLOAD_2
+      #ifdef MSG_FILAMENT_CHANGE_UNLOAD_3
+        , MSG_FILAMENT_CHANGE_UNLOAD_3
+      #endif
+    #endif
+  );
 }
 
-void lcd_advanced_pause_wait_for_nozzles_to_heat() {
-  START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_HEATING_1);
-  #ifdef MSG_FILAMENT_CHANGE_HEATING_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_HEATING_2);
-    #define _FC_LINES_C 3
-  #else
-    #define _FC_LINES_C 2
-  #endif
-  #if LCD_HEIGHT > _FC_LINES_C + 1
-    STATIC_ITEM(" ");
-  #endif
-  HOTEND_STATUS_ITEM();
-  END_SCREEN();
+void lcd_advanced_pause_heating_message() {
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_HEATING_1
+    #ifdef MSG_FILAMENT_CHANGE_HEATING_2
+      , MSG_FILAMENT_CHANGE_HEATING_2
+      #ifdef MSG_FILAMENT_CHANGE_HEATING_3
+        , MSG_FILAMENT_CHANGE_HEATING_3
+      #endif
+    #endif
+  );
 }
 
-void lcd_advanced_pause_heat_nozzle() {
-  START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_HEAT_1);
-  #ifdef MSG_FILAMENT_CHANGE_INSERT_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_HEAT_2);
-    #define _FC_LINES_D 3
-  #else
-    #define _FC_LINES_D 2
-  #endif
-  #if LCD_HEIGHT > _FC_LINES_D + 1
-    STATIC_ITEM(" ");
-  #endif
-  HOTEND_STATUS_ITEM();
-  END_SCREEN();
+void lcd_advanced_pause_heat_message() {
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_HEAT_1
+    #ifdef MSG_FILAMENT_CHANGE_HEAT_2
+      , MSG_FILAMENT_CHANGE_HEAT_2
+      #ifdef MSG_FILAMENT_CHANGE_HEAT_3
+        , MSG_FILAMENT_CHANGE_HEAT_3
+      #endif
+    #endif
+  );
 }
 
 void lcd_advanced_pause_insert_message() {
-  START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_INSERT_1);
-  #ifdef MSG_FILAMENT_CHANGE_INSERT_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_INSERT_2);
-    #define __FC_LINES_E 3
-  #else
-    #define __FC_LINES_E 2
-  #endif
-  #ifdef MSG_FILAMENT_CHANGE_INSERT_3
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_INSERT_3);
-    #define _FC_LINES_E (__FC_LINES_E + 1)
-  #else
-    #define _FC_LINES_E __FC_LINES_E
-  #endif
-  #if LCD_HEIGHT > _FC_LINES_E + 1
-    STATIC_ITEM(" ");
-  #endif
-  HOTEND_STATUS_ITEM();
-  END_SCREEN();
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_INSERT_1
+    #ifdef MSG_FILAMENT_CHANGE_INSERT_2
+      , MSG_FILAMENT_CHANGE_INSERT_2
+      #ifdef MSG_FILAMENT_CHANGE_INSERT_3
+        , MSG_FILAMENT_CHANGE_INSERT_3
+      #endif
+    #endif
+  );
 }
 
 void lcd_advanced_pause_load_message() {
-  START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_LOAD_1);
-  #ifdef MSG_FILAMENT_CHANGE_LOAD_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_LOAD_2);
-    #define __FC_LINES_F 3
-  #else
-    #define __FC_LINES_F 2
-  #endif
-  #ifdef MSG_FILAMENT_CHANGE_LOAD_3
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_LOAD_3);
-    #define _FC_LINES_F (__FC_LINES_F + 1)
-  #else
-    #define _FC_LINES_F __FC_LINES_F
-  #endif
-  #if LCD_HEIGHT > _FC_LINES_F + 1
-    STATIC_ITEM(" ");
-  #endif
-  HOTEND_STATUS_ITEM();
-  END_SCREEN();
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_LOAD_1
+    #ifdef MSG_FILAMENT_CHANGE_LOAD_2
+      , MSG_FILAMENT_CHANGE_LOAD_2
+      #ifdef MSG_FILAMENT_CHANGE_LOAD_3
+        , MSG_FILAMENT_CHANGE_LOAD_3
+      #endif
+    #endif
+  );
+}
+
+void lcd_advanced_pause_waiting_message() {
+  _lcd_advanced_pause_message(MSG_ADVANCED_PAUSE_WAITING_1
+    #ifdef MSG_ADVANCED_PAUSE_WAITING_2
+      , MSG_ADVANCED_PAUSE_WAITING_2
+      #ifdef MSG_ADVANCED_PAUSE_WAITING_3
+        , MSG_ADVANCED_PAUSE_WAITING_3
+      #endif
+    #endif
+  );
+}
+
+void lcd_advanced_pause_resume_message() {
+  _lcd_advanced_pause_message(MSG_FILAMENT_CHANGE_RESUME_1
+    #ifdef MSG_FILAMENT_CHANGE_RESUME_2
+      , MSG_FILAMENT_CHANGE_RESUME_2
+      #ifdef MSG_FILAMENT_CHANGE_RESUME_3
+        , MSG_FILAMENT_CHANGE_RESUME_3
+      #endif
+    #endif
+  );
 }
 
 void lcd_advanced_pause_purge_message() {
   START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
   STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_1);
   #ifdef MSG_FILAMENT_CHANGE_PURGE_2
     STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_2);
-    #define __FC_LINES_G 3
-  #else
-    #define __FC_LINES_G 2
+    #ifdef MSG_FILAMENT_CHANGE_PURGE_3
+      STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_3);
+    #endif
   #endif
-  #ifdef MSG_FILAMENT_CHANGE_PURGE_3
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_3);
-    #define _FC_LINES_G (__FC_LINES_G + 1)
+  #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
+    #define _PURGE_BASE 3
   #else
-    #define _FC_LINES_G __FC_LINES_G
+    #define _PURGE_BASE 2
   #endif
-  #if LCD_HEIGHT > _FC_LINES_G + 1
+  #if (_PURGE_BASE + defined(MSG_FILAMENT_CHANGE_PURGE_2) + defined(MSG_FILAMENT_CHANGE_PURGE_3)) < LCD_HEIGHT - 1
     STATIC_ITEM(" ");
   #endif
   HOTEND_STATUS_ITEM();
-  END_SCREEN();
-}
-
-#if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
-  void menu_advanced_pause_continuous_purge() {
-    START_SCREEN();
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_1);
-    #ifdef MSG_FILAMENT_CHANGE_PURGE_2
-      STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_2);
-      #define __FC_LINES_G 3
-    #else
-      #define __FC_LINES_G 2
-    #endif
-    #ifdef MSG_FILAMENT_CHANGE_PURGE_3
-      STATIC_ITEM(MSG_FILAMENT_CHANGE_PURGE_3);
-      #define _FC_LINES_G (__FC_LINES_G + 1)
-    #else
-      #define _FC_LINES_G __FC_LINES_G
-    #endif
-    #if LCD_HEIGHT > _FC_LINES_G + 1
-      STATIC_ITEM(" ");
-    #endif
-    HOTEND_STATUS_ITEM();
+  #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
     STATIC_ITEM(MSG_USERWAIT);
-    END_SCREEN();
-  }
-#endif
-
-void lcd_advanced_pause_resume_message() {
-  START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
-  STATIC_ITEM(MSG_FILAMENT_CHANGE_RESUME_1);
-  #ifdef MSG_FILAMENT_CHANGE_RESUME_2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_RESUME_2);
-  #endif
-  #ifdef MSG_FILAMENT_CHANGE_RESUME_3
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_RESUME_3);
   #endif
   END_SCREEN();
 }
 
 FORCE_INLINE screenFunc_t ap_message_screen(const AdvancedPauseMessage message) {
   switch (message) {
-    case ADVANCED_PAUSE_MESSAGE_INIT:                     return lcd_advanced_pause_init_message;
-    case ADVANCED_PAUSE_MESSAGE_UNLOAD:                   return lcd_advanced_pause_unload_message;
-    case ADVANCED_PAUSE_MESSAGE_INSERT:                   return lcd_advanced_pause_insert_message;
-    case ADVANCED_PAUSE_MESSAGE_LOAD:                     return lcd_advanced_pause_load_message;
-    case ADVANCED_PAUSE_MESSAGE_PURGE:                    return lcd_advanced_pause_purge_message;
-    case ADVANCED_PAUSE_MESSAGE_RESUME:                   return lcd_advanced_pause_resume_message;
-    case ADVANCED_PAUSE_MESSAGE_CLICK_TO_HEAT_NOZZLE:     return lcd_advanced_pause_heat_nozzle;
-    case ADVANCED_PAUSE_MESSAGE_WAIT_FOR_NOZZLES_TO_HEAT: return lcd_advanced_pause_wait_for_nozzles_to_heat;
-    case ADVANCED_PAUSE_MESSAGE_OPTION:                   advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_WAIT_FOR;
-                                                          return menu_advanced_pause_option;
+    case ADVANCED_PAUSE_MESSAGE_INIT:    return lcd_advanced_pause_init_message;
+    case ADVANCED_PAUSE_MESSAGE_UNLOAD:  return lcd_advanced_pause_unload_message;
+    case ADVANCED_PAUSE_MESSAGE_WAITING: return lcd_advanced_pause_waiting_message;
+    case ADVANCED_PAUSE_MESSAGE_INSERT:  return lcd_advanced_pause_insert_message;
+    case ADVANCED_PAUSE_MESSAGE_LOAD:    return lcd_advanced_pause_load_message;
     #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
-      case ADVANCED_PAUSE_MESSAGE_CONTINUOUS_PURGE:       return menu_advanced_pause_continuous_purge;
+      case ADVANCED_PAUSE_MESSAGE_CONTINUOUS_PURGE:
+    #else
+      case ADVANCED_PAUSE_MESSAGE_PURGE:
     #endif
+                                         return lcd_advanced_pause_purge_message;
+    case ADVANCED_PAUSE_MESSAGE_RESUME:  return lcd_advanced_pause_resume_message;
+    case ADVANCED_PAUSE_MESSAGE_HEAT:    return lcd_advanced_pause_heat_message;
+    case ADVANCED_PAUSE_MESSAGE_HEATING: return lcd_advanced_pause_heating_message;
+    case ADVANCED_PAUSE_MESSAGE_OPTION:  advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_WAIT_FOR;
+                                         return menu_advanced_pause_option;
     case ADVANCED_PAUSE_MESSAGE_STATUS:
     default: break;
   }


### PR DESCRIPTION
`M25` / `M125` calls `pause_print` then goes to the `wait_for_filament_reload` function, which allows heaters to time out and reheats them before returning. Currently this always puts up a misleading "Insert filament and press button to continue..." message.

For `M25`/`M125` pausing, this PR changes the message to "Press button to resume print."

Also:
- Add a common method for displaying messages to reduce code size