### PR TITLE
Fix G33 sprintf output warning

### DIFF
--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -649,7 +649,7 @@ void GcodeSuite::G33() {
       else { // !end iterations
         char mess[15];
         if (iterations < 31)
-          sprintf_P(mess, PSTR("Iteration : %02i"), (int)iterations);
+          sprintf_P(mess, PSTR("Iteration : %02i"), iterations);
         else
           strcpy_P(mess, PSTR("No convergence"));
         SERIAL_ECHO(mess);

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -649,7 +649,7 @@ void GcodeSuite::G33() {
       else { // !end iterations
         char mess[15];
         if (iterations < 31)
-          sprintf_P(mess, PSTR("Iteration : %02i"), iterations);
+          sprintf_P(mess, PSTR("Iteration : %02i"), (unsigned int)iterations);
         else
           strcpy_P(mess, PSTR("No convergence"));
         SERIAL_ECHO(mess);


### PR DESCRIPTION
https://github.com/MarlinFirmware/Marlin/issues/12729
