### PR TITLE
[2.0.x] Constrain setting hotend temperature to maxtemp

### DIFF
--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -407,7 +407,7 @@ class Temperature {
       #if ENABLED(AUTO_POWER_CONTROL)
         powerManager.power_on();
       #endif
-      target_temperature[HOTEND_INDEX] = celsius;
+      target_temperature[HOTEND_INDEX] = MIN(celsius, maxttemp[HOTEND_INDEX]);
       #if WATCH_HOTENDS
         start_watching_heater(HOTEND_INDEX);
       #endif


### PR DESCRIPTION
The current code is able to accept request to set a higher hotend temperature then maxtemp limit set in Configuration.h. 

Set of higher bed temperature then BED_MAXTEMP is already limited in Temperature::setTargetBed().