### PR TITLE
modified #ifdef so that STM32 Core code is not included when compilin…

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL.cpp
@@ -21,7 +21,8 @@
  *
  */
 
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_STM32/HAL_Servo_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_Servo_STM32.cpp
@@ -20,7 +20,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -20,7 +20,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.cpp
@@ -19,7 +19,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
 
 // --------------------------------------------------------------------------
 // Includes

--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/HAL_STM32/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_impl.cpp
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/HAL_STM32/watchdog_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/watchdog_STM32.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#ifdef ARDUINO_ARCH_STM32
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/HAL_STM32F4/EEPROM_Emul/eeprom_emul.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/EEPROM_Emul/eeprom_emul.cpp
@@ -47,7 +47,7 @@
 /** @addtogroup EEPROM_Emulation
   * @{
   */
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && (defined(STM32F4))
 
 /* Includes ------------------------------------------------------------------*/
 #include "eeprom_emul.h"

--- a/Marlin/src/HAL/HAL_STM32F4/EmulatedEeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/EmulatedEeprom.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && (defined(STM32F4))
 
 /**
  * Description: functions for I2C connected external EEPROM.
@@ -139,4 +139,4 @@ void eeprom_update_block(const void *__src, void *__dst, size_t __n) {
 }
 
 #endif // ENABLED(EEPROM_SETTINGS) && DISABLED(I2C_EEPROM) && DISABLED(SPI_EEPROM)
-#endif // STM32F4 || STM32F4xx
+#endif // STM32GENERIC && STM32F4

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && defined(STM32F4)
 
 // --------------------------------------------------------------------------
 // Includes
@@ -130,4 +130,4 @@ uint16_t HAL_adc_get_result(void) {
   return HAL_adc_result;
 }
 
-#endif // STM32F4 || STM32F4xx
+#endif // // STM32GENERIC && STM32F4

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_Servo_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_Servo_STM32F4.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && defined(STM32F4)
 
 #include "../../inc/MarlinConfig.h"
 
@@ -50,4 +50,4 @@ void libServo::move(const int value) {
 }
 #endif // HAS_SERVOS
 
-#endif // STM32F4 || STM32F4xx
+#endif // STM32GENERIC && STM32F4

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
@@ -30,7 +30,7 @@
  * Adapted to the STM32F4 HAL
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && defined(STM32F4)
 
 // --------------------------------------------------------------------------
 // Includes
@@ -173,4 +173,4 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
 
 #endif // SOFTWARE_SPI
 
-#endif // STM32F4 || STM32F4xx
+#endif // STM32GENERIC && STM32F4

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_timers_STM32F4.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && defined(STM32F4)
 
 // --------------------------------------------------------------------------
 // Includes
@@ -156,4 +156,4 @@ bool HAL_timer_interrupt_enabled(const uint8_t timer_num) {
   return false;
 }
 
-#endif // STM32F4 || STM32F4xx
+#endif // STM32GENERIC && STM32F4

--- a/Marlin/src/HAL/HAL_STM32F4/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/persistent_store_eeprom.cpp
@@ -21,7 +21,7 @@
  *
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && defined(STM32F4)
 
 #include "../shared/persistent_store_api.h"
 
@@ -66,4 +66,4 @@ bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t 
 size_t PersistentStore::capacity() { return E2END + 1; }
 
 #endif // EEPROM_SETTINGS
-#endif // STM32F4 || STM32F4xx
+#endif // STM32GENERIC && STM32F4

--- a/Marlin/src/HAL/HAL_STM32F4/watchdog_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/watchdog_STM32F4.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#if defined(STM32GENERIC) && (defined(STM32F4) || defined(STM32F4xx))
+#if defined(STM32GENERIC) && defined(STM32F4)
 
 #include "../../inc/MarlinConfig.h"
 
@@ -54,4 +54,4 @@
 
 #endif // USE_WATCHDOG
 
-#endif // STM32F4 || STM32F4xx
+#endif // STM32GENERIC && STM32F4


### PR DESCRIPTION

### Description

Modified sources so that STM32 Core code is not included when compiling with STM32 Generic


### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

STM32F4 Compile error with STM32Generic #12521