### PR TITLE
UBL G29 T current position fix 

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -191,10 +191,20 @@
  */
 #if ENABLED(Z_SAFE_HOMING)
   #ifndef Z_SAFE_HOMING_X_POINT
-    #define Z_SAFE_HOMING_X_POINT X_CENTER
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      // Home at grid point close to bed center so this grid point will have z height very close to 0
+      #define Z_SAFE_HOMING_X_POINT ((GRID_MAX_POINTS_X/2)*(X_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_X-1)+MESH_INSET)
+    #else
+      #define Z_SAFE_HOMING_X_POINT X_CENTER
+    #endif
   #endif
   #ifndef Z_SAFE_HOMING_Y_POINT
-    #define Z_SAFE_HOMING_Y_POINT Y_CENTER
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      // Home at grid point close to bed center so this grid point will have z height very close to 0
+      #define Z_SAFE_HOMING_Y_POINT ((GRID_MAX_POINTS_Y/2)*(Y_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_Y-1)+MESH_INSET)
+    #else
+      #define Z_SAFE_HOMING_Y_POINT Y_CENTER
+    #endif
   #endif
   #define X_TILT_FULCRUM Z_SAFE_HOMING_X_POINT
   #define Y_TILT_FULCRUM Z_SAFE_HOMING_Y_POINT

--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -190,21 +190,17 @@
  * Safe Homing Options
  */
 #if ENABLED(Z_SAFE_HOMING)
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    // Home close to center so grid points have z heights very close to 0
+    #define _SAFE_POINT(A) (((GRID_MAX_POINTS_##A) / 2) * (A##_BED_SIZE - 2 * (MESH_INSET)) / (GRID_MAX_POINTS_##A - 1) + MESH_INSET)
+  #else
+    #define _SAFE_POINT(A) A##_CENTER
+  #endif
   #ifndef Z_SAFE_HOMING_X_POINT
-    #if ENABLED(AUTO_BED_LEVELING_UBL)
-      // Home at grid point close to bed center so this grid point will have z height very close to 0
-      #define Z_SAFE_HOMING_X_POINT ((GRID_MAX_POINTS_X/2)*(X_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_X-1)+MESH_INSET)
-    #else
-      #define Z_SAFE_HOMING_X_POINT X_CENTER
-    #endif
+    #define Z_SAFE_HOMING_X_POINT _SAFE_POINT(X)
   #endif
   #ifndef Z_SAFE_HOMING_Y_POINT
-    #if ENABLED(AUTO_BED_LEVELING_UBL)
-      // Home at grid point close to bed center so this grid point will have z height very close to 0
-      #define Z_SAFE_HOMING_Y_POINT ((GRID_MAX_POINTS_Y/2)*(Y_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_Y-1)+MESH_INSET)
-    #else
-      #define Z_SAFE_HOMING_Y_POINT Y_CENTER
-    #endif
+    #define Z_SAFE_HOMING_Y_POINT _SAFE_POINT(Y)
   #endif
   #define X_TILT_FULCRUM Z_SAFE_HOMING_X_POINT
   #define Y_TILT_FULCRUM Z_SAFE_HOMING_Y_POINT

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1145,7 +1145,7 @@
 
 #if ENABLED(Z_SAFE_HOMING)
   #if ENABLED(AUTO_BED_LEVELING_UBL)
-  //Try to home on a grid point to better allow checking mesh center
+    // Try to home on a grid point to better allow checking mesh center
     #define Z_SAFE_HOMING_X_POINT ((GRID_MAX_POINTS_X/2)*(X_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_X-1)+MESH_INSET) // X point for Z homing when homing all axes (G28).
     #define Z_SAFE_HOMING_Y_POINT ((GRID_MAX_POINTS_Y/2)*(Y_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_Y-1)+MESH_INSET) // Y point for Z homing when homing all axes (G28).
   #else

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1144,8 +1144,14 @@
 //#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
-  #define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+  //Try to home on a grid point to better allow checking mesh center
+    #define Z_SAFE_HOMING_X_POINT ((GRID_MAX_POINTS_X/2)*(X_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_X-1)+MESH_INSET) // X point for Z homing when homing all axes (G28).
+    #define Z_SAFE_HOMING_Y_POINT ((GRID_MAX_POINTS_Y/2)*(Y_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_Y-1)+MESH_INSET) // Y point for Z homing when homing all axes (G28).
+  #else
+    #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
+    #define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
+  #endif
 #endif
 
 // Homing speeds (mm/m)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1144,14 +1144,8 @@
 //#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #if ENABLED(AUTO_BED_LEVELING_UBL)
