### PR TITLE
Enable SD Card on RepRap Display and RADDS

### DIFF
--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -246,6 +246,10 @@
     #define BTN_EN2         52
     #define BTN_ENC         48
 
+    #undef SDSS
+    #define SDSS            10
+    #define SD_DETECT_PIN   14
+
   #elif ENABLED(SSD1306_OLED_I2C_CONTROLLER)
 
     #define BTN_EN1         50

--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -193,7 +193,6 @@
 //
 // Misc. Functions
 //
-#define SDSS                4
 #define SD_DETECT_PIN      14
 #define PS_ON_PIN          40   // SERVO3_PIN
 
@@ -227,7 +226,6 @@
 
     #define BTN_BACK        71
 
-    #undef SDSS
     #define SDSS            10
     #define SD_DETECT_PIN   14
 
@@ -246,7 +244,6 @@
     #define BTN_EN2         52
     #define BTN_ENC         48
 
-    #undef SDSS
     #define SDSS            10
     #define SD_DETECT_PIN   14
 
@@ -272,3 +269,7 @@
   #endif // SPARK_FULL_GRAPHICS
 
 #endif // ULTRA_LCD
+
+#ifndef SDSS
+  #define SDSS              4
+#endif


### PR DESCRIPTION
### Description

With this PR the neccessary pins in radds.h are defined (just copied from directly above from the section of the RADDS_DISPLAY) for the use of the SD card slot.

### Benefits

With this fix you can use the SD Slot on the RepRap Discount Fall Graphics Display which is connected to a RADDS Board (via https://www.thingiverse.com/thing:1740725)

### Related Issues

Marlin didn't show the content of a SD Card with a RepRap Discount Full Graphic Display connected to a RADDS board via adapter even if the SDSUPPORT is set. A plugged in or unplugged and replugged SD card was recognized in the info screen but the main menu shows, that there was no SD card detected and didn't show any content of the card.