### PR TITLE
Fix (broken) link to Install ReArm tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download earlier versions of Marlin on the [Releases page](https://github.com/Ma
 
 ## Building Marlin 2.0
 
-To build Marlin 2.0 you'll need [Arduino IDE 1.9](https://www.arduino.cc/en/main/software) or [PlatformIO](http://docs.platformio.org/en/latest/ide.html#platformio-ide). We've posted detailed instructions on how to [build Marlin 2.0 for ARM](http://marlinfw.org/docs/basics/install_arm.html).
+To build Marlin 2.0 you'll need [Arduino IDE 1.9](https://www.arduino.cc/en/main/software) or [PlatformIO](http://docs.platformio.org/en/latest/ide.html#platformio-ide). We've posted detailed instructions on how to [build Marlin 2.0 for ARM](http://marlinfw.org/docs/basics/install_rearm.html).
 
 ## Hardware Abstraction Layer (HAL)
 


### PR DESCRIPTION
### Description
Old link for Installing Marlin for 32 bit boards is broken, the new is link: http://marlinfw.org/docs/basics/install_rearm.html

 (I think/hope this is the correct one)

### Benefits

People will find the tutorial to build Marlin 2.0 for 32 bit boards :) 