### PR TITLE
Fix chopper_timing struct datatypes and initialization

### DIFF
--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -209,8 +209,8 @@
     chopconf.tbl = 1;
     chopconf.toff = chopper_timing.toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hstrt + 3;
-    chopconf.hstrt = chopper_timing.hend - 1;
+    chopconf.hend = chopper_timing.hend + 3;
+    chopconf.hstrt = chopper_timing.hstrt - 1;
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);
@@ -453,8 +453,8 @@
     chopconf.tbl = 0b01; // blank_time = 24
     chopconf.toff = chopper_timing.toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hstrt + 3;
-    chopconf.hstrt = chopper_timing.hend - 1;
+    chopconf.hend = chopper_timing.hend + 3;
+    chopconf.hstrt = chopper_timing.hstrt - 1;
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);
@@ -546,8 +546,8 @@
     TMC2660_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
     chopconf.toff = chopper_timing.toff;
-    chopconf.hend = chopper_timing.hstrt + 3;
-    chopconf.hstrt = chopper_timing.hend - 1;
+    chopconf.hend = chopper_timing.hend + 3;
+    chopconf.hstrt = chopper_timing.hstrt - 1;
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA);

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -68,8 +68,8 @@
 
   typedef struct {
     uint8_t toff;
-    int8_t hstrt;
-    uint8_t hend;
+    int8_t hend;
+    uint8_t hstrt;
   } chopper_timing_t;
 
   static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;


### PR DESCRIPTION
Fix struct member order and datatypes for `chopper_timing`.
Fix mixup with assigning hysteresis parameters.