### PR TITLE
[2.0.x] Add RUMBA32 Board

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -234,6 +234,7 @@
 #define BOARD_BEAST            1802   // STM32FxxxVxT6 Libmaple based stm32f4 controller
 #define BOARD_STM32F4          1804   // STM32 STM32GENERIC based STM32F4 controller
 #define BOARD_ARMED            1807   // Arm'ed STM32F4 based controller
+#define BOARD_RUMBA32          1809   // RUMBA32 STM32F4 based controller
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -407,6 +407,8 @@
   #include "pins_STM32F4.h"           // STM32F4                                    env:STM32F4
 #elif MB(ARMED)
   #include "pins_ARMED.h"             // STM32F4                                    env:ARMED
+#elif MB(RUMBA32)
+  #include "pins_RUMBA32.h"           // STM32F4                                    env:RUMBA32
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins_RUMBA32.h
+++ b/Marlin/src/pins/pins_RUMBA32.h
@@ -24,10 +24,7 @@
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
 #endif
 
-#ifndef RUMBA32_V1_0
-  #define RUMBA32_V1_0
-#endif
-
+#define RUMBA32_V1_0
 #define DEFAULT_MACHINE_NAME "RUMBA32"
 #define BOARD_NAME "RUMBA32"
 

--- a/Marlin/src/pins/pins_RUMBA32.h
+++ b/Marlin/src/pins/pins_RUMBA32.h
@@ -1,0 +1,132 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef STM32F4
+  #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#endif
+
+#ifndef RUMBA32_V1_0
+  #define RUMBA32_V1_0
+#endif
+
+#define DEFAULT_MACHINE_NAME "RUMBA32"
+#define BOARD_NAME "RUMBA32"
+
+//#define I2C_EEPROM
+
+#define E2END 0xFFF // EEPROM end address (4kB)
+
+#if HOTENDS > 3 || E_STEPPERS > 3
+  #error "RUMBA32 supports up to 3 hotends / E-steppers."
+#endif
+
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          	PB12
+#define X_MAX_PIN          	PB13
+#define Y_MIN_PIN          	PB15
+#define Y_MAX_PIN          	PD8
+#define Z_MIN_PIN          	PD9
+#define Z_MAX_PIN          	PD10
+
+//
+// Steppers
+//
+#define X_STEP_PIN         	PA0
+#define X_DIR_PIN          	PC15
+#define X_ENABLE_PIN       	PC11
+#define X_CS_PIN       		PC14
+
+#define Y_STEP_PIN         	PE5
+#define Y_DIR_PIN          	PE6
+#define Y_ENABLE_PIN       	PE3
+#define Y_CS_PIN       		PE4
+
+#define Z_STEP_PIN         	PE1
+#define Z_DIR_PIN          	PE2
+#define Z_ENABLE_PIN       	PB7
+#define Z_CS_PIN       		PE0
+
+#define E0_STEP_PIN         PB5
+#define E0_DIR_PIN          PB6
+#define E0_ENABLE_PIN       PC12
+#define E0_CS_PIN       	PC13
+
+#define E1_STEP_PIN         PD6
+#define E1_DIR_PIN          PD7
+#define E1_ENABLE_PIN       PD4
+#define E1_CS_PIN       	PD5
+
+#define E2_STEP_PIN         PD2
+#define E2_DIR_PIN          PD3
+#define E2_ENABLE_PIN       PD0
+#define E2_CS_PIN       	PD1
+
+#define SCK_PIN            PA5
+#define MISO_PIN           PA6
+#define MOSI_PIN           PA7
+
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN       	PC4
+#define TEMP_1_PIN       	PC3
+#define TEMP_2_PIN       	PC2
+#define TEMP_3_PIN       	PC1
+#define TEMP_BED_PIN    	PC0
+
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN        PC6
+#define HEATER_1_PIN        PC7
+#define HEATER_2_PIN        PC8
+#define HEATER_BED_PIN      PA1
+
+#define FAN_PIN             PC9
+#define FAN1_PIN            PA8
+
+
+//
+// Misc. Functions
+//
+#define LED_PIN            PB14
+#define BTN_PIN            PC10
+#define PS_ON_PIN          PE11
+#define KILL_PIN           PC5
+
+#define SDSS               PA2
+#define SD_DETECT_PIN      PB0
+#define BEEPER_PIN         PE8
+#define LCD_PINS_RS        PE10
+#define LCD_PINS_ENABLE    PE9
+#define LCD_PINS_D4        PE12
+#define LCD_PINS_D5        PE13
+#define LCD_PINS_D6        PE14
+#define LCD_PINS_D7        PE15
+#define BTN_EN1            PB1
+#define BTN_EN2            PB2
+#define BTN_ENC            PE7

--- a/Marlin/src/pins/pins_RUMBA32.h
+++ b/Marlin/src/pins/pins_RUMBA32.h
@@ -39,76 +39,75 @@
   #error "RUMBA32 supports up to 3 hotends / E-steppers."
 #endif
 
-
 //
 // Limit Switches
 //
