### PR TITLE
[2.0.x] L6470 bugfixes & resolve class L6470 name duplication

### DIFF
--- a/Marlin/src/HAL/shared/HAL_spi_L6470.cpp
+++ b/Marlin/src/HAL/shared/HAL_spi_L6470.cpp
@@ -101,7 +101,7 @@ uint8_t L6470_transfer(uint8_t data, int16_t ss_pin, const uint8_t chain_positio
   // first device in chain has data sent last
   digitalWrite(ss_pin, LOW);
 
-  for (uint8_t i = L6470::chain[0]; (i >= 1) && !spi_abort; i--) {    // stop sending data if spi_abort is active
+  for (uint8_t i = L6470_chain[0]; (i >= 1) && ! Marlin_L6470.spi_abort; i--) {    // stop sending data if spi_abort is active
     DISABLE_ISRS();  // disable interrupts during SPI transfer (can't allow partial command to chips)
     uint8_t temp = L6470_SpiTransfer_Mode_3(uint8_t(i == chain_position ? data : dSPIN_NOP));
     ENABLE_ISRS();  // enable interrupts
@@ -115,7 +115,7 @@ uint8_t L6470_transfer(uint8_t data, int16_t ss_pin, const uint8_t chain_positio
 void L6470_transfer(uint8_t L6470_buf[], const uint8_t length) {
   // first device in chain has data sent last
 
-  if (spi_active) {                    // interrupted SPI transfer so need to
+  if (Marlin_L6470.spi_active) {                    // interrupted SPI transfer so need to
     WRITE(L6470_CHAIN_SS_PIN, HIGH);   // guarantee min high of 650nS
     DELAY_US(1);
   }

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -529,7 +529,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
   #endif
 
   #if ENABLED(MONITOR_L6470_DRIVER_STATUS)
-    L6470.monitor_driver();
+    Marlin_L6470.monitor_driver();
   #endif
 
   // Limit check_axes_activity frequency to 10Hz
@@ -697,7 +697,7 @@ void setup() {
   #endif
 
   #if HAS_DRIVER(L6470)
-    L6470.init();         // setup SPI and then init chips
+    Marlin_L6470.init();         // setup SPI and then init chips
   #endif
 
   #if ENABLED(MAX7219_DEBUG)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -447,9 +447,9 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   #if HAS_DRIVER(L6470)
     // Set L6470 absolute position registers to counts
-    for (uint8_t j = 1; j <= L6470::chain[0]; j++) {
-      const uint8_t cv = L6470::chain[j];
-      L6470.set_param(cv, L6470_ABS_POS, stepper.position((AxisEnum)L6470.axis_xref[cv]));
+    for (uint8_t j = 1; j <= L6470_chain[0]; j++) {
+      const uint8_t cv = L6470_chain[j];
+      Marlin_L6470.set_param(cv, L6470_ABS_POS, stepper.position((AxisEnum)Marlin_L6470.axis_xref[cv]));
     }
   #endif
 }

--- a/Marlin/src/gcode/feature/L6470/M122.cpp
+++ b/Marlin/src/gcode/feature/L6470/M122.cpp
@@ -31,8 +31,8 @@
 inline void echo_yes_no(const bool yes) { serialprintPGM(yes ? PSTR(" YES") : PSTR(" NO ")); }
 
 void L6470_status_decode(const uint16_t status, const uint8_t axis) {
-  if (L6470.spi_abort) return;  // don't do anything if set_directions() has occurred
-  L6470.say_axis(axis);
+  if (Marlin_L6470.spi_abort) return;  // don't do anything if set_directions() has occurred
+  Marlin_L6470.say_axis(axis);
   #if ENABLED(L6470_CHITCHAT)
     char temp_buf[20];
     sprintf_P(temp_buf, PSTR("   status: %4x   "), status);
@@ -43,7 +43,7 @@ void L6470_status_decode(const uint16_t status, const uint8_t axis) {
   serialprintPGM(status & STATUS_HIZ ? PSTR("OFF") : PSTR("ON "));
   SERIAL_ECHOPGM("   BUSY: "); echo_yes_no(!(status & STATUS_BUSY));
   SERIAL_ECHOPGM("   DIR: ");
-  serialprintPGM((((status & STATUS_DIR) >> 4) ^ L6470.index_to_dir[axis]) ? PSTR("FORWARD") : PSTR("REVERSE"));
+  serialprintPGM((((status & STATUS_DIR) >> 4) ^ Marlin_L6470.index_to_dir[axis]) ? PSTR("FORWARD") : PSTR("REVERSE"));
   SERIAL_ECHOPGM("   Last Command: ");
   if (status & STATUS_WRONG_CMD) SERIAL_ECHOPGM("IN");
   SERIAL_ECHOPGM("VALID    ");
@@ -60,7 +60,7 @@ void L6470_status_decode(const uint16_t status, const uint8_t axis) {
  */
 void GcodeSuite::M122() {
 
-  L6470.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
+  Marlin_L6470.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
 
   #define L6470_SAY_STATUS(Q) L6470_status_decode(stepper##Q.getStatus(), Q)
 
@@ -108,8 +108,8 @@ void GcodeSuite::M122() {
     L6470_SAY_STATUS(E5);
   #endif
 
-  L6470.spi_active = false;   // done with all SPI transfers - clear handshake flags
-  L6470.spi_abort = false;
+  Marlin_L6470.spi_active = false;   // done with all SPI transfers - clear handshake flags
+  Marlin_L6470.spi_abort = false;
 }
 
 #endif // HAS_DRIVER(L6470)

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -80,7 +80,7 @@
  */
 
 void L6470_report_current(L6470 &motor, const uint8_t axis) {
-  if (L6470.spi_abort) return;  // don't do anything if set_directions() has occurred
+  if (Marlin_L6470.spi_abort) return;  // don't do anything if set_directions() has occurred
   const uint16_t status = motor.getStatus() ;
   const uint8_t overcurrent_threshold = (uint8_t)motor.GetParam(L6470_OCD_TH),
                 stall_threshold = (uint8_t)motor.GetParam(L6470_STALL_TH),
@@ -90,7 +90,7 @@ void L6470_report_current(L6470 &motor, const uint8_t axis) {
   const float comp_coef = 1600.0f / adc_out_limited;
   const int microsteps = _BV(motor.GetParam(L6470_STEP_MODE) & 0x07);
   char temp_buf[80];
-  L6470.say_axis(axis);
+  Marlin_L6470.say_axis(axis);
   #if ENABLED(L6470_CHITCHAT)
     sprintf_P(temp_buf, PSTR("   status: %4x   "), status);
     SERIAL_ECHO(temp_buf);
@@ -101,7 +101,7 @@ void L6470_report_current(L6470 &motor, const uint8_t axis) {
   sprintf_P(temp_buf, PSTR("   Stall Threshold: %2d (%7.2f mA)"), stall_threshold, (stall_threshold + 1) * 31.25);
   SERIAL_ECHO(temp_buf);
   SERIAL_ECHOPGM("   Motor Status: ");
-  const char * const stat_str;
+  char * stat_str;
   switch (motor_status) {
     default:
     case 0: stat_str = PSTR("stopped"); break;
@@ -209,7 +209,7 @@ void GcodeSuite::M906() {
   if (report_current) {
     #define L6470_REPORT_CURRENT(Q) L6470_report_current(stepper##Q, Q)
 
-    L6470.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
+    Marlin_L6470.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
 
     #if AXIS_DRIVER_TYPE_X(L6470)
       L6470_REPORT_CURRENT(X);
@@ -251,8 +251,8 @@ void GcodeSuite::M906() {
       L6470_REPORT_CURRENT(E5);
     #endif
 
-    L6470.spi_active = false;   // done with all SPI transfers - clear handshake flags
-    L6470.spi_abort = false;
+    Marlin_L6470.spi_active = false;   // done with all SPI transfers - clear handshake flags
+    Marlin_L6470.spi_abort = false;
   }
 }
 

--- a/Marlin/src/gcode/feature/L6470/M916-918.cpp
+++ b/Marlin/src/gcode/feature/L6470/M916-918.cpp
@@ -77,7 +77,7 @@ void GcodeSuite::M916() {
 
   uint8_t j;   // general purpose counter
 
-  if (L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
+  if (Marlin_L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
     return;  // quit if invalid user input
 
   L6470_ECHOLNPAIR("feedrate = ", final_feedrate);
@@ -85,7 +85,7 @@ void GcodeSuite::M916() {
   planner.synchronize();                             // wait for all current movement commands to complete
 
   for (j = 0; j < driver_count; j++)
-    L6470.get_status(axis_index[j]);  // clear out any pre-existing error flags
+    Marlin_L6470.get_status(axis_index[j]);  // clear out any pre-existing error flags
 
   char temp_axis_string[] = " ";
   temp_axis_string[0] = axis_mon[0][0];  // need to have a string for use within sprintf format section
@@ -99,7 +99,7 @@ void GcodeSuite::M916() {
     L6470_ECHOLNPAIR("kval_hold = ", kval_hold);   // set & report KVAL_HOLD for this run
 
     for (j = 0; j < driver_count; j++)
-      L6470.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
+      Marlin_L6470.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
 
     // turn the motor(s) both directions
     sprintf_P(gcode_string, PSTR("G0 %s%4.3f  F%4.3f"), temp_axis_string, position_min, final_feedrate);
@@ -114,7 +114,7 @@ void GcodeSuite::M916() {
     status_composite = 0;    // clear out the old bits
 
     for (j = 0; j < driver_count; j++) {
-      axis_status[j] = (~L6470.get_status(axis_index[j])) & L6470_ERROR_MASK;    // bits of interest are all active low
+      axis_status[j] = (~Marlin_L6470.get_status(axis_index[j])) & L6470_ERROR_MASK;    // bits of interest are all active low
       status_composite |= axis_status[j] ;
     }
 
@@ -122,7 +122,7 @@ void GcodeSuite::M916() {
       L6470_ECHOLNPGM("Test aborted (Undervoltage lockout active)");
       for (j = 0; j < driver_count; j++) {
         L6470_ECHOPGM("...");
-        L6470.error_status_decode(axis_status[j], axis_index[j]);
+        Marlin_L6470.error_status_decode(axis_status[j], axis_index[j]);
       }
       return;
     }
@@ -138,7 +138,7 @@ void GcodeSuite::M916() {
     L6470_ECHOLNPGM("has occurred");
     for (j = 0; j < driver_count; j++) {
       L6470_ECHOPGM("...");
-      L6470.error_status_decode(axis_status[j], axis_index[j]);
+      Marlin_L6470.error_status_decode(axis_status[j], axis_index[j]);
     }
   }
   else
@@ -193,14 +193,14 @@ void GcodeSuite::M917() {
 
   uint8_t j;   // general purpose counter
 
-  if (L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
+  if (Marlin_L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
     return;  // quit if invalid user input
 
   L6470_ECHOLNPAIR("feedrate = ", final_feedrate);
 
   planner.synchronize();                             // wait for all current movement commands to complete
   for (j = 0; j < driver_count; j++)
-    L6470.get_status(axis_index[j]);  // clear out any pre-existing error flags
+    Marlin_L6470.get_status(axis_index[j]);  // clear out any pre-existing error flags
   char temp_axis_string[] = " ";
   temp_axis_string[0] = axis_mon[0][0];  // need to have a string for use within sprintf format section
   char gcode_string[80];
@@ -233,7 +233,7 @@ void GcodeSuite::M917() {
     status_composite = 0;    // clear out the old bits
 
     for (j = 0; j < driver_count; j++) {
-      axis_status[j] = (~L6470.get_status(axis_index[j])) & L6470_ERROR_MASK;    // bits of interest are all active low
+      axis_status[j] = (~Marlin_L6470.get_status(axis_index[j])) & L6470_ERROR_MASK;    // bits of interest are all active low
       status_composite |= axis_status[j];
     }
 
@@ -241,7 +241,7 @@ void GcodeSuite::M917() {
       L6470_ECHOLNPGM("Test aborted (Undervoltage lockout active)");
       for (j = 0; j < driver_count; j++) {
         L6470_ECHOPGM("...");
-        L6470.error_status_decode(axis_status[j], axis_index[j]);
+        Marlin_L6470.error_status_decode(axis_status[j], axis_index[j]);
       }
       return;
     }
@@ -257,7 +257,7 @@ void GcodeSuite::M917() {
           L6470_EOL();
           L6470_ECHOLNPAIR("Lowering KVAL_HOLD by about 5% to ", kval_hold);
           for (j = 0; j < driver_count; j++)
-            L6470.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
+            Marlin_L6470.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
         }
         L6470_ECHOLNPGM(".");
         gcode.reset_stepper_timeout(); // reset_stepper_timeout to keep steppers powered
@@ -265,7 +265,7 @@ void GcodeSuite::M917() {
         safe_delay(5000);
         status_composite_temp = 0;
         for (j = 0; j < driver_count; j++) {
-          axis_status[j] = (~L6470.get_status(axis_index[j])) & L6470_ERROR_MASK;    // bits of interest are all active low
+          axis_status[j] = (~Marlin_L6470.get_status(axis_index[j])) & L6470_ERROR_MASK;    // bits of interest are all active low
           status_composite_temp |= axis_status[j];
         }
       }
@@ -407,10 +407,10 @@ void GcodeSuite::M917() {
 
     if (test_phase != 4) {
       for (j = 0; j < driver_count; j++) {                       // update threshold(s)
-        L6470.set_param(axis_index[j], L6470_OCD_TH, ocd_th_val);
-        L6470.set_param(axis_index[j], L6470_STALL_TH, stall_th_val);
-        if (L6470.get_param(axis_index[j], L6470_OCD_TH) != ocd_th_val) L6470_ECHOLNPGM("OCD mismatch");
-        if (L6470.get_param(axis_index[j], L6470_STALL_TH) != stall_th_val) L6470_ECHOLNPGM("STALL mismatch");
+        Marlin_L6470.set_param(axis_index[j], L6470_OCD_TH, ocd_th_val);
+        Marlin_L6470.set_param(axis_index[j], L6470_STALL_TH, stall_th_val);
+        if (Marlin_L6470.get_param(axis_index[j], L6470_OCD_TH) != ocd_th_val) L6470_ECHOLNPGM("OCD mismatch");
+        if (Marlin_L6470.get_param(axis_index[j], L6470_STALL_TH) != stall_th_val) L6470_ECHOLNPGM("STALL mismatch");
       }
     }
 
@@ -420,7 +420,7 @@ void GcodeSuite::M917() {
     L6470_ECHOLNPGM("Completed with errors");
     for (j = 0; j < driver_count; j++) {
       L6470_ECHOPGM("...");
-      L6470.error_status_decode(axis_status[j], axis_index[j]);
+      Marlin_L6470.error_status_decode(axis_status[j], axis_index[j]);
     }
   }
   else
@@ -464,7 +464,7 @@ void GcodeSuite::M918() {
 
   uint8_t j;   // general purpose counter
 
-  if (L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
+  if (Marlin_L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
     return;  // quit if invalid user input
 
   uint8_t m_steps = parser.byteval('M');
@@ -490,7 +490,7 @@ void GcodeSuite::M918() {
   }
 
   for (j = 0; j < driver_count; j++)
-    L6470.set_param(axis_index[j], L6470_STEP_MODE, m_bits);   // set microsteps
+    Marlin_L6470.set_param(axis_index[j], L6470_STEP_MODE, m_bits);   // set microsteps
 
   L6470_ECHOLNPAIR("target (maximum) feedrate = ",final_feedrate);
 
@@ -500,7 +500,7 @@ void GcodeSuite::M918() {
   planner.synchronize();                  // wait for all current movement commands to complete
 
   for (j = 0; j < driver_count; j++)
-    L6470.get_status(axis_index[j]);      // clear all error flags
+    Marlin_L6470.get_status(axis_index[j]);      // clear all error flags
 
   char temp_axis_string[2];
   temp_axis_string[0] = axis_mon[0][0];   // need to have a string for use within sprintf format section
@@ -523,7 +523,7 @@ void GcodeSuite::M918() {
     planner.synchronize();
 
     for (j = 0; j < driver_count; j++) {
-      axis_status[j] = (~L6470.get_status(axis_index[j])) & 0x0800;    // bits of interest are all active low
+      axis_status[j] = (~Marlin_L6470.get_status(axis_index[j])) & 0x0800;    // bits of interest are all active low
       status_composite |= axis_status[j];
     }
     if (status_composite) break;       // quit if any errors flags are raised
@@ -533,7 +533,7 @@ void GcodeSuite::M918() {
     L6470_ECHOLNPGM("Completed with errors");
     for (j = 0; j < driver_count; j++) {
       L6470_ECHOPGM("...");
-      L6470.error_status_decode(axis_status[j], axis_index[j]);
+      Marlin_L6470.error_status_decode(axis_status[j], axis_index[j]);
     }
   }
   else

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -29,9 +29,7 @@
 #if ENABLED(M114_DETAIL)
 
   #if HAS_DRIVER(L6470)
-    //C:\Users\bobku\Documents\GitHub\Marlin-Bob-2\Marlin\src\gcode\host\M114.cpp
-    //C:\Users\bobku\Documents\GitHub\Marlin-Bob-2\Marlin\src\module\bob_L6470.cpp
-    #include "../../module/L6470/L6470_Marlin.h"
+    #include "../../libs/L6470/L6470_Marlin.h"
   #endif
 
   void report_xyze(const float pos[], const uint8_t n = 4, const uint8_t precision = 3) {
@@ -91,7 +89,7 @@
       //#define ABS_POS_SIGN_MASK 0b1111 1111 1110 0000 0000 0000 0000 0000
       #define ABS_POS_SIGN_MASK 0b11111111111000000000000000000000
       #define REPORT_ABSOLUTE_POS(Q) do{                            \
-          L6470.say_axis(Q, false);                                 \
+          Marlin_L6470.say_axis(Q, false);                                 \
           temp = L6470_GETPARAM(L6470_ABS_POS,Q);                   \
           if (temp & ABS_POS_SIGN_MASK) temp |= ABS_POS_SIGN_MASK;  \
           sprintf_P(temp_buf, PSTR(":%8ld   "), temp);              \

--- a/Marlin/src/libs/L6470/L6470_Marlin.cpp
+++ b/Marlin/src/libs/L6470/L6470_Marlin.cpp
@@ -30,11 +30,11 @@
 
 #include "L6470_Marlin.h"
 
-L6470_Marlin L6470;
+L6470_Marlin Marlin_L6470;
 
-#include "../stepper_indirection.h"
+#include "../../module/stepper_indirection.h"
 #include "../../gcode/gcode.h"
-#include "../planner.h"
+#include "../../module/planner.h"
 
 uint8_t L6470_Marlin::dir_commands[MAX_L6470];  // array to hold direction command for each driver
 
@@ -83,7 +83,9 @@ uint8_t L6470_Marlin::axis_xref[MAX_L6470] = {
 volatile bool L6470_Marlin::spi_abort = false;
 bool L6470_Marlin::spi_active = false;
 
-void L6470_Marlin::populate_chain_array() {
+void L6470_spi_init();
+
+void populate_chain_array() {
 
   #define _L6470_INIT_SPI(Q)  do{ stepper##Q.set_chain_info(Q, Q##_CHAIN_POS); }while(0)
 
@@ -409,8 +411,8 @@ bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], 
   //
   for (uint8_t k = 0; k < driver_count; k++) {
     bool not_found = true;
-    for (j = 1; j <= L6470::chain[0]; j++) {
-      const char * const ind_axis = index_to_axis[L6470::chain[j]];
+    for (j = 1; j <= L6470_chain[0]; j++) {
+      const char * const ind_axis = index_to_axis[L6470_chain[j]];
       if (ind_axis[0] == axis_mon[k][0] && ind_axis[1] == axis_mon[k][1]) { // See if a L6470 driver
         not_found = false;
         break;
@@ -632,7 +634,7 @@ void L6470_Marlin::error_status_decode(const uint16_t status, const uint8_t axis
     char temp_buf[120];
     char* p = &temp_buf[0];
     uint8_t j;
-    for (j = 0; j < L6470::chain[0]; j++) // find the table for this stepper
+    for (j = 0; j < L6470_chain[0]; j++) // find the table for this stepper
       if (driver_L6470_data[j].driver_index == stepper_index) break;
 
     driver_L6470_data[j].driver_status = status;

--- a/Marlin/src/libs/L6470/L6470_Marlin.h
+++ b/Marlin/src/libs/L6470/L6470_Marlin.h
@@ -20,6 +20,8 @@
  *
  */
 
+#pragma once
+
 #include "../../inc/MarlinConfig.h"
 
 #include <L6470.h>
@@ -54,6 +56,9 @@
 #define HAS_L6470_EXTRUDER ( AXIS_DRIVER_TYPE_E0(L6470) || AXIS_DRIVER_TYPE_E1(L6470) || AXIS_DRIVER_TYPE_E2(L6470) \
                           || AXIS_DRIVER_TYPE_E3(L6470) || AXIS_DRIVER_TYPE_E4(L6470) || AXIS_DRIVER_TYPE_E5(L6470) )
 
+uint8_t L6470_transfer(uint8_t data, int16_t ss_pin, const uint8_t chain_position);
+void L6470_transfer(uint8_t L6470_buf[], const uint8_t length);
+
 class L6470_Marlin {
 public:
   static bool index_to_dir[MAX_L6470];
@@ -86,8 +91,6 @@ public:
 
   static void say_axis(const uint8_t axis, const bool label=true);
 
-private:
-  void populate_chain_array();
 };
 
-extern L6470_Marlin L6470;
+extern L6470_Marlin Marlin_L6470;

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -101,6 +101,8 @@ FORCE_INLINE signed char pgm_read_any(const signed char *p) { return pgm_read_by
   FORCE_INLINE type array(AxisEnum axis) { return pgm_read_any(&array##_P[axis]); } \
   typedef void __void_##CONFIG##__
 
+//#define XYZ_CONSTS(type, array, CONFIG) constexpr type array##_P[XYZ] = { X_##CONFIG, Y_##CONFIG, Z_##CONFIG }
+
 XYZ_DEFS(float, base_min_pos,   MIN_POS);
 XYZ_DEFS(float, base_max_pos,   MAX_POS);
 XYZ_DEFS(float, base_home_pos,  HOME_POS);

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -354,10 +354,6 @@ void Stepper::wake_up() {
  */
 void Stepper::set_directions() {
 
-  #if HAS_DRIVER(L6470)
-    uint8_t L6470_buf[MAX_L6470 + 1];   // chip command sequence - element 0 not used
-  #endif
-
   #define SET_STEP_DIR(A)                       \
     if (motor_direction(_AXIS(A))) {            \
       A##_APPLY_DIR(INVERT_## A##_DIR, false);  \
@@ -406,22 +402,24 @@ void Stepper::set_directions() {
 
   #if HAS_DRIVER(L6470)
 
-    if (L6470.spi_active) {
-      L6470.spi_abort = true;                     // interrupted a SPI transfer - need to shut it down gracefully
-      for (uint8_t j = 1; j <= L6470::chain[0]; j++)
+    uint8_t L6470_buf[MAX_L6470 + 1];   // chip command sequence - element 0 not used
+
+    if (Marlin_L6470.spi_active) {
+      Marlin_L6470.spi_abort = true;                     // interrupted a SPI transfer - need to shut it down gracefully
+      for (uint8_t j = 1; j <= L6470_chain[0]; j++)
         L6470_buf[j] = dSPIN_NOP;                 // fill buffer with NOOP commands
-      L6470.transfer(L6470_buf, L6470::chain[0]);  // send enough NOOPs to complete any command
-      L6470.transfer(L6470_buf, L6470::chain[0]);
-      L6470.transfer(L6470_buf, L6470::chain[0]);
+      L6470_transfer(L6470_buf, L6470_chain[0]);  // send enough NOOPs to complete any command
+      L6470_transfer(L6470_buf, L6470_chain[0]);
+      L6470_transfer(L6470_buf, L6470_chain[0]);
     }
 
-    // The L6470.dir_commands[] array holds the direction command for each stepper
+    // The Marlin_L6470.dir_commands[] array holds the direction command for each stepper
 
-    //scan command array and copy matches into L6470.transfer
-    for (uint8_t j = 1; j <= L6470::chain[0]; j++)
-      L6470_buf[j] = L6470.dir_commands[L6470::chain[j]];
+    //scan command array and copy matches into Marlin_L6470.dir_commands
+    for (uint8_t j = 1; j <= L6470_chain[0]; j++)
+      L6470_buf[j] = Marlin_L6470.dir_commands[L6470_chain[j]];
 
-    L6470.transfer(L6470_buf, L6470::chain[0]);  // send the command stream to the drivers
+    L6470_transfer(L6470_buf, L6470_chain[0]);  // send the command stream to the drivers
 
   #endif
 

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -38,7 +38,7 @@
 #include "../module/stepper.h"
 
 #if HAS_DRIVER(L6470)
-  #include "L6470/L6470_Marlin.h"
+  #include "../libs/L6470/L6470_Marlin.h"
 #endif
 
 //
@@ -610,7 +610,7 @@ void reset_stepper_drivers() {
   #endif
 
   #if HAS_DRIVER(L6470)
-    L6470.init_to_defaults();
+    Marlin_L6470.init_to_defaults();
   #endif
 
   #if HAS_TRINAMIC

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -83,8 +83,8 @@
 
 // L6470 has STEP on normal pins, but DIR/ENABLE via SPI
 #if HAS_DRIVER(L6470)
-  #include "L6470/L6470_Marlin.h"
-  #define L6470_WRITE_DIR_COMMAND(STATE,Q) do{ L6470_dir_commands[Q] = (STATE ?  dSPIN_STEP_CLOCK_REV : dSPIN_STEP_CLOCK_FWD); }while(0)
+  #include "../libs/L6470/L6470_Marlin.h"
+  #define L6470_WRITE_DIR_COMMAND(STATE,Q) do{ Marlin_L6470.dir_commands[Q] = (STATE ?  dSPIN_STEP_CLOCK_REV : dSPIN_STEP_CLOCK_FWD); }while(0)
 #endif
 
 void restore_stepper_drivers();  // Called by PSU_ON


### PR DESCRIPTION
The class L6470 existed both in the library and in L6470_Marlin.h.  To resolve this I renamed the one in L6470_Marlin.h to Marlin_L6470.

Fixed a lot of name issues and added in some missing declarations.

The chain[] array shouldn't be in the library's L6470 class because it is not specific to a stepper.  I'm doing a PR on the library to make that change.  This PR is dependent on the library change.

I did NOT include the XYZ array macro definition fix in this PR.  As best I can tell the one that was just merged still causes problems.