### PR TITLE
Fix TMC compile issues

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -838,18 +838,14 @@
     bool stealthchop_was_enabled = st.en_pwm_mode();
 
     st.TCOOLTHRS(0xFFFFF);
-    #if STEALTHCHOP_ENABLED
-      st.en_pwm_mode(false);
-    #endif
+    st.en_pwm_mode(false);
     st.diag1_stall(true);
 
     return stealthchop_was_enabled;
   }
   void tmc_disable_stallguard(TMC2130Stepper &st, const bool restore_stealth) {
     st.TCOOLTHRS(0);
-    #if STEALTHCHOP_ENABLED
-      st.en_pwm_mode(restore_stealth);
-    #endif
+    st.en_pwm_mode(restore_stealth);
     st.diag1_stall(false);
   }
   bool tmc_enable_stallguard(TMC2660Stepper) {

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -82,7 +82,7 @@ class TMCStorage {
     }
 
     struct {
-      #if STEALTHCHOP_ENABLED
+      #if HAS_STEALTHCHOP
         bool stealthChop_enabled = false;
       #endif
       #if ENABLED(HYBRID_THRESHOLD)
@@ -113,7 +113,7 @@ class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
       TMC::rms_current(mA, mult);
     }
 
-    #if STEALTHCHOP_ENABLED
+    #if HAS_STEALTHCHOP
       inline void refresh_stepping_mode() { this->en_pwm_mode(this->stored.stealthChop_enabled); }
       inline bool get_stealthChop_status() { return this->en_pwm_mode(); }
     #endif
@@ -158,7 +158,7 @@ class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID> : public TMC2208Stepper,
       TMC2208Stepper::rms_current(mA, mult);
     }
 
-    #if STEALTHCHOP_ENABLED
+    #if HAS_STEALTHCHOP
       inline void refresh_stepping_mode() { en_spreadCycle(!this->stored.stealthChop_enabled); }
       inline bool get_stealthChop_status() { return !this->en_spreadCycle(); }
     #endif
@@ -168,9 +168,6 @@ class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID> : public TMC2208Stepper,
       inline void init_lcd_variables(const AxisEnum spmm_id) {
         #if ENABLED(HYBRID_THRESHOLD)
           this->stored.hybrid_thrs = _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[spmm_id]);
-        #endif
-        #if STEALTHCHOP_ENABLED
-          this->stored.stealthChop_enabled = !this->en_spreadCycle();
         #endif
       }
 

--- a/Marlin/src/lcd/menu/menu_tmc.cpp
+++ b/Marlin/src/lcd/menu/menu_tmc.cpp
@@ -241,7 +241,7 @@ void menu_tmc_current() {
 
 #endif
 
-#if STEALTHCHOP_ENABLED
+#if HAS_STEALTHCHOP
 
   #define TMC_EDIT_STEP_MODE(ST) MENU_ITEM_EDIT_CALLBACK(bool, MSG_##ST, &stepper##ST.stored.stealthChop_enabled, refresh_stepping_mode_##ST)
 
@@ -343,7 +343,7 @@ void menu_tmc() {
   #if ENABLED(SENSORLESS_HOMING)
     MENU_ITEM(submenu, MSG_TMC_HOMING_THRS, menu_tmc_homing_thrs);
   #endif
-  #if STEALTHCHOP_ENABLED
+  #if HAS_STEALTHCHOP
     MENU_ITEM(submenu, MSG_TMC_STEPPING_MODE, menu_tmc_step_mode);
   #endif
   END_MENU();


### PR DESCRIPTION
* Fix the TMC related compile issues that were introduced by the recent change to `drivers.h`.
* `STEALTHCHOP_XYZE` now set the default state for chopper mode, but the user can change the modes afterwards as long as the driver supports it.