### PR TITLE
Fix closed-loop planner stall

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1540,7 +1540,7 @@ void Planner::synchronize() {
   while (
     has_blocks_queued() || cleaning_buffer_counter
     #if ENABLED(EXTERNAL_CLOSED_LOOP_CONTROLLER)
-      || !READ(CLOSED_LOOP_MOVE_COMPLETE_PIN)
+      || (READ(CLOSED_LOOP_ENABLE_PIN) && !READ(CLOSED_LOOP_MOVE_COMPLETE_PIN))
     #endif
   ) idle();
 }


### PR DESCRIPTION
PR fixes issue with Closed Loop Stepper control that relies on the external controller outputting a signal at all times whether enabled or not. 

Changes to only check for a move complete when the closed loop controller is actually enabled. 