### PR TITLE
[LPC176x] Update PIO extrascript

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
@@ -10,18 +10,16 @@ target_drive = "REARM"
 import os
 import platform
 current_OS = platform.system()
+Import("env")
 
-#env_vars = subprocess.check_output('platformio run -t envdump')
-#env_vars = env_vars.split('\n')
-#for env in env_vars:
-#  print env
-#exit(0)
+def detect_error(e):
+    print '\nUnable to find destination disk (' + e + ')\n' \
+          'Please select it in platformio.ini using the upload_port keyword ' \
+          '(https://docs.platformio.org/en/latest/projectconf/section_env_upload.html)\n' \
+          'or copy the firmware (.pioenvs/' + env.get('PIOENV') + '/firmware.bin) manually to the appropriate disk\n'
 
-build_type = os.environ.get("BUILD_TYPE", 'Not Set')
-if build_type == 'upload' or build_type == 'traceback' or build_type == 'Not Set' :
-
+try:
     if current_OS == 'Windows':
-
         #
         # platformio.ini will accept this for a Windows upload port designation: 'upload_port = L:'
         #   Windows - doesn't care about the disk's name, only cares about the drive letter
@@ -30,119 +28,114 @@ if build_type == 'upload' or build_type == 'traceback' or build_type == 'Not Set
         #
         # get all drives on this computer
         #
-
         import subprocess
-
-        driveStr = subprocess.check_output("fsutil fsinfo drives")  # typical result (string): 'Drives: C:\ D:\ E:\ F:\ G:\ H:\ I:\ J:\ K:\ L:\ M:\ Y:\ Z:\'
-        driveStr = driveStr.strip().lstrip('Drives: ')  # typical result (string): 'C:\ D:\ E:\ F:\ G:\ H:\ I:\ J:\ K:\ L:\ M:\ Y:\ Z:\'
-        drives = driveStr.split()  # typical result (array of stings): ['C:\\', 'D:\\', 'E:\\', 'F:\\', 'G:\\', 'H:\\', 'I:\\', 'J:\\', 'K:\\', 'L:\\', 'M:\\', 'Y:\\', 'Z:\\']
+        # typical result (string): 'Drives: C:\ D:\ E:\ F:\ G:\ H:\ I:\ J:\ K:\ L:\ M:\ Y:\ Z:\'
+        driveStr = subprocess.check_output("fsutil fsinfo drives")
+        # typical result (string): 'C:\ D:\ E:\ F:\ G:\ H:\ I:\ J:\ K:\ L:\ M:\ Y:\ Z:\'
+        driveStr = driveStr.strip().lstrip('Drives: ')
+        # typical result (array of stings): ['C:\\', 'D:\\', 'E:\\', 'F:\\',
+        # 'G:\\', 'H:\\', 'I:\\', 'J:\\', 'K:\\', 'L:\\', 'M:\\', 'Y:\\', 'Z:\\']
+        drives = driveStr.split()
 
         upload_disk = 'Disk not found'
         target_file_found = False
         target_drive_found = False
         for drive in drives:
-          final_drive_name = drive.strip().rstrip('\\')   # typical result (string): 'C:'
-          try:
-            volume_info = subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT)
-          except Exception as e:
-            continue
-          else:
-            if target_drive in volume_info and target_file_found == False:  # set upload if not found target file yet
-              target_drive_found = True
-              upload_disk = final_drive_name
-            if target_filename in volume_info:
-              if target_file_found == False:
-                upload_disk = final_drive_name
-              target_file_found = True
+            final_drive_name = drive.strip().rstrip('\\')   # typical result (string): 'C:'
+            try:
+                volume_info = subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT)
+            except Exception as e:
+                continue
+            else:
+                if target_drive in volume_info and target_file_found == False:  # set upload if not found target file yet
+                    target_drive_found = True
+                    upload_disk = final_drive_name
+                if target_filename in volume_info:
+                    if target_file_found == False:
+                        upload_disk = final_drive_name
+                    target_file_found = True
 
         #
         # set upload_port to drive if found
         #
 
         if target_file_found == True or target_drive_found == True:
-          Import("env")
-          env.Replace(
-              UPLOAD_PORT = upload_disk
-          )
-          print 'upload disk: ' , upload_disk
+            env.Replace(
+                UPLOAD_PORT=upload_disk
+            )
+            print 'upload disk: ', upload_disk
         else:
-          print '\nUnable to find destination disk.  File must be copied manually. \n'
+            detect_error('Autodetect Error')
 
-
-    if current_OS == 'Linux':
-
+    elif current_OS == 'Linux':
         #
         # platformio.ini will accept this for a Linux upload port designation: 'upload_port = /media/media_name/drive'
         #
-
         upload_disk = 'Disk not found'
         target_file_found = False
         target_drive_found = False
         medias = os.listdir('/media')  #
         for media in medias:
