### PR TITLE
Fix init of last_direction_bits

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -534,3 +534,16 @@
 #define IS_CARTESIAN !IS_KINEMATIC
 
 #define HAS_ACTION_COMMANDS (defined(ACTION_ON_KILL) || defined(ACTION_ON_PAUSE) || defined(ACTION_ON_PAUSED) || defined(ACTION_ON_RESUME) || defined(ACTION_ON_RESUMED) || defined(ACTION_ON_CANCEL) || defined(G29_ACTION_ON_RECOVER) || defined(G29_ACTION_ON_FAILURE) || defined(ACTION_ON_FILAMENT_RUNOUT))
+
+#ifndef INVERT_X_DIR
+  #define INVERT_X_DIR false
+#endif
+#ifndef INVERT_Y_DIR
+  #define INVERT_Y_DIR false
+#endif
+#ifndef INVERT_Z_DIR
+  #define INVERT_Z_DIR false
+#endif
+#ifndef INVERT_E_DIR
+  #define INVERT_E_DIR false
+#endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -129,10 +129,10 @@ Stepper stepper; // Singleton
 
 // private:
 
-block_t* Stepper::current_block = NULL; // A pointer to the block currently being traced
+block_t* Stepper::current_block; // (= NULL) A pointer to the block currently being traced
 
-uint8_t Stepper::last_direction_bits = 0,
-        Stepper::axis_did_move = 0;
+uint8_t Stepper::last_direction_bits, // = 0
+        Stepper::axis_did_move; // = 0
 
 bool Stepper::abort_current_block;
 
@@ -2143,8 +2143,6 @@ void Stepper::init() {
     E_AXIS_INIT(5);
   #endif
 
-  set_directions();
-
   // Init Stepper ISR to 122 Hz for quick starting
   HAL_timer_start(STEP_TIMER_NUM, 122);
 
@@ -2152,11 +2150,12 @@ void Stepper::init() {
 
   sei();
 
-  // initialize the direction bits for first moves
-  last_direction_bits = 0;
-  SET_BIT_TO(last_direction_bits, X_AXIS, INVERT_X_DIR);
-  SET_BIT_TO(last_direction_bits, Y_AXIS, INVERT_Y_DIR);
-  SET_BIT_TO(last_direction_bits, Z_AXIS, INVERT_Z_DIR);
+  // Init direction bits for first moves
+  last_direction_bits = 0
+    | (INVERT_X_DIR ? _BV(X_AXIS) : 0)
+    | (INVERT_Y_DIR ? _BV(Y_AXIS) : 0)
+    | (INVERT_Z_DIR ? _BV(Z_AXIS) : 0);
+
   set_directions();
 }
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -132,7 +132,7 @@ Stepper stepper; // Singleton
 block_t* Stepper::current_block = NULL; // A pointer to the block currently being traced
 
 uint8_t Stepper::last_direction_bits = 0,
-        Stepper::axis_did_move;
+        Stepper::axis_did_move = 0;
 
 bool Stepper::abort_current_block;
 
@@ -2151,6 +2151,13 @@ void Stepper::init() {
   ENABLE_STEPPER_DRIVER_INTERRUPT();
 
   sei();
+
+  // initialize the direction bits for first moves
+  last_direction_bits = 0;
+  SET_BIT_TO(last_direction_bits, X_AXIS, INVERT_X_DIR);
+  SET_BIT_TO(last_direction_bits, Y_AXIS, INVERT_Y_DIR);
+  SET_BIT_TO(last_direction_bits, Z_AXIS, INVERT_Z_DIR);
+  set_directions();
 }
 
 /**


### PR DESCRIPTION
This fixes a bug that happens at boot whereby an axis that is inverted will go the wrong way. My debugging tools are pretty bad so I could be wrong about this but I've replicated the symptom and repair.

### Requirements
This has no requirements. I'm not certain it's the best way to achieve the result but it does work.

### Description
The last_direction_bits are flags that are compared to see if direction has flipped. If not, we keep sending pulses. In the current state an axis that is inverted will go negative if asked to go positive. So, if you have an endstop at X-Max, for example, the head will crash into the left side when first homed. Once any move decreasing an axis happens the bits are all reset and things become fine.

Thus, at startup if the bits correspond to increasing axis then axes move in the right direction immediately.

### Benefits

See above.

### Related Issues

This fixes a bug. From what I could see there are a number of forum requests for help that are misidentifying the issue and thinking they can't get inverted state working reliably so they just flip their cables.


