### PR TITLE
[1.1.x] Fix LCD button / newbutton issue

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -5606,15 +5606,14 @@ void lcd_reset_alert_level() { lcd_status_message_level = 0; }
 
         #endif // LCD_HAS_DIRECTIONAL_BUTTONS
 
-        buttons = newbutton;
         #if ENABLED(LCD_HAS_SLOW_BUTTONS)
-          buttons |= slow_buttons;
+          newbutton |= slow_buttons;
         #endif
+        buttons = newbutton;
 
         #if ENABLED(ADC_KEYPAD)
 
           uint8_t newbutton_reprapworld_keypad = 0;
-          buttons = 0;
           if (buttons_reprapworld_keypad == 0) {
             newbutton_reprapworld_keypad = get_ADC_keyValue();
             if (WITHIN(newbutton_reprapworld_keypad, 1, 8))


### PR DESCRIPTION
### Logic errors in ultralcd.cpp
1) Minor:
   buttons is a volatile variable. button |= slow_buttons should not be done
   if newbuttons |= ... can be done

2) Major:
   #if ENABLED(ADC_KEYPAD) ... buttons = 0 is done after buttons = newbuttons
   The values from a rotary encoder (which I installed) are erased by this
   line, and newbuttons would have been 0 anyway if there was no button.

   TL;DR: Don't undo reading the rotary encoder before reading the ADC keys

### Benefits // Related Issues

I created a display having a rotary encoder and back/home buttons by using an ADC_KEY. Being in a deep menu, these extra keys are helpful, while also giving the benefit of having a rotary encoder instead of emulating one using the up/down keys. The encoder would not work even though the pins were read correctly.