### PR TITLE
TMC2130 Sensorless homing with dual stepper drivers

### DIFF
--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -278,7 +278,7 @@ void test_tmc_connection(const bool test_x, const bool test_y, const bool test_z
 #if USE_SENSORLESS
   // Track enabled status of stealthChop and only re-enable where applicable
   struct sensorless_t {
-    bool x, y, z;
+    bool x, y, z, x2, y2, z2, z3;
   };
 
   bool tmc_enable_stallguard(TMC2130Stepper &st);

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -71,14 +71,14 @@
                 fr_mm_s = MIN(homing_feedrate(X_AXIS), homing_feedrate(Y_AXIS)) * SQRT(sq(mlratio) + 1.0);
 
     #if ENABLED(SENSORLESS_HOMING)
-      sensorless_t stealth_states { false, false, false };
+      sensorless_t stealth_states { false, false, false, false, false, false, false };
       stealth_states.x = tmc_enable_stallguard(stepperX);
       stealth_states.y = tmc_enable_stallguard(stepperY);
       #if AXIS_HAS_STALLGUARD(X2)
-        tmc_enable_stallguard(stepperX2);
+        stealth_states.x2 = tmc_enable_stallguard(stepperX2);
       #endif
       #if AXIS_HAS_STALLGUARD(Y2)
-        tmc_enable_stallguard(stepperY2);
+        stealth_states.y2 = tmc_enable_stallguard(stepperY2);
       #endif
     #endif
 
@@ -92,10 +92,10 @@
       tmc_disable_stallguard(stepperX, stealth_states.x);
       tmc_disable_stallguard(stepperY, stealth_states.y);
       #if AXIS_HAS_STALLGUARD(X2)
-        tmc_disable_stallguard(stepperX2, stealth_states.x);
+        tmc_disable_stallguard(stepperX2, stealth_states.x2);
       #endif
       #if AXIS_HAS_STALLGUARD(Y2)
-        tmc_disable_stallguard(stepperY2, stealth_states.y);
+        tmc_disable_stallguard(stepperY2, stealth_states.y2);
       #endif
     #endif
   }

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -74,6 +74,12 @@
       sensorless_t stealth_states { false, false, false };
       stealth_states.x = tmc_enable_stallguard(stepperX);
       stealth_states.y = tmc_enable_stallguard(stepperY);
+      #if AXIS_HAS_STALLGUARD(X2)
+        tmc_enable_stallguard(stepperX2);
+      #endif
+      #if AXIS_HAS_STALLGUARD(Y2)
+        tmc_enable_stallguard(stepperY2);
+      #endif
     #endif
 
     do_blocking_move_to_xy(1.5 * mlx * x_axis_home_dir, 1.5 * mly * home_dir(Y_AXIS), fr_mm_s);
@@ -85,6 +91,12 @@
     #if ENABLED(SENSORLESS_HOMING)
       tmc_disable_stallguard(stepperX, stealth_states.x);
       tmc_disable_stallguard(stepperY, stealth_states.y);
