### PR TITLE
Add M412 to enable/disable filament runout detection

### DIFF
--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -1,0 +1,45 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+
+#include "../../gcode.h"
+#include "../../../feature/runout.h"
+
+/**
+ * M412: Enable / Disable filament runout detection
+ */
+void GcodeSuite::M412() {
+  if (parser.seen('S')) {
+    runout.reset();
+    runout.enabled = parser.value_bool();
+  }
+  else {
+    SERIAL_ECHO_START();
+    SERIAL_ECHOPGM("Filament runout ");
+    serialprintln_onoff(runout.enabled);
+  }
+}
+
+#endif // FILAMENT_RUNOUT_SENSOR

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -568,6 +568,10 @@ void GcodeSuite::process_parsed_command(
         case 407: M407(); break;                                  // M407: Display measured filament diameter
       #endif
 
+      #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+        case 412: M412(); break;                                  // M412: Enable/Disable filament runout detection
+      #endif
+
       #if HAS_LEVELING
         case 420: M420(); break;                                  // M420: Enable/Disable Bed Leveling
       #endif

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -78,7 +78,7 @@
  * M3   - Turn laser/spindle on, set spindle/laser speed/power, set rotation to clockwise
  * M4   - Turn laser/spindle on, set spindle/laser speed/power, set rotation to counter-clockwise
  * M5   - Turn laser/spindle off
- * M12  - Set up closed loop control system. More features coming soon. (Requires EXTERNAL_CLOSED_LOOP_CONTROLLER)
+ * M12  - Set up closed loop control system. (Requires EXTERNAL_CLOSED_LOOP_CONTROLLER)
  * M17  - Enable/Power all stepper motors
  * M18  - Disable all stepper motors; same as M84
  * M20  - List SD card. (Requires SDSUPPORT)
@@ -196,6 +196,7 @@
  * M406 - Disable Filament Sensor flow control. (Requires FILAMENT_WIDTH_SENSOR)
  * M407 - Display measured filament diameter in millimeters. (Requires FILAMENT_WIDTH_SENSOR)
  * M410 - Quickstop. Abort all planned moves.
+ * M412 - Enable / Disable filament runout detection. (Requires FILAMENT_RUNOUT_SENSOR)
  * M420 - Enable/Disable Leveling (with current values) S1=enable S0=disable (Requires MESH_BED_LEVELING or ABL)
  * M421 - Set a single Z coordinate in the Mesh Leveling grid. X<units> Y<units> Z<units> (Requires MESH_BED_LEVELING, AUTO_BED_LEVELING_BILINEAR, or AUTO_BED_LEVELING_UBL)
  * M422 - Set Z Stepper automatic alignment position using probe. X<units> Y<units> A<axis> (Requires Z_STEPPER_AUTO_ALIGN)
@@ -706,6 +707,10 @@ private:
     static void M405();
     static void M406();
     static void M407();
+  #endif
+
+  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+    static void M412();
   #endif
 
   #if HAS_LEVELING

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -347,7 +347,7 @@ void menu_configuration() {
   #endif
 
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    MENU_ITEM_EDIT(bool, MSG_RUNOUT_SENSOR_ENABLE, &runout.enabled);
+    MENU_ITEM_EDIT_CALLBACK(bool, MSG_RUNOUT_SENSOR_ENABLE, &runout.enabled, runout.reset);
   #endif
 
   #if DISABLED(SLIM_LCD_MENUS)


### PR DESCRIPTION
Add `M412 S[0|1]` G-code to enable / disable the filament runout sensors.

**NOTE:** @Geeetech3D currently uses `M408` and `M409` to enable / disable the filament runout sensors on their machines in their fork of Marlin 1.1.8. We are not able to use those G-codes because `M408` is reserved for use by PanelDue for JSON data about the current machine state. Since this is documented on the RepRap wiki, Geeetech should have picked a different pair of codes. Whenever they migrate to Marlin 2.0 it will be changed.