### PR TITLE
Fix a RAPTOR2 pin conflict

### DIFF
--- a/Marlin/src/pins/pins_FORMBOT_RAPTOR2.h
+++ b/Marlin/src/pins/pins_FORMBOT_RAPTOR2.h
@@ -28,7 +28,6 @@
 #define BOARD_NAME           "Formbot Raptor2"
 
 #define FAN_PIN             6
-#define SDSS                5
 
 #include "pins_FORMBOT_RAPTOR.h"
 


### PR DESCRIPTION
Formbot Raptor 2 SDSS is using the same pin as the Raptor 1, and new entry overlaps with pins in use by spindle laser breaking SD functionality.