### PR TITLE
[Small bugfix] ABL Probing grid is to be centered on the bed.

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -385,9 +385,9 @@ G29_TYPE GcodeSuite::G29() {
 
       if (parser.seen('H')) {
         const int16_t size = (int16_t)parser.value_linear_units();
-        left_probe_bed_position  = MAX((MIN_PROBE_X + MAX_PROBE_X - size) / 2, MIN_PROBE_X);
+        left_probe_bed_position  = MAX((X_BED_SIZE - size) / 2 , MIN_PROBE_X);
         right_probe_bed_position = MIN(left_probe_bed_position + size,         MAX_PROBE_X);
-        front_probe_bed_position = MAX((MIN_PROBE_Y + MAX_PROBE_Y - size) / 2, MIN_PROBE_Y);
+        front_probe_bed_position = MAX((Y_BED_SIZE - size) / 2, MIN_PROBE_Y);
         back_probe_bed_position  = MIN(front_probe_bed_position + size,        MAX_PROBE_Y);
       }
       else {

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -385,10 +385,10 @@ G29_TYPE GcodeSuite::G29() {
 
       if (parser.seen('H')) {
         const int16_t size = (int16_t)parser.value_linear_units();
-        left_probe_bed_position  = MAX((X_BED_SIZE - size) / 2 , MIN_PROBE_X);
-        right_probe_bed_position = MIN(left_probe_bed_position + size,         MAX_PROBE_X);
-        front_probe_bed_position = MAX((Y_BED_SIZE - size) / 2, MIN_PROBE_Y);
-        back_probe_bed_position  = MIN(front_probe_bed_position + size,        MAX_PROBE_Y);
+        left_probe_bed_position  = MAX(X_CENTER - size / 2, MIN_PROBE_X);
+        right_probe_bed_position = MIN(left_probe_bed_position + size, MAX_PROBE_X);
+        front_probe_bed_position = MAX(Y_CENTER - size / 2, MIN_PROBE_Y);
+        back_probe_bed_position  = MIN(front_probe_bed_position + size, MAX_PROBE_Y);
       }
       else {
         left_probe_bed_position  = parser.seenval('L') ? (int)RAW_X_POSITION(parser.value_linear_units()) : LEFT_PROBE_BED_POSITION;


### PR DESCRIPTION
The purpose (#12242) is to have a probing grid centered on the bed (typically the print is centered too...).

@thinkyhead  I'm still not sure about the probe offset (I don't know if it's already taken into account when computing the probing grid); maybe the following change is right:

`left_probe_bed_position  = MAX((X_BED_SIZE - size) / 2 - X_PROBE_OFFSET_FROM_EXTRUDER, MIN_PROBE_X);`
`front_probe_bed_position = MAX((Y_BED_SIZE - size) / 2 - Y_PROBE_OFFSET_FROM_EXTRUDER, MIN_PROBE_Y);`