### PR TITLE
MMU2 fixes

### DIFF
--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -38,10 +38,6 @@ MMU2 mmu2;
 #include "../../module/stepper_indirection.h"
 #include "../../Marlin.h"
 
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  #include "../runout.h"
-#endif
-
 #define MMU_TODELAY 100
 #define MMU_TIMEOUT 10
 #define MMU_CMD_TIMEOUT 60000ul //5min timeout for mmu commands (except P0)
@@ -109,7 +105,8 @@ MMU2::MMU2() {
 }
 
 void MMU2::init() {
-  findaRunoutValid = false;
+
+  set_runout_valid(false);
 
   #if PIN_EXISTS(MMU2_RST)
     // TODO use macros for this
@@ -508,7 +505,7 @@ void MMU2::toolChange(uint8_t index) {
 
   if (!enabled) return;
 
-  findaRunoutValid = false;
+  set_runout_valid(false);
 
   if (index != extruder) {
 
@@ -534,7 +531,7 @@ void MMU2::toolChange(uint8_t index) {
     KEEPALIVE_STATE(NOT_BUSY);
   }
 
-  findaRunoutValid = true;
+  set_runout_valid(true);
 }
 
 
@@ -553,7 +550,7 @@ void MMU2::toolChange(const char* special) {
 
   #if ENABLED(MMU2_MENUS)
 
-    findaRunoutValid = false;
+    set_runout_valid(false);
     KEEPALIVE_STATE(IN_HANDLER);
 
     switch(*special) {
@@ -585,7 +582,7 @@ void MMU2::toolChange(const char* special) {
 
     KEEPALIVE_STATE(NOT_BUSY);
 
-    findaRunoutValid = true;
+    set_runout_valid(true);
 
   #endif
 }
@@ -806,7 +803,8 @@ void MMU2::filamentRunout() {
 
     // no active tool
     extruder = MMU2_NO_TOOL;
-    findaRunoutValid = false;
+
+    set_runout_valid(false);
 
     BUZZ(200, 404);
 
@@ -845,7 +843,8 @@ void MMU2::filamentRunout() {
 
     // no active tool
     extruder = MMU2_NO_TOOL;
-    findaRunoutValid = false;
+
+    set_runout_valid(false);
 
     KEEPALIVE_STATE(NOT_BUSY);
 

--- a/Marlin/src/feature/prusa_MMU2/mmu2.h
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.h
@@ -24,6 +24,10 @@
 
 #include "../../inc/MarlinConfig.h"
 
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #include "../runout.h"
+#endif
+
 struct E_Step;
 
 class MMU2 {
@@ -77,6 +81,14 @@ private:
   static int16_t version, buildnr;
   static millis_t last_request, next_P0_request;
   static char rx_buffer[16], tx_buffer[16];
+
+  static inline void set_runout_valid(const bool valid) {
+    findaRunoutValid = valid;
+    #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+      if (valid) runout.reset();
+    #endif
+  }
+
 };
 
 extern MMU2 mmu2;

--- a/Marlin/src/feature/prusa_MMU2/mmu2.h
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.h
@@ -75,7 +75,7 @@ private:
   static volatile int8_t finda;
   static volatile bool findaRunoutValid;
   static int16_t version, buildnr;
-  static millis_t next_request, next_response;
+  static millis_t last_request, next_P0_request;
   static char rx_buffer[16], tx_buffer[16];
 };
 


### PR DESCRIPTION
In the merge of the initial PR #12967 the handling of command timeouts got a little messed up. There are two different timeouts which where reduced to the shorter one which is only for the P0 command. Now the long-running commands like T0..4 all time out far too early. This PR fixes the issue and also adds a reset of filament sensors after a successful tool change to avoid false positives.