### PR TITLE
Fix M29 handling in parser

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -630,7 +630,8 @@ inline void get_serial_commands() {
           gcode_LastN = gcode_N;
         }
         #if ENABLED(SDSUPPORT)
-          else if (card.flag.saving && command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' '))
+          // Pronterface "M29" and "M29 " has no line number 
+          else if (card.flag.saving && !(command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ')))
             return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM), i);
         #endif
 

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -631,7 +631,7 @@ inline void get_serial_commands() {
         }
         #if ENABLED(SDSUPPORT)
           // Pronterface "M29" and "M29 " has no line number 
-          else if (card.flag.saving && !(command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ')))
+          else if (card.flag.saving && !(command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ' ||  || command[3] == '*')))
             return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM), i);
         #endif
 
@@ -840,7 +840,7 @@ void advance_command_queue() {
 
     if (card.flag.saving) {
       char* command = command_queue[cmd_queue_index_r];
-      if (command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ')) {
+      if (command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ' ||  || command[3] == '*')) {
         // M29 closes the file
         card.closefile();
         SERIAL_ECHOLNPGM(MSG_FILE_SAVED);

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -535,6 +535,10 @@ static int read_serial(const uint8_t index) {
 
 #endif // FAST_FILE_TRANSFER
 
+FORCE_INLINE bool is_M29(const char * const cmd) {
+  return cmd[0] == 'M' && cmd[1] == '2' && cmd[2] == '9' && !WITHIN(cmd[3], '0', '9');
+}
+
 /**
  * Get all commands waiting on the serial port and queue them.
  * Exit when the buffer is full or when no more characters are
@@ -631,7 +635,7 @@ inline void get_serial_commands() {
         }
         #if ENABLED(SDSUPPORT)
           // Pronterface "M29" and "M29 " has no line number 
-          else if (card.flag.saving && !(command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ' ||  || command[3] == '*')))
+          else if (card.flag.saving && !is_M29(command))
             return gcode_line_error(PSTR(MSG_ERR_NO_CHECKSUM), i);
         #endif
 
@@ -840,7 +844,7 @@ void advance_command_queue() {
 
     if (card.flag.saving) {
       char* command = command_queue[cmd_queue_index_r];
-      if (command[0] == 'M' && command[1] == '2' && command[2] == '9' && (command[3] == '\0' || command[3] == ' ' ||  || command[3] == '*')) {
+      if (is_M29(command)) {
         // M29 closes the file
         card.closefile();
         SERIAL_ECHOLNPGM(MSG_FILE_SAVED);


### PR DESCRIPTION
### Description
In #13010 code was changed to match "M29" or "M29 " which is good, but the logic to generate the *line number error* was reversed.

Logic should be if in card-saving mode generate errors line errors for anything that's *NOT* "M29" or "M29 "

BTW there was a second block of code changed in #13010 and that's OK. 
### Related Issues

This is a bug fix that came from #13010