### PR TITLE
No RGB_LED with 3DFabXYZ i3

### DIFF
--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -2072,7 +2072,7 @@
  * LED Type. Enable only one of the following two options.
  *
  */
-#define RGB_LED
+//#define RGB_LED
 //#define RGBW_LED
 
 #if ENABLED(RGB_LED) || ENABLED(RGBW_LED)

--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -202,7 +202,7 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 9        // Set a custom pin for the controller fan
+  #define CONTROLLER_FAN_PIN 9           // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
 #endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

Electron/TEVO i3 6th gen printer with MKS Base 1.4 controller.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
The changes fix issues with the example 3DFabXYZ i3 printer configs.

### Benefits

<!-- What does this fix or improve? -->
Addresses controller heat issues by enabling the Controller_Fan.
and removes RGB_LED issue caused by none PWM pins defined for RGB.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
