### PR TITLE
Fix for bug #12851. JunctionDeviation calculates wrong cos(theta) on CoreXY

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2391,6 +2391,14 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         delta_mm[E_AXIS] * inverse_millimeters
       };
     #endif
+    #if IS_CORE
+      /**
+       * On CoreXY the length of the vector [A,B] is SQRT(2) times the length of the head movement vector [X,Y]. So taking Z and E into
+       * account, we cannot scale to a unit vector with "inverse_millimeters".
+       * => normalize the complete junction vector
+      */
+      normalize_junction_vector(unit_vec);
+    #endif
 
     // Skip first block or when previous_nominal_speed is used as a flag for homing and offset cycles.
     if (moves_queued && !UNEAR_ZERO(previous_nominal_speed_sqr)) {

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2391,12 +2391,13 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         delta_mm[E_AXIS] * inverse_millimeters
       };
     #endif
-    #if IS_CORE
+
+    #if IS_CORE && ENABLED(JUNCTION_DEVIATION)
       /**
-       * On CoreXY the length of the vector [A,B] is SQRT(2) times the length of the head movement vector [X,Y]. So taking Z and E into
-       * account, we cannot scale to a unit vector with "inverse_millimeters".
+       * On CoreXY the length of the vector [A,B] is SQRT(2) times the length of the head movement vector [X,Y].
+       * So taking Z and E into account, we cannot scale to a unit vector with "inverse_millimeters".
        * => normalize the complete junction vector
-      */
+       */
       normalize_junction_vector(unit_vec);
     #endif
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
On CoreXY machines where junction deviation is enabled the tool head sometimes moves in a very jerky way and even loses steps which causes layer shifts. This was described in #12851.
The problem could be reproduced with the following Gcode on my machine at a travel acceleration of 4000 and a junction deviation of 0.01:
```
G1 X150 Y20 F24000
G1 X140 Y40
G1 X160 Y80
G1 X140 Y120
G1 X160 Y160
G1 X140 Y200
G1 X160 Y240
G1 X140 Y280
```
#### Root cause
In order to calculate the angle between two motion vectors they have to be normalized. The existing code uses the factor `inverse_millimeters` for all axis. However, on CoreXY the length of the motion vector [A,B] is SQRT(2) times the length of the head motion vector [X,Y]. So taking Z and E into account, we cannot scale to a unit vector with `inverse_millimeters`. Instead we have normalize the complete junction vector.

### Benefits

The tool head moves much smoother on CoreXY machines and obeys the velocity restrictions of junction deviation for all angles between consecutive motion vectors.

### Related Issues
Fixes bug #12851