### PR TITLE
[1.1.x] Set DEFAULT_NOMINAL_FILAMENT_DIA to 1.75 in Anet A6 config

### DIFF
--- a/Marlin/example_configurations/Anet/A6/Configuration.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration.h
@@ -141,8 +141,8 @@
 // :[1, 2, 3, 4, 5]
 #define EXTRUDERS 1
 
-// Generally expected filament diameter (1.75, 2.85, 3.0, ...). Used for Volumetric, Filament Width Sensor, etc.
-#define DEFAULT_NOMINAL_FILAMENT_DIA 3.0
+// The Anet A6 original extruder is designed for 1.75mm
+#define DEFAULT_NOMINAL_FILAMENT_DIA 1.75
 
 // For Cyclops or any "multi-extruder" that shares a single nozzle.
 //#define SINGLENOZZLE


### PR DESCRIPTION
### Description

This PR changes default nominal filament dia to 1.75, which is default in Anet A6 printer.

### Benefits

Correct default size.