### PR TITLE
Fix BABYSTEP_ZPROBE_OFFSET

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -36,7 +36,7 @@
   #include "../../module/configuration_store.h"
 #endif
 
-#if WATCH_HOTENDS || WATCH_THE_BED
+#if WATCH_HOTENDS || WATCH_THE_BED || ENABLED(BABYSTEP_ZPROBE_OFFSET)
   #include "../../module/temperature.h"
 #endif
 


### PR DESCRIPTION
Did not compile without  `WATCH_HOTENDS || WATCH_THE_BED`.
Add condition to include "../../module/temperature.h".
Fixing #12399