### PR TITLE
[2.0.x]Hide "Pause SD Print" Menu entry if SD Support is disabled

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -139,7 +139,9 @@ void menu_main() {
   ;
 
   if (busy) {
-    MENU_ITEM(function, MSG_PAUSE_PRINT, lcd_pause);
+    #if ENABLED(SDSUPPORT)
+      MENU_ITEM(function, MSG_PAUSE_PRINT, lcd_pause);
+    #endif
     #if ENABLED(SDSUPPORT) || defined(ACTION_ON_CANCEL)
       MENU_ITEM(submenu, MSG_STOP_PRINT, menu_abort_confirm);
     #endif


### PR DESCRIPTION
### Description

If SD Support is disabled, the LCD Menu while printing still showed up "Pause SD Print".
To save flash size this PR disables this menu entry if SD Support is disabled.
The menu entry also does not work when printing by usb (octoprint).

### Benefits

- Flash Size
- Less User confusion

### Related Issues
#13230 
