### PR TITLE
Various fixes for MarlinUI and ExtUI

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -510,6 +510,7 @@ else ifeq ($(HARDWARE_VARIANT), archim)
   VPATH   += $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/cores/arduino/USB
   VPATH   += $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/libraries/Wire/src
   VPATH   += $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/libraries/SPI/src
+  VPATH   += $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/libraries/U8glib/src/clib
   VPATH   += $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/variants/archim
   LDSCRIPT = $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/variants/archim/linker_scripts/gcc/flash.ld
   LDLIBS   = $(ARDUINO_INSTALL_DIR)/packages/ultimachine/hardware/sam/1.6.9-b/variants/archim/libsam_sam3x8e_gcc_rel.a
@@ -611,6 +612,10 @@ else ifeq ($(HARDWARE_VARIANT), archim)
   CDEFS      += -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSB_VID=0x27b1 -DUSB_PID=0x0001 -DUSBCON '-DUSB_MANUFACTURER="UltiMachine"' '-DUSB_PRODUCT="Archim"'
   LIB_CXXSRC += variant.cpp IPAddress.cpp Reset.cpp RingBuffer.cpp Stream.cpp UARTClass.cpp  USARTClass.cpp abi.cpp new.cpp watchdog.cpp CDC.cpp PluggableUSB.cpp  USBCore.cpp
   LIB_SRC    += cortex_handlers.c iar_calls_sam3.c syscalls_sam3.c dtostrf.c itoa.c
+
+  ifeq ($(U8GLIB), 1)
+    LIB_SRC += u8g_com_api.c u8g_pb32h1.c
+  endif
 endif
 
 # Add all the source directories as include directories too

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -196,7 +196,7 @@
 #define MMM_TO_MMS(MM_M) ((MM_M)/60.0f)
 #define MMS_TO_MMM(MM_S) ((MM_S)*60.0f)
 
-#define NOOP do{} while(0)
+#define NOOP (0)
 
 #define CEILING(x,y) (((x) + (y) - 1) / (y))
 

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -25,8 +25,8 @@
 
 uint8_t marlin_debug_flags = MARLIN_DEBUG_NONE;
 
-const char errormagic[] PROGMEM = "Error:";
-const char echomagic[]  PROGMEM = "echo:";
+static const char errormagic[] PROGMEM = "Error:";
+static const char echomagic[]  PROGMEM = "echo:";
 
 #if NUM_SERIAL > 1
   void serialprintPGM_P(const int8_t p, const char * str) {

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -917,7 +917,7 @@
     }
 
     inline void set_message_with_feedback(PGM_P const msg_P) {
-      ui.setstatusPGM(msg_P);
+      ui.set_status_P(msg_P);
       ui.quick_feedback();
     }
 

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -399,14 +399,19 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
 }
 
 /**
+ * For Paused Print:
+ * - Show "Press button (or M108) to resume"
+ *
+ * For Filament Change:
  * - Show "Insert filament and press button to continue"
+ *
  * - Wait for a click before returning
- * - Heaters can time out, reheated before accepting a click
+ * - Heaters can time out and must reheat before continuing
  *
  * Used by M125 and M600
  */
 
