### PR TITLE
Flush RX buffer on G-code line errors to prevent hang

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -251,14 +251,6 @@ void flush_and_request_resend() {
   ok_to_send();
 }
 
-void gcode_line_error(PGM_P err, uint8_t port) {
-  SERIAL_ERROR_START_P(port);
-  serialprintPGM_P(port, err);
-  SERIAL_ECHOLN_P(port, gcode_LastN);
-  flush_and_request_resend();
-  serial_count[port] = 0;
-}
-
 static bool serial_data_available() {
   return false
     || MYSERIAL0.available()
@@ -276,6 +268,15 @@ static int read_serial(const uint8_t index) {
     #endif
     default: return -1;
   }
+}
+
+void gcode_line_error(PGM_P err, uint8_t port) {
+  SERIAL_ERROR_START_P(port);
+  serialprintPGM_P(port, err);
+  SERIAL_ECHOLN_P(port, gcode_LastN);
+  while (read_serial(port) != -1);           // clear out the RX buffer
+  flush_and_request_resend();
+  serial_count[port] = 0;
 }
 
 #if ENABLED(FAST_FILE_TRANSFER)

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -251,7 +251,7 @@ void flush_and_request_resend() {
   ok_to_send();
 }
 
-static bool serial_data_available() {
+inline bool serial_data_available() {
   return false
     || MYSERIAL0.available()
     #if NUM_SERIAL > 1
@@ -260,7 +260,7 @@ static bool serial_data_available() {
   ;
 }
 
-static int read_serial(const uint8_t index) {
+inline int read_serial(const uint8_t index) {
   switch (index) {
     case 0: return MYSERIAL0.read();
     #if NUM_SERIAL > 1
@@ -287,7 +287,7 @@ void gcode_line_error(PGM_P err, uint8_t port) {
     #define CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
   #endif
 
-  static bool serial_data_available(const uint8_t index) {
+  inline bool serial_data_available(const uint8_t index) {
     switch (index) {
       case 0: return MYSERIAL0.available();
       #if NUM_SERIAL > 1


### PR DESCRIPTION
### Description
On a gcode line error the RX buffer isn't getting flushed.  `flush_and_request_resend()` does call `serial.flush()` which at some point *used* to flush the the RX buffer but doesn't any longer (<https://www.arduino.cc/en/serial/flush>). Now it just flushes the TX buffer by busy-waiting.

If you don't clear the RX buffer the resent gcode line is likely to be corrupted too because of garbage left over in the RX buffer.

This PR clears the RX buffer on a line error.

Without this fix when running with OctoPrint some CRC errors would lead to resynchronization errors and a hang situation.

Note:  if the intent of `flush_and_request_resend()` is to flush the RX buffer then this code should be moved into there. Currently `flush_and_request_resend()`  just flushes the TX buffer which doesn't make a lot of sense to me.

### Benefits

This fixes a resynchronizing bug with OctoPrint  on CRC errors.