### PR TITLE
Allow host to to be notified of filament run out and control pause.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/default/Configuration.h
+++ b/Marlin/src/config/default/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/default/Configuration.h
+++ b/Marlin/src/config/default/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -995,7 +995,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -996,18 +996,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1010,18 +1010,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1009,7 +1009,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
+++ b/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
+++ b/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A2/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Anet/A2/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A6/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration.h
@@ -1103,7 +1103,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A6/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration.h
@@ -1104,18 +1104,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Anet/A8/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration.h
@@ -1003,18 +1003,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Anet/A8/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration.h
@@ -1002,7 +1002,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/AnyCubic/i3/Configuration.h
+++ b/Marlin/src/config/examples/AnyCubic/i3/Configuration.h
@@ -1000,7 +1000,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/AnyCubic/i3/Configuration.h
+++ b/Marlin/src/config/examples/AnyCubic/i3/Configuration.h
@@ -1001,18 +1001,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/ArmEd/Configuration.h
+++ b/Marlin/src/config/examples/ArmEd/Configuration.h
@@ -991,18 +991,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/ArmEd/Configuration.h
+++ b/Marlin/src/config/examples/ArmEd/Configuration.h
@@ -990,7 +990,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
@@ -977,7 +977,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
@@ -978,18 +978,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
@@ -989,7 +989,21 @@
   #define NUM_RUNOUT_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -977,7 +977,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -978,18 +978,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Cartesio/Configuration.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration.h
@@ -988,7 +988,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Cartesio/Configuration.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration.h
@@ -989,18 +989,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration.h
@@ -999,7 +999,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration.h
@@ -1000,18 +1000,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -989,8 +989,22 @@
   #define FIL_RUNOUT_INVERTING true // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
-  #define FILAMENT_RUNOUT_SCRIPT "M600"
   #define FIL_RUNOUT_PIN 2 // Creality CR10-S stock sensor
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
+  #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -991,18 +991,17 @@
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
   #define FIL_RUNOUT_PIN 2 // Creality CR10-S stock sensor
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
@@ -1009,18 +1009,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
@@ -1008,7 +1008,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration.h
@@ -999,7 +999,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration.h
@@ -1000,18 +1000,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
@@ -994,18 +994,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
@@ -993,7 +993,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -994,18 +994,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -993,7 +993,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
@@ -999,7 +999,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
@@ -1000,18 +1000,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Einstart-S/Configuration.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration.h
@@ -999,7 +999,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Einstart-S/Configuration.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration.h
@@ -1000,18 +1000,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Felix/Configuration.h
+++ b/Marlin/src/config/examples/Felix/Configuration.h
@@ -971,7 +971,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Felix/Configuration.h
+++ b/Marlin/src/config/examples/Felix/Configuration.h
@@ -972,18 +972,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Felix/DUAL/Configuration.h
+++ b/Marlin/src/config/examples/Felix/DUAL/Configuration.h
@@ -971,7 +971,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Felix/DUAL/Configuration.h
+++ b/Marlin/src/config/examples/Felix/DUAL/Configuration.h
@@ -972,18 +972,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/Marlin/src/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -983,18 +983,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/Marlin/src/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -982,7 +982,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -995,7 +995,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -996,18 +996,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
@@ -1088,18 +1088,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
@@ -1087,7 +1087,21 @@
   #define FIL_RUNOUT_INVERTING true  // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -1019,7 +1019,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -1020,18 +1020,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -1015,18 +1015,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -1014,7 +1014,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
