### PR TITLE
Rename LCD menus according to variable types

### DIFF
--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -57,24 +57,51 @@ void safe_delay(millis_t ms) {
   #define RJDIGIT(n, f) ((n) >= (f) ? DIGIMOD(n, f) : ' ')
   #define MINUSOR(n, alt) (n >= 0 ? (alt) : (n = -n, '-'))
 
-  // Convert unsigned int to string 123 format
-  char* i8tostr3(const uint8_t i) {
+  // Convert unsigned 8bit int to string 123 format
+  char* ui8tostr3(const uint8_t i) {
     conv[4] = RJDIGIT(i, 100);
     conv[5] = RJDIGIT(i, 10);
     conv[6] = DIGIMOD(i, 1);
     return &conv[4];
   }
 
-  // Convert signed int to rj string with 123 or -12 format
-  char* itostr3(int i) {
-    conv[4] = MINUSOR(i, RJDIGIT(i, 100));
-    conv[5] = RJDIGIT(i, 10);
-    conv[6] = DIGIMOD(i, 1);
+  // Convert signed 8bit int to rj string with 123 or -12 format
+  char* i8tostr3(const int8_t x) {
+    int xx = x;
+    conv[4] = MINUSOR(xx, RJDIGIT(xx, 100));
+    conv[5] = RJDIGIT(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
     return &conv[4];
   }
 
-  // Convert unsigned int to lj string with 123 format
-  char* itostr3left(const int i) {
+  // Convert unsigned 16bit int to string 123 format
+  char* ui16tostr3(const uint16_t xx) {
+    conv[4] = RJDIGIT(xx, 100);
+    conv[5] = RJDIGIT(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[4];
+  }
+
+  // Convert unsigned 16bit int to string 1234 format
+  char* ui16tostr4(const uint16_t xx) {
+    conv[3] = RJDIGIT(xx, 1000);
+    conv[4] = RJDIGIT(xx, 100);
+    conv[5] = RJDIGIT(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[3];
+  }
+
+  // Convert signed 16bit int to rj string with 123 or -12 format
+  char* i16tostr3(const int16_t x) {
+    int xx = x;
+    conv[4] = MINUSOR(xx, RJDIGIT(xx, 100));
+    conv[5] = RJDIGIT(xx, 10);
+    conv[6] = DIGIMOD(xx, 1);
+    return &conv[4];
+  }
+
+  // Convert unsigned 16bit int to lj string with 123 format
+  char* i16tostr3left(const int16_t i) {
     char *str = &conv[6];
     *str = DIGIMOD(i, 1);
     if (i >= 10) {
@@ -85,8 +112,8 @@ void safe_delay(millis_t ms) {
     return str;
   }
 
-  // Convert signed int to rj string with 1234, _123, -123, _-12, or __-1 format
-  char* itostr4sign(const int i) {
+  // Convert signed 16bit int to rj string with 1234, _123, -123, _-12, or __-1 format
+  char* i16tostr4sign(const int16_t i) {
     const bool neg = i < 0;
     const int ii = neg ? -i : i;
     if (i >= 1000) {
@@ -141,7 +168,7 @@ void safe_delay(millis_t ms) {
     // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
     char* ftostr4sign(const float &f) {
       const int i = (f * 100 + (f < 0 ? -5: 5)) / 10;
-      if (!WITHIN(i, -99, 999)) return itostr4sign((int)f);
+      if (!WITHIN(i, -99, 999)) return i16tostr4sign((int)f);
       const bool neg = i < 0;
       const int ii = neg ? -i : i;
       conv[3] = neg ? '-' : (ii >= 100 ? DIGIMOD(ii, 100) : ' ');

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -56,16 +56,25 @@ inline void serial_delay(const millis_t ms) {
 #if ENABLED(ULTRA_LCD) || ENABLED(DEBUG_LEVELING_FEATURE) || ENABLED(EXTENSIBLE_UI)
 
   // Convert uint8_t to string with 123 format
-  char* i8tostr3(const uint8_t x);
+  char* ui8tostr3(const uint8_t x);
 
-  // Convert signed int to rj string with 123 or -12 format
-  char* itostr3(const int x);
+  // Convert int8_t to string with 123 format
+  char* i8tostr3(const int8_t x);
+
+  // Convert uint16_t to string with 123 format
+  char* ui16tostr3(const uint16_t x);
+
+  // Convert uint16_t to string with 1234 format
+  char* ui16tostr4(const uint16_t x);
+
+  // Convert int16_t to string with 123 format
+  char* i16tostr3(const int16_t x);
 
   // Convert unsigned int to lj string with 123 format
-  char* itostr3left(const int xx);
+  char* i16tostr3left(const int16_t xx);
 
   // Convert signed int to rj string with _123, -123, _-12, or __-1 format
-  char* itostr4sign(const int x);
+  char* i16tostr4sign(const int16_t x);
 
   // Convert unsigned float to string with 1.23 format
   char* ftostr12ns(const float &x);
@@ -95,14 +104,14 @@ inline void serial_delay(const millis_t ms) {
   char* ftostr62rj(const float &x);
 
   // Convert float to rj string with 123 or -12 format
-  FORCE_INLINE char* ftostr3(const float &x) { return itostr3(int(x + (x < 0 ? -0.5f : 0.5f))); }
+  FORCE_INLINE char* ftostr3(const float &x) { return i16tostr3(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
 
   #if ENABLED(LCD_DECIMAL_SMALL_XY)
     // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
     char* ftostr4sign(const float &fx);
   #else
     // Convert float to rj string with 1234, _123, -123, __12, _-12, ___1, or __-1 format
-    FORCE_INLINE char* ftostr4sign(const float &x) { return itostr4sign(int(x + (x < 0 ? -0.5f : 0.5f))); }
+    FORCE_INLINE char* ftostr4sign(const float &x) { return i16tostr4sign(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
   #endif
 
 #endif // ULTRA_LCD

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -528,7 +528,7 @@ FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, co
 
   if (prefix >= 0) lcd_put_wchar(prefix);
 
-  lcd_put_u8str(itostr3(t1 + 0.5));
+  lcd_put_u8str(i16tostr3(t1 + 0.5));
   lcd_put_wchar('/');
 
   #if !HEATER_IDLE_HANDLER
@@ -548,7 +548,7 @@ FORCE_INLINE void _draw_heater_status(const int8_t heater, const char prefix, co
     }
     else
   #endif
-      lcd_put_u8str(itostr3left(t2 + 0.5));
+      lcd_put_u8str(i16tostr3left(t2 + 0.5));
 
   if (prefix >= 0) {
     lcd_put_wchar(LCD_STR_DEGREE[0]);
@@ -578,7 +578,7 @@ FORCE_INLINE void _draw_bed_status(const bool blink) {
       #endif
     ));
     if (progress)
-      lcd_put_u8str(itostr3(progress));
+      lcd_put_u8str(ui8tostr3(progress));
     else
       lcd_put_u8str_P(PSTR("---"));
     lcd_put_wchar('%');
@@ -627,7 +627,7 @@ void MarlinUI::draw_status_message(const bool blink) {
       lcd_put_u8str_P(PSTR("Dia "));
       lcd_put_u8str(ftostr12ns(filament_width_meas));
       lcd_put_u8str_P(PSTR(" V"));
-      lcd_put_u8str(itostr3(100.0 * (
+      lcd_put_u8str(i16tostr3(100.0 * (
           parser.volumetric_enabled
             ? planner.volumetric_area_nominal / planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
             : planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
@@ -849,7 +849,7 @@ void MarlinUI::draw_status_screen() {
 
       lcd_moveto(0, 2);
       lcd_put_wchar(LCD_STR_FEEDRATE[0]);
-      lcd_put_u8str(itostr3(feedrate_percentage));
+      lcd_put_u8str(i16tostr3(feedrate_percentage));
       lcd_put_wchar('%');
 
       char buffer[14];
@@ -883,7 +883,7 @@ void MarlinUI::draw_status_screen() {
               per = planner.flow_percentage[0];
             }
           lcd_put_wchar(c);
-          lcd_put_u8str(itostr3(per));
+          lcd_put_u8str(i16tostr3(per));
           lcd_put_wchar('%');
         #endif
       #endif
@@ -924,7 +924,7 @@ void MarlinUI::draw_status_screen() {
 
     lcd_moveto(LCD_WIDTH - 9, 1);
     lcd_put_wchar(LCD_STR_FEEDRATE[0]);
-    lcd_put_u8str(itostr3(feedrate_percentage));
+    lcd_put_u8str(i16tostr3(feedrate_percentage));
     lcd_put_wchar('%');
 
     // ========== Line 3 ==========
@@ -1378,9 +1378,9 @@ void MarlinUI::draw_status_screen() {
        */
       lcd_moveto(_LCD_W_POS, 0);
       lcd_put_wchar('(');
-      lcd_put_u8str(itostr3(x));
+      lcd_put_u8str(ui8tostr3(x));
       lcd_put_wchar(',');
-      lcd_put_u8str(itostr3(inverted_y));
+      lcd_put_u8str(ui8tostr3(inverted_y));
       lcd_put_wchar(')');
 
       #if LCD_HEIGHT <= 3   // 16x2 or 20x2 display

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -52,7 +52,7 @@
 #endif
 
 FORCE_INLINE void _draw_centered_temp(const int16_t temp, const uint8_t tx, const uint8_t ty) {
-  const char *str = itostr3(temp);
+  const char *str = i16tostr3(temp);
   const uint8_t len = str[0] != ' ' ? 3 : str[1] != ' ' ? 2 : 1;
   lcd_moveto(tx - len * (INFO_FONT_WIDTH) / 2 + 1, ty);
   lcd_put_u8str(&str[3-len]);
@@ -249,7 +249,7 @@ void MarlinUI::draw_status_screen() {
     strcpy(zstring, ftostr52sp(LOGICAL_Z_POSITION(current_position[Z_AXIS])));
     #if ENABLED(FILAMENT_LCD_DISPLAY)
       strcpy(wstring, ftostr12ns(filament_width_meas));
-      strcpy(mstring, itostr3(100.0 * (
+      strcpy(mstring, i16tostr3(100.0 * (
           parser.volumetric_enabled
             ? planner.volumetric_area_nominal / planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
             : planner.volumetric_multiplier[FILAMENT_SENSOR_EXTRUDER_NUM]
@@ -338,7 +338,7 @@ void MarlinUI::draw_status_screen() {
             }
           #endif
           lcd_moveto(STATUS_FAN_TEXT_X, STATUS_FAN_TEXT_Y);
-          lcd_put_u8str(itostr3(thermalManager.fanPercent(spd)));
+          lcd_put_u8str(i16tostr3(thermalManager.fanPercent(spd)));
           lcd_put_wchar(c);
         }
       }
@@ -393,7 +393,7 @@ void MarlinUI::draw_status_screen() {
         if (PAGE_CONTAINS(41, 48)) {
           // Percent complete
           lcd_moveto(55, 48);
-          lcd_put_u8str(itostr3(progress));
+          lcd_put_u8str(ui8tostr3(progress));
           lcd_put_wchar('%');
         }
       #endif
@@ -484,7 +484,7 @@ void MarlinUI::draw_status_screen() {
 
     set_font(FONT_STATUSMENU);
     lcd_moveto(12, EXTRAS_2_BASELINE);
-    lcd_put_u8str(itostr3(feedrate_percentage));
+    lcd_put_u8str(i16tostr3(feedrate_percentage));
     lcd_put_wchar('%');
 
     //

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -258,11 +258,11 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
       lcd_put_wchar('E');
       lcd_put_wchar((char)('1' + extruder));
       lcd_put_wchar(' ');
-      lcd_put_u8str(itostr3(thermalManager.degHotend(extruder)));
+      lcd_put_u8str(i16tostr3(thermalManager.degHotend(extruder)));
       lcd_put_wchar('/');
 
       if (get_blink() || !thermalManager.is_heater_idle(extruder))
-        lcd_put_u8str(itostr3(thermalManager.degTargetHotend(extruder)));
+        lcd_put_u8str(i16tostr3(thermalManager.degTargetHotend(extruder)));
     }
 
   #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -523,10 +523,10 @@ namespace ExtUI {
   }
 
   #if ENABLED(PRINTCOUNTER)
-    char* getTotalPrints_str(char buffer[21])    { strcpy(buffer,itostr3left(print_job_timer.getStats().totalPrints));    return buffer; }
-    char* getFinishedPrints_str(char buffer[21]) { strcpy(buffer,itostr3left(print_job_timer.getStats().finishedPrints)); return buffer; }
-    char* getTotalPrintTime_str(char buffer[21]) { duration_t(print_job_timer.getStats().printTime).toString(buffer);     return buffer; }
-    char* getLongestPrint_str(char buffer[21])   { duration_t(print_job_timer.getStats().printTime).toString(buffer);     return buffer; }
+    char* getTotalPrints_str(char buffer[21])    { strcpy(buffer,i16tostr3left(print_job_timer.getStats().totalPrints));    return buffer; }
+    char* getFinishedPrints_str(char buffer[21]) { strcpy(buffer,i16tostr3left(print_job_timer.getStats().finishedPrints)); return buffer; }
+    char* getTotalPrintTime_str(char buffer[21]) { duration_t(print_job_timer.getStats().printTime).toString(buffer);       return buffer; }
+    char* getLongestPrint_str(char buffer[21])   { duration_t(print_job_timer.getStats().printTime).toString(buffer);       return buffer; }
     char* getFilamentUsed_str(char buffer[21])   {
       printStatistics stats = print_job_timer.getStats();
       sprintf_P(buffer, PSTR("%ld.%im"), long(stats.filamentUsed / 1000), int16_t(stats.filamentUsed / 100) % 10);

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -115,7 +115,7 @@ void MenuItem_gcode::action(PGM_P pgcode) { enqueue_and_echo_commands_P(pgcode);
  *
  * The prerequisite is that in the header the type was already declared:
  *
- *   DECLARE_MENU_EDIT_TYPE(int16_t, int3, itostr3, 1)
+ *   DECLARE_MENU_EDIT_TYPE(int16_t, int3, i16tostr3, 1)
  *
  * For example, DEFINE_MENU_EDIT_ITEM(int3) expands into these functions:
  *
@@ -163,6 +163,8 @@ void MenuItemBase::init(PGM_P const el, void * const ev, const int32_t minv, con
 DEFINE_MENU_EDIT_ITEM(int3);
 DEFINE_MENU_EDIT_ITEM(int4);
 DEFINE_MENU_EDIT_ITEM(int8);
+DEFINE_MENU_EDIT_ITEM(uint8);
+DEFINE_MENU_EDIT_ITEM(uint16);
 DEFINE_MENU_EDIT_ITEM(float3);
 DEFINE_MENU_EDIT_ITEM(float52);
 DEFINE_MENU_EDIT_ITEM(float43);

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -43,9 +43,11 @@ bool printer_busy();
     static inline char* strfunc(const float value) { return STRFUNC((TYPE) value); } \
   };
 
-DECLARE_MENU_EDIT_TYPE(int16_t,  int3,        itostr3,         1     );
-DECLARE_MENU_EDIT_TYPE(int16_t,  int4,        itostr4sign,     1     );
-DECLARE_MENU_EDIT_TYPE(uint8_t,  int8,        i8tostr3,        1     );
+DECLARE_MENU_EDIT_TYPE(int16_t,  int3,        i16tostr3,       1     );
+DECLARE_MENU_EDIT_TYPE(int16_t,  int4,        i16tostr4sign,   1     );
+DECLARE_MENU_EDIT_TYPE(int8_t,   int8,        i8tostr3,        1     );
+DECLARE_MENU_EDIT_TYPE(uint8_t,  uint8,       ui8tostr3,       1     );
+DECLARE_MENU_EDIT_TYPE(uint16_t, uint16,      ui16tostr3,      1     );
 DECLARE_MENU_EDIT_TYPE(float,    float3,      ftostr3,         1     );
 DECLARE_MENU_EDIT_TYPE(float,    float52,     ftostr52,      100     );
 DECLARE_MENU_EDIT_TYPE(float,    float43,     ftostr43sign, 1000     );
@@ -102,6 +104,8 @@ FORCE_INLINE void draw_menu_item_edit_P(const bool sel, const uint8_t row, PGM_P
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(int3);
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(int4);
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(int8);
+DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(uint8);
+DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(uint16);
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float3);
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float52);
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float43);
@@ -171,6 +175,8 @@ class TMenuItem : MenuItemBase {
 DECLARE_MENU_EDIT_ITEM(int3);
 DECLARE_MENU_EDIT_ITEM(int4);
 DECLARE_MENU_EDIT_ITEM(int8);
+DECLARE_MENU_EDIT_ITEM(uint8);
+DECLARE_MENU_EDIT_ITEM(uint16);
 DECLARE_MENU_EDIT_ITEM(float3);
 DECLARE_MENU_EDIT_ITEM(float52);
 DECLARE_MENU_EDIT_ITEM(float43);

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -169,7 +169,7 @@ static void lcd_factory_settings() {
   void menu_case_light() {
     START_MENU();
     MENU_BACK(MSG_MAIN);
-    MENU_ITEM_EDIT_CALLBACK(int8, MSG_CASE_LIGHT_BRIGHTNESS, &case_light_brightness, 0, 255, update_case_light, true);
+    MENU_ITEM_EDIT_CALLBACK(uint8, MSG_CASE_LIGHT_BRIGHTNESS, &case_light_brightness, 0, 255, update_case_light, true);
     MENU_ITEM_EDIT_CALLBACK(bool, MSG_CASE_LIGHT, (bool*)&case_light_on, update_case_light);
     END_MENU();
   }
@@ -217,7 +217,7 @@ static void lcd_factory_settings() {
     dac_driver_getValues();
     START_MENU();
     MENU_BACK(MSG_CONTROL);
-    #define EDIT_DAC_PERCENT(N) MENU_ITEM_EDIT_CALLBACK(int8, MSG_##N " " MSG_DAC_PERCENT, &driverPercent[_AXIS(N)], 0, 100, dac_driver_commit)
+    #define EDIT_DAC_PERCENT(N) MENU_ITEM_EDIT_CALLBACK(uint8, MSG_##N " " MSG_DAC_PERCENT, &driverPercent[_AXIS(N)], 0, 100, dac_driver_commit)
     EDIT_DAC_PERCENT(X);
     EDIT_DAC_PERCENT(Y);
     EDIT_DAC_PERCENT(Z);
@@ -274,7 +274,7 @@ static void lcd_factory_settings() {
     #endif
     START_MENU();
     MENU_BACK(MSG_CONFIGURATION);
-    MENU_ITEM_EDIT(int8, MSG_FAN_SPEED, &ui.preheat_fan_speed[material], 0, 255);
+    MENU_ITEM_EDIT(uint8, MSG_FAN_SPEED, &ui.preheat_fan_speed[material], 0, 255);
     #if HAS_TEMP_HOTEND
       MENU_ITEM_EDIT(int3, MSG_NOZZLE, &ui.preheat_hotend_temp[material], MINTEMP_ALL, MAXTEMP_ALL - 15);
     #endif

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -53,8 +53,8 @@
     printStatistics stats = print_job_timer.getStats();
 
     START_SCREEN();                                                                                // 12345678901234567890
-    STATIC_ITEM(MSG_INFO_PRINT_COUNT ": ", false, false, itostr3left(stats.totalPrints));          // Print Count: 999
-    STATIC_ITEM(MSG_INFO_COMPLETED_PRINTS": ", false, false, itostr3left(stats.finishedPrints));   // Completed  : 666
+    STATIC_ITEM(MSG_INFO_PRINT_COUNT ": ", false, false, i16tostr3left(stats.totalPrints));        // Print Count: 999
+    STATIC_ITEM(MSG_INFO_COMPLETED_PRINTS": ", false, false, i16tostr3left(stats.finishedPrints)); // Completed  : 666
 
     duration_t elapsed = stats.printTime;
     elapsed.toString(buffer);

--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -55,13 +55,13 @@
 void menu_led_custom() {
   START_MENU();
   MENU_BACK(MSG_LED_CONTROL);
-  MENU_ITEM_EDIT_CALLBACK(int8, MSG_INTENSITY_R, &leds.color.r, 0, 255, leds.update, true);
-  MENU_ITEM_EDIT_CALLBACK(int8, MSG_INTENSITY_G, &leds.color.g, 0, 255, leds.update, true);
-  MENU_ITEM_EDIT_CALLBACK(int8, MSG_INTENSITY_B, &leds.color.b, 0, 255, leds.update, true);
+  MENU_ITEM_EDIT_CALLBACK(uint8, MSG_INTENSITY_R, &leds.color.r, 0, 255, leds.update, true);
+  MENU_ITEM_EDIT_CALLBACK(uint8, MSG_INTENSITY_G, &leds.color.g, 0, 255, leds.update, true);
+  MENU_ITEM_EDIT_CALLBACK(uint8, MSG_INTENSITY_B, &leds.color.b, 0, 255, leds.update, true);
   #if ENABLED(RGBW_LED) || ENABLED(NEOPIXEL_LED)
-    MENU_ITEM_EDIT_CALLBACK(int8, MSG_INTENSITY_W, &leds.color.w, 0, 255, leds.update, true);
+    MENU_ITEM_EDIT_CALLBACK(uint8, MSG_INTENSITY_W, &leds.color.w, 0, 255, leds.update, true);
     #if ENABLED(NEOPIXEL_LED)
-      MENU_ITEM_EDIT_CALLBACK(int8, MSG_LED_BRIGHTNESS, &leds.color.i, 0, 255, leds.update, true);
+      MENU_ITEM_EDIT_CALLBACK(uint8, MSG_LED_BRIGHTNESS, &leds.color.i, 0, 255, leds.update, true);
     #endif
   #endif
   END_MENU();

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -339,21 +339,21 @@ void menu_temperature() {
   //
   #if FAN_COUNT > 0
     #if HAS_FAN0
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.lcd_tmpfan_speed[0], 0, 255, thermalManager.lcd_setFanSpeed0);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.lcd_tmpfan_speed[0], 0, 255, thermalManager.lcd_setFanSpeed0);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.new_fan_speed[0], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.new_fan_speed[0], 3, 255);
       #endif
     #endif
     #if HAS_FAN1 || (ENABLED(SINGLENOZZLE) && EXTRUDERS > 1)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int8, MSG_FAN_SPEED " 2", &thermalManager.lcd_tmpfan_speed[1], 0, 255, thermalManager.lcd_setFanSpeed1);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED " 2", &thermalManager.lcd_tmpfan_speed[1], 0, 255, thermalManager.lcd_setFanSpeed1);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 2", &thermalManager.new_fan_speed[1], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED " 2", &thermalManager.new_fan_speed[1], 3, 255);
       #endif
     #endif
     #if HAS_FAN2 || (ENABLED(SINGLENOZZLE) && EXTRUDERS > 2)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int8, MSG_FAN_SPEED " 3", &thermalManager.lcd_tmpfan_speed[2], 0, 255, thermalManager.lcd_setFanSpeed2);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED " 3", &thermalManager.lcd_tmpfan_speed[2], 0, 255, thermalManager.lcd_setFanSpeed2);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 3", &thermalManager.new_fan_speed[2], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED " 3", &thermalManager.new_fan_speed[2], 3, 255);
       #endif
     #endif
   #endif // FAN_COUNT > 0

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -141,21 +141,21 @@ void menu_tune() {
   //
   #if FAN_COUNT > 0
     #if HAS_FAN0
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.lcd_tmpfan_speed[0], 0, 255, thermalManager.lcd_setFanSpeed0);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.lcd_tmpfan_speed[0], 0, 255, thermalManager.lcd_setFanSpeed0);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.new_fan_speed[0], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.new_fan_speed[0], 3, 255);
       #endif
     #endif
     #if HAS_FAN1 || (ENABLED(SINGLENOZZLE) && EXTRUDERS > 1)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int8, MSG_FAN_SPEED " 2", &thermalManager.lcd_tmpfan_speed[1], 0, 255, thermalManager.lcd_setFanSpeed1);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED " 2", &thermalManager.lcd_tmpfan_speed[1], 0, 255, thermalManager.lcd_setFanSpeed1);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 2", &thermalManager.new_fan_speed[1], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED " 2", &thermalManager.new_fan_speed[1], 3, 255);
       #endif
     #endif
     #if HAS_FAN2 || (ENABLED(SINGLENOZZLE) && EXTRUDERS > 2)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(int8, MSG_FAN_SPEED " 3", &thermalManager.lcd_tmpfan_speed[2], 0, 255, thermalManager.lcd_setFanSpeed2);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED " 3", &thermalManager.lcd_tmpfan_speed[2], 0, 255, thermalManager.lcd_setFanSpeed2);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(int8, MSG_EXTRA_FAN_SPEED " 3", &thermalManager.new_fan_speed[2], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED " 3", &thermalManager.new_fan_speed[2], 3, 255);
       #endif
     #endif
   #endif // FAN_COUNT > 0


### PR DESCRIPTION
Separate this part of #12884 into its own PR.

Rename and add some integer-to-string conversion utilities and menu edit types.