### PR TITLE
ExtUI: Fix for fan wrapping around from 0 to 100

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -572,7 +572,7 @@ namespace ExtUI {
 
   void setTargetFan_percent(const float value, const fan_t fan) {
     if (fan < FAN_COUNT)
-      thermalManager.set_fan_speed(fan - FAN0, map(value, 0, 100, 0, 255));
+      thermalManager.set_fan_speed(fan - FAN0, map(clamp(value, 0, 100), 0, 100, 0, 255));
   }
 
   void setFeedrate_percent(const float value) {


### PR DESCRIPTION
- When at 0 the user was able to decrease speeds past 0 and loops back to 100
