### PR TITLE
Fix problems with LPC1768 EEPROM flash emulation

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/persistent_store_flash.cpp
@@ -92,7 +92,6 @@ bool PersistentStore::access_finish() {
     if (--current_slot < 0) {
       // all slots have been used, erase everything and start again
       __disable_irq();
-      PrepareSector(EEPROM_SECTOR, EEPROM_SECTOR);
       status = EraseSector(EEPROM_SECTOR, EEPROM_SECTOR);
       __enable_irq();
 
@@ -100,7 +99,6 @@ bool PersistentStore::access_finish() {
     }
 
     __disable_irq();
-    PrepareSector(EEPROM_SECTOR, EEPROM_SECTOR);
     status = CopyRAM2Flash(SLOT_ADDRESS(EEPROM_SECTOR, current_slot), ram_eeprom, IAP_WRITE_4096);
     __enable_irq();
 

--- a/Marlin/src/HAL/HAL_LPC1768/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/persistent_store_flash.cpp
@@ -57,7 +57,7 @@ extern "C" {
 #define EEPROM_ERASE (0xff)
 #define SLOT_ADDRESS(sector, slot) (((uint8_t *)SECTOR_START(sector)) + slot * EEPROM_SIZE)
 
-static uint8_t ram_eeprom[EEPROM_SIZE];
+static uint8_t ram_eeprom[EEPROM_SIZE] __attribute__((aligned(4))) = {0};
 static bool eeprom_dirty = false;
 static int current_slot = 0;
 


### PR DESCRIPTION

### Description
On LPC176X systems we emulate eeprom using flash memory. The operation to copy from RAM to flash on this processor requires that the RAM buffer is word aligned. This is currently not always the case (depends on other items in memory). This PR adds attributes to ensure that the required alignment is always applied.

### Benefits
Ensure correct operation of eeprom emulation. The PR also includes changes to remove unneeded duplicate function calls (the same function call is made by the framework).

### Related Issues
Fixes issues:
https://github.com/MarlinFirmware/Marlin/issues/12442
https://github.com/MarlinFirmware/Marlin/issues/12407

Note that on LPC1769 systems and updated framework may also be required (as this changes the timing used for flash operations). This change is present from version 0.0.6 of the framework.