### PR TITLE
Bugfix 2.0.x add motherboard pins define

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -183,6 +183,8 @@
 #define BOARD_COHESION3D_MINI     1756  // Cohesion3D Mini
 #define BOARD_SMOOTHIEBOARD       1757  // Smoothieboard
 #define BOARD_AZTEEG_X5_MINI_WIFI 1758  // Azteeg X5 Mini (Power outputs: Hotend0, Bed, Fan)
+#define BOARD_BIQU_SKR_V1_1       1759  // BIQU SKR_V1.1 (Power outputs: Hotend0,Hotend1, Fan, Bed)
+#define BOARD_BIQU_B300_V1_0      1760  // BIQU B300_V1.0 (Power outputs: Hotend0, Fan, Bed, SPI Driver)
 
 //
 // SAM3X8E ARM Cortex M3

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -321,7 +321,7 @@
 #elif MB(BIQU_SKR_V1_1)
   #include "pins_BIQU_SKR_V1.1.h"     // LPC1768                                    env:LPC1768
 #elif MB(BIQU_B300_V1_0)
-  #include "pins_BIQU_B300_V1.0.h"     // LPC1768                                    env:LPC1768
+  #include "pins_BIQU_B300_V1.0.h"    // LPC1768                                    env:LPC1768
 
 //
 // Other 32-bit Boards

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -318,6 +318,10 @@
   #include "pins_COHESION3D_MINI.h"   // LPC1769                                    env:LPC1769
 #elif MB(SMOOTHIEBOARD)
   #include "pins_SMOOTHIEBOARD.h"     // LPC1769                                    env:LPC1769
+#elif MB(BIQU_SKR_V1_1)
+  #include "pins_BIQU_SKR_V1.1.h"     // LPC1768                                    env:LPC1768
+#elif MB(BIQU_B300_V1_0)
+  #include "pins_BIQU_B300_V1.0.h"     // LPC1768                                    env:LPC1768
 
 //
 // Other 32-bit Boards

