### PR TITLE
Prevent undefined lcd_tmpfan_speed on NO_LCD_MENUS

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -260,7 +260,7 @@ void MarlinUI::init() {
     encoderDiff = 0;
   #endif
 
-  #if HAS_TRINAMIC
+  #if HAS_TRINAMIC && HAS_LCD_MENU
     init_tmc_section();
   #endif
 }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -164,7 +164,7 @@ int16_t Temperature::current_temperature_raw[HOTENDS], // = { 0 }
     if (target >= FAN_COUNT) return;
 
     fan_speed[target] = speed;
-    #if ENABLED(ULTRA_LCD)
+    #if HAS_LCD_MENU
       lcd_tmpfan_speed[target] = speed;
     #endif
   }


### PR DESCRIPTION
This fixes a build error introduced by 082f6a2 when NO_LCD_MENUS
is uncommented:
```
 Marlin/src/module/temperature.cpp: In static member function
 'static void Temperature::set_fan_speed(uint8_t, uint16_t)':
 Marlin/src/module/temperature.cpp:168:7: error: 'lcd_tmpfan_speed'
 was not declared in this scope
```
Given that `ENABLED(ULTRA_LCD)` is always true when `HAS_LCD_MENU`
is also true,
```cpp
 #if ENABLED(ULTIPANEL)
   ...
   #define ULTRA_LCD
 #endif
 ...
 #define HAS_LCD_MENU  (ENABLED(ULTIPANEL) && DISABLED(NO_LCD_MENUS))
```
this shouldn't change the logic other than fixing the build error.

Fixes #12993.
