### PR TITLE
Consolidate LCD scrolling filename code

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -112,9 +112,37 @@ millis_t next_button_update_ms;
 
 #if HAS_LCD_MENU
   #include "menu/menu.h"
+  #include "../sd/cardreader.h"
 
-  #if ENABLED(SDSUPPORT) && ENABLED(SCROLL_LONG_FILENAMES)
-    uint8_t MarlinUI::filename_scroll_pos, MarlinUI::filename_scroll_max;
+  #if ENABLED(SDSUPPORT)
+
+    #if ENABLED(SCROLL_LONG_FILENAMES)
+      uint8_t MarlinUI::filename_scroll_pos, MarlinUI::filename_scroll_max;
+    #endif
+
+    const char * const MarlinUI::scrolled_filename(CardReader &theCard, const uint8_t maxlen, uint8_t hash, const bool doScroll) {
+      const char *outstr = theCard.longest_filename();
+      if (theCard.longFilename[0]) {
+        #if ENABLED(SCROLL_LONG_FILENAMES)
+          if (doScroll) {
+            for (uint8_t l = FILENAME_LENGTH; l--;)
+              hash = ((hash << 1) | (hash >> 7)) ^ theCard.filename[l];      // rotate, xor
+            static uint8_t filename_scroll_hash;
+            if (filename_scroll_hash != hash) {                              // If the hash changed...
+              filename_scroll_hash = hash;                                   // Save the new hash
+              filename_scroll_max = MAX(0, utf8_strlen(theCard.longFilename) - maxlen); // Update the scroll limit
+              filename_scroll_pos = 0;                                       // Reset scroll to the start
+              lcd_status_update_delay = 8;                                   // Don't scroll right away
+            }
+            outstr += filename_scroll_pos;
+          }
+        #else
+          theCard.longFilename[maxlen] = '\0'; // cutoff at screen edge
+        #endif
+      }
+      return outstr;
+    }
+
   #endif
 
   screenFunc_t MarlinUI::currentScreen; // Initialized in CTOR

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -23,6 +23,12 @@
 
 #include "../inc/MarlinConfig.h"
 
+#if HAS_BUZZER
+  #include "../libs/buzzer.h"
+#endif
+
+#define HAS_ENCODER_ACTION (HAS_LCD_MENU || ENABLED(ULTIPANEL_FEEDMULTIPLY))
+
 #if HAS_SPI_LCD
 
   #include "../Marlin.h"
@@ -31,16 +37,6 @@
     #include "../feature/pause.h"
     #include "../module/motion.h" // for active_extruder
   #endif
-
-#endif
-
-#if HAS_BUZZER
-  #include "../libs/buzzer.h"
-#endif
-
-#define HAS_ENCODER_ACTION (HAS_LCD_MENU || ENABLED(ULTIPANEL_FEEDMULTIPLY))
-
-#if HAS_SPI_LCD
 
   enum LCDViewAction : uint8_t {
     LCDVIEW_NONE,
@@ -65,6 +61,10 @@
   #define LCD_UPDATE_INTERVAL 100
 
   #if HAS_LCD_MENU
+
+    #if ENABLED(SDSUPPORT)
+      #include "../sd/cardreader.h"
+    #endif
 
     typedef void (*screenFunc_t)();
     typedef void (*menuAction_t)();
@@ -212,9 +212,6 @@
     FONT_MENU
   };
 #endif
-
-#define LCD_MESSAGEPGM(x)      ui.setstatusPGM(PSTR(x))
-#define LCD_ALERTMESSAGEPGM(x) ui.setalertstatusPGM(PSTR(x))
 
 ////////////////////////////////////////////
 //////////// MarlinUI Singleton ////////////
@@ -379,8 +376,11 @@ public:
       static void enable_encoder_multiplier(const bool onoff);
     #endif
 
-    #if ENABLED(SCROLL_LONG_FILENAMES)
-      static uint8_t filename_scroll_pos, filename_scroll_max;
+    #if ENABLED(SDSUPPORT)
+      #if ENABLED(SCROLL_LONG_FILENAMES)
+        static uint8_t filename_scroll_pos, filename_scroll_max;
+      #endif
+      static const char * const scrolled_filename(CardReader &theCard, const uint8_t maxlen, uint8_t hash, const bool doScroll);
     #endif
 
     #if IS_KINEMATIC
@@ -524,3 +524,6 @@ private:
 };
 
 extern MarlinUI ui;
+
+#define LCD_MESSAGEPGM(x)      ui.setstatusPGM(PSTR(x))
+#define LCD_ALERTMESSAGEPGM(x) ui.setalertstatusPGM(PSTR(x))


### PR DESCRIPTION
Move the LCD filename scrolling logic into `MarlinUI` to save ~562 bytes.