### PR TITLE
[2.0.x] Fix skew factor not calculating from test square measurements

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1208,34 +1208,28 @@
   #define _SKEW_FACTOR(a,b,c) _SKEW_SIDE(float(a),_GET_SIDE(float(a),float(b),float(c)),float(c))
 
   #ifndef XY_SKEW_FACTOR
-    constexpr float XY_SKEW_FACTOR = (
-      #if defined(XY_DIAG_AC) && defined(XY_DIAG_BD) && defined(XY_SIDE_AD)
-        _SKEW_FACTOR(XY_DIAG_AC, XY_DIAG_BD, XY_SIDE_AD)
-      #else
-        0.0
-      #endif
-    );
+    #if defined(XY_DIAG_AC) && defined(XY_DIAG_BD) && defined(XY_SIDE_AD)
+      #define XY_SKEW_FACTOR _SKEW_FACTOR(XY_DIAG_AC, XY_DIAG_BD, XY_SIDE_AD)
+    #else
+      #define XY_SKEW_FACTOR 0.0
+    #endif
   #endif
   #ifndef XZ_SKEW_FACTOR
     #if defined(XY_SIDE_AD) && !defined(XZ_SIDE_AD)
       #define XZ_SIDE_AD XY_SIDE_AD
     #endif
-    constexpr float XZ_SKEW_FACTOR = (
-      #if defined(XZ_DIAG_AC) && defined(XZ_DIAG_BD) && defined(XZ_SIDE_AD)
-        _SKEW_FACTOR(XZ_DIAG_AC, XZ_DIAG_BD, XZ_SIDE_AD)
-      #else
-        0.0
-      #endif
-    );
+    #if defined(XZ_DIAG_AC) && defined(XZ_DIAG_BD) && defined(XZ_SIDE_AD)
+      #define XZ_SKEW_FACTOR _SKEW_FACTOR(XZ_DIAG_AC, XZ_DIAG_BD, XZ_SIDE_AD)
+    #else
+      #define XZ_SKEW_FACTOR 0.0
+    #endif
   #endif
   #ifndef YZ_SKEW_FACTOR
-    constexpr float YZ_SKEW_FACTOR = (
-      #if defined(YZ_DIAG_AC) && defined(YZ_DIAG_BD) && defined(YZ_SIDE_AD)
-        _SKEW_FACTOR(YZ_DIAG_AC, YZ_DIAG_BD, YZ_SIDE_AD)
-      #else
-        0.0
-      #endif
-    );
+    #if defined(YZ_DIAG_AC) && defined(YZ_DIAG_BD) && defined(YZ_SIDE_AD)
+      #define YZ_SKEW_FACTOR _SKEW_FACTOR(YZ_DIAG_AC, YZ_DIAG_BD, YZ_SIDE_AD)
+    #else
+      #define YZ_SKEW_FACTOR 0.0
+    #endif
   #endif
 #endif // SKEW_CORRECTION
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -175,13 +175,9 @@ typedef struct {
         min_travel_feedrate_mm_s;               // (mm/s) M205 T - Minimum travel feedrate
 } planner_settings_t;
 
-#ifndef XY_SKEW_FACTOR
+#if DISABLED(SKEW_CORRECTION)
   #define XY_SKEW_FACTOR 0
-#endif
-#ifndef XZ_SKEW_FACTOR
   #define XZ_SKEW_FACTOR 0
-#endif
-#ifndef YZ_SKEW_FACTOR
   #define YZ_SKEW_FACTOR 0
 #endif
 


### PR DESCRIPTION
### Issue

When configuring skew correction using the calibration square method ([here](https://github.com/MarlinFirmware/Marlin/blob/03ef2d6c82048564db284bc3965595c561bf5840/Marlin/Configuration.h#L1250)), the calculated XY_SKEW_FACTOR remains zero regardless of the measurements entered.

### Cause

It appears to be caused by Conditionals_post.h ([here](https://github.com/MarlinFirmware/Marlin/blob/03ef2d6c82048564db284bc3965595c561bf5840/Marlin/src/inc/Conditionals_post.h#L1211)) defining these values as constexprs instead of macros, which then makes the #ifndef check return true in planner.h ([here](https://github.com/MarlinFirmware/Marlin/blob/03ef2d6c82048564db284bc3965595c561bf5840/Marlin/src/module/planner.h#L178)) where the values are then reset to zero.

### Fix

I've changed Conditionals_post to define these as macros instead of constexprs. I've also changed the planner code to check if SKEW_CORRECTION is disabled instead of checking if the individual values are defined. This isn't really necessary, but it could help avoid another bug like this in the future (e.g. in case planner.h somehow gets included before Conditionals_post.h) by resulting in a compiler error instead of resetting the values to zero.