### PR TITLE
[1.1.x] Level bed corners Z-hop height option

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1110,9 +1110,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1110,8 +1110,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
@@ -1123,8 +1123,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/example_configurations/AlephObjects/TAZ4/Configuration.h
@@ -1123,9 +1123,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
+++ b/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
+++ b/Marlin/example_configurations/AliExpress/CL-260/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A2plus/Configuration.h
+++ b/Marlin/example_configurations/Anet/A2plus/Configuration.h
@@ -1178,9 +1178,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A2plus/Configuration.h
+++ b/Marlin/example_configurations/Anet/A2plus/Configuration.h
@@ -1178,8 +1178,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A6/Configuration.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration.h
@@ -1242,8 +1242,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A6/Configuration.h
+++ b/Marlin/example_configurations/Anet/A6/Configuration.h
@@ -1242,9 +1242,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A8/Configuration.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration.h
@@ -1116,8 +1116,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Anet/A8/Configuration.h
+++ b/Marlin/example_configurations/Anet/A8/Configuration.h
@@ -1116,9 +1116,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
@@ -1103,9 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/Cyclops/Configuration.h
@@ -1103,8 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
@@ -1103,9 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration.h
@@ -1103,8 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration.h
@@ -1091,9 +1091,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/Hephestos/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos/Configuration.h
@@ -1091,8 +1091,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
@@ -1101,9 +1101,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/example_configurations/BQ/Hephestos_2/Configuration.h
@@ -1101,8 +1101,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration.h
@@ -1091,9 +1091,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/BQ/WITBOX/Configuration.h
+++ b/Marlin/example_configurations/BQ/WITBOX/Configuration.h
@@ -1091,8 +1091,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -1102,8 +1102,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Cartesio/Configuration.h
+++ b/Marlin/example_configurations/Cartesio/Configuration.h
@@ -1102,9 +1102,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration.h
@@ -1113,8 +1113,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10/Configuration.h
@@ -1113,9 +1113,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration.h
@@ -1108,8 +1108,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10S/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10S/Configuration.h
@@ -1108,9 +1108,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
@@ -1122,8 +1122,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-10mini/Configuration.h
@@ -1122,9 +1122,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-8/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration.h
@@ -1113,9 +1113,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/CR-8/Configuration.h
+++ b/Marlin/example_configurations/Creality/CR-8/Configuration.h
@@ -1113,8 +1113,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration.h
@@ -1107,9 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-2/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-2/Configuration.h
@@ -1107,8 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration.h
@@ -1107,9 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-3/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-3/Configuration.h
@@ -1107,8 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration.h
@@ -1113,9 +1113,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Creality/Ender-4/Configuration.h
+++ b/Marlin/example_configurations/Creality/Ender-4/Configuration.h
@@ -1113,8 +1113,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1085,9 +1085,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Felix/Configuration.h
+++ b/Marlin/example_configurations/Felix/Configuration.h
@@ -1085,8 +1085,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -1085,9 +1085,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Felix/DUAL/Configuration.h
+++ b/Marlin/example_configurations/Felix/DUAL/Configuration.h
@@ -1085,8 +1085,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
@@ -1109,8 +1109,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/example_configurations/FolgerTech/i3-2020/Configuration.h
@@ -1109,9 +1109,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
@@ -1118,8 +1118,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/GT2560/Configuration.h
@@ -1118,9 +1118,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1119,8 +1119,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1119,9 +1119,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1118,8 +1118,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1118,9 +1118,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
@@ -1107,9 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
+++ b/Marlin/example_configurations/Infitary/i3-M508/Configuration.h
@@ -1107,8 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/JGAurora/A5/Configuration.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration.h
@@ -1114,9 +1114,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/JGAurora/A5/Configuration.h
+++ b/Marlin/example_configurations/JGAurora/A5/Configuration.h
@@ -1114,8 +1114,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Malyan/M150/Configuration.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration.h
@@ -1131,8 +1131,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Malyan/M150/Configuration.h
+++ b/Marlin/example_configurations/Malyan/M150/Configuration.h
@@ -1131,9 +1131,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
@@ -1107,9 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/basic/Configuration.h
@@ -1107,8 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
@@ -1107,9 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/example_configurations/Micromake/C1/enhanced/Configuration.h
@@ -1107,8 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
@@ -1152,9 +1152,9 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/example_configurations/RepRapPro/Huxley/Configuration.h
@@ -1152,8 +1152,9 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/example_configurations/RepRapWorld/Megatronics/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1101,9 +1101,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/RigidBot/Configuration.h
+++ b/Marlin/example_configurations/RigidBot/Configuration.h
@@ -1101,8 +1101,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1116,8 +1116,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/SCARA/Configuration.h
+++ b/Marlin/example_configurations/SCARA/Configuration.h
@@ -1116,9 +1116,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Sanguinololu/Configuration.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration.h
@@ -1134,9 +1134,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Sanguinololu/Configuration.h
+++ b/Marlin/example_configurations/Sanguinololu/Configuration.h
@@ -1134,8 +1134,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -1162,8 +1162,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/TinyBoy2/Configuration.h
+++ b/Marlin/example_configurations/TinyBoy2/Configuration.h
@@ -1162,9 +1162,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X1/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X1/Configuration.h
@@ -1103,9 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X1/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X1/Configuration.h
@@ -1103,8 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X3A/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X3A/Configuration.h
@@ -1107,9 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X3A/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X3A/Configuration.h
@@ -1107,8 +1107,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X5S/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X5S/Configuration.h
@@ -1103,9 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/X5S/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/X5S/Configuration.h
@@ -1103,8 +1103,9 @@
 #define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/XY100/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/XY100/Configuration.h
