### PR TITLE
Software reset via panel button press

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -686,20 +686,22 @@ void minkill() {
 
   #if HAS_KILL
 
+    // Wait for kill to be released
     while (!READ(KILL_PIN)) {
       #if ENABLED(USE_WATCHDOG)
         watchdog_reset();
       #endif
-    } // Wait for the kill pin to be released.
+    }
 
+    // Wait for kill to be pressed
     while (READ(KILL_PIN)) {
       #if ENABLED(USE_WATCHDOG)
         watchdog_reset();
       #endif
-    } // Once the kill pin is pressed again, we'll reset
+    }
 
-    void(*resetFunc)(void) = 0; // Declare reset function at address 0
-    resetFunc();                // The kill switch was pushed again... reset/restart the application.
+    void(*resetFunc)(void) = 0; // Declare resetFunc() at address 0
+    resetFunc();                // Jump to address 0
 
   #else // !HAS_KILL
 

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -684,11 +684,30 @@ void minkill() {
     suicide();
   #endif
 
+  #if !HAS_KILL
   while (1) {
     #if ENABLED(USE_WATCHDOG)
       watchdog_reset();
     #endif
   } // Wait for reset
+
+  #else // HAS_KILL
+
+  while (!READ(KILL_PIN)) {
+    #if ENABLED(USE_WATCHDOG)
+      watchdog_reset();
+    #endif
+  } // Wait for the kill pin to be released.
+
+  while (READ(KILL_PIN)) {
+    #if ENABLED(USE_WATCHDOG)
+      watchdog_reset();
+    #endif
+  } // Once the kill pin is pressed again, we'll reset
+
+  void(* resetFunc) (void) = 0;//declare reset function at address 0
+  resetFunc(); // The kill switch was pushed again... reset/restart the application.
+  #endif // HAS_KILL
 }
 
 /**

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -684,30 +684,32 @@ void minkill() {
     suicide();
   #endif
 
-  #if !HAS_KILL
-  while (1) {
-    #if ENABLED(USE_WATCHDOG)
-      watchdog_reset();
-    #endif
-  } // Wait for reset
+  #if HAS_KILL
 
-  #else // HAS_KILL
+    while (!READ(KILL_PIN)) {
+      #if ENABLED(USE_WATCHDOG)
+        watchdog_reset();
+      #endif
+    } // Wait for the kill pin to be released.
 
-  while (!READ(KILL_PIN)) {
-    #if ENABLED(USE_WATCHDOG)
-      watchdog_reset();
-    #endif
-  } // Wait for the kill pin to be released.
+    while (READ(KILL_PIN)) {
+      #if ENABLED(USE_WATCHDOG)
+        watchdog_reset();
+      #endif
+    } // Once the kill pin is pressed again, we'll reset
 
-  while (READ(KILL_PIN)) {
-    #if ENABLED(USE_WATCHDOG)
-      watchdog_reset();
-    #endif
-  } // Once the kill pin is pressed again, we'll reset
+    void(*resetFunc)(void) = 0; // Declare reset function at address 0
+    resetFunc();                // The kill switch was pushed again... reset/restart the application.
 
-  void(* resetFunc) (void) = 0;//declare reset function at address 0
-  resetFunc(); // The kill switch was pushed again... reset/restart the application.
-  #endif // HAS_KILL
+  #else // !HAS_KILL
+
+    for (;;) {
+      #if ENABLED(USE_WATCHDOG)
+        watchdog_reset();
+      #endif
+    } // Wait for reset
+
+  #endif // !HAS_KILL
 }
 
 /**


### PR DESCRIPTION
Pressing the kill button a second time (once in killed state)
will call the Arduino reset vector and restart Marlin.

Signed-off-by: Bruce Beare <bbeare1@gmail.com>

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

No longer have to power cycle after hitting the front panel switch (if HAS_KILL). Instead, you can press it a second time and the board restarts Marlin.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
