### PR TITLE
[2.0.x] PoC ESP32 i2s dma

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -85,6 +85,8 @@ void HAL_init(void) {
   #if ENABLED(WIFISUPPORT)
     OTA_init();
   #endif
+
+  i2s_init();
 }
 
 void HAL_idletask(void) {

--- a/Marlin/src/HAL/HAL_ESP32/HAL.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.h
@@ -31,7 +31,7 @@
 #include <stdint.h>
 
 #undef DISABLED
-#undef _BV
+#undef M_PI
 
 #include <Arduino.h>
 
@@ -43,6 +43,7 @@
 
 #include "fastio_ESP32.h"
 #include "watchdog_ESP32.h"
+#include "i2s.h"
 
 #include "HAL_timers_ESP32.h"
 

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
@@ -113,7 +113,7 @@ void HAL_timer_start(const uint8_t timer_num, uint32_t frequency) {
   const tTimerConfig timer = TimerConfig[timer_num];
 
   timer_config_t config;
-  config.divider     = STEPPER_TIMER_PRESCALE;
+  config.divider     = timer.divider;
   config.counter_dir = TIMER_COUNT_UP;
   config.counter_en  = TIMER_PAUSE;
   config.alarm_en    = TIMER_ALARM_EN;

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
@@ -43,9 +43,15 @@ typedef uint64_t hal_timer_t;
 
 #define HAL_TIMER_RATE APB_CLK_FREQ // frequency of timer peripherals
 
-#define STEPPER_TIMER_PRESCALE     40
-#define STEPPER_TIMER_RATE         (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE) // frequency of stepper timer, 2MHz
-#define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000)          // stepper timer ticks per µs
+#if ENABLED(I2S_STEPPER_STREAM)
+  #define STEPPER_TIMER_PRESCALE     1
+  #define STEPPER_TIMER_RATE         250000                           // 250khz, 4us pulses of i2s word clock
+  #define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs // wrong would be 0.25
+#else
+  #define STEPPER_TIMER_PRESCALE     40
+  #define STEPPER_TIMER_RATE         (HAL_TIMER_RATE / STEPPER_TIMER_PRESCALE) // frequency of stepper timer, 2MHz
+  #define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000)          // stepper timer ticks per µs
+#endif
 
 #define STEP_TIMER_MIN_INTERVAL   8 // minimum time in µs between stepper interrupts
 

--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -21,38 +21,40 @@
  */
 #pragma once
 
+#include "i2s.h"
+
 /**
  * Utility functions
  */
 
-// set pin as input
-#define _SET_INPUT(IO)      pinMode(IO, INPUT)
+// Set pin as input
+#define _SET_INPUT(IO)        pinMode(IO, INPUT)
 
-// set pin as output
-#define _SET_OUTPUT(IO)     pinMode(IO, OUTPUT)
+// Set pin as output
+#define _SET_OUTPUT(IO)       pinMode(IO, OUTPUT)
 
-// set pin as input with pullup mode
-#define _PULLUP(IO, v)      pinMode(IO, v ? INPUT_PULLUP : INPUT)
+// Set pin as input with pullup mode
+#define _PULLUP(IO, v)        pinMode(IO, v ? INPUT_PULLUP : INPUT)
 
 // Read a pin wrapper
-#define READ(IO)            digitalRead(IO)
+#define READ(IO)              digitalRead(IO)
 
 // Write to a pin wrapper
-#define WRITE(IO, v)        digitalWrite(IO, v)
+#define WRITE(IO, v)          (TEST(IO, 7) ? i2s_write(IO & 0x7F, v) : digitalWrite(IO, v))
 
-// set pin as input wrapper
-#define SET_INPUT(IO)       _SET_INPUT(IO)
+// Set pin as input wrapper
+#define SET_INPUT(IO)         _SET_INPUT(IO)
 
-// set pin as input with pullup wrapper
-#define SET_INPUT_PULLUP(IO) do{ _SET_INPUT(IO); _PULLUP(IO, HIGH); }while(0)
+// Set pin as input with pullup wrapper
+#define SET_INPUT_PULLUP(IO)  do{ _SET_INPUT(IO); _PULLUP(IO, HIGH); }while(0)
 
-// set pin as output wrapper
-#define SET_OUTPUT(IO)  do{ _SET_OUTPUT(IO); WRITE(IO, LOW); }while(0)
+// Set pin as output wrapper
+#define SET_OUTPUT(IO)        do{ _SET_OUTPUT(IO); WRITE(IO, LOW); }while(0)
 
-#define OUT_WRITE(IO,V)         do{ _SET_OUTPUT(IO); WRITE(IO,V); }while(0)
+#define OUT_WRITE(IO,V)       do{ _SET_OUTPUT(IO); WRITE(IO,V); }while(0)
 
 //
-// ports and functions
+// Ports and functions
 //
 
 // UART

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -1,0 +1,322 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifdef ARDUINO_ARCH_ESP32
+
+#include <Arduino.h> // replace that with the proper imports
+#include "i2s.h"
+#include "../../core/macros.h"
+#include "driver/periph_ctrl.h"
+#include "rom/lldesc.h"
+#include "soc/i2s_struct.h"
+#include "freertos/queue.h"
+#include "../../module/stepper.h"
+
+#define DMA_BUF_COUNT 8                                // number of DMA buffers to store data
+#define DMA_BUF_LEN   4092                             // maximum size in bytes
+#define I2S_SAMPLE_SIZE 4                              // 4 bytes, 32 bits per sample
+#define DMA_SAMPLE_COUNT DMA_BUF_LEN / I2S_SAMPLE_SIZE // number of samples per buffer
+
+typedef enum {
+  I2S_NUM_0 = 0x0,  /*!< I2S 0*/
+  I2S_NUM_1 = 0x1,  /*!< I2S 1*/
+  I2S_NUM_MAX,
+} i2s_port_t;
+
+typedef struct {
+  uint32_t     **buffers;
+  uint32_t     *current;
+  uint32_t     rw_pos;
+  lldesc_t     **desc;
+  xQueueHandle queue;
+} i2s_dma_t;
+
+static portMUX_TYPE i2s_spinlock[I2S_NUM_MAX] = {portMUX_INITIALIZER_UNLOCKED, portMUX_INITIALIZER_UNLOCKED};
+static i2s_dev_t* I2S[I2S_NUM_MAX] = {&I2S0, &I2S1};
+static i2s_dma_t dma;
+
+// output value
+uint32_t i2s_port_data;
+
+#define I2S_ENTER_CRITICAL()  portENTER_CRITICAL(&i2s_spinlock[i2s_num])
+#define I2S_EXIT_CRITICAL()   portEXIT_CRITICAL(&i2s_spinlock[i2s_num])
+
+static inline void gpio_matrix_out_check(uint32_t gpio, uint32_t signal_idx, bool out_inv, bool oen_inv) {
+  //if pin = -1, do not need to configure
+  if (gpio != -1) {
+    PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[gpio], PIN_FUNC_GPIO);
+    gpio_set_direction((gpio_num_t)gpio, (gpio_mode_t)GPIO_MODE_DEF_OUTPUT);
+    gpio_matrix_out(gpio, signal_idx, out_inv, oen_inv);
+  }
+}
+
+static esp_err_t i2s_reset_fifo(i2s_port_t i2s_num) {
+  I2S_ENTER_CRITICAL();
+  I2S[i2s_num]->conf.rx_fifo_reset = 1;
+  I2S[i2s_num]->conf.rx_fifo_reset = 0;
+  I2S[i2s_num]->conf.tx_fifo_reset = 1;
+  I2S[i2s_num]->conf.tx_fifo_reset = 0;
+  I2S_EXIT_CRITICAL();
+
+  return ESP_OK;
+}
+
+esp_err_t i2s_start(i2s_port_t i2s_num) {
+  //start DMA link
+  I2S_ENTER_CRITICAL();
+  i2s_reset_fifo(i2s_num);
+
+  //reset dma
+  I2S[i2s_num]->lc_conf.in_rst = 1;
+  I2S[i2s_num]->lc_conf.in_rst = 0;
+  I2S[i2s_num]->lc_conf.out_rst = 1;
+  I2S[i2s_num]->lc_conf.out_rst = 0;
+
+  I2S[i2s_num]->conf.tx_reset = 1;
+  I2S[i2s_num]->conf.tx_reset = 0;
+  I2S[i2s_num]->conf.rx_reset = 1;
+  I2S[i2s_num]->conf.rx_reset = 0;
+
+  I2S[i2s_num]->int_clr.val = 0xFFFFFFFF;
+  I2S[i2s_num]->out_link.start = 1;
+  I2S[i2s_num]->conf.tx_start = 1;
+  I2S_EXIT_CRITICAL();
+
+  return ESP_OK;
+}
+
+esp_err_t i2s_stop(i2s_port_t i2s_num) {
+  I2S_ENTER_CRITICAL();
+  I2S[i2s_num]->out_link.stop = 1;
+  I2S[i2s_num]->conf.tx_start = 0;
+
+  I2S[i2s_num]->int_clr.val = I2S[i2s_num]->int_st.val; //clear pending interrupt
+  I2S_EXIT_CRITICAL();
+
+  return ESP_OK;
+}
+
+static void IRAM_ATTR i2s_intr_handler_default(void *arg) {
+  int dummy;
+  lldesc_t *finish_desc;
+  portBASE_TYPE high_priority_task_awoken = pdFALSE;
+
+  if (I2S0.int_st.out_eof) {
+    // Get the descriptor of the last item in the linkedlist
+    finish_desc = (lldesc_t*) I2S0.out_eof_des_addr;
+
+    // If the queue is full it's because we have an underflow,
+    // more than buf_count isr without new data, remove the front buffer
+    if (xQueueIsQueueFullFromISR(dma.queue))
+      xQueueReceiveFromISR(dma.queue, &dummy, &high_priority_task_awoken);
+
+    xQueueSendFromISR(dma.queue, (void *)(&finish_desc->buf), &high_priority_task_awoken);
+  }
+
+  if (high_priority_task_awoken == pdTRUE) portYIELD_FROM_ISR();
+
+  // clear interrupt
+  I2S0.int_clr.val = I2S0.int_st.val; //clear pending interrupt
+}
+
+void stepperTask(void* parameter) {
+  uint32_t i, remaining = 0;
+
+  while (1) {
+    xQueueReceive(dma.queue, &dma.current, portMAX_DELAY);
+    dma.rw_pos = 0;
+
+    for (i = 0; i < DMA_SAMPLE_COUNT; i++) {
+      // Fill with the port data post pulse_phase until the next step
+      if (remaining) {
+        i2s_push_sample();
+        remaining--;
+      }
+      else {
+        Stepper::stepper_pulse_phase_isr();
+        remaining = Stepper::stepper_block_phase_isr();
+      }
+    }
+  }
+}
+
+int i2s_init() {
+  periph_module_enable(PERIPH_I2S0_MODULE);
+
+  /**
+   * Each i2s transfer will take 
+   *   fpll = PLL_D2_CLK      -- clka_en = 0
+   * 
+   *   fi2s = fpll / N + b/a  -- N = clkm_div_num
+   *   fi2s = 160MHz / 2
+   *   fi2s = 80MHz
+   *   
+   *   fbclk = fi2s / M   -- M = tx_bck_div_num
+   *   fbclk = 80MHz / 2
+   *   fbclk = 40MHz
+   * 
+   *   fwclk = fbclk / 32
+   * 
+   *   for fwclk = 250kHz (4uS pulse time)
+   *      N = 10
+   *      M = 20
+   */
+
+  // Allocate the array of pointers to the buffers
+  dma.buffers = (uint32_t **)malloc(sizeof(uint32_t*) * DMA_BUF_COUNT);
+  if (dma.buffers == NULL) return -1;
+
+  // Allocate each buffer that can be used by the DMA controller
+  for (int buf_idx = 0; buf_idx < DMA_BUF_COUNT; buf_idx++) {
+    dma.buffers[buf_idx] = (uint32_t*) heap_caps_calloc(1, DMA_BUF_LEN, MALLOC_CAP_DMA);
+    if (dma.buffers[buf_idx] == NULL) return -1;
+  }
+
+  // Allocate the array of DMA descriptors
+  dma.desc = (lldesc_t**) malloc(sizeof(lldesc_t*) * DMA_BUF_COUNT);
+  if (dma.desc == NULL) return -1;
+
+  // Allocate each DMA descriptor that will be used by the DMA controller
+  for (int buf_idx = 0; buf_idx < DMA_BUF_COUNT; buf_idx++) {
+    dma.desc[buf_idx] = (lldesc_t*) heap_caps_malloc(sizeof(lldesc_t), MALLOC_CAP_DMA);
+    if (dma.desc[buf_idx] == NULL) return -1;
+  }
+
+  // Initialize
+  for (int buf_idx = 0; buf_idx < DMA_BUF_COUNT; buf_idx++) {
+    dma.desc[buf_idx]->owner = 1;
+    dma.desc[buf_idx]->eof = 1; // set to 1 will trigger the interrupt
+    dma.desc[buf_idx]->sosf = 0;
+    dma.desc[buf_idx]->length = DMA_BUF_LEN;
+    dma.desc[buf_idx]->size = DMA_BUF_LEN;
+    dma.desc[buf_idx]->buf = (uint8_t *) dma.buffers[buf_idx];
+    dma.desc[buf_idx]->offset = 0;
+    dma.desc[buf_idx]->empty = (uint32_t)((buf_idx < (DMA_BUF_COUNT - 1)) ? (dma.desc[buf_idx + 1]) : dma.desc[0]);
+  }
+
+  dma.queue = xQueueCreate(DMA_BUF_COUNT, sizeof(uint32_t *));
+
+  // Set the first DMA descriptor
+  I2S0.out_link.addr = (uint32_t)dma.desc[0];
+
+  // stop i2s
+  i2s_stop(I2S_NUM_0);
+
+  // configure I2S data port interface.
+  i2s_reset_fifo(I2S_NUM_0);
+
+  //reset i2s
+  I2S0.conf.tx_reset = 1;
+  I2S0.conf.tx_reset = 0;
+  I2S0.conf.rx_reset = 1;
+  I2S0.conf.rx_reset = 0;
+
+  //reset dma
+  I2S0.lc_conf.in_rst = 1;
+  I2S0.lc_conf.in_rst = 0;
+  I2S0.lc_conf.out_rst = 1;
+  I2S0.lc_conf.out_rst = 0;
+
+  //Enable and configure DMA
+  I2S0.lc_conf.check_owner = 0;
+  I2S0.lc_conf.out_loop_test = 0;
+  I2S0.lc_conf.out_auto_wrback = 0;
+  I2S0.lc_conf.out_data_burst_en = 0;
+  I2S0.lc_conf.outdscr_burst_en = 0;
+  I2S0.lc_conf.out_no_restart_clr = 0;
+  I2S0.lc_conf.indscr_burst_en = 0;
+  I2S0.lc_conf.out_eof_mode = 1;
+
+  I2S0.conf2.lcd_en = 0;
+  I2S0.conf2.camera_en = 0;
+  I2S0.pdm_conf.pcm2pdm_conv_en = 0;
+  I2S0.pdm_conf.pdm2pcm_conv_en = 0;
+
+  I2S0.fifo_conf.dscr_en = 0;
+
+  I2S0.conf_chan.tx_chan_mod = 0;
+  I2S0.fifo_conf.tx_fifo_mod = 0;
+  I2S0.conf.tx_mono = 0;
+
+  I2S0.conf_chan.rx_chan_mod = 0;
+  I2S0.fifo_conf.rx_fifo_mod = 0;
+  I2S0.conf.rx_mono = 0;
+
+  I2S0.fifo_conf.dscr_en = 1; //connect dma to fifo
+
+  I2S0.conf.tx_start = 0;
+  I2S0.conf.rx_start = 0;
+
+  I2S0.conf.tx_msb_right = 1;
+  I2S0.conf.tx_right_first = 1;
+
+  I2S0.conf.tx_slave_mod = 0; // Master
+  I2S0.fifo_conf.tx_fifo_mod_force_en = 1;
+
+  I2S0.pdm_conf.rx_pdm_en = 0;
+  I2S0.pdm_conf.tx_pdm_en = 0;
+
+  I2S0.conf.tx_short_sync = 0;
+  I2S0.conf.rx_short_sync = 0;
+  I2S0.conf.tx_msb_shift = 0;
+  I2S0.conf.rx_msb_shift = 0;
+
+  // set clock
+  I2S0.clkm_conf.clka_en = 0;       // Use PLL/2 as reference
+  I2S0.clkm_conf.clkm_div_num = 10; // minimum value of 2, reset value of 4, max 256
+  I2S0.clkm_conf.clkm_div_a = 0;    // 0 at reset, what about divide by 0? (not an issue)
+  I2S0.clkm_conf.clkm_div_b = 0;    // 0 at reset
+
+  // fbck = fi2s / tx_bck_div_num
+  I2S0.sample_rate_conf.tx_bck_div_num = 2; // minimum value of 2 defaults to 6
+
+  // Enable TX interrupts
+  I2S0.int_ena.out_eof = 1;
+  I2S0.int_ena.out_dscr_err = 0;
+  I2S0.int_ena.out_total_eof = 0;
+  I2S0.int_ena.out_done = 0;
+
+  // Allocate and Enable the I2S interrupt
+  intr_handle_t i2s_isr_handle;
+  esp_intr_alloc(ETS_I2S0_INTR_SOURCE, 0, i2s_intr_handler_default, NULL, &i2s_isr_handle);
+  esp_intr_enable(i2s_isr_handle);
+
+  // Create the task that will feed the buffer
+  xTaskCreate(stepperTask, "StepperTask", 10000, NULL, 1, NULL);
+
+  // Route the i2s pins to the appropriate GPIO
+  gpio_matrix_out_check(22, I2S0O_DATA_OUT23_IDX, 0, 0);
+  gpio_matrix_out_check(25, I2S0O_WS_OUT_IDX, 0, 0);
+  gpio_matrix_out_check(26, I2S0O_BCK_OUT_IDX, 0, 0);
+
+  // Start the I2S peripheral
+  return i2s_start(I2S_NUM_0);
+}
+
+void i2s_write(uint8_t pin, uint8_t val) {
+  SET_BIT_TO(i2s_port_data, pin, val);
+}
+
+void i2s_push_sample() {
+  dma.current[dma.rw_pos++] = i2s_port_data;
+}
+
+#endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/i2s.h
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.h
@@ -1,0 +1,31 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+// current value of the outputs provided over i2s
+extern uint32_t i2s_port_data;
+
+int i2s_init();
+
+void i2s_write(uint8_t pin, uint8_t val);
+
+void i2s_push_sample();

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1474,7 +1474,12 @@ void Stepper::stepper_pulse_phase_isr() {
       #endif
     #endif
 
-    #if MINIMUM_STEPPER_PULSE
+    #if ENABLED(I2S_STEPPER_STREAM)
+      i2s_push_sample();
+    #endif
+
+    // TODO: need to deal with MINIMUM_STEPPER_PULSE over i2s
+    #if MINIMUM_STEPPER_PULSE && DISABLED(I2S_STEPPER_STREAM)
       // Just wait for the requested pulse duration
       while (HAL_timer_get_count(PULSE_TIMER_NUM) < pulse_end) { /* nada */ }
     #endif
@@ -2143,12 +2148,11 @@ void Stepper::init() {
     E_AXIS_INIT(5);
   #endif
 
-  // Init Stepper ISR to 122 Hz for quick starting
-  HAL_timer_start(STEP_TIMER_NUM, 122);
-
-  ENABLE_STEPPER_DRIVER_INTERRUPT();
-
-  sei();
+  #if DISABLED(I2S_STEPPER_STREAM)
+    HAL_timer_start(STEP_TIMER_NUM, 122); // Init Stepper ISR to 122 Hz for quick starting
+    ENABLE_STEPPER_DRIVER_INTERRUPT();
+    sei();
+  #endif
 
   // Init direction bits for first moves
   last_direction_bits = 0

--- a/Marlin/src/pins/pins_ESP32.h
+++ b/Marlin/src/pins/pins_ESP32.h
@@ -36,24 +36,24 @@
 //
 // Steppers
 //
-#define X_STEP_PIN         27
-#define X_DIR_PIN          26
-#define X_ENABLE_PIN       25
+#define X_STEP_PIN         128
+#define X_DIR_PIN          129
+#define X_ENABLE_PIN       130
 //#define X_CS_PIN            0
 
-#define Y_STEP_PIN         33
-#define Y_DIR_PIN          32
-#define Y_ENABLE_PIN       X_ENABLE_PIN
+#define Y_STEP_PIN         131
+#define Y_DIR_PIN          132
+#define Y_ENABLE_PIN       133
 //#define Y_CS_PIN           13
 
-#define Z_STEP_PIN         14
-#define Z_DIR_PIN          12
-#define Z_ENABLE_PIN       X_ENABLE_PIN
+#define Z_STEP_PIN         134
+#define Z_DIR_PIN          135
+#define Z_ENABLE_PIN       136
 //#define Z_CS_PIN            5 // SS_PIN
 
-#define E0_STEP_PIN        16
-#define E0_DIR_PIN         17
-#define E0_ENABLE_PIN      X_ENABLE_PIN
+#define E0_STEP_PIN        137
+#define E0_DIR_PIN         138
+#define E0_ENABLE_PIN      139
 //#define E0_CS_PIN          21
 
 //

--- a/platformio.ini
+++ b/platformio.ini
@@ -356,7 +356,8 @@ lib_ignore  =
 platform    = https://github.com/platformio/platform-espressif32.git#feature/stage
 board       = esp32dev
 framework   = arduino
-upload_port = COM3
+upload_speed = 115200
+monitor_speed = 115200
 lib_ignore  =
   LiquidCrystal_I2C
   LiquidCrystal
@@ -364,6 +365,8 @@ lib_ignore  =
   LiquidTWI2
   TMC26XStepper
   c1921b4
+  SailfishLCD
+  SailfishRGB_LED
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_ESP32>
 
 #


### PR DESCRIPTION
### Description

disclaimer: I'm opening this to hopefully have some discussion on this feature, the code is quite hacky at the moment hence the PoC in the title.

So i've been working more on getting Marlin to work on the ESP32. The current HAL merged is good enough for a print but the main limitation is that the ESP32 only has limited number of GPIOs which significantly limits the number of steppers and peripherals.

The idea is to use the I2S peripheral to stream data to a set of shift registers and therefore add new outputs to the ESP32. I originally modified the ESP32's HAL to use the i2s shift registers as a simple GPIO expander https://github.com/simon-jouet/Marlin/commits/esp32-i2s by using the fixed channel of the i2s stream.

In this MR I extended this work to actually use the DMA controller and precomputes the steps instead of constantly calling the stepper ISR
  - The number of interrupts is now much much lower than before and each ISR is very quick. The main job of scheduling the steps is done in a normal task that isn't time sensitive
  - The steps can be controlled very precisely, at the moment I set the I2S stream to 250khz which allows a step every 4us, this can be modified for pretty much anything up to 1.25MHz. (it's 8us per motor as the pulse needs to go low on the next i2s word)
  - There won't be any need for the bresenham algorithm as each motors' step can be scheduled independently and the performance are exactly the same if you have 1 or 10 steppers. (the code in this PR still uses the bresenham algorithm)

I think this work can be useful for most of the 32 bits microcontrollers that have a DMA controller and I believe this could be extended to do exactly the same over SPI instead of I2S but I haven't tried.

Here is a poor quality of the printer in action: https://youtu.be/J7FaX1tkwW8 and most of the discussion for this work was done here previously https://github.com/simon-jouet/ESP32Controller/issues/4