### PR TITLE
Followup to #13039

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -347,8 +347,10 @@ void disable_all_steppers() {
       host_action_prompt_show();
     #endif
 
+    const bool run_runout_script = !runout.host_handling;
+
     #if ENABLED(HOST_ACTION_COMMANDS)
-      if (!runout.host_handling
+      if (run_runout_script
         && ( strstr(FILAMENT_RUNOUT_SCRIPT, "M600")
           || strstr(FILAMENT_RUNOUT_SCRIPT, "M125")
           #if ENABLED(ADVANCED_PAUSE_FEATURE)
@@ -372,10 +374,9 @@ void disable_all_steppers() {
       SERIAL_ECHOPGM(" " ACTION_REASON_ON_FILAMENT_RUNOUT " ");
       SERIAL_CHAR(tool);
       SERIAL_EOL();
-
     #endif // HOST_ACTION_COMMANDS
 
-    if (!runout.host_handling)
+    if (run_runout_script)
       enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
   }
 
@@ -385,7 +386,7 @@ void disable_all_steppers() {
 
   void event_probe_failure() {
     #ifdef G29_FAILURE_COMMANDS
-      process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
+      GcodeSuite::process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
     #endif
     #ifdef ACTION_ON_G29_FAILURE
       host_action(PSTR(ACTION_ON_G29_FAILURE)); }
@@ -403,7 +404,7 @@ void disable_all_steppers() {
       host_prompt_do(PROMPT_INFO, PSTR("G29 Retrying"));
     #endif
     #ifdef G29_RECOVER_COMMANDS
-      process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
+      GcodeSuite::process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
     #endif
     #ifdef ACTION_ON_G29_RECOVER
       host_action(PSTR(ACTION_ON_G29_RECOVER));

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -386,7 +386,7 @@ void disable_all_steppers() {
 
   void event_probe_failure() {
     #ifdef G29_FAILURE_COMMANDS
-      GcodeSuite::process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
+      gcode.process_subcommands_now_P(PSTR(G29_FAILURE_COMMANDS));
     #endif
     #ifdef ACTION_ON_G29_FAILURE
       host_action(PSTR(ACTION_ON_G29_FAILURE)); }
@@ -404,7 +404,7 @@ void disable_all_steppers() {
       host_prompt_do(PROMPT_INFO, PSTR("G29 Retrying"));
     #endif
     #ifdef G29_RECOVER_COMMANDS
-      GcodeSuite::process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
+      gcode.process_subcommands_now_P(PSTR(G29_RECOVER_COMMANDS));
     #endif
     #ifdef ACTION_ON_G29_RECOVER
       host_action(PSTR(ACTION_ON_G29_RECOVER));


### PR DESCRIPTION
- Fixed compile error when accessing "process_subcommands_now_P"
- Used "const run_runout_script" var to eliminate double-negation (makes code more understandable and makes it easier to tweak that value[1]).

[1] We will need to do so for compatibility with Cura LE, at least until we are able to implement HOST_PROMPT_SUPPORT