### PR TITLE
Enable M240, set photo pins for 3DFabXYZ i3

### DIFF
--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1813,7 +1813,7 @@
  * Add the M240 G-code to take a photo.
  * The photo can be triggered by a digital pin or a physical movement.
  */
-//#define PHOTO_GCODE
+#define PHOTO_GCODE
 #if ENABLED(PHOTO_GCODE)
   // A position to move to (and raise Z) before taking the photo
   //#define PHOTO_POSITION { X_MAX_POS - 5, Y_MAX_POS, 0 }  // { xpos, ypos, zraise }
@@ -1822,11 +1822,11 @@
 
   // Canon RC-1 or homebrew digital camera trigger
   // Data from: http://www.doc-diy.net/photo/rc-1_hacked/
-  //#define PHOTOGRAPH_PIN 23
+  //#define PHOTOGRAPH_PIN 12
 
   // Canon Hack Development Kit
   // http://captain-slow.dk/2014/03/09/3d-printing-timelapses/
-  //#define CHDK_PIN        4
+  #define CHDK_PIN       12
 
   // Optional second move with delay to trigger the camera shutter
   //#define PHOTO_SWITCH_POSITION { X_MAX_POS, Y_MAX_POS }  // { xpos, ypos }

--- a/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/Marlin/src/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1832,7 +1832,7 @@
   //#define PHOTO_SWITCH_POSITION { X_MAX_POS, Y_MAX_POS }  // { xpos, ypos } (M240 I J)
 
   // Duration to hold the switch or keep CHDK_PIN high
-  //#define PHOTO_SWITCH_MS   50 // (ms) (M240 D)
+  #define PHOTO_SWITCH_MS   50 // (ms) (M240 D)
 #endif
 
 /**


### PR DESCRIPTION
### Requirements

MKS BASE 1.4 board

### Description
Changed the pushed default pins for:
PHOTOGRAPH_PIN & CHDK_PIN to 12 
as the pins 23 & 4 are unavailable on the MKS Base 1.4 board

### Benefits

Fixes issue with unavailable pins.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

I noticed that in the sanity check PHOTOGRAPH_PIN & CHDK_PIN can not be enabled at the same time.
Is there a reason why the default configurations are not using the same pin assignment?

