### PR TITLE
Don't say "paused" on active sd print

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -45,10 +45,7 @@
   #include "../feature/runout.h"
 #endif
 
-#if HAS_LCD_MENU
-  #include "../lcd/ultralcd.h"
-#endif
-
+#include "../lcd/ultralcd.h"
 #include "../libs/buzzer.h"
 #include "../libs/nozzle.h"
 #include "pause.h"
@@ -531,7 +528,7 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
   SERIAL_ECHOPAIR("\nextruder_duplication_enabled:", extruder_duplication_enabled);
   SERIAL_ECHOPAIR("\nactive_extruder:", active_extruder);
   SERIAL_ECHOPGM("\n\n");
-  */
+  //*/
 
   if (!did_pause_print) return;
 
@@ -590,9 +587,10 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
     }
   #endif
 
-  #if ENABLED(ULTRA_LCD)
-    ui.reset_status();
-  #endif
+  // Resume the print job timer if it was running
+  if (print_job_timer.isPaused()) print_job_timer.start();
+
+  ui.reset_status();
 }
 
 #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -68,15 +68,16 @@ void GcodeSuite::M125() {
     park_point.y += (active_extruder ? hotend_offset[Y_AXIS][active_extruder] : 0);
   #endif
 
-  const bool job_running = print_job_timer.isRunning(),
-             sd_printing = IS_SD_PRINTING();
-
   if (pause_print(retract, park_point)) {
+    #if ENABLED(SDSUPPORT)
+      const bool sd_printing = IS_SD_PRINTING() || parser.boolval('S'); // Undocumented parameter
+    #else
+      constexpr bool sd_printing = false;
+    #endif
     if (!sd_printing) {
       wait_for_confirmation();
       resume_print();
     }
-    if (job_running) print_job_timer.start();
   }
 }
 

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -129,8 +129,6 @@ void GcodeSuite::M600() {
     #endif
   );
 
-  const bool job_running = print_job_timer.isRunning();
-
   if (pause_print(retract, park_point, unload_length, true DXC_PASS)) {
     wait_for_confirmation(true, beep_count DXC_PASS);
     resume_print(slow_load_length, fast_load_length, ADVANCED_PAUSE_PURGE_LENGTH, beep_count DXC_PASS);
@@ -141,9 +139,6 @@ void GcodeSuite::M600() {
     if (active_extruder_before_filament_change != active_extruder)
       tool_change(active_extruder_before_filament_change, 0, true);
   #endif
-
-  // Resume the print job timer if it was running
-  if (job_running) print_job_timer.start();
 }
 
 #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -113,7 +113,7 @@ void GcodeSuite::M25() {
   print_job_timer.pause();
 
   #if ENABLED(PARK_HEAD_ON_PAUSE)
-    enqueue_and_echo_commands_P(PSTR("M125")); // Must be enqueued with pauseSDPrint set to be last in the buffer
+    enqueue_and_echo_commands_P(PSTR("M125 S")); // To be last in the buffer, must enqueue after pauseSDPrint
   #endif
 }
 

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -45,12 +45,7 @@
     #if ENABLED(POWER_LOSS_RECOVERY)
       if (recovery.enabled) recovery.save(true, false);
     #endif
-    card.pauseSDPrint();
-    print_job_timer.pause();
-    #if ENABLED(PARK_HEAD_ON_PAUSE)
-      enqueue_and_echo_commands_P(PSTR("M125"));
-    #endif
-    ui.reset_status();
+    enqueue_and_echo_commands_P(PSTR("M25"));
   }
 
   void lcd_sdcard_resume() {

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -26,9 +26,7 @@
 #if HAS_SPI_LCD || ENABLED(MALYAN_LCD) || ENABLED(EXTENSIBLE_UI)
   #include "ultralcd.h"
   MarlinUI ui;
-  #if ENABLED(SDSUPPORT)
-    #include "../sd/cardreader.h"
-  #endif
+  #include "../sd/cardreader.h"
   #if ENABLED(EXTENSIBLE_UI)
     #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
   #endif
@@ -1243,7 +1241,7 @@ void MarlinUI::update() {
     static const char printing[] PROGMEM = MSG_PRINTING;
     static const char welcome[] PROGMEM = WELCOME_MSG;
     PGM_P msg;
-    if (print_job_timer.isPaused())
+    if (!IS_SD_PRINTING() && print_job_timer.isPaused())
       msg = paused;
     #if ENABLED(SDSUPPORT)
       else if (IS_SD_PRINTING())
@@ -1257,4 +1255,4 @@ void MarlinUI::update() {
     set_status_P(msg, -1);
   }
 
-#endif
+#endif // HAS_SPI_LCD || EXTENSIBLE_UI

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1922,7 +1922,7 @@ void Temperature::isr() {
     ;
 
     /**
-     * Standard PWM modulation
+     * Standard heater PWM modulation
      */
     if (pwm_count_tmp >= 127) {
       pwm_count_tmp -= 127;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1027,15 +1027,20 @@ void CardReader::printingHasFinished() {
     #if ENABLED(SD_FINISHED_STEPPERRELEASE) && defined(SD_FINISHED_RELEASECOMMAND)
       planner.finish_and_disable();
     #endif
+
     print_job_timer.stop();
-    if (print_job_timer.duration() > 60)
-      enqueue_and_echo_commands_P(PSTR("M31"));
+    if (print_job_timer.duration() > 60) enqueue_and_echo_commands_P(PSTR("M31"));
+
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif
+
     #if ENABLED(ULTRA_LCD) && ENABLED(LCD_SET_PROGRESS_MANUALLY)
       ui.progress_bar_percent = 0;
     #endif
+
+    ui.reset_status();
+
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
       ui.reselect_last_file();
     #endif


### PR DESCRIPTION
Currently the `ui.reset_status` method will show "Paused" any time the print job timer is paused. Since the `print_resume` and `M600` handlers call `ui.reset_status` before restarting the print job timer, but after resuming the SD print, the "paused" message isn't cleared.

Meanwhile the pause/resume methods are a little janky and are getting some things wrong.

This PR…
- shuffles around some calls to `ui.reset_status` to prevent a false "Paused" message,
- modifies `reset_status` to not say "Paused" if SD printing is active (even if the timer is paused),
- changes `resume_print` so that it handles resuming the paused print job timer,
- passes an (undocumented) 'S' parameter to `M125` from `M25` to indicate an SD pause, and
- changes `lcd_sdcard_pause` to simply send `M25`, which does the same thing.