### PR TITLE
Fix DWT peripheral access for STM32 (M7)

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL.cpp
@@ -78,14 +78,20 @@ uint16_t HAL_adc_result;
 // Public functions
 // --------------------------------------------------------------------------
 
+
+// Needed for DELAY_NS() / DELAY_US() on CORTEX-M7
+#if (defined(__arm__) || defined(__thumb__)) && __CORTEX_M == 7
+  // HAL pre-initialization task
+  // Force the preinit function to run between the premain() and main() function
+  // of the STM32 arduino core
+  __attribute__((constructor (102)))
+  void HAL_preinit() {
+    enableCycleCounter();
+  }
+#endif
+
 // HAL initialization task
 void HAL_init(void) {
-
-  // Needed for DELAY_NS() / DELAY_US() on CORTEX-M7
-  #if (defined(__arm__) || defined(__thumb__)) && __CORTEX_M == 7
-    enableCycleCounter();
-  #endif
-
   FastIO_init();
 
   #if ENABLED(SDSUPPORT)


### PR DESCRIPTION
The access to the DWT peripheral for the `CYCCNT` register needs to happen before entering the `main()` function. The code needs to be called after the setup of the system clocks, so the right place would be between the `premain()` and `main()` function of the STM32 Arduino core.

This patch moves the DWT access code in a new function, which is then placed between the `premain()` and `main()` function.

Without this change the STM32 Cortex-M7 MCU will HALT when not being attached to a debug session over SWD/JTAG.

Reference thread at the [STM32 Arduino core](https://github.com/stm32duino/Arduino_Core_STM32/issues/371).