### PR TITLE
Revert E_AXIS_N cast

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -428,11 +428,11 @@
  */
 #if ENABLED(DISTINCT_E_FACTORS) && E_STEPPERS > 1
   #define XYZE_N (XYZ + E_STEPPERS)
-  #define E_AXIS_N(E) (uint8_t(E_AXIS) + E)
+  #define E_AXIS_N(E) (E_AXIS + E)
 #else
   #undef DISTINCT_E_FACTORS
   #define XYZE_N XYZE
-  #define E_AXIS_N(E) uint8_t(E_AXIS)
+  #define E_AXIS_N(E) E_AXIS
 #endif
 
 /**


### PR DESCRIPTION
Fixes #12990.

Compile issue with multiple extruders.
```
Marlin/src/feature/tmc_util.cpp: In function 'void init_tmc_section()':
Marlin/src/feature/tmc_util.cpp:1011:47: error: invalid conversion from 'uint8_t {aka unsigned char}' to 'AxisEnum' [-fpermissive]
stepperE1.init_lcd_variables(E_AXIS_N(1));
```
There probably was a reason why this was initially this changes like this but at least this PR restores the ability to compile configurations.