### PR TITLE
Confirmation on Abort SD print

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -67,8 +67,8 @@
 
   void menu_sdcard_abort_confirm() {
     START_MENU();
-    MENU_ITEM(function, MSG_STOP_PRINT, lcd_sdcard_stop);
     MENU_BACK(MSG_MAIN);
+    MENU_ITEM(function, MSG_STOP_PRINT, lcd_sdcard_stop);
     END_MENU();
   }
 

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -65,6 +65,13 @@
     ui.return_to_status();
   }
 
+  void menu_sdcard_abort_confirm() {
+    START_MENU();
+    MENU_ITEM(function, MSG_STOP_PRINT, lcd_sdcard_stop);
+    MENU_BACK(MSG_MAIN);
+    END_MENU();
+  }
+
 #endif // SDSUPPORT
 
 void menu_tune();
@@ -88,7 +95,8 @@ void menu_main() {
           MENU_ITEM(function, MSG_PAUSE_PRINT, lcd_sdcard_pause);
         else
           MENU_ITEM(function, MSG_RESUME_PRINT, lcd_sdcard_resume);
-        MENU_ITEM(function, MSG_STOP_PRINT, lcd_sdcard_stop);
+
+        MENU_ITEM(submenu, MSG_STOP_PRINT, menu_sdcard_abort_confirm);
       }
       else {
         MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);


### PR DESCRIPTION
Create submenu for abort sd print with abort above return button, so double tap still stops quickly but an accidental click doesnt kill a print.