### PR TITLE
[2.0.x] HAL_STM32 - Fix SD write

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -117,9 +117,7 @@ uint8_t spiRec(void) {
 void spiRead(uint8_t* buf, uint16_t nbyte) {
   if (nbyte == 0) return;
   SPI.beginTransaction(spiConfig);
-  for (int i = 0; i < nbyte; i++) {
-    buf[i] = SPI.transfer(0xFF);
-  }
+  SPI.transfer(buf, nbyte);
   SPI.endTransaction();
 }
 
@@ -145,9 +143,10 @@ void spiSend(uint8_t b) {
  * @details Use DMA
  */
 void spiSendBlock(uint8_t token, const uint8_t* buf) {
+  uint8_t rxBuf[512];
   SPI.beginTransaction(spiConfig);
   SPI.transfer(token);
-  SPI.transfer((uint8_t*)buf, (uint8_t*)0, 512);
+  SPI.transfer((uint8_t*)buf, &rxBuf, 512);
   SPI.endTransaction();
 }
 

--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -116,6 +116,7 @@ uint8_t spiRec(void) {
  */
 void spiRead(uint8_t* buf, uint16_t nbyte) {
   if (nbyte == 0) return;
+  memset(buf, 0xff, nbyte);
   SPI.beginTransaction(spiConfig);
   SPI.transfer(buf, nbyte);
   SPI.endTransaction();

--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -116,7 +116,7 @@ uint8_t spiRec(void) {
  */
 void spiRead(uint8_t* buf, uint16_t nbyte) {
   if (nbyte == 0) return;
-  memset(buf, 0xff, nbyte);
+  memset(buf, 0xFF, nbyte);
   SPI.beginTransaction(spiConfig);
   SPI.transfer(buf, nbyte);
   SPI.endTransaction();


### PR DESCRIPTION
### Description

`spiSendBlock()` in `HAL_spi_STM32.cpp` passes 0 as the receive buffer in the call to `SPI.transfer()`. `SPI.transfer()` will return an error if no receive buffer is provied. There is no function in the **Arduino Core STM32** that only sends a block of data without receiving so we need to use a temporary rx buffer. (We can't use the tx buffer as it's contents will then be overwritten by the data read).

Optimization: Replaced the loop in `spiRead()` with a call to `SPI.transfer(buf, length)`.

### Benefits

SD Card write now works.

### Related Issues

https://github.com/hasenbanck/remram/issues/12