### PR TITLE
modify nomove to false for tool change on filament swap

### DIFF
--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -88,7 +88,7 @@ void GcodeSuite::M600() {
       #if ENABLED(DUAL_X_CARRIAGE)
         && dual_x_carriage_mode != DXC_DUPLICATION_MODE && dual_x_carriage_mode != DXC_SCALED_DUPLICATION_MODE
       #endif
-    ) tool_change(target_extruder, 0, true);
+    ) tool_change(target_extruder, 0, false);
   #endif
 
   // Initial retract before move to filament change position
@@ -137,7 +137,7 @@ void GcodeSuite::M600() {
   #if EXTRUDERS > 1
     // Restore toolhead if it was changed
     if (active_extruder_before_filament_change != active_extruder)
-      tool_change(active_extruder_before_filament_change, 0, true);
+      tool_change(active_extruder_before_filament_change, 0, false);
   #endif
 }
 

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -71,7 +71,7 @@ void GcodeSuite::M701() {
     // Change toolhead if specified
     uint8_t active_extruder_before_filament_change = active_extruder;
     if (active_extruder != target_extruder)
-      tool_change(target_extruder, 0, true);
+      tool_change(target_extruder, 0, false);
   #endif
 
   // Lift Z axis
@@ -96,7 +96,7 @@ void GcodeSuite::M701() {
   #if EXTRUDERS > 1
     // Restore toolhead if it was changed
     if (active_extruder_before_filament_change != active_extruder)
-      tool_change(active_extruder_before_filament_change, 0, true);
+      tool_change(active_extruder_before_filament_change, 0, false);
   #endif
 
   // Show status screen
@@ -138,7 +138,7 @@ void GcodeSuite::M702() {
     // Change toolhead if specified
     uint8_t active_extruder_before_filament_change = active_extruder;
     if (active_extruder != target_extruder)
-      tool_change(target_extruder, 0, true);
+      tool_change(target_extruder, 0, false);
   #endif
 
   // Lift Z axis
@@ -149,7 +149,7 @@ void GcodeSuite::M702() {
   #if EXTRUDERS > 1 && ENABLED(FILAMENT_UNLOAD_ALL_EXTRUDERS)
     if (!parser.seenval('T')) {
       HOTEND_LOOP() {
-        if (e != active_extruder) tool_change(e, 0, true);
+        if (e != active_extruder) tool_change(e, 0, false);
         unload_filament(-fc_settings[e].unload_length, true, ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT);
       }
     }
@@ -170,7 +170,7 @@ void GcodeSuite::M702() {
   #if EXTRUDERS > 1
     // Restore toolhead if it was changed
     if (active_extruder_before_filament_change != active_extruder)
-      tool_change(active_extruder_before_filament_change, 0, true);
+      tool_change(active_extruder_before_filament_change, 0, false);
   #endif
 
   // Show status screen


### PR DESCRIPTION
When no move is set, and you select change filament on the inactive extruder from the LCD, the inactive tool crashes into the active tool heading to the park position. This allows the inactive tool to park and get out of the way.