### PR TITLE
[2.0.x] Fix MKS Mini and SD card conflct over SPI mode on STM32F1

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -104,7 +104,7 @@ void spiInit(uint8_t spiRate) {
     case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
     default:                clock = SPI_CLOCK_DIV2; // Default from the SPI library
   }
-  spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE3);
+  spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
   SPI.begin();
 }
 


### PR DESCRIPTION
### Description
SD card does not work on MKS MINI on STM32F1 because of SPI modes difference.
Change SPI mode to SPI_MODE0 to fix this problem.

### Benefits
STM32F1-based boards can use MKS MINI controller with SD card.

### Additional Information
MKS MINI display uses SPI_MODE0 and does not operate with any other SPI mode.
HAL_STM32F1 uses SPI_MODE3 to access SD card.
SD card initialization is a success, but tit is not possible to read card's content after UI update.

SD card can operate in either SPI_MODE3 or SPI_MODE0, so HAL_STM32F1 is modified to use SPI_MODE0 for SD card.