### PR TITLE
Endless loop of line number errors with Pronterface SD card upload

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -630,8 +630,7 @@ inline void get_serial_commands() {
           gcode_LastN = gcode_N;
         }
         #if ENABLED(SDSUPPORT)
-          else if (card.flag.saving &&        // No line number with M29 in Pronterface
-                      ((strcmp(command, "M29") != 0) && strcmp(command, "M29 ") != 0))
+          else if (card.flag.saving && command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' '))
             return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM), i);
         #endif
 
@@ -840,7 +839,7 @@ void advance_command_queue() {
 
     if (card.flag.saving) {
       char* command = command_queue[cmd_queue_index_r];
-      if (strstr_P(command, PSTR("M29"))) {
+      if (command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ')) {
         // M29 closes the file
         card.closefile();
         SERIAL_ECHOLNPGM(MSG_FILE_SAVED);

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -630,7 +630,8 @@ inline void get_serial_commands() {
           gcode_LastN = gcode_N;
         }
         #if ENABLED(SDSUPPORT)
-          else if (card.flag.saving && strcmp(command, "M29") != 0) // No line number with M29 in Pronterface
+          else if (card.flag.saving &&        // No line number with M29 in Pronterface
+                      ((strcmp(command, "M29") != 0) && strcmp(command, "M29 ") != 0))
             return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM), i);
         #endif
 


### PR DESCRIPTION
### Description

When uploading to a SD card with the 18Nov2017 version of Pronterface you get an endless loop of line number errors. This is because Pronterface is (now??) sending a "M29 " with a trailing blank. The original code is checking for "M29" without a trailing blank. I left the original check for "M29" in place since, presumably, some version sent it that way.
### Benefits

This fixes a bug in the termination protocol of SD card uploads with Pronterface. Without the fix you get an endless loop of line number errors.

