### PR TITLE
Modify MBL to use IJ instead of XY

### DIFF
--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -119,8 +119,8 @@
   #endif // IS_CARTESIAN && !SEGMENT_LEVELED_MOVES
 
   void mesh_bed_leveling::report_mesh() {
-    SERIAL_PROTOCOLLNPGM("Num X,Y: " STRINGIFY(GRID_MAX_POINTS_X) "," STRINGIFY(GRID_MAX_POINTS_Y));
-    SERIAL_PROTOCOLPGM("Z offset: "); SERIAL_PROTOCOL_F(z_offset, 5);
+    SERIAL_PROTOCOLPGM(STRINGIFY(GRID_MAX_POINTS_X) "x" STRINGIFY(GRID_MAX_POINTS_Y) " mesh. Z offset: ");
+    SERIAL_PROTOCOL_F(z_offset, 5);
     SERIAL_PROTOCOLLNPGM("\nMeasured points:");
     print_2d_array(GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y, 5,
       [](const uint8_t ix, const uint8_t iy) { return z_values[ix][iy]; }

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -47,19 +47,12 @@ inline void echo_not_entered(const char c) { SERIAL_CHAR(c); SERIAL_PROTOCOLLNPG
  *
  * Parameters With MESH_BED_LEVELING:
  *
- *  S0              Produce a mesh report
+ *  S0              Report the current mesh values
  *  S1              Start probing mesh points
  *  S2              Probe the next mesh point
- *  S3 Xn Yn Zn.nn  Manually modify a single point
+ *  S3 In Jn Zn.nn  Manually modify a single point
  *  S4 Zn.nn        Set z offset. Positive away from bed, negative closer to bed.
  *  S5              Reset and disable mesh
- *
- * The S0 report the points as below
- *
- *  +----> X-axis  1-n
- *  |
- *  |
- *  v Y-axis  1-n
  *
  */
 void GcodeSuite::G29() {
@@ -75,7 +68,7 @@ void GcodeSuite::G29() {
     return;
   }
 
-  int8_t px, py;
+  int8_t ix, iy;
 
   switch (state) {
     case MeshReport:
@@ -126,8 +119,8 @@ void GcodeSuite::G29() {
           soft_endstops_enabled = false;
         #endif
 
-        mbl.zigzag(mbl_probe_index++, px, py);
-        _manual_goto_xy(mbl.index_to_xpos[px], mbl.index_to_ypos[py]);
+        mbl.zigzag(mbl_probe_index++, ix, iy);
+        _manual_goto_xy(mbl.index_to_xpos[ix], mbl.index_to_ypos[iy]);
       }
       else {
         // One last "return to the bed" (as originally coded) at completion
@@ -158,30 +151,30 @@ void GcodeSuite::G29() {
       break;
 
     case MeshSet:
-      if (parser.seenval('X')) {
-        px = parser.value_int() - 1;
-        if (!WITHIN(px, 0, GRID_MAX_POINTS_X - 1)) {
-          SERIAL_PROTOCOLPAIR("X out of range (0-", int(GRID_MAX_POINTS_X));
+      if (parser.seenval('I')) {
+        ix = parser.value_int();
+        if (!WITHIN(ix, 0, GRID_MAX_POINTS_X - 1)) {
+          SERIAL_PROTOCOLPAIR("I out of range (0-", int(GRID_MAX_POINTS_X - 1));
           SERIAL_PROTOCOLLNPGM(")");
           return;
         }
       }
       else
-        return echo_not_entered('X');
+        return echo_not_entered('J');
 
-      if (parser.seenval('Y')) {
-        py = parser.value_int() - 1;
-        if (!WITHIN(py, 0, GRID_MAX_POINTS_Y - 1)) {
-          SERIAL_PROTOCOLPAIR("Y out of range (0-", int(GRID_MAX_POINTS_Y));
+      if (parser.seenval('J')) {
+        iy = parser.value_int();
+        if (!WITHIN(iy, 0, GRID_MAX_POINTS_Y - 1)) {
+          SERIAL_PROTOCOLPAIR("J out of range (0-", int(GRID_MAX_POINTS_Y - 1));
           SERIAL_PROTOCOLLNPGM(")");
           return;
         }
       }
       else
-        return echo_not_entered('Y');
+        return echo_not_entered('J');
 
       if (parser.seenval('Z'))
-        mbl.z_values[px][py] = parser.value_linear_units();
+        mbl.z_values[ix][iy] = parser.value_linear_units();
       else
         return echo_not_entered('Z');
       break;


### PR DESCRIPTION
For consistency with other leveling systems, use 0-based offsets when specifying mesh indices.