### PR TITLE
[2.0.x] Limit set hotend and bed temperature to maxtemp-15

### DIFF
--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -407,7 +407,7 @@ class Temperature {
       #if ENABLED(AUTO_POWER_CONTROL)
         powerManager.power_on();
       #endif
-      target_temperature[HOTEND_INDEX] = MIN(celsius, maxttemp[HOTEND_INDEX]);
+      target_temperature[HOTEND_INDEX] = MIN(celsius, maxttemp[HOTEND_INDEX] - 15);
       #if WATCH_HOTENDS
         start_watching_heater(HOTEND_INDEX);
       #endif
@@ -451,7 +451,7 @@ class Temperature {
         #endif
         target_temperature_bed =
           #ifdef BED_MAXTEMP
-            MIN(celsius, BED_MAXTEMP)
+            MIN(celsius, BED_MAXTEMP - 15)
           #else
             celsius
           #endif


### PR DESCRIPTION
According to the comment by @AnHardt in https://github.com/MarlinFirmware/Marlin/pull/12702 max. operational temperature must be limited to MAXTEMP-15.