### PR TITLE
Add z probe offset measurement/adjustment using LCD only

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1502,8 +1502,9 @@
   #define USER_DESC_4 "Heat Bed/Home/Level"
   #define USER_GCODE_4 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nG28\nG29"
 
-  #define USER_DESC_5 "Home & Info"
-  #define USER_GCODE_5 "G28\nM503"
+  #define USER_DESC_5 "Home, set z offset"
+  #define USER_GCODE_5 "G29 Z\nG28 Z"
+
 #endif
 
 /**

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -89,6 +89,7 @@ class unified_bed_leveling {
       static float measure_business_card_thickness(float in_height);
       static void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool) _O0;
       static void fine_tune_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map) _O0;
+      static void adjust_z_probe_offset();
     #endif
 
     static bool g29_parameter_parsing() _O0;

--- a/Marlin/ubl.h
+++ b/Marlin/ubl.h
@@ -89,7 +89,9 @@ class unified_bed_leveling {
       static float measure_business_card_thickness(float in_height);
       static void manually_probe_remaining_mesh(const float&, const float&, const float&, const float&, const bool) _O0;
       static void fine_tune_mesh(const float &rx, const float &ry, const bool do_ubl_mesh_map) _O0;
+      #if HAS_BED_PROBE
       static void adjust_z_probe_offset();
+      #endif
     #endif
 
     static bool g29_parameter_parsing() _O0;

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1448,6 +1448,7 @@
         lcd_return_to_status();
     }
 
+#if HAS_BED_PROBE
 void unified_bed_leveling::adjust_z_probe_offset() {
   home_all_axes();
 
@@ -1494,7 +1495,7 @@ void unified_bed_leveling::adjust_z_probe_offset() {
   //restore_ubl_active_state_and_leave();
   lcd_return_to_status();
   }
-
+  #endif // HAS_BED_PROBE
   #endif // NEWPANEL
 
   /**

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1484,16 +1484,9 @@ void unified_bed_leveling::adjust_z_probe_offset() {
     lcd_quick_feedback(true);
   } else {
     zprobe_zoffset = new_z-orig_z;
-    //enqueue_and_echo_commands_P(PSTR("G28 Z\n"));
-    //homeaxis(Z_AXIS);
-    //current_position[Z_AXIS] = 0;
-    // set_axis_is_at_home(Z_AXIS);
-    // sync_plan_position();
-    // current_position[axis] = base_home_pos(axis);
-    //float diff = base_home_pos(Z_AXIS) - current_position[Z_AXIS];
-    //set_home_offset(Z_AXIS, diff)
   }
 
+  //Restore original position
   do_blocking_move_to_z(orig_z);
   do_blocking_move_to_xy(orig_x, orig_x);
 

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1477,9 +1477,8 @@ void unified_bed_leveling::adjust_z_probe_offset() {
     } while (!is_lcd_clicked());
 
   if (click_and_hold()) {
-  // If the click is held down, restore original pos
+  // If the click is held down, cancel the editing
     lcd_return_to_status();
-    do_blocking_move_to_z(orig_z);
     LCD_MESSAGEPGM(MSG_EDITING_STOPPED);
     lcd_quick_feedback(true);
   } else {

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1273,7 +1273,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
         ubl_encoderPosition = (ubl.encoder_diff > 0) ? 1 : -1;
         ubl.encoder_diff = 0;
 
-        mesh_edit_accumulator += float(ubl_encoderPosition) * 0.005f * 0.5f;
+        mesh_edit_accumulator += float(ubl_encoderPosition) * MBL_Z_STEP;//0.005f * 0.5f;
         mesh_edit_value = mesh_edit_accumulator;
         encoderPosition = 0;
         lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1272,8 +1272,11 @@ void lcd_quick_feedback(const bool clear_buttons) {
       if (ubl.encoder_diff) {
         ubl_encoderPosition = (ubl.encoder_diff > 0) ? 1 : -1;
         ubl.encoder_diff = 0;
-
-        mesh_edit_accumulator += float(ubl_encoderPosition) * MBL_Z_STEP;//0.005f * 0.5f;
+        #ifdef MBL_Z_STEP
+        mesh_edit_accumulator += float(ubl_encoderPosition) * MBL_Z_STEP;
+        #else
+        mesh_edit_accumulator += float(ubl_encoderPosition) * 0.005f * 0.5f;
+        #endif
         mesh_edit_value = mesh_edit_accumulator;
         encoderPosition = 0;
         lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;


### PR DESCRIPTION
Allow the zprobe_zoffset to be measured and set/adjusted before printing by turning the knob to lower the nozzle to the bed after homing the axes.
Assumes that Z_MIN_POS is set to e.g. -1 to some movement below the current z home position.

It is common to need to adjust the zprobe_zoffset (the z offset between the height where the probe triggers and the tip of the nozzle).
This value needs to be adjusted whenever the thickness of the bed changes (for e.g. an inductive probe) or whenever the nozzle is changed.
I generally don't have a pc connected to my printer (out in the shed), so I use the LCD screen a lot. It is very convenient if one can do an Auto-home then use the LCD knob to move the nozzle down to the bed and set the zprobe_zoffset using the z distance the nozzle moved.

This code achieves this by adding a new Z option to the G29 code, that first does a home all axes, then causes the LCD to go into a mode where the user can move the nozzle down or up using the knob. 

Clicking the knob causes the zprobe_zoffset to be set. Click and hold cancels the edit without changing zprobe_zoffset, in a similar fashion to the UBL G29 P4 command for fine tuning mesh height values (the code was more or less copied from there).

To allow this functionality to be driven from the LCD, I re-purposed user script 5 (in configuration_adv.h) to do "G29 Z\nG28 Z", where G29 Z first does a G28, then enters the editing mode, and the final G28 Z ensures the new zprobe_zoffset is applied.

### Benefits

Provides a quick, easy, and foolproof way to adjust zprobe_zoffset using the LCD knob only. 

### Requirements

Z probe, automatic bed leveling.
LCD screen with knob.

### Related Issues
