### PR TITLE
[1.1.x] Optional ADC_KEYPAD pin with ANET_10

### DIFF
--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -154,39 +154,39 @@
  */
 
 #if ENABLED(ULTRA_LCD)
-  #define LCD_SDSS             28
+  #define LCD_SDSS         28
   #if ENABLED(ADC_KEYPAD)
-    #define SERVO0_PIN         27   // free for BLTouch/3D-Touch
+    #define SERVO0_PIN     27   // free for BLTouch/3D-Touch
     #ifndef LCD_I2C_TYPE_PCF8575
-      #define LCD_PINS_RS      28
-      #define LCD_PINS_ENABLE  29
-      #define LCD_PINS_D4      10
-      #define LCD_PINS_D5      11
-      #define LCD_PINS_D6      16
-      #define LCD_PINS_D7      17
+      #define LCD_PINS_RS  28
+      #define LCD_PINS_ENABLE 29
+      #define LCD_PINS_D4  10
+      #define LCD_PINS_D5  11
+      #define LCD_PINS_D6  16
+      #define LCD_PINS_D7  17
     #endif
     #ifndef BTN_EN1
-      #define BTN_EN1          -1
-      #define BTN_EN2          -1
+      #define BTN_EN1      -1
+      #define BTN_EN2      -1
     #endif
     #ifndef BTN_ENC
-      #define BTN_ENC          -1
+      #define BTN_ENC      -1
     #endif
     #ifndef ADC_KEYPAD_PIN
-      #define ADC_KEYPAD_PIN    1
+      #define ADC_KEYPAD_PIN 1   // Analog Input
     #endif
   #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) || ENABLED(ANET_FULL_GRAPHICS_LCD)
     // Pin definitions for the Anet A6 Full Graphics display and the RepRapDiscount Full Graphics
     // display using an adapter board  // https://go.aisler.net/benlye/anet-lcd-adapter/pcb
     // See below for alternative pin definitions for use with https://www.thingiverse.com/thing:2103748
-    #define SERVO0_PIN         29   // free for BLTouch/3D-Touch
-    #define BEEPER_PIN         17
-    #define LCD_PINS_RS        27
-    #define LCD_PINS_ENABLE    28
-    #define LCD_PINS_D4        30
-    #define BTN_EN1            11
-    #define BTN_EN2            10
-    #define BTN_ENC            16
+    #define SERVO0_PIN     29   // free for BLTouch/3D-Touch
+    #define BEEPER_PIN     17
+    #define LCD_PINS_RS    27
+    #define LCD_PINS_ENABLE 28
+    #define LCD_PINS_D4    30
+    #define BTN_EN1        11
+    #define BTN_EN2        10
+    #define BTN_ENC        16
     #ifndef ST7920_DELAY_1
       #define ST7920_DELAY_1 DELAY_NS(0)
     #endif
@@ -200,7 +200,7 @@
     #define STD_ENCODER_STEPS_PER_MENU_ITEM 1
   #endif
 #else
-  #define SERVO0_PIN         27
+  #define SERVO0_PIN       27
 #endif
 
 /**

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -165,13 +165,6 @@
       #define LCD_PINS_D6  16
       #define LCD_PINS_D7  17
     #endif
-    #ifndef BTN_EN1
-      #define BTN_EN1      -1
-      #define BTN_EN2      -1
-    #endif
-    #ifndef BTN_ENC
-      #define BTN_ENC      -1
-    #endif
     #ifndef ADC_KEYPAD_PIN
       #define ADC_KEYPAD_PIN 1   // Analog Input
     #endif

--- a/Marlin/pins_ANET_10.h
+++ b/Marlin/pins_ANET_10.h
@@ -154,31 +154,39 @@
  */
 
 #if ENABLED(ULTRA_LCD)
-  #define LCD_SDSS           28
+  #define LCD_SDSS             28
   #if ENABLED(ADC_KEYPAD)
-    #define SERVO0_PIN       27   // free for BLTouch/3D-Touch
-    #define LCD_PINS_RS      28
-    #define LCD_PINS_ENABLE  29
-    #define LCD_PINS_D4      10
-    #define LCD_PINS_D5      11
-    #define LCD_PINS_D6      16
-    #define LCD_PINS_D7      17
-    #define BTN_EN1          -1
-    #define BTN_EN2          -1
-    #define BTN_ENC          -1
-    #define ADC_KEYPAD_PIN    1
+    #define SERVO0_PIN         27   // free for BLTouch/3D-Touch
+    #ifndef LCD_I2C_TYPE_PCF8575
+      #define LCD_PINS_RS      28
+      #define LCD_PINS_ENABLE  29
+      #define LCD_PINS_D4      10
+      #define LCD_PINS_D5      11
+      #define LCD_PINS_D6      16
+      #define LCD_PINS_D7      17
+    #endif
+    #ifndef BTN_EN1
+      #define BTN_EN1          -1
+      #define BTN_EN2          -1
+    #endif
+    #ifndef BTN_ENC
+      #define BTN_ENC          -1
+    #endif
+    #ifndef ADC_KEYPAD_PIN
+      #define ADC_KEYPAD_PIN    1
+    #endif
   #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) || ENABLED(ANET_FULL_GRAPHICS_LCD)
     // Pin definitions for the Anet A6 Full Graphics display and the RepRapDiscount Full Graphics
     // display using an adapter board  // https://go.aisler.net/benlye/anet-lcd-adapter/pcb
     // See below for alternative pin definitions for use with https://www.thingiverse.com/thing:2103748
-    #define SERVO0_PIN       29   // free for BLTouch/3D-Touch
-    #define BEEPER_PIN       17
-    #define LCD_PINS_RS      27
-    #define LCD_PINS_ENABLE  28
-    #define LCD_PINS_D4      30
-    #define BTN_EN1          11
-    #define BTN_EN2          10
-    #define BTN_ENC          16
+    #define SERVO0_PIN         29   // free for BLTouch/3D-Touch
+    #define BEEPER_PIN         17
+    #define LCD_PINS_RS        27
+    #define LCD_PINS_ENABLE    28
+    #define LCD_PINS_D4        30
+    #define BTN_EN1            11
+    #define BTN_EN2            10
+    #define BTN_ENC            16
     #ifndef ST7920_DELAY_1
       #define ST7920_DELAY_1 DELAY_NS(0)
     #endif


### PR DESCRIPTION
… Encoder

Neither overwrite nor set:

1) LCD_PINS_* if LCD_I2C_TYPE_PCF8575 is set
2) BTN_EN1, BTN_EN1 If BTN_EN1 is set
3) BTN_ENC if set
4) ADC_KEYPAD_PIN if set

### Benefits

This allows adding a rotary encoder to Anet A8 with LCD2004 by using a PCF8575 to free some pins