### PR TITLE
[2.0.x] Fix TEMP_STAT_LED startup init

### DIFF
--- a/Marlin/src/feature/leds/tempstat.cpp
+++ b/Marlin/src/feature/leds/tempstat.cpp
@@ -47,11 +47,9 @@ void handle_status_leds(void) {
       red_led = new_led;
       #if PIN_EXISTS(STAT_LED_RED)
         WRITE(STAT_LED_RED_PIN, new_led);
-        #if PIN_EXISTS(STAT_LED_BLUE)
-          WRITE(STAT_LED_BLUE_PIN, !new_led);
-        #endif
-      #else
-        WRITE(STAT_LED_BLUE_PIN, new_led);
+      #endif
+      #if PIN_EXISTS(STAT_LED_BLUE)
+        WRITE(STAT_LED_BLUE_PIN, !new_led);
       #endif
     }
   }

--- a/Marlin/src/feature/leds/tempstat.cpp
+++ b/Marlin/src/feature/leds/tempstat.cpp
@@ -32,17 +32,17 @@
 #include "../../module/temperature.h"
 
 void handle_status_leds(void) {
-  static uint8_t red_led = LOW;
+  static uint8_t red_led = -1;  // Invalid value to force leds initializzation on startup
   static millis_t next_status_led_update_ms = 0;
   if (ELAPSED(millis(), next_status_led_update_ms)) {
     next_status_led_update_ms += 500; // Update every 0.5s
     float max_temp = 0.0;
     #if HAS_HEATED_BED
-      max_temp = MAX(max_temp, thermalManager.degTargetBed(), thermalManager.degBed());
+      max_temp = MAX(thermalManager.degTargetBed(), thermalManager.degBed());
     #endif
     HOTEND_LOOP()
       max_temp = MAX(max_temp, thermalManager.degHotend(e), thermalManager.degTargetHotend(e));
-    const uint8_t new_led = (max_temp > 55.0) ? HIGH : (max_temp < 54.0) ? LOW : red_led;
+    const uint8_t new_led = (max_temp > 55.0) ? HIGH : (max_temp < 54.0 || red_led == -1) ? LOW : red_led;
     if (new_led != red_led) {
       red_led = new_led;
       #if PIN_EXISTS(STAT_LED_RED)

--- a/Marlin/src/feature/leds/tempstat.cpp
+++ b/Marlin/src/feature/leds/tempstat.cpp
@@ -32,7 +32,7 @@
 #include "../../module/temperature.h"
 
 void handle_status_leds(void) {
-  static uint8_t red_led = -1;  // Invalid value to force leds initializzation on startup
+  static int8_t old_red = -1;  // Invalid value to force LED initialization
   static millis_t next_status_led_update_ms = 0;
   if (ELAPSED(millis(), next_status_led_update_ms)) {
     next_status_led_update_ms += 500; // Update every 0.5s
@@ -42,14 +42,14 @@ void handle_status_leds(void) {
     #endif
     HOTEND_LOOP()
       max_temp = MAX(max_temp, thermalManager.degHotend(e), thermalManager.degTargetHotend(e));
-    const uint8_t new_led = (max_temp > 55.0) ? HIGH : (max_temp < 54.0 || red_led == -1) ? LOW : red_led;
-    if (new_led != red_led) {
-      red_led = new_led;
+    const int8_t new_red = (max_temp > 55.0) ? HIGH : (max_temp < 54.0 || old_red < 0) ? LOW : old_red;
+    if (new_red != old_red) {
+      old_red = new_red;
       #if PIN_EXISTS(STAT_LED_RED)
-        WRITE(STAT_LED_RED_PIN, new_led);
+        WRITE(STAT_LED_RED_PIN, new_red);
       #endif
       #if PIN_EXISTS(STAT_LED_BLUE)
-        WRITE(STAT_LED_BLUE_PIN, !new_led);
+        WRITE(STAT_LED_BLUE_PIN, !new_red);
       #endif
     }
   }


### PR DESCRIPTION
Blue led is not turned on startup if it should (Fix #13118)
