### PR TITLE
Allow 4 fan animation frames

### DIFF
--- a/Marlin/src/lcd/dogm/dogm_Statusscreen.h
+++ b/Marlin/src/lcd/dogm/dogm_Statusscreen.h
@@ -668,8 +668,8 @@
   #undef STATUS_FAN_FRAMES
 #elif !defined(STATUS_FAN_FRAMES)
   #define STATUS_FAN_FRAMES 2
-#elif STATUS_FAN_FRAMES > 3
-  #error "Only 3 fan animation frames currently supported."
+#elif STATUS_FAN_FRAMES > 4
+  #error "Max 4 fan animation frames currently supported."
 #endif
 
 //

--- a/Marlin/src/lcd/dogm/dogm_Statusscreen.h
+++ b/Marlin/src/lcd/dogm/dogm_Statusscreen.h
@@ -669,7 +669,7 @@
 #elif !defined(STATUS_FAN_FRAMES)
   #define STATUS_FAN_FRAMES 2
 #elif STATUS_FAN_FRAMES > 4
-  #error "Max 4 fan animation frames currently supported."
+  #error "A maximum of 4 fan animation frames is currently supported."
 #endif
 
 //


### PR DESCRIPTION
Compiling with 4 fan animation frames on the display is prevented by an outdated sanity check