### PR TITLE
Apply minimum C in M303

### DIFF
--- a/Marlin/src/gcode/temperature/M303.cpp
+++ b/Marlin/src/gcode/temperature/M303.cpp
@@ -32,7 +32,7 @@
  *
  *       S<temperature> sets the target temperature. (default 150C / 70C)
  *       E<extruder> (-1 for the bed) (default 0)
- *       C<cycles>
+ *       C<cycles> Minimum 3. Default 5.
  *       U<bool> with a non-zero value will apply the result to current settings
  */
 void GcodeSuite::M303() {

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -331,7 +331,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
    * Alternately heat and cool the nozzle, observing its behavior to
    * determine the best PID values to achieve a stable temperature.
    * Needs sufficient heater power to make some overshoot at target
-   * temperature to succseede.
+   * temperature to succeed.
    */
   void Temperature::PID_autotune(const float &target, const int8_t heater, const int8_t ncycles, const bool set_result/*=false*/) {
     float current = 0.0;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -330,6 +330,8 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
    *
    * Alternately heat and cool the nozzle, observing its behavior to
    * determine the best PID values to achieve a stable temperature.
+   * Needs sufficient heater power to make some overshoot at target
+   * temperature to succseede.
    */
   void Temperature::PID_autotune(const float &target, const int8_t heater, const int8_t ncycles, const bool set_result/*=false*/) {
     float current = 0.0;
@@ -540,7 +542,7 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
         break;
       }
 
-      if (cycles > ncycles) {
+      if (cycles > ncycles && cycles > 2) {
         SERIAL_ECHOLNPGM(MSG_PID_AUTOTUNE_FINISHED);
 
         #if HAS_PID_FOR_BOTH


### PR DESCRIPTION
PID_autotune() needs to be called with a 'C'ycles-parameter >2 to give meaningful (different from 0) PID-factors.
Therefor enforce 3 cycles.
Fixing one aspect of #13007
Also see https://github.com/MarlinFirmware/MarlinDocumentation/pull/210
