### PR TITLE
Fix FIL_RUNOUT_INVERTING (for parity with 1.1.9)

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -111,7 +111,7 @@ class FilamentSensorBase {
     static void filament_present(const uint8_t extruder);
 
   public:
-    static void setup() {
+    static inline void setup() {
       #if ENABLED(FIL_RUNOUT_PULLUP)
         #define INIT_RUNOUT_PIN(P) SET_INPUT_PULLUP(P)
       #elif ENABLED(FIL_RUNOUT_PULLDOWN)
@@ -138,14 +138,8 @@ class FilamentSensorBase {
       #endif
     }
 
-    #if FIL_RUNOUT_INVERTING
-      #define FIL_RUNOUT_INVERT_MASK (_BV(NUM_RUNOUT_SENSORS) - 1)
-    #else
-      #define FIL_RUNOUT_INVERT_MASK 0
-    #endif
-
-    // Return a bitmask of all runout sensor states
-    static uint8_t poll_runout_pins() {
+    // Return a bitmask of runout pin states
+    static inline uint8_t poll_runout_pins() {
       return (
         (READ(FIL_RUNOUT_PIN ) ? _BV(0) : 0)
         #if NUM_RUNOUT_SENSORS > 1
@@ -163,7 +157,18 @@ class FilamentSensorBase {
             #endif
           #endif
         #endif
-      ) ^ FIL_RUNOUT_INVERT_MASK;
+      );
+    }
+
+    // Return a bitmask of runout flag states (1 bits always indicates runout)
+    static inline uint8_t poll_runout_states() {
+      return poll_runout_pins() ^ uint8_t(
+        #if DISABLED(FIL_RUNOUT_INVERTING)
+          _BV(NUM_RUNOUT_SENSORS) - 1
+        #else
+          0
+        #endif
+      );
     }
 };
 
@@ -219,22 +224,22 @@ class FilamentSensorBase {
    */
   class FilamentSensorSwitch : public FilamentSensorBase {
     private:
-      static bool poll_runout_pin(const uint8_t extruder) {
-        const uint8_t runout_bits = poll_runout_pins();
+      static inline bool poll_runout_state(const uint8_t extruder) {
+        const uint8_t runout_states = poll_runout_states();
         #if NUM_RUNOUT_SENSORS == 1
           UNUSED(extruder);
-          return runout_bits;                     // A single sensor applying to all extruders
+          return runout_states;                     // A single sensor applying to all extruders
         #else
           #if ENABLED(DUAL_X_CARRIAGE)
             if (dual_x_carriage_mode == DXC_DUPLICATION_MODE || dual_x_carriage_mode == DXC_SCALED_DUPLICATION_MODE)
-              return runout_bits;                 // Any extruder
+              return runout_states;                 // Any extruder
             else
           #elif ENABLED(DUAL_NOZZLE_DUPLICATION_MODE)
             if (extruder_duplication_enabled)
-              return runout_bits;                 // Any extruder
+              return runout_states;                 // Any extruder
             else
           #endif
-              return TEST(runout_bits, extruder); // Specific extruder
+              return TEST(runout_states, extruder); // Specific extruder
         #endif
       }
 
@@ -242,7 +247,7 @@ class FilamentSensorBase {
       static inline void block_completed(const block_t* const b) { UNUSED(b); }
 
       static inline void run() {
-        const bool out = poll_runout_pin(active_extruder);
+        const bool out = poll_runout_state(active_extruder);
         if (!out) filament_present(active_extruder);
         #ifdef FILAMENT_RUNOUT_SENSOR_DEBUG
           static bool was_out = false;
@@ -272,7 +277,7 @@ class FilamentSensorBase {
     public:
       static float runout_distance_mm;
 
-      static void reset() {
+      static inline void reset() {
         LOOP_L_N(i, EXTRUDERS) filament_present(i);
       }
 


### PR DESCRIPTION
The filament runout code is working in reverse in terms of the meaning of `FIL_RUNOUT_INVERTING`. This PR makes a distinction in `runout.h` between a method to read the pins (`poll_runout_pins`) and a method to read the interpreted "runout" state (`poll_runout_states`).