### PR TITLE
[2.0.x] Added missing include for "cardreader.h"

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -25,10 +25,10 @@
 // These displays all share the MarlinUI class
 #if HAS_SPI_LCD || ENABLED(MALYAN_LCD) || ENABLED(EXTENSIBLE_UI)
   #include "ultralcd.h"
-  MarlinUI ui;
   #if ENABLED(SDSUPPORT)
     #include "../sd/cardreader.h"
   #endif
+  MarlinUI ui;
 #endif
 
 #if HAS_SPI_LCD

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -26,6 +26,9 @@
 #if HAS_SPI_LCD || ENABLED(MALYAN_LCD) || ENABLED(EXTENSIBLE_UI)
   #include "ultralcd.h"
   MarlinUI ui;
+  #if ENABLED(SDSUPPORT)
+    #include "../sd/cardreader.h"
+  #endif
 #endif
 
 #if HAS_SPI_LCD


### PR DESCRIPTION
- This is required for IS_SD_PRINTING on line 1183
