### PR TITLE
Report on M92 with no arguments

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2366,6 +2366,13 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #define SAY_UNITS_P(PORT, COLON) say_units(COLON)
   #endif
 
+  void report_M92(
+    #if NUM_SERIAL > 1
+      const int8_t port,
+    #endif
+    const bool echo=true, const int8_t e=-1
+  );
+
   /**
    * M503 - Report current settings in RAM
    *
@@ -2458,21 +2465,12 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #endif // !NO_VOLUMETRICS
 
     CONFIG_ECHO_HEADING("Steps per unit:");
-    CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P(port, "  M92 X", LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]));
-    SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]));
-    SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]));
-    #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
-    #endif
-    SERIAL_EOL_P(port);
-    #if ENABLED(DISTINCT_E_FACTORS)
-      CONFIG_ECHO_START();
-      for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR_P(port, "  M92 T", (int)i);
-        SERIAL_ECHOLNPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS + i]));
-      }
-    #endif
+    report_M92(
+      #if NUM_SERIAL > 1
+        port,
+      #endif
+      !forReplay
+    );
 
     CONFIG_ECHO_HEADING("Maximum feedrates (units/s):");
     CONFIG_ECHO_START();


### PR DESCRIPTION
- Have `M92` report the current values with no arguments.
- Add a hidden option to report the full-step size in mm with `M92 H`.
- …and the ideal (magic) layer height with `M92 [H] L`.

```
> M92
echo: M92 X80.00 Y80.00 Z400.00 E95.00

> M92 L0.1
echo:{ micro_steps:16, z_full_step_mm:0.04, magic:[0.08,0.12] }

> M92 H8
echo:{ micro_steps:8, z_full_step_mm:0.02 }
```