### PR TITLE
Updated BIQU SKR V1.1 pins file, with TMC2130 configuration options

### DIFF
--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -113,8 +113,8 @@
 //#define USB_SD_DISABLED     // Disable host access to SD card as mass storage device through USB
 #define USB_SD_ONBOARD        // Enable host access to SD card as mass storage device through USB
 
-//#define LPC_SD_LCD            // Marlin uses the SD drive attached to the LCD
-#define LPC_SD_ONBOARD      // Marlin uses the SD drive on the control board.  There is no SD detect pin
+//#define LPC_SD_LCD          // Marlin uses the SD drive attached to the LCD
+#define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board.  There is no SD detect pin
                               // for the onboard card.  Init card from LCD menu or send M21 whenever printer
                               // is powered on to enable SD access.
 

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -57,7 +57,6 @@
 #define E0_DIR_PIN         P2_13
 #define E0_ENABLE_PIN      P2_12
 
-
 #define E1_STEP_PIN        P0_01
 #define E1_DIR_PIN         P0_00
 #define E1_ENABLE_PIN      P0_10
@@ -66,9 +65,10 @@
 // Temperature Sensors
 //  3.3V max when defined as an analog input
 //
-#define TEMP_BED_PIN       0
-#define TEMP_0_PIN         1
-#define TEMP_1_PIN         2
+#define TEMP_BED_PIN       0   // Analog Input
+#define TEMP_0_PIN         1   // Analog Input
+#define TEMP_1_PIN         2   // Analog Input
+
 //
 // Heaters / Fans
 //
@@ -84,16 +84,14 @@
 /**
  * LCD / Controller
  * 
- * Deinitions for the LCD displays that can be used with this board. as of 20/01/2019 only 
- * the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER display has been tested with these 
- * settings. This display can be connected to the SKR just using standard cables via the
- * EXP1 and EXP2 ports. Some other displays may need a custom cable and/or require changes
- * to the pins defined below.
+ * As of 20 JAN 2019 only the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER display has
+ * been tested with these settings. It can be connected to the SKR using standard cables
+ * via the EXP1 and EXP2 ports. Other displays may need a custom cable and/or changes to
+ * the pins defined below.
  *
- * 
- * SD card on the LCD uses the same SPI signals as the LCD. This results in garbage/lines
- * on the LCD display during accesses of the SD card. The menus/code has been arranged so
- * that the garbage/lines are erased immediately after the SD card accesses are completed.
+ * The SD card on the LCD controller uses the same SPI signals as the LCD, resulting in
+ * garbage/lines on the LCD display during SD card access. The LCD code mitigates this
+ * by redrawing the screen after SD card accesses.
  */
 
 #if ENABLED(ULTRA_LCD)

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -1,5 +1,7 @@
 /**
  * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
@@ -57,6 +59,7 @@
 #define E0_DIR_PIN         P2_13
 #define E0_ENABLE_PIN      P2_12
 
+
 #define E1_STEP_PIN        P0_01
 #define E1_DIR_PIN         P0_00
 #define E1_ENABLE_PIN      P0_10
@@ -65,10 +68,9 @@
 // Temperature Sensors
 //  3.3V max when defined as an analog input
 //
-#define TEMP_BED_PIN       0   // A0 (T0) - (67) - TEMP_BED_PIN
-#define TEMP_0_PIN         1   // A1 (T1) - (68) - TEMP_0_PIN
-#define TEMP_1_PIN         2   // A2 (T2) - (69) - TEMP_1_PIN
-
+#define TEMP_BED_PIN       0
+#define TEMP_0_PIN         1
+#define TEMP_1_PIN         2
 //
 // Heaters / Fans
 //
@@ -81,139 +83,52 @@
 #define FAN_PIN            P2_03
 #define HEATER_BED_PIN     P2_05
 
-//
-// Misc. Functions
-//
-#define SDSS               P1_23   // (53)
-
 /**
  * LCD / Controller
+ * 
+ * Deinitions for the LCD displays that can be used with this board. as of 20/01/2019 only 
+ * the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER display has been tested with these 
+ * settings. This display can be connected to the SKR just using standard cables via the
+ * EXP1 and EXP2 ports. Some other displays may need a custom cable and/or require changes
+ * to the pins defined below.
  *
- * All controllers can use J3 and J5 on the Re-ARM board.  Custom cabling will be required.
- */
-
-/**
- * Smart LCD adapter
- *
- * The Smart LCD adapter can be used for the two 10 pin LCD controllers such as
- * REPRAP_DISCOUNT_SMART_CONTROLLER.  It can't be used for controllers that use
- * DOGLCD_A0, DOGLCD_CS, LCD_PINS_D5, LCD_PINS_D6 or LCD_PINS_D7. A custom cable
- * is needed to pick up 5V for the EXP1 connection.
- *
+ * 
  * SD card on the LCD uses the same SPI signals as the LCD. This results in garbage/lines
  * on the LCD display during accesses of the SD card. The menus/code has been arranged so
  * that the garbage/lines are erased immediately after the SD card accesses are completed.
  */
 
 #if ENABLED(ULTRA_LCD)
