### PR TITLE
[2.0.x] Limit PID autotune target to maxtemp

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -286,7 +286,11 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       next_auto_fan_check_ms = next_temp_ms + 2500UL;
     #endif
 
-    if (target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)) {
+    #ifdef BED_MAXTEMP
+      if (target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)) {
+    #else
+      if ((heater >= 0) && (target > (maxttemp[heater] - 15))) {
+    #endif
       SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
       return;
     }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -289,7 +289,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
     #ifdef BED_MAXTEMP
       if (target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)) {
     #else
-      if ((heater >= 0) && (target > (maxttemp[heater] - 15))) {
+      if (heater >= 0 && target > maxttemp[heater] - 15) {
     #endif
       SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
       return;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -286,13 +286,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       next_auto_fan_check_ms = next_temp_ms + 2500UL;
     #endif
 
-    if (
-      #ifdef BED_MAXTEMP
-        target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)
-      #else
-        heater >= 0 && target > maxttemp[heater] - 15
-      #endif
-    ) {
+    if (target > GHV(BED_MAXTEMP, maxttemp[heater]) - 15)) {
       SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
       return;
     }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -286,6 +286,11 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       next_auto_fan_check_ms = next_temp_ms + 2500UL;
     #endif
 
+    if (target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)) {
+      SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
+      return;
+    }
+
     SERIAL_ECHOLNPGM(MSG_PID_AUTOTUNE_START);
 
     disable_all_heaters();

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -286,11 +286,13 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
       next_auto_fan_check_ms = next_temp_ms + 2500UL;
     #endif
 
-    #ifdef BED_MAXTEMP
-      if (target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)) {
-    #else
-      if (heater >= 0 && target > maxttemp[heater] - 15) {
-    #endif
+    if (
+      #ifdef BED_MAXTEMP
+        target > ((heater < 0 ? BED_MAXTEMP : maxttemp[heater]) - 15)
+      #else
+        heater >= 0 && target > maxttemp[heater] - 15
+      #endif
+    ) {
       SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
       return;
     }


### PR DESCRIPTION
A user reported that he started PID autotune via M303 gcode by setting target temperature to 1850C by accident.

This code should block start of PID autotune by raising an error if target temperature is higher then maxtemp value set in Configuration.h.

Marlin is already trying to limit max. target temperature to maxtemp - 15C if user wants to start PID autotune from LCD menu.

This should fix https://github.com/MarlinFirmware/Marlin/issues/12679