-          drives = os.listdir('/media/' + media)  #
-          if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
-            target_drive_found = True
-            upload_disk = '/media/' + media + '/' + target_drive + '/'
-          for drive in drives:
-            try:
-              files = os.listdir('/media/' + media + '/' + drive )
-            except:
-              continue
-            else:
-              if target_filename in files:
-                if target_file_found == False:
-                  upload_disk = '/media/' + media + '/' + drive + '/'
-                  target_file_found = True
+            drives = os.listdir('/media/' + media)  #
+            if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
+                target_drive_found = True
+                upload_disk = '/media/' + media + '/' + target_drive + '/'
+            for drive in drives:
+                try:
+                    files = os.listdir('/media/' + media + '/' + drive)
+                except:
+                    continue
+                else:
+                    if target_filename in files:
+                        if target_file_found == False:
+                            upload_disk = '/media/' + media + '/' + drive + '/'
+                            target_file_found = True
 
         #
         # set upload_port to drive if found
         #
 
         if target_file_found == True or target_drive_found == True:
-          Import("env")
-          env.Replace(
-            UPLOAD_FLAGS = "-P$UPLOAD_PORT",
-            UPLOAD_PORT = upload_disk
-          )
-          print 'upload disk: ' , upload_disk
+            env.Replace(
+                UPLOAD_FLAGS="-P$UPLOAD_PORT",
+                UPLOAD_PORT=upload_disk
+            )
+            print 'upload disk: ', upload_disk
         else:
-           print '\nUnable to find destination disk.  File must be copied manually. \n'
+            detect_error('Autodetect Error')
 
-
-    if current_OS == 'Darwin':  # MAC
-
+    elif current_OS == 'Darwin':  # MAC
         #
         # platformio.ini will accept this for a OSX upload port designation: 'upload_port = /media/media_name/drive'
         #
-
-        import os
         upload_disk = 'Disk not found'
-        drives = os.listdir('/Volumes')  #  human readable names
+        drives = os.listdir('/Volumes')  # human readable names
         target_file_found = False
         target_drive_found = False
         if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
-          target_drive_found = True
-          upload_disk = '/Volumes/' + target_drive + '/'
+            target_drive_found = True
+            upload_disk = '/Volumes/' + target_drive + '/'
         for drive in drives:
-          try:
-            filenames = os.listdir('/Volumes/' + drive + '/')   # will get an error if the drive is protected
-          except:
-            continue
-          else:
-            if target_filename in filenames:
-              if target_file_found == False:
-                upload_disk = '/Volumes/' + drive + '/'
-              target_file_found = True
+            try:
+                filenames = os.listdir('/Volumes/' + drive + '/')   # will get an error if the drive is protected
+            except:
+                continue
+            else:
+                if target_filename in filenames:
+                    if target_file_found == False:
+                        upload_disk = '/Volumes/' + drive + '/'
+                    target_file_found = True
         #
         # set upload_port to drive if found
         #
 
         if target_file_found == True or target_drive_found == True:
-          Import("env")
-          env.Replace(
-              UPLOAD_PORT = upload_disk
-          )
-          print '\nupload disk: ' , upload_disk, '\n'
+            env.Replace(
+                UPLOAD_PORT=upload_disk
+            )
+            print '\nupload disk: ', upload_disk, '\n'
         else:
-           print '\nUnable to find destination disk.  File must be copied manually. \n'
+            detect_error('Autodetect Error')
+
+except Exception as e:
+    detect_error(str(e))

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,13 +29,13 @@ build_flags = -fmax-errors=5
   -g
   -ggdb
 lib_deps =
-  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
+  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   LiquidCrystal@1.3.4
   TMCStepper@<1.0.0
   Adafruit NeoPixel@1.1.3
-  https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
-  https://github.com/ameyer/Arduino-L6470/archive/master.zip
-  https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
+  LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
+  Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/master.zip
+  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
 
 #################################
 #                               #
@@ -161,7 +161,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/HAL_LPC1768>
 monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
-  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
+  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMCStepper@<1.0.0
 
 [env:LPC1769]
@@ -179,7 +179,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/HAL_LPC1768>
 monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
-  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
+  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMCStepper@<1.0.0
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,13 +29,13 @@ build_flags = -fmax-errors=5
   -g
   -ggdb
 lib_deps =
-  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
+  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   LiquidCrystal@1.3.4
   TMCStepper@<1.0.0
   Adafruit NeoPixel@1.1.3
-  LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
-  Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/master.zip
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
+  https://github.com/lincomatic/LiquidTWI2/archive/30aa480.zip
+  https://github.com/ameyer/Arduino-L6470/archive/master.zip
+  https://github.com/trinamic/TMC26XStepper/archive/c1921b4.zip
 
 #################################
 #                               #


### PR DESCRIPTION
### Description

Update the LPC176x platforms upload drive finding extrascript to exit gracefully on error, allowing the build to continue normally. The old method used to detect whether it was an upload target or just a build did not work so the script will always try to locate a drive, there is probably a way to detect the running build target but I didn't see it.

~~As an extra the platformio.ini is updated to assign names to the downloaded zip libraries, rather than leaving it as the downloaded filename.~~
DUE doesn't like libraries with names, don't have time to argue with it.

### Related Issues
#12877 