### PR TITLE
Simpler AVR + Trinamic + Soft Serial sanity-check

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/SanityCheck.h
+++ b/Marlin/src/HAL/HAL_AVR/SanityCheck.h
@@ -97,20 +97,8 @@
 #endif // SPINDLE_LASER_ENABLE
 
 /**
- * TMC2208 software UART and ENDSTOP_INTERRUPTS both use pin change interrupts (PCI)
+ * The Trinamic library includes SoftwareSerial.h, leading to a compile error.
  */
-#if HAS_DRIVER(TMC2208) && ENABLED(ENDSTOP_INTERRUPTS_FEATURE) && !( \
-       defined(X_HARDWARE_SERIAL ) \
-    || defined(X2_HARDWARE_SERIAL) \
-    || defined(Y_HARDWARE_SERIAL ) \
-    || defined(Y2_HARDWARE_SERIAL) \
-    || defined(Z_HARDWARE_SERIAL ) \
-    || defined(Z2_HARDWARE_SERIAL) \
-    || defined(Z3_HARDWARE_SERIAL) \
-    || defined(E0_HARDWARE_SERIAL) \
-    || defined(E1_HARDWARE_SERIAL) \
-    || defined(E2_HARDWARE_SERIAL) \
-    || defined(E3_HARDWARE_SERIAL) \
-    || defined(E4_HARDWARE_SERIAL) )
-  #error "Select hardware UART for TMC2208 to use both TMC2208 and ENDSTOP_INTERRUPTS_FEATURE."
+#if HAS_TRINAMIC && ENABLED(ENDSTOP_INTERRUPTS_FEATURE)
+  #error "TMCStepper includes SoftwareSerial.h which is incompatible with ENDSTOP_INTERRUPTS_FEATURE. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
 #endif


### PR DESCRIPTION
In response to the comment https://github.com/MarlinFirmware/Marlin/issues/9221#issuecomment-445494464 by @teemuatlut.

The current `TMCStepper` library always includes `SoftwareSerial.h` and this conflicts with endstop interrupts on AVR, which needs to use the same PCI vectors that `SoftwareSerial` _always_ uses. This PR adds a sanity check when Trinamic drivers and endstop interrupts are both enabled on AVR.