### PR TITLE
Support individual solenoid disable with M381

### DIFF
--- a/Marlin/src/feature/solenoid.cpp
+++ b/Marlin/src/feature/solenoid.cpp
@@ -28,71 +28,70 @@
 
 #include "../module/motion.h" // for active_extruder
 
-// this is used primarily when MANUAL_SOLENOID_CONTROL
-static void set_solenoid(const uint8_t num, bool active)
-{
-  int value = active ? HIGH : LOW;
+#if ENABLED(MANUAL_SOLENOID_CONTROL)
+  #define HAS_SOLENOID(N) HAS_SOLENOID_##N
+#else
+  #define HAS_SOLENOID(N) (HAS_SOLENOID_##N && EXTRUDERS > N)
+#endif
+
+// Used primarily with MANUAL_SOLENOID_CONTROL
+static void set_solenoid(const uint8_t num, const bool active) {
+  const uint8_t value = active ? HIGH : LOW;
   switch (num) {
     case 0:
       OUT_WRITE(SOL0_PIN, value);
       break;
-  #if HAS_SOLENOID_1
-    case 1:
-      OUT_WRITE(SOL1_PIN, value);
-      break;
-  #endif
-  #if HAS_SOLENOID_2
-    case 2:
-      OUT_WRITE(SOL2_PIN, value);
-      break;
-  #endif
-  #if HAS_SOLENOID_3
-    case 3:
-      OUT_WRITE(SOL3_PIN, value);
-      break;
-  #endif
-  #if HAS_SOLENOID_4
-    case 4:
-      OUT_WRITE(SOL4_PIN, value);
-      break;
-  #endif
-  #if HAS_SOLENOID_5
-    case 5:
-      OUT_WRITE(SOL5_PIN, value);
-      break;
-  #endif
+    #if HAS_SOLENOID(1)
+      case 1:
+        OUT_WRITE(SOL1_PIN, value);
+        break;
+    #endif
+    #if HAS_SOLENOID(2)
+      case 2:
+        OUT_WRITE(SOL2_PIN, value);
+        break;
+    #endif
+    #if HAS_SOLENOID(3)
+      case 3:
+        OUT_WRITE(SOL3_PIN, value);
+        break;
+    #endif
+    #if HAS_SOLENOID(4)
+      case 4:
+        OUT_WRITE(SOL4_PIN, value);
+        break;
+    #endif
+    #if HAS_SOLENOID(5)
+      case 5:
+        OUT_WRITE(SOL5_PIN, value);
+        break;
+    #endif
     default:
       SERIAL_ECHO_MSG(MSG_INVALID_SOLENOID);
       break;
   }
 }
 
-void enable_solenoid(const uint8_t num) {
-  set_solenoid(num, true);
-}
-
-void disable_solenoid(const uint8_t num) {
-  set_solenoid(num, false);
-}
-
+void enable_solenoid(const uint8_t num) { set_solenoid(num, true); }
+void disable_solenoid(const uint8_t num) { set_solenoid(num, false); }
 void enable_solenoid_on_active_extruder() { enable_solenoid(active_extruder); }
 
 void disable_all_solenoids() {
-  OUT_WRITE(SOL0_PIN, LOW);
-  #if HAS_SOLENOID_1 && EXTRUDERS > 1
-    OUT_WRITE(SOL1_PIN, LOW);
+  disable_solenoid(0);
+  #if HAS_SOLENOID(1)
+    disable_solenoid(1);
   #endif
-  #if HAS_SOLENOID_2 && EXTRUDERS > 2
-    OUT_WRITE(SOL2_PIN, LOW);
+  #if HAS_SOLENOID(2)
+    disable_solenoid(2);
   #endif
-  #if HAS_SOLENOID_3 && EXTRUDERS > 3
-    OUT_WRITE(SOL3_PIN, LOW);
+  #if HAS_SOLENOID(3)
+    disable_solenoid(3);
   #endif
-  #if HAS_SOLENOID_4 && EXTRUDERS > 4
-    OUT_WRITE(SOL4_PIN, LOW);
+  #if HAS_SOLENOID(4)
+    disable_solenoid(4);
   #endif
-  #if HAS_SOLENOID_5 && EXTRUDERS > 5
-    OUT_WRITE(SOL5_PIN, LOW);
+  #if HAS_SOLENOID(5)
+    disable_solenoid(5);
   #endif
 }
 

--- a/Marlin/src/feature/solenoid.cpp
+++ b/Marlin/src/feature/solenoid.cpp
@@ -28,40 +28,51 @@
 
 #include "../module/motion.h" // for active_extruder
 
-void enable_solenoid(const uint8_t num) {
+// this is used primarily when MANUAL_SOLENOID_CONTROL
+static void set_solenoid(const uint8_t num, bool active)
+{
+  int value = active ? HIGH : LOW;
   switch (num) {
     case 0:
-      OUT_WRITE(SOL0_PIN, HIGH);
+      OUT_WRITE(SOL0_PIN, value);
       break;
-      #if HAS_SOLENOID_1 && EXTRUDERS > 1
-        case 1:
-          OUT_WRITE(SOL1_PIN, HIGH);
-          break;
-      #endif
-      #if HAS_SOLENOID_2 && EXTRUDERS > 2
-        case 2:
-          OUT_WRITE(SOL2_PIN, HIGH);
-          break;
-      #endif
-      #if HAS_SOLENOID_3 && EXTRUDERS > 3
-        case 3:
-          OUT_WRITE(SOL3_PIN, HIGH);
-          break;
-      #endif
-      #if HAS_SOLENOID_4 && EXTRUDERS > 4
-        case 4:
-          OUT_WRITE(SOL4_PIN, HIGH);
-          break;
-      #endif
-      #if HAS_SOLENOID_5 && EXTRUDERS > 5
-        case 5:
-          OUT_WRITE(SOL5_PIN, HIGH);
-          break;
-      #endif
+  #if HAS_SOLENOID_1
+    case 1:
+      OUT_WRITE(SOL1_PIN, value);
+      break;
+  #endif
+  #if HAS_SOLENOID_2
+    case 2:
+      OUT_WRITE(SOL2_PIN, value);
+      break;
+  #endif
+  #if HAS_SOLENOID_3
+    case 3:
+      OUT_WRITE(SOL3_PIN, value);
+      break;
+  #endif
+  #if HAS_SOLENOID_4
+    case 4:
+      OUT_WRITE(SOL4_PIN, value);
+      break;
+  #endif
+  #if HAS_SOLENOID_5
+    case 5:
+      OUT_WRITE(SOL5_PIN, value);
+      break;
+  #endif
     default:
       SERIAL_ECHO_MSG(MSG_INVALID_SOLENOID);
       break;
   }
+}
+
+void enable_solenoid(const uint8_t num) {
+  set_solenoid(num, true);
+}
+
+void disable_solenoid(const uint8_t num) {
+  set_solenoid(num, false);
 }
 
 void enable_solenoid_on_active_extruder() { enable_solenoid(active_extruder); }

--- a/Marlin/src/feature/solenoid.h
+++ b/Marlin/src/feature/solenoid.h
@@ -24,3 +24,4 @@
 void enable_solenoid_on_active_extruder();
 void disable_all_solenoids();
 void enable_solenoid(const uint8_t num);
+void disable_solenoid(const uint8_t num);

--- a/Marlin/src/gcode/control/M380_M381.cpp
+++ b/Marlin/src/gcode/control/M380_M381.cpp
@@ -35,7 +35,7 @@
  */
 void GcodeSuite::M380() {
   #if ENABLED(MANUAL_SOLENOID_CONTROL)
-    enable_solenoid(parser.seenval('S') ? parser.value_int() : active_extruder);
+    enable_solenoid(parser.intval('S', active_extruder));
   #else
     enable_solenoid_on_active_extruder();
   #endif
@@ -43,13 +43,13 @@ void GcodeSuite::M380() {
 
 /**
  * M381: Disable all solenoids if EXT_SOLENOID
- *       Disable selected solenoid or active if MANUAL_SOLENOID CONTROL
+ *       Disable selected/active solenoid if MANUAL_SOLENOID_CONTROL
  */
 void GcodeSuite::M381() { 
   #if ENABLED(MANUAL_SOLENOID_CONTROL)
-    disable_solenoid(parser.seenval('S') ? parser.value_int() : active_extruder);
+    disable_solenoid(parser.intval('S', active_extruder));
   #else
-	disable_all_solenoids();	// not manual solenoid control
+    disable_all_solenoids();
   #endif
 }
 

--- a/Marlin/src/gcode/control/M380_M381.cpp
+++ b/Marlin/src/gcode/control/M380_M381.cpp
@@ -42,8 +42,15 @@ void GcodeSuite::M380() {
 }
 
 /**
- * M381: Disable all solenoids
+ * M381: Disable all solenoids if EXT_SOLENOID
+ *       Disable selected solenoid or active if MANUAL_SOLENOID CONTROL
  */
-void GcodeSuite::M381() { disable_all_solenoids(); }
+void GcodeSuite::M381() { 
+  #if ENABLED(MANUAL_SOLENOID_CONTROL)
+    disable_solenoid(parser.seenval('S') ? parser.value_int() : active_extruder);
+  #else
+	disable_all_solenoids();	// not manual solenoid control
+  #endif
+}
 
 #endif // EXT_SOLENOID || MANUAL_SOLENOID_CONTROL

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -547,7 +547,7 @@ void GcodeSuite::process_parsed_command(
 
       #if ENABLED(EXT_SOLENOID) || ENABLED(MANUAL_SOLENOID_CONTROL)
         case 380: M380(); break;                                  // M380: Activate solenoid on active (or specified) extruder
-        case 381: M381(); break;                                  // M381: Disable all solenoids
+        case 381: M381(); break;                                  // M381: Disable all solenoids or, if MANUAL_SOLENOID_CONTROL, active (or specified) solenoid
       #endif
 
       case 400: M400(); break;                                    // M400: Finish all moves


### PR DESCRIPTION
Trying to support a board with 3 solenoids not extruders.
Add Snnn option to M381, don't EXTRUDER_ test iff MANUAL_SOLENOID_CONTROL.

### Requirements

* This has no specific requirements. It enhances the M381 command by adding solenoid selection.

### Description

This adds an S option to M381if MANUAL_SOLENOID_CONTROL is 1 to let you individually disable a solenoid. If not 1, then this has the legacy action of turning off all solenoids. Change: if 1 the default becomes to turn off the active solenoid.

This also removes the extruder count checking when enabling a solenoid so you don't need fake extruders.

### Benefits

I have a CNC with multiple solenoids that aren't heaters or fans and just need a simple way to control them - the old 'turn off all' paradigm doesn't work well with that though. This seems perfect and specifically accurate.

### Related Issues

As far as I know this should be benign. It does remove checking for # extruders when turning on a solenoid but again that seems like a benefit.