+  #define BEEPER_PIN       P1_30
+  #define BTN_EN1          P3_26
+  #define BTN_EN2          P3_25
+  #define BTN_ENC          P2_11
 
-  #if ENABLED(CR10_STOCKDISPLAY)
-
-    // Re-Arm can support Creality stock display without SD card reader and single cable on EXP3.
-    // Re-Arm J3 pins 1 (p1.31) & 2 (P3.26) are not used. Stock cable will need to have one
-    // 10-pin IDC connector trimmed or replaced with a 12-pin IDC connector to fit J3.
-    // Requires REVERSE_ENCODER_DIRECTION in Configuration.h
-
-    #define BEEPER_PIN     P2_11   // J3-3 & AUX-4
-
-    #define BTN_EN1        P0_16   // J3-7 & AUX-4
-    #define BTN_EN2        P1_23   // J3-5 & AUX-4
-    #define BTN_ENC        P3_25   // J3-4 & AUX-4
-
-    #define LCD_PINS_RS    P0_15   // J3-9 & AUX-4 (CS)
-    #define LCD_PINS_ENABLE P0_18  // J3-10 & AUX-3 (SID, MOSI)
-    #define LCD_PINS_D4    P2_06   // J3-8 & AUX-3 (SCK, CLK)
-
-  #else
-
-    #define BEEPER_PIN     P1_30   // (37) not 5V tolerant
-
-    #define BTN_EN1        P3_26   // (31) J3-2 & AUX-4
-    #define BTN_EN2        P3_25   // (33) J3-4 & AUX-4
-    #define BTN_ENC        P2_11   // (35) J3-3 & AUX-4
-
-    #define SD_DETECT_PIN  P1_31   // (49) not 5V tolerant   J3-1 & AUX-3
-    #define KILL_PIN       P1_22   // (41) J5-4 & AUX-4
-    #define LCD_PINS_RS    P0_16   // (16) J3-7 & AUX-4
-    #define LCD_SDSS       P0_16   // (16) J3-7 & AUX-4
-
-    #if ENABLED(REPRAPWORLD_KEYPAD)
-      #define SHIFT_OUT    P0_18   // (51)  (MOSI) J3-10 & AUX-3
-      #define SHIFT_CLK    P0_15   // (52)  (SCK)  J3-9 & AUX-3
-      #define SHIFT_LD     P1_31   // (49)  not 5V tolerant   J3-1 & AUX-3
-    #elif DISABLED(NEWPANEL)
-      //#define SHIFT_CLK  P3_26   // (31)  J3-2 & AUX-4
-      //#define SHIFT_LD   P3_25   // (33)  J3-4 & AUX-4
-      //#define SHIFT_OUT  P2_11   // (35)  J3-3 & AUX-4
-      //#define SHIFT_EN   P1_22   // (41)  J5-4 & AUX-4
-    #endif
-
-    #if ENABLED(VIKI2) || ENABLED(miniVIKI)
-      // #define LCD_SCREEN_ROT_180
-
-      #define BTN_EN1      P3_26   // (31) J3-2 & AUX-4
-      #define BTN_EN2      P3_25   // (33) J3-4 & AUX-4
-      #define BTN_ENC      P2_11   // (35) J3-3 & AUX-4
-
-      #define SD_DETECT_PIN P1_31  // (49) not 5V tolerant   J3-1 & AUX-3
-      #define KILL_PIN     P1_22   // (41) J5-4 & AUX-4
-
-      #define DOGLCD_CS    P0_16   // (16)
-      #define DOGLCD_A0    P2_06   // (59) J3-8 & AUX-2
-      #define DOGLCD_SCK   SCK_PIN
-      #define DOGLCD_MOSI  MOSI_PIN
-
-      #define STAT_LED_BLUE_PIN   P0_26   // (63)  may change if cable changes
-      #define STAT_LED_RED_PIN    P1_21   // ( 6)  may change if cable changes
-    #else
-      #define DOGLCD_CS    P0_26   // (63) J5-3 & AUX-2
-      #define DOGLCD_A0    P2_06   // (59) J3-8 & AUX-2
-      #define LCD_BACKLIGHT_PIN P0_16 // (16) J3-7 & AUX-4 - only used on DOGLCD controllers
-      #define LCD_PINS_ENABLE P0_18   // (51) (MOSI) J3-10 & AUX-3
-      #define LCD_PINS_D4  P0_15   // (52) (SCK)  J3-9 & AUX-3
-      #if ENABLED(ULTIPANEL)
-        #define LCD_PINS_D5 P1_17  // (71) ENET_MDIO
-        #define LCD_PINS_D6 P1_14  // (73) ENET_RX_ER
-        #define LCD_PINS_D7 P1_10  // (75) ENET_RXD1
-      #endif
-    #endif
-
-    //#define MISO_PIN      P0_17   // (50)  system defined J3-10 & AUX-3
-    //#define MOSI_PIN      P0_18   // (51)  system defined J3-10 & AUX-3
-    //#define SCK_PIN       P0_15   // (52)  system defined J3-9 & AUX-3
-    //#define SS_PIN        P1_23   // (53)  system defined J3-5 & AUX-3 - sometimes called SDSS
-
-    #if ENABLED(MINIPANEL)
-      // GLCD features
-      //#define LCD_CONTRAST   190
-      // Uncomment screen orientation
-      //#define LCD_SCREEN_ROT_90
-      //#define LCD_SCREEN_ROT_180
-      //#define LCD_SCREEN_ROT_270
-    #endif
-
-  #endif
-
-#endif // ULTRA_LCD
+  #define SD_DETECT_PIN    P1_31
+  #define LCD_SDSS         P1_23
+  #define LCD_PINS_RS      P0_16
+  #define LCD_PINS_ENABLE  P0_18
+  #define LCD_PINS_D4      P0_15
+#endif
 
 //
