### PR TITLE
[2.0.x] Enhancement M106/M107 auto switch

### DIFF
--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -27,8 +27,11 @@
 #include "../gcode.h"
 #include "../../Marlin.h" // for fan_speed — should move those to Planner
 
-#if ENABLED(SINGLENOZZLE)
+#if EXTRUDERS > 1
   #include "../../module/motion.h"
+#endif
+
+#if ENABLED(SINGLENOZZLE)
   #include "../../module/tool_change.h"
 #endif
 
@@ -53,11 +56,15 @@
  */
 void GcodeSuite::M106() {
 
-  const uint8_t p = parser.boolval('A') ? active_extruder : parser.byteval('P');
+  #if EXTRUDERS > 1 
+    const uint8_t p = parser.boolval('A') ? active_extruder : parser.byteval('P');
+  #else
+    const uint8_t p = parser.byteval('P');
+  #endif 
 
   const uint16_t s = parser.ushortval('S', 255);
 
-  #if ENABLED(SINGLENOZZLE)
+  #if ENABLED(SINGLENOZZLE) && EXTRUDERS > 1
     if (p != active_extruder) {
       if (p < EXTRUDERS) singlenozzle_fan_speed[p] = MIN(s, 255U);
       return;
@@ -92,9 +99,13 @@ void GcodeSuite::M106() {
  */
 void GcodeSuite::M107() {
 
-  const uint8_t p = parser.boolval('A') ? active_extruder : parser.byteval('P');
+  #if EXTRUDERS > 1
+    const uint8_t p = parser.boolval('A') ? active_extruder : parser.byteval('P');
+  #else
+    const uint8_t p = parser.byteval('P');
+  #endif 
 
-  #if ENABLED(SINGLENOZZLE)
+  #if ENABLED(SINGLENOZZLE) && EXTRUDERS > 1
     if (p != active_extruder) {
       if (p < EXTRUDERS) singlenozzle_fan_speed[p] = 0;
       return;

--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -29,11 +29,6 @@
 
 #if ENABLED(SINGLENOZZLE)
   #include "../../module/motion.h"
-  #include "../../module/tool_change.h"
-#endif
-
-#if ENABLED(AUTO_FILAMENT_FAN_SELECTION)
-  #include "../../module/planner.h"
 #endif
 
 /**

--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLED(SINGLENOZZLE)
   #include "../../module/motion.h"
+  #include "../../module/tool_change.h"
 #endif
 
 /**

--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -56,11 +56,12 @@
  */
 void GcodeSuite::M106() {
 
-  #if EXTRUDERS > 1 
-    const uint8_t p = parser.boolval('A') ? active_extruder : parser.byteval('P');
-  #else
-    const uint8_t p = parser.byteval('P');
-  #endif 
+  const uint8_t p =
+    #if EXTRUDERS > 1 
+      parser.seen('A') ? active_extruder :
+    #endif 
+    parser.byteval('P')
+  ;
 
   const uint16_t s = parser.ushortval('S', 255);
 
@@ -99,11 +100,12 @@ void GcodeSuite::M106() {
  */
 void GcodeSuite::M107() {
 
-  #if EXTRUDERS > 1
-    const uint8_t p = parser.boolval('A') ? active_extruder : parser.byteval('P');
-  #else
-    const uint8_t p = parser.byteval('P');
-  #endif 
+  const uint8_t p =
+    #if EXTRUDERS > 1 
+      parser.seen('A') ? active_extruder :
+    #endif 
+    parser.byteval('P')
+  ;
 
   #if ENABLED(SINGLENOZZLE) && EXTRUDERS > 1
     if (p != active_extruder) {

--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -40,12 +40,12 @@
  *
  *  S<int>   Speed between 0-255
  *  P<index> Fan index, if more than one fan
- *  A        Fan index set to active extruder index, if more than one fan
+ *  A        Use the active extruder index as the fan index
  *
- *  As long as the A argument is not supported by any slicer.
- *  Most slicer have a customizable gcode post processing, based on python,
- *  where you can easy modify fan control using regular expression.
- *  pattern:"(M10[67])( P\d|)( S\d+|)"  substitution:"$1 A$3" 
+ *  As long as the A argument is not supported by any slicer,
+ *  most slicers have customizable g-code post-processing based on Python
+ *  so fan control can be modified with a regular expression.
+ *  For example: "(M10[67]) *(P\d+)? *(S\d+)?" ... substituting "$1 A $3"
  *
  * With EXTRA_FAN_SPEED enabled:
  *
@@ -57,9 +57,9 @@
 void GcodeSuite::M106() {
 
   const uint8_t p =
-    #if EXTRUDERS > 1 
+    #if EXTRUDERS > 1
       parser.seen('A') ? active_extruder :
-    #endif 
+    #endif
     parser.byteval('P')
   ;
 
@@ -101,9 +101,9 @@ void GcodeSuite::M106() {
 void GcodeSuite::M107() {
 
   const uint8_t p =
-    #if EXTRUDERS > 1 
+    #if EXTRUDERS > 1
       parser.seen('A') ? active_extruder :
-    #endif 
+    #endif
     parser.byteval('P')
   ;
 


### PR DESCRIPTION
### Description

Part-Cooling Fan M106/M107 Auto Selection
This change adds the parameter A to M106/M107 command. 
If given, currend used extruder index will be used for PWM Fan selection
e.g. on RADDS board are 2 PWM Controlled fan outs. 
     Using a Dual Extruder solution, M106/M107 with parameter A set,
     will set/reset the PWM Fanout selected by current used extruder index.

### Benefits

Easy realization of Dual-/Multi-Hotend solutions with separate part cooler on boards with multiple PWM Fan outs, without the need of hardware changes. Also the M106/M107 commands containing gcode is easy to processed for to use this parameter enhancement. 

current behavior is not affected.  

### Related Issues

Dicussed in PR https://github.com/MarlinFirmware/Marlin/pull/12351