--- a/Marlin/src/pins/pins_BIQU_B300_V1.0.h
+++ b/Marlin/src/pins/pins_BIQU_B300_V1.0.h
@@ -1,0 +1,185 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * BIQU BQ111-A4
+ *
+ * Applies to the following boards:
+ *
+ *  BOARD_BIQU_BQ111_A4 (Hotend, Fan, Bed)
+ *
+ */
+
+#ifndef TARGET_LPC1768
+  #error "Oops!  Make sure you have the LPC1768 environment selected in your IDE."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "BIQU Thunder B300 V1.0"
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN         P1_24   // 10k pullup to 3.3V, 1K series
+#define X_MAX_PIN         P1_25   // 10k pullup to 3.3V, 1K series
+#define Y_MIN_PIN         P1_26   // 10k pullup to 3.3V, 1K series
+#define Y_MAX_PIN         P1_27   // 10k pullup to 3.3V, 1K series
+#define Z_MIN_PIN         P1_28   // 10k pullup to 3.3V, 1K series
+#define Z_MAX_PIN         P1_29   // 10k pullup to 3.3V, 1K series
+
+
+//
+// Steppers
+//
+#define X_STEP_PIN         P2_00
+#define X_DIR_PIN          P0_05
+#define X_ENABLE_PIN       P0_04
+#ifndef X_CS_PIN
+  #define X_CS_PIN         P1_15   // ETH
+#endif
+
+
+#define Y_STEP_PIN         P2_01
+#define Y_DIR_PIN          P0_11
+#define Y_ENABLE_PIN       P0_10
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN         P1_14   // ETH
+#endif
+
+#define Z_STEP_PIN         P2_02
+#define Z_DIR_PIN          P0_20
+#define Z_ENABLE_PIN       P0_19
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN         P1_16   // ETH
+#endif
+
+#define E0_STEP_PIN        P2_03
+#define E0_DIR_PIN         P0_22
+#define E0_ENABLE_PIN      P0_21
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN        P1_17   // ETH
+#endif
+
+
+//
+// Software SPI pins for TMC2130 stepper drivers
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #define TMC_SW_MOSI      P0_18   // ETH
+  #define TMC_SW_MISO      P0_17   // ETH
+  #define TMC_SW_SCK       P0_15   // ETH
+#endif
+
+//
+// Temperature Sensors
+//  3.3V max when defined as an analog input
+//
+#define TEMP_0_PIN          1   // A0 (T0)
+#define TEMP_BED_PIN        0   // A1 (T1)
+
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       P2_07
+#define HEATER_BED_PIN     P2_05
+#ifndef FAN_PIN
+  #define FAN_PIN          P2_04
+#endif
+
+//
+// Unused
+//
+//#define PIN_P2_10         P2_10   // IBOOT-1
+//#define PIN_P0_27         P0_27   // Onboard SD Detect
+
+/**
+ * LCD / Controller
+ *
+ * REPRAP_DISCOUNT_SMART_CONTROLLER is not supported due to the lack of LCD_PINS_D5,
+ * LCD_PINS_D6 or LCD_PINS_D7 in the EXP1 connector.
+ *
+ * A remote SD card is not supported as the pins routed to EXP2 are the same as used
+ * for the onboard SD card, and a chip select signal is not provided for the remote
+ * SD card.
+ */
+#if ENABLED(ULTRA_LCD)
+
+  #define BEEPER_PIN          P1_31   // EXP1-1
+
+  #define BTN_EN1             P3_26   // EXP2-3
+  #define BTN_EN2             P3_25   // EXP2-5
+  #define BTN_ENC             P1_30   // EXP1-2
+
+  #define SD_DETECT_PIN       P0_27   // EXP2-7
+  #define LCD_PINS_RS         P0_16   // EXP1-4
+  #define LCD_PINS_ENABLE     P0_18   // (MOSI) EXP1-3
+  #define LCD_PINS_D4         P0_15   // (SCK)  EXP1-5
+
+  #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) && DISABLED(DOGLCD)
+    #error "REPRAP_DISCOUNT_SMART_CONTROLLER is not supported by the BIQU BQ111-A4"
+  #endif
+
+  #if ENABLED(SDSUPPORT)
+    #error "SDSUPPORT is not supported by the BIQU BQ111-A4 when an LCD controller is used"
+  #endif
+
+#endif // ULTRA_LCD
+
+
+/**
+ * SD Card Reader
+ *
+ * Software SPI is used to interface with a stand-alone SD card reader connected to EXP1.
+ * Hardware SPI can't be used because P0_17 (MISO) is not brought out on this board.
+ */
+#if ENABLED(SDSUPPORT)
+
+  #define SCK_PIN   P0_15   // EXP1-5
+  #define MISO_PIN  P0_16   // EXP1-4
+  #define MOSI_PIN  P0_18   // EXP1-3
+  #define SS_PIN    P1_30   // EXP1-2
+  #define SDSS      SS_PIN
+
+#endif // SDSUPPORT
+
+
+/**
+ *  PWMS
+ *
+ *  There are 6 PWMS.  Each PWM can be assigned to one of two pins.
+ *
+ *  PWM1.1   P0_18   LCD_PINS_ENABLE
+ *  PWM1.1   P2_0    X_STEP_PIN
+ *  PWM1.2   P1_20   <none>
+ *  PWM1.2   P2_1    Y_STEP_PIN
+ *  PWM1.3   P1_21   <none>
+ *  PWM1.3   P2_2    Z_STEP_PIN
+ *  PWM1.4   P1_23   <none>
+ *  PWM1.4   P2_3    E0_STEP_PIN
+ *  PWM1.5   P1_24   X_MIN_PIN
+ *  PWM1.5   P2_4    FAN_PIN
+ *  PWM1.6   P1_26   Y_MIN_PIN
+ *  PWM1.6   P2_5    HEATER_BED_PIN
+ */

