### PR TITLE
[2.0.x] Improvements to runout sensor, fix for screen size when using LIGHTWEIGHT_UI #12542

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -296,9 +296,8 @@ class FilamentSensorBase {
       }
 
       static inline void block_completed(const block_t* const b) {
-        if(b->steps[X_AXIS] || b->steps[Y_AXIS] || b->steps[Z_AXIS]) {
-          // Only count extrusions while moving to avoid
-          // triggering on filament change or retractions.
+        if (b->steps[X_AXIS] || b->steps[Y_AXIS] || b->steps[Z_AXIS]) {
+          // Only trigger on extrusion with XYZ movement to allow filament change and retract/recover.
           const uint8_t e = b->extruder;
           const int32_t steps = b->steps[E_AXIS];
           runout_mm_countdown[e] -= (TEST(b->direction_bits, E_AXIS) ? -steps : steps) * planner.steps_to_mm[E_AXIS_N(e)];

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -186,7 +186,8 @@ class FilamentSensorBase {
         old_state = new_state;
 
         #ifdef FILAMENT_RUNOUT_SENSOR_DEBUG
-          if (change) SERIAL_PROTOCOLLNPAIR("Motion detected: ", int(change));
+          for(uint8_t e = 0; e < EXTRUDERS; e++)
+            if(change & (1 << e)) SERIAL_PROTOCOLLNPAIR("Motion detected T", e);
         #endif
 
         motion_detected |= change;
@@ -295,9 +296,13 @@ class FilamentSensorBase {
       }
 
       static inline void block_completed(const block_t* const b) {
-        const uint8_t e = b->extruder;
-        const int32_t steps = b->steps[E_AXIS];
-        runout_mm_countdown[e] -= (TEST(b->direction_bits, E_AXIS) ? -steps : steps) * planner.steps_to_mm[E_AXIS_N(e)];
+        if(b->steps[X_AXIS] || b->steps[Y_AXIS] || b->steps[Z_AXIS]) {
+          // Only count extrusions while moving to avoid
+          // triggering on filament change or retractions.
+          const uint8_t e = b->extruder;
+          const int32_t steps = b->steps[E_AXIS];
+          runout_mm_countdown[e] -= (TEST(b->direction_bits, E_AXIS) ? -steps : steps) * planner.steps_to_mm[E_AXIS_N(e)];
+        }
       }
   };
 

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -186,8 +186,8 @@ class FilamentSensorBase {
         old_state = new_state;
 
         #ifdef FILAMENT_RUNOUT_SENSOR_DEBUG
-          for(uint8_t e = 0; e < EXTRUDERS; e++)
-            if(change & (1 << e)) SERIAL_PROTOCOLLNPAIR("Motion detected T", e);
+          for (uint8_t e = 0; e < EXTRUDERS; e++)
+            if (TEST(change, e)) SERIAL_PROTOCOLLNPAIR("Motion detected T", e);
         #endif
 
         motion_detected |= change;

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1641,9 +1641,7 @@
 
 // Get LCD character width/height, which may be overridden by pins, configs, etc.
 #ifndef LCD_WIDTH
-  #if ENABLED(LIGHTWEIGHT_UI)
-    #define LCD_WIDTH 16
-  #elif HAS_GRAPHICAL_LCD
+  #if HAS_GRAPHICAL_LCD
     #define LCD_WIDTH 22
   #elif ENABLED(ULTIPANEL)
     #define LCD_WIDTH 20
@@ -1652,9 +1650,7 @@
   #endif
 #endif
 #ifndef LCD_HEIGHT
-  #if ENABLED(LIGHTWEIGHT_UI)
-    #define LCD_HEIGHT 4
-  #elif HAS_GRAPHICAL_LCD
+  #if HAS_GRAPHICAL_LCD
     #define LCD_HEIGHT 5
   #elif ENABLED(ULTIPANEL)
     #define LCD_HEIGHT 4


### PR DESCRIPTION
Improvements to filament runout sensor
----
- Will ignore retraction/extrusion without movement.
- Enhanced debug message for legibility.


Fix screen size when using LIGHTWEIGHT_UI (#12542)
----
- LIGHTWEIGHT_UI uses text mode for the status screen but continues
to draw the menu with u8g. Therefore, the menus should not be resized
when using LIGHTWEIGHT_UI