### PR TITLE
Add support for FYSETC F6 V1.3 board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -344,3 +344,16 @@ lib_ignore  =
   TMC26XStepper
   c1921b4
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_ESP32>
+
+#
+# FYSETC F6 V1.3
+#
+[env:fysetc_f6_13]
+platform          = atmelavr
+framework         = arduino
+board             = fysetc_f6_13
+build_flags       = ${common.build_flags}
+board_build.f_cpu = 16000000L
+lib_deps          = ${common.lib_deps}
+src_filter        = ${common.default_src_filter} +<src/HAL/HAL_AVR>
+monitor_speed     = 250000


### PR DESCRIPTION
Adding support for the FYSETC F6 1.3 board.

The FYSETC F6 board has some pin definitions added to the atmega2560 pins, so that some of the pins can't communicate with the board when the firmware will be compiled with the default atmega2560 board. Especially the x- and z-axis in combination with SPI stepper drivers (e.g. TMC2130) don't work. My pull request for adding the board in PlatformIO is already merged into the develop-branch.

Related pull requests on the platformio repositories:
https://github.com/platformio/platform-atmelavr/pull/118
https://github.com/platformio/platformio-pkg-framework-arduinoavr/pull/15

Related issue: https://github.com/MarlinFirmware/Marlin/issues/11611