### PR TITLE
Change temperature pin order for RemRam V1

### DIFF
--- a/Marlin/src/pins/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/pins_REMRAM_V1.h
@@ -83,9 +83,9 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         65   // THERM_2
-#define TEMP_1_PIN         66   // THERM_3
-#define TEMP_BED_PIN       64   // THERM_1
+#define TEMP_0_PIN         64   // THERM_1
+#define TEMP_1_PIN         65   // THERM_2
+#define TEMP_BED_PIN       66   // THERM_3
 
 //
 // Heaters / Fans


### PR DESCRIPTION
Beta testers of RemRam suggested to adopt the RAMPS order of temperature probe connectors (First connector is the extruder probe, the last connector is the bed probe). This commit fixes the order to the RAMPS order.