-// SD Support (as with the AZTEEG_X5_MINI_WIFI)
+// SD Support
 //
 //#define USB_SD_DISABLED     // Disable host access to SD card as mass storage device through USB
 #define USB_SD_ONBOARD        // Enable host access to SD card as mass storage device through USB
 
-//#define LPC_SD_LCD          // Marlin uses the SD drive attached to the LCD
-#define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board.  There is no SD detect pin
+//#define LPC_SD_LCD            // Marlin uses the SD drive attached to the LCD
+#define LPC_SD_ONBOARD      // Marlin uses the SD drive on the control board.  There is no SD detect pin
                               // for the onboard card.  Init card from LCD menu or send M21 whenever printer
                               // is powered on to enable SD access.
 
 #if ENABLED(LPC_SD_LCD)
 
-  #define SCK_PIN            P0_15
-  #define MISO_PIN           P0_17
-  #define MOSI_PIN           P0_18
-  #define SS_PIN             P1_23   // Chip select for SD card used by Marlin
-  #define ONBOARD_SD_CS      P0_06   // Chip select for "System" SD card
+  #define SCK_PIN          P0_15
+  #define MISO_PIN         P0_17
+  #define MOSI_PIN         P0_18
+  #define SS_PIN           P1_23   // Chip select for SD card used by Marlin
+  #define ONBOARD_SD_CS    P0_06   // Chip select for "System" SD card
 
 #elif ENABLED(LPC_SD_ONBOARD)
 
