### PR TITLE
Don't show superscript ³ with NOT_EXTENDED_ISO10646_1_5X7

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -31,10 +31,16 @@
 
 #define en 1234
 #if LCD_LANGUAGE == en
- 
-  #define THIS_LANGUAGES_SPECIAL_SYMBOLS _UxGT("³")
+  #define NOT_EXTENDED_ISO10646_1_5X7
+  #define THIS_LANGUAGES_SPECIAL_SYMBOLS      _UxGT("³")
 #endif
 #undef en
+
+#ifdef NOT_EXTENDED_ISO10646_1_5X7
+  #define MSG_CUBED                           _UxGT("^3")
+#else
+  #define MSG_CUBED                           _UxGT("³")
+#endif
 
 #ifndef CHARSIZE
   #define CHARSIZE 1
@@ -673,7 +679,7 @@
   #define MSG_FILAMENT                        _UxGT("Filament")
 #endif
 #ifndef MSG_VOLUMETRIC_ENABLED
-  #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm³")
+  #define MSG_VOLUMETRIC_ENABLED              _UxGT("E in mm") MSG_CUBED
 #endif
 #ifndef MSG_FILAMENT_DIAM
   #define MSG_FILAMENT_DIAM                   _UxGT("Fil. Dia.")

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -28,11 +28,11 @@
  * See also http://marlinfw.org/docs/development/lcd_language.html
  *
  */
+#define THIS_LANGUAGES_SPECIAL_SYMBOLS        _UxGT("³")
 
 #define en 1234
 #if LCD_LANGUAGE == en
   #define NOT_EXTENDED_ISO10646_1_5X7
-  #define THIS_LANGUAGES_SPECIAL_SYMBOLS      _UxGT("³")
 #endif
 #undef en
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -31,7 +31,7 @@
 
 #define en 1234
 #if LCD_LANGUAGE == en
-  #define NOT_EXTENDED_ISO10646_1_5X7
+ 
   #define THIS_LANGUAGES_SPECIAL_SYMBOLS _UxGT("³")
 #endif
 #undef en


### PR DESCRIPTION
if active this line;
" #define NOT_EXTENDED_ISO10646_1_5X7" dont see "³" symbol. Just see "mm"
but line delete you see "mm³"

I deleted this line and upload code my mega test and:

![](https://image.ibb.co/gVwkxA/20181123-021351.jpg)


