### PR TITLE
Prevent reentry into ExtUI::onIdle() method

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -97,7 +97,8 @@ inline float clamp(const float value, const float minimum, const float maximum) 
 
 static struct {
   uint8_t printer_killed  : 1;
-  uint8_t manual_motion : 1;
+  uint8_t manual_motion   : 1;
+  uint8_t prevent_rentry  : 1;
 } flags;
 
 namespace ExtUI {
@@ -762,27 +763,37 @@ void MarlinUI::init() {
 }
 
 void MarlinUI::update() {
-  #if ENABLED(SDSUPPORT)
-    static bool last_sd_status;
-    const bool sd_status = IS_SD_INSERTED();
-    if (sd_status != last_sd_status) {
-      last_sd_status = sd_status;
-      if (sd_status) {
-        card.initsd();
-        if (card.isDetected())
-          ExtUI::onMediaInserted();
-        else
-          ExtUI::onMediaError();
+  /**
+  * The flag prevent_rentry is used to prevent re-entry
+  * into the ExtUI callback methods, which could cause
+  * the UI to crash. Re-entry can happen because some
+  * functions (such as planner.synchronize) call idle().
+  */
+  if(!flags.prevent_rentry) {
+    flags.prevent_rentry = true;
+    #if ENABLED(SDSUPPORT)
+      static bool last_sd_status;
+      const bool sd_status = IS_SD_INSERTED();
+      if (sd_status != last_sd_status) {
+        last_sd_status = sd_status;
+        if (sd_status) {
+          card.initsd();
+          if (card.isDetected())
+            ExtUI::onMediaInserted();
+          else
+            ExtUI::onMediaError();
+        }
+        else {
+          const bool ok = card.isDetected();
+          card.release();
+          if (ok) ExtUI::onMediaRemoved();
+        }
       }
-      else {
-        const bool ok = card.isDetected();
-        card.release();
-        if (ok) ExtUI::onMediaRemoved();
-      }
-    }
-  #endif // SDSUPPORT
-  ExtUI::_processManualMoveToDestination();
-  ExtUI::onIdle();
+    #endif // SDSUPPORT
+    ExtUI::_processManualMoveToDestination();
+    ExtUI::onIdle();
+    flags.prevent_rentry = false;
+  }
 }
 
 void MarlinUI::kill_screen(PGM_P const msg) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -763,13 +763,13 @@ void MarlinUI::init() {
 }
 
 void MarlinUI::update() {
-  /**
+ /**
   * The flag prevent_rentry is used to prevent re-entry
   * into the ExtUI callback methods, which could cause
   * the UI to crash. Re-entry can happen because some
   * functions (such as planner.synchronize) call idle().
   */
-  if(!flags.prevent_rentry) {
+  if (!flags.prevent_rentry) {
     flags.prevent_rentry = true;
     #if ENABLED(SDSUPPORT)
       static bool last_sd_status;


### PR DESCRIPTION
- Added a guard to the ExtUI methods to prevent re-entry, as this can
  cause problems.

We ran into a situation where the UI would cause the machine to crash when the user began extruding in one nozzle, then immediately touched the button to extrude from another nozzle. What was happening is that the "tool_change()" was calling "planner.synchronize()", and this was calling the idle() loop, which re-entered ExtUI::onIdle(), which registered another touch on the button, which caused another nozzle switch...

Although it would have been possible to handle the issue in our GUI code, it seems to me that if the ExtUI interface prevented "onIdle()" from being re-entered, it would save folks that are writing UI code some trouble. If an UI really needs "onIdle()" to be called during blocking operations such as "planner.synchronize()", we could add a method called "ExtUI:allowReentry()" that would clear the re-entry guard and allow that to happen.