### PR TITLE
[2.0.x] better endstops fix

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -293,10 +293,10 @@ void Endstops::not_homing() {
 void Endstops::resync() {
   if (!abort_enabled()) return;     // If endstops/probes are disabled the loop below can hang
 
-  #if ENABLED(ENDSTOP_INTERRUPTS_FEATURE) && !ENDSTOP_NOISE_THRESHOLD
+  #if ENABLED(ENDSTOP_INTERRUPTS_FEATURE)
     update();
   #else
-    safe_delay(2);  // Wait for Temperature ISR (runs at 1KHz)
+    safe_delay(2);  // Wait for Temperature ISR calls update at least 1 time (runs at 1KHz)
   #endif
   #if ENDSTOP_NOISE_THRESHOLD
     while (endstop_poll_count) safe_delay(1);

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -296,7 +296,7 @@ void Endstops::resync() {
   #if ENABLED(ENDSTOP_INTERRUPTS_FEATURE)
     update();
   #else
-    safe_delay(2);  // Wait for Temperature ISR calls update at least 1 time (runs at 1KHz)
+    safe_delay(2);  // Wait for Temperature ISR to run at least once (runs at 1KHz)
   #endif
   #if ENDSTOP_NOISE_THRESHOLD
     while (endstop_poll_count) safe_delay(1);


### PR DESCRIPTION
When endstops use both interrupt and threshold we must call `update` explicitly to re-sync status.