### PR TITLE
Make CardReader class static

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -19,7 +19,7 @@ void sd_mmc_spi_mem_init(void) {
 }
 
 Ctrl_status sd_mmc_spi_test_unit_ready(void) {
-  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.cardOK)
+  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.flag.cardOK)
     return CTRL_NO_PRESENT;
   return CTRL_GOOD;
 }
@@ -27,7 +27,7 @@ Ctrl_status sd_mmc_spi_test_unit_ready(void) {
 // NOTE: This function is defined as returning the address of the last block
 // in the card, which is cardSize() - 1
 Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector) {
-  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.cardOK)
+  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.flag.cardOK)
     return CTRL_NO_PRESENT;
   *nb_sector = card.getSd2Card().cardSize() - 1;
   return CTRL_GOOD;
@@ -42,7 +42,7 @@ bool sd_mmc_spi_wr_protect(void) {
 }
 
 bool sd_mmc_spi_removal(void) {
-  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.cardOK)
+  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.flag.cardOK)
     return true;
   return false;
 }
@@ -61,7 +61,7 @@ uint8_t sector_buf[SD_MMC_BLOCK_SIZE];
 // #define DEBUG_MMC
 
 Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
-  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.cardOK)
+  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.flag.cardOK)
     return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
@@ -95,7 +95,7 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
 }
 
 Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
-  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.cardOK)
+  if (!IS_SD_INSERTED() || IS_SD_PRINTING() || IS_SD_FILE_OPEN() || !card.flag.cardOK)
     return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC

--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -106,7 +106,7 @@ void HAL_idletask(void) {
     // the disk if Marlin has it mounted. Unfortuately there is currently no way
     // to unmount the disk from the LCD menu.
     // if (IS_SD_PRINTING() || IS_SD_FILE_OPEN())
-    if (card.cardOK)
+    if (card.flag.cardOK)
       MSC_Aquire_Lock();
     else
       MSC_Release_Lock();

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -41,7 +41,7 @@ char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
 char eeprom_filename[] = "eeprom.dat";
 
 bool PersistentStore::access_start() {
-  if (!card.cardOK) return false;
+  if (!card.flag.cardOK) return false;
   int16_t bytes_read = 0;
   constexpr char eeprom_zero = 0xFF;
   card.openFile(eeprom_filename, true);
@@ -54,7 +54,7 @@ bool PersistentStore::access_start() {
 }
 
 bool PersistentStore::access_finish() {
-  if (!card.cardOK) return false;
+  if (!card.flag.cardOK) return false;
   card.openFile(eeprom_filename, true);
   int16_t bytes_written = card.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
   card.closefile();

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -967,7 +967,7 @@ void loop() {
     #if ENABLED(SDSUPPORT)
       card.checkautostart();
 
-      if (card.abort_sd_printing) {
+      if (card.flag.abort_sd_printing) {
         card.stopSDPrint(
           #if SD_RESORT
             true

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -84,8 +84,8 @@ void PrintJobRecovery::changed() {
  */
 void PrintJobRecovery::check() {
   if (enabled) {
-    if (!card.cardOK) card.initsd();
-    if (card.cardOK) {
+    if (!card.flag.cardOK) card.initsd();
+    if (card.flag.cardOK) {
       load();
       if (!valid()) return purge();
       enqueue_and_echo_commands_P(PSTR("M1000 S"));

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -68,7 +68,7 @@ typedef struct {
   char command_queue[BUFSIZE][MAX_CMD_SIZE];
 
   // SD Filename and position
-  char sd_filename[MAXPATHNAMELENGTH];
+  char sd_filename[MAXPATHNAMELENGTH + 1];
   uint32_t sdpos;
 
   // Job elapsed time

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -503,7 +503,7 @@ static int read_serial(const uint8_t index) {
             break;
           case StreamState::STREAM_COMPLETE:
             stream_state = StreamState::STREAM_RESET;
-            card.binary_mode = false;
+            card.flag.binary_mode = false;
             card.closefile();
             CARD_ECHO_P("echo: ");
             CARD_ECHO_P(card.filename);
@@ -514,7 +514,7 @@ static int read_serial(const uint8_t index) {
             return;
           case StreamState::STREAM_FAILED:
             stream_state = StreamState::STREAM_RESET;
-            card.binary_mode = false;
+            card.flag.binary_mode = false;
             card.closefile();
             card.removeFile(card.filename);
             CARD_ECHOLN_P("echo: File transfer failed");
@@ -549,7 +549,7 @@ inline void get_serial_commands() {
             ;
 
   #if ENABLED(FAST_FILE_TRANSFER)
-    if (card.saving && card.binary_mode) {
+    if (card.flag.saving && card.flag.binary_mode) {
       /**
        * For binary stream file transfer, use serial_line_buffer as the working
        * receive buffer (which limits the packet size to MAX_CMD_SIZE).
@@ -630,7 +630,7 @@ inline void get_serial_commands() {
           gcode_LastN = gcode_N;
         }
         #if ENABLED(SDSUPPORT)
-          else if (card.saving && strcmp(command, "M29") != 0) // No line number with M29 in Pronterface
+          else if (card.flag.saving && strcmp(command, "M29") != 0) // No line number with M29 in Pronterface
             return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM), i);
         #endif
 
@@ -838,7 +838,7 @@ void advance_command_queue() {
 
   #if ENABLED(SDSUPPORT)
 
-    if (card.saving) {
+    if (card.flag.saving) {
       char* command = command_queue[cmd_queue_index_r];
       if (strstr_P(command, PSTR("M29"))) {
         // M29 closes the file
@@ -860,7 +860,7 @@ void advance_command_queue() {
       else {
         // Write the string from the read buffer to SD
         card.write_command(command);
-        if (card.logging)
+        if (card.flag.logging)
           gcode.process_next_command(); // The card is saving because it's logging
         else
           ok_to_send();

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -118,7 +118,7 @@ void GcodeSuite::M25() {
  * M26: Set SD Card file index
  */
 void GcodeSuite::M26() {
-  if (card.cardOK && parser.seenval('S'))
+  if (card.flag.cardOK && parser.seenval('S'))
     card.setIndex(parser.value_long());
 }
 
@@ -178,7 +178,7 @@ void GcodeSuite::M28() {
     }
 
     // Binary transfer mode
-    if ((card.binary_mode = binary_mode)) {
+    if ((card.flag.binary_mode = binary_mode)) {
       SERIAL_ECHO_START_P(port);
       SERIAL_ECHO_P(port, " preparing to receive: ");
       SERIAL_ECHOLN_P(port, p);
@@ -202,14 +202,14 @@ void GcodeSuite::M28() {
  * Processed in write to file routine
  */
 void GcodeSuite::M29() {
-  // card.saving = false;
+  // card.flag.saving = false;
 }
 
 /**
  * M30 <filename>: Delete SD Card file
  */
 void GcodeSuite::M30() {
-  if (card.cardOK) {
+  if (card.flag.cardOK) {
     card.closefile();
     card.removeFile(parser.string_arg);
   }
@@ -228,7 +228,7 @@ void GcodeSuite::M30() {
 void GcodeSuite::M32() {
   if (IS_SD_PRINTING()) planner.synchronize();
 
-  if (card.cardOK) {
+  if (card.flag.cardOK) {
     const bool call_procedure = parser.boolval('P');
 
     card.openFile(parser.string_arg, true, call_procedure);
@@ -286,7 +286,7 @@ void GcodeSuite::M32() {
  * M524: Abort the current SD print job (started with M24)
  */
 void GcodeSuite::M524() {
-  if (IS_SD_PRINTING()) card.abort_sd_printing = true;
+  if (IS_SD_PRINTING()) card.flag.abort_sd_printing = true;
 }
 
 /**

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -575,7 +575,7 @@ namespace ExtUI {
   }
 
   bool isPrintingFromMedia() {
-    return IFSD(card.cardOK && card.isFileOpen(), false);
+    return IFSD(card.flag.cardOK && card.isFileOpen(), false);
   }
 
   bool isPrinting() {
@@ -583,7 +583,7 @@ namespace ExtUI {
   }
 
   bool isMediaInserted() {
-    return IFSD(IS_SD_INSERTED() && card.cardOK, false);
+    return IFSD(IS_SD_INSERTED() && card.flag.cardOK, false);
   }
 
   void pausePrint() {
@@ -612,7 +612,7 @@ namespace ExtUI {
   void stopPrint() {
     #if ENABLED(SDSUPPORT)
       wait_for_heatup = wait_for_user = false;
-      card.abort_sd_printing = true;
+      card.flag.abort_sd_printing = true;
       ExtUI::onStatusChanged(PSTR(MSG_PRINT_ABORTED));
     #endif
   }
@@ -648,7 +648,7 @@ namespace ExtUI {
   }
 
   bool FileList::isDir() {
-    return IFSD(card.filenameIsDir, false);
+    return IFSD(card.flag.filenameIsDir, false);
   }
 
   uint16_t FileList::count() {
@@ -697,13 +697,13 @@ void MarlinUI::update() {
       last_sd_status = sd_status;
       if (sd_status) {
         card.initsd();
-        if (card.cardOK)
+        if (card.flag.cardOK)
           ExtUI::onMediaInserted();
         else
           ExtUI::onMediaError();
       }
       else {
-        const bool ok = card.cardOK;
+        const bool ok = card.flag.cardOK;
         card.release();
         if (ok) ExtUI::onMediaRemoved();
       }

--- a/Marlin/src/lcd/malyanlcd.cpp
+++ b/Marlin/src/lcd/malyanlcd.cpp
@@ -278,7 +278,7 @@ void process_lcd_p_command(const char* command) {
         // There may be a difference in how V1 and V2 LCDs handle subdirectory
         // prints. Investigate more. This matches the V1 motion controller actions
         // but the V2 LCD switches to "print" mode on {SYS:DIR} response.
-        if (card.filenameIsDir) {
+        if (card.flag.filenameIsDir) {
           card.chdir(card.filename);
           write_to_lcd_P(PSTR("{SYS:DIR}"));
         }
@@ -330,7 +330,7 @@ void process_lcd_s_command(const char* command) {
 
     case 'L': {
       #if ENABLED(SDSUPPORT)
-        if (!card.cardOK) card.initsd();
+        if (!card.flag.cardOK) card.initsd();
 
         // A more efficient way to do this would be to
         // implement a callback in the ls_SerialPrint code, but
@@ -342,7 +342,7 @@ void process_lcd_s_command(const char* command) {
         uint16_t file_count = card.get_num_Files();
         for (uint16_t i = 0; i < file_count; i++) {
           card.getfilename(i);
-          sprintf_P(message_buffer, card.filenameIsDir ? PSTR("{DIR:%s}") : PSTR("{FILE:%s}"), card.longest_filename());
+          sprintf_P(message_buffer, card.flag.filenameIsDir ? PSTR("{DIR:%s}") : PSTR("{FILE:%s}"), card.longest_filename());
           write_to_lcd(message_buffer);
         }
 

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -58,7 +58,7 @@
 
   void lcd_sdcard_stop() {
     wait_for_heatup = wait_for_user = false;
-    card.abort_sd_printing = true;
+    card.flag.abort_sd_printing = true;
     ui.setstatusPGM(PSTR(MSG_PRINT_ABORTED), -1);
     ui.return_to_status();
   }
@@ -86,7 +86,7 @@ void menu_main() {
   MENU_BACK(MSG_WATCH);
 
   #if ENABLED(SDSUPPORT)
-    if (card.cardOK) {
+    if (card.flag.cardOK) {
       if (card.isFileOpen()) {
         if (IS_SD_PRINTING())
           MENU_ITEM(function, MSG_PAUSE_PRINT, lcd_sdcard_pause);

--- a/Marlin/src/lcd/menu/menu_sdcard.cpp
+++ b/Marlin/src/lcd/menu/menu_sdcard.cpp
@@ -125,7 +125,7 @@ void menu_sdcard() {
 
       card.getfilename_sorted(nr);
 
-      if (card.filenameIsDir)
+      if (card.flag.filenameIsDir)
         MENU_ITEM(sdfolder, MSG_CARD_MENU, card);
       else
         MENU_ITEM(sdfile, MSG_CARD_MENU, card);

--- a/Marlin/src/sd/SdFatConfig.h
+++ b/Marlin/src/sd/SdFatConfig.h
@@ -106,7 +106,7 @@
  * Defines for 8.3 and long (vfat) filenames
  */
 
-#define FILENAME_LENGTH 13 // Number of UTF-16 characters per entry
+#define FILENAME_LENGTH 12 // Number of UTF-16 characters per entry
 
 // Total bytes needed to store a single long filename
-#define LONG_FILENAME_LENGTH (FILENAME_LENGTH * MAX_VFAT_ENTRIES + 1)
+#define LONG_FILENAME_LENGTH ((FILENAME_LENGTH) * (MAX_VFAT_ENTRIES))

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -35,6 +35,19 @@
 
 enum LsAction : uint8_t { LS_SerialPrint, LS_Count, LS_GetFilename };
 
+typedef struct {
+  bool saving:1,
+       logging:1,
+       sdprinting:1,
+       cardOK:1,
+       filenameIsDir:1,
+       abort_sd_printing:1
+       #if ENABLED(FAST_FILE_TRANSFER)
+         , binary_mode:1
+       #endif
+    ;
+} card_flags_t;
+
 class CardReader {
 public:
   CardReader();
@@ -113,7 +126,7 @@ public:
     static void removeJobRecoveryFile();
   #endif
 
-  static inline void pauseSDPrint() { sdprinting = false; }
+  static inline void pauseSDPrint() { flag.sdprinting = false; }
   static inline bool isFileOpen() { return file.isOpen(); }
   static inline bool eof() { return sdpos >= filesize; }
   static inline int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
@@ -145,12 +158,11 @@ public:
   static inline char* longest_filename() { return longFilename[0] ? longFilename : filename; }
 
 public:
-  static bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
+  static card_flags_t flag;
   static char filename[FILENAME_LENGTH + 1], longFilename[LONG_FILENAME_LENGTH + 1];
   static int8_t autostart_index;
 
   #if ENABLED(FAST_FILE_TRANSFER)
-    static bool binary_mode;
     #if NUM_SERIAL > 1
       static uint8_t transfer_port;
     #else
@@ -261,7 +273,7 @@ private:
   #define IS_SD_INSERTED() true
 #endif
 
-#define IS_SD_PRINTING()  card.sdprinting
+#define IS_SD_PRINTING()  card.flag.sdprinting
 #define IS_SD_FILE_OPEN() card.isFileOpen()
 
 extern CardReader card;

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -27,7 +27,9 @@
 
 #define SD_RESORT ENABLED(SDCARD_SORT_ALPHA) && ENABLED(SDSORT_DYNAMIC_RAM)
 
-#define MAX_DIR_DEPTH 10          // Maximum folder depth
+#define MAX_DIR_DEPTH     10       // Maximum folder depth
+#define MAXDIRNAMELENGTH   8       // DOS folder name size
+#define MAXPATHNAMELENGTH  (1 + (MAXDIRNAMELENGTH + 1) * (MAX_DIR_DEPTH) + 1 + FILENAME_LENGTH) // "/" + N * ("ADIRNAME/") + "filename.ext"
 
 #include "SdFile.h"
 
@@ -37,96 +39,96 @@ class CardReader {
 public:
   CardReader();
 
-  void initsd();
-  void write_command(char *buf);
+  static void initsd();
+  static void write_command(char *buf);
 
-  void beginautostart();
-  void checkautostart();
+  static void beginautostart();
+  static void checkautostart();
 
-  void openFile(char * const path, const bool read, const bool subcall=false);
-  void openLogFile(char * const path);
-  void removeFile(const char * const name);
-  void closefile(const bool store_location=false);
-  void release();
-  void openAndPrintFile(const char *name);
-  void startFileprint();
-  void stopSDPrint(
+  static void openFile(char * const path, const bool read, const bool subcall=false);
+  static void openLogFile(char * const path);
+  static void removeFile(const char * const name);
+  static void closefile(const bool store_location=false);
+  static void release();
+  static void openAndPrintFile(const char *name);
+  static void startFileprint();
+  static void stopSDPrint(
     #if SD_RESORT
       const bool re_sort=false
     #endif
   );
-  void getStatus(
+  static void getStatus(
     #if NUM_SERIAL > 1
       const int8_t port = -1
     #endif
   );
-  void printingHasFinished();
-  void printFilename(
+  static void printingHasFinished();
+  static void printFilename(
     #if NUM_SERIAL > 1
       const int8_t port = -1
     #endif
   );
 
   #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
-    void printLongPath(char *path
+    static void printLongPath(char *path
       #if NUM_SERIAL > 1
         , const int8_t port = -1
       #endif
     );
   #endif
 
-  void getfilename(uint16_t nr, const char* const match=NULL);
-  uint16_t getnrfilenames();
+  static void getfilename(uint16_t nr, const char* const match=NULL);
+  static uint16_t getnrfilenames();
 
-  void getAbsFilename(char *t);
+  static void getAbsFilename(char *t);
 
-  void ls(
+  static void ls(
     #if NUM_SERIAL > 1
       const int8_t port = -1
     #endif
   );
-  void chdir(const char *relpath);
-  int8_t updir();
-  void setroot();
+  static void chdir(const char *relpath);
+  static int8_t updir();
+  static void setroot();
 
-  const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo);
+  static const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo);
 
-  uint16_t get_num_Files();
+  static uint16_t get_num_Files();
 
   #if ENABLED(SDCARD_SORT_ALPHA)
-    void presort();
-    void getfilename_sorted(const uint16_t nr);
+    static void presort();
+    static void getfilename_sorted(const uint16_t nr);
     #if ENABLED(SDSORT_GCODE)
-      FORCE_INLINE void setSortOn(bool b) { sort_alpha = b; presort(); }
-      FORCE_INLINE void setSortFolders(int i) { sort_folders = i; presort(); }
-      //FORCE_INLINE void setSortReverse(bool b) { sort_reverse = b; }
+      FORCE_INLINE static void setSortOn(bool b) { sort_alpha = b; presort(); }
+      FORCE_INLINE static void setSortFolders(int i) { sort_folders = i; presort(); }
+      //FORCE_INLINE static void setSortReverse(bool b) { sort_reverse = b; }
     #endif
   #else
-    FORCE_INLINE void getfilename_sorted(const uint16_t nr) { getfilename(nr); }
+    FORCE_INLINE static void getfilename_sorted(const uint16_t nr) { getfilename(nr); }
   #endif
 
   #if ENABLED(POWER_LOSS_RECOVERY)
-    bool jobRecoverFileExists();
-    void openJobRecoveryFile(const bool read);
-    void removeJobRecoveryFile();
+    static bool jobRecoverFileExists();
+    static void openJobRecoveryFile(const bool read);
+    static void removeJobRecoveryFile();
   #endif
 
-  inline void pauseSDPrint() { sdprinting = false; }
-  inline bool isFileOpen() { return file.isOpen(); }
-  inline bool eof() { return sdpos >= filesize; }
-  inline int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
-  inline void setIndex(const uint32_t index) { sdpos = index; file.seekSet(index); }
-  inline uint32_t getIndex() { return sdpos; }
-  inline uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
-  inline char* getWorkDirName() { workDir.getFilename(filename); return filename; }
-  inline int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
-  inline int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
+  static inline void pauseSDPrint() { sdprinting = false; }
+  static inline bool isFileOpen() { return file.isOpen(); }
+  static inline bool eof() { return sdpos >= filesize; }
+  static inline int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
+  static inline void setIndex(const uint32_t index) { sdpos = index; file.seekSet(index); }
+  static inline uint32_t getIndex() { return sdpos; }
+  static inline uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
+  static inline char* getWorkDirName() { workDir.getFilename(filename); return filename; }
+  static inline int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
+  static inline int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
 
-  Sd2Card& getSd2Card() { return sd2card; }
+  static Sd2Card& getSd2Card() { return sd2card; }
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)
-    void auto_report_sd_status(void);
-    inline void set_auto_report_interval(uint8_t v
+    static void auto_report_sd_status(void);
+    static inline void set_auto_report_interval(uint8_t v
       #if NUM_SERIAL > 1
         , int8_t port
       #endif
@@ -140,40 +142,40 @@ public:
     }
   #endif
 
-  inline char* longest_filename() { return longFilename[0] ? longFilename : filename; }
+  static inline char* longest_filename() { return longFilename[0] ? longFilename : filename; }
 
 public:
-  bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
-  char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
-  int8_t autostart_index;
+  static bool saving, logging, sdprinting, cardOK, filenameIsDir, abort_sd_printing;
+  static char filename[FILENAME_LENGTH + 1], longFilename[LONG_FILENAME_LENGTH + 1];
+  static int8_t autostart_index;
 
   #if ENABLED(FAST_FILE_TRANSFER)
-    bool binary_mode;
+    static bool binary_mode;
     #if NUM_SERIAL > 1
-      uint8_t transfer_port;
+      static uint8_t transfer_port;
     #else
       static constexpr uint8_t transfer_port = 0;
     #endif
   #endif
 
 private:
-  SdFile root, workDir, workDirParents[MAX_DIR_DEPTH];
-  uint8_t workDirDepth;
+  static SdFile root, workDir, workDirParents[MAX_DIR_DEPTH];
+  static uint8_t workDirDepth;
 
   // Sort files and folders alphabetically.
   #if ENABLED(SDCARD_SORT_ALPHA)
-    uint16_t sort_count;        // Count of sorted items in the current directory
+    static uint16_t sort_count;   // Count of sorted items in the current directory
     #if ENABLED(SDSORT_GCODE)
-      bool sort_alpha;          // Flag to enable / disable the feature
-      int sort_folders;         // Flag to enable / disable folder sorting
-      //bool sort_reverse;      // Flag to enable / disable reverse sorting
+      static bool sort_alpha;     // Flag to enable / disable the feature
+      static int sort_folders;    // Folder sorting before/none/after
+      //static bool sort_reverse; // Flag to enable / disable reverse sorting
     #endif
 
     // By default the sort index is static
     #if ENABLED(SDSORT_DYNAMIC_RAM)
-      uint8_t *sort_order;
+      static uint8_t *sort_order;
     #else
-      uint8_t sort_order[SDSORT_LIMIT];
+      static uint8_t sort_order[SDSORT_LIMIT];
     #endif
 
     #if ENABLED(SDSORT_USES_RAM) && ENABLED(SDSORT_CACHE_NAMES) && DISABLED(SDSORT_DYNAMIC_RAM)
@@ -188,21 +190,21 @@ private:
       // If using dynamic ram for names, allocate on the heap.
       #if ENABLED(SDSORT_CACHE_NAMES)
         #if ENABLED(SDSORT_DYNAMIC_RAM)
-          char **sortshort, **sortnames;
+          static char **sortshort, **sortnames;
         #else
-          char sortshort[SDSORT_LIMIT][FILENAME_LENGTH];
-          char sortnames[SDSORT_LIMIT][SORTED_LONGNAME_MAXLEN];
+          static char sortshort[SDSORT_LIMIT][FILENAME_LENGTH + 1];
+          static char sortnames[SDSORT_LIMIT][SORTED_LONGNAME_MAXLEN + 1];
         #endif
       #elif DISABLED(SDSORT_USES_STACK)
-        char sortnames[SDSORT_LIMIT][SORTED_LONGNAME_MAXLEN];
+        static char sortnames[SDSORT_LIMIT][SORTED_LONGNAME_MAXLEN + 1];
       #endif
 
       // Folder sorting uses an isDir array when caching items.
       #if HAS_FOLDER_SORTING
         #if ENABLED(SDSORT_DYNAMIC_RAM)
-          uint8_t *isDir;
+          static uint8_t *isDir;
         #elif ENABLED(SDSORT_CACHE_NAMES) || DISABLED(SDSORT_USES_STACK)
-          uint8_t isDir[(SDSORT_LIMIT+7)>>3];
+          static uint8_t isDir[(SDSORT_LIMIT+7)>>3];
         #endif
       #endif
 
@@ -210,28 +212,31 @@ private:
 
   #endif // SDCARD_SORT_ALPHA
 
-  Sd2Card sd2card;
-  SdVolume volume;
-  SdFile file;
+  static Sd2Card sd2card;
+  static SdVolume volume;
+  static SdFile file;
 
-  #define SD_PROCEDURE_DEPTH 1
-  #define MAXPATHNAMELENGTH (FILENAME_LENGTH*MAX_DIR_DEPTH + MAX_DIR_DEPTH + 1)
-  uint8_t file_subcall_ctr;
-  uint32_t filespos[SD_PROCEDURE_DEPTH];
-  char proc_filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH];
-  uint32_t filesize, sdpos;
+  #ifndef SD_PROCEDURE_DEPTH
+    #define SD_PROCEDURE_DEPTH 1
+  #endif
 
-  LsAction lsAction; //stored for recursion.
-  uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
-  char* diveDirName;
-  void lsDive(const char *prepend, SdFile parent, const char * const match=NULL
+  static uint8_t file_subcall_ctr;
+  static uint32_t filespos[SD_PROCEDURE_DEPTH];
+  static char proc_filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH + 1];
+
+  static uint32_t filesize, sdpos;
+
+  static LsAction lsAction; //stored for recursion.
+  static uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
+  static char *diveDirName;
+  static void lsDive(const char *prepend, SdFile parent, const char * const match=NULL
     #if NUM_SERIAL > 1
       , const int8_t port = -1
     #endif
   );
 
   #if ENABLED(SDCARD_SORT_ALPHA)
-    void flush_presort();
+    static void flush_presort();
   #endif
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)


### PR DESCRIPTION
Until we decide to support multiple SD card readers, this change will help to optimize the code.

- Make `CardReader` a static class to save ~500 bytes of flash and improve execution speed.
- Make `CardReader` flags into bitfields to save a few bytes of SRAM (costing 42 bytes of flash).
