### PR TITLE
No error on T0 with single-extruder and fix MIXING_EXTRUDER virtual tools

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -499,9 +499,10 @@ inline void invalid_extruder_error(const uint8_t e) {
  */
 void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool no_move/*=false*/) {
   #if EXTRUDERS < 2
-
-    return invalid_extruder_error(tmp_extruder);
-
+  {
+    if(tmp_extruder) return invalid_extruder_error(tmp_extruder);
+    return;
+  }
   #elif ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
 
       if (tmp_extruder >= MIXING_VIRTUAL_TOOLS)

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -498,12 +498,7 @@ inline void invalid_extruder_error(const uint8_t e) {
  * previous tool out of the way and the new tool into place.
  */
 void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool no_move/*=false*/) {
-  #if EXTRUDERS < 2
-  {
-    if(tmp_extruder) return invalid_extruder_error(tmp_extruder);
-    return;
-  }
-  #elif ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
+  #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
 
       if (tmp_extruder >= MIXING_VIRTUAL_TOOLS)
         return invalid_extruder_error(tmp_extruder);
@@ -511,6 +506,11 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
       mixer.T(uint_fast8_t(tmp_extruder));
       UNUSED(fr_mm_s);
       UNUSED(no_move);
+
+  #elif EXTRUDERS < 2
+
+    if (tmp_extruder) invalid_extruder_error(tmp_extruder);
+    return;
 
   #else
 


### PR DESCRIPTION
When octoprint connects it calls T0 and gets an invalid extruder error with single extrusion systems. We can either only return this when a non 0 tool is called, or simply return from the T function for single extruder / single hotend systems. I feel this is the better option to still error on a tool call if you run a dual extruder file by accident.