### PR TITLE
[2.0.x] Follow up to #12439, fix compilation errors.

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -134,7 +134,6 @@ namespace ExtUI {
       // The ms count is
       return (uint32_t)(currTime / (F_CPU / 8000));
     }
-
   #endif // __SAM3X8E__
 
   void delay_us(unsigned long us) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -179,7 +179,7 @@ namespace ExtUI {
   #ifdef __SAM3X8E__
     uint32_t safe_millis();
   #else
-    FORCE_INLINE uint32_t safe_millis() {return millis();} // TODO: Implement for AVR
+    FORCE_INLINE uint32_t safe_millis() { return millis(); } // TODO: Implement for AVR
   #endif
 
   void delay_us(unsigned long us);

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -179,7 +179,7 @@ namespace ExtUI {
   #ifdef __SAM3X8E__
     uint32_t safe_millis();
   #else
-    #define safe_millis() millis() // TODO: Implement for AVR
+    FORCE_INLINE uint32_t safe_millis() {return millis();} // TODO: Implement for AVR
   #endif
 
   void delay_us(unsigned long us);

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -29,10 +29,29 @@
   #if ENABLED(SDSUPPORT)
     #include "../sd/cardreader.h"
   #endif
-
   #if ENABLED(EXTENSIBLE_UI)
     #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
   #endif
+#endif
+
+#if HAS_SPI_LCD
+  #if ENABLED(STATUS_MESSAGE_SCROLLING)
+    uint8_t MarlinUI::status_scroll_offset; // = 0
+    #if LONG_FILENAME_LENGTH > CHARSIZE * 2 * (LCD_WIDTH)
+      #define MAX_MESSAGE_LENGTH LONG_FILENAME_LENGTH
+    #else
+      #define MAX_MESSAGE_LENGTH CHARSIZE * 2 * (LCD_WIDTH)
+    #endif
+  #else
+    #define MAX_MESSAGE_LENGTH CHARSIZE * (LCD_WIDTH)
+  #endif
+#elif ENABLED(EXTENSIBLE_UI)
+  #define MAX_MESSAGE_LENGTH 63
+#endif
+
+#ifdef MAX_MESSAGE_LENGTH
+  uint8_t MarlinUI::status_message_level; // = 0
+  char MarlinUI::status_message[MAX_MESSAGE_LENGTH + 1];
 #endif
 
 #if HAS_SPI_LCD
@@ -73,24 +92,6 @@
 
 #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
   uint8_t lcd_sd_status;
-#endif
-
-#if ENABLED(STATUS_MESSAGE_SCROLLING)
-  uint8_t MarlinUI::status_scroll_offset; // = 0
-  #if LONG_FILENAME_LENGTH > CHARSIZE * 2 * (LCD_WIDTH)
-    #define MAX_MESSAGE_LENGTH LONG_FILENAME_LENGTH
-  #else
-    #define MAX_MESSAGE_LENGTH CHARSIZE * 2 * (LCD_WIDTH)
-  #endif
-#elif ENABLED(EXTENSIBLE_UI)
-  #define MAX_MESSAGE_LENGTH 63
-#else
-  #define MAX_MESSAGE_LENGTH CHARSIZE * (LCD_WIDTH)
-#endif
-
-#if HAS_SPI_LCD || ENABLED(EXTENSIBLE_UI)
-  uint8_t MarlinUI::status_message_level; // = 0
-  char MarlinUI::status_message[MAX_MESSAGE_LENGTH + 1];
 #endif
 
 #if HAS_LCD_MENU && LCD_TIMEOUT_TO_STATUS


### PR DESCRIPTION
Change `safe_millis()` from `#define` to `FORCE_INLINE` to allow for namespace qualification, i.e `ExtUI::safe_millis()`. Prior to change, the following error would be generated:

```
src/lcd/extensible_ui/lib/ui_sounds.cpp: In member function 'bool tiny_timer_t::elapsed(tiny_time_t)':
src/lcd/extensible_ui/lib/ui_sounds.cpp:34:40: error: 'millis' is not a member of 'ExtUI'
   uint8_t now = tiny_time_t::tiny_time(ExtUI::safe_millis());
```

Move definitions of `status_message` and `status_message_level` outside of `#if HAS_SPI_LCD` block, otherwise they will not get defined when `EXTENSIBLE_UI` is enabled and `HAS_SPI_LCD` is disabled, leading to the following link errors:

```
applet/src/lcd/ultralcd.o: In function `MarlinUI::has_status()':
ultralcd.cpp:(.text._ZN8MarlinUI10has_statusEv+0x10): undefined reference to `MarlinUI::status_message'
applet/src/lcd/ultralcd.o: In function `MarlinUI::set_status(char const*, bool)':
ultralcd.cpp:(.text._ZN8MarlinUI10set_statusEPKcb+0x48): undefined reference to `MarlinUI::status_message_level'
ultralcd.cpp:(.text._ZN8MarlinUI10set_statusEPKcb+0x4c): undefined reference to `MarlinUI::status_message'
applet/src/lcd/ultralcd.o: In function `MarlinUI::set_status_P(char const*, signed char)':
ultralcd.cpp:(.text._ZN8MarlinUI12set_status_PEPKca+0x54): undefined reference to `MarlinUI::status_message_level'
ultralcd.cpp:(.text._ZN8MarlinUI12set_status_PEPKca+0x58): undefined reference to `MarlinUI::status_message'
applet/src/gcode/control/M999.o: In function `GcodeSuite::M999()':
M999.cpp:(.text._ZN10GcodeSuite4M999Ev+0x4c): undefined reference to `MarlinUI::status_message_level'
```