### PR TITLE
Added MKS MINI 12864 support to FYSETC F6 V1.3

### DIFF
--- a/Marlin/src/pins/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/pins_FYSETC_F6_13.h
@@ -199,7 +199,7 @@
   #define BTN_ENC          35
 
   #if ENABLED(MKS_MINI_12864)
-      #define DOGLCD_A0         27
-      #define DOGLCD_CS         25
+    #define DOGLCD_A0      27
+    #define DOGLCD_CS      25
   #endif
 #endif

--- a/Marlin/src/pins/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/pins_FYSETC_F6_13.h
@@ -197,4 +197,9 @@
   #define BTN_EN1          31
   #define BTN_EN2          33
   #define BTN_ENC          35
+
+  #if ENABLED(MKS_MINI_12864)
+      #define DOGLCD_A0         27
+      #define DOGLCD_CS         25
+  #endif
 #endif


### PR DESCRIPTION
### Description

Adds the 2 missing pin defs to support the MKS MINI 12864 LCD front panel support on the FYSETC F6 V1.3. Tested on my own F6.

### Benefits

FYSETC F6 V1.3 users that want to use an MKS MINI 12864.

### Related Issues

#11611 
