### PR TITLE
Removed extra .0s in powerloss G92 commands.

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -235,7 +235,7 @@ void PrintJobRecovery::resume() {
 
   // Set Z to 0, raise Z by 2mm, and Home (XY only for Cartesian) with no raise
   // (Only do simulated homing in Marlin Dev Mode.)
-  gcode.process_subcommands_now_P(PSTR("G92.0 Z0|G1 Z" STRINGIFY(RECOVERY_ZRAISE) "|G28 R0"
+  gcode.process_subcommands_now_P(PSTR("G92 Z0|G1 Z" STRINGIFY(RECOVERY_ZRAISE) "|G28 R0"
     #if ENABLED(MARLIN_DEV_MODE)
       " S"
     #elif !IS_KINEMATIC
@@ -305,7 +305,7 @@ void PrintJobRecovery::resume() {
     }
   #endif
 
-  // Restore Z (plus raise) and E positions with G92.0
+  // Restore Z (plus raise) and E positions with G92
   dtostrf(info.current_position[Z_AXIS] + RECOVERY_ZRAISE, 1, 3, str_1);
   dtostrf(info.current_position[E_AXIS]
     #if ENABLED(SAVE_EACH_CMD_MODE)
@@ -313,7 +313,7 @@ void PrintJobRecovery::resume() {
     #endif
     , 1, 3, str_2
   );
-  sprintf_P(cmd, PSTR("G92.0 Z%s E%s"), str_1, str_2);
+  sprintf_P(cmd, PSTR("G92 Z%s E%s"), str_1, str_2);
   gcode.process_subcommands_now(cmd);
 
   // Move back to the saved XY


### PR DESCRIPTION
### Description

Removed extra .0s in G92.0 commands in power_loss_recovery.cpp. I looked everywhere in the code and wasn't able to find references to them being different than G92. 

### Benefits

This supposedly saves 4 bytes of memory and makes the g-code look a little more like what everyone is used to.

### Related Issues

None.