-    // Try to home on a grid point to better allow checking mesh center
-    #define Z_SAFE_HOMING_X_POINT ((GRID_MAX_POINTS_X/2)*(X_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_X-1)+MESH_INSET) // X point for Z homing when homing all axes (G28).
-    #define Z_SAFE_HOMING_Y_POINT ((GRID_MAX_POINTS_Y/2)*(Y_BED_SIZE-2*MESH_INSET)/(GRID_MAX_POINTS_Y-1)+MESH_INSET) // Y point for Z homing when homing all axes (G28).
-  #else
-    #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
-    #define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
-  #endif
+  #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
+  #define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
 #endif
 
 // Homing speeds (mm/m)

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -210,9 +210,9 @@
       serialprintPGM(csv ? PSTR("CSV:\n") : PSTR("LCD:\n"));
     }
 
-//Add XY_PROBE_OFFSET_FROM_EXTRUDER because probe_pt() subtracted these when
-//moving to the xy position to be measured. This ensures better agreement between
-//the current z position after G28 and the mesh values.
+    // Add XY_PROBE_OFFSET_FROM_EXTRUDER because probe_pt() subtracts these when
+    // moving to the xy position to be measured. This ensures better agreement between
+    // the current Z position after G28 and the mesh values.
     const float current_xi = find_closest_x_index(current_position[X_AXIS]+X_PROBE_OFFSET_FROM_EXTRUDER),
                 current_yi = find_closest_y_index(current_position[Y_AXIS]+Y_PROBE_OFFSET_FROM_EXTRUDER);
 

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -210,8 +210,11 @@
       serialprintPGM(csv ? PSTR("CSV:\n") : PSTR("LCD:\n"));
     }
 
-    const float current_xi = get_cell_index_x(current_position[X_AXIS] + (MESH_X_DIST) / 2.0),
-                current_yi = get_cell_index_y(current_position[Y_AXIS] + (MESH_Y_DIST) / 2.0);
+//Add XY_PROBE_OFFSET_FROM_EXTRUDER because probe_pt() subtracted these when
+//moving to the xy position to be measured. This ensures better agreement between
+//the current z position after G28 and the mesh values.
+    const float current_xi = find_closest_x_index(current_position[X_AXIS]+X_PROBE_OFFSET_FROM_EXTRUDER),
+                current_yi = find_closest_y_index(current_position[Y_AXIS]+Y_PROBE_OFFSET_FROM_EXTRUDER);
 
     if (!lcd) SERIAL_EOL();
     for (int8_t j = GRID_MAX_POINTS_Y - 1; j >= 0; j--) {

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -213,8 +213,8 @@
     // Add XY_PROBE_OFFSET_FROM_EXTRUDER because probe_pt() subtracts these when
     // moving to the xy position to be measured. This ensures better agreement between
     // the current Z position after G28 and the mesh values.
-    const float current_xi = find_closest_x_index(current_position[X_AXIS]+X_PROBE_OFFSET_FROM_EXTRUDER),
-                current_yi = find_closest_y_index(current_position[Y_AXIS]+Y_PROBE_OFFSET_FROM_EXTRUDER);
+    const float current_xi = find_closest_x_index(current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER),
+                current_yi = find_closest_y_index(current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER);
 
     if (!lcd) SERIAL_EOL();
     for (int8_t j = GRID_MAX_POINTS_Y - 1; j >= 0; j--) {


### PR DESCRIPTION
Account for x and y probe offset when indicating current position [] on grid when displaying mesh map.

Also, adjust the default Safe Home position to be on a grid point to allow easy validation, i.e. we expect the grid z offset value at the home position to be very close to 0, depending on how reproducible the z probing is.

### Description
After doing a G29 P1, the mesh topology displayed using G29 T would show larger than expected z errors when compared with the z height displayed on the LCD screen.

This turned out to be due to the code for finding the nearest mesh point to the current nozzle position not taking the x and y z probe offsets into account.

### Benefits

This fix makes it easier to verify the mesh using the LCD readout z value.

### Related Issues

