### PR TITLE
[2.0.x] Fix errors and some compiler warnings when building for HAL_STM32 with PlatformIO

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -24,10 +24,6 @@
 
 #define CPU_32_BIT
 
-#ifndef vsnprintf_P
-  #define vsnprintf_P vsnprintf
-#endif
-
 // --------------------------------------------------------------------------
 // Includes
 // --------------------------------------------------------------------------
@@ -105,8 +101,6 @@
   #define NUM_SERIAL 1
 #endif
 
-#define _BV(b) (1 << (b))
-
 /**
  * TODO: review this to return 1 for pins that are not analog input
  */
@@ -177,7 +171,7 @@ void _delay_ms(const int delay);
 
 extern "C" char* _sbrk(int incr);
 
-static int freeMemory() {
+inline static int freeMemory() {
   volatile char top;
   return &top - reinterpret_cast<char*>(_sbrk(0));
 }

--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -171,7 +171,7 @@ void _delay_ms(const int delay);
 
 extern "C" char* _sbrk(int incr);
 
-inline static int freeMemory() {
+static inline int freeMemory() {
   volatile char top;
   return &top - reinterpret_cast<char*>(_sbrk(0));
 }

--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
@@ -43,7 +43,6 @@ void FastIO_init(); // Must be called before using fast io macros
 // Defines
 // --------------------------------------------------------------------------
 
-#define _BV(b) (1 << (b))
 #define _BV32(b) (1UL << (b))
 
 #if defined(STM32F0xx) || defined(STM32F1xx) || defined(STM32F3xx) || defined(STM32L0xx) || defined(STM32L4xx)

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -56,7 +56,9 @@
 #define NANOSECONDS_PER_CYCLE (1000000000.0 / F_CPU)
 
 // Remove compiler warning on an unused variable
+#if !defined(ARDUINO_ARCH_STM32) || defined(STM32GENERIC)
 #define UNUSED(x) ((void)(x))
+#endif
 
 // Macros to make a string from a macro
 #define STRINGIFY_(M) #M

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -57,7 +57,7 @@
 
 // Remove compiler warning on an unused variable
 #if !defined(ARDUINO_ARCH_STM32) || defined(STM32GENERIC)
-#define UNUSED(x) ((void)(x))
+  #define UNUSED(x) ((void)(x))
 #endif
 
 // Macros to make a string from a macro

--- a/Marlin/src/pins/pins_ARMED.h
+++ b/Marlin/src/pins/pins_ARMED.h
@@ -29,10 +29,13 @@
 #endif
 
 #define DEFAULT_MACHINE_NAME "Arm'ed"
+
+#undef BOARD_NAME
 #define BOARD_NAME "Arm'ed"
 
 #define I2C_EEPROM
 
+#undef E2END
 #define E2END 0xFFF // EEPROM end address (4kB)
 
 #if HOTENDS > 2 || E_STEPPERS > 2

--- a/platformio.ini
+++ b/platformio.ini
@@ -284,13 +284,13 @@ monitor_speed = 250000
 # ARMED
 #
 [env:ARMED]
-platform      = ststm32
-framework     = arduino
-board         = ARMED
-build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing -std=gnu11 -std=gnu++11
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, c1921b4
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F4>
+platform    = ststm32
+framework   = arduino
+board       = armed_v1
+build_flags = ${common.build_flags} -DUSBCON -DUSBD_VID=0x0483 '-DUSB_MANUFACTURER="Unknown"' '-DUSB_PRODUCT="ARMED_V1"' -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing -std=gnu11 -std=gnu++11
+lib_deps    = ${common.lib_deps}
+lib_ignore  = Adafruit NeoPixel, c1921b4
+src_filter  = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
 #


### PR DESCRIPTION
### Description

When building with the latest PlatformIO (4.6.0) and Arduino Core for STM32 (1.4.0) there are some compiler warnings and errors.

- Warning: `vsnprintf_P`and `UNUSED(x)` is already defined in the Arduino Core STM32.
- Warning: `_BV(b)` is already defined in `Marlin/src/core/macros.h`
- Warning `E2END` is defined in the Arduino Core STM32 for EEPROM emulation. The **ARMED** board uses an external EEPROM and must define its own `E2END`.
- Error: `BOARD_NAME` is defined when PlatformIO invokes the compiler (not defined as a string), hence the `#undef BOARD_NAME` in `pins_ARMED.h`

### Benefits

Successfull build using PlatformIO and Arduino IDE.
