### PR TITLE
Also use FAST_PWM_FAN for controller fan

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -839,13 +839,6 @@ void setup() {
     endstops.enable_z_probe(false);
   #endif
 
-  #if ENABLED(USE_CONTROLLER_FAN)
-    SET_OUTPUT(CONTROLLER_FAN_PIN);
-    #if ENABLED(FAST_PWM_FAN)
-      Temperature::setPwmFrequency(CONTROLLER_FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
-    #endif
-  #endif
-
   #if HAS_STEPPER_RESET
     enableStepperDrivers();
   #endif

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -841,6 +841,9 @@ void setup() {
 
   #if ENABLED(USE_CONTROLLER_FAN)
     SET_OUTPUT(CONTROLLER_FAN_PIN);
+    #if ENABLED(FAST_PWM_FAN)
+      Temperature::setPwmFrequency(CONTROLLER_FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
+    #endif
   #endif
 
   #if HAS_STEPPER_RESET

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1228,6 +1228,12 @@ void Temperature::init() {
   HAL_timer_start(TEMP_TIMER_NUM, TEMP_TIMER_FREQUENCY);
   ENABLE_TEMPERATURE_INTERRUPT();
 
+  #if ENABLED(USE_CONTROLLER_FAN)
+    SET_OUTPUT(CONTROLLER_FAN_PIN);
+    #if ENABLED(FAST_PWM_FAN)
+      setPwmFrequency(CONTROLLER_FAN_PIN, 1); // No prescaling. Pwm frequency = F_CPU/256/8
+    #endif
+  #endif
   #if HAS_AUTO_FAN_0
     #if E0_AUTO_FAN_PIN == FAN1_PIN
       SET_OUTPUT(E0_AUTO_FAN_PIN);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -622,11 +622,11 @@ class Temperature {
       static void set_heating_message(const uint8_t e);
     #endif
 
+  private:
+
     #if ENABLED(FAST_PWM_FAN)
       static void setPwmFrequency(const pin_t pin, int val);
     #endif
-
-  private:
 
     static void set_current_temp_raw();
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -622,11 +622,11 @@ class Temperature {
       static void set_heating_message(const uint8_t e);
     #endif
 
-  private:
-
     #if ENABLED(FAST_PWM_FAN)
       static void setPwmFrequency(const pin_t pin, int val);
     #endif
+
+  private:
 
     static void set_current_temp_raw();
 


### PR DESCRIPTION
Currently enabling `FAST_PWM_FAN` doesn't have effect for the controller fan (`USE_CONTROLLER_FAN` feature). This pull request corrects that.

Please note, I used the simple approach of making `Temperature::setPwmFrequency()` public to be able to call it from `Marlin.cpp`. I realize that might not be the best solution and I'm open to suggestions on how to improve that.