### PR TITLE
Fixed displaying of kill MSG_OUTAGE_RECOVERY string.

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -197,7 +197,7 @@ void PrintJobRecovery::save(const bool force/*=false*/) {
 
     // KILL now if the power-loss pin was triggered
     #if PIN_EXISTS(POWER_LOSS)
-      if (READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) kill(MSG_OUTAGE_RECOVERY);
+      if (READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) kill(PSTR(MSG_OUTAGE_RECOVERY));
     #endif
   }
 }


### PR DESCRIPTION
Marlin is displaying garbage instead of MSG_OUTAGE_RECOVERY string on LCD, when printer is killed.

The same problem is also in 1.1.x branch of Marlin.