### PR TITLE
Define G21 as NOOP w/o INCH_MODE_SUPPORT (FR #13228)

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -206,6 +206,8 @@ void GcodeSuite::process_parsed_command(
       #if ENABLED(INCH_MODE_SUPPORT)
         case 20: G20(); break;                                    // G20: Inch Mode
         case 21: G21(); break;                                    // G21: MM Mode
+      #else
+        case 21: NOOP; break;                                     // G21: MM Mode
       #endif
 
       #if ENABLED(G26_MESH_VALIDATION)

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -207,7 +207,7 @@ void GcodeSuite::process_parsed_command(
         case 20: G20(); break;                                    // G20: Inch Mode
         case 21: G21(); break;                                    // G21: MM Mode
       #else
-        case 21: NOOP; break;                                     // G21: MM Mode
+        case 21: NOOP; break;                                     // No error on unknown G21
       #endif
 
       #if ENABLED(G26_MESH_VALIDATION)


### PR DESCRIPTION
Ticket #13228

If INCH_MODE_SUPPORT is undefined, G20 is an unknown command as it should
be (Marlin is, by default, operating in metric mode). G21, however, is
found in many slicers and printer start gcode sections and should be
accepted (as a NOOP) to avoid the unknown commands.
