### PR TITLE
[1.1.x] Correct Ender 3 bed size

### DIFF
--- a/Marlin/example_configurations/Creality/Ender-3/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration.h
@@ -876,8 +876,8 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 220
-#define Y_BED_SIZE 220
+#define X_BED_SIZE 235
+#define Y_BED_SIZE 235
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0


### PR DESCRIPTION
### Description

Ender 3 bed size was set to 220 but is 235 in reality. Confirmed in manufacturer's original firmware configuration [1]

[1] https://github.com/Creality3DPrinting/Ender-3

### Benefits

Increase printable area

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/12763
