### PR TITLE
Add Fast PWM for Controller Fan 

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1171,6 +1171,13 @@ void Temperature::init() {
     #endif
   #endif
 
+  #if ENABLED(USE_CONTROLLER_FAN)
+    SET_OUTPUT(CONTROLLER_FAN_PIN);
+    #if ENABLED(FAST_PWM_FAN)
+      setPwmFrequency(CONTROLLER_FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
+    #endif
+  #endif
+
   #if ENABLED(HEATER_0_USES_MAX6675)
 
     OUT_WRITE(SCK_PIN, LOW);


### PR DESCRIPTION
Added Fast PWM implementation if there is a controller fan  so he does not produce noise

  ### Benefits

When the FLAG FAST_PWM_FAN is enabled it passes the pwm config onto the CONTROLLER_FAN_PIN which is being used. This way the PWM gets applied to the controller and the Attached mosfet.

For some Fans the Coil Whine is really bad. This solves the issue. 
 