+      #if AXIS_HAS_STALLGUARD(X2)
+        tmc_disable_stallguard(stepperX2, stealth_states.x);
+      #endif
+      #if AXIS_HAS_STALLGUARD(Y2)
+        tmc_disable_stallguard(stepperY2, stealth_states.y);
+      #endif
     #endif
   }
 

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -222,7 +222,7 @@ void home_delta() {
 
   // Disable stealthChop if used. Enable diag1 pin on driver.
   #if ENABLED(SENSORLESS_HOMING)
-    sensorless_t stealth_states { false, false, false };
+    sensorless_t stealth_states { false, false, false, false, false, false, false };
     stealth_states.x = tmc_enable_stallguard(stepperX);
     stealth_states.y = tmc_enable_stallguard(stepperY);
     stealth_states.z = tmc_enable_stallguard(stepperZ);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1057,6 +1057,9 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
       #if X_SENSORLESS
         case X_AXIS:
           stealth_states.x = tmc_enable_stallguard(stepperX);
+          #if AXIS_HAS_STALLGUARD(X2)
+            tmc_enable_stallguard(stepperX2);
+          #endif
           #if CORE_IS_XY && Y_SENSORLESS
             stealth_states.y = tmc_enable_stallguard(stepperY);
           #elif CORE_IS_XZ && Z_SENSORLESS
@@ -1067,6 +1070,9 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
       #if Y_SENSORLESS
         case Y_AXIS:
           stealth_states.y = tmc_enable_stallguard(stepperY);
+          #if AXIS_HAS_STALLGUARD(Y2)
+            tmc_enable_stallguard(stepperY2);
+          #endif
           #if CORE_IS_XY && X_SENSORLESS
             stealth_states.x = tmc_enable_stallguard(stepperX);
           #elif CORE_IS_YZ && Z_SENSORLESS
@@ -1077,6 +1083,12 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
       #if Z_SENSORLESS
         case Z_AXIS:
           stealth_states.z = tmc_enable_stallguard(stepperZ);
+          #if AXIS_HAS_STALLGUARD(Z2)
+            tmc_enable_stallguard(stepperZ2);
+          #endif
+          #if AXIS_HAS_STALLGUARD(Z3)
+            tmc_enable_stallguard(stepperZ3);
+          #endif
           #if CORE_IS_XZ && X_SENSORLESS
             stealth_states.x = tmc_enable_stallguard(stepperX);
           #elif CORE_IS_YZ && Y_SENSORLESS
@@ -1094,6 +1106,9 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
       #if X_SENSORLESS
         case X_AXIS:
           tmc_disable_stallguard(stepperX, enable_stealth.x);
+          #if AXIS_HAS_STALLGUARD(X2)
+            tmc_disable_stallguard(stepperX2, enable_stealth.x);
+          #endif
           #if CORE_IS_XY && Y_SENSORLESS
             tmc_disable_stallguard(stepperY, enable_stealth.y);
           #elif CORE_IS_XZ && Z_SENSORLESS
@@ -1104,6 +1119,9 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
       #if Y_SENSORLESS
         case Y_AXIS:
           tmc_disable_stallguard(stepperY, enable_stealth.y);
+          #if AXIS_HAS_STALLGUARD(Y2)
+            tmc_disable_stallguard(stepperY2, enable_stealth.y);
+          #endif
           #if CORE_IS_XY && X_SENSORLESS
             tmc_disable_stallguard(stepperX, enable_stealth.x);
           #elif CORE_IS_YZ && Z_SENSORLESS
@@ -1114,6 +1132,12 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
       #if Z_SENSORLESS
         case Z_AXIS:
           tmc_disable_stallguard(stepperZ, enable_stealth.z);
+          #if AXIS_HAS_STALLGUARD(Z2)
+            tmc_disable_stallguard(stepperZ2, enable_stealth.z);
+          #endif
+          #if AXIS_HAS_STALLGUARD(Z3)
+            tmc_disable_stallguard(stepperZ3, enable_stealth.z);
+          #endif
           #if CORE_IS_XZ && X_SENSORLESS
             tmc_disable_stallguard(stepperX, enable_stealth.x);
           #elif CORE_IS_YZ && Y_SENSORLESS

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1050,7 +1050,7 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
    * Set sensorless homing if the axis has it, accounting for Core Kinematics.
    */
   sensorless_t start_sensorless_homing_per_axis(const AxisEnum axis) {
-    sensorless_t stealth_states { false, false, false };
+    sensorless_t stealth_states { false, false, false, false, false, false, false };
 
     switch (axis) {
       default: break;
@@ -1058,7 +1058,7 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
         case X_AXIS:
           stealth_states.x = tmc_enable_stallguard(stepperX);
           #if AXIS_HAS_STALLGUARD(X2)
-            tmc_enable_stallguard(stepperX2);
+            stealth_states.x2 = tmc_enable_stallguard(stepperX2);
           #endif
           #if CORE_IS_XY && Y_SENSORLESS
             stealth_states.y = tmc_enable_stallguard(stepperY);
@@ -1071,7 +1071,7 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
         case Y_AXIS:
           stealth_states.y = tmc_enable_stallguard(stepperY);
           #if AXIS_HAS_STALLGUARD(Y2)
-            tmc_enable_stallguard(stepperY2);
+            stealth_states.y2 = tmc_enable_stallguard(stepperY2);
           #endif
           #if CORE_IS_XY && X_SENSORLESS
             stealth_states.x = tmc_enable_stallguard(stepperX);
@@ -1084,10 +1084,10 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
         case Z_AXIS:
           stealth_states.z = tmc_enable_stallguard(stepperZ);
           #if AXIS_HAS_STALLGUARD(Z2)
-            tmc_enable_stallguard(stepperZ2);
+            stealth_states.z2 = tmc_enable_stallguard(stepperZ2);
           #endif
           #if AXIS_HAS_STALLGUARD(Z3)
-            tmc_enable_stallguard(stepperZ3);
+            stealth_states.z3 = tmc_enable_stallguard(stepperZ3);
           #endif
           #if CORE_IS_XZ && X_SENSORLESS
             stealth_states.x = tmc_enable_stallguard(stepperX);
@@ -1107,7 +1107,7 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
         case X_AXIS:
           tmc_disable_stallguard(stepperX, enable_stealth.x);
           #if AXIS_HAS_STALLGUARD(X2)
-            tmc_disable_stallguard(stepperX2, enable_stealth.x);
+            tmc_disable_stallguard(stepperX2, enable_stealth.x2);
           #endif
           #if CORE_IS_XY && Y_SENSORLESS
             tmc_disable_stallguard(stepperY, enable_stealth.y);
@@ -1120,7 +1120,7 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
         case Y_AXIS:
           tmc_disable_stallguard(stepperY, enable_stealth.y);
           #if AXIS_HAS_STALLGUARD(Y2)
-            tmc_disable_stallguard(stepperY2, enable_stealth.y);
+            tmc_disable_stallguard(stepperY2, enable_stealth.y2);
           #endif
           #if CORE_IS_XY && X_SENSORLESS
             tmc_disable_stallguard(stepperX, enable_stealth.x);
@@ -1133,10 +1133,10 @@ inline float get_homing_bump_feedrate(const AxisEnum axis) {
         case Z_AXIS:
           tmc_disable_stallguard(stepperZ, enable_stealth.z);
           #if AXIS_HAS_STALLGUARD(Z2)
-            tmc_disable_stallguard(stepperZ2, enable_stealth.z);
+            tmc_disable_stallguard(stepperZ2, enable_stealth.z2);
           #endif
           #if AXIS_HAS_STALLGUARD(Z3)
-            tmc_disable_stallguard(stepperZ3, enable_stealth.z);
+            tmc_disable_stallguard(stepperZ3, enable_stealth.z3);
           #endif
           #if CORE_IS_XZ && X_SENSORLESS
             tmc_disable_stallguard(stepperX, enable_stealth.x);

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -551,7 +551,7 @@ static bool do_probe_move(const float z, const float fr_mm_s) {
 
   // Disable stealthChop if used. Enable diag1 pin on driver.
   #if ENABLED(SENSORLESS_PROBING)
-    sensorless_t stealth_states { false, false, false };
+    sensorless_t stealth_states { false, false, false, false, false, false, false };
     #if ENABLED(DELTA)
       stealth_states.x = tmc_enable_stallguard(stepperX);
       stealth_states.y = tmc_enable_stallguard(stepperY);


### PR DESCRIPTION
(As per #11893)

This patch fixes TMC2130 sensorless homing with X2/Y2/Z2/Z3. 

The 2nd commit tracks the operating mode for extra drivers separately, but I believe the only reason they would be in a different mode to the primary driver is if something has gone wrong, or if _HYBRID_THRESHOLD is set differently on the same axis for some reason. This accounts for it, but I'm not sure if this should be allowed behavior.

Only other thing to note, the config file already recommends disabling bump when using sensorless homing, but I'd like to point out it's pretty much mandatory with dual drivers, as the backwards motion can cause enough resistance on the opposite stepper to trigger stallguard if the sensitivity is high enough.