### PR TITLE
Fix "no effect" and "unused variable" compile warnings

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -196,7 +196,7 @@
 #define MMM_TO_MMS(MM_M) ((MM_M)/60.0f)
 #define MMS_TO_MMM(MM_S) ((MM_S)*60.0f)
 
-#define NOOP (0)
+#define NOOP (void(0))
 
 #define CEILING(x,y) (((x) + (y) - 1) / (y))
 

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -213,9 +213,11 @@ void PrintJobRecovery::write() {
 
   open(false);
   file.seekSet(0);
+  const int16_t ret = file.write(&info, sizeof(info));
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
-    const int16_t ret = file.write(&info, sizeof(info));
     if (ret == -1) SERIAL_ECHOLNPGM("Power-loss file write failed.");
+  #else
+    UNUSED(ret);
   #endif
 }
 

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -213,8 +213,8 @@ void PrintJobRecovery::write() {
 
   open(false);
   file.seekSet(0);
-  const int16_t ret = file.write(&info, sizeof(info));
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
+    const int16_t ret = file.write(&info, sizeof(info));
     if (ret == -1) SERIAL_ECHOLNPGM("Power-loss file write failed.");
   #endif
 }


### PR DESCRIPTION
» warning: statement has no effect
» unused variable 'ret'