### PR TITLE
cli / sei => DISABLE_ISRS / ENABLE_ISRS

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -84,13 +84,13 @@ class TFilamentMonitor : public FilamentMonitorBase {
     static inline void run() {
       if (enabled && !filament_ran_out && (IS_SD_PRINTING() || print_job_timer.isRunning())) {
         #if FILAMENT_RUNOUT_DISTANCE_MM > 0
-          cli(); // Prevent RunoutResponseDelayed::block_completed from accumulating here
+          DISABLE_ISRS(); // Prevent RunoutResponseDelayed::block_completed from accumulating here
         #endif
         response.run();
         sensor.run();
         const bool ran_out = response.has_run_out();
         #if FILAMENT_RUNOUT_DISTANCE_MM > 0
-          sei();
+          ENABLE_ISRS();
         #endif
         if (ran_out) {
           filament_ran_out = true;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2306,7 +2306,7 @@ void Stepper::report_positions() {
   // MUST ONLY BE CALLED BY AN ISR,
   // No other ISR should ever interrupt this!
   void Stepper::babystep(const AxisEnum axis, const bool direction) {
-    cli();
+    DISABLE_ISRS();
 
     switch (axis) {
 
@@ -2394,7 +2394,7 @@ void Stepper::report_positions() {
 
       default: break;
     }
-    sei();
+    ENABLE_ISRS();
   }
 
 #endif // BABYSTEPPING


### PR DESCRIPTION
Use `DISABLE_ISRS` and `ENABLE_ISRS` in place of `cli` and `sei` where possible. This might clear up some issues on platforms that do `cli` and `sei` differently.

Reference: #12801