### PR TITLE
[2.0.x] Fixed compilation with MMU2_MENUS disabled

### DIFF
--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -37,7 +37,7 @@
   #include "../../../lcd/ultralcd.h"
 #endif
 
-#if ENABLED(PRUSA_MMU2)
+#if ENABLED(MMU2_MENUS)
   #include "../../../lcd/menu/menu_mmu2.h"
 #endif
 
@@ -75,7 +75,7 @@ void GcodeSuite::M600() {
   #endif
 
   // Show initial "wait for start" message
-  #if HAS_LCD_MENU && DISABLED(PRUSA_MMU2)
+  #if HAS_LCD_MENU && DISABLED(MMU2_MENUS)
     lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_INIT, ADVANCED_PAUSE_MODE_PAUSE_PRINT, target_extruder);
   #endif
 
@@ -114,7 +114,7 @@ void GcodeSuite::M600() {
     park_point.y += (active_extruder ? hotend_offset[Y_AXIS][active_extruder] : 0);
   #endif
 
-  #if ENABLED(PRUSA_MMU2)
+  #if ENABLED(MMU2_MENUS)
     // For MMU2 reset retract and load/unload values so they don't mess with MMU filament handling
     constexpr float unload_length = 0.5f,
                     slow_load_length = 0.0f,
@@ -141,7 +141,7 @@ void GcodeSuite::M600() {
   );
 
   if (pause_print(retract, park_point, unload_length, true DXC_PASS)) {
-    #if ENABLED(PRUSA_MMU2)
+    #if ENABLED(MMU2_MENUS)
       mmu2_M600();
       resume_print(slow_load_length, fast_load_length, 0, beep_count DXC_PASS);
     #else


### PR DESCRIPTION
This will fix compilation of Marlin with option `PRUSA_MMU2` enabled, but `MMU2_MENUS` disabled.

Function `mmu2_M600()` is defined only if option `MMU2_MENUS` is enabled.