### PR TITLE
Execute gcode commands on stopping print by LCD menu

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -15295,6 +15295,9 @@ void loop() {
       #if ENABLED(POWER_LOSS_RECOVERY)
         card.removeJobRecoveryFile();
       #endif
+      #if ENABLED(SD_STOPPED_STEPPERRELEASE) && defined(SD_STOPPED_RELEASECOMMAND)
+        enqueue_and_echo_commands_P(PSTR(SD_STOPPED_RELEASECOMMAND));
+      #endif
     }
 
   #endif // SDSUPPORT

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Anet/A2plus/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A2plus/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Anet/A6/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Anet/A8/Configuration_adv.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration_adv.h
@@ -585,6 +585,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE false         // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "G27 P0"      // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G27 P2" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Cartesio/Configuration_adv.h
+++ b/Marlin/example_configurations/Cartesio/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/CR-8/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration_adv.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Felix/Configuration_adv.h
+++ b/Marlin/example_configurations/Felix/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/RigidBot/Configuration_adv.h
+++ b/Marlin/example_configurations/RigidBot/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/SCARA/Configuration_adv.h
+++ b/Marlin/example_configurations/SCARA/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Tronxy/X3A/Configuration_adv.h
+++ b/Marlin/example_configurations/Tronxy/X3A/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration_adv.h
@@ -580,6 +580,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/generic/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/generic/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration_adv.h
@@ -584,6 +584,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration_adv.h
@@ -579,6 +579,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/hangprinter/Configuration_adv.h
+++ b/Marlin/example_configurations/hangprinter/Configuration_adv.h
@@ -591,6 +591,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/makibox/Configuration_adv.h
+++ b/Marlin/example_configurations/makibox/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration_adv.h
@@ -577,6 +577,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.

--- a/Marlin/example_configurations/wt150/Configuration_adv.h
+++ b/Marlin/example_configurations/wt150/Configuration_adv.h
@@ -578,6 +578,9 @@
 
   #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
   #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the z enabled so your bed stays in place.
+  #define SD_STOPPED_STEPPERRELEASE false          // Disable steppers when SD Print is stopped by LCD
+  //#define SD_STOPPED_RELEASECOMMAND SD_FINISHED_RELEASECOMMAND // same as when SD Print is finished
+  //#define SD_STOPPED_RELEASECOMMAND "G91\nG0 Z5\nM84 X Y Z E" // Example
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.


### PR DESCRIPTION
On aborting a print, users rarely desire the nozzle to burn into the print or the build plate, especially with active steppers are holding it in place. This request to change this behavior has been made several times and the users are told to wait for it to be implemented (or Godot to come) while suffering hardware damage.

This is the solution proposed in Issue #12585, but refined. It has been tested on an Anet A8. It applies to bugfix-1.1.x.

Introduce
SD_STOPPED_STEPPERRELEASE (boolean) and
SD_STOPPED_RELEASECOMMAND (String)
to control the behavior of the stop command on the LCD menu.

These config settings are to be made in Config_adv.h

One of the example configs (BQ/Hephestos_2) used G27 P0 as the stop command, I matched the proposed example gcode to say "G27 P2". Otherwise the example is "G91s\nG0 Z5s\nM84 X Y Z E"