-#if HAS_LCD_MENU && ENABLED(EMERGENCY_PARSER)
+#if (HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI)) && ENABLED(EMERGENCY_PARSER)
   #define _PMSG(L) L
 #elif ENABLED(EMERGENCY_PARSER)
   #define _PMSG(L) L##_M108

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -164,7 +164,7 @@ int8_t g26_prime_flag;
    */
   bool user_canceled() {
     if (!ui.button_pressed()) return false; // Return if the button isn't pressed
-    ui.setstatusPGM(PSTR("Mesh Validation Stopped."), 99);
+    ui.set_status_P(PSTR("Mesh Validation Stopped."), 99);
     #if HAS_LCD_MENU
       ui.quick_feedback();
     #endif
@@ -414,7 +414,7 @@ inline bool turn_on_heaters() {
 
     if (g26_bed_temp > 25) {
       #if ENABLED(ULTRA_LCD)
-        ui.setstatusPGM(PSTR("G26 Heating Bed."), 99);
+        ui.set_status_P(PSTR("G26 Heating Bed."), 99);
         ui.quick_feedback();
         #if HAS_LCD_MENU
           ui.capture();
@@ -435,7 +435,7 @@ inline bool turn_on_heaters() {
 
   // Start heating the active nozzle
   #if ENABLED(ULTRA_LCD)
-    ui.setstatusPGM(PSTR("G26 Heating Nozzle."), 99);
+    ui.set_status_P(PSTR("G26 Heating Nozzle."), 99);
     ui.quick_feedback();
   #endif
   thermalManager.setTargetHotend(g26_hotend_temp, active_extruder);
@@ -469,7 +469,7 @@ inline bool prime_nozzle() {
     if (g26_prime_flag == -1) {  // The user wants to control how much filament gets purged
 
       ui.capture();
-      ui.setstatusPGM(PSTR("User-Controlled Prime"), 99);
+      ui.set_status_P(PSTR("User-Controlled Prime"), 99);
       ui.chirp();
 
       set_destination_from_current();
@@ -493,7 +493,7 @@ inline bool prime_nozzle() {
 
       ui.wait_for_release();
 
-      ui.setstatusPGM(PSTR("Done Priming"), 99);
+      ui.set_status_P(PSTR("Done Priming"), 99);
       ui.quick_feedback();
       ui.release();
     }
@@ -501,7 +501,7 @@ inline bool prime_nozzle() {
   #endif
   {
     #if ENABLED(ULTRA_LCD)
-      ui.setstatusPGM(PSTR("Fixed Length Prime."), 99);
+      ui.set_status_P(PSTR("Fixed Length Prime."), 99);
       ui.quick_feedback();
     #endif
     set_destination_from_current();
@@ -894,7 +894,7 @@ void GcodeSuite::G26() {
   } while (--g26_repeats && location.x_index >= 0 && location.y_index >= 0);
 
   LEAVE:
-  ui.setstatusPGM(PSTR("Leaving G26"), -1);
+  ui.set_status_P(PSTR("Leaving G26"), -1);
 
   retract_filament(destination);
   destination[Z_AXIS] = Z_CLEARANCE_BETWEEN_PROBES;

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -522,7 +522,7 @@ void GcodeSuite::G33() {
   if (verbose_level == 0) SERIAL_PROTOCOLPGM(" (DRY-RUN)");
   if (set_up) SERIAL_PROTOCOLPGM("  (SET-UP)");
   SERIAL_EOL();
-  ui.setstatusPGM(checkingac);
+  ui.set_status_P(checkingac);
 
   print_calibration_settings(_endstop_results, _angle_results);
 
@@ -683,7 +683,7 @@ void GcodeSuite::G33() {
           sprintf_P(&mess[15], PSTR("0.%03i"), (int)LROUND(zero_std_dev_min * 1000.0));
         else
           sprintf_P(&mess[15], PSTR("%03i.x"), (int)LROUND(zero_std_dev_min));
-        ui.setstatus(mess);
+        ui.set_status(mess);
         print_calibration_settings(_endstop_results, _angle_results);
         serialprintPGM(save_message);
         SERIAL_EOL();
@@ -699,7 +699,7 @@ void GcodeSuite::G33() {
         SERIAL_PROTOCOLPGM("std dev:");
         SERIAL_PROTOCOL_F(zero_std_dev, 3);
         SERIAL_EOL();
-        ui.setstatus(mess);
+        ui.set_status(mess);
         if (verbose_level > 1)
           print_calibration_settings(_endstop_results, _angle_results);
       }
@@ -719,7 +719,7 @@ void GcodeSuite::G33() {
         sprintf_P(&mess[15], PSTR("0.%03i"), (int)LROUND(zero_std_dev * 1000.0));
       else
         sprintf_P(&mess[15], PSTR("%03i.x"), (int)LROUND(zero_std_dev));
-      ui.setstatus(mess);
+      ui.set_status(mess);
     }
     ac_home();
   }

--- a/Marlin/src/gcode/lcd/M0_M1.cpp
+++ b/Marlin/src/gcode/lcd/M0_M1.cpp
@@ -62,7 +62,7 @@ void GcodeSuite::M0_M1() {
   #if HAS_LCD_MENU
 
     if (has_message)
-      ui.setstatus(args, true);
+      ui.set_status(args, true);
     else {
       LCD_MESSAGEPGM(MSG_USERWAIT);
       #if ENABLED(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0

--- a/Marlin/src/gcode/lcd/M117.cpp
+++ b/Marlin/src/gcode/lcd/M117.cpp
@@ -28,6 +28,6 @@
  */
 void GcodeSuite::M117() {
 
-  ui.setstatus(parser.string_arg);
+  ui.set_status(parser.string_arg);
 
 }

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -28,6 +28,7 @@
 #include "../../sd/cardreader.h"
 #include "../../module/printcounter.h"
 #include "../../module/stepper.h"
+#include "../../lcd/ultralcd.h"
 
 #if ENABLED(POWER_LOSS_RECOVERY)
   #include "../../feature/power_loss_recovery.h"
@@ -100,6 +101,8 @@ void GcodeSuite::M24() {
     else
   #endif
       print_job_timer.start();
+
+  ui.reset_status();
 }
 
 /**

--- a/Marlin/src/gcode/stats/M31.cpp
+++ b/Marlin/src/gcode/stats/M31.cpp
@@ -40,7 +40,7 @@ void GcodeSuite::M31() {
   char buffer[21];
   duration_t elapsed = print_job_timer.duration();
   elapsed.toString(buffer);
-  ui.setstatus(buffer);
+  ui.set_status(buffer);
 
   SERIAL_ECHO_START_P(port);
   SERIAL_ECHOLNPAIR_P(port, "Print time: ", buffer);

--- a/Marlin/src/gcode/temperature/M140_M190.cpp
+++ b/Marlin/src/gcode/temperature/M140_M190.cpp
@@ -64,7 +64,7 @@ void GcodeSuite::M190() {
   }
   else return;
 
-  ui.setstatusPGM(thermalManager.isHeatingBed() ? PSTR(MSG_BED_HEATING) : PSTR(MSG_BED_COOLING));
+  ui.set_status_P(thermalManager.isHeatingBed() ? PSTR(MSG_BED_HEATING) : PSTR(MSG_BED_COOLING));
 
   thermalManager.wait_for_bed(no_wait_for_cooling);
 }

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -99,10 +99,6 @@ void ST7920_Lite_Status_Screen::write_str_P(PGM_P const str) {
   while (char c = pgm_read_byte(p_str++)) write_byte(c);
 }
 
-void ST7920_Lite_Status_Screen::write_str(progmem_str str) {
-  write_str_P((PGM_P)str);
-}
-
 void ST7920_Lite_Status_Screen::write_number(const int16_t value, const uint8_t digits/*=3*/) {
   char str[7];
   PGM_P fmt;
@@ -501,11 +497,11 @@ void ST7920_Lite_Status_Screen::draw_progress_bar(const uint8_t value) {
   // Draw centered
   if (value > 9) {
     write_number(value, 4);
-    write_str(F("% "));
+    write_str_P(PSTR("% "));
   }
   else {
     write_number(value, 3);
-    write_str(F("%  "));
+    write_str_P(PSTR("%  "));
   }
 }
 
@@ -558,12 +554,12 @@ void ST7920_Lite_Status_Screen::draw_temps(uint8_t line, const int16_t temp, con
   write_number(temp);
 
   if (showTarget) {
-    write_str(F("\x1A"));
+    write_byte('\x1A');
     write_number(target);
   };
 
   if (targetStateChange) {
-    if (!showTarget) write_str(F("    "));
+    if (!showTarget) write_str_P(PSTR("    "));
     draw_degree_symbol(5, line, !showTarget);
     draw_degree_symbol(9, line,  showTarget);
   }

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -18,8 +18,6 @@
 #include "../../core/macros.h"
 #include "../../libs/duration_t.h"
 
-typedef const __FlashStringHelper *progmem_str;
-
 class ST7920_Lite_Status_Screen {
   private:
     static struct st7920_state_t {
@@ -47,7 +45,6 @@ class ST7920_Lite_Status_Screen {
     static void write_str(const char *str);
     static void write_str(const char *str, const uint8_t len);
     static void write_str_P(PGM_P const str);
-    static void write_str(progmem_str str);
     static void write_number(const int16_t value, const uint8_t digits=3);
 
     static void _extended_function_set(const bool extended, const bool graphics);

--- a/Marlin/src/lcd/extensible_ui/lib/example.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/example.cpp
@@ -55,8 +55,7 @@ namespace ExtUI {
   void onPrintTimerPaused() {}
   void onPrintTimerStopped() {}
   void onFilamentRunout() {}
-  void onStatusChanged(const char* msg) {}
-  void onStatusChanged(progmem_str msg) {}
+  void onStatusChanged(const char * const msg) {}
   void onFactoryReset() {}
   void onLoadSettings() {}
   void onStoreSettings() {}

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -94,6 +94,7 @@ static struct {
 } flags;
 
 namespace ExtUI {
+
   #ifdef __SAM3X8E__
     /**
      * Implement a special millis() to allow time measurement
@@ -134,12 +135,7 @@ namespace ExtUI {
       return (uint32_t)(currTime / (F_CPU / 8000));
     }
 
-  #else
-
-    // TODO: Implement for AVR
-    FORCE_INLINE uint32_t safe_millis() { return millis(); }
-
-  #endif
+  #endif // __SAM3X8E__
 
   void delay_us(unsigned long us) {
     DELAY_US(us);
@@ -287,12 +283,14 @@ namespace ExtUI {
   }
 
   void setActiveTool(const extruder_t extruder, bool no_move) {
-    const uint8_t e = extruder - E0;
-    #if DO_SWITCH_EXTRUDER || ENABLED(SWITCHING_NOZZLE) || ENABLED(PARKING_EXTRUDER)
-      if (e != active_extruder)
-        tool_change(e, 0, no_move);
+    #if EXTRUDERS > 1
+      const uint8_t e = extruder - E0;
+      #if DO_SWITCH_EXTRUDER || ENABLED(SWITCHING_NOZZLE) || ENABLED(PARKING_EXTRUDER)
+        if (e != active_extruder)
+          tool_change(e, 0, no_move);
+      #endif
+      active_extruder = e;
     #endif
-    active_extruder = e;
   }
 
   extruder_t getActiveTool() {
@@ -533,24 +531,26 @@ namespace ExtUI {
 
   float getFeedrate_percent() { return feedrate_percentage; }
 
-  void enqueueCommands(progmem_str gcode) {
-    enqueue_and_echo_commands_P((PGM_P)gcode);
+  void enqueueCommands_P(PGM_P const gcode) {
+    enqueue_and_echo_commands_P(gcode);
   }
 
   bool isAxisPositionKnown(const axis_t axis) {
     return TEST(axis_known_position, axis);
   }
 
-  progmem_str getFirmwareName_str() {
-    return F("Marlin " SHORT_BUILD_VERSION);
+  PGM_P getFirmwareName_str() {
+    static const char firmware_name[] PROGMEM = "Marlin " SHORT_BUILD_VERSION;
+    return firmware_name;
   }
 
   void setTargetTemp_celsius(float value, const heater_t heater) {
     #if HAS_HEATED_BED
-    if (heater == BED)
-      thermalManager.setTargetBed(clamp(value,0,200));
+      if (heater == BED)
+        thermalManager.setTargetBed(clamp(value,0,200));
+      else
     #endif
-      thermalManager.setTargetHotend(clamp(value,0,500), heater - H0);
+        thermalManager.setTargetHotend(clamp(value,0,500), heater - H0);
   }
 
   void setTargetTemp_celsius(float value, const extruder_t extruder) {
@@ -579,7 +579,7 @@ namespace ExtUI {
   }
 
   bool isPrinting() {
-    return (planner.movesplanned() || IS_SD_PRINTING() || isPrintingFromMedia());
+    return (planner.movesplanned() || isPrintingFromMedia() || IFSD(IS_SD_PRINTING(), false));
   }
 
   bool isMediaInserted() {
@@ -593,19 +593,20 @@ namespace ExtUI {
       #if ENABLED(PARK_HEAD_ON_PAUSE)
         enqueue_and_echo_commands_P(PSTR("M125"));
       #endif
-      ExtUI::onStatusChanged(PSTR(MSG_PRINT_PAUSED));
+      ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
     #endif
   }
 
   void resumePrint() {
     #if ENABLED(SDSUPPORT)
+      ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
       #if ENABLED(PARK_HEAD_ON_PAUSE)
+        wait_for_heatup = wait_for_user = false;
         enqueue_and_echo_commands_P(PSTR("M24"));
       #else
         card.startFileprint();
         print_job_timer.start();
       #endif
-      ExtUI::onStatusChanged(PSTR(MSG_PRINTING));
     #endif
   }
 
@@ -613,7 +614,7 @@ namespace ExtUI {
     #if ENABLED(SDSUPPORT)
       wait_for_heatup = wait_for_user = false;
       card.flag.abort_sd_printing = true;
-      ExtUI::onStatusChanged(PSTR(MSG_PRINT_ABORTED));
+      ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
     #endif
   }
 
@@ -621,7 +622,7 @@ namespace ExtUI {
 
   void FileList::refresh() { num_files = 0xFFFF; }
 
-  bool FileList::seek(uint16_t pos, bool skip_range_check) {
+  bool FileList::seek(const uint16_t pos, const bool skip_range_check) {
     #if ENABLED(SDSUPPORT)
       if (!skip_range_check && pos > (count() - 1)) return false;
       const uint16_t nr =
@@ -632,6 +633,8 @@ namespace ExtUI {
 
       card.getfilename_sorted(nr);
       return card.filename && card.filename[0] != '\0';
+    #else
+      return false;
     #endif
   }
 
@@ -671,7 +674,7 @@ namespace ExtUI {
     #endif
   }
 
-  void FileList::changeDir(const char *dirname) {
+  void FileList::changeDir(const char * const dirname) {
     #if ENABLED(SDSUPPORT)
       card.chdir(dirname);
       num_files = 0xFFFF;
@@ -711,20 +714,6 @@ void MarlinUI::update() {
   #endif // SDSUPPORT
   ExtUI::_processManualMoveToDestination();
   ExtUI::onIdle();
-}
-
-void MarlinUI::setstatus(const char * const message, const bool persist/*=false*/)  { ExtUI::onStatusChanged(message); }
-void MarlinUI::setstatusPGM(PGM_P const message, int8_t level/*=0*/)                { ExtUI::onStatusChanged((progmem_str)message); }
-void MarlinUI::setalertstatusPGM(PGM_P const message)                               { setstatusPGM(message, 0); }
-
-void MarlinUI::status_printf_P(const uint8_t level, const char * const fmt, ...) {
-  char buff[64];
-  va_list args;
-  va_start(args, fmt);
-  vsnprintf_P(buff, sizeof(buff), fmt, args);
-  va_end(args);
-  buff[63] = '\0';
-  ExtUI::onStatusChanged(buff);
 }
 
 void MarlinUI::kill_screen(PGM_P const msg) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -45,8 +45,6 @@
 
 #include "../../inc/MarlinConfig.h"
 
-typedef const __FlashStringHelper *progmem_str;
-
 namespace ExtUI {
 
   enum axis_t     : uint8_t { X, Y, Z };
@@ -62,13 +60,13 @@ namespace ExtUI {
   bool isAxisPositionKnown(const axis_t);
   bool canMove(const axis_t);
   bool canMove(const extruder_t);
-  void enqueueCommands(progmem_str);
+  void enqueueCommands_P(PGM_P const);
 
   /**
    * Getters and setters
    * Should be used by the EXTENSIBLE_UI to query or change Marlin's state.
    */
-  progmem_str getFirmwareName_str();
+  PGM_P getFirmwareName_str();
 
   float getActualTemp_celsius(const heater_t);
   float getActualTemp_celsius(const extruder_t);
@@ -178,7 +176,12 @@ namespace ExtUI {
    * safe_millis must be called at least every 1 sec to guarantee time
    * yield should be called within lengthy loops
    */
-  uint32_t safe_millis();
+  #ifdef __SAM3X8E__
+    uint32_t safe_millis();
+  #else
+    #define safe_millis() millis() // TODO: Implement for AVR
+  #endif
+
   void delay_us(unsigned long us);
   void delay_ms(unsigned long ms);
   void yield();
@@ -205,14 +208,14 @@ namespace ExtUI {
     public:
       FileList();
       void refresh();
-      bool seek(uint16_t, bool skip_range_check = false);
+      bool seek(const uint16_t, const bool skip_range_check = false);
 
       const char *longFilename();
       const char *shortFilename();
       const char *filename();
       bool isDir();
 
-      void changeDir(const char *dirname);
+      void changeDir(const char * const dirname);
       void upDir();
       bool isAtRootDir();
       uint16_t    count();
@@ -234,8 +237,7 @@ namespace ExtUI {
   void onPrintTimerPaused();
   void onPrintTimerStopped();
   void onFilamentRunout();
-  void onStatusChanged(const char* msg);
-  void onStatusChanged(progmem_str msg);
+  void onStatusChanged(const char * const msg);
   void onFactoryReset();
   void onStoreSettings();
   void onLoadSettings();

--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -480,7 +480,7 @@ void MarlinUI::init() {
 /**
  * Set an alert.
  */
-void MarlinUI::setalertstatusPGM(PGM_P const message) {
+void MarlinUI::set_alert_status_P(PGM_P const message) {
   write_to_lcd_P(PSTR("{E:"));
   write_to_lcd_P(message);
   write_to_lcd_P("}");

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -59,7 +59,7 @@
   void lcd_sdcard_stop() {
     wait_for_heatup = wait_for_user = false;
     card.flag.abort_sd_printing = true;
-    ui.setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
+    ui.set_status_P(PSTR(MSG_PRINT_ABORTED), -1);
     ui.return_to_status();
   }
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -243,14 +243,21 @@ public:
   #if HAS_SPI_LCD || ENABLED(MALYAN_LCD) || ENABLED(EXTENSIBLE_UI)
     static void init();
     static void update();
-    static void setalertstatusPGM(PGM_P message);
+    static void set_alert_status_P(PGM_P message);
   #else // NO LCD
     static inline void init() {}
     static inline void update() {}
-    static inline void setalertstatusPGM(PGM_P message) { UNUSED(message); }
+    static inline void set_alert_status_P(PGM_P message) { UNUSED(message); }
   #endif
 
   #if HAS_SPI_LCD || ENABLED(EXTENSIBLE_UI)
+
+    static char status_message[];
+    static bool has_status();
+
+
+    static uint8_t status_message_level;      // Higher levels block lower levels
+    static inline void reset_alert_level() { status_message_level = 0; }
 
     #if HAS_SPI_LCD
 
@@ -296,16 +303,10 @@ public:
 
       #endif
 
-      // Status message
-      static char status_message[];
       #if ENABLED(STATUS_MESSAGE_SCROLLING)
         static uint8_t status_scroll_offset;
       #endif
-      static bool has_status();
-
       static uint8_t lcd_status_update_delay;
-      static uint8_t status_message_level;      // Higher levels block lower levels
-      static inline void reset_alert_level() { status_message_level = 0; }
 
       #if HAS_PRINT_PROGRESS
         #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
@@ -341,26 +342,22 @@ public:
       static void status_screen();
 
     #else
-
       static void refresh() {}
-      static inline void reset_alert_level() {}
-      static constexpr bool has_status() { return true; }
-
     #endif
 
     static bool get_blink();
     static void kill_screen(PGM_P const lcd_msg);
     static void draw_kill_screen();
-    static void setstatus(const char* const message, const bool persist=false);
-    static void setstatusPGM(PGM_P const message, const int8_t level=0);
+    static void set_status(const char* const message, const bool persist=false);
+    static void set_status_P(PGM_P const message, const int8_t level=0);
     static void status_printf_P(const uint8_t level, PGM_P const fmt, ...);
     static void reset_status();
 
   #else // MALYAN_LCD or NO LCD
 
     static inline void refresh() {}
-    static inline void setstatus(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
-    static inline void setstatusPGM(PGM_P const message, const int8_t level=0) { UNUSED(message); UNUSED(level); }
+    static inline void set_status(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
+    static inline void set_status_P(PGM_P const message, const int8_t level=0) { UNUSED(message); UNUSED(level); }
     static inline void status_printf_P(const uint8_t level, PGM_P const fmt, ...) { UNUSED(level); UNUSED(fmt); }
     static inline void reset_status() {}
     static inline void reset_alert_level() {}
@@ -508,6 +505,10 @@ private:
 
   static void _synchronize();
 
+  #if HAS_SPI_LCD || ENABLED(EXTENSIBLE_UI)
+    static void finishstatus(const bool persist);
+  #endif
+
   #if HAS_SPI_LCD
     #if HAS_LCD_MENU
       #if LCD_TIMEOUT_TO_STATUS
@@ -517,13 +518,10 @@ private:
       #endif
     #endif
     static void draw_status_screen();
-    static void finishstatus(const bool persist);
-  #else
-    static inline void finishstatus(const bool persist) { UNUSED(persist); refresh(); }
   #endif
 };
 
 extern MarlinUI ui;
 
-#define LCD_MESSAGEPGM(x)      ui.setstatusPGM(PSTR(x))
-#define LCD_ALERTMESSAGEPGM(x) ui.setalertstatusPGM(PSTR(x))
+#define LCD_MESSAGEPGM(x)      ui.set_status_P(PSTR(x))
+#define LCD_ALERTMESSAGEPGM(x) ui.set_alert_status_P(PSTR(x))

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -371,7 +371,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
 
     PGM_P const ds_str = deploy ? PSTR(MSG_MANUAL_DEPLOY) : PSTR(MSG_MANUAL_STOW);
     ui.return_to_status();       // To display the new status message
-    ui.setstatusPGM(ds_str, 99);
+    ui.set_status_P(ds_str, 99);
     serialprintPGM(ds_str);
     SERIAL_EOL();
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2464,7 +2464,7 @@ void Temperature::isr() {
       #if HOTENDS > 1
         ui.status_printf_P(0, heating ? PSTR("E%i " MSG_HEATING) : PSTR("E%i " MSG_COOLING), int(e + 1));
       #else
-        ui.setstatusPGM(heating ? PSTR("E " MSG_HEATING) : PSTR("E " MSG_COOLING));
+        ui.set_status_P(heating ? PSTR("E " MSG_HEATING) : PSTR("E " MSG_COOLING));
       #endif
     }
   #endif

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -521,7 +521,7 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
       SERIAL_PROTOCOLLNPGM(MSG_SD_FILE_SELECTED);
 
       getfilename(0, fname);
-      ui.setstatus(longFilename[0] ? longFilename : fname);
+      ui.set_status(longFilename[0] ? longFilename : fname);
       //if (longFilename[0]) {
       //  SERIAL_PROTOCOLPAIR(MSG_SD_FILE_LONG_NAME, longFilename);
       //}
@@ -545,7 +545,7 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
         emergency_parser.disable();
       #endif
       SERIAL_PROTOCOLLNPAIR(MSG_SD_WRITE_TO_FILE, fname);
-      ui.setstatus(fname);
+      ui.set_status(fname);
     }
   }
 }


### PR DESCRIPTION
This is workaround to an issue where M24 requires M108, as reported in #12437. Should M24 maybe clear `wait_for_user` on its own?

Despite this fix, there is still an annoying bug where somewhere in "M24" the LCD message string gets reset to "Print paused". This is a bit frustrating since the user sees "Print paused" immediately after pushing the button for the print be resumed. It would be nice if "M24" would either not update the status or said "Print resuming..." instead.