### PR TITLE
Bugfix for incorrect stepper direction on reset

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2143,16 +2143,14 @@ void Stepper::init() {
     E_AXIS_INIT(5);
   #endif
 
+  set_directions();
+
   // Init Stepper ISR to 122 Hz for quick starting
   HAL_timer_start(STEP_TIMER_NUM, 122);
 
   ENABLE_STEPPER_DRIVER_INTERRUPT();
 
   sei();
-
-  Z_DIR_WRITE(0);    // Init directions to last_direction_bits = 0  Keeps Z from being reversed
-  Z2_DIR_WRITE(0);
-  Z3_DIR_WRITE(0);
 }
 
 /**


### PR DESCRIPTION
### Description

On a uC reset I was finding that the first move (e.g `G1 Z2`) would move in the wrong direction, but would almost immediately correct itself and then be fine until the next reset.  At the end of `Stepper::init` I found the following code:
```
  Z_DIR_WRITE(0);    // Init directions to last_direction_bits = 0  Keeps Z from being reversed
  Z2_DIR_WRITE(0);
  Z3_DIR_WRITE(0);
```
These hardcoded calls do not respect the Configuration.h flags on whether the DIR lines are inverted or not (e.g. INVERT_Z_DIR).  

There is an existing function `Stepper::set_directions` which looks at the last_direction bits and sets all the steppers appropriately and respects the Configuration.h flags.  I replaced those lines with a set_directions() call. I also moved it up before the stepper interrupt was enabled since it seemed like a good idea to have them setup correctly before interrupts started firing.
### Benefits

Stops the first few stepper moves from moving in the wrong direction.  Cleaner and reuse of code.

### Related Issues

See issue <https://github.com/MarlinFirmware/Marlin/issues/13024>