### PR TITLE
Optimize target_extruder, ignore T with mixing

### DIFF
--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -34,7 +34,8 @@
    */
   void GcodeSuite::M200() {
 
-    if (get_target_extruder_from_command()) return;
+    const int8_t target_extruder = get_target_extruder_from_command();
+    if (target_extruder < 0) return;
 
     if (parser.seen('D')) {
       // setting any extruder filament size disables volumetric on the assumption that
@@ -55,11 +56,12 @@
  */
 void GcodeSuite::M201() {
 
-  GET_TARGET_EXTRUDER();
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i])) {
-      const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
+      const uint8_t a = (i == E_AXIS ? E_AXIS_N(target_extruder) : i);
       planner.settings.max_acceleration_mm_per_s2[a] = parser.value_axis_units((AxisEnum)a);
     }
   }
@@ -74,11 +76,12 @@ void GcodeSuite::M201() {
  */
 void GcodeSuite::M203() {
 
-  GET_TARGET_EXTRUDER();
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   LOOP_XYZE(i)
     if (parser.seen(axis_codes[i])) {
-      const uint8_t a = i + (i == E_AXIS ? TARGET_EXTRUDER : 0);
+      const uint8_t a = (i == E_AXIS ? E_AXIS_N(target_extruder) : i);
       planner.settings.max_feedrate_mm_s[a] = parser.value_axis_units((AxisEnum)a);
     }
 }

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -40,7 +40,9 @@
  *   Z<zoffset>
  */
 void GcodeSuite::M218() {
-  if (get_target_extruder_from_command() || target_extruder == 0) return;
+
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   if (parser.seenval('X')) hotend_offset[X_AXIS][target_extruder] = parser.value_linear_units();
   if (parser.seenval('Y')) hotend_offset[Y_AXIS][target_extruder] = parser.value_linear_units();

--- a/Marlin/src/gcode/config/M221.cpp
+++ b/Marlin/src/gcode/config/M221.cpp
@@ -27,7 +27,10 @@
  * M221: Set extrusion percentage (M221 T0 S95)
  */
 void GcodeSuite::M221() {
-  if (get_target_extruder_from_command()) return;
+
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
+
   if (parser.seenval('S')) {
     planner.flow_percentage[target_extruder] = parser.value_int();
     planner.refresh_e_factor(target_extruder);

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -31,21 +31,22 @@
  */
 void GcodeSuite::M92() {
 
-  GET_TARGET_EXTRUDER();
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   LOOP_XYZE(i) {
     if (parser.seen(axis_codes[i])) {
       if (i == E_AXIS) {
-        const float value = parser.value_per_axis_units((AxisEnum)(E_AXIS + TARGET_EXTRUDER));
+        const float value = parser.value_per_axis_units((AxisEnum)(E_AXIS_N(target_extruder)));
         if (value < 20) {
-          float factor = planner.settings.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] / value; // increase e constants if M92 E14 is given for netfab.
+          float factor = planner.settings.axis_steps_per_mm[E_AXIS_N(target_extruder)] / value; // increase e constants if M92 E14 is given for netfab.
           #if HAS_CLASSIC_JERK && (DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE))
             planner.max_jerk[E_AXIS] *= factor;
           #endif
-          planner.settings.max_feedrate_mm_s[E_AXIS + TARGET_EXTRUDER] *= factor;
-          planner.max_acceleration_steps_per_s2[E_AXIS + TARGET_EXTRUDER] *= factor;
+          planner.settings.max_feedrate_mm_s[E_AXIS_N(target_extruder)] *= factor;
+          planner.max_acceleration_steps_per_s2[E_AXIS_N(target_extruder)] *= factor;
         }
-        planner.settings.axis_steps_per_mm[E_AXIS + TARGET_EXTRUDER] = value;
+        planner.settings.axis_steps_per_mm[E_AXIS_N(target_extruder)] = value;
       }
       else {
         planner.settings.axis_steps_per_mm[i] = parser.value_per_axis_units((AxisEnum)i);

--- a/Marlin/src/gcode/control/T.cpp
+++ b/Marlin/src/gcode/control/T.cpp
@@ -33,27 +33,27 @@
  *   F[units/min] Set the movement feedrate
  *   S1           Don't move the tool in XY after change
  */
-void GcodeSuite::T(const uint8_t tmp_extruder) {
+void GcodeSuite::T(const uint8_t tool_index) {
 
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOPAIR(">>> T(", tmp_extruder);
+      SERIAL_ECHOPAIR(">>> T(", tool_index);
       SERIAL_CHAR(')');
       SERIAL_EOL();
       DEBUG_POS("BEFORE", current_position);
     }
   #endif
 
-  #if HOTENDS == 1 || (ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1)
+  #if EXTRUDERS < 2
 
-    tool_change(tmp_extruder);
+    tool_change(tool_index);
 
-  #elif HOTENDS > 1
+  #else
 
     tool_change(
-      tmp_extruder,
+      tool_index,
       MMM_TO_MMS(parser.linearval('F')),
-      (tmp_extruder == active_extruder) || parser.boolval('S')
+      (tool_index == active_extruder) || parser.boolval('S')
     );
 
   #endif

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -54,7 +54,8 @@
 void GcodeSuite::M600() {
   point_t park_point = NOZZLE_PARK_POINT;
 
-  if (get_target_extruder_from_command()) return;
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   #if ENABLED(DUAL_X_CARRIAGE)
     int8_t DXC_ext = target_extruder;

--- a/Marlin/src/gcode/feature/pause/M603.cpp
+++ b/Marlin/src/gcode/feature/pause/M603.cpp
@@ -43,7 +43,8 @@
  */
 void GcodeSuite::M603() {
 
-  if (get_target_extruder_from_command()) return;
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   // Unload length
   if (parser.seen('U')) {

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -55,7 +55,9 @@ void GcodeSuite::M701() {
     if (axis_unhomed_error()) park_point.z = 0;
   #endif
 
-  if (get_target_extruder_from_command()) return;
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
+
 
   // Z axis lift
   if (parser.seenval('Z')) park_point.z = parser.linearval('Z');
@@ -121,7 +123,8 @@ void GcodeSuite::M702() {
     if (axis_unhomed_error()) park_point.z = 0;
   #endif
 
-  if (get_target_extruder_from_command()) return;
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   // Z axis lift
   if (parser.seenval('Z')) park_point.z = parser.linearval('Z');
@@ -154,8 +157,8 @@ void GcodeSuite::M702() {
   #endif
   {
     // Unload length
-    const float unload_length = -ABS(parser.seen('U') ? parser.value_axis_units(E_AXIS) :
-                                                        fc_settings[target_extruder].unload_length);
+    const float unload_length = -ABS(parser.seen('U') ? parser.value_axis_units(E_AXIS)
+                                                      : fc_settings[target_extruder].unload_length);
 
     unload_filament(unload_length, true, ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT);
   }

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -73,7 +73,8 @@ void GcodeSuite::M906() {
         #endif
         break;
       case E_AXIS: {
-        if (get_target_extruder_from_command()) return;
+        const int8_t target_extruder = get_target_extruder_from_command();
+        if (target_extruder < 0) return;
         switch (target_extruder) {
           #if AXIS_IS_TMC(E0)
             case 0: TMC_SET_CURRENT(E0); break;

--- a/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M915.cpp
@@ -232,7 +232,8 @@
           #endif
           break;
         case E_AXIS: {
-          if (get_target_extruder_from_command()) return;
+          const int8_t target_extruder = get_target_extruder_from_command();
+          if (target_extruder < 0) return;
           switch (target_extruder) {
             #if AXIS_HAS_STEALTHCHOP(E0)
               case 0: TMC_SET_PWMTHRS_E(0); break;

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -38,7 +38,6 @@ GcodeSuite gcode;
 
 #include "../Marlin.h" // for idle() and suspend_auto_report
 
-uint8_t GcodeSuite::target_extruder;
 millis_t GcodeSuite::previous_move_ms;
 
 bool GcodeSuite::axis_relative_modes[] = AXIS_RELATIVE_MODES;
@@ -58,11 +57,10 @@ bool GcodeSuite::axis_relative_modes[] = AXIS_RELATIVE_MODES;
 #endif
 
 /**
- * Set target_extruder from the T parameter or the active_extruder
- *
- * Returns TRUE if the target is invalid
+ * Get the target extruder from the T parameter or the active_extruder
+ * Return -1 if the T parameter is out of range
  */
-bool GcodeSuite::get_target_extruder_from_command() {
+int8_t GcodeSuite::get_target_extruder_from_command() {
   if (parser.seenval('T')) {
     const int8_t e = parser.value_byte();
     if (e >= EXTRUDERS) {
@@ -70,14 +68,11 @@ bool GcodeSuite::get_target_extruder_from_command() {
       SERIAL_CHAR('M');
       SERIAL_ECHO(parser.codenum);
       SERIAL_ECHOLNPAIR(" " MSG_INVALID_EXTRUDER " ", e);
-      return true;
+      return -1;
     }
-    target_extruder = e;
+    return e;
   }
-  else
-    target_extruder = active_extruder;
-
-  return false;
+  return active_extruder;
 }
 
 /**
@@ -539,7 +534,9 @@ void GcodeSuite::process_parsed_command(
         case 302: M302(); break;                                  // M302: Allow cold extrudes (set the minimum extrude temperature)
       #endif
 
-      case 303: M303(); break;                                    // M303: PID autotune
+      #if HAS_PID_HEATING
+        case 303: M303(); break;                                  // M303: PID autotune
+      #endif
 
       #if ENABLED(MORGAN_SCARA)
         case 360: if (M360()) return; break;                      // M360: SCARA Theta pos1

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -822,7 +822,7 @@ private:
 
   static void M999();
 
-  static void T(const uint8_t tmp_extruder);
+  static void T(const uint8_t tool_index);
 
 };
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -267,8 +267,6 @@ public:
 
   GcodeSuite() {}
 
-  static uint8_t target_extruder;
-
   static bool axis_relative_modes[];
 
   #if ENABLED(CNC_WORKSPACE_PLANES)
@@ -290,8 +288,9 @@ public:
   static millis_t previous_move_ms;
   FORCE_INLINE static void reset_stepper_timeout() { previous_move_ms = millis(); }
 
-  static bool get_target_extruder_from_command();
+  static int8_t get_target_extruder_from_command();
   static void get_destination_from_command();
+
   static void process_parsed_command(
     #if USE_EXECUTE_COMMANDS_IMMEDIATE
       const bool no_ok = false
@@ -305,17 +304,6 @@ public:
   #endif
 
   FORCE_INLINE static void home_all_axes() { G28(true); }
-
-  /**
-   * Multi-stepper support for M92, M201, M203
-   */
-  #if ENABLED(DISTINCT_E_FACTORS)
-    #define GET_TARGET_EXTRUDER() if (gcode.get_target_extruder_from_command()) return
-    #define TARGET_EXTRUDER gcode.target_extruder
-  #else
-    #define GET_TARGET_EXTRUDER() NOOP
-    #define TARGET_EXTRUDER 0
-  #endif
 
   #if ENABLED(HOST_KEEPALIVE_FEATURE)
     /**
@@ -669,7 +657,9 @@ private:
     static void M302();
   #endif
 
-  static void M303();
+  #if HAS_PID_HEATING
+    static void M303();
+  #endif
 
   #if ENABLED(PIDTEMPBED)
     static void M304();

--- a/Marlin/src/gcode/temperature/M104_M109.cpp
+++ b/Marlin/src/gcode/temperature/M104_M109.cpp
@@ -39,10 +39,15 @@
  * M104: Set hot end temperature
  */
 void GcodeSuite::M104() {
-  if (get_target_extruder_from_command()) return;
+
   if (DEBUGGING(DRYRUN)) return;
 
-  const uint8_t e = target_extruder;
+  #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
+    constexpr int8_t e = 0;
+  #else
+    const int8_t e = get_target_extruder_from_command();
+    if (e < 0) return;
+  #endif
 
   if (parser.seenval('S')) {
     const int16_t temp = parser.value_celsius();
@@ -82,8 +87,14 @@ void GcodeSuite::M104() {
  */
 void GcodeSuite::M109() {
 
-  if (get_target_extruder_from_command()) return;
   if (DEBUGGING(DRYRUN)) return;
+
+  #if ENABLED(MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
+    constexpr int8_t target_extruder = 0;
+  #else
+    const int8_t target_extruder = get_target_extruder_from_command();
+    if (target_extruder < 0) return;
+  #endif
 
   const bool no_wait_for_cooling = parser.seenval('S'),
              set_temp = no_wait_for_cooling || parser.seenval('R');

--- a/Marlin/src/gcode/temperature/M105.cpp
+++ b/Marlin/src/gcode/temperature/M105.cpp
@@ -31,7 +31,9 @@
  * M105: Read hot end and bed temperature
  */
 void GcodeSuite::M105() {
-  if (get_target_extruder_from_command()) return;
+
+  const int8_t target_extruder = get_target_extruder_from_command();
+  if (target_extruder < 0) return;
 
   #if NUM_SERIAL > 1
     const int16_t port = command_queue_port[cmd_queue_index_r];
@@ -39,9 +41,9 @@ void GcodeSuite::M105() {
 
   #if HAS_TEMP_SENSOR
     SERIAL_PROTOCOLPGM_P(port, MSG_OK);
-    thermalManager.print_heaterstates(
+    thermalManager.print_heater_states(target_extruder
       #if NUM_SERIAL > 1
-        port
+        , port
       #endif
     );
   #else // !HAS_TEMP_SENSOR

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -236,7 +236,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
    * Alternately heat and cool the nozzle, observing its behavior to
    * determine the best PID values to achieve a stable temperature.
    */
-  void Temperature::PID_autotune(const float &target, const int8_t hotend, const int8_t ncycles, const bool set_result/*=false*/) {
+  void Temperature::PID_autotune(const float &target, const int8_t heater, const int8_t ncycles, const bool set_result/*=false*/) {
     float current = 0.0;
     int cycles = 0;
     bool heating = true;
@@ -249,10 +249,10 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
     float max = 0, min = 10000;
 
     #if HAS_PID_FOR_BOTH
-      #define GHV(B,H) (hotend < 0 ? (B) : (H))
-      #define SHV(S,B,H) do{ if (hotend < 0) S##_bed = B; else S [hotend] = H; }while(0)
-      #define ONHEATINGSTART() (hotend < 0 ? printerEventLEDs.onBedHeatingStart() : printerEventLEDs.onHotendHeatingStart())
-      #define ONHEATING(S,C,T) do{ if (hotend < 0) printerEventLEDs.onBedHeating(S,C,T); else printerEventLEDs.onHotendHeating(S,C,T); }while(0)
+      #define GHV(B,H) (heater < 0 ? (B) : (H))
+      #define SHV(S,B,H) do{ if (heater < 0) S##_bed = B; else S [heater] = H; }while(0)
+      #define ONHEATINGSTART() (heater < 0 ? printerEventLEDs.onBedHeatingStart() : printerEventLEDs.onHotendHeatingStart())
+      #define ONHEATING(S,C,T) do{ if (heater < 0) printerEventLEDs.onBedHeating(S,C,T); else printerEventLEDs.onHotendHeating(S,C,T); }while(0)
     #elif ENABLED(PIDTEMPBED)
       #define GHV(B,H) B
       #define SHV(S,B,H) (S##_bed = B)
@@ -260,7 +260,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       #define ONHEATING(S,C,T) printerEventLEDs.onBedHeating(S,C,T)
     #else
       #define GHV(B,H) H
-      #define SHV(S,B,H) (S [hotend] = H)
+      #define SHV(S,B,H) (S [heater] = H)
       #define ONHEATINGSTART() printerEventLEDs.onHotendHeatingStart()
       #define ONHEATING(S,C,T) printerEventLEDs.onHotendHeating(S,C,T)
     #endif
@@ -268,7 +268,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
     #if WATCH_THE_BED || WATCH_HOTENDS
       #define HAS_TP_BED (ENABLED(THERMAL_PROTECTION_BED) && ENABLED(PIDTEMPBED))
       #if HAS_TP_BED && ENABLED(THERMAL_PROTECTION_HOTENDS) && ENABLED(PIDTEMP)
-        #define GTV(B,H) (hotend < 0 ? (B) : (H))
+        #define GTV(B,H) (heater < 0 ? (B) : (H))
       #elif HAS_TP_BED
         #define GTV(B,H) (B)
       #else
@@ -286,22 +286,6 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       next_auto_fan_check_ms = next_temp_ms + 2500UL;
     #endif
 
-    #if ENABLED(PIDTEMP)
-      #define _TOP_HOTEND HOTENDS - 1
-    #else
-      #define _TOP_HOTEND -1
-    #endif
-    #if ENABLED(PIDTEMPBED)
-      #define _BOT_HOTEND -1
-    #else
-      #define _BOT_HOTEND 0
-    #endif
-
-    if (!WITHIN(hotend, _BOT_HOTEND, _TOP_HOTEND)) {
-      SERIAL_ECHOLNPGM(MSG_PID_BAD_EXTRUDER_NUM);
-      return;
-    }
-
     SERIAL_ECHOLNPGM(MSG_PID_AUTOTUNE_START);
 
     disable_all_heaters();
@@ -310,7 +294,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
 
     wait_for_heatup = true; // Can be interrupted with M108
     #if ENABLED(PRINTER_EVENT_LEDS)
-      const float start_temp = GHV(current_temperature_bed, current_temperature[hotend]);
+      const float start_temp = GHV(current_temperature_bed, current_temperature[heater]);
       LEDColor color = ONHEATINGSTART();
     #endif
 
@@ -323,7 +307,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
         updateTemperaturesFromRawValues();
 
         // Get the current temperature and constrain it
-        current = GHV(current_temperature_bed, current_temperature[hotend]);
+        current = GHV(current_temperature_bed, current_temperature[heater]);
         NOLESS(max, current);
         NOMORE(min, current);
 
@@ -412,7 +396,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       // Report heater states every 2 seconds
       if (ELAPSED(ms, next_temp_ms)) {
         #if HAS_TEMP_SENSOR
-          print_heaterstates();
+          print_heater_states(heater >= 0 ? heater : active_extruder);
           SERIAL_EOL();
         #endif
         next_temp_ms = ms + 2000UL;
@@ -423,9 +407,9 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
             #if WATCH_THE_BED && WATCH_HOTENDS
               true
             #elif WATCH_HOTENDS
-              hotend >= 0
+              heater >= 0
             #else
-              hotend < 0
+              heater < 0
             #endif
           ) {
             if (!heated) {                                          // If not yet reached target...
@@ -435,10 +419,10 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
                 if (current > watch_temp_target) heated = true;     // - Flag if target temperature reached
               }
               else if (ELAPSED(ms, temp_change_ms))                 // Watch timer expired
-                _temp_error(hotend, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, hotend));
+                _temp_error(heater, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, heater));
             }
             else if (current < target - (MAX_OVERSHOOT_PID_AUTOTUNE)) // Heated, then temperature fell too far?
-              _temp_error(hotend, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, hotend));
+              _temp_error(heater, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, heater));
           }
         #endif
       } // every 2 seconds
@@ -477,15 +461,15 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
         }while(0)
 
         #define _SET_EXTRUDER_PID() do { \
-          PID_PARAM(Kp, hotend) = tune_pid.Kp; \
-          PID_PARAM(Ki, hotend) = scalePID_i(tune_pid.Ki); \
-          PID_PARAM(Kd, hotend) = scalePID_d(tune_pid.Kd); \
+          PID_PARAM(Kp, heater) = tune_pid.Kp; \
+          PID_PARAM(Ki, heater) = scalePID_i(tune_pid.Ki); \
+          PID_PARAM(Kd, heater) = scalePID_d(tune_pid.Kd); \
           updatePID(); }while(0)
 
         // Use the result? (As with "M303 U1")
         if (set_result) {
           #if HAS_PID_FOR_BOTH
-            if (hotend < 0) _SET_BED_PID(); else _SET_EXTRUDER_PID();
+            if (heater < 0) _SET_BED_PID(); else _SET_EXTRUDER_PID();
           #elif ENABLED(PIDTEMP)
             _SET_EXTRUDER_PID();
           #else
@@ -575,13 +559,13 @@ int Temperature::getHeaterPower(const int heater) {
 //
 // Temperature Error Handlers
 //
-void Temperature::_temp_error(const int8_t e, PGM_P const serial_msg, PGM_P const lcd_msg) {
+void Temperature::_temp_error(const int8_t heater, PGM_P const serial_msg, PGM_P const lcd_msg) {
   static bool killed = false;
   if (IsRunning()) {
     SERIAL_ERROR_START();
     serialprintPGM(serial_msg);
     SERIAL_ERRORPGM(MSG_STOPPED_HEATER);
-    if (e >= 0) SERIAL_ERRORLN((int)e); else SERIAL_ERRORLNPGM(MSG_HEATER_BED);
+    if (heater >= 0) SERIAL_ERRORLN((int)heater); else SERIAL_ERRORLNPGM(MSG_HEATER_BED);
   }
   #if DISABLED(BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE)
     if (!killed) {
@@ -594,12 +578,12 @@ void Temperature::_temp_error(const int8_t e, PGM_P const serial_msg, PGM_P cons
   #endif
 }
 
-void Temperature::max_temp_error(const int8_t e) {
-  _temp_error(e, PSTR(MSG_T_MAXTEMP), TEMP_ERR_PSTR(MSG_ERR_MAXTEMP, e));
+void Temperature::max_temp_error(const int8_t heater) {
+  _temp_error(heater, PSTR(MSG_T_MAXTEMP), TEMP_ERR_PSTR(MSG_ERR_MAXTEMP, heater));
 }
 
-void Temperature::min_temp_error(const int8_t e) {
-  _temp_error(e, PSTR(MSG_T_MINTEMP), TEMP_ERR_PSTR(MSG_ERR_MINTEMP, e));
+void Temperature::min_temp_error(const int8_t heater) {
+  _temp_error(heater, PSTR(MSG_T_MINTEMP), TEMP_ERR_PSTR(MSG_ERR_MINTEMP, heater));
 }
 
 float Temperature::get_pid_output(const int8_t e) {
@@ -2346,15 +2330,15 @@ void Temperature::isr() {
     delay(2);
   }
 
-  void Temperature::print_heaterstates(
+  void Temperature::print_heater_states(const uint8_t target_extruder
     #if NUM_SERIAL > 1
-      const int8_t port
+      , const int8_t port
     #endif
   ) {
     #if HAS_TEMP_HOTEND
-      print_heater_state(degHotend(gcode.target_extruder), degTargetHotend(gcode.target_extruder)
+      print_heater_state(degHotend(target_extruder), degTargetHotend(target_extruder)
         #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawHotendTemp(gcode.target_extruder)
+          , rawHotendTemp(target_extruder)
         #endif
         #if NUM_SERIAL > 1
           , port
@@ -2392,7 +2376,7 @@ void Temperature::isr() {
       );
     #endif
     SERIAL_PROTOCOLPGM_P(port, " @:");
-    SERIAL_PROTOCOL_P(port, getHeaterPower(gcode.target_extruder));
+    SERIAL_PROTOCOL_P(port, getHeaterPower(target_extruder));
     #if HAS_HEATED_BED
       SERIAL_PROTOCOLPGM_P(port, " B@:");
       SERIAL_PROTOCOL_P(port, getHeaterPower(-1));
@@ -2414,7 +2398,7 @@ void Temperature::isr() {
     void Temperature::auto_report_temperatures() {
       if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
         next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
-        print_heaterstates();
+        print_heater_states(active_extruder);
         SERIAL_EOL();
       }
     }
@@ -2480,9 +2464,9 @@ void Temperature::isr() {
         }
 
         now = millis();
-        if (ELAPSED(now, next_temp_ms)) { //Print temp & remaining time every 1s while waiting
+        if (ELAPSED(now, next_temp_ms)) { // Print temp & remaining time every 1s while waiting
           next_temp_ms = now + 1000UL;
-          print_heaterstates();
+          print_heater_states(target_extruder);
           #if TEMP_RESIDENCY_TIME > 0
             SERIAL_PROTOCOLPGM(" W:");
             if (residency_start_ms)
@@ -2587,8 +2571,6 @@ void Temperature::isr() {
         KEEPALIVE_STATE(NOT_BUSY);
       #endif
 
-      gcode.target_extruder = active_extruder; // for print_heaterstates
-
       #if ENABLED(PRINTER_EVENT_LEDS)
         const float start_temp = degBed();
         printerEventLEDs.onBedHeatingStart();
@@ -2607,7 +2589,7 @@ void Temperature::isr() {
         now = millis();
         if (ELAPSED(now, next_temp_ms)) { //Print Temp Reading every 1 second while heating up.
           next_temp_ms = now + 1000UL;
-          print_heaterstates();
+          print_heater_states(active_extruder);
           #if TEMP_BED_RESIDENCY_TIME > 0
             SERIAL_PROTOCOLPGM(" W:");
             if (residency_start_ms)

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -601,9 +601,9 @@ class Temperature {
     #endif // HEATER_IDLE_HANDLER
 
     #if HAS_TEMP_SENSOR
-      static void print_heaterstates(
+      static void print_heater_states(const uint8_t target_extruder
         #if NUM_SERIAL > 1
-          const int8_t port = -1
+          , const int8_t port = -1
         #endif
       );
       #if ENABLED(AUTO_REPORT_TEMPERATURES)

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -500,8 +500,8 @@ inline void invalid_extruder_error(const uint8_t e) {
 void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool no_move/*=false*/) {
   #if ENABLED(MIXING_EXTRUDER)
 
-    UNUSED(fr_mm_s);
-    UNUSED(no_move);
+    UNUSED(fr_mm_s); UNUSED(no_move);
+
     if (tmp_extruder >= MIXING_VIRTUAL_TOOLS)
       return invalid_extruder_error(tmp_extruder);
 
@@ -512,8 +512,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
   #elif EXTRUDERS < 2
 
-    UNUSED(fr_mm_s);
-    UNUSED(no_move);
+    UNUSED(fr_mm_s); UNUSED(no_move);
+
     if (tmp_extruder) invalid_extruder_error(tmp_extruder);
     return;
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -517,7 +517,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
     if (tmp_extruder) invalid_extruder_error(tmp_extruder);
     return;
 
-  #else
+  #else // EXTRUDERS > 1
 
     planner.synchronize();
 
@@ -751,5 +751,5 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, int(active_extruder));
 
-  #endif // EXTRUDERS <= 1 && (!MIXING_EXTRUDER || MIXING_VIRTUAL_TOOLS <= 1)
+  #endif // EXTRUDERS > 1
 }


### PR DESCRIPTION
Reduce code size by ~400 bytes for an average configuration by using local target extruder variables instead of a global.
- Have `get_target_extruder_from_command` return the index or -1 on error.
- Pass the extruder index to `print_heater_states` for clarity.
- Check `M303` parameters in … wait for it … `M303`.
- For `MIXING_EXTRUDER` (virtual tools) ignore extruder index for `M104`,`M109` as a workaround for slicers' being unaware of "virtual tools."
- Make sure `GcodeSuite::T` matches up with `tool_change`.