### PR TITLE
Revert ADC_KEYPAD direction behavior

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -47,6 +47,7 @@
   #define ULTIPANEL
 
   // this helps to implement ADC_KEYPAD menus
+  #define REVERSE_MENU_DIRECTION
   #define ENCODER_PULSES_PER_STEP 1
   #define ENCODER_STEPS_PER_MENU_ITEM 1
   #define ENCODER_FEEDRATE_DEADZONE 2

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -55,6 +55,7 @@ static void lcd_factory_settings() {
   #include "../lcdprint.h"
 
   static void progress_bar_test() {
+    ui.encoder_direction_normal();
     static int8_t bar_percent = 0;
     if (ui.use_click()) {
       ui.goto_previous_screen();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -305,18 +305,26 @@ bool MarlinUI::get_blink() {
       if (keypad_buttons) {
         #if HAS_ENCODER_ACTION
           refresh(LCDVIEW_REDRAW_NOW);
-          if (encoderDirection == -1) { // side effect which signals we are inside a menu
-            #if HAS_LCD_MENU
-              if      (RRK(EN_KEYPAD_DOWN))   encoderPosition += ENCODER_STEPS_PER_MENU_ITEM;
-              else if (RRK(EN_KEYPAD_UP))     encoderPosition -= ENCODER_STEPS_PER_MENU_ITEM;
+          #if HAS_LCD_MENU
+            if (encoderDirection == -1) {     // ADC_KEYPAD forces REVERSE_MENU_DIRECTION, so this indicates menu navigation
+                   if (RRK(EN_KEYPAD_UP))     encoderPosition += ENCODER_STEPS_PER_MENU_ITEM;
+              else if (RRK(EN_KEYPAD_DOWN))   encoderPosition -= ENCODER_STEPS_PER_MENU_ITEM;
               else if (RRK(EN_KEYPAD_LEFT))   { MenuItem_back::action(); quick_feedback(); }
               else if (RRK(EN_KEYPAD_RIGHT))  { return_to_status(); quick_feedback(); }
+            }
+            else
+          #endif
+          {
+            #if HAS_LCD_MENU
+                   if (RRK(EN_KEYPAD_UP))     encoderPosition -= ENCODER_PULSES_PER_STEP;
+              else if (RRK(EN_KEYPAD_DOWN))   encoderPosition += ENCODER_PULSES_PER_STEP;
+              else if (RRK(EN_KEYPAD_LEFT))   { MenuItem_back::action(); quick_feedback(); }
+              else if (RRK(EN_KEYPAD_RIGHT))  encoderPosition = 0;
+            #else
+                   if (RRK(EN_KEYPAD_UP)   || RRK(EN_KEYPAD_LEFT))  encoderPosition -= ENCODER_PULSES_PER_STEP;
+              else if (RRK(EN_KEYPAD_DOWN) || RRK(EN_KEYPAD_RIGHT)) encoderPosition += ENCODER_PULSES_PER_STEP;
             #endif
           }
-          else if (RRK(EN_KEYPAD_DOWN))     encoderPosition -= ENCODER_PULSES_PER_STEP;
-          else if (RRK(EN_KEYPAD_UP))       encoderPosition += ENCODER_PULSES_PER_STEP;
-          else if (RRK(EN_KEYPAD_LEFT))     { MenuItem_back::action(); quick_feedback(); }
-          else if (RRK(EN_KEYPAD_RIGHT))    encoderPosition = 0;
         #endif
         next_button_update_ms = millis() + ADC_MIN_KEY_DELAY;
         return true;

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -188,7 +188,10 @@
   #define B_DW (_BV(BL_DW))
   #define B_RI (_BV(BL_RI))
   #define B_ST (_BV(BL_ST))
-  #define BUTTON_CLICK() (buttons & (B_MI|B_ST))
+
+  #ifndef BUTTON_CLICK
+    #define BUTTON_CLICK() (buttons & (B_MI|B_ST))
+  #endif
 
 #endif
 


### PR DESCRIPTION
ADC Keypad requires `REVERSE_MENU_DIRECTION` to be able to use `encoderDirection == -1` as an indication that a menu screen is currently activated. So this PR reverts the changes that broke that test.