### PR TITLE
Debug of G2-G3 for UBL

### DIFF
--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -232,11 +232,11 @@ void move_to(const float &rx, const float &ry, const float &z, const float &e_de
 
   if (z != last_z) {
     last_z = z;
-    feed_value = planner.settings.max_feedrate_mm_s[Z_AXIS]/(3.0);  // Base the feed rate off of the configured Z_AXIS feed rate
+    feed_value = planner.settings.max_feedrate_mm_s[Z_AXIS]/(2.0);  // Base the feed rate off of the configured Z_AXIS feed rate
 
     destination[X_AXIS] = current_position[X_AXIS];
     destination[Y_AXIS] = current_position[Y_AXIS];
-    destination[Z_AXIS] = z;                          // We know the last_z==z or we wouldn't be in this block of code.
+    destination[Z_AXIS] = z;                          // We know the last_z!=z or we wouldn't be in this block of code.
     destination[E_AXIS] = current_position[E_AXIS];
 
     G26_line_to_destination(feed_value);
@@ -245,7 +245,7 @@ void move_to(const float &rx, const float &ry, const float &z, const float &e_de
 
   // Check if X or Y is involved in the movement.
   // Yes: a 'normal' movement. No: a retract() or recover()
-  feed_value = has_xy_component ? PLANNER_XY_FEEDRATE() / 10.0 : planner.settings.max_feedrate_mm_s[E_AXIS] / 1.5;
+  feed_value = has_xy_component ? PLANNER_XY_FEEDRATE() / 3.0 : planner.settings.max_feedrate_mm_s[E_AXIS] / 1.5;
 
   if (g26_debug_flag) SERIAL_ECHOLNPAIR("in move_to() feed_value for XY:", feed_value);
 
@@ -828,6 +828,19 @@ void GcodeSuite::G26() {
         recover_filament(destination);
         const float save_feedrate = feedrate_mm_s;
         feedrate_mm_s = PLANNER_XY_FEEDRATE() / 10.0;
+
+        if (g26_debug_flag) {
+          SERIAL_ECHOPAIR(" plan_arc(ex=", endpoint[X_AXIS]);
+          SERIAL_ECHOPAIR(", ey=", endpoint[Y_AXIS]);
+          SERIAL_ECHOPAIR(", ez=", endpoint[Z_AXIS]);
+          SERIAL_ECHOPAIR(", len=", arc_offset);
+          SERIAL_ECHOPAIR(") -> (ex=", current_position[X_AXIS]);
+          SERIAL_ECHOPAIR(", ey=", current_position[Y_AXIS]);
+          SERIAL_ECHOPAIR(", ez=", current_position[Z_AXIS]);
+          SERIAL_CHAR(')');
+          SERIAL_EOL();
+        }
+
         plan_arc(endpoint, arc_offset, false);  // Draw a counter-clockwise arc
         feedrate_mm_s = save_feedrate;
         set_destination_from_current();

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -35,6 +35,10 @@
   #include "../../module/scara.h"
 #endif
 
+#if ENABLED(AUTO_BED_LEVELING_UBL)
+  #include "../../feature/bedlevel/ubl/ubl.h"
+#endif
+
 #if N_ARC_CORRECTION < 1
   #undef N_ARC_CORRECTION
   #define N_ARC_CORRECTION 1
@@ -54,6 +58,14 @@ void plan_arc(
   const float (&offset)[2],   // Center of rotation relative to current_position
   const uint8_t clockwise     // Clockwise?
 ) {
+
+SERIAL_ECHOPAIR("   current[X]=", current_position[X_AXIS]);
+SERIAL_ECHOPAIR(" current[Y]=", current_position[Y_AXIS]);
+SERIAL_ECHOPAIR(" current[Z]=", current_position[Z_AXIS]);
+SERIAL_ECHOPAIR(" current[E]=", current_position[E_AXIS]);
+SERIAL_EOL();
+
+
   #if ENABLED(CNC_WORKSPACE_PLANES)
     AxisEnum p_axis, q_axis, l_axis;
     switch (gcode.workspace_plane) {
@@ -70,6 +82,7 @@ void plan_arc(
   float r_P = -offset[0], r_Q = -offset[1];
 
   const float radius = HYPOT(r_P, r_Q),
+              start_z  = current_position[Z_AXIS],
               center_P = current_position[p_axis] - r_P,
               center_Q = current_position[q_axis] - r_Q,
               rt_X = cart[p_axis] - center_P,
@@ -89,6 +102,13 @@ void plan_arc(
   const float flat_mm = radius * angular_travel,
               mm_of_travel = linear_travel ? HYPOT(flat_mm, linear_travel) : ABS(flat_mm);
   if (mm_of_travel < 0.001f) return;
+
+SERIAL_ECHOPAIR(" plan_arc(ex=", cart[X_AXIS]);
+SERIAL_ECHOPAIR(", ey=", cart[Y_AXIS]);
+SERIAL_ECHOPAIR(", ez=", cart[Z_AXIS]);
+SERIAL_ECHOPAIR(", rx=", offset[X_AXIS]);
+SERIAL_ECHOPAIR(", ry=", offset[Y_AXIS]);
+SERIAL_ECHO(")\n");
 
   uint16_t segments = FLOOR(mm_of_travel / (MM_PER_ARC_SEGMENT));
   if (segments == 0) segments = 1;
@@ -179,37 +199,85 @@ void plan_arc(
     // Update raw location
     raw[p_axis] = center_P + r_P;
     raw[q_axis] = center_Q + r_Q;
-    raw[l_axis] += linear_per_segment;
+//  raw[l_axis] += linear_per_segment;
+    raw[l_axis] = start_z;
+
     raw[E_AXIS] += extruder_per_segment;
 
     clamp_to_software_endstops(raw);
+//    #if ENABLED(AUTO_BED_LEVELING_UBL)
+//destination[X_AXIS] = raw[X_AXIS];
+//destination[Y_AXIS] = raw[Y_AXIS];
+//destination[Z_AXIS] = raw[Z_AXIS];
+//destination[E_AXIS] = raw[E_AXIS];
+
+//      ubl.line_to_destination_cartesian(MMS_SCALED(feedrate_mm_s), active_extruder);  // UBL's motion routine needs to know 
+                                                                                        // about all moves
+//    #else
 
     #if HAS_LEVELING && !PLANNER_LEVELING
       planner.apply_leveling(raw);
     #endif
+
+SERIAL_ECHOPAIR("   rawx=", raw[X_AXIS]);
+SERIAL_ECHOPAIR(" rawy=", raw[Y_AXIS]);
+SERIAL_ECHOPAIR(" rawz=", raw[Z_AXIS]);
+SERIAL_ECHOPAIR(" rawe=", raw[E_AXIS]);
+SERIAL_EOL();
+
 
     if (!planner.buffer_line(raw, fr_mm_s, active_extruder, MM_PER_ARC_SEGMENT
       #if ENABLED(SCARA_FEEDRATE_SCALING)
         , inv_duration
       #endif
     ))
+//    #endif
       break;
   }
 
   // Ensure last segment arrives at target location.
   COPY(raw, cart);
 
+//#if ENABLED(AUTO_BED_LEVELING_UBL)
+//destination[X_AXIS] = raw[X_AXIS];
+//destination[Y_AXIS] = raw[Y_AXIS];
+//destination[Z_AXIS] = raw[Z_AXIS];
+//destination[E_AXIS] = raw[E_AXIS];
+
+//  ubl.line_to_destination_cartesian(MMS_SCALED(feedrate_mm_s), active_extruder);  // UBL's motion routine needs to know 
+                                                                                    // about all moves
+//#else
+
+  raw[l_axis] = start_z;
+
   #if HAS_LEVELING && !PLANNER_LEVELING
     planner.apply_leveling(raw);
   #endif
+
+SERIAL_ECHOPAIR("   RAWX=", raw[X_AXIS]);
+SERIAL_ECHOPAIR(" RAWY=", raw[Y_AXIS]);
+SERIAL_ECHOPAIR(" RAWZ=", raw[Z_AXIS]);
+SERIAL_ECHOPAIR(" RAWE=", raw[E_AXIS]);
+SERIAL_EOL();
+
 
   planner.buffer_line(raw, fr_mm_s, active_extruder, MM_PER_ARC_SEGMENT
     #if ENABLED(SCARA_FEEDRATE_SCALING)
       , inv_duration
     #endif
   );
+//#endif
 
+  raw[l_axis] = start_z;
   COPY(current_position, raw);
+
+SERIAL_ECHOPAIR("   CURRENT[X]=", current_position[X_AXIS]);
+SERIAL_ECHOPAIR(" CURRENT[Y]=", current_position[Y_AXIS]);
+SERIAL_ECHOPAIR(" CURRENT[Z]=", current_position[Z_AXIS]);
+SERIAL_ECHOPAIR(" CURRENT[E]=", current_position[E_AXIS]);
+SERIAL_EOL();
+
+
 } // plan_arc
 
 /**

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -211,9 +211,9 @@ void plan_arc(
   #endif
 
   planner.buffer_line(raw, fr_mm_s, active_extruder, MM_PER_ARC_SEGMENT
-  #if ENABLED(SCARA_FEEDRATE_SCALING)
-    , inv_duration
-  #endif
+    #if ENABLED(SCARA_FEEDRATE_SCALING)
+      , inv_duration
+    #endif
   );
 
   raw[l_axis] = start_L;

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -186,7 +186,6 @@ void plan_arc(
     raw[p_axis] = center_P + r_P;
     raw[q_axis] = center_Q + r_Q;
     raw[l_axis] = start_L;
-
     raw[E_AXIS] += extruder_per_segment;
 
     clamp_to_software_endstops(raw);
@@ -216,11 +215,9 @@ void plan_arc(
     , inv_duration
   #endif
   );
-//#endif
 
   raw[l_axis] = start_L;
   COPY(current_position, raw);
-
 } // plan_arc
 
 /**

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -35,10 +35,6 @@
   #include "../../module/scara.h"
 #endif
 
-#if ENABLED(AUTO_BED_LEVELING_UBL)
-  #include "../../feature/bedlevel/ubl/ubl.h"
-#endif
-
 #if N_ARC_CORRECTION < 1
   #undef N_ARC_CORRECTION
   #define N_ARC_CORRECTION 1
@@ -58,7 +54,6 @@ void plan_arc(
   const float (&offset)[2],   // Center of rotation relative to current_position
   const uint8_t clockwise     // Clockwise?
 ) {
-
   #if ENABLED(CNC_WORKSPACE_PLANES)
     AxisEnum p_axis, q_axis, l_axis;
     switch (gcode.workspace_plane) {

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -75,7 +75,9 @@ void plan_arc(
   float r_P = -offset[0], r_Q = -offset[1];
 
   const float radius = HYPOT(r_P, r_Q),
-              start_L  = current_position[l_axis],
+              #if ENABLED(AUTO_BED_LEVELING_UBL)
+                start_L  = current_position[l_axis],
+              #endif
               center_P = current_position[p_axis] - r_P,
               center_Q = current_position[q_axis] - r_Q,
               rt_X = cart[p_axis] - center_P,
@@ -185,7 +187,11 @@ void plan_arc(
     // Update raw location
     raw[p_axis] = center_P + r_P;
     raw[q_axis] = center_Q + r_Q;
-    raw[l_axis] = start_L;
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      raw[l_axis] = start_L;
+    #else
+      raw[l_axis] += linear_per_segment;
+    #endif
     raw[E_AXIS] += extruder_per_segment;
 
     clamp_to_software_endstops(raw);
@@ -204,7 +210,11 @@ void plan_arc(
 
   // Ensure last segment arrives at target location.
   COPY(raw, cart);
-  raw[l_axis] = start_L;
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    raw[l_axis] = start_L;
+  #else
+    raw[l_axis] += linear_per_segment;
+  #endif
 
   #if HAS_LEVELING && !PLANNER_LEVELING
     planner.apply_leveling(raw);
@@ -216,7 +226,11 @@ void plan_arc(
   #endif
   );
 
-  raw[l_axis] = start_L;
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    raw[l_axis] = start_L;
+  #else
+    raw[l_axis] += linear_per_segment;
+  #endif
   COPY(current_position, raw);
 } // plan_arc
 

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -207,8 +207,6 @@ void plan_arc(
   COPY(raw, cart);
   #if ENABLED(AUTO_BED_LEVELING_UBL)
     raw[l_axis] = start_L;
-  #else
-    raw[l_axis] += linear_per_segment;
   #endif
 
   #if HAS_LEVELING && !PLANNER_LEVELING
@@ -223,8 +221,6 @@ void plan_arc(
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)
     raw[l_axis] = start_L;
-  #else
-    raw[l_axis] += linear_per_segment;
   #endif
   COPY(current_position, raw);
 } // plan_arc


### PR DESCRIPTION
I think G2 & G3 have been broken for a while with various bed leveling schemes.   

There is a lot of debug code (that can easily be ignored) in this Pull Request.   That will be stripped out before any merge happens.   But it may be useful for people to see what is going on with and without the modifications.

I'm trying to get G2 & G3 working for G26 with UBL.   But it is my belief that Bi-Linear is also affected by the current code.   I would appreciate if somebody can confirm or deny that claim!

I think these changes fix the problem for UBL.  (I have not done super extensive QA to insure that yet).   But I would like to hear any insight or opinions people have before I continue!

THANKS!

