### PR TITLE
language_pt-br warnings due to extra tokens at end of #else directive

### DIFF
--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -369,7 +369,7 @@
 
   #define MSG_FILAMENT_CHANGE_RESUME_1        _UxGT("Esperando impressao")
   #define MSG_FILAMENT_CHANGE_RESUME_2        _UxGT("continuar")
-#else LCD_HEIGHT < 4
+#else // LCD_HEIGHT < 4
   #define MSG_FILAMENT_CHANGE_INIT_1          _UxGT("Aguarde...")
   #define MSG_FILAMENT_CHANGE_UNLOAD_1        _UxGT("Ejetando...")
   #define MSG_FILAMENT_CHANGE_INSERT_1        _UxGT("Insira e Clique")


### PR DESCRIPTION
When the LCD language is changed to pt-br, we get a lot of warns.
It is because of the extra tokens at end of the #else directive.

### Description

After changing the LCD language to pt-br:
#define LCD_LANGUAGE pt-br
It will give us a warn:

In file included from sketch/language.h:317:0,
                 from sketch/MarlinConfig.h:44,
                 from sketch/Marlin.h:35,
                 from sketch/endstops.cpp:27:
sketch/language_pt-br.h:372:7: warning: extra tokens at end of #else directive [-Wendif-labels]
 #else LCD_HEIGHT < 4
       ^

To fix it, we need to comment out the "LCD_HEIGHT < 4" as on the language_en.h file.
#else // LCD_HEIGHT < 4

### Benefits

It removes all the warns related with the extra tokens at end of #else directive