### PR TITLE
[2.0.x] Fix missing declaration 'host_action' in Marlin.cpp

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -313,7 +313,7 @@ void disable_all_steppers() {
 
 #if HAS_ACTION_COMMANDS
 
-  void host_action(const char * const pstr, const bool eol=true) {
+  void host_action(const char * const pstr, const bool eol) {
     SERIAL_ECHOPGM("//action:");
     serialprintPGM(pstr);
     if (eol) SERIAL_EOL();

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -371,6 +371,7 @@ void protected_pin_err();
 #endif
 
 #if HAS_ACTION_COMMANDS
+  void host_action(const char * const pstr, const bool eol=true);
   #ifdef ACTION_ON_KILL
     void host_action_kill();
   #endif


### PR DESCRIPTION
Hello, 
This small PR, fix the compile issue with host_action in Marlin.cpp
_I hope to do well_

##Issue:
host_action() not declared in header
