### PR TITLE
Fix Z-move to uninitialized position in SWITCHING_EXTRUDERS tool_change (no_move=true) 

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -96,13 +96,11 @@
 #endif // DO_SWITCH_EXTRUDER
 
 #if ENABLED(SWITCHING_NOZZLE)
-
   void move_nozzle_servo(const uint8_t e) {
     planner.synchronize();
     MOVE_SERVO(SWITCHING_NOZZLE_SERVO_NR, servo_angles[SWITCHING_NOZZLE_SERVO_NR][e]);
     safe_delay(500);
   }
-
 #endif // SWITCHING_NOZZLE
 
 #if ENABLED(PARKING_EXTRUDER)
@@ -594,8 +592,9 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
       #endif
 
+      set_destination_from_current();
+
       if (!no_move) {
-        set_destination_from_current();
         #if DISABLED(SWITCHING_NOZZLE)
           // Do a small lift to avoid the workpiece in the move back (below)
           #if ENABLED(TOOLCHANGE_PARK)


### PR DESCRIPTION
Fix for #12482

When SWITCHING_EXTRUDERS is enabled and "tool_change()" is called with "no_move=true", the toolhead will move to an uninitalized position in Z.

This regression was introduced by 6471a75a22 and it is caused by the following lines in `toolchange.cpp`:

```
      if (!no_move) {
         set_destination_from_current();
         ...
      }

      ...

      if (safe_to_move && !no_move && IsRunning()) {
         ...
      }
      #if ENABLED(SWITCHING_NOZZLE)
        else {
          // Move back down. (Including when the new tool is higher.)
          do_blocking_move_to_z(destination[Z_AXIS], planner.settings.max_feedrate_mm_s[Z_AXIS]);
        }
      #endif
```

When `no_move=true` and `IsRunning()=false`, then `set_destination_from_current()` never gets called, so `do_blocking_move_to_z()` sends the Z_AXIS to an uninitalized position.