-#define X_MIN_PIN          	PB12
-#define X_MAX_PIN          	PB13
-#define Y_MIN_PIN          	PB15
-#define Y_MAX_PIN          	PD8
-#define Z_MIN_PIN          	PD9
-#define Z_MAX_PIN          	PD10
+#define X_MIN_PIN          PB12
+#define X_MAX_PIN          PB13
+#define Y_MIN_PIN          PB15
+#define Y_MAX_PIN          PD8
+#define Z_MIN_PIN          PD9
+#define Z_MAX_PIN          PD10
 
 //
 // Steppers
 //
-#define X_STEP_PIN         	PA0
-#define X_DIR_PIN          	PC15
-#define X_ENABLE_PIN       	PC11
-#define X_CS_PIN       		PC14
+#define X_STEP_PIN         PA0
+#define X_DIR_PIN          PC15
+#define X_ENABLE_PIN       PC11
+#define X_CS_PIN           PC14
 
-#define Y_STEP_PIN         	PE5
-#define Y_DIR_PIN          	PE6
-#define Y_ENABLE_PIN       	PE3
-#define Y_CS_PIN       		PE4
+#define Y_STEP_PIN         PE5
+#define Y_DIR_PIN          PE6
+#define Y_ENABLE_PIN       PE3
+#define Y_CS_PIN           PE4
 
-#define Z_STEP_PIN         	PE1
-#define Z_DIR_PIN          	PE2
-#define Z_ENABLE_PIN       	PB7
-#define Z_CS_PIN       		PE0
+#define Z_STEP_PIN         PE1
+#define Z_DIR_PIN          PE2
+#define Z_ENABLE_PIN       PB7
+#define Z_CS_PIN           PE0
 
-#define E0_STEP_PIN         PB5
-#define E0_DIR_PIN          PB6
-#define E0_ENABLE_PIN       PC12
-#define E0_CS_PIN       	PC13
+#define E0_STEP_PIN        PB5
+#define E0_DIR_PIN         PB6
+#define E0_ENABLE_PIN      PC12
+#define E0_CS_PIN          PC13
 
-#define E1_STEP_PIN         PD6
-#define E1_DIR_PIN          PD7
-#define E1_ENABLE_PIN       PD4
-#define E1_CS_PIN       	PD5
+#define E1_STEP_PIN        PD6
+#define E1_DIR_PIN         PD7
+#define E1_ENABLE_PIN      PD4
+#define E1_CS_PIN          PD5
 
-#define E2_STEP_PIN         PD2
-#define E2_DIR_PIN          PD3
-#define E2_ENABLE_PIN       PD0
-#define E2_CS_PIN       	PD1
-
-#define SCK_PIN            PA5
-#define MISO_PIN           PA6
-#define MOSI_PIN           PA7
-
+#define E2_STEP_PIN        PD2
+#define E2_DIR_PIN         PD3
+#define E2_ENABLE_PIN      PD0
+#define E2_CS_PIN          PD1
 
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN       	PC4
-#define TEMP_1_PIN       	PC3
-#define TEMP_2_PIN       	PC2
-#define TEMP_3_PIN       	PC1
-#define TEMP_BED_PIN    	PC0
-
+#define TEMP_0_PIN         PC4
+#define TEMP_1_PIN         PC3
+#define TEMP_2_PIN         PC2
+#define TEMP_3_PIN         PC1
+#define TEMP_BED_PIN       PC0
 
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN        PC6
-#define HEATER_1_PIN        PC7
-#define HEATER_2_PIN        PC8
-#define HEATER_BED_PIN      PA1
+#define HEATER_0_PIN       PC6
+#define HEATER_1_PIN       PC7
+#define HEATER_2_PIN       PC8
+#define HEATER_BED_PIN     PA1
 
-#define FAN_PIN             PC9
-#define FAN1_PIN            PA8
+#define FAN_PIN            PC9
+#define FAN1_PIN           PA8
 
+//
+// I2C
+//
+#define SCK_PIN            PA5
+#define MISO_PIN           PA6
+#define MOSI_PIN           PA7
 
 //
 // Misc. Functions
@@ -121,6 +120,10 @@
 #define SDSS               PA2
 #define SD_DETECT_PIN      PB0
 #define BEEPER_PIN         PE8
+
+//
+// LCD / Controller
+//
 #define LCD_PINS_RS        PE10
 #define LCD_PINS_ENABLE    PE9
 #define LCD_PINS_D4        PE12


### PR DESCRIPTION
### Description

This is a PR to add support for the [RUMBA32 board](https://github.com/Aus3D/RUMBA32) I am developing for Aus3D. We are just testing the final prototype boards at the moment and are planning to offer these for sale in the next couple of weeks via the Aus3D website. 

RUMBA32 features an STM32F446 microcontroller, and with these board definition files runs correctly using the STM32 HAL (not the STM32F4 or other specific ones, but the "HAL_STM32", targeting [Arduino_Core_STM32](https://github.com/stm32duino/Arduino_Core_STM32)).

I'm unsure what information is usually provided with a request to add a new board - if there's any other info that would be helpful, let me know and I will get it sorted.