### PR TITLE
Update pins_BIQU_SKR_V1.1.h

### DIFF
--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -75,10 +75,10 @@
 //
 #define HEATER_0_PIN       P2_07
 #if HOTENDS == 1
-    #define FAN1_PIN       P2_04
-  #else
-    #define HEATER_1_PIN   P2_04
-  #endif 
+  #define FAN1_PIN         P2_04
+#else
+  #define HEATER_1_PIN     P2_04
+#endif 
 #define FAN_PIN            P2_03
 #define HEATER_BED_PIN     P2_05
 

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -74,7 +74,11 @@
 // Heaters / Fans
 //
 #define HEATER_0_PIN       P2_07
-#define HEATER_1_PIN       P2_04
+#if HOTENDS == 1
+    #define FAN1_PIN       P2_04
+  #else
+    #define HEATER_1_PIN   P2_04
+  #endif 
 #define FAN_PIN            P2_03
 #define HEATER_BED_PIN     P2_05
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

There is only one switched fan header on the SKR board. With this change HEATER1 connector on the board can be used as a second fan connector (FAN1_PIN) if there is only one hotend in use. This output has a beefy MOSFET to drive a heater so it's safe to drive a fan.


### Benefits

Creates an extra fan header if user only utilizes one hotend.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