--- a/Marlin/src/pins/pins_BIQU_B300_V1.0.h
+++ b/Marlin/src/pins/pins_BIQU_B300_V1.0.h
@@ -41,44 +41,44 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN         P1_24   // 10k pullup to 3.3V, 1K series
-#define X_MAX_PIN         P1_25   // 10k pullup to 3.3V, 1K series
-#define Y_MIN_PIN         P1_26   // 10k pullup to 3.3V, 1K series
-#define Y_MAX_PIN         P1_27   // 10k pullup to 3.3V, 1K series
-#define Z_MIN_PIN         P1_28   // 10k pullup to 3.3V, 1K series
-#define Z_MAX_PIN         P1_29   // 10k pullup to 3.3V, 1K series
+#define X_MIN_PIN           P1_24   // 10k pullup to 3.3V, 1K series
+#define X_MAX_PIN           P1_25   // 10k pullup to 3.3V, 1K series
+#define Y_MIN_PIN           P1_26   // 10k pullup to 3.3V, 1K series
+#define Y_MAX_PIN           P1_27   // 10k pullup to 3.3V, 1K series
+#define Z_MIN_PIN           P1_28   // 10k pullup to 3.3V, 1K series
+#define Z_MAX_PIN           P1_29   // 10k pullup to 3.3V, 1K series
 
 
 //
 // Steppers
 //
-#define X_STEP_PIN         P2_00
-#define X_DIR_PIN          P0_05
-#define X_ENABLE_PIN       P0_04
+#define X_STEP_PIN          P2_00
+#define X_DIR_PIN           P0_05
+#define X_ENABLE_PIN        P0_04
 #ifndef X_CS_PIN
-  #define X_CS_PIN         P1_15   // ETH
+  #define X_CS_PIN          P1_15   // ETH
 #endif
 
 
-#define Y_STEP_PIN         P2_01
-#define Y_DIR_PIN          P0_11
-#define Y_ENABLE_PIN       P0_10
+#define Y_STEP_PIN          P2_01
+#define Y_DIR_PIN           P0_11
+#define Y_ENABLE_PIN        P0_10
 #ifndef Y_CS_PIN
-  #define Y_CS_PIN         P1_14   // ETH
+  #define Y_CS_PIN          P1_14   // ETH
 #endif
 
-#define Z_STEP_PIN         P2_02
-#define Z_DIR_PIN          P0_20
-#define Z_ENABLE_PIN       P0_19
+#define Z_STEP_PIN          P2_02
+#define Z_DIR_PIN           P0_20
+#define Z_ENABLE_PIN        P0_19
 #ifndef Z_CS_PIN
-  #define Z_CS_PIN         P1_16   // ETH
+  #define Z_CS_PIN          P1_16   // ETH
 #endif
 
-#define E0_STEP_PIN        P2_03
-#define E0_DIR_PIN         P0_22
-#define E0_ENABLE_PIN      P0_21
+#define E0_STEP_PIN         P2_03
+#define E0_DIR_PIN          P0_22
+#define E0_ENABLE_PIN       P0_21
 #ifndef E0_CS_PIN
-  #define E0_CS_PIN        P1_17   // ETH
+  #define E0_CS_PIN         P1_17   // ETH
 #endif
 
 
@@ -86,9 +86,9 @@
 // Software SPI pins for TMC2130 stepper drivers
 //
 #if ENABLED(TMC_USE_SW_SPI)
-  #define TMC_SW_MOSI      P0_18   // ETH
-  #define TMC_SW_MISO      P0_17   // ETH
-  #define TMC_SW_SCK       P0_15   // ETH
+  #define TMC_SW_MOSI       P0_18   // ETH
+  #define TMC_SW_MISO       P0_17   // ETH
+  #define TMC_SW_SCK        P0_15   // ETH
 #endif
 
 //
@@ -102,10 +102,10 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN       P2_07
-#define HEATER_BED_PIN     P2_05
+#define HEATER_0_PIN        P2_07
+#define HEATER_BED_PIN      P2_05
 #ifndef FAN_PIN
-  #define FAN_PIN          P2_04
+  #define FAN_PIN           P2_04
 #endif
 
 //
@@ -126,16 +126,16 @@
  */
 #if ENABLED(ULTRA_LCD)
 
-  #define BEEPER_PIN          P1_31   // EXP1-1
+  #define BEEPER_PIN        P1_31   // EXP1-1
 