@@ -1004,7 +1004,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
@@ -1005,18 +1005,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -997,18 +997,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -996,7 +996,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1006,18 +1006,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1005,7 +1005,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1004,7 +1004,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1005,18 +1005,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
@@ -994,18 +994,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
@@ -993,7 +993,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration.h
@@ -1001,7 +1001,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration.h
@@ -1002,18 +1002,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -1010,18 +1010,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -1009,7 +1009,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -1013,7 +1013,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -1014,18 +1014,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -988,7 +988,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -989,18 +989,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
@@ -994,18 +994,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
@@ -993,7 +993,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -994,18 +994,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -993,7 +993,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Mks/Robin/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Robin/Configuration.h
@@ -991,18 +991,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Mks/Robin/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Robin/Configuration.h
@@ -990,7 +990,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RapideLite/RL200/Configuration.h
+++ b/Marlin/src/config/examples/RapideLite/RL200/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/RapideLite/RL200/Configuration.h
+++ b/Marlin/src/config/examples/RapideLite/RL200/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
@@ -1038,7 +1038,21 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
@@ -1039,18 +1039,17 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RigidBot/Configuration.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration.h
@@ -987,7 +987,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RigidBot/Configuration.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration.h
@@ -988,18 +988,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -1003,18 +1003,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -1002,7 +1002,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/STM32F10/Configuration.h
+++ b/Marlin/src/config/examples/STM32F10/Configuration.h
@@ -991,7 +991,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/STM32F10/Configuration.h
+++ b/Marlin/src/config/examples/STM32F10/Configuration.h
@@ -992,18 +992,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/STM32F4/Configuration.h
+++ b/Marlin/src/config/examples/STM32F4/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/STM32F4/Configuration.h
+++ b/Marlin/src/config/examples/STM32F4/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Sanguinololu/Configuration.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration.h
@@ -1021,18 +1021,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Sanguinololu/Configuration.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration.h
@@ -1020,7 +1020,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/TheBorg/Configuration.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/TheBorg/Configuration.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/TinyBoy2/Configuration.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration.h
@@ -1045,7 +1045,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/TinyBoy2/Configuration.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration.h
@@ -1046,18 +1046,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Tronxy/X1/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X1/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Tronxy/X1/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X1/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
@@ -994,18 +994,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
@@ -993,7 +993,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
@@ -1000,7 +1000,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
@@ -1001,18 +1001,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim1/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim1/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/VORONDesign/Configuration.h
+++ b/Marlin/src/config/examples/VORONDesign/Configuration.h
@@ -998,7 +998,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/VORONDesign/Configuration.h
+++ b/Marlin/src/config/examples/VORONDesign/Configuration.h
@@ -999,18 +999,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration.h
@@ -1019,7 +1019,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration.h
@@ -1020,18 +1020,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/WASP/PowerWASP/Configuration.h
+++ b/Marlin/src/config/examples/WASP/PowerWASP/Configuration.h
@@ -1009,18 +1009,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/WASP/PowerWASP/Configuration.h
+++ b/Marlin/src/config/examples/WASP/PowerWASP/Configuration.h
@@ -1008,7 +1008,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -999,7 +999,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1000,18 +1000,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
+++ b/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
@@ -990,18 +990,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
+++ b/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
@@ -989,7 +989,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1178,18 +1178,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1177,7 +1177,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1117,7 +1117,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1118,18 +1118,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1116,7 +1116,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1117,18 +1117,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1116,7 +1116,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1117,18 +1117,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/Marlin/src/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1108,18 +1108,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/Marlin/src/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1107,7 +1107,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1120,18 +1120,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1119,7 +1119,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/Marlin/src/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1105,18 +1105,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/Marlin/src/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1104,7 +1104,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/Marlin/src/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1109,18 +1109,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/Marlin/src/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1108,7 +1108,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/generic/Configuration.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration.h
@@ -1105,18 +1105,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/generic/Configuration.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration.h
@@ -1104,7 +1104,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
@@ -1106,7 +1106,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
@@ -1107,18 +1107,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
@@ -1108,18 +1108,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
@@ -1107,7 +1107,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
@@ -1108,18 +1108,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
@@ -1107,7 +1107,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1004,18 +1004,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1003,7 +1003,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/makibox/Configuration.h
+++ b/Marlin/src/config/examples/makibox/Configuration.h
@@ -992,7 +992,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/makibox/Configuration.h
+++ b/Marlin/src/config/examples/makibox/Configuration.h
@@ -993,18 +993,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -991,7 +991,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -992,18 +992,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
@@ -984,7 +984,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
@@ -985,18 +985,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/wt150/Configuration.h
+++ b/Marlin/src/config/examples/wt150/Configuration.h
@@ -995,18 +995,17 @@
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
-  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
-  // happens when printing from an SD card.
+  // Set one or more commands to run on filament runout.
+  //  - Always applies to SD-card printing.
+  //  - Applies to host-based printing if ACTION_ON_FILAMENT_RUNOUT is not set.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
 
