### PR TITLE
Squelched warning mentioned in #11061

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1598,8 +1598,10 @@ void Planner::synchronize() {
       if (!changed_dir) return;
     #endif
 
-    const bool positive[XYZ] = {  da > 0,  db > 0, dc > 0 },
-               non_zero[XYZ] = { da != 0, db != 0, dc != 0 };
+    const bool positive[XYZ] = {  da > 0,  db > 0, dc > 0 };
+    #ifdef BACKLASH_SMOOTHING_MM
+      const bool non_zero[XYZ] = { da != 0, db != 0, dc != 0 };
+    #endif
     bool made_adjustment = false;
 
     LOOP_XYZ(i) {


### PR DESCRIPTION
non_zero array is only used when BACKLASH_SMOOTHING_MM is enabled.