@@ -223,10 +138,129 @@
     #define SHARED_SD_CARD
     #undef SD_DETECT_PIN // there is also no detect pin for the onboard card
   #endif
-  #define SCK_PIN            P0_07
-  #define MISO_PIN           P0_08
-  #define MOSI_PIN           P0_09
-  #define SS_PIN             P0_06   // Chip select for SD card used by Marlin
-  #define ONBOARD_SD_CS      P0_06   // Chip select for "System" SD card
+  #define SCK_PIN          P0_07
+  #define MISO_PIN         P0_08
+  #define MOSI_PIN         P0_09
+  #define SS_PIN           P0_06   // Chip select for SD card used by Marlin
+  #define ONBOARD_SD_CS    P0_06   // Chip select for "System" SD card
 
 #endif
+
+// Trinamic driver support
+
+#if HAS_TRINAMIC
+  // Using TMC devices in intelligent mode requires extra connections to each device. Unfortunately
+  // the SKR does not have many free pins (especially if a display is in use). The SPI based devices
+  // will require 3 connections (clock, mosi, miso), plus a chip select line (CS) for each driver.
+  // The UART based devices require 2 pis per deriver (one of which must be interrupt capable). With SPI
+  // we are able to share the same SPI pins used for the display/sd card reader which means that the SPI
+  // based devices are probably a good choice for this board.
+  //
+  // Use of SOFTWARE_DRIVER_ENABLE is a good option. This uses SPI to control the driver enable and
+  // allows the hardware ENABLE pins for each driver to be re-purposed as SPI chip select. To use
+  // this mode the driver modules will probably need to be modified. Removing the pin used for the
+  // enable line from the module and wiring this connection directly to GND (this is the case for TMC2130).
+  // Using this option and sharing all of the SPI pins allows 5 TMC2130 drivers to be used along with
+  // a REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER without requiring the use of any extra pins.
+  //
+  // Other options will probably require the use of any free pins and the TFT serial port or
+  // the use of different type of display (like the TFT) and use of the pins normally used for the
+  // display and encoder. Unfotunately tests show that it is not possible to use endstop and thermister
+  // pins for chip select. Sample configurations are provided below, but only some have been tested.
+  //
+  // One other option is to share the enable and chip select pins when using SPI. Several users
+  // have reported that this works. However it is unlikely that this configuration will allow SPI
+  // communication with the device when the drivers are active. Which means that some of the more advanced
+  // TMC options may not be available.
+
+  // We are using one or more TMC SPI based drivers, we will use software SPI because we may be sharing
+  // the pins with a display or sd card
+  #define TMC_USE_SW_SPI
+  #define TMC_SW_MOSI       P0_18
+  #define TMC_SW_MISO       P0_17
+  // To minimise pin usage use the same clock pin as the display/SD card reader. Doing this may generate
+  // small glitches on the LCD display
+  #define TMC_SW_SCK        P0_15
+  // If pin 2_06 is not in use for other purposes then it can be used for the clock to avoid the display glitches.
+  //#define TMC_SW_SCK        P2_06
+
+  #if ENABLED(SOFTWARE_DRIVER_ENABLE)
+    // We are using software enable. This allows us to re-purpose the enable pins for use as chip-select.
+    // Note: This will require that the driver modules have been modified to always be enabled and the enable
+    // pin has been removed.
+    #if AXIS_DRIVER_TYPE_X(TMC2130)
+      #define X_CS_PIN         P4_28
+      #undef  X_ENABLE_PIN
+      #define X_ENABLE_PIN     -1
+    #endif
+
+    #if AXIS_DRIVER_TYPE_Y(TMC2130)
+      #define Y_CS_PIN         P2_00
+      #undef  Y_ENABLE_PIN
+      #define Y_ENABLE_PIN     -1
+    #endif
+
+    #if AXIS_DRIVER_TYPE_Z(TMC2130)
+      #define Z_CS_PIN         P0_19
+      #undef  Z_ENABLE_PIN
+      #define Z_ENABLE_PIN     -1
+    #endif
+
+    #if AXIS_DRIVER_TYPE_E0(TMC2130)
+      #define E0_CS_PIN        P2_12
+      #undef  E0_ENABLE_PIN
+      #define E0_ENABLE_PIN    -1
+    #endif
+
+
+    #if AXIS_DRIVER_TYPE_E1(TMC2130)
+      #define E1_CS_PIN        P0_10
+      #undef  E1_ENABLE_PIN
+      #define E1_ENABLE_PIN    -1
+    #endif
+  #else
+    // We need to define a chip-select pin for each driver
+    // The following are example configurations
+
+    // Example 1. No LCD attached or a TFT style display that uses the RX/TX pins on the AUX header
+    // Note that LPC_SD_LCD must not be enabled Nothing should be connected to EXP1 and EXP2
+    //#define SKR_USE_LCD_PINS_FOR_CS
+    #ifdef SKR_USE_LCD_PINS_FOR_CS
+      #define X_CS_PIN      P1_23
+      #define Y_CS_PIN      P3_26
+      #define Z_CS_PIN      P2_11
+      #define E0_CS_PIN     P3_25
+      #define E1_CS_PIN     P1_31
+    #endif
+
+    // Example 2. A REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER display is in use. 
+    // Note that with this configuration the SD card reader attached to the LCD (if present) can not be
+    // used (as the pins will be in use). So LPC_SD_LCD must not be defined.
+    //#define SKR_USE_LCD_SD_CARD_PINS_FOR_CS
+    #ifdef SKR_USE_LCD_SD_CARD_PINS_FOR_CS
+      #define X_CS_PIN      P0_02
+      #define Y_CS_PIN      P0_03
+      #define Z_CS_PIN      P2_06
+      // We use SD_DETECT_PIN for E0
+      #undef SD_DETECT_PIN
+      #define E0_CS_PIN     P1_31
+      // We use LCD_SDSS pin for E1
+      #undef  LCD_SDSS
+      #define LCD_SDSS      -1
+      #define E1_CS_PIN     P1_23
+    #endif
+
+    // Example 3: We use the driver enable pins for chip select.
+    // Note that with this option we must not send commands to the drivers when they are enabled. This means
+    // that advanced features like driver monitoring will not be available.
+    //#define SKR_USE_ENABLE_CS
+    #ifdef SKR_USE_ENABLE_FOR_CS
+      #define X_CS_PIN      X_ENABLE_PIN
+      #define Y_CS_PIN      Y_ENABLE_PIN
+      #define Z_CS_PIN      Z_ENABLE_PIN
+      #define E0_CS_PIN     E0_ENABLE_PIN
+      #define E1_CS_PIN     E1_ENABLE_PIN
+    #endif
+  #endif
+#endif
+

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -259,4 +259,3 @@
     #endif
   #endif
 #endif
-

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -1,7 +1,5 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- * Copyright (C) 2017 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.


### PR DESCRIPTION
Removed references to the ReARM, deleted displays that have not been tested. Added TMC2130 configuration options. Cleanup spacing etc.

### Description
Removed references to the ReARM, deleted displays that have not been tested. Added TMC2130 configuration options. Cleanup spacing etc.

### Benefits

New file has tested display configuration and various tested configuration options for support of TMC2130 drivers.

### Related Issues
This file is the result of discussions and tests found in this issue:
https://github.com/MarlinFirmware/Marlin/issues/12632