-  #define BTN_EN1             P3_26   // EXP2-3
-  #define BTN_EN2             P3_25   // EXP2-5
-  #define BTN_ENC             P1_30   // EXP1-2
+  #define BTN_EN1           P3_26   // EXP2-3
+  #define BTN_EN2           P3_25   // EXP2-5
+  #define BTN_ENC           P1_30   // EXP1-2
 
-  #define SD_DETECT_PIN       P0_27   // EXP2-7
-  #define LCD_PINS_RS         P0_16   // EXP1-4
-  #define LCD_PINS_ENABLE     P0_18   // (MOSI) EXP1-3
-  #define LCD_PINS_D4         P0_15   // (SCK)  EXP1-5
+  #define SD_DETECT_PIN     P0_27   // EXP2-7
+  #define LCD_PINS_RS       P0_16   // EXP1-4
+  #define LCD_PINS_ENABLE   P0_18   // (MOSI) EXP1-3
+  #define LCD_PINS_D4       P0_15   // (SCK)  EXP1-5
 
   #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) && DISABLED(DOGLCD)
     #error "REPRAP_DISCOUNT_SMART_CONTROLLER is not supported by the BIQU BQ111-A4"
@@ -146,7 +146,6 @@
   #endif
 
 #endif // ULTRA_LCD