-  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
-  // a SD print), the host will be notified and will be responsible for pausing
-  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  // With this option, if filament runs out during host-based printing, Marlin
+  // will send "//action:<ACTION_ON_FILAMENT_RUNOUT>" to the host and let the
+  // host handle filament change. If left undefined the FILAMENT_RUNOUT_SCRIPT
+  // will be used on filament runout for both host-based and SD-card printing.
   //
-  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
-  // e.g. '//action:filament_runout 0'. The host must be configured to handle
-  // the action command and execute a pause (i.e. by stopping to send commands).
+  // The host must be able to respond to the //action: command set here.
   //
   //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 

--- a/Marlin/src/config/examples/wt150/Configuration.h
+++ b/Marlin/src/config/examples/wt150/Configuration.h
@@ -994,7 +994,21 @@
   #define FIL_RUNOUT_INVERTING false // set to true to invert the logic of the sensor.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // The FILAMENT_RUNOUT_SCRIPT will execute when a runout is detected. If
+  // ACTION_ON_FILAMENT_RUNOUT is defined, it will only execute when a runout
+  // happens when printing from an SD card.
   #define FILAMENT_RUNOUT_SCRIPT "M600"
+
+  // When ACTION_ON_FILAMENT_RUNOUT is declared and printing from the host (i.e, not
+  // a SD print), the host will be notified and will be responsible for pausing
+  // the print (the FILAMENT_RUNOUT_SCRIPT will not run in this case).
+  //
+  // The notification will be '//action:ACTION_ON_FILAMENT_RUNOUT <extruder_number>',
+  // e.g. '//action:filament_runout 0'. The host must be configured to handle
+  // the action command and execute a pause (i.e. by stopping to send commands).
+  //
+  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -95,7 +95,13 @@ class TFilamentMonitor : public FilamentMonitorBase {
         if (ran_out) {
           filament_ran_out = true;
           #if ENABLED(EXTENSIBLE_UI)
-            ExtUI::onFilamentRunout();
+            ExtUI::onFilamentRunout(ExtUI::getActiveTool());
+          #endif
+          #ifdef FILAMENT_RUNOUT_ACTION
+            SERIAL_ECHOLNPAIR("//action:" FILAMENT_RUNOUT_ACTION " ", active_extruder);
+            if(!IS_SD_PRINTING())
+              reset();
+            else
           #endif
           enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
           planner.synchronize();

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -99,7 +99,7 @@ class TFilamentMonitor : public FilamentMonitorBase {
           #endif
           #ifdef FILAMENT_RUNOUT_ACTION
             SERIAL_ECHOLNPAIR("//action:" FILAMENT_RUNOUT_ACTION " ", active_extruder);
-            if(!IS_SD_PRINTING())
+            if (!IS_SD_PRINTING())
               reset();
             else
           #endif

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -237,7 +237,7 @@ namespace ExtUI {
   void onPrintTimerStarted();
   void onPrintTimerPaused();
   void onPrintTimerStopped();
-  void onFilamentRunout();
+  void onFilamentRunout(const extruder_t extruder);
   void onStatusChanged(const char * const msg);
   void onFactoryReset();
   void onStoreSettings();


### PR DESCRIPTION
It is now possible to specify an ACTION_ON_FILAMENT_RUNOUT for the cases in which the print host (rather than Marlin) should initiate the pause.

- When ACTION_ON_FILAMENT_RUNOUT is **not** defined:
  - A filament run out will always cause FILAMENT_RUNOUT_SCRIPT to run (current Marlin behavior).
- When ACTION_ON_FILAMENT_RUNOUT is defined:
  - A filament run out while printing **from the host** will cause the host to be notified, but print resumes until the host stops sending commands.
    - Run out condition will be reset immediately after notification.
    - FILAMENT_RUNOUT_SCRIPT will **not** execute.
  - A filament run out while printing from **SD card/USB flash drive** will cause FILAMENT_RUNOUT_SCRIPT to run.

Also, enhanced ExtUI callback to specify extruder for which the run out occurred so this can be shown on the display.
