### PR TITLE
[2.0.x] Fix to runout sensor code

### DIFF
--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -44,8 +44,7 @@ void FilamentSensorBase::filament_present(const uint8_t extruder) {
 }
 
 #if ENABLED(FILAMENT_MOTION_SENSOR)
-  uint8_t FilamentSensorEncoder::motion_detected,
-          FilamentSensorEncoder::old_state; // = 0
+  uint8_t FilamentSensorEncoder::motion_detected;
 #endif
 
 #if FILAMENT_RUNOUT_DISTANCE_MM > 0


### PR DESCRIPTION
- "old_state" is no longer a class static variable.
- Follow up to edfd106bc