### PR TITLE
Fix 'no PID' used define

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -803,7 +803,7 @@ float Temperature::get_pid_output(const int8_t e) {
         pid_output = 0;
       else
     #endif
-    pid_output = (current_temperature[HOTEND_INDEX] < target_temperature[HOTEND_INDEX]) ? PID_MAX : 0;
+    pid_output = (current_temperature[HOTEND_INDEX] < target_temperature[HOTEND_INDEX]) ? BANG_MAX : 0;
   #endif
 
   return pid_output;


### PR DESCRIPTION
Replaced PID_MAX with BANG_MAX since it should be the correct define to be used when pid is not enabled