### PR TITLE
Repetier / Octoprint suggestion for out_of_filament

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/default/Configuration.h
+++ b/Marlin/src/config/default/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -1008,7 +1008,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/Marlin/src/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1022,7 +1022,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
+++ b/Marlin/src/config/examples/AliExpress/CL-260/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A2/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A2plus/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A2plus/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A6/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A6/Configuration.h
@@ -1116,7 +1116,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Anet/A8/Configuration.h
+++ b/Marlin/src/config/examples/Anet/A8/Configuration.h
@@ -1015,7 +1015,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/AnyCubic/i3/Configuration.h
+++ b/Marlin/src/config/examples/AnyCubic/i3/Configuration.h
@@ -1013,7 +1013,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/ArmEd/Configuration.h
+++ b/Marlin/src/config/examples/ArmEd/Configuration.h
@@ -1003,7 +1003,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
+++ b/Marlin/src/config/examples/Azteeg/X5GT/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/Marlin/src/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos/Configuration.h
@@ -990,7 +990,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/Marlin/src/config/examples/BQ/Hephestos_2/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
+++ b/Marlin/src/config/examples/BQ/WITBOX/Configuration.h
@@ -990,7 +990,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Cartesio/Configuration.h
+++ b/Marlin/src/config/examples/Cartesio/Configuration.h
@@ -1001,7 +1001,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-10/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10/Configuration.h
@@ -1012,7 +1012,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10S/Configuration.h
@@ -1003,7 +1003,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-10mini/Configuration.h
@@ -1021,7 +1021,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/CR-8/Configuration.h
+++ b/Marlin/src/config/examples/Creality/CR-8/Configuration.h
@@ -1012,7 +1012,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-2/Configuration.h
@@ -1006,7 +1006,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-3/Configuration.h
@@ -1006,7 +1006,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
+++ b/Marlin/src/config/examples/Creality/Ender-4/Configuration.h
@@ -1012,7 +1012,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Einstart-S/Configuration.h
+++ b/Marlin/src/config/examples/Einstart-S/Configuration.h
@@ -1012,7 +1012,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Felix/Configuration.h
+++ b/Marlin/src/config/examples/Felix/Configuration.h
@@ -984,7 +984,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Felix/DUAL/Configuration.h
+++ b/Marlin/src/config/examples/Felix/DUAL/Configuration.h
@@ -984,7 +984,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/Marlin/src/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -995,7 +995,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/Marlin/src/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -1008,7 +1008,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/Raptor/Configuration.h
@@ -1100,7 +1100,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -1032,7 +1032,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/Marlin/src/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -1027,7 +1027,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/GT2560/Configuration.h
@@ -1017,7 +1017,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -1009,7 +1009,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1018,7 +1018,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1017,7 +1017,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/Marlin/src/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
+++ b/Marlin/src/config/examples/Infitary/i3-M508/Configuration.h
@@ -1006,7 +1006,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/JGAurora/A5/Configuration.h
+++ b/Marlin/src/config/examples/JGAurora/A5/Configuration.h
@@ -1014,7 +1014,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/MakerParts/Configuration.h
+++ b/Marlin/src/config/examples/MakerParts/Configuration.h
@@ -1022,7 +1022,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Malyan/M150/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M150/Configuration.h
@@ -1026,7 +1026,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Malyan/M200/Configuration.h
+++ b/Marlin/src/config/examples/Malyan/M200/Configuration.h
@@ -1001,7 +1001,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/basic/Configuration.h
@@ -1006,7 +1006,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/Marlin/src/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -1006,7 +1006,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Mks/Robin/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Robin/Configuration.h
@@ -1003,7 +1003,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Mks/Sbase/Configuration.h
+++ b/Marlin/src/config/examples/Mks/Sbase/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RapideLite/RL200/Configuration.h
+++ b/Marlin/src/config/examples/RapideLite/RL200/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/Marlin/src/config/examples/RepRapPro/Huxley/Configuration.h
@@ -1051,7 +1051,7 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/Marlin/src/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/RigidBot/Configuration.h
+++ b/Marlin/src/config/examples/RigidBot/Configuration.h
@@ -1000,7 +1000,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/SCARA/Configuration.h
+++ b/Marlin/src/config/examples/SCARA/Configuration.h
@@ -1015,7 +1015,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/STM32F10/Configuration.h
+++ b/Marlin/src/config/examples/STM32F10/Configuration.h
@@ -1004,7 +1004,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/STM32F4/Configuration.h
+++ b/Marlin/src/config/examples/STM32F4/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Sanguinololu/Configuration.h
+++ b/Marlin/src/config/examples/Sanguinololu/Configuration.h
@@ -1033,7 +1033,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/TheBorg/Configuration.h
+++ b/Marlin/src/config/examples/TheBorg/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/TinyBoy2/Configuration.h
+++ b/Marlin/src/config/examples/TinyBoy2/Configuration.h
@@ -1058,7 +1058,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/X1/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X1/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X3A/Configuration.h
@@ -1006,7 +1006,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/X5S/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
+++ b/Marlin/src/config/examples/Tronxy/XY100/Configuration.h
@@ -1013,7 +1013,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim1/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/Marlin/src/config/examples/UltiMachine/Archim2/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/VORONDesign/Configuration.h
+++ b/Marlin/src/config/examples/VORONDesign/Configuration.h
@@ -1011,7 +1011,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Velleman/K8200/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8200/Configuration.h
@@ -1032,7 +1032,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Velleman/K8400/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/Marlin/src/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/WASP/PowerWASP/Configuration.h
+++ b/Marlin/src/config/examples/WASP/PowerWASP/Configuration.h
@@ -1021,7 +1021,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/Marlin/src/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1012,7 +1012,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
+++ b/Marlin/src/config/examples/adafruit/ST7565/Configuration.h
@@ -1002,7 +1002,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1190,7 +1190,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1130,7 +1130,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1129,7 +1129,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1129,7 +1129,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/Marlin/src/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1120,7 +1120,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/Marlin/src/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1132,7 +1132,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/Marlin/src/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1117,7 +1117,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/Marlin/src/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1121,7 +1121,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/generic/Configuration.h
+++ b/Marlin/src/config/examples/delta/generic/Configuration.h
@@ -1117,7 +1117,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_mini/Configuration.h
@@ -1119,7 +1119,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_pro/Configuration.h
@@ -1120,7 +1120,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
+++ b/Marlin/src/config/examples/delta/kossel_xl/Configuration.h
@@ -1120,7 +1120,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/Marlin/src/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1016,7 +1016,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/makibox/Configuration.h
+++ b/Marlin/src/config/examples/makibox/Configuration.h
@@ -1005,7 +1005,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/stm32f103ret6/Configuration.h
+++ b/Marlin/src/config/examples/stm32f103ret6/Configuration.h
@@ -1004,7 +1004,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
+++ b/Marlin/src/config/examples/tvrrug/Round2/Configuration.h
@@ -997,7 +997,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/config/examples/wt150/Configuration.h
+++ b/Marlin/src/config/examples/wt150/Configuration.h
@@ -1007,7 +1007,7 @@
   //
   // The host must be able to respond to the //action: command set here.
   //
-  //#define ACTION_ON_FILAMENT_RUNOUT "pause: filament_runout"
+  //#define ACTION_ON_FILAMENT_RUNOUT "out_of_filament"
 
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -100,8 +100,7 @@ class TFilamentMonitor : public FilamentMonitorBase {
           #ifdef ACTION_ON_FILAMENT_RUNOUT
             #if NUM_RUNOUT_SENSORS > 1
               host_action_filament_runout(false);
-              SERIAL_CHAR(' ');
-              SERIAL_ECHOLN(int(active_extruder));
+              SERIAL_ECHOLNPAIR(" T", int(active_extruder));
             #else
               host_action_filament_runout();
             #endif


### PR DESCRIPTION
Followup to #12817 taking the form suggested by #12982.

- Replace "`pause: filament_runout`" with "`out_of_filament`"
- Add "`T1`" (etc.) for runout on extra runout sensors.

Workspace for continuing development of this feature.