### PR TITLE
Update "mm³" in language_en.h

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -32,6 +32,7 @@
 #define en 1234
 #if LCD_LANGUAGE == en
   #define NOT_EXTENDED_ISO10646_1_5X7
+  #define THIS_LANGUAGES_SPECIAL_SYMBOLS _UxGT("³")
 #endif
 #undef en
 
@@ -672,7 +673,7 @@
   #define MSG_FILAMENT                        _UxGT("Filament")
 #endif
 #ifndef MSG_VOLUMETRIC_ENABLED
-  #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3")
+  #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
 #endif
 #ifndef MSG_FILAMENT_DIAM
   #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")


### PR DESCRIPTION
add this line;
```cpp
#define THIS_LANGUAGES_SPECIAL_SYMBOLS _UxGT("³")
```
changed this line;
```cpp
#define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm3") to;
#define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
```
so I changed "mm3 to mm³".