### PR TITLE
Update LPC SD pins for BIQU SKR

### DIFF
--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -192,3 +192,39 @@
   #endif
 
 #endif // ULTRA_LCD
+
+//
+// SD Support
+//
+//#define USB_SD_DISABLED     // Disable host access to SD card as mass storage device through USB
+#define USB_SD_ONBOARD      // Enable host access to SD card as mass storage device through USB
+
+//#define LPC_SD_LCD          // Marlin uses the SD drive attached to the LCD
+#define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board.  There is no SD detect pin
+                              // for the onboard card.  Init card from LCD menu or send M21 whenever printer
+                              // is powered on to enable SD access.
+
+#if ENABLED(LPC_SD_LCD)
+
+  #define SCK_PIN            P0_15
+  #define MISO_PIN           P0_17
+  #define MOSI_PIN           P0_18
+  #define SS_PIN             P1_23   // Chip select for SD card used by Marlin
+  #define ONBOARD_SD_CS      P0_06   // Chip select for "System" SD card
+
+#elif ENABLED(LPC_SD_ONBOARD)
+
+  #if ENABLED(USB_SD_ONBOARD)
+    // When sharing the SD card with a PC we want the menu options to
+    // mount/unmount the card and refresh it. So we disable card detect.
+    #define SHARED_SD_CARD
+    #undef SD_DETECT_PIN // there is also no detect pin for the onboard card
+  #endif
+  #define SCK_PIN            P0_07
+  #define MISO_PIN           P0_08
+  #define MOSI_PIN           P0_09
+  #define SS_PIN             P0_06   // Chip select for SD card used by Marlin
+  #define ONBOARD_SD_CS      P0_06   // Chip select for "System" SD card
+
+#endif
+

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -194,10 +194,10 @@
 #endif // ULTRA_LCD
 
 //
-// SD Support
+// SD Support (as with the AZTEEG_X5_MINI_WIFI)
 //
 //#define USB_SD_DISABLED     // Disable host access to SD card as mass storage device through USB
-#define USB_SD_ONBOARD      // Enable host access to SD card as mass storage device through USB
+#define USB_SD_ONBOARD        // Enable host access to SD card as mass storage device through USB
 
 //#define LPC_SD_LCD          // Marlin uses the SD drive attached to the LCD
 #define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board.  There is no SD detect pin
@@ -227,4 +227,3 @@
   #define ONBOARD_SD_CS      P0_06   // Chip select for "System" SD card
 
 #endif
-


### PR DESCRIPTION
### Description

LPC SD pins are missing in BIQU SKR. 
Some LPC1768 based board (MKS Sbase, AZTEEG X5 MINI WIFI, RAMPS Re arm) pins.h have these pins
But the other don't have (these board also should be fixed, but I don't have those board)
I tested with my board sd card access from PC, working well (LPC_SD_ONBOARD && USB_SD_ONBOARD)

### Benefits

1. 'on board SD card' access from PC  support
2. external SD access support

### Related Issues

there is not related issue yet