@@ -1114,8 +1114,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Tronxy/XY100/Configuration.h
+++ b/Marlin/example_configurations/Tronxy/XY100/Configuration.h
@@ -1114,9 +1114,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8200/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration.h
@@ -1133,9 +1133,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8200/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8200/Configuration.h
@@ -1133,8 +1133,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8400/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8400/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/example_configurations/Velleman/K8400/Dual-head/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
@@ -1113,9 +1113,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/example_configurations/Wanhao/Duplicator 6/Configuration.h
@@ -1113,8 +1113,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1103,8 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/adafruit/ST7565/Configuration.h
+++ b/Marlin/example_configurations/adafruit/ST7565/Configuration.h
@@ -1103,9 +1103,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
@@ -1301,9 +1301,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/example_configurations/delta/Anycubic/Kossel/Configuration.h
@@ -1301,8 +1301,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1239,8 +1239,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1239,9 +1239,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/FLSUN/kossel/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel/Configuration.h
@@ -1238,9 +1238,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/FLSUN/kossel/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel/Configuration.h
@@ -1238,8 +1238,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -1238,9 +1238,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/FLSUN/kossel_mini/Configuration.h
@@ -1238,8 +1238,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
@@ -1241,9 +1241,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/example_configurations/delta/Hatchbox_Alpha/Configuration.h
@@ -1241,8 +1241,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1226,9 +1226,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/generic/Configuration.h
+++ b/Marlin/example_configurations/delta/generic/Configuration.h
@@ -1226,8 +1226,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1228,8 +1228,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_mini/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_mini/Configuration.h
@@ -1228,9 +1228,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1229,8 +1229,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_pro/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_pro/Configuration.h
@@ -1229,9 +1229,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1229,8 +1229,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/delta/kossel_xl/Configuration.h
+++ b/Marlin/example_configurations/delta/kossel_xl/Configuration.h
@@ -1229,9 +1229,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
@@ -1117,9 +1117,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/example_configurations/gCreate/gMax1.5+/Configuration.h
@@ -1117,8 +1117,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/hangprinter/Configuration.h
+++ b/Marlin/example_configurations/hangprinter/Configuration.h
@@ -1274,9 +1274,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/hangprinter/Configuration.h
+++ b/Marlin/example_configurations/hangprinter/Configuration.h
@@ -1274,8 +1274,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1106,9 +1106,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/makibox/Configuration.h
+++ b/Marlin/example_configurations/makibox/Configuration.h
@@ -1106,8 +1106,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1098,8 +1098,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/tvrrug/Round2/Configuration.h
+++ b/Marlin/example_configurations/tvrrug/Round2/Configuration.h
@@ -1098,9 +1098,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -1108,8 +1108,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
-  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
+  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/example_configurations/wt150/Configuration.h
+++ b/Marlin/example_configurations/wt150/Configuration.h
@@ -1108,9 +1108,9 @@
 //#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
-  #define LEVEL_CORNERS_INSET 30      // (mm) An inset for corner leveling
-  #define LEVEL_BED_CORNERS_Z_HOP 4.0 // (mm) Move nozzle up before moving between corners
-  //#define LEVEL_CENTER_TOO          // Move to the center after the last corner
+  #define LEVEL_CORNERS_INSET 30    // (mm) An inset for corner leveling
+  #define LEVEL_CORNERS_Z_HOP  4.0  // (mm) Move nozzle up before moving between corners
+  //#define LEVEL_CENTER_TOO        // Move to the center after the last corner
 #endif
 
 /**

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1829,7 +1829,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
      */
     static int8_t bed_corner;
     void _lcd_goto_next_corner() {
-      line_to_z(4.0);
+      line_to_z(LEVEL_BED_CORNERS_Z_HOP);
       switch (bed_corner) {
         case 0:
           current_position[X_AXIS] = X_MIN_BED + LEVEL_CORNERS_INSET;

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1824,12 +1824,18 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
   #if ENABLED(LEVEL_BED_CORNERS)
 
+    #ifndef LEVEL_CORNERS_Z_HOP
+      #define LEVEL_CORNERS_Z_HOP 4.0
+    #endif
+
+    static_assert(LEVEL_CORNERS_Z_HOP >= 0, "LEVEL_CORNERS_Z_HOP must be >= 0. Please update your configuration.");
+
     /**
      * Level corners, starting in the front-left corner.
      */
     static int8_t bed_corner;
     void _lcd_goto_next_corner() {
-      line_to_z(LEVEL_BED_CORNERS_Z_HOP);
+      line_to_z(LEVEL_CORNERS_Z_HOP);
       switch (bed_corner) {
         case 0:
           current_position[X_AXIS] = X_MIN_BED + LEVEL_CORNERS_INSET;


### PR DESCRIPTION
### Description
Current "Z-Hop" value is hardcoded in code and nozzle is pushing my (oversized) clips on bed.
Because change is simple and current code is hitting clips I think it's worth to backport it into 1.1.x branch.

### Benefits
Anyone can set "Z-hop" value when leveling bed corners.