-
 
 /**
  * SD Card Reader
@@ -163,7 +162,6 @@
   #define SDSS      SS_PIN
 
 #endif // SDSUPPORT
-
 
 /**
  *  PWMS

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -1,0 +1,200 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#ifndef TARGET_LPC1768
+  #error "Oops!  Make sure you have the LPC1768 environment selected in your IDE."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "BIQU SKR V1.1"
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          P1_29
+#define X_MAX_PIN          P1_28
+#define Y_MIN_PIN          P1_27
+#define Y_MAX_PIN          P1_26
+#define Z_MIN_PIN          P1_25
+#define Z_MAX_PIN          P1_24
+
+//
+// Steppers
+//
+#define X_STEP_PIN         P0_04   //
+#define X_DIR_PIN          P0_05   //
+#define X_ENABLE_PIN       P4_28   //
+
+#define Y_STEP_PIN         P2_01   //
+#define Y_DIR_PIN          P2_02   //
+#define Y_ENABLE_PIN       P2_00   //
+
+#define Z_STEP_PIN         P0_20   //
+#define Z_DIR_PIN          P0_21   //
+#define Z_ENABLE_PIN       P0_19   //
+
+#define E0_STEP_PIN        P0_11
+#define E0_DIR_PIN         P2_13
+#define E0_ENABLE_PIN      P2_12
+
+#define E1_STEP_PIN        P0_01
+#define E1_DIR_PIN         P0_00
+#define E1_ENABLE_PIN      P0_10
+
+
+
+
+//
+// Temperature Sensors
+//  3.3V max when defined as an analog input
+//
+#define TEMP_BED_PIN       0   // A0 (T0) - (67) - TEMP_BED_PIN
+#define TEMP_0_PIN         1   // A1 (T1) - (68) - TEMP_0_PIN
+#define TEMP_1_PIN         2   // A2 (T2) - (69) - TEMP_1_PIN
+
+
+
+#define HEATER_0_PIN     P2_07
+#define HEATER_1_PIN     P2_04
+#define FAN_PIN          P2_03
+#define HEATER_BED_PIN   P2_05
+
+
+#define SDSS              P1_23   // (53)
+
+
+
+
+/**
+ * LCD / Controller
+ *
+ * All controllers can use J3 and J5 on the Re-ARM board.  Custom cabling will be required.
+ */
+
+/**
+ * Smart LCD adapter
+ *
+ * The Smart LCD adapter can be used for the two 10 pin LCD controllers such as
+ * REPRAP_DISCOUNT_SMART_CONTROLLER.  It can't be used for controllers that use
+ * DOGLCD_A0, DOGLCD_CS, LCD_PINS_D5, LCD_PINS_D6 or LCD_PINS_D7. A custom cable
+ * is needed to pick up 5V for the EXP1 connection.
+ *
+ * SD card on the LCD uses the same SPI signals as the LCD. This results in garbage/lines
+ * on the LCD display during accesses of the SD card. The menus/code has been arranged so
+ * that the garbage/lines are erased immediately after the SD card accesses are completed.
+ */
+
+#if ENABLED(ULTRA_LCD)
+
+  #if ENABLED(CR10_STOCKDISPLAY)
+
+    // Re-Arm can support Creality stock display without SD card reader and single cable on EXP3.
+    // Re-Arm J3 pins 1 (p1.31) & 2 (P3.26) are not used. Stock cable will need to have one
+    // 10-pin IDC connector trimmed or replaced with a 12-pin IDC connector to fit J3.
+    // Requires REVERSE_ENCODER_DIRECTION in Configuration.h
+
+    #define BEEPER_PIN          P2_11   // J3-3 & AUX-4
+
+    #define BTN_EN1             P0_16   // J3-7 & AUX-4
+    #define BTN_EN2             P1_23   // J3-5 & AUX-4
+    #define BTN_ENC             P3_25   // J3-4 & AUX-4
+
+    #define LCD_PINS_RS         P0_15   // J3-9 & AUX-4 (CS)
+    #define LCD_PINS_ENABLE     P0_18   // J3-10 & AUX-3 (SID, MOSI)
+    #define LCD_PINS_D4         P2_06   // J3-8 & AUX-3 (SCK, CLK)
+
+  #else
+
+    #define BEEPER_PIN          P1_30   // (37) not 5V tolerant
+
+    #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
+    #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
+    #define BTN_ENC             P2_11   // (35) J3-3 & AUX-4
+
+    #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
+    #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
+    #define LCD_PINS_RS         P0_16   // (16) J3-7 & AUX-4
+    #define LCD_SDSS            P0_16   // (16) J3-7 & AUX-4
+
+    #if ENABLED(NEWPANEL)
+      #if ENABLED(REPRAPWORLD_KEYPAD)
+        #define SHIFT_OUT         P0_18   // (51)  (MOSI) J3-10 & AUX-3
+        #define SHIFT_CLK         P0_15   // (52)  (SCK)  J3-9 & AUX-3
+        #define SHIFT_LD          P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
+      #endif
+    #else
+      //#define SHIFT_CLK           P3_26   // (31)  J3-2 & AUX-4
+      //#define SHIFT_LD            P3_25   // (33)  J3-4 & AUX-4
+      //#define SHIFT_OUT           P2_11   // (35)  J3-3 & AUX-4
+      //#define SHIFT_EN            P1_22   // (41)  J5-4 & AUX-4
+    #endif
+
+    #if ENABLED(VIKI2) || ENABLED(miniVIKI)
+      // #define LCD_SCREEN_ROT_180
+
+      #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
+      #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
+      #define BTN_ENC             P2_11   // (35) J3-3 & AUX-4
+
+      #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
+      #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
+
+      #define DOGLCD_CS           P0_16   // (16)
+      #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
+      #define DOGLCD_SCK          SCK_PIN
+      #define DOGLCD_MOSI         MOSI_PIN
+
+      #define STAT_LED_BLUE_PIN   P0_26   // (63)  may change if cable changes
+      #define STAT_LED_RED_PIN    P1_21   // ( 6)  may change if cable changes
+    #else
+      #define DOGLCD_CS           P0_26   // (63) J5-3 & AUX-2
+      #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
+      #define LCD_BACKLIGHT_PIN   P0_16   // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
+      #define LCD_PINS_ENABLE     P0_18   // (51) (MOSI) J3-10 & AUX-3
+      #define LCD_PINS_D4         P0_15   // (52) (SCK)  J3-9 & AUX-3
+      #if ENABLED(ULTIPANEL)
+        #define LCD_PINS_D5       P1_17   // (71) ENET_MDIO
+        #define LCD_PINS_D6       P1_14   // (73) ENET_RX_ER
+        #define LCD_PINS_D7       P1_10   // (75) ENET_RXD1
+      #endif
+    #endif
+
+    //#define MISO_PIN            P0_17   // (50)  system defined J3-10 & AUX-3
+    //#define MOSI_PIN            P0_18   // (51)  system defined J3-10 & AUX-3
+    //#define SCK_PIN             P0_15   // (52)  system defined J3-9 & AUX-3
+    //#define SS_PIN              P1_23   // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
+
+    #if ENABLED(MINIPANEL)
+      // GLCD features
+      //#define LCD_CONTRAST   190
+      // Uncomment screen orientation
+      //#define LCD_SCREEN_ROT_90
+      //#define LCD_SCREEN_ROT_180
+      //#define LCD_SCREEN_ROT_270
+    #endif
+
+  #endif
+
+#endif // ULTRA_LCD

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -21,7 +21,6 @@
  *
  */
 
