### PR TITLE
Add ExtUI methods to babystep probe/nozzle offsets

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -474,7 +474,7 @@ namespace ExtUI {
     void smartAdjustAxis_steps(const int16_t steps, const axis_t axis, bool linked_nozzles) {
       const float mm = steps * planner.steps_to_mm[axis];
 
-      if(!babystepAxis_steps(steps, axis)) return;
+      if (!babystepAxis_steps(steps, axis)) return;
 
       #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
         // Make it so babystepping in Z adjusts the Z probe offset.

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -137,8 +137,10 @@ namespace ExtUI {
   void setActiveTool(const extruder_t, bool no_move);
 
   #if ENABLED(BABYSTEPPING)
-    void babystepAxis_mm(const float, const axis_t, bool linked_nozzles = true);
-    void babystepAxis_steps(const int16_t, const axis_t, bool linked_nozzles = true);
+    int16_t mmToWholeSteps(const float mm, const axis_t axis);
+
+    bool babystepAxis_steps(const int16_t steps, const axis_t axis);
+    void smartAdjustAxis_steps(const int16_t steps, const axis_t axis, bool linked_nozzles);
   #endif
 
   #if HOTENDS > 1

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -136,16 +136,20 @@ namespace ExtUI {
   extruder_t getActiveTool();
   void setActiveTool(const extruder_t, bool no_move);
 
+  #if ENABLED(BABYSTEPPING)
+    void babystepAxis_mm(const float, const axis_t, bool linked_nozzles = true);
+    void babystepAxis_steps(const int16_t, const axis_t, bool linked_nozzles = true);
+  #endif
 
   #if HOTENDS > 1
     float getNozzleOffset_mm(const axis_t, const extruder_t);
     void setNozzleOffset_mm(const float, const axis_t, const extruder_t);
+    void normalizeNozzleOffset(const axis_t axis);
   #endif
 
-  #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
+  #if HAS_BED_PROBE
     float getZOffset_mm();
     void setZOffset_mm(const float);
-    void addZOffset_steps(const int16_t);
   #endif
 
   #if ENABLED(BACKLASH_GCODE)


### PR DESCRIPTION
Since we are developing a dual-extruder printer, we wanted to make it as easy as possible to fine tune the Z-offsets and nozzle offsets during a print. Although UltraLCD implements babystepping for adjusting the Z-offset, the current implementation is confusing for dual-nozzles, because if the nozzle offsets are incorrect and the the user tries to adjust the Z-offset for one color to get a perfect first layer, it will be wrong for the other color. Furthermore, UltraLCD provides no ability to adjust the nozzle offsets during a print.

This PR adds a two methods to ExtUI to address the problem:

```
    void babystepAxis_mm(const float, const axis_t, bool linked_nozzles = true);
    void babystepAxis_steps(const int16_t, const axis_t, bool linked_nozzles = true);
```

These methods allow an axis to be babystepped during an active print. For a single nozzle printer, babystepping X and Y simply shifts the current print, while babystepping Z also adjusts `zprobe_zoffset`.

For the case in which the printer has multiple nozzles, the `linked_nozzles` flag indicates whether the user intends both nozzles to be adjusted together as one or whether the user intends to adjust the currently printing nozzle while keeping the other nozzles in place relative to the bed.

This combines the "Z-Offset" and "Nozzle Offsets" adjustment into a single "Adjust Offsets" screen that is active when the printer is printing:

![img_4703s](https://user-images.githubusercontent.com/29129419/49529102-96841980-f872-11e8-8c3f-be946acafb9a.JPG)

With this, a user can start a dual print, step Z up and down in order to choose the ideal "squish" for the first nozzle. Once the second color to begins printing, they can toggle the "Linked Nozzles" button to "no" and move the second nozzle relative to the material already on the bed -- i.e. step Z up and down to adjust the "squish" for that color and step X and Y to get the two colors to align perfectly on the bed.

The underlying code takes into account which nozzle is printing and adjusts either the "zprobe_offset" or the "nozzle_offset" as appropriate. Using this, the user can fully calibrate their Z-offsets and nozzle spacing from one place by making fine X, Y and Z adjustments during a dual-print.

**Caveats:**
* Since BABYSTEP_XY is not defined for delta printers, the `babystepAxis_mm` will only work for Z on deltas.
* This new functionality is only exposed via the new ExtUI. The UltraLCD implementation has not been changed.