-
 #ifndef TARGET_LPC1768
   #error "Oops!  Make sure you have the LPC1768 environment selected in your IDE."
 #endif
@@ -43,17 +42,17 @@
 //
 // Steppers
 //
-#define X_STEP_PIN         P0_04   //
-#define X_DIR_PIN          P0_05   //
-#define X_ENABLE_PIN       P4_28   //
+#define X_STEP_PIN         P0_04
+#define X_DIR_PIN          P0_05
+#define X_ENABLE_PIN       P4_28
 
-#define Y_STEP_PIN         P2_01   //
-#define Y_DIR_PIN          P2_02   //
-#define Y_ENABLE_PIN       P2_00   //
+#define Y_STEP_PIN         P2_01
+#define Y_DIR_PIN          P2_02
+#define Y_ENABLE_PIN       P2_00
 
-#define Z_STEP_PIN         P0_20   //
-#define Z_DIR_PIN          P0_21   //
-#define Z_ENABLE_PIN       P0_19   //
+#define Z_STEP_PIN         P0_20
+#define Z_DIR_PIN          P0_21
+#define Z_ENABLE_PIN       P0_19
 
 #define E0_STEP_PIN        P0_11
 #define E0_DIR_PIN         P2_13
@@ -63,9 +62,6 @@
 #define E1_DIR_PIN         P0_00
 #define E1_ENABLE_PIN      P0_10
 
-
-
-
 //
 // Temperature Sensors
 //  3.3V max when defined as an analog input
@@ -74,18 +70,18 @@
 #define TEMP_0_PIN         1   // A1 (T1) - (68) - TEMP_0_PIN
 #define TEMP_1_PIN         2   // A2 (T2) - (69) - TEMP_1_PIN
 
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       P2_07
+#define HEATER_1_PIN       P2_04
+#define FAN_PIN            P2_03
+#define HEATER_BED_PIN     P2_05
 
-
-#define HEATER_0_PIN     P2_07
-#define HEATER_1_PIN     P2_04
-#define FAN_PIN          P2_03
-#define HEATER_BED_PIN   P2_05
-
-
-#define SDSS              P1_23   // (53)
-
-
-
+//
+// Misc. Functions
+//
+#define SDSS               P1_23   // (53)
 
 /**
  * LCD / Controller
@@ -115,76 +111,76 @@
     // 10-pin IDC connector trimmed or replaced with a 12-pin IDC connector to fit J3.
     // Requires REVERSE_ENCODER_DIRECTION in Configuration.h
 
-    #define BEEPER_PIN          P2_11   // J3-3 & AUX-4
+    #define BEEPER_PIN     P2_11   // J3-3 & AUX-4
 
-    #define BTN_EN1             P0_16   // J3-7 & AUX-4
-    #define BTN_EN2             P1_23   // J3-5 & AUX-4
-    #define BTN_ENC             P3_25   // J3-4 & AUX-4
+    #define BTN_EN1        P0_16   // J3-7 & AUX-4
+    #define BTN_EN2        P1_23   // J3-5 & AUX-4
+    #define BTN_ENC        P3_25   // J3-4 & AUX-4
 
-    #define LCD_PINS_RS         P0_15   // J3-9 & AUX-4 (CS)
-    #define LCD_PINS_ENABLE     P0_18   // J3-10 & AUX-3 (SID, MOSI)
-    #define LCD_PINS_D4         P2_06   // J3-8 & AUX-3 (SCK, CLK)
+    #define LCD_PINS_RS    P0_15   // J3-9 & AUX-4 (CS)
+    #define LCD_PINS_ENABLE P0_18  // J3-10 & AUX-3 (SID, MOSI)
+    #define LCD_PINS_D4    P2_06   // J3-8 & AUX-3 (SCK, CLK)
 
   #else
 
-    #define BEEPER_PIN          P1_30   // (37) not 5V tolerant
+    #define BEEPER_PIN     P1_30   // (37) not 5V tolerant
 
-    #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
-    #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
-    #define BTN_ENC             P2_11   // (35) J3-3 & AUX-4
+    #define BTN_EN1        P3_26   // (31) J3-2 & AUX-4
+    #define BTN_EN2        P3_25   // (33) J3-4 & AUX-4
+    #define BTN_ENC        P2_11   // (35) J3-3 & AUX-4
 
-    #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
-    #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
-    #define LCD_PINS_RS         P0_16   // (16) J3-7 & AUX-4
-    #define LCD_SDSS            P0_16   // (16) J3-7 & AUX-4
+    #define SD_DETECT_PIN  P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
+    #define KILL_PIN       P1_22   // (41) J5-4 & AUX-4
+    #define LCD_PINS_RS    P0_16   // (16) J3-7 & AUX-4
+    #define LCD_SDSS       P0_16   // (16) J3-7 & AUX-4
 
     #if ENABLED(NEWPANEL)
       #if ENABLED(REPRAPWORLD_KEYPAD)
-        #define SHIFT_OUT         P0_18   // (51)  (MOSI) J3-10 & AUX-3
-        #define SHIFT_CLK         P0_15   // (52)  (SCK)  J3-9 & AUX-3
-        #define SHIFT_LD          P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
+        #define SHIFT_OUT  P0_18   // (51)  (MOSI) J3-10 & AUX-3
+        #define SHIFT_CLK  P0_15   // (52)  (SCK)  J3-9 & AUX-3
+        #define SHIFT_LD   P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
       #endif
     #else
-      //#define SHIFT_CLK           P3_26   // (31)  J3-2 & AUX-4
-      //#define SHIFT_LD            P3_25   // (33)  J3-4 & AUX-4
-      //#define SHIFT_OUT           P2_11   // (35)  J3-3 & AUX-4
-      //#define SHIFT_EN            P1_22   // (41)  J5-4 & AUX-4
+      //#define SHIFT_CLK  P3_26   // (31)  J3-2 & AUX-4
+      //#define SHIFT_LD   P3_25   // (33)  J3-4 & AUX-4
+      //#define SHIFT_OUT  P2_11   // (35)  J3-3 & AUX-4
+      //#define SHIFT_EN   P1_22   // (41)  J5-4 & AUX-4
     #endif
 
     #if ENABLED(VIKI2) || ENABLED(miniVIKI)
       // #define LCD_SCREEN_ROT_180
 
-      #define BTN_EN1             P3_26   // (31) J3-2 & AUX-4
-      #define BTN_EN2             P3_25   // (33) J3-4 & AUX-4
-      #define BTN_ENC             P2_11   // (35) J3-3 & AUX-4
+      #define BTN_EN1      P3_26   // (31) J3-2 & AUX-4
+      #define BTN_EN2      P3_25   // (33) J3-4 & AUX-4
+      #define BTN_ENC      P2_11   // (35) J3-3 & AUX-4
 
-      #define SD_DETECT_PIN       P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
-      #define KILL_PIN            P1_22   // (41) J5-4 & AUX-4
+      #define SD_DETECT_PIN P1_31  // (49) not 5V tolerant   J3-1 & AUX-3
+      #define KILL_PIN     P1_22   // (41) J5-4 & AUX-4
 
-      #define DOGLCD_CS           P0_16   // (16)
-      #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
-      #define DOGLCD_SCK          SCK_PIN
-      #define DOGLCD_MOSI         MOSI_PIN
+      #define DOGLCD_CS    P0_16   // (16)
+      #define DOGLCD_A0    P2_06   // (59) J3-8 & AUX-2
+      #define DOGLCD_SCK   SCK_PIN
+      #define DOGLCD_MOSI  MOSI_PIN
 
       #define STAT_LED_BLUE_PIN   P0_26   // (63)  may change if cable changes
       #define STAT_LED_RED_PIN    P1_21   // ( 6)  may change if cable changes
     #else
-      #define DOGLCD_CS           P0_26   // (63) J5-3 & AUX-2
-      #define DOGLCD_A0           P2_06   // (59) J3-8 & AUX-2
-      #define LCD_BACKLIGHT_PIN   P0_16   // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
-      #define LCD_PINS_ENABLE     P0_18   // (51) (MOSI) J3-10 & AUX-3
-      #define LCD_PINS_D4         P0_15   // (52) (SCK)  J3-9 & AUX-3
+      #define DOGLCD_CS    P0_26   // (63) J5-3 & AUX-2
+      #define DOGLCD_A0    P2_06   // (59) J3-8 & AUX-2
+      #define LCD_BACKLIGHT_PIN P0_16 // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
+      #define LCD_PINS_ENABLE P0_18   // (51) (MOSI) J3-10 & AUX-3
+      #define LCD_PINS_D4  P0_15   // (52) (SCK)  J3-9 & AUX-3
       #if ENABLED(ULTIPANEL)
-        #define LCD_PINS_D5       P1_17   // (71) ENET_MDIO
-        #define LCD_PINS_D6       P1_14   // (73) ENET_RX_ER
-        #define LCD_PINS_D7       P1_10   // (75) ENET_RXD1
+        #define LCD_PINS_D5 P1_17  // (71) ENET_MDIO
+        #define LCD_PINS_D6 P1_14  // (73) ENET_RX_ER
+        #define LCD_PINS_D7 P1_10  // (75) ENET_RXD1
       #endif
     #endif
 
-    //#define MISO_PIN            P0_17   // (50)  system defined J3-10 & AUX-3
-    //#define MOSI_PIN            P0_18   // (51)  system defined J3-10 & AUX-3
-    //#define SCK_PIN             P0_15   // (52)  system defined J3-9 & AUX-3
-    //#define SS_PIN              P1_23   // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
+    //#define MISO_PIN      P0_17   // (50)  system defined J3-10 & AUX-3
+    //#define MOSI_PIN      P0_18   // (51)  system defined J3-10 & AUX-3
+    //#define SCK_PIN       P0_15   // (52)  system defined J3-9 & AUX-3
+    //#define SS_PIN        P1_23   // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
 
     #if ENABLED(MINIPANEL)
       // GLCD features

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -134,13 +134,11 @@
     #define LCD_PINS_RS    P0_16   // (16) J3-7 & AUX-4
     #define LCD_SDSS       P0_16   // (16) J3-7 & AUX-4
 
-    #if ENABLED(NEWPANEL)
-      #if ENABLED(REPRAPWORLD_KEYPAD)
-        #define SHIFT_OUT  P0_18   // (51)  (MOSI) J3-10 & AUX-3
-        #define SHIFT_CLK  P0_15   // (52)  (SCK)  J3-9 & AUX-3
-        #define SHIFT_LD   P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
-      #endif
-    #else
+    #if ENABLED(REPRAPWORLD_KEYPAD)
+      #define SHIFT_OUT    P0_18   // (51)  (MOSI) J3-10 & AUX-3
+      #define SHIFT_CLK    P0_15   // (52)  (SCK)  J3-9 & AUX-3
+      #define SHIFT_LD     P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
+    #elif DISABLED(NEWPANEL)
       //#define SHIFT_CLK  P3_26   // (31)  J3-2 & AUX-4
       //#define SHIFT_LD   P3_25   // (33)  J3-4 & AUX-4
       //#define SHIFT_OUT  P2_11   // (35)  J3-3 & AUX-4


### PR DESCRIPTION
### add motherboard pins define

* pins_BIQU_SKR_V1.1 is a pins define of motherboard "bigtree/BIQU SKR V1.1".
* pins_BIQU_B300_V1.0 is a pins define of motherboard "bigtree/BIQU B300 V1.0". this motherboard is used in BIQU Thunder 3D printer.  and On-board SPI interface can drive tmc2130 directly through SPI without additional wiring

