### PR TITLE
Simplify serial port redirect

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -69,7 +69,7 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
     char buffer[80];
     sprintf_P(buffer, PSTR("SDRD: %d @ 0x%08x\n"), nb_sector, addr);
     PORT_REDIRECT(0);
-    SERIAL_ECHO_P(buffer);
+    SERIAL_ECHO(buffer);
   }
   #endif
 
@@ -106,7 +106,7 @@ Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
     char buffer[80];
     sprintf_P(buffer, PSTR("SDWR: %d @ 0x%08x\n"), nb_sector, addr);
     PORT_REDIRECT(0);
-    SERIAL_ECHO_P(buffer);
+    SERIAL_ECHO(buffer);
   }
   #endif
 

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -65,9 +65,12 @@ Ctrl_status sd_mmc_spi_usb_read_10(uint32_t addr, uint16_t nb_sector) {
     return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
+  {
     char buffer[80];
     sprintf_P(buffer, PSTR("SDRD: %d @ 0x%08x\n"), nb_sector, addr);
-    SERIAL_ECHO_P(0, buffer);
+    PORT_REDIRECT(0);
+    SERIAL_ECHO_P(buffer);
+  }
   #endif
 
   // Start reading
@@ -99,9 +102,12 @@ Ctrl_status sd_mmc_spi_usb_write_10(uint32_t addr, uint16_t nb_sector) {
     return CTRL_NO_PRESENT;
 
   #ifdef DEBUG_MMC
+  {
     char buffer[80];
     sprintf_P(buffer, PSTR("SDWR: %d @ 0x%08x\n"), nb_sector, addr);
-    SERIAL_ECHO_P(0, buffer);
+    PORT_REDIRECT(0);
+    SERIAL_ECHO_P(buffer);
+  }
   #endif
 
   if (!card.getSd2Card().writeStart(addr, nb_sector))

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -29,21 +29,12 @@ static const char errormagic[] PROGMEM = "Error:";
 static const char echomagic[]  PROGMEM = "echo:";
 
 #if NUM_SERIAL > 1
-
   int8_t serial_port_index = SERIAL_PORT;
-
-  void serialprintPGM(PGM_P str) {
-    while (char ch = pgm_read_byte(str++)) SERIAL_CHAR_P(ch);
-  }
-
-#else
-
-  void serialprintPGM(PGM_P str) {
-    while (char ch = pgm_read_byte(str++)) SERIAL_CHAR(ch);
-  }
-
 #endif
 
+void serialprintPGM(PGM_P str) {
+  while (const char c = pgm_read_byte(str++)) SERIAL_CHAR(c);
+}
 void serial_echo_start()  { serialprintPGM(echomagic); }
 void serial_error_start() { serialprintPGM(errormagic); }
 

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -29,29 +29,20 @@ static const char errormagic[] PROGMEM = "Error:";
 static const char echomagic[]  PROGMEM = "echo:";
 
 #if NUM_SERIAL > 1
-  void serialprintPGM_P(const int8_t p, const char * str) {
-    while (char ch = pgm_read_byte(str++)) SERIAL_CHAR_P(p, ch);
+
+  int8_t serial_port_index = SERIAL_PORT;
+
+  void serialprintPGM(PGM_P str) {
+    while (char ch = pgm_read_byte(str++)) SERIAL_CHAR_P(ch);
   }
 
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, const char *v)   { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, char v)          { serialprintPGM_P(p, s_P); SERIAL_CHAR_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, int v)           { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, long v)          { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, float v)         { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, double v)        { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, unsigned int v)  { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, unsigned long v) { serialprintPGM_P(p, s_P); SERIAL_ECHO_P(p, v); }
+#else
 
-  void serial_spaces_P(const int8_t p, uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR_P(p, ' '); }
-
-  void serial_echo_start_P(const int8_t p)  { serialprintPGM_P(p, echomagic); }
-  void serial_error_start_P(const int8_t p) { serialprintPGM_P(p, errormagic); }
+  void serialprintPGM(PGM_P str) {
+    while (char ch = pgm_read_byte(str++)) SERIAL_CHAR(ch);
+  }
 
 #endif
-
-void serialprintPGM(PGM_P str) {
-  while (char ch = pgm_read_byte(str++)) SERIAL_CHAR(ch);
-}
 
 void serial_echo_start()  { serialprintPGM(echomagic); }
 void serial_error_start() { serialprintPGM(errormagic); }

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -43,142 +43,39 @@ extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (MARLIN_DEBUG_## F))
 
 #if TX_BUFFER_SIZE < 1
-  #define SERIAL_FLUSHTX_P()
   #define SERIAL_FLUSHTX()
 #endif
 
 #if NUM_SERIAL > 1
-
   extern int8_t serial_port_index;
+  #define _PORT_REDIRECT(n,p)   REMEMBER(n,serial_port_index,p)
+  #define _PORT_RESTORE(n)      RESTORE(n)
+  #define SERIAL_OUT(WHAT, ...)  (serial_port_index ? MYSERIAL1.WHAT(##__VA_ARGS__) : MYSERIAL0.WHAT(##__VA_ARGS__))
+#else
+  #define _PORT_REDIRECT(n,p)   NOOP
+  #define _PORT_RESTORE(n)      NOOP
+  #define SERIAL_OUT(WHAT, ...) MYSERIAL0.WHAT(__VA_ARGS__)
+#endif
 
-  //
-  // Serial out to all ports
-  //
-  #define SERIAL_CHAR(x)                    (MYSERIAL0.write(x), MYSERIAL1.write(x))
-  #define SERIAL_ECHO(x)                    (MYSERIAL0.print(x), MYSERIAL1.print(x))
-  #define SERIAL_ECHO_F(x,y)                (MYSERIAL0.print(x,y), MYSERIAL1.print(x,y))
-  #define SERIAL_ECHOLN(x)                  (MYSERIAL0.println(x), MYSERIAL1.println(x))
-  #define SERIAL_PRINT(x,b)                 (MYSERIAL0.print(x,b), MYSERIAL1.print(x,b))
-  #define SERIAL_PRINTLN(x,b)               (MYSERIAL0.println(x,b), MYSERIAL1.println(x,b))
-  #define SERIAL_PRINTF(args...)            (MYSERIAL0.printf(args), MYSERIAL1.printf(args))
-  #define SERIAL_FLUSH()                    (MYSERIAL0.flush(), MYSERIAL1.flush())
-  #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX()                (MYSERIAL0.flushTX(), MYSERIAL1.flushTX())
-  #endif
+#define PORT_REDIRECT(p)        _PORT_REDIRECT(1,p)
+#define PORT_RESTORE()          _PORT_RESTORE(1)
 
-  //
-  // Serial out with port redirect
-  //
-  #define _PORT_REDIRECT(n,p)               REMEMBER(n,serial_port_index,p)
-  #define _PORT_RESTORE(n)                  RESTORE(n)
-
-  #define SERIAL_CHAR_P(x)                  (serial_port_index ? MYSERIAL1.write(x) : MYSERIAL0.write(x))
-  #define SERIAL_ECHO_P(x)                  (serial_port_index ? MYSERIAL1.print(x) : MYSERIAL0.print(x))
-  #define SERIAL_ECHO_F_P(x,y)              (serial_port_index ? MYSERIAL1.print(x,y) : MYSERIAL0.print(x,y))
-  #define SERIAL_ECHOLN_P(x)                (serial_port_index ? MYSERIAL1.println(x) : MYSERIAL0.println(x))
-  #define SERIAL_PRINT_P(x,b)               (serial_port_index ? MYSERIAL1.print(x,b) : MYSERIAL0.print(x,b))
-  #define SERIAL_PRINTLN_P(x,b)             (serial_port_index ? MYSERIAL1.println(x,b) : MYSERIAL0.println(x,b))
-  #define SERIAL_PRINTF_P(args...)          (serial_port_index ? MYSERIAL1.printf(args) : MYSERIAL0.printf(args))
-  #define SERIAL_FLUSH_P()                  (serial_port_index ? MYSERIAL1.flush() : MYSERIAL0.flush())
-  #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX_P()              (serial_port_index ? MYSERIAL1.flushTX() : MYSERIAL0.flushTX())
-  #endif
-
-  #define SERIAL_ECHOPGM_P(x)               (serialprintPGM_P(PSTR(x)))
-  #define SERIAL_ECHOLNPGM_P(x)             (serialprintPGM_P(PSTR(x "\n")))
-  #define SERIAL_ECHOPAIR_P(pre, value)     (serial_echopair_PGM_P(PSTR(pre),(value)))
-
-  #define SERIAL_ECHO_START_P()             serial_echo_start_P()
-  #define SERIAL_ERROR_START_P()            serial_error_start_P()
-  #define SERIAL_EOL_P()                    SERIAL_CHAR_P('\n')
-
-  #define SERIAL_ECHOPAIR_F_P(pre, value, y)   do{ SERIAL_ECHO_P(pre); SERIAL_ECHO_F_P(value, y); }while(0)
-  #define SERIAL_ECHOLNPAIR_F_P(pre, value, y) do{ SERIAL_ECHOPAIR_F_P(pre, value, y); SERIAL_EOL_P(); }while(0)
-
-  void serial_echopair_PGM_P(PGM_P const s_P, const char *v);
-  void serial_echopair_PGM_P(PGM_P const s_P, char v);
-  void serial_echopair_PGM_P(PGM_P const s_P, int v);
-  void serial_echopair_PGM_P(PGM_P const s_P, long v);
-  void serial_echopair_PGM_P(PGM_P const s_P, float v);
-  void serial_echopair_PGM_P(PGM_P const s_P, double v);
-  void serial_echopair_PGM_P(PGM_P const s_P, unsigned int v);
-  void serial_echopair_PGM_P(PGM_P const s_P, unsigned long v);
-  inline void serial_echopair_PGM_P(PGM_P const s_P, uint8_t v) { serial_echopair_PGM_P(s_P, (int)v); }
-  inline void serial_echopair_PGM_P(PGM_P const s_P, bool v)    { serial_echopair_PGM_P(s_P, (int)v); }
-  inline void serial_echopair_PGM_P(PGM_P const s_P, void *v)   { serial_echopair_PGM_P(s_P, (unsigned long)v); }
-
-  void serial_spaces_P(uint8_t count);
-  #define SERIAL_ECHO_SP_P(C)               serial_spaces_P(C)
-
-  void serialprintPGM_P(PGM_P str);
-  void serial_echo_start_P();
-  void serial_error_start_P();
-
-#else // NUM_SERIAL <= 1
-
-  //
-  // Serial out to all ports
-  //
-  #define SERIAL_CHAR(x)                    MYSERIAL0.write(x)
-  #define SERIAL_ECHO(x)                    MYSERIAL0.print(x)
-  #define SERIAL_ECHO_F(x,y)                MYSERIAL0.print(x,y)
-  #define SERIAL_ECHOLN(x)                  MYSERIAL0.println(x)
-  #define SERIAL_PRINT(x,b)                 MYSERIAL0.print(x,b)
-  #define SERIAL_PRINTLN(x,b)               MYSERIAL0.println(x,b)
-  #define SERIAL_PRINTF(args...)            MYSERIAL0.printf(args)
-  #define SERIAL_FLUSH()                    MYSERIAL0.flush()
-  #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX()                MYSERIAL0.flushTX()
-  #endif
-
-  //
-  // Serial out with port redirect
-  //
-  #define _PORT_REDIRECT(n,p)               NOOP
-  #define _PORT_RESTORE(n)                  NOOP
-
-  #define SERIAL_CHAR_P(x)                  SERIAL_CHAR(x)
-  #define SERIAL_ECHO_P(x)                  SERIAL_ECHO(x)
-  #define SERIAL_ECHO_F_P(x,y)              SERIAL_ECHO_F(x,y)
-  #define SERIAL_ECHOLN_P(x)                SERIAL_ECHOLN(x)
-  #define SERIAL_PRINT_P(x,b)               SERIAL_PRINT(x,b)
-  #define SERIAL_PRINTLN_P(x,b)             SERIAL_PRINTLN(x,b)
-  #define SERIAL_PRINTF_P(args...)          SERIAL_PRINTF(args)
-  #define SERIAL_FLUSH_P()                  SERIAL_FLUSH()
-  #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX_P()              SERIAL_FLUSHTX()
-  #endif
-
-  #define SERIAL_ECHOPGM_P(x)               SERIAL_ECHOPGM(x)
-  #define SERIAL_ECHOLNPGM_P(x)             SERIAL_ECHOLNPGM(x)
-  #define SERIAL_ECHOPAIR_P(pre, value)     SERIAL_ECHOPAIR(pre, value)
-
-  #define SERIAL_ECHO_P(x)                  SERIAL_ECHO(x)
-  #define SERIAL_ECHOLN_P(x)                SERIAL_ECHOLN(x)
-
-  #define SERIAL_ECHO_START_P()             SERIAL_ECHO_START()
-  #define SERIAL_ERROR_START_P()            SERIAL_ERROR_START()
-  #define SERIAL_EOL_P()                    SERIAL_EOL()
-
-  #define SERIAL_ECHOPAIR_F_P(pre, value, y)   SERIAL_ECHOPAIR_F(pre, value, y)
-  #define SERIAL_ECHOLNPAIR_F_P(pre, value, y) SERIAL_ECHOLNPAIR_F(pre, value, y)
-
-  #define serial_echopair_PGM_P(s_P,v)      serial_echopair_PGM(s_P, v)
-
-  #define serial_spaces_P(c)                serial_spaces(c)
-  #define SERIAL_ECHO_SP_P(C)               SERIAL_ECHO_SP(C)
-
-  #define serialprintPGM_P(s)               serialprintPGM(s)
-
-#endif // NUM_SERIAL < 2
-
-#define PORT_REDIRECT(p)                    _PORT_REDIRECT(1,p)
-#define PORT_RESTORE()                      _PORT_RESTORE(1)
+#define SERIAL_CHAR(x)          SERIAL_OUT(write, x)
+#define SERIAL_ECHO(x)          SERIAL_OUT(print, x)
+#define SERIAL_ECHO_F(x,y)      SERIAL_OUT(print, x, y)
+#define SERIAL_ECHOLN(x)        SERIAL_OUT(println, x)
+#define SERIAL_PRINT(x,b)       SERIAL_OUT(print, x, b)
+#define SERIAL_PRINTLN(x,b)     SERIAL_OUT(println, x, b)
+#define SERIAL_PRINTF(args...)  SERIAL_OUT(printf, args)
+#define SERIAL_FLUSH()          SERIAL_OUT(flush)
+#if TX_BUFFER_SIZE > 0
+  #define SERIAL_FLUSHTX()      SERIAL_OUT(flushTX)
+#endif
 
 #define SERIAL_ECHOPGM(x)                   (serialprintPGM(PSTR(x)))
 #define SERIAL_ECHOLNPGM(x)                 (serialprintPGM(PSTR(x "\n")))
 #define SERIAL_ECHOPAIR(pre, value)         (serial_echopair_PGM(PSTR(pre), value))
-#define SERIAL_ECHOLNPAIR(pre, value)       do { SERIAL_ECHOPAIR(pre, value); SERIAL_EOL(); } while(0)
+#define SERIAL_ECHOLNPAIR(pre, value)       do{ SERIAL_ECHOPAIR(pre, value); SERIAL_EOL(); }while(0)
 
 #define SERIAL_ECHOPAIR_F(pre, value, y)    do{ SERIAL_ECHO(pre); SERIAL_ECHO_F(value, y); }while(0)
 #define SERIAL_ECHOLNPAIR_F(pre, value, y)  do{ SERIAL_ECHOPAIR_F(pre, value, y); SERIAL_EOL(); }while(0)
@@ -188,13 +85,8 @@ extern uint8_t marlin_debug_flags;
 #define SERIAL_EOL()                        SERIAL_CHAR('\n')
 
 #define SERIAL_ECHO_MSG(STR)                do{ SERIAL_ECHO_START(); SERIAL_ECHOLNPGM(STR); }while(0)
-#define SERIAL_ECHO_MSG_P(STR)              do{ SERIAL_ECHO_START_P(); SERIAL_ECHOLNPGM_P(STR); }while(0)
 #define SERIAL_ERROR_MSG(STR)               do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPGM(STR); }while(0)
-#define SERIAL_ERROR_MSG_P(STR)             do{ SERIAL_ERROR_START_P(); SERIAL_ECHOLNPGM_P(STR); }while(0)
 
-#define SERIAL_ECHOLNPAIR_P(pre, value)     do{ SERIAL_ECHOPAIR_P(pre, value); SERIAL_EOL_P(); }while(0)
-
-void serial_spaces(uint8_t count);
 #define SERIAL_ECHO_SP(C)                   serial_spaces(C)
 
 //
@@ -217,6 +109,7 @@ void serial_echo_start();
 void serial_error_start();
 void serialprint_onoff(const bool onoff);
 void serialprintln_onoff(const bool onoff);
+void serial_spaces(uint8_t count);
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
   void print_xyz(PGM_P const prefix, PGM_P const suffix, const float x, const float y, const float z);

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -50,7 +50,11 @@ extern uint8_t marlin_debug_flags;
   extern int8_t serial_port_index;
   #define _PORT_REDIRECT(n,p)   REMEMBER(n,serial_port_index,p)
   #define _PORT_RESTORE(n)      RESTORE(n)
-  #define SERIAL_OUT(WHAT, ...)  (serial_port_index ? MYSERIAL1.WHAT(##__VA_ARGS__) : MYSERIAL0.WHAT(##__VA_ARGS__))
+  #define SERIAL_BOTH 0x7F
+  #define SERIAL_OUT(WHAT, ...) do{ \
+    if (!serial_port_index || serial_port_index == SERIAL_BOTH) MYSERIAL0.WHAT(##__VA_ARGS__); \
+    if ( serial_port_index) MYSERIAL1.WHAT(##__VA_ARGS__); \
+  }while(0)
 #else
   #define _PORT_REDIRECT(n,p)   NOOP
   #define _PORT_RESTORE(n)      NOOP

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -43,11 +43,13 @@ extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (MARLIN_DEBUG_## F))
 
 #if TX_BUFFER_SIZE < 1
-  #define SERIAL_FLUSHTX_P(p)
+  #define SERIAL_FLUSHTX_P()
   #define SERIAL_FLUSHTX()
 #endif
 
 #if NUM_SERIAL > 1
+
+  extern int8_t serial_port_index;
 
   //
   // Serial out to all ports
@@ -67,47 +69,50 @@ extern uint8_t marlin_debug_flags;
   //
   // Serial out with port redirect
   //
-  #define SERIAL_CHAR_P(p,x)                (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.write(x) : MYSERIAL1.write(x)) : SERIAL_CHAR(x))
-  #define SERIAL_ECHO_P(p,x)                (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x) : MYSERIAL1.print(x)) : SERIAL_ECHO(x))
-  #define SERIAL_ECHO_F_P(p,x,y)            (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x,y) : MYSERIAL1.print(x,y)) : SERIAL_ECHO_F(x,y))
-  #define SERIAL_ECHOLN_P(p,x)              (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.println(x) : MYSERIAL1.println(x)) : SERIAL_ECHOLN(x))
-  #define SERIAL_PRINT_P(p,x,b)             (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.print(x,b) : MYSERIAL1.print(x,b)) : SERIAL_PRINT(x,b))
-  #define SERIAL_PRINTLN_P(p,x,b)           (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.println(x,b) : MYSERIAL1.println(x,b)) : SERIAL_PRINTLN(x,b))
-  #define SERIAL_PRINTF_P(p,args...)        (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.printf(args) : MYSERIAL1.printf(args)) : SERIAL_PRINTF(args))
-  #define SERIAL_FLUSH_P(p)                 (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.flush() : MYSERIAL1.flush()) : SERIAL_FLUSH())
+  #define _PORT_REDIRECT(n,p)               REMEMBER(n,serial_port_index,p)
+  #define _PORT_RESTORE(n)                  RESTORE(n)
+
+  #define SERIAL_CHAR_P(x)                  (serial_port_index ? MYSERIAL1.write(x) : MYSERIAL0.write(x))
+  #define SERIAL_ECHO_P(x)                  (serial_port_index ? MYSERIAL1.print(x) : MYSERIAL0.print(x))
+  #define SERIAL_ECHO_F_P(x,y)              (serial_port_index ? MYSERIAL1.print(x,y) : MYSERIAL0.print(x,y))
+  #define SERIAL_ECHOLN_P(x)                (serial_port_index ? MYSERIAL1.println(x) : MYSERIAL0.println(x))
+  #define SERIAL_PRINT_P(x,b)               (serial_port_index ? MYSERIAL1.print(x,b) : MYSERIAL0.print(x,b))
+  #define SERIAL_PRINTLN_P(x,b)             (serial_port_index ? MYSERIAL1.println(x,b) : MYSERIAL0.println(x,b))
+  #define SERIAL_PRINTF_P(args...)          (serial_port_index ? MYSERIAL1.printf(args) : MYSERIAL0.printf(args))
+  #define SERIAL_FLUSH_P()                  (serial_port_index ? MYSERIAL1.flush() : MYSERIAL0.flush())
   #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX_P(p)             (WITHIN(p, 0, NUM_SERIAL-1) ? (p == 0 ? MYSERIAL0.flushTX() : MYSERIAL1.flushTX()) : SERIAL_FLUSHTX())
+    #define SERIAL_FLUSHTX_P()              (serial_port_index ? MYSERIAL1.flushTX() : MYSERIAL0.flushTX())
   #endif
 
-  #define SERIAL_ECHOPGM_P(p,x)             (serialprintPGM_P(p,PSTR(x)))
-  #define SERIAL_ECHOLNPGM_P(p,x)           (serialprintPGM_P(p,PSTR(x "\n")))
-  #define SERIAL_ECHOPAIR_P(p, pre, value)  (serial_echopair_PGM_P(p,PSTR(pre),(value)))
+  #define SERIAL_ECHOPGM_P(x)               (serialprintPGM_P(PSTR(x)))
+  #define SERIAL_ECHOLNPGM_P(x)             (serialprintPGM_P(PSTR(x "\n")))
+  #define SERIAL_ECHOPAIR_P(pre, value)     (serial_echopair_PGM_P(PSTR(pre),(value)))
 
-  #define SERIAL_ECHO_START_P(p)            serial_echo_start_P(p)
-  #define SERIAL_ERROR_START_P(p)           serial_error_start_P(p)
-  #define SERIAL_EOL_P(p)                   SERIAL_CHAR_P(p,'\n')
+  #define SERIAL_ECHO_START_P()             serial_echo_start_P()
+  #define SERIAL_ERROR_START_P()            serial_error_start_P()
+  #define SERIAL_EOL_P()                    SERIAL_CHAR_P('\n')
 
-  #define SERIAL_ECHOPAIR_F_P(p, pre, value, y)   do{ SERIAL_ECHO_P(p, pre); SERIAL_ECHO_F_P(p, value, y); }while(0)
-  #define SERIAL_ECHOLNPAIR_F_P(p, pre, value, y) do{ SERIAL_ECHOPAIR_F_P(p, pre, value, y); SERIAL_EOL_P(p); }while(0)
+  #define SERIAL_ECHOPAIR_F_P(pre, value, y)   do{ SERIAL_ECHO_P(pre); SERIAL_ECHO_F_P(value, y); }while(0)
+  #define SERIAL_ECHOLNPAIR_F_P(pre, value, y) do{ SERIAL_ECHOPAIR_F_P(pre, value, y); SERIAL_EOL_P(); }while(0)
 
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, const char *v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, char v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, int v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, long v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, float v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, double v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, unsigned int v);
-  void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, unsigned long v);
-  inline void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, uint8_t v) { serial_echopair_PGM_P(p, s_P, (int)v); }
-  inline void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, bool v)    { serial_echopair_PGM_P(p, s_P, (int)v); }
-  inline void serial_echopair_PGM_P(const int8_t p, PGM_P const s_P, void *v)   { serial_echopair_PGM_P(p, s_P, (unsigned long)v); }
+  void serial_echopair_PGM_P(PGM_P const s_P, const char *v);
+  void serial_echopair_PGM_P(PGM_P const s_P, char v);
+  void serial_echopair_PGM_P(PGM_P const s_P, int v);
+  void serial_echopair_PGM_P(PGM_P const s_P, long v);
+  void serial_echopair_PGM_P(PGM_P const s_P, float v);
+  void serial_echopair_PGM_P(PGM_P const s_P, double v);
+  void serial_echopair_PGM_P(PGM_P const s_P, unsigned int v);
+  void serial_echopair_PGM_P(PGM_P const s_P, unsigned long v);
+  inline void serial_echopair_PGM_P(PGM_P const s_P, uint8_t v) { serial_echopair_PGM_P(s_P, (int)v); }
+  inline void serial_echopair_PGM_P(PGM_P const s_P, bool v)    { serial_echopair_PGM_P(s_P, (int)v); }
+  inline void serial_echopair_PGM_P(PGM_P const s_P, void *v)   { serial_echopair_PGM_P(s_P, (unsigned long)v); }
 
-  void serial_spaces_P(const int8_t p, uint8_t count);
-  #define SERIAL_ECHO_SP_P(p,C)             serial_spaces_P(p,C)
+  void serial_spaces_P(uint8_t count);
+  #define SERIAL_ECHO_SP_P(C)               serial_spaces_P(C)
 
-  void serialprintPGM_P(const int8_t p, PGM_P str);
-  void serial_echo_start_P(const int8_t p);
-  void serial_error_start_P(const int8_t p);
+  void serialprintPGM_P(PGM_P str);
+  void serial_echo_start_P();
+  void serial_error_start_P();
 
 #else // NUM_SERIAL <= 1
 
@@ -129,40 +134,46 @@ extern uint8_t marlin_debug_flags;
   //
   // Serial out with port redirect
   //
-  #define SERIAL_CHAR_P(p,x)                SERIAL_CHAR(x)
-  #define SERIAL_ECHO_P(p,x)                SERIAL_ECHO(x)
-  #define SERIAL_ECHO_F_P(p,x,y)            SERIAL_ECHO_F(x,y)
-  #define SERIAL_ECHOLN_P(p,x)              SERIAL_ECHOLN(x)
-  #define SERIAL_PRINT_P(p,x,b)             SERIAL_PRINT(x,b)
-  #define SERIAL_PRINTLN_P(p,x,b)           SERIAL_PRINTLN(x,b)
-  #define SERIAL_PRINTF_P(p,args...)        SERIAL_PRINTF(args)
-  #define SERIAL_FLUSH_P(p)                 SERIAL_FLUSH()
+  #define _PORT_REDIRECT(n,p)               NOOP
+  #define _PORT_RESTORE(n)                  NOOP
+
+  #define SERIAL_CHAR_P(x)                  SERIAL_CHAR(x)
+  #define SERIAL_ECHO_P(x)                  SERIAL_ECHO(x)
+  #define SERIAL_ECHO_F_P(x,y)              SERIAL_ECHO_F(x,y)
+  #define SERIAL_ECHOLN_P(x)                SERIAL_ECHOLN(x)
+  #define SERIAL_PRINT_P(x,b)               SERIAL_PRINT(x,b)
+  #define SERIAL_PRINTLN_P(x,b)             SERIAL_PRINTLN(x,b)
+  #define SERIAL_PRINTF_P(args...)          SERIAL_PRINTF(args)
+  #define SERIAL_FLUSH_P()                  SERIAL_FLUSH()
   #if TX_BUFFER_SIZE > 0
-    #define SERIAL_FLUSHTX_P(p)             SERIAL_FLUSHTX()
+    #define SERIAL_FLUSHTX_P()              SERIAL_FLUSHTX()
   #endif
 
-  #define SERIAL_ECHOPGM_P(p,x)             SERIAL_ECHOPGM(x)
-  #define SERIAL_ECHOLNPGM_P(p,x)           SERIAL_ECHOLNPGM(x)
-  #define SERIAL_ECHOPAIR_P(p, pre, value)  SERIAL_ECHOPAIR(pre, value)
+  #define SERIAL_ECHOPGM_P(x)               SERIAL_ECHOPGM(x)
+  #define SERIAL_ECHOLNPGM_P(x)             SERIAL_ECHOLNPGM(x)
+  #define SERIAL_ECHOPAIR_P(pre, value)     SERIAL_ECHOPAIR(pre, value)
 
-  #define SERIAL_ECHO_P(p,x)                SERIAL_ECHO(x)
-  #define SERIAL_ECHOLN_P(p,x)              SERIAL_ECHOLN(x)
+  #define SERIAL_ECHO_P(x)                  SERIAL_ECHO(x)
+  #define SERIAL_ECHOLN_P(x)                SERIAL_ECHOLN(x)
 
-  #define SERIAL_ECHO_START_P(p)            SERIAL_ECHO_START()
-  #define SERIAL_ERROR_START_P(p)           SERIAL_ERROR_START()
-  #define SERIAL_EOL_P(p)                   SERIAL_EOL()
+  #define SERIAL_ECHO_START_P()             SERIAL_ECHO_START()
+  #define SERIAL_ERROR_START_P()            SERIAL_ERROR_START()
+  #define SERIAL_EOL_P()                    SERIAL_EOL()
 
-  #define SERIAL_ECHOPAIR_F_P(p, pre, value, y)   SERIAL_ECHOPAIR_F(pre, value, y)
-  #define SERIAL_ECHOLNPAIR_F_P(p, pre, value, y) SERIAL_ECHOLNPAIR_F(pre, value, y)
+  #define SERIAL_ECHOPAIR_F_P(pre, value, y)   SERIAL_ECHOPAIR_F(pre, value, y)
+  #define SERIAL_ECHOLNPAIR_F_P(pre, value, y) SERIAL_ECHOLNPAIR_F(pre, value, y)
 
-  #define serial_echopair_PGM_P(p,s_P,v)    serial_echopair_PGM(s_P, v)
+  #define serial_echopair_PGM_P(s_P,v)      serial_echopair_PGM(s_P, v)
 
-  #define serial_spaces_P(p,c)              serial_spaces(c)
-  #define SERIAL_ECHO_SP_P(p,C)             SERIAL_ECHO_SP(C)
+  #define serial_spaces_P(c)                serial_spaces(c)
+  #define SERIAL_ECHO_SP_P(C)               SERIAL_ECHO_SP(C)
 
-  #define serialprintPGM_P(p,s)             serialprintPGM(s)
+  #define serialprintPGM_P(s)               serialprintPGM(s)
 
 #endif // NUM_SERIAL < 2
+
+#define PORT_REDIRECT(p)                    _PORT_REDIRECT(1,p)
+#define PORT_RESTORE()                      _PORT_RESTORE(1)
 
 #define SERIAL_ECHOPGM(x)                   (serialprintPGM(PSTR(x)))
 #define SERIAL_ECHOLNPGM(x)                 (serialprintPGM(PSTR(x "\n")))
@@ -177,11 +188,11 @@ extern uint8_t marlin_debug_flags;
 #define SERIAL_EOL()                        SERIAL_CHAR('\n')
 
 #define SERIAL_ECHO_MSG(STR)                do{ SERIAL_ECHO_START(); SERIAL_ECHOLNPGM(STR); }while(0)
-#define SERIAL_ECHO_MSG_P(p, STR)           do{ SERIAL_ECHO_START_P(p); SERIAL_ECHOLNPGM_P(p, STR); }while(0)
+#define SERIAL_ECHO_MSG_P(STR)              do{ SERIAL_ECHO_START_P(); SERIAL_ECHOLNPGM_P(STR); }while(0)
 #define SERIAL_ERROR_MSG(STR)               do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPGM(STR); }while(0)
-#define SERIAL_ERROR_MSG_P(p, STR)          do{ SERIAL_ERROR_START_P(p); SERIAL_ECHOLNPGM_P(p, STR); }while(0)
+#define SERIAL_ERROR_MSG_P(STR)             do{ SERIAL_ERROR_START_P(); SERIAL_ECHOLNPGM_P(STR); }while(0)
 
-#define SERIAL_ECHOLNPAIR_P(p, pre, value)  do{ SERIAL_ECHOPAIR_P(p, pre, value); SERIAL_EOL_P(p); }while(0)
+#define SERIAL_ECHOLNPAIR_P(pre, value)     do{ SERIAL_ECHOPAIR_P(pre, value); SERIAL_EOL_P(); }while(0)
 
 void serial_spaces(uint8_t count);
 #define SERIAL_ECHO_SP(C)                   serial_spaces(C)

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -133,5 +133,5 @@ public:
   inline void restore() { ref_ = val_; }
 };
 
-#define REMEMBER(N,X, ...) restorer<typeof(X)> N##_restorer(X, ##__VA_ARGS__)
-#define RESTORE(N) N##_restorer.restore()
+#define REMEMBER(N,X, ...) restorer<typeof(X)> restorer_##N(X, ##__VA_ARGS__)
+#define RESTORE(N) restorer_##N.restore()

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -35,29 +35,29 @@
   #include "math.h"
 
   void unified_bed_leveling::echo_name() {
-    SERIAL_ECHOPGM_P("Unified Bed Leveling");
+    SERIAL_ECHOPGM("Unified Bed Leveling");
   }
 
   void unified_bed_leveling::report_current_mesh() {
     if (!leveling_is_valid()) return;
-    SERIAL_ECHO_MSG_P("  G29 I99");
+    SERIAL_ECHO_MSG("  G29 I99");
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
       for (uint8_t y = 0;  y < GRID_MAX_POINTS_Y; y++)
         if (!isnan(z_values[x][y])) {
-          SERIAL_ECHO_START_P();
-          SERIAL_ECHOPAIR_P("  M421 I", x);
-          SERIAL_ECHOPAIR_P(" J", y);
-          SERIAL_ECHOPAIR_F_P(" Z", z_values[x][y], 2);
-          SERIAL_EOL_P();
+          SERIAL_ECHO_START();
+          SERIAL_ECHOPAIR("  M421 I", x);
+          SERIAL_ECHOPAIR(" J", y);
+          SERIAL_ECHOPAIR_F(" Z", z_values[x][y], 2);
+          SERIAL_EOL();
           serial_delay(75); // Prevent Printrun from exploding
         }
   }
 
   void unified_bed_leveling::report_state() {
     echo_name();
-    SERIAL_ECHOPGM_P(" System v" UBL_VERSION " ");
-    if (!planner.leveling_active) SERIAL_ECHOPGM_P("in");
-    SERIAL_ECHOLNPGM_P("active.");
+    SERIAL_ECHOPGM(" System v" UBL_VERSION " ");
+    if (!planner.leveling_active) SERIAL_ECHOPGM("in");
+    SERIAL_ECHOLNPGM("active.");
     serial_delay(50);
   }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -34,46 +34,30 @@
 
   #include "math.h"
 
-  void unified_bed_leveling::echo_name(
-    #if NUM_SERIAL > 1
-      const int8_t port/*= -1*/
-    #endif
-  ) {
-    SERIAL_ECHOPGM_P(port, "Unified Bed Leveling");
+  void unified_bed_leveling::echo_name() {
+    SERIAL_ECHOPGM_P("Unified Bed Leveling");
   }
 
-  void unified_bed_leveling::report_current_mesh(
-    #if NUM_SERIAL > 1
-      const int8_t port/*= -1*/
-    #endif
-  ) {
+  void unified_bed_leveling::report_current_mesh() {
     if (!leveling_is_valid()) return;
-    SERIAL_ECHO_MSG_P(port, "  G29 I99");
+    SERIAL_ECHO_MSG_P("  G29 I99");
     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
       for (uint8_t y = 0;  y < GRID_MAX_POINTS_Y; y++)
         if (!isnan(z_values[x][y])) {
-          SERIAL_ECHO_START_P(port);
-          SERIAL_ECHOPAIR_P(port, "  M421 I", x);
-          SERIAL_ECHOPAIR_P(port, " J", y);
-          SERIAL_ECHOPAIR_F_P(port, " Z", z_values[x][y], 2);
-          SERIAL_EOL_P(port);
+          SERIAL_ECHO_START_P();
+          SERIAL_ECHOPAIR_P("  M421 I", x);
+          SERIAL_ECHOPAIR_P(" J", y);
+          SERIAL_ECHOPAIR_F_P(" Z", z_values[x][y], 2);
+          SERIAL_EOL_P();
           serial_delay(75); // Prevent Printrun from exploding
         }
   }
 
-  void unified_bed_leveling::report_state(
-    #if NUM_SERIAL > 1
-      const int8_t port/*= -1*/
-    #endif
-  ) {
-    echo_name(
-      #if NUM_SERIAL > 1
-        port
-      #endif
-    );
-    SERIAL_ECHOPGM_P(port, " System v" UBL_VERSION " ");
-    if (!planner.leveling_active) SERIAL_ECHOPGM_P(port, "in");
-    SERIAL_ECHOLNPGM_P(port, "active.");
+  void unified_bed_leveling::report_state() {
+    echo_name();
+    SERIAL_ECHOPGM_P(" System v" UBL_VERSION " ");
+    if (!planner.leveling_active) SERIAL_ECHOPGM_P("in");
+    SERIAL_ECHOLNPGM_P("active.");
     serial_delay(50);
   }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -94,21 +94,9 @@ class unified_bed_leveling {
 
   public:
 
-    static void echo_name(
-      #if NUM_SERIAL > 1
-        const int8_t port = -1
-      #endif
-    );
-    static void report_current_mesh(
-      #if NUM_SERIAL > 1
-        const int8_t port = -1
-      #endif
-    );
-    static void report_state(
-      #if NUM_SERIAL > 1
-        const int8_t port = -1
-      #endif
-    );
+    static void echo_name();
+    static void report_current_mesh();
+    static void report_state();
     static void save_ubl_active_state_and_disable();
     static void restore_ubl_active_state_and_leave();
     static void display_map(const int) _O0;

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -34,14 +34,14 @@
 void M217_report(const bool eeprom=false) {
 
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    serialprintPGM_P(eeprom ? PSTR("  M217") : PSTR("Singlenozzle:"));
-    SERIAL_ECHOPAIR_P(" S", LINEAR_UNIT(toolchange_settings.swap_length));
-    SERIAL_ECHOPAIR_P(" P", LINEAR_UNIT(toolchange_settings.prime_speed));
-    SERIAL_ECHOPAIR_P(" R", LINEAR_UNIT(toolchange_settings.retract_speed));
+    serialprintPGM(eeprom ? PSTR("  M217") : PSTR("Singlenozzle:"));
+    SERIAL_ECHOPAIR(" S", LINEAR_UNIT(toolchange_settings.swap_length));
+    SERIAL_ECHOPAIR(" P", LINEAR_UNIT(toolchange_settings.prime_speed));
+    SERIAL_ECHOPAIR(" R", LINEAR_UNIT(toolchange_settings.retract_speed));
 
     #if ENABLED(TOOLCHANGE_PARK)
-      SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(toolchange_settings.change_point.x));
-      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(toolchange_settings.change_point.y));
+      SERIAL_ECHOPAIR(" X", LINEAR_UNIT(toolchange_settings.change_point.x));
+      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(toolchange_settings.change_point.y));
     #endif
 
   #else
@@ -50,7 +50,7 @@ void M217_report(const bool eeprom=false) {
 
   #endif
 
-  SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(toolchange_settings.z_raise));
+  SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(toolchange_settings.z_raise));
   SERIAL_EOL();
 }
 

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -33,19 +33,15 @@
 
 void M217_report(const bool eeprom=false) {
 
-  #if NUM_SERIAL > 1
-    const int16_t port = command_queue_port[cmd_queue_index_r];
-  #endif
-
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    serialprintPGM_P(port, eeprom ? PSTR("  M217") : PSTR("Singlenozzle:"));
-    SERIAL_ECHOPAIR_P(port, " S", LINEAR_UNIT(toolchange_settings.swap_length));
-    SERIAL_ECHOPAIR_P(port, " P", LINEAR_UNIT(toolchange_settings.prime_speed));
-    SERIAL_ECHOPAIR_P(port, " R", LINEAR_UNIT(toolchange_settings.retract_speed));
+    serialprintPGM_P(eeprom ? PSTR("  M217") : PSTR("Singlenozzle:"));
+    SERIAL_ECHOPAIR_P(" S", LINEAR_UNIT(toolchange_settings.swap_length));
+    SERIAL_ECHOPAIR_P(" P", LINEAR_UNIT(toolchange_settings.prime_speed));
+    SERIAL_ECHOPAIR_P(" R", LINEAR_UNIT(toolchange_settings.retract_speed));
 
     #if ENABLED(TOOLCHANGE_PARK)
-      SERIAL_ECHOPAIR_P(port, " X", LINEAR_UNIT(toolchange_settings.change_point.x));
-      SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(toolchange_settings.change_point.y));
+      SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(toolchange_settings.change_point.x));
+      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(toolchange_settings.change_point.y));
     #endif
 
   #else
@@ -54,7 +50,7 @@ void M217_report(const bool eeprom=false) {
 
   #endif
 
-  SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(toolchange_settings.z_raise));
+  SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(toolchange_settings.z_raise));
   SERIAL_EOL();
 }
 

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -24,21 +24,21 @@
 #include "../../module/planner.h"
 
 void report_M92(const bool echo=true, const int8_t e=-1) {
-  if (echo) SERIAL_ECHO_START_P(); else SERIAL_CHAR_P(' ');
-  SERIAL_ECHOPAIR_P(" M92 X", LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]));
-  SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]));
-  SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]));
+  if (echo) SERIAL_ECHO_START(); else SERIAL_CHAR(' ');
+  SERIAL_ECHOPAIR(" M92 X", LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]));
+  SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]));
+  SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]));
   #if DISABLED(DISTINCT_E_FACTORS)
-    SERIAL_ECHOPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
+    SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
   #endif
-  SERIAL_EOL_P();
+  SERIAL_EOL();
 
   #if ENABLED(DISTINCT_E_FACTORS)
     for (uint8_t i = 0; i < E_STEPPERS; i++) {
       if (e >= 0 && i != e) continue;
-      if (echo) SERIAL_ECHO_START_P(); else SERIAL_CHAR(' ');
-      SERIAL_ECHOPAIR_P(" M92 T", (int)i);
-      SERIAL_ECHOLNPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)]));
+      if (echo) SERIAL_ECHO_START(); else SERIAL_CHAR(' ');
+      SERIAL_ECHOPAIR(" M92 T", (int)i);
+      SERIAL_ECHOLNPAIR(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)]));
     }
   #endif
 }

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -23,27 +23,22 @@
 #include "../gcode.h"
 #include "../../module/planner.h"
 
-void report_M92(
-  #if NUM_SERIAL > 1
-    const int8_t port,
-  #endif
-  const bool echo=true, const int8_t e=-1
-) {
-  if (echo) SERIAL_ECHO_START_P(port); else SERIAL_CHAR(' ');
-  SERIAL_ECHOPAIR_P(port, " M92 X", LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]));
-  SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]));
-  SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]));
+void report_M92(const bool echo=true, const int8_t e=-1) {
+  if (echo) SERIAL_ECHO_START_P(); else SERIAL_CHAR_P(' ');
+  SERIAL_ECHOPAIR_P(" M92 X", LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]));
+  SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]));
+  SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]));
   #if DISABLED(DISTINCT_E_FACTORS)
-    SERIAL_ECHOPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
+    SERIAL_ECHOPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
   #endif
-  SERIAL_EOL_P(port);
+  SERIAL_EOL_P();
 
   #if ENABLED(DISTINCT_E_FACTORS)
     for (uint8_t i = 0; i < E_STEPPERS; i++) {
       if (e >= 0 && i != e) continue;
-      if (echo) SERIAL_ECHO_START_P(port); else SERIAL_CHAR(' ');
-      SERIAL_ECHOPAIR_P(port, " M92 T", (int)i);
-      SERIAL_ECHOLNPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)]));
+      if (echo) SERIAL_ECHO_START_P(); else SERIAL_CHAR(' ');
+      SERIAL_ECHOPAIR_P(" M92 T", (int)i);
+      SERIAL_ECHOLNPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)]));
     }
   #endif
 }
@@ -71,12 +66,7 @@ void GcodeSuite::M92() {
     #if ENABLED(MAGIC_NUMBERS_GCODE)
       "HL"
     #endif
-  )) return report_M92(
-    #if NUM_SERIAL > 1
-      command_queue_port[cmd_queue_index_r],
-    #endif
-    true, target_extruder
-  );
+  )) return report_M92(true, target_extruder);
 
   LOOP_XYZE(i) {
     if (parser.seenval(axis_codes[i])) {

--- a/Marlin/src/gcode/eeprom/M500-M504.cpp
+++ b/Marlin/src/gcode/eeprom/M500-M504.cpp
@@ -80,6 +80,6 @@ void GcodeSuite::M502() {
    */
   void GcodeSuite::M504() {
     if (settings.validate())
-      SERIAL_ECHO_MSG_P("EEPROM OK");
+      SERIAL_ECHO_MSG("EEPROM OK");
   }
 #endif

--- a/Marlin/src/gcode/eeprom/M500-M504.cpp
+++ b/Marlin/src/gcode/eeprom/M500-M504.cpp
@@ -33,17 +33,11 @@
   #include "../../gcode/queue.h"
 #endif
 
-#if ADD_PORT_ARG
-  #define CHAT_PORT command_queue_port[cmd_queue_index_r]
-#else
-  #define CHAT_PORT
-#endif
-
 /**
  * M500: Store settings in EEPROM
  */
 void GcodeSuite::M500() {
-  (void)settings.save(CHAT_PORT);
+  (void)settings.save();
   #if ENABLED(EXTENSIBLE_UI)
     ExtUI::onStoreSettings();
   #endif
@@ -53,11 +47,7 @@ void GcodeSuite::M500() {
  * M501: Read settings from EEPROM
  */
 void GcodeSuite::M501() {
-  (void)settings.load(
-    #if ENABLED(EEPROM_SETTINGS)
-      CHAT_PORT
-    #endif
-  );
+  (void)settings.load();
   #if ENABLED(EXTENSIBLE_UI)
     ExtUI::onLoadSettings();
   #endif
@@ -67,7 +57,7 @@ void GcodeSuite::M501() {
  * M502: Revert to default settings
  */
 void GcodeSuite::M502() {
-  (void)settings.reset(CHAT_PORT);
+  (void)settings.reset();
   #if ENABLED(EXTENSIBLE_UI)
     ExtUI::onFactoryReset();
   #endif
@@ -79,12 +69,7 @@ void GcodeSuite::M502() {
    * M503: print settings currently in memory
    */
   void GcodeSuite::M503() {
-    (void)settings.report(
-      parser.seen('S') && !parser.value_bool()
-      #if NUM_SERIAL > 1
-        , command_queue_port[cmd_queue_index_r]
-      #endif
-    );
+    (void)settings.report(parser.boolval('S', true));
   }
 
 #endif // !DISABLE_M503
@@ -94,7 +79,7 @@ void GcodeSuite::M502() {
    * M504: Validate EEPROM Contents
    */
   void GcodeSuite::M504() {
-    if (settings.validate(CHAT_PORT))
-      SERIAL_ECHO_MSG_P(command_queue_port[cmd_queue_index_r], "EEPROM OK");
+    if (settings.validate())
+      SERIAL_ECHO_MSG_P("EEPROM OK");
   }
 #endif

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -754,6 +754,8 @@ void GcodeSuite::process_parsed_command(
 void GcodeSuite::process_next_command() {
   char * const current_command = command_queue[cmd_queue_index_r];
 
+  PORT_REDIRECT(command_queue_port[cmd_queue_index_r]);
+
   if (DEBUGGING(ECHO)) {
     SERIAL_ECHO_START();
     SERIAL_ECHOLN(current_command);

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -29,10 +29,10 @@
 
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
   static void cap_line(PGM_P const name, bool ena=false) {
-    SERIAL_ECHOPGM_P("Cap:");
-    serialprintPGM_P(name);
-    SERIAL_CHAR_P(':');
-    SERIAL_ECHOLN_P(int(ena ? 1 : 0));
+    SERIAL_ECHOPGM("Cap:");
+    serialprintPGM(name);
+    SERIAL_CHAR(':');
+    SERIAL_ECHOLN(int(ena ? 1 : 0));
   }
 #endif
 
@@ -41,7 +41,7 @@
  */
 void GcodeSuite::M115() {
 
-  SERIAL_ECHOLNPGM_P(MSG_M115_REPORT);
+  SERIAL_ECHOLNPGM(MSG_M115_REPORT);
 
   #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
 

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -29,10 +29,10 @@
 
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
   static void cap_line(PGM_P const name, bool ena=false) {
-    SERIAL_ECHOPGM("Cap:");
-    serialprintPGM(name);
-    SERIAL_CHAR(':');
-    SERIAL_ECHOLN(int(ena ? 1 : 0));
+    SERIAL_ECHOPGM_P("Cap:");
+    serialprintPGM_P(name);
+    SERIAL_CHAR_P(':');
+    SERIAL_ECHOLN_P(int(ena ? 1 : 0));
   }
 #endif
 
@@ -40,14 +40,8 @@
  * M115: Capabilities string
  */
 void GcodeSuite::M115() {
-  #if NUM_SERIAL > 1
-    const int8_t port = command_queue_port[cmd_queue_index_r];
-    #define CAPLINE(STR,...) cap_line(PSTR(STR), port, __VA_ARGS__)
-  #else
-    #define CAPLINE(STR,...) cap_line(PSTR(STR), __VA_ARGS__)
-  #endif
 
-  SERIAL_ECHOLNPGM_P(port, MSG_M115_REPORT);
+  SERIAL_ECHOLNPGM_P(MSG_M115_REPORT);
 
   #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
 

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -328,13 +328,10 @@ void GCodeParser::parse(char *p) {
 #endif // CNC_COORDINATE_SYSTEMS
 
 void GCodeParser::unknown_command_error() {
-  #if NUM_SERIAL > 1
-    const int16_t port = command_queue_port[cmd_queue_index_r];
-  #endif
-  SERIAL_ECHO_START_P(port);
-  SERIAL_ECHOPAIR_P(port, MSG_UNKNOWN_COMMAND, command_ptr);
-  SERIAL_CHAR_P(port, '"');
-  SERIAL_EOL_P(port);
+  SERIAL_ECHO_START_P();
+  SERIAL_ECHOPAIR_P(MSG_UNKNOWN_COMMAND, command_ptr);
+  SERIAL_CHAR_P('"');
+  SERIAL_EOL_P();
 }
 
 #if ENABLED(DEBUG_GCODE_PARSER)

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -328,10 +328,10 @@ void GCodeParser::parse(char *p) {
 #endif // CNC_COORDINATE_SYSTEMS
 
 void GCodeParser::unknown_command_error() {
-  SERIAL_ECHO_START_P();
-  SERIAL_ECHOPAIR_P(MSG_UNKNOWN_COMMAND, command_ptr);
-  SERIAL_CHAR_P('"');
-  SERIAL_EOL_P();
+  SERIAL_ECHO_START();
+  SERIAL_ECHOPAIR(MSG_UNKNOWN_COMMAND, command_ptr);
+  SERIAL_CHAR('"');
+  SERIAL_EOL();
 }
 
 #if ENABLED(DEBUG_GCODE_PARSER)

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -222,19 +222,19 @@ void ok_to_send() {
     PORT_REDIRECT(port);
   #endif
   if (!send_ok[cmd_queue_index_r]) return;
-  SERIAL_ECHOPGM_P(MSG_OK);
+  SERIAL_ECHOPGM(MSG_OK);
   #if ENABLED(ADVANCED_OK)
     char* p = command_queue[cmd_queue_index_r];
     if (*p == 'N') {
-      SERIAL_ECHO_P(' ');
-      SERIAL_ECHO_P(*p++);
+      SERIAL_ECHO(' ');
+      SERIAL_ECHO(*p++);
       while (NUMERIC_SIGNED(*p))
-        SERIAL_ECHO_P(*p++);
+        SERIAL_ECHO(*p++);
     }
-    SERIAL_ECHOPGM_P(" P"); SERIAL_ECHO_P(int(BLOCK_BUFFER_SIZE - planner.movesplanned() - 1));
-    SERIAL_ECHOPGM_P(" B"); SERIAL_ECHO_P(BUFSIZE - commands_in_queue);
+    SERIAL_ECHOPGM(" P"); SERIAL_ECHO(int(BLOCK_BUFFER_SIZE - planner.movesplanned() - 1));
+    SERIAL_ECHOPGM(" B"); SERIAL_ECHO(BUFSIZE - commands_in_queue);
   #endif
-  SERIAL_EOL_P();
+  SERIAL_EOL();
 }
 
 /**
@@ -247,9 +247,9 @@ void flush_and_request_resend() {
     if (port < 0) return;
     PORT_REDIRECT(port);
   #endif
-  SERIAL_FLUSH_P();
-  SERIAL_ECHOPGM_P(MSG_RESEND);
-  SERIAL_ECHOLN_P(gcode_LastN + 1);
+  SERIAL_FLUSH();
+  SERIAL_ECHOPGM(MSG_RESEND);
+  SERIAL_ECHOLN(gcode_LastN + 1);
   ok_to_send();
 }
 
@@ -274,9 +274,9 @@ inline int read_serial(const uint8_t index) {
 
 void gcode_line_error(PGM_P const err, const int8_t port) {
   PORT_REDIRECT(port);
-  SERIAL_ERROR_START_P();
-  serialprintPGM_P(err);
-  SERIAL_ECHOLN_P(gcode_LastN);
+  SERIAL_ERROR_START();
+  serialprintPGM(err);
+  SERIAL_ECHOLN(gcode_LastN);
   while (read_serial(port) != -1);           // clear out the RX buffer
   flush_and_request_resend();
   serial_count[port] = 0;
@@ -398,16 +398,16 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
               stream_state = StreamState::PACKET_RESET;
               bytes_received = 0;
               time_stream_start = millis();
-              SERIAL_ECHO_P("echo: Datastream initialized (");
-              SERIAL_ECHO_P(stream_header.filesize);
-              SERIAL_ECHOLN_P("Bytes expected)");
-              SERIAL_ECHO_P("so"); // confirm active stream and the maximum block size supported
-              SERIAL_CHAR_P(static_cast<uint8_t>(buffer_size & 0xFF));
-              SERIAL_CHAR_P(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
-              SERIAL_CHAR_P('\n');
+              SERIAL_ECHO("echo: Datastream initialized (");
+              SERIAL_ECHO(stream_header.filesize);
+              SERIAL_ECHOLN("Bytes expected)");
+              SERIAL_ECHO("so"); // confirm active stream and the maximum block size supported
+              SERIAL_CHAR(static_cast<uint8_t>(buffer_size & 0xFF));
+              SERIAL_CHAR(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
+              SERIAL_CHAR('\n');
             }
             else {
-              SERIAL_ECHOLN_P("echo: Datastream initialization error (invalid token)");
+              SERIAL_ECHOLN("echo: Datastream initialization error (invalid token)");
               stream_state = StreamState::STREAM_FAILED;
             }
             buffer_next_index = 0;
@@ -423,7 +423,7 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
                 stream_state = StreamState::PACKET_DATA;
               }
               else {
-                SERIAL_ECHO_P("echo: Datastream packet out of order");
+                SERIAL_ECHO("echo: Datastream packet out of order");
                 stream_state = StreamState::PACKET_FLUSHRX;
               }
             }
@@ -435,7 +435,7 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
               buffer[buffer_next_index] = data;
             }
             else {
-              SERIAL_ECHO_P("echo: Datastream packet data buffer overrun");
+              SERIAL_ECHO("echo: Datastream packet data buffer overrun");
               stream_state = StreamState::STREAM_FAILED;
               break;
             }
@@ -460,22 +460,22 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
               else {
                 if (bytes_received < stream_header.filesize) {
                   stream_state = StreamState::PACKET_RESET;    // reset and receive next packet
-                  SERIAL_ECHOLN_P("ok");   // transmit confirm packet received and valid token
+                  SERIAL_ECHOLN("ok");   // transmit confirm packet received and valid token
                 }
                 else  {
                   stream_state = StreamState::STREAM_COMPLETE; // no more data required
                 }
                 if (card.write(buffer, buffer_next_index) < 0) {
                   stream_state = StreamState::STREAM_FAILED;
-                  SERIAL_ECHO_P("echo: IO ERROR");
+                  SERIAL_ECHO("echo: IO ERROR");
                   break;
                 };
               }
             }
             else {
-              SERIAL_ECHO_P("echo: Block(");
-              SERIAL_ECHO_P(packet.header.id);
-              SERIAL_ECHOLN_P(") Corrupt");
+              SERIAL_ECHO("echo: Block(");
+              SERIAL_ECHO(packet.header.id);
+              SERIAL_ECHOLN(") Corrupt");
               stream_state = StreamState::PACKET_FLUSHRX;
             }
             break;
@@ -483,9 +483,9 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
             if (packet_retries < MAX_RETRIES) {
               packet_retries ++;
               stream_state = StreamState::PACKET_RESET;
-              SERIAL_ECHO_P("echo: Resend request ");
-              SERIAL_ECHOLN_P(packet_retries);
-              SERIAL_ECHOLN_P("rs"); // transmit resend packet token
+              SERIAL_ECHO("echo: Resend request ");
+              SERIAL_ECHOLN(packet_retries);
+              SERIAL_ECHOLN("rs"); // transmit resend packet token
             }
             else {
               stream_state = StreamState::STREAM_FAILED;
@@ -501,27 +501,27 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
             packet.timeout = millis() + STREAM_MAX_WAIT;
             break;
           case StreamState::PACKET_TIMEOUT:
-            SERIAL_ECHOLN_P("echo: Datastream timeout");
+            SERIAL_ECHOLN("echo: Datastream timeout");
             stream_state = StreamState::PACKET_RESEND;
             break;
           case StreamState::STREAM_COMPLETE:
             stream_state = StreamState::STREAM_RESET;
             card.flag.binary_mode = false;
             card.closefile();
-            SERIAL_ECHO_P("echo: ");
-            SERIAL_ECHO_P(card.filename);
-            SERIAL_ECHO_P(" transfer completed @ ");
-            SERIAL_ECHO_P(((bytes_received / (millis() - time_stream_start) * 1000) / 1024 ));
-            SERIAL_ECHOLN_P("KiB/s");
-            SERIAL_ECHOLN_P("sc"); // transmit stream complete token
+            SERIAL_ECHO("echo: ");
+            SERIAL_ECHO(card.filename);
+            SERIAL_ECHO(" transfer completed @ ");
+            SERIAL_ECHO(((bytes_received / (millis() - time_stream_start) * 1000) / 1024 ));
+            SERIAL_ECHOLN("KiB/s");
+            SERIAL_ECHOLN("sc"); // transmit stream complete token
             return;
           case StreamState::STREAM_FAILED:
             stream_state = StreamState::STREAM_RESET;
             card.flag.binary_mode = false;
             card.closefile();
             card.removeFile(card.filename);
-            SERIAL_ECHOLN_P("echo: File transfer failed");
-            SERIAL_ECHOLN_P("sf"); // transmit stream failed token
+            SERIAL_ECHOLN("echo: File transfer failed");
+            SERIAL_ECHOLN("sf"); // transmit stream failed token
             return;
         }
       }

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -219,21 +219,22 @@ void ok_to_send() {
   #if NUM_SERIAL > 1
     const int16_t port = command_queue_port[cmd_queue_index_r];
     if (port < 0) return;
+    PORT_REDIRECT(port);
   #endif
   if (!send_ok[cmd_queue_index_r]) return;
-  SERIAL_ECHOPGM_P(port, MSG_OK);
+  SERIAL_ECHOPGM_P(MSG_OK);
   #if ENABLED(ADVANCED_OK)
     char* p = command_queue[cmd_queue_index_r];
     if (*p == 'N') {
-      SERIAL_ECHO_P(port, ' ');
-      SERIAL_ECHO_P(port, *p++);
+      SERIAL_ECHO_P(' ');
+      SERIAL_ECHO_P(*p++);
       while (NUMERIC_SIGNED(*p))
-        SERIAL_ECHO_P(port, *p++);
+        SERIAL_ECHO_P(*p++);
     }
-    SERIAL_ECHOPGM_P(port, " P"); SERIAL_ECHO_P(port, int(BLOCK_BUFFER_SIZE - planner.movesplanned() - 1));
-    SERIAL_ECHOPGM_P(port, " B"); SERIAL_ECHO_P(port, BUFSIZE - commands_in_queue);
+    SERIAL_ECHOPGM_P(" P"); SERIAL_ECHO_P(int(BLOCK_BUFFER_SIZE - planner.movesplanned() - 1));
+    SERIAL_ECHOPGM_P(" B"); SERIAL_ECHO_P(BUFSIZE - commands_in_queue);
   #endif
-  SERIAL_EOL_P(port);
+  SERIAL_EOL_P();
 }
 
 /**
@@ -244,10 +245,11 @@ void flush_and_request_resend() {
   #if NUM_SERIAL > 1
     const int16_t port = command_queue_port[cmd_queue_index_r];
     if (port < 0) return;
+    PORT_REDIRECT(port);
   #endif
-  SERIAL_FLUSH_P(port);
-  SERIAL_ECHOPGM_P(port, MSG_RESEND);
-  SERIAL_ECHOLN_P(port, gcode_LastN + 1);
+  SERIAL_FLUSH_P();
+  SERIAL_ECHOPGM_P(MSG_RESEND);
+  SERIAL_ECHOLN_P(gcode_LastN + 1);
   ok_to_send();
 }
 
@@ -270,22 +272,17 @@ inline int read_serial(const uint8_t index) {
   }
 }
 
-void gcode_line_error(PGM_P err, uint8_t port) {
-  SERIAL_ERROR_START_P(port);
-  serialprintPGM_P(port, err);
-  SERIAL_ECHOLN_P(port, gcode_LastN);
+void gcode_line_error(PGM_P const err, const int8_t port) {
+  PORT_REDIRECT(port);
+  SERIAL_ERROR_START_P();
+  serialprintPGM_P(err);
+  SERIAL_ECHOLN_P(gcode_LastN);
   while (read_serial(port) != -1);           // clear out the RX buffer
   flush_and_request_resend();
   serial_count[port] = 0;
 }
 
 #if ENABLED(FAST_FILE_TRANSFER)
-
-  #if ENABLED(SDSUPPORT)
-    #define CARD_CHAR_P(C)   SERIAL_CHAR_P(card.transfer_port, C)
-    #define CARD_ECHO_P(V)   SERIAL_ECHO_P(card.transfer_port, V)
-    #define CARD_ECHOLN_P(V) SERIAL_ECHOLN_P(card.transfer_port, V)
-  #endif
 
   inline bool serial_data_available(const uint8_t index) {
     switch (index) {
@@ -380,6 +377,11 @@ void gcode_line_error(PGM_P err, uint8_t port) {
     void receive(char (&buffer)[buffer_size]) {
       uint8_t data = 0;
       millis_t transfer_timeout = millis() + RX_TIMESLICE;
+
+      #if ENABLED(SDSUPPORT)
+        PORT_REDIRECT(card.transfer_port);
+      #endif
+
       while (PENDING(millis(), transfer_timeout)) {
         switch (stream_state) {
           case StreamState::STREAM_RESET:
@@ -388,24 +390,24 @@ void gcode_line_error(PGM_P err, uint8_t port) {
             packet_reset();
             stream_state = StreamState::PACKET_HEADER;
             break;
-          case StreamState::STREAM_HEADER: // we could also transfer the filename in this packet, rather than handling it in the gcode
-            for (size_t i = 0; i < sizeof(stream_header); ++i) {
+          case StreamState::STREAM_HEADER: // The filename could also be in this packet, rather than handling it in the gcode
+            for (size_t i = 0; i < sizeof(stream_header); ++i)
               stream_header_bytes[i] = buffer[i];
-            }
+
             if (stream_header.token == 0x1234) {
               stream_state = StreamState::PACKET_RESET;
               bytes_received = 0;
               time_stream_start = millis();
-              CARD_ECHO_P("echo: Datastream initialized (");
-              CARD_ECHO_P(stream_header.filesize);
-              CARD_ECHOLN_P("Bytes expected)");
-              CARD_ECHO_P("so"); // confirm active stream and the maximum block size supported
-              CARD_CHAR_P(static_cast<uint8_t>(buffer_size & 0xFF));
-              CARD_CHAR_P(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
-              CARD_CHAR_P('\n');
+              SERIAL_ECHO_P("echo: Datastream initialized (");
+              SERIAL_ECHO_P(stream_header.filesize);
+              SERIAL_ECHOLN_P("Bytes expected)");
+              SERIAL_ECHO_P("so"); // confirm active stream and the maximum block size supported
+              SERIAL_CHAR_P(static_cast<uint8_t>(buffer_size & 0xFF));
+              SERIAL_CHAR_P(static_cast<uint8_t>((buffer_size >> 8) & 0xFF));
+              SERIAL_CHAR_P('\n');
             }
             else {
-              CARD_ECHOLN_P("echo: Datastream initialization error (invalid token)");
+              SERIAL_ECHOLN_P("echo: Datastream initialization error (invalid token)");
               stream_state = StreamState::STREAM_FAILED;
             }
             buffer_next_index = 0;
@@ -421,7 +423,7 @@ void gcode_line_error(PGM_P err, uint8_t port) {
                 stream_state = StreamState::PACKET_DATA;
               }
               else {
-                CARD_ECHO_P("echo: Datastream packet out of order");
+                SERIAL_ECHO_P("echo: Datastream packet out of order");
                 stream_state = StreamState::PACKET_FLUSHRX;
               }
             }
@@ -433,7 +435,7 @@ void gcode_line_error(PGM_P err, uint8_t port) {
               buffer[buffer_next_index] = data;
             }
             else {
-              CARD_ECHO_P("echo: Datastream packet data buffer overrun");
+              SERIAL_ECHO_P("echo: Datastream packet data buffer overrun");
               stream_state = StreamState::STREAM_FAILED;
               break;
             }
@@ -458,22 +460,22 @@ void gcode_line_error(PGM_P err, uint8_t port) {
               else {
                 if (bytes_received < stream_header.filesize) {
                   stream_state = StreamState::PACKET_RESET;    // reset and receive next packet
-                  CARD_ECHOLN_P("ok");   // transmit confirm packet received and valid token
+                  SERIAL_ECHOLN_P("ok");   // transmit confirm packet received and valid token
                 }
                 else  {
                   stream_state = StreamState::STREAM_COMPLETE; // no more data required
                 }
                 if (card.write(buffer, buffer_next_index) < 0) {
                   stream_state = StreamState::STREAM_FAILED;
-                  CARD_ECHO_P("echo: IO ERROR");
+                  SERIAL_ECHO_P("echo: IO ERROR");
                   break;
                 };
               }
             }
             else {
-              CARD_ECHO_P("echo: Block(");
-              CARD_ECHO_P(packet.header.id);
-              CARD_ECHOLN_P(") Corrupt");
+              SERIAL_ECHO_P("echo: Block(");
+              SERIAL_ECHO_P(packet.header.id);
+              SERIAL_ECHOLN_P(") Corrupt");
               stream_state = StreamState::PACKET_FLUSHRX;
             }
             break;
@@ -481,9 +483,9 @@ void gcode_line_error(PGM_P err, uint8_t port) {
             if (packet_retries < MAX_RETRIES) {
               packet_retries ++;
               stream_state = StreamState::PACKET_RESET;
-              CARD_ECHO_P("echo: Resend request ");
-              CARD_ECHOLN_P(packet_retries);
-              CARD_ECHOLN_P("rs"); // transmit resend packet token
+              SERIAL_ECHO_P("echo: Resend request ");
+              SERIAL_ECHOLN_P(packet_retries);
+              SERIAL_ECHOLN_P("rs"); // transmit resend packet token
             }
             else {
               stream_state = StreamState::STREAM_FAILED;
@@ -499,27 +501,27 @@ void gcode_line_error(PGM_P err, uint8_t port) {
             packet.timeout = millis() + STREAM_MAX_WAIT;
             break;
           case StreamState::PACKET_TIMEOUT:
-            CARD_ECHOLN_P("echo: Datastream timeout");
+            SERIAL_ECHOLN_P("echo: Datastream timeout");
             stream_state = StreamState::PACKET_RESEND;
             break;
           case StreamState::STREAM_COMPLETE:
             stream_state = StreamState::STREAM_RESET;
             card.flag.binary_mode = false;
             card.closefile();
-            CARD_ECHO_P("echo: ");
-            CARD_ECHO_P(card.filename);
-            CARD_ECHO_P(" transfer completed @ ");
-            CARD_ECHO_P(((bytes_received / (millis() - time_stream_start) * 1000) / 1024 ));
-            CARD_ECHOLN_P("KiB/s");
-            CARD_ECHOLN_P("sc"); // transmit stream complete token
+            SERIAL_ECHO_P("echo: ");
+            SERIAL_ECHO_P(card.filename);
+            SERIAL_ECHO_P(" transfer completed @ ");
+            SERIAL_ECHO_P(((bytes_received / (millis() - time_stream_start) * 1000) / 1024 ));
+            SERIAL_ECHOLN_P("KiB/s");
+            SERIAL_ECHOLN_P("sc"); // transmit stream complete token
             return;
           case StreamState::STREAM_FAILED:
             stream_state = StreamState::STREAM_RESET;
             card.flag.binary_mode = false;
             card.closefile();
             card.removeFile(card.filename);
-            CARD_ECHOLN_P("echo: File transfer failed");
-            CARD_ECHOLN_P("sf"); // transmit stream failed token
+            SERIAL_ECHOLN_P("echo: File transfer failed");
+            SERIAL_ECHOLN_P("sf"); // transmit stream failed token
             return;
         }
       }

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -50,13 +50,13 @@
  * M20: List SD card to serial output
  */
 void GcodeSuite::M20() {
-  SERIAL_ECHOLNPGM_P(MSG_BEGIN_FILE_LIST);
+  SERIAL_ECHOLNPGM(MSG_BEGIN_FILE_LIST);
   card.ls(
     #if NUM_SERIAL > 1
       command_queue_port[cmd_queue_index_r]
     #endif
   );
-  SERIAL_ECHOLNPGM_P(MSG_END_FILE_LIST);
+  SERIAL_ECHOLNPGM(MSG_END_FILE_LIST);
 }
 
 /**
@@ -165,7 +165,7 @@ void GcodeSuite::M27() {
   #endif
 
   if (parser.seen('C')) {
-    SERIAL_ECHOPGM_P("Current file: ");
+    SERIAL_ECHOPGM("Current file: ");
     card.printFilename();
   }
 
@@ -203,9 +203,9 @@ void GcodeSuite::M28() {
 
     // Binary transfer mode
     if ((card.flag.binary_mode = binary_mode)) {
-      SERIAL_ECHO_START_P();
-      SERIAL_ECHO_P(" preparing to receive: ");
-      SERIAL_ECHOLN_P(p);
+      SERIAL_ECHO_START();
+      SERIAL_ECHO(" preparing to receive: ");
+      SERIAL_ECHOLN(p);
       card.openFile(p, false);
       #if NUM_SERIAL > 1
         card.transfer_port = command_queue_port[cmd_queue_index_r];

--- a/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
+++ b/Marlin/src/gcode/sdcard/M20-M30_M32-M34_M524_M928.cpp
@@ -50,17 +50,13 @@
  * M20: List SD card to serial output
  */
 void GcodeSuite::M20() {
-  #if NUM_SERIAL > 1
-    const int16_t port = command_queue_port[cmd_queue_index_r];
-  #endif
-
-  SERIAL_ECHOLNPGM_P(port, MSG_BEGIN_FILE_LIST);
+  SERIAL_ECHOLNPGM_P(MSG_BEGIN_FILE_LIST);
   card.ls(
     #if NUM_SERIAL > 1
-      port
+      command_queue_port[cmd_queue_index_r]
     #endif
   );
-  SERIAL_ECHOLNPGM_P(port, MSG_END_FILE_LIST);
+  SERIAL_ECHOLNPGM_P(MSG_END_FILE_LIST);
 }
 
 /**
@@ -165,11 +161,11 @@ void GcodeSuite::M26() {
  */
 void GcodeSuite::M27() {
   #if NUM_SERIAL > 1
-    const int16_t port = command_queue_port[cmd_queue_index_r];
+    const int16_t port = serial_port_index;
   #endif
 
   if (parser.seen('C')) {
-    SERIAL_ECHOPGM_P(port, "Current file: ");
+    SERIAL_ECHOPGM_P("Current file: ");
     card.printFilename();
   }
 
@@ -197,10 +193,6 @@ void GcodeSuite::M28() {
 
   #if ENABLED(FAST_FILE_TRANSFER)
 
-    #if NUM_SERIAL > 1
-      const int16_t port = command_queue_port[cmd_queue_index_r];
-    #endif
-
     bool binary_mode = false;
     char *p = parser.string_arg;
     if (p[0] == 'B' && NUMERIC(p[1])) {
@@ -211,12 +203,12 @@ void GcodeSuite::M28() {
 
     // Binary transfer mode
     if ((card.flag.binary_mode = binary_mode)) {
-      SERIAL_ECHO_START_P(port);
-      SERIAL_ECHO_P(port, " preparing to receive: ");
-      SERIAL_ECHOLN_P(port, p);
+      SERIAL_ECHO_START_P();
+      SERIAL_ECHO_P(" preparing to receive: ");
+      SERIAL_ECHOLN_P(p);
       card.openFile(p, false);
       #if NUM_SERIAL > 1
-        card.transfer_port = port;
+        card.transfer_port = command_queue_port[cmd_queue_index_r];
       #endif
     }
     else

--- a/Marlin/src/gcode/stats/M31.cpp
+++ b/Marlin/src/gcode/stats/M31.cpp
@@ -42,6 +42,6 @@ void GcodeSuite::M31() {
   elapsed.toString(buffer);
   ui.set_status(buffer);
 
-  SERIAL_ECHO_START_P(port);
-  SERIAL_ECHOLNPAIR_P(port, "Print time: ", buffer);
+  SERIAL_ECHO_START_P();
+  SERIAL_ECHOLNPAIR_P("Print time: ", buffer);
 }

--- a/Marlin/src/gcode/stats/M31.cpp
+++ b/Marlin/src/gcode/stats/M31.cpp
@@ -42,6 +42,6 @@ void GcodeSuite::M31() {
   elapsed.toString(buffer);
   ui.set_status(buffer);
 
-  SERIAL_ECHO_START_P();
-  SERIAL_ECHOLNPAIR_P("Print time: ", buffer);
+  SERIAL_ECHO_START();
+  SERIAL_ECHOLNPAIR("Print time: ", buffer);
 }

--- a/Marlin/src/gcode/temperature/M105.cpp
+++ b/Marlin/src/gcode/temperature/M105.cpp
@@ -40,15 +40,15 @@ void GcodeSuite::M105() {
   #endif
 
   #if HAS_TEMP_SENSOR
-    SERIAL_ECHOPGM_P(port, MSG_OK);
+    SERIAL_ECHOPGM_P(MSG_OK);
     thermalManager.print_heater_states(target_extruder
       #if NUM_SERIAL > 1
         , port
       #endif
     );
   #else // !HAS_TEMP_SENSOR
-    SERIAL_ERROR_MSG_P(port, MSG_ERR_NO_THERMISTORS);
+    SERIAL_ERROR_MSG_P(MSG_ERR_NO_THERMISTORS);
   #endif
 
-  SERIAL_EOL_P(port);
+  SERIAL_EOL_P();
 }

--- a/Marlin/src/gcode/temperature/M105.cpp
+++ b/Marlin/src/gcode/temperature/M105.cpp
@@ -40,15 +40,15 @@ void GcodeSuite::M105() {
   #endif
 
   #if HAS_TEMP_SENSOR
-    SERIAL_ECHOPGM_P(MSG_OK);
+    SERIAL_ECHOPGM(MSG_OK);
     thermalManager.print_heater_states(target_extruder
       #if NUM_SERIAL > 1
         , port
       #endif
     );
   #else // !HAS_TEMP_SENSOR
-    SERIAL_ERROR_MSG_P(MSG_ERR_NO_THERMISTORS);
+    SERIAL_ERROR_MSG(MSG_ERR_NO_THERMISTORS);
   #endif
 
-  SERIAL_EOL_P();
+  SERIAL_EOL();
 }

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -380,33 +380,33 @@ void MarlinSettings::postprocess() {
 #endif // SD_FIRMWARE_UPDATE
 
 #if ENABLED(EEPROM_CHITCHAT)
-  #define CHITCHAT_ECHO(V)                SERIAL_ECHO(V)
-  #define CHITCHAT_ECHOLNPGM(STR)         SERIAL_ECHOLNPGM(STR)
-  #define CHITCHAT_ECHOPAIR(STR,V)        SERIAL_ECHOPAIR(STR,V)
-  #define CHITCHAT_ECHOLNPAIR(STR,V)      SERIAL_ECHOLNPAIR(STR,V)
-  #define CHITCHAT_ECHO_START_P()         SERIAL_ECHO_START_P()
-  #define CHITCHAT_ERROR_START_P()        SERIAL_ERROR_START_P()
-  #define CHITCHAT_ERROR_MSG_P(STR)       SERIAL_ERROR_MSG_P(STR)
-  #define CHITCHAT_ECHO_P(VAL)            SERIAL_ECHO_P(VAL)
-  #define CHITCHAT_ECHOPGM_P(STR)         SERIAL_ECHOPGM_P(STR)
-  #define CHITCHAT_ECHOLNPGM_P(STR)       SERIAL_ECHOLNPGM_P(STR)
-  #define CHITCHAT_ECHOPAIR_P(STR, VAL)   SERIAL_ECHOPAIR_P(STR, VAL)
-  #define CHITCHAT_ECHOLNPAIR_P(STR, VAL) SERIAL_ECHOLNPAIR_P(STR, VAL)
-  #define CHITCHAT_EOL()                  SERIAL_EOL()
+  #define CHITCHAT_ECHO(V)              SERIAL_ECHO(V)
+  #define CHITCHAT_ECHOLNPGM(STR)       SERIAL_ECHOLNPGM(STR)
+  #define CHITCHAT_ECHOPAIR(STR,V)      SERIAL_ECHOPAIR(STR,V)
+  #define CHITCHAT_ECHOLNPAIR(STR,V)    SERIAL_ECHOLNPAIR(STR,V)
+  #define CHITCHAT_ECHO_START()         SERIAL_ECHO_START()
+  #define CHITCHAT_ERROR_START()        SERIAL_ERROR_START()
+  #define CHITCHAT_ERROR_MSG(STR)       SERIAL_ERROR_MSG(STR)
+  #define CHITCHAT_ECHO(VAL)            SERIAL_ECHO(VAL)
+  #define CHITCHAT_ECHOPGM(STR)         SERIAL_ECHOPGM(STR)
+  #define CHITCHAT_ECHOLNPGM(STR)       SERIAL_ECHOLNPGM(STR)
+  #define CHITCHAT_ECHOPAIR(STR, VAL)   SERIAL_ECHOPAIR(STR, VAL)
+  #define CHITCHAT_ECHOLNPAIR(STR, VAL) SERIAL_ECHOLNPAIR(STR, VAL)
+  #define CHITCHAT_EOL()                SERIAL_EOL()
 #else
-  #define CHITCHAT_ECHO(V)                NOOP
-  #define CHITCHAT_ECHOLNPGM(STR)         NOOP
-  #define CHITCHAT_ECHOPAIR(STR,V)        NOOP
-  #define CHITCHAT_ECHOLNPAIR(STR,V)      NOOP
-  #define CHITCHAT_ECHO_START_P()         NOOP
-  #define CHITCHAT_ERROR_START_P()        NOOP
-  #define CHITCHAT_ERROR_MSG_P(STR)       NOOP
-  #define CHITCHAT_ECHO_P(VAL)            NOOP
-  #define CHITCHAT_ECHOPGM_P(STR)         NOOP
-  #define CHITCHAT_ECHOLNPGM_P(STR)       NOOP
-  #define CHITCHAT_ECHOPAIR_P(STR, VAL)   NOOP
-  #define CHITCHAT_ECHOLNPAIR_P(STR, VAL) NOOP
-  #define CHITCHAT_EOL()                  NOOP
+  #define CHITCHAT_ECHO(V)              NOOP
+  #define CHITCHAT_ECHOLNPGM(STR)       NOOP
+  #define CHITCHAT_ECHOPAIR(STR,V)      NOOP
+  #define CHITCHAT_ECHOLNPAIR(STR,V)    NOOP
+  #define CHITCHAT_ECHO_START()         NOOP
+  #define CHITCHAT_ERROR_START()        NOOP
+  #define CHITCHAT_ERROR_MSG(STR)       NOOP
+  #define CHITCHAT_ECHO(VAL)            NOOP
+  #define CHITCHAT_ECHOPGM(STR)         NOOP
+  #define CHITCHAT_ECHOLNPGM(STR)       NOOP
+  #define CHITCHAT_ECHOPAIR(STR, VAL)   NOOP
+  #define CHITCHAT_ECHOLNPAIR(STR, VAL) NOOP
+  #define CHITCHAT_EOL()                NOOP
 #endif
 
 #if ENABLED(EEPROM_SETTINGS)
@@ -417,7 +417,7 @@ void MarlinSettings::postprocess() {
   #define EEPROM_WRITE(VAR) persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
   #define EEPROM_READ(VAR) persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating)
   #define EEPROM_READ_ALWAYS(VAR) persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
-  #define EEPROM_ASSERT(TST,ERR) do{ if (!(TST)) { SERIAL_ERROR_MSG_P(ERR); eeprom_error = true; } }while(0)
+  #define EEPROM_ASSERT(TST,ERR) do{ if (!(TST)) { SERIAL_ERROR_MSG(ERR); eeprom_error = true; } }while(0)
 
   #if ENABLED(DEBUG_EEPROM_READWRITE)
     #define _FIELD_TEST(FIELD) \
@@ -435,7 +435,7 @@ void MarlinSettings::postprocess() {
 
   bool MarlinSettings::size_error(const uint16_t size) {
     if (size != datasize()) {
-      CHITCHAT_ERROR_MSG_P("EEPROM datasize error.");
+      CHITCHAT_ERROR_MSG("EEPROM datasize error.");
       return true;
     }
     return false;
@@ -1111,10 +1111,10 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(final_crc);
 
       // Report storage size
-      CHITCHAT_ECHO_START_P();
-      CHITCHAT_ECHOPAIR_P("Settings Stored (", eeprom_size);
-      CHITCHAT_ECHOPAIR_P(" bytes; crc ", (uint32_t)final_crc);
-      CHITCHAT_ECHOLNPGM_P(")");
+      CHITCHAT_ECHO_START();
+      CHITCHAT_ECHOPAIR("Settings Stored (", eeprom_size);
+      CHITCHAT_ECHOPAIR(" bytes; crc ", (uint32_t)final_crc);
+      CHITCHAT_ECHOLNPGM(")");
 
       eeprom_error |= size_error(eeprom_size);
     }
@@ -1151,10 +1151,10 @@ void MarlinSettings::postprocess() {
         stored_ver[0] = '?';
         stored_ver[1] = '\0';
       }
-      CHITCHAT_ECHO_START_P();
-      CHITCHAT_ECHOPGM_P("EEPROM version mismatch ");
-      CHITCHAT_ECHOPAIR_P("(EEPROM=", stored_ver);
-      CHITCHAT_ECHOLNPGM_P(" Marlin=" EEPROM_VERSION ")");
+      CHITCHAT_ECHO_START();
+      CHITCHAT_ECHOPGM("EEPROM version mismatch ");
+      CHITCHAT_ECHOPAIR("(EEPROM=", stored_ver);
+      CHITCHAT_ECHOLNPGM(" Marlin=" EEPROM_VERSION ")");
       eeprom_error = true;
     }
     else {
@@ -1819,25 +1819,25 @@ void MarlinSettings::postprocess() {
 
       eeprom_error = size_error(eeprom_index - (EEPROM_OFFSET));
       if (eeprom_error) {
-        CHITCHAT_ECHO_START_P();
-        CHITCHAT_ECHOPAIR_P("Index: ", int(eeprom_index - (EEPROM_OFFSET)));
-        CHITCHAT_ECHOLNPAIR_P(" Size: ", datasize());
+        CHITCHAT_ECHO_START();
+        CHITCHAT_ECHOPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)));
+        CHITCHAT_ECHOLNPAIR(" Size: ", datasize());
       }
       else if (working_crc != stored_crc) {
         eeprom_error = true;
-        CHITCHAT_ERROR_START_P();
-        CHITCHAT_ECHOPGM_P("EEPROM CRC mismatch - (stored) ");
-        CHITCHAT_ECHO_P(stored_crc);
-        CHITCHAT_ECHOPGM_P(" != ");
-        CHITCHAT_ECHO_P(working_crc);
-        CHITCHAT_ECHOLNPGM_P(" (calculated)!");
+        CHITCHAT_ERROR_START();
+        CHITCHAT_ECHOPGM("EEPROM CRC mismatch - (stored) ");
+        CHITCHAT_ECHO(stored_crc);
+        CHITCHAT_ECHOPGM(" != ");
+        CHITCHAT_ECHO(working_crc);
+        CHITCHAT_ECHOLNPGM(" (calculated)!");
       }
       else if (!validating) {
-        CHITCHAT_ECHO_START_P();
-        CHITCHAT_ECHO_P(version);
-        CHITCHAT_ECHOPAIR_P(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
-        CHITCHAT_ECHOPAIR_P(" bytes; crc ", (uint32_t)working_crc);
-        CHITCHAT_ECHOLNPGM_P(")");
+        CHITCHAT_ECHO_START();
+        CHITCHAT_ECHO(version);
+        CHITCHAT_ECHOPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
+        CHITCHAT_ECHOPAIR(" bytes; crc ", (uint32_t)working_crc);
+        CHITCHAT_ECHOLNPGM(")");
       }
 
       if (!validating && !eeprom_error) postprocess();
@@ -1847,30 +1847,30 @@ void MarlinSettings::postprocess() {
           ubl.report_state();
 
           if (!ubl.sanity_check()) {
-            SERIAL_EOL_P();
+            SERIAL_EOL();
             #if ENABLED(EEPROM_CHITCHAT)
               ubl.echo_name();
-              CHITCHAT_ECHOLNPGM_P(" initialized.\n");
+              CHITCHAT_ECHOLNPGM(" initialized.\n");
             #endif
           }
           else {
             eeprom_error = true;
             #if ENABLED(EEPROM_CHITCHAT)
-              CHITCHAT_ECHOPGM_P("?Can't enable ");
+              CHITCHAT_ECHOPGM("?Can't enable ");
               ubl.echo_name();
-              CHITCHAT_ECHOLNPGM_P(".");
+              CHITCHAT_ECHOLNPGM(".");
             #endif
             ubl.reset();
           }
 
           if (ubl.storage_slot >= 0) {
             load_mesh(ubl.storage_slot);
-            CHITCHAT_ECHOPAIR_P("Mesh ", ubl.storage_slot);
-            CHITCHAT_ECHOLNPGM_P(" loaded from storage.");
+            CHITCHAT_ECHOPAIR("Mesh ", ubl.storage_slot);
+            CHITCHAT_ECHOLNPGM(" loaded from storage.");
           }
           else {
             ubl.reset();
-            CHITCHAT_ECHOLNPGM_P("UBL System reset()");
+            CHITCHAT_ECHOLNPGM("UBL System reset()");
           }
         }
       #endif
@@ -1996,7 +1996,7 @@ void MarlinSettings::postprocess() {
 #else // !EEPROM_SETTINGS
 
   bool MarlinSettings::save() {
-    CHITCHAT_ERROR_MSG_P("EEPROM disabled");
+    CHITCHAT_ERROR_MSG("EEPROM disabled");
     return false;
   }
 
@@ -2311,48 +2311,48 @@ void MarlinSettings::reset() {
 
   postprocess();
 
-  CHITCHAT_ECHO_START_P();
-  CHITCHAT_ECHOLNPGM_P("Hardcoded Default Settings Loaded");
+  CHITCHAT_ECHO_START();
+  CHITCHAT_ECHOLNPGM("Hardcoded Default Settings Loaded");
 }
 
 #if DISABLED(DISABLE_M503)
 
-  #define CONFIG_ECHO_START()       do{ if (!forReplay) SERIAL_ECHO_START_P(); }while(0)
-  #define CONFIG_ECHO_MSG(STR)      do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(STR); }while(0)
-  #define CONFIG_ECHO_HEADING(STR)  do{ if (!forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(STR); } }while(0)
+  #define CONFIG_ECHO_START()       do{ if (!forReplay) SERIAL_ECHO_START(); }while(0)
+  #define CONFIG_ECHO_MSG(STR)      do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM(STR); }while(0)
+  #define CONFIG_ECHO_HEADING(STR)  do{ if (!forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOLNPGM(STR); } }while(0)
 
   #if HAS_TRINAMIC
-    void say_M906() { SERIAL_ECHOPGM_P("  M906"); }
+    void say_M906() { SERIAL_ECHOPGM("  M906"); }
     #if HAS_STEALTHCHOP
       void say_M569(const char * const etc=NULL) {
-        SERIAL_ECHOPGM_P("  M569 S1");
+        SERIAL_ECHOPGM("  M569 S1");
         if (etc) {
-          SERIAL_CHAR_P(' ');
-          serialprintPGM_P(etc);
-          SERIAL_EOL_P();
+          SERIAL_CHAR(' ');
+          serialprintPGM(etc);
+          SERIAL_EOL();
         }
       }
     #endif
     #if ENABLED(HYBRID_THRESHOLD)
-      void say_M913() { SERIAL_ECHOPGM_P("  M913"); }
+      void say_M913() { SERIAL_ECHOPGM("  M913"); }
     #endif
     #if USE_SENSORLESS
-      void say_M914() { SERIAL_ECHOPGM_P("  M914"); }
+      void say_M914() { SERIAL_ECHOPGM("  M914"); }
     #endif
   #endif
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
-    void say_M603() { SERIAL_ECHOPGM_P("  M603 "); }
+    void say_M603() { SERIAL_ECHOPGM("  M603 "); }
   #endif
 
   inline void say_units(const bool colon) {
-    serialprintPGM_P(
+    serialprintPGM(
       #if ENABLED(INCH_MODE_SUPPORT)
         parser.linear_unit_factor != 1.0 ? PSTR(" (in)") :
       #endif
       PSTR(" (mm)")
     );
-    if (colon) SERIAL_ECHOLNPGM_P(":");
+    if (colon) SERIAL_ECHOLNPGM(":");
   }
 
   void report_M92(const bool echo=true, const int8_t e=-1);
@@ -2368,15 +2368,15 @@ void MarlinSettings::reset() {
      */
     CONFIG_ECHO_START();
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHOPGM_P("  G2");
-      SERIAL_CHAR_P(parser.linear_unit_factor == 1.0 ? '1' : '0');
-      SERIAL_ECHOPGM_P(" ;");
+      SERIAL_ECHOPGM("  G2");
+      SERIAL_CHAR(parser.linear_unit_factor == 1.0 ? '1' : '0');
+      SERIAL_ECHOPGM(" ;");
       say_units(false);
     #else
-      SERIAL_ECHOPGM_P("  G21    ; Units in mm");
+      SERIAL_ECHOPGM("  G21    ; Units in mm");
       say_units(false);
     #endif
-    SERIAL_EOL_P();
+    SERIAL_EOL();
 
     #if HAS_LCD_MENU
 
@@ -2384,17 +2384,17 @@ void MarlinSettings::reset() {
 
       CONFIG_ECHO_START();
       #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
-        SERIAL_ECHOPGM_P("  M149 ");
-        SERIAL_CHAR_P(parser.temp_units_code());
-        SERIAL_ECHOPGM_P(" ; Units in ");
-        serialprintPGM_P(parser.temp_units_name());
+        SERIAL_ECHOPGM("  M149 ");
+        SERIAL_CHAR(parser.temp_units_code());
+        SERIAL_ECHOPGM(" ; Units in ");
+        serialprintPGM(parser.temp_units_name());
       #else
-        SERIAL_ECHOLNPGM_P("  M149 C ; Units in Celsius");
+        SERIAL_ECHOLNPGM("  M149 C ; Units in Celsius");
       #endif
 
     #endif
 
-    SERIAL_EOL_P();
+    SERIAL_EOL();
 
     #if DISABLED(NO_VOLUMETRICS)
 
@@ -2403,36 +2403,36 @@ void MarlinSettings::reset() {
        */
       if (!forReplay) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPGM_P("Filament settings:");
+        SERIAL_ECHOPGM("Filament settings:");
         if (parser.volumetric_enabled)
-          SERIAL_EOL_P();
+          SERIAL_EOL();
         else
-          SERIAL_ECHOLNPGM_P(" Disabled");
+          SERIAL_ECHOLNPGM(" Disabled");
       }
 
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M200 D", LINEAR_UNIT(planner.filament_size[0]));
-      SERIAL_EOL_P();
+      SERIAL_ECHOPAIR("  M200 D", LINEAR_UNIT(planner.filament_size[0]));
+      SERIAL_EOL();
       #if EXTRUDERS > 1
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P("  M200 T1 D", LINEAR_UNIT(planner.filament_size[1]));
-        SERIAL_EOL_P();
+        SERIAL_ECHOPAIR("  M200 T1 D", LINEAR_UNIT(planner.filament_size[1]));
+        SERIAL_EOL();
         #if EXTRUDERS > 2
           CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR_P("  M200 T2 D", LINEAR_UNIT(planner.filament_size[2]));
-          SERIAL_EOL_P();
+          SERIAL_ECHOPAIR("  M200 T2 D", LINEAR_UNIT(planner.filament_size[2]));
+          SERIAL_EOL();
           #if EXTRUDERS > 3
             CONFIG_ECHO_START();
-            SERIAL_ECHOPAIR_P("  M200 T3 D", LINEAR_UNIT(planner.filament_size[3]));
-            SERIAL_EOL_P();
+            SERIAL_ECHOPAIR("  M200 T3 D", LINEAR_UNIT(planner.filament_size[3]));
+            SERIAL_EOL();
             #if EXTRUDERS > 4
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P("  M200 T4 D", LINEAR_UNIT(planner.filament_size[4]));
-              SERIAL_EOL_P();
+              SERIAL_ECHOPAIR("  M200 T4 D", LINEAR_UNIT(planner.filament_size[4]));
+              SERIAL_EOL();
               #if EXTRUDERS > 5
                 CONFIG_ECHO_START();
-                SERIAL_ECHOPAIR_P("  M200 T5 D", LINEAR_UNIT(planner.filament_size[5]));
-                SERIAL_EOL_P();
+                SERIAL_ECHOPAIR("  M200 T5 D", LINEAR_UNIT(planner.filament_size[5]));
+                SERIAL_EOL();
               #endif // EXTRUDERS > 5
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3
@@ -2449,93 +2449,93 @@ void MarlinSettings::reset() {
 
     CONFIG_ECHO_HEADING("Maximum feedrates (units/s):");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P("  M203 X", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]));
-    SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]));
-    SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]));
+    SERIAL_ECHOPAIR("  M203 X", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]));
+    SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]));
+    SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]));
     #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS]));
+      SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS]));
     #endif
-    SERIAL_EOL_P();
+    SERIAL_EOL();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START();
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR_P("  M203 T", (int)i);
-        SERIAL_ECHOLNPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)]));
+        SERIAL_ECHOPAIR("  M203 T", (int)i);
+        SERIAL_ECHOLNPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)]));
       }
     #endif
 
     CONFIG_ECHO_HEADING("Maximum Acceleration (units/s2):");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P("  M201 X", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]));
-    SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]));
-    SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]));
+    SERIAL_ECHOPAIR("  M201 X", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]));
+    SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]));
+    SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]));
     #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS]));
+      SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS]));
     #endif
-    SERIAL_EOL_P();
+    SERIAL_EOL();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START();
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR_P("  M201 T", (int)i);
-        SERIAL_ECHOLNPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)]));
+        SERIAL_ECHOPAIR("  M201 T", (int)i);
+        SERIAL_ECHOLNPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)]));
       }
     #endif
 
     CONFIG_ECHO_HEADING("Acceleration (units/s2): P<print_accel> R<retract_accel> T<travel_accel>");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P("  M204 P", LINEAR_UNIT(planner.settings.acceleration));
-    SERIAL_ECHOPAIR_P(" R", LINEAR_UNIT(planner.settings.retract_acceleration));
-    SERIAL_ECHOLNPAIR_P(" T", LINEAR_UNIT(planner.settings.travel_acceleration));
+    SERIAL_ECHOPAIR("  M204 P", LINEAR_UNIT(planner.settings.acceleration));
+    SERIAL_ECHOPAIR(" R", LINEAR_UNIT(planner.settings.retract_acceleration));
+    SERIAL_ECHOLNPAIR(" T", LINEAR_UNIT(planner.settings.travel_acceleration));
 
     if (!forReplay) {
       CONFIG_ECHO_START();
-      SERIAL_ECHOPGM_P("Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>");
+      SERIAL_ECHOPGM("Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>");
       #if ENABLED(JUNCTION_DEVIATION)
-        SERIAL_ECHOPGM_P(" J<junc_dev>");
+        SERIAL_ECHOPGM(" J<junc_dev>");
       #endif
       #if HAS_CLASSIC_JERK
-        SERIAL_ECHOPGM_P(" X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk>");
+        SERIAL_ECHOPGM(" X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk>");
         #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
-          SERIAL_ECHOPGM_P(" E<max_e_jerk>");
+          SERIAL_ECHOPGM(" E<max_e_jerk>");
         #endif
       #endif
-      SERIAL_EOL_P();
+      SERIAL_EOL();
     }
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P("  M205 B", LINEAR_UNIT(planner.settings.min_segment_time_us));
-    SERIAL_ECHOPAIR_P(" S", LINEAR_UNIT(planner.settings.min_feedrate_mm_s));
-    SERIAL_ECHOPAIR_P(" T", LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s));
+    SERIAL_ECHOPAIR("  M205 B", LINEAR_UNIT(planner.settings.min_segment_time_us));
+    SERIAL_ECHOPAIR(" S", LINEAR_UNIT(planner.settings.min_feedrate_mm_s));
+    SERIAL_ECHOPAIR(" T", LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s));
 
     #if ENABLED(JUNCTION_DEVIATION)
-      SERIAL_ECHOPAIR_P(" J", LINEAR_UNIT(planner.junction_deviation_mm));
+      SERIAL_ECHOPAIR(" J", LINEAR_UNIT(planner.junction_deviation_mm));
     #endif
     #if HAS_CLASSIC_JERK
-      SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
-      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
-      SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));
+      SERIAL_ECHOPAIR(" X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
+      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
+      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));
       #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
-        SERIAL_ECHOPAIR_P(" E", LINEAR_UNIT(planner.max_jerk[E_AXIS]));
+        SERIAL_ECHOPAIR(" E", LINEAR_UNIT(planner.max_jerk[E_AXIS]));
       #endif
     #endif
 
-    SERIAL_EOL_P();
+    SERIAL_EOL();
 
     #if HAS_M206_COMMAND
       CONFIG_ECHO_HEADING("Home offset:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M206 X", LINEAR_UNIT(home_offset[X_AXIS]));
-      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(home_offset[Y_AXIS]));
-      SERIAL_ECHOLNPAIR_P(" Z", LINEAR_UNIT(home_offset[Z_AXIS]));
+      SERIAL_ECHOPAIR("  M206 X", LINEAR_UNIT(home_offset[X_AXIS]));
+      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(home_offset[Y_AXIS]));
+      SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(home_offset[Z_AXIS]));
     #endif
 
     #if HAS_HOTEND_OFFSET
       CONFIG_ECHO_HEADING("Hotend offsets:");
       CONFIG_ECHO_START();
       for (uint8_t e = 1; e < HOTENDS; e++) {
-        SERIAL_ECHOPAIR_P("  M218 T", (int)e);
-        SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
-        SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
-        SERIAL_ECHOLNPAIR_F_P(" Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]), 3);
+        SERIAL_ECHOPAIR("  M218 T", (int)e);
+        SERIAL_ECHOPAIR(" X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
+        SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
+        SERIAL_ECHOLNPAIR_F(" Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]), 3);
       }
     #endif
 
@@ -2553,7 +2553,7 @@ void MarlinSettings::reset() {
         if (!forReplay) {
           CONFIG_ECHO_START();
           ubl.echo_name();
-          SERIAL_ECHOLNPGM_P(":");
+          SERIAL_ECHOLNPGM(":");
         }
 
       #elif HAS_ABL
@@ -2563,11 +2563,11 @@ void MarlinSettings::reset() {
       #endif
 
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M420 S", planner.leveling_active ? 1 : 0);
+      SERIAL_ECHOPAIR("  M420 S", planner.leveling_active ? 1 : 0);
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-        SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.z_fade_height));
+        SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.z_fade_height));
       #endif
-      SERIAL_EOL_P();
+      SERIAL_EOL();
 
       #if ENABLED(MESH_BED_LEVELING)
 
@@ -2575,9 +2575,9 @@ void MarlinSettings::reset() {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P("  G29 S3 X", (int)px + 1);
-              SERIAL_ECHOPAIR_P(" Y", (int)py + 1);
-              SERIAL_ECHOLNPAIR_F_P(" Z", LINEAR_UNIT(mbl.z_values[px][py]), 5);
+              SERIAL_ECHOPAIR("  G29 S3 X", (int)px + 1);
+              SERIAL_ECHOPAIR(" Y", (int)py + 1);
+              SERIAL_ECHOLNPAIR_F(" Z", LINEAR_UNIT(mbl.z_values[px][py]), 5);
             }
           }
         }
@@ -2585,11 +2585,11 @@ void MarlinSettings::reset() {
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
 
         if (!forReplay) {
-          SERIAL_EOL_P();
+          SERIAL_EOL();
           ubl.report_state();
-          SERIAL_ECHOLNPAIR_P("\nActive Mesh Slot: ", ubl.storage_slot);
-          SERIAL_ECHOPAIR_P("EEPROM can hold ", calc_num_meshes());
-          SERIAL_ECHOLNPGM_P(" meshes.\n");
+          SERIAL_ECHOLNPAIR("\nActive Mesh Slot: ", ubl.storage_slot);
+          SERIAL_ECHOPAIR("EEPROM can hold ", calc_num_meshes());
+          SERIAL_ECHOLNPGM(" meshes.\n");
         }
 
        //ubl.report_current_mesh();   // This is too verbose for large meshes. A better (more terse)
@@ -2600,9 +2600,9 @@ void MarlinSettings::reset() {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P("  G29 W I", (int)px);
-              SERIAL_ECHOPAIR_P(" J", (int)py);
-              SERIAL_ECHOLNPAIR_F_P(" Z", LINEAR_UNIT(z_values[px][py]), 5);
+              SERIAL_ECHOPAIR("  G29 W I", (int)px);
+              SERIAL_ECHOPAIR(" J", (int)py);
+              SERIAL_ECHOLNPAIR_F(" Z", LINEAR_UNIT(z_values[px][py]), 5);
             }
           }
         }
@@ -2627,10 +2627,10 @@ void MarlinSettings::reset() {
             case Z_PROBE_SERVO_NR:
           #endif
             CONFIG_ECHO_START();
-            SERIAL_ECHOPAIR_P("  M281 P", int(i));
-            SERIAL_ECHOPAIR_P(" L", servo_angles[i][0]);
-            SERIAL_ECHOPAIR_P(" U", servo_angles[i][1]);
-            SERIAL_EOL_P();
+            SERIAL_ECHOPAIR("  M281 P", int(i));
+            SERIAL_ECHOPAIR(" L", servo_angles[i][0]);
+            SERIAL_ECHOPAIR(" U", servo_angles[i][1]);
+            SERIAL_EOL();
           default: break;
         }
       }
@@ -2641,51 +2641,51 @@ void MarlinSettings::reset() {
 
       CONFIG_ECHO_HEADING("SCARA settings: S<seg-per-sec> P<theta-psi-offset> T<theta-offset>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M665 S", delta_segments_per_second);
-      SERIAL_ECHOPAIR_P(" P", scara_home_offset[A_AXIS]);
-      SERIAL_ECHOPAIR_P(" T", scara_home_offset[B_AXIS]);
-      SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(scara_home_offset[Z_AXIS]));
-      SERIAL_EOL_P();
+      SERIAL_ECHOPAIR("  M665 S", delta_segments_per_second);
+      SERIAL_ECHOPAIR(" P", scara_home_offset[A_AXIS]);
+      SERIAL_ECHOPAIR(" T", scara_home_offset[B_AXIS]);
+      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(scara_home_offset[Z_AXIS]));
+      SERIAL_EOL();
 
     #elif ENABLED(DELTA)
 
       CONFIG_ECHO_HEADING("Endstop adjustment:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M666 X", LINEAR_UNIT(delta_endstop_adj[X_AXIS]));
-      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(delta_endstop_adj[Y_AXIS]));
-      SERIAL_ECHOLNPAIR_P(" Z", LINEAR_UNIT(delta_endstop_adj[Z_AXIS]));
+      SERIAL_ECHOPAIR("  M666 X", LINEAR_UNIT(delta_endstop_adj[X_AXIS]));
+      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(delta_endstop_adj[Y_AXIS]));
+      SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(delta_endstop_adj[Z_AXIS]));
 
       CONFIG_ECHO_HEADING("Delta settings: L<diagonal_rod> R<radius> H<height> S<segments_per_s> B<calibration radius> XYZ<tower angle corrections>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M665 L", LINEAR_UNIT(delta_diagonal_rod));
-      SERIAL_ECHOPAIR_P(" R", LINEAR_UNIT(delta_radius));
-      SERIAL_ECHOPAIR_P(" H", LINEAR_UNIT(delta_height));
-      SERIAL_ECHOPAIR_P(" S", delta_segments_per_second);
-      SERIAL_ECHOPAIR_P(" B", LINEAR_UNIT(delta_calibration_radius));
-      SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
-      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
-      SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS]));
-      SERIAL_EOL_P();
+      SERIAL_ECHOPAIR("  M665 L", LINEAR_UNIT(delta_diagonal_rod));
+      SERIAL_ECHOPAIR(" R", LINEAR_UNIT(delta_radius));
+      SERIAL_ECHOPAIR(" H", LINEAR_UNIT(delta_height));
+      SERIAL_ECHOPAIR(" S", delta_segments_per_second);
+      SERIAL_ECHOPAIR(" B", LINEAR_UNIT(delta_calibration_radius));
+      SERIAL_ECHOPAIR(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
+      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
+      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS]));
+      SERIAL_EOL();
 
     #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
 
       CONFIG_ECHO_HEADING("Endstop adjustment:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPGM_P("  M666");
+      SERIAL_ECHOPGM("  M666");
       #if ENABLED(X_DUAL_ENDSTOPS)
-        SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(endstops.x2_endstop_adj));
+        SERIAL_ECHOPAIR(" X", LINEAR_UNIT(endstops.x2_endstop_adj));
       #endif
       #if ENABLED(Y_DUAL_ENDSTOPS)
-        SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(endstops.y2_endstop_adj));
+        SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(endstops.y2_endstop_adj));
       #endif
       #if ENABLED(Z_TRIPLE_ENDSTOPS)
-        SERIAL_ECHOLNPAIR_P("S1 Z", LINEAR_UNIT(endstops.z2_endstop_adj));
+        SERIAL_ECHOLNPAIR("S1 Z", LINEAR_UNIT(endstops.z2_endstop_adj));
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P("  M666 S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
+        SERIAL_ECHOPAIR("  M666 S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
       #elif ENABLED(Z_DUAL_ENDSTOPS)
-        SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(endstops.z2_endstop_adj));
+        SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(endstops.z2_endstop_adj));
       #endif
-      SERIAL_EOL_P();
+      SERIAL_EOL();
 
     #endif // [XYZ]_DUAL_ENDSTOPS
 
@@ -2694,10 +2694,10 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Material heatup parameters:");
       for (uint8_t i = 0; i < COUNT(ui.preheat_hotend_temp); i++) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P("  M145 S", (int)i);
-        SERIAL_ECHOPAIR_P(" H", TEMP_UNIT(ui.preheat_hotend_temp[i]));
-        SERIAL_ECHOPAIR_P(" B", TEMP_UNIT(ui.preheat_bed_temp[i]));
-        SERIAL_ECHOLNPAIR_P(" F", int(ui.preheat_fan_speed[i]));
+        SERIAL_ECHOPAIR("  M145 S", (int)i);
+        SERIAL_ECHOPAIR(" H", TEMP_UNIT(ui.preheat_hotend_temp[i]));
+        SERIAL_ECHOPAIR(" B", TEMP_UNIT(ui.preheat_bed_temp[i]));
+        SERIAL_ECHOLNPAIR(" F", int(ui.preheat_fan_speed[i]));
       }
 
     #endif
@@ -2710,15 +2710,15 @@ void MarlinSettings::reset() {
           if (forReplay) {
             HOTEND_LOOP() {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P("  M301 E", e);
-              SERIAL_ECHOPAIR_P(" P", PID_PARAM(Kp, e));
-              SERIAL_ECHOPAIR_P(" I", unscalePID_i(PID_PARAM(Ki, e)));
-              SERIAL_ECHOPAIR_P(" D", unscalePID_d(PID_PARAM(Kd, e)));
+              SERIAL_ECHOPAIR("  M301 E", e);
+              SERIAL_ECHOPAIR(" P", PID_PARAM(Kp, e));
+              SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, e)));
+              SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, e)));
               #if ENABLED(PID_EXTRUSION_SCALING)
-                SERIAL_ECHOPAIR_P(" C", PID_PARAM(Kc, e));
-                if (e == 0) SERIAL_ECHOPAIR_P(" L", thermalManager.lpq_len);
+                SERIAL_ECHOPAIR(" C", PID_PARAM(Kc, e));
+                if (e == 0) SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
               #endif
-              SERIAL_EOL_P();
+              SERIAL_EOL();
             }
           }
           else
@@ -2726,23 +2726,23 @@ void MarlinSettings::reset() {
         // !forReplay || HOTENDS == 1
         {
           CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR_P("  M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echo values for E0
-          SERIAL_ECHOPAIR_P(" I", unscalePID_i(PID_PARAM(Ki, 0)));
-          SERIAL_ECHOPAIR_P(" D", unscalePID_d(PID_PARAM(Kd, 0)));
+          SERIAL_ECHOPAIR("  M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echo values for E0
+          SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, 0)));
+          SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, 0)));
           #if ENABLED(PID_EXTRUSION_SCALING)
-            SERIAL_ECHOPAIR_P(" C", PID_PARAM(Kc, 0));
-            SERIAL_ECHOPAIR_P(" L", thermalManager.lpq_len);
+            SERIAL_ECHOPAIR(" C", PID_PARAM(Kc, 0));
+            SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
           #endif
-          SERIAL_EOL_P();
+          SERIAL_EOL();
         }
       #endif // PIDTEMP
 
       #if ENABLED(PIDTEMPBED)
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P("  M304 P", thermalManager.bed_pid.Kp);
-        SERIAL_ECHOPAIR_P(" I", unscalePID_i(thermalManager.bed_pid.Ki));
-        SERIAL_ECHOPAIR_P(" D", unscalePID_d(thermalManager.bed_pid.Kd));
-        SERIAL_EOL_P();
+        SERIAL_ECHOPAIR("  M304 P", thermalManager.bed_pid.Kp);
+        SERIAL_ECHOPAIR(" I", unscalePID_i(thermalManager.bed_pid.Ki));
+        SERIAL_ECHOPAIR(" D", unscalePID_d(thermalManager.bed_pid.Kd));
+        SERIAL_EOL();
       #endif
 
     #endif // PIDTEMP || PIDTEMPBED
@@ -2750,35 +2750,35 @@ void MarlinSettings::reset() {
     #if HAS_LCD_CONTRAST
       CONFIG_ECHO_HEADING("LCD Contrast:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P("  M250 C", ui.contrast);
+      SERIAL_ECHOLNPAIR("  M250 C", ui.contrast);
     #endif
 
     #if ENABLED(POWER_LOSS_RECOVERY)
       CONFIG_ECHO_HEADING("Power-Loss Recovery:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P("  M413 S", int(recovery.enabled));
+      SERIAL_ECHOLNPAIR("  M413 S", int(recovery.enabled));
     #endif
 
     #if ENABLED(FWRETRACT)
 
       CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M207 S", LINEAR_UNIT(fwretract.settings.retract_length));
-      SERIAL_ECHOPAIR_P(" W", LINEAR_UNIT(fwretract.settings.swap_retract_length));
-      SERIAL_ECHOPAIR_P(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_feedrate_mm_s)));
-      SERIAL_ECHOLNPAIR_P(" Z", LINEAR_UNIT(fwretract.settings.retract_zraise));
+      SERIAL_ECHOPAIR("  M207 S", LINEAR_UNIT(fwretract.settings.retract_length));
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(fwretract.settings.swap_retract_length));
+      SERIAL_ECHOPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_feedrate_mm_s)));
+      SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(fwretract.settings.retract_zraise));
 
       CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length));
-      SERIAL_ECHOPAIR_P(" W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length));
-      SERIAL_ECHOLNPAIR_P(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s)));
+      SERIAL_ECHOPAIR("  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length));
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length));
+      SERIAL_ECHOLNPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s)));
 
       #if ENABLED(FWRETRACT_AUTORETRACT)
 
         CONFIG_ECHO_HEADING("Auto-Retract: S=0 to disable, 1 to interpret E-only moves as retract/recover");
         CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR_P("  M209 S", fwretract.autoretract_enabled ? 1 : 0);
+        SERIAL_ECHOLNPAIR("  M209 S", fwretract.autoretract_enabled ? 1 : 0);
 
       #endif // FWRETRACT_AUTORETRACT
 
@@ -2790,11 +2790,11 @@ void MarlinSettings::reset() {
     #if HAS_BED_PROBE
       if (!forReplay) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPGM_P("Z-Probe Offset");
+        SERIAL_ECHOPGM("Z-Probe Offset");
         say_units(true);
       }
       CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P("  M851 Z", LINEAR_UNIT(zprobe_zoffset));
+      SERIAL_ECHOLNPAIR("  M851 Z", LINEAR_UNIT(zprobe_zoffset));
     #endif
 
     /**
@@ -2804,11 +2804,11 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Skew Factor: ");
       CONFIG_ECHO_START();
       #if ENABLED(SKEW_CORRECTION_FOR_Z)
-        SERIAL_ECHOPAIR_F_P("  M852 I", LINEAR_UNIT(planner.skew_factor.xy), 6);
-        SERIAL_ECHOPAIR_F_P(" J", LINEAR_UNIT(planner.skew_factor.xz), 6);
-        SERIAL_ECHOLNPAIR_F_P(" K", LINEAR_UNIT(planner.skew_factor.yz), 6);
+        SERIAL_ECHOPAIR_F("  M852 I", LINEAR_UNIT(planner.skew_factor.xy), 6);
+        SERIAL_ECHOPAIR_F(" J", LINEAR_UNIT(planner.skew_factor.xz), 6);
+        SERIAL_ECHOLNPAIR_F(" K", LINEAR_UNIT(planner.skew_factor.yz), 6);
       #else
-        SERIAL_ECHOLNPAIR_F_P("  M852 S", LINEAR_UNIT(planner.skew_factor.xy), 6);
+        SERIAL_ECHOLNPAIR_F("  M852 S", LINEAR_UNIT(planner.skew_factor.xy), 6);
       #endif
     #endif
 
@@ -2823,65 +2823,65 @@ void MarlinSettings::reset() {
         say_M906();
       #endif
       #if AXIS_IS_TMC(X)
-        SERIAL_ECHOPAIR_P(" X", stepperX.getMilliamps());
+        SERIAL_ECHOPAIR(" X", stepperX.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Y)
-        SERIAL_ECHOPAIR_P(" Y", stepperY.getMilliamps());
+        SERIAL_ECHOPAIR(" Y", stepperY.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Z)
-        SERIAL_ECHOPAIR_P(" Z", stepperZ.getMilliamps());
+        SERIAL_ECHOPAIR(" Z", stepperZ.getMilliamps());
       #endif
       #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
-        SERIAL_EOL_P();
+        SERIAL_EOL();
       #endif
 
       #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
         say_M906();
-        SERIAL_ECHOPGM_P(" I1");
+        SERIAL_ECHOPGM(" I1");
       #endif
       #if AXIS_IS_TMC(X2)
-        SERIAL_ECHOPAIR_P(" X", stepperX2.getMilliamps());
+        SERIAL_ECHOPAIR(" X", stepperX2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Y2)
-        SERIAL_ECHOPAIR_P(" Y", stepperY2.getMilliamps());
+        SERIAL_ECHOPAIR(" Y", stepperY2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Z2)
-        SERIAL_ECHOPAIR_P(" Z", stepperZ2.getMilliamps());
+        SERIAL_ECHOPAIR(" Z", stepperZ2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
-        SERIAL_EOL_P();
+        SERIAL_EOL();
       #endif
 
       #if AXIS_IS_TMC(Z3)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" I2 Z", stepperZ3.getMilliamps());
+        SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.getMilliamps());
       #endif
 
       #if AXIS_IS_TMC(E0)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" T0 E", stepperE0.getMilliamps());
+        SERIAL_ECHOLNPAIR(" T0 E", stepperE0.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E1)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" T1 E", stepperE1.getMilliamps());
+        SERIAL_ECHOLNPAIR(" T1 E", stepperE1.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E2)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" T2 E", stepperE2.getMilliamps());
+        SERIAL_ECHOLNPAIR(" T2 E", stepperE2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E3)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" T3 E", stepperE3.getMilliamps());
+        SERIAL_ECHOLNPAIR(" T3 E", stepperE3.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E4)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" T4 E", stepperE4.getMilliamps());
+        SERIAL_ECHOLNPAIR(" T4 E", stepperE4.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E5)
         say_M906();
-        SERIAL_ECHOLNPAIR_P(" T5 E", stepperE5.getMilliamps());
+        SERIAL_ECHOLNPAIR(" T5 E", stepperE5.getMilliamps());
       #endif
-      SERIAL_EOL_P();
+      SERIAL_EOL();
 
       /**
        * TMC Hybrid Threshold
@@ -2893,66 +2893,66 @@ void MarlinSettings::reset() {
           say_M913();
         #endif
         #if AXIS_HAS_STEALTHCHOP(X)
-          SERIAL_ECHOPAIR_P(" X", TMC_GET_PWMTHRS(X, X));
+          SERIAL_ECHOPAIR(" X", TMC_GET_PWMTHRS(X, X));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y)
-          SERIAL_ECHOPAIR_P(" Y", TMC_GET_PWMTHRS(Y, Y));
+          SERIAL_ECHOPAIR(" Y", TMC_GET_PWMTHRS(Y, Y));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z)
-          SERIAL_ECHOPAIR_P(" Z", TMC_GET_PWMTHRS(Z, Z));
+          SERIAL_ECHOPAIR(" Z", TMC_GET_PWMTHRS(Z, Z));
         #endif
         #if AXIS_HAS_STEALTHCHOP(X) || AXIS_HAS_STEALTHCHOP(Y) || AXIS_HAS_STEALTHCHOP(Z)
-          SERIAL_EOL_P();
+          SERIAL_EOL();
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(X2) || AXIS_HAS_STEALTHCHOP(Y2) || AXIS_HAS_STEALTHCHOP(Z2)
           say_M913();
-          SERIAL_ECHOPGM_P(" I1");
+          SERIAL_ECHOPGM(" I1");
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2)
-          SERIAL_ECHOPAIR_P(" X", TMC_GET_PWMTHRS(X, X2));
+          SERIAL_ECHOPAIR(" X", TMC_GET_PWMTHRS(X, X2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y2)
-          SERIAL_ECHOPAIR_P(" Y", TMC_GET_PWMTHRS(Y, Y2));
+          SERIAL_ECHOPAIR(" Y", TMC_GET_PWMTHRS(Y, Y2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z2)
-          SERIAL_ECHOPAIR_P(" Z", TMC_GET_PWMTHRS(Z, Z2));
+          SERIAL_ECHOPAIR(" Z", TMC_GET_PWMTHRS(Z, Z2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2) || AXIS_HAS_STEALTHCHOP(Y2) || AXIS_HAS_STEALTHCHOP(Z2)
-          SERIAL_EOL_P();
+          SERIAL_EOL();
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(Z3)
           say_M913();
-          SERIAL_ECHOPGM_P(" I2");
-          SERIAL_ECHOLNPAIR_P(" Z", TMC_GET_PWMTHRS(Z, Z3));
+          SERIAL_ECHOPGM(" I2");
+          SERIAL_ECHOLNPAIR(" Z", TMC_GET_PWMTHRS(Z, Z3));
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(E0)
           say_M913();
-          SERIAL_ECHOLNPAIR_P(" T0 E", TMC_GET_PWMTHRS(E, E0));
+          SERIAL_ECHOLNPAIR(" T0 E", TMC_GET_PWMTHRS(E, E0));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E1)
           say_M913();
-          SERIAL_ECHOLNPAIR_P(" T1 E", TMC_GET_PWMTHRS(E, E1));
+          SERIAL_ECHOLNPAIR(" T1 E", TMC_GET_PWMTHRS(E, E1));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E2)
           say_M913();
-          SERIAL_ECHOLNPAIR_P(" T2 E", TMC_GET_PWMTHRS(E, E2));
+          SERIAL_ECHOLNPAIR(" T2 E", TMC_GET_PWMTHRS(E, E2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E3)
           say_M913();
-          SERIAL_ECHOLNPAIR_P(" T3 E", TMC_GET_PWMTHRS(E, E3));
+          SERIAL_ECHOLNPAIR(" T3 E", TMC_GET_PWMTHRS(E, E3));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E4)
           say_M913();
-          SERIAL_ECHOLNPAIR_P(" T4 E", TMC_GET_PWMTHRS(E, E4));
+          SERIAL_ECHOLNPAIR(" T4 E", TMC_GET_PWMTHRS(E, E4));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E5)
           say_M913();
-          SERIAL_ECHOLNPAIR_P(" T5 E", TMC_GET_PWMTHRS(E, E5));
+          SERIAL_ECHOLNPAIR(" T5 E", TMC_GET_PWMTHRS(E, E5));
         #endif
-        SERIAL_EOL_P();
+        SERIAL_EOL();
       #endif // HYBRID_THRESHOLD
 
       /**
@@ -2964,15 +2964,15 @@ void MarlinSettings::reset() {
         #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
           say_M914();
           #if X_SENSORLESS
-            SERIAL_ECHOPAIR_P(" X", stepperX.sgt());
+            SERIAL_ECHOPAIR(" X", stepperX.sgt());
           #endif
           #if Y_SENSORLESS
-            SERIAL_ECHOPAIR_P(" Y", stepperY.sgt());
+            SERIAL_ECHOPAIR(" Y", stepperY.sgt());
           #endif
           #if Z_SENSORLESS
-            SERIAL_ECHOPAIR_P(" Z", stepperZ.sgt());
+            SERIAL_ECHOPAIR(" Z", stepperZ.sgt());
           #endif
-          SERIAL_EOL_P();
+          SERIAL_EOL();
         #endif
 
         #define HAS_X2_SENSORLESS (defined(X_STALL_SENSITIVITY) && AXIS_HAS_STALLGUARD(X2))
@@ -2981,23 +2981,23 @@ void MarlinSettings::reset() {
         #define HAS_Z3_SENSORLESS (defined(Z_STALL_SENSITIVITY) && AXIS_HAS_STALLGUARD(Z3))
         #if HAS_X2_SENSORLESS || HAS_Y2_SENSORLESS || HAS_Z2_SENSORLESS
           say_M914();
-          SERIAL_ECHOPGM_P(" I1");
+          SERIAL_ECHOPGM(" I1");
           #if HAS_X2_SENSORLESS
-            SERIAL_ECHOPAIR_P(" X", stepperX2.sgt());
+            SERIAL_ECHOPAIR(" X", stepperX2.sgt());
           #endif
           #if HAS_Y2_SENSORLESS
-            SERIAL_ECHOPAIR_P(" Y", stepperY2.sgt());
+            SERIAL_ECHOPAIR(" Y", stepperY2.sgt());
           #endif
           #if HAS_Z2_SENSORLESS
-            SERIAL_ECHOPAIR_P(" Z", stepperZ2.sgt());
+            SERIAL_ECHOPAIR(" Z", stepperZ2.sgt());
           #endif
-          SERIAL_EOL_P();
+          SERIAL_EOL();
         #endif
 
         #if HAS_Z3_SENSORLESS
           say_M914();
-          SERIAL_ECHOPGM_P(" I2");
-          SERIAL_ECHOLNPAIR_P(" Z", stepperZ3.sgt());
+          SERIAL_ECHOPGM(" I2");
+          SERIAL_ECHOLNPAIR(" Z", stepperZ3.sgt());
         #endif
 
       #endif // USE_SENSORLESS
@@ -3025,10 +3025,10 @@ void MarlinSettings::reset() {
         #endif
 
         if (chop_x || chop_y || chop_z) say_M569();
-        if (chop_x) SERIAL_ECHOPGM_P(" X");
-        if (chop_y) SERIAL_ECHOPGM_P(" Y");
-        if (chop_z) SERIAL_ECHOPGM_P(" Z");
-        if (chop_x || chop_y || chop_z) SERIAL_EOL_P();
+        if (chop_x) SERIAL_ECHOPGM(" X");
+        if (chop_y) SERIAL_ECHOPGM(" Y");
+        if (chop_z) SERIAL_ECHOPGM(" Z");
+        if (chop_x || chop_y || chop_z) SERIAL_EOL();
 
         #if AXIS_HAS_STEALTHCHOP(X2)
           const bool chop_x2 = stepperX2.get_stealthChop_status();
@@ -3047,10 +3047,10 @@ void MarlinSettings::reset() {
         #endif
 
         if (chop_x2 || chop_y2 || chop_z2) say_M569(PSTR("I1"));
-        if (chop_x2) SERIAL_ECHOPGM_P(" X");
-        if (chop_y2) SERIAL_ECHOPGM_P(" Y");
-        if (chop_z2) SERIAL_ECHOPGM_P(" Z");
-        if (chop_x2 || chop_y2 || chop_z2) SERIAL_EOL_P();
+        if (chop_x2) SERIAL_ECHOPGM(" X");
+        if (chop_y2) SERIAL_ECHOPGM(" Y");
+        if (chop_z2) SERIAL_ECHOPGM(" Z");
+        if (chop_x2 || chop_y2 || chop_z2) SERIAL_EOL();
 
         #if AXIS_HAS_STEALTHCHOP(Z3)
           if (stepperZ3.get_stealthChop_status()) { say_M569(PSTR("I2 Z")); }
@@ -3086,11 +3086,11 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Linear Advance:");
       CONFIG_ECHO_START();
       #if EXTRUDERS < 2
-        SERIAL_ECHOLNPAIR_P("  M900 K", planner.extruder_advance_K[0]);
+        SERIAL_ECHOLNPAIR("  M900 K", planner.extruder_advance_K[0]);
       #else
         LOOP_L_N(i, EXTRUDERS) {
-          SERIAL_ECHOPAIR_P("  M900 T", int(i));
-          SERIAL_ECHOLNPAIR_P(" K", planner.extruder_advance_K[i]);
+          SERIAL_ECHOPAIR("  M900 T", int(i));
+          SERIAL_ECHOLNPAIR(" K", planner.extruder_advance_K[i]);
         }
       #endif
     #endif
@@ -3098,10 +3098,10 @@ void MarlinSettings::reset() {
     #if HAS_MOTOR_CURRENT_PWM
       CONFIG_ECHO_HEADING("Stepper motor currents:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P("  M907 X", stepper.motor_current_setting[0]);
-      SERIAL_ECHOPAIR_P(" Z", stepper.motor_current_setting[1]);
-      SERIAL_ECHOPAIR_P(" E", stepper.motor_current_setting[2]);
-      SERIAL_EOL_P();
+      SERIAL_ECHOPAIR("  M907 X", stepper.motor_current_setting[0]);
+      SERIAL_ECHOPAIR(" Z", stepper.motor_current_setting[1]);
+      SERIAL_ECHOPAIR(" E", stepper.motor_current_setting[2]);
+      SERIAL_EOL();
     #endif
 
     /**
@@ -3112,36 +3112,36 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_START();
       #if EXTRUDERS == 1
         say_M603();
-        SERIAL_ECHOPAIR_P("L", LINEAR_UNIT(fc_settings[0].load_length));
-        SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[0].unload_length));
+        SERIAL_ECHOPAIR("L", LINEAR_UNIT(fc_settings[0].load_length));
+        SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[0].unload_length));
       #else
         say_M603();
-        SERIAL_ECHOPAIR_P("T0 L", LINEAR_UNIT(fc_settings[0].load_length));
-        SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[0].unload_length));
+        SERIAL_ECHOPAIR("T0 L", LINEAR_UNIT(fc_settings[0].load_length));
+        SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[0].unload_length));
         CONFIG_ECHO_START();
         say_M603();
-        SERIAL_ECHOPAIR_P("T1 L", LINEAR_UNIT(fc_settings[1].load_length));
-        SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[1].unload_length));
+        SERIAL_ECHOPAIR("T1 L", LINEAR_UNIT(fc_settings[1].load_length));
+        SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[1].unload_length));
         #if EXTRUDERS > 2
           CONFIG_ECHO_START();
           say_M603();
-          SERIAL_ECHOPAIR_P("T2 L", LINEAR_UNIT(fc_settings[2].load_length));
-          SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[2].unload_length));
+          SERIAL_ECHOPAIR("T2 L", LINEAR_UNIT(fc_settings[2].load_length));
+          SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[2].unload_length));
           #if EXTRUDERS > 3
             CONFIG_ECHO_START();
             say_M603();
-            SERIAL_ECHOPAIR_P("T3 L", LINEAR_UNIT(fc_settings[3].load_length));
-            SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[3].unload_length));
+            SERIAL_ECHOPAIR("T3 L", LINEAR_UNIT(fc_settings[3].load_length));
+            SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[3].unload_length));
             #if EXTRUDERS > 4
               CONFIG_ECHO_START();
               say_M603();
-              SERIAL_ECHOPAIR_P("T4 L", LINEAR_UNIT(fc_settings[4].load_length));
-              SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[4].unload_length));
+              SERIAL_ECHOPAIR("T4 L", LINEAR_UNIT(fc_settings[4].load_length));
+              SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[4].unload_length));
               #if EXTRUDERS > 5
                 CONFIG_ECHO_START();
                 say_M603();
-                SERIAL_ECHOPAIR_P("T5 L", LINEAR_UNIT(fc_settings[5].load_length));
-                SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[5].unload_length));
+                SERIAL_ECHOPAIR("T5 L", LINEAR_UNIT(fc_settings[5].load_length));
+                SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[5].unload_length));
               #endif // EXTRUDERS > 5
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -46,20 +46,6 @@
 
 #include "configuration_store.h"
 
-#if ADD_PORT_ARG
-  #define PORTARG_SOLO     const int8_t port
-  #define PORTARG_BEFORE   const int8_t port,
-  #define PORTARG_AFTER   ,const int8_t port
-  #define PORTVAR_SOLO     port
-  #define PORTVAR_BEFORE   port,
-#else
-  #define PORTARG_SOLO
-  #define PORTARG_BEFORE
-  #define PORTARG_AFTER
-  #define PORTVAR_SOLO
-  #define PORTVAR_BEFORE
-#endif
-
 #include "endstops.h"
 #include "planner.h"
 #include "stepper.h"
@@ -394,33 +380,33 @@ void MarlinSettings::postprocess() {
 #endif // SD_FIRMWARE_UPDATE
 
 #if ENABLED(EEPROM_CHITCHAT)
-  #define CHITCHAT_ECHO(V)                      SERIAL_ECHO(V)
-  #define CHITCHAT_ECHOLNPGM(STR)               SERIAL_ECHOLNPGM(STR)
-  #define CHITCHAT_ECHOPAIR(STR,V)              SERIAL_ECHOPAIR(STR,V)
-  #define CHITCHAT_ECHOLNPAIR(STR,V)            SERIAL_ECHOLNPAIR(STR,V)
-  #define CHITCHAT_ECHO_START_P(port)           SERIAL_ECHO_START_P(port)
-  #define CHITCHAT_ERROR_START_P(port)          SERIAL_ERROR_START_P(port)
-  #define CHITCHAT_ERROR_MSG_P(port, STR)       SERIAL_ERROR_MSG_P(port, STR)
-  #define CHITCHAT_ECHO_P(port, VAL)            SERIAL_ECHO_P(port, VAL)
-  #define CHITCHAT_ECHOPGM_P(port, STR)         SERIAL_ECHOPGM_P(port, STR)
-  #define CHITCHAT_ECHOLNPGM_P(port, STR)       SERIAL_ECHOLNPGM_P(port, STR)
-  #define CHITCHAT_ECHOPAIR_P(port, STR, VAL)   SERIAL_ECHOPAIR_P(port, STR, VAL)
-  #define CHITCHAT_ECHOLNPAIR_P(port, STR, VAL) SERIAL_ECHOLNPAIR_P(port, STR, VAL)
-  #define CHITCHAT_EOL()                        SERIAL_EOL()
+  #define CHITCHAT_ECHO(V)                SERIAL_ECHO(V)
+  #define CHITCHAT_ECHOLNPGM(STR)         SERIAL_ECHOLNPGM(STR)
+  #define CHITCHAT_ECHOPAIR(STR,V)        SERIAL_ECHOPAIR(STR,V)
+  #define CHITCHAT_ECHOLNPAIR(STR,V)      SERIAL_ECHOLNPAIR(STR,V)
+  #define CHITCHAT_ECHO_START_P()         SERIAL_ECHO_START_P()
+  #define CHITCHAT_ERROR_START_P()        SERIAL_ERROR_START_P()
+  #define CHITCHAT_ERROR_MSG_P(STR)       SERIAL_ERROR_MSG_P(STR)
+  #define CHITCHAT_ECHO_P(VAL)            SERIAL_ECHO_P(VAL)
+  #define CHITCHAT_ECHOPGM_P(STR)         SERIAL_ECHOPGM_P(STR)
+  #define CHITCHAT_ECHOLNPGM_P(STR)       SERIAL_ECHOLNPGM_P(STR)
+  #define CHITCHAT_ECHOPAIR_P(STR, VAL)   SERIAL_ECHOPAIR_P(STR, VAL)
+  #define CHITCHAT_ECHOLNPAIR_P(STR, VAL) SERIAL_ECHOLNPAIR_P(STR, VAL)
+  #define CHITCHAT_EOL()                  SERIAL_EOL()
 #else
-  #define CHITCHAT_ECHO(V)                      NOOP
-  #define CHITCHAT_ECHOLNPGM(STR)               NOOP
-  #define CHITCHAT_ECHOPAIR(STR,V)              NOOP
-  #define CHITCHAT_ECHOLNPAIR(STR,V)            NOOP
-  #define CHITCHAT_ECHO_START_P(port)           NOOP
-  #define CHITCHAT_ERROR_START_P(port)          NOOP
-  #define CHITCHAT_ERROR_MSG_P(port, STR)       NOOP
-  #define CHITCHAT_ECHO_P(port, VAL)            NOOP
-  #define CHITCHAT_ECHOPGM_P(port, STR)         NOOP
-  #define CHITCHAT_ECHOLNPGM_P(port, STR)       NOOP
-  #define CHITCHAT_ECHOPAIR_P(port, STR, VAL)   NOOP
-  #define CHITCHAT_ECHOLNPAIR_P(port, STR, VAL) NOOP
-  #define CHITCHAT_EOL()                        NOOP
+  #define CHITCHAT_ECHO(V)                NOOP
+  #define CHITCHAT_ECHOLNPGM(STR)         NOOP
+  #define CHITCHAT_ECHOPAIR(STR,V)        NOOP
+  #define CHITCHAT_ECHOLNPAIR(STR,V)      NOOP
+  #define CHITCHAT_ECHO_START_P()         NOOP
+  #define CHITCHAT_ERROR_START_P()        NOOP
+  #define CHITCHAT_ERROR_MSG_P(STR)       NOOP
+  #define CHITCHAT_ECHO_P(VAL)            NOOP
+  #define CHITCHAT_ECHOPGM_P(STR)         NOOP
+  #define CHITCHAT_ECHOLNPGM_P(STR)       NOOP
+  #define CHITCHAT_ECHOPAIR_P(STR, VAL)   NOOP
+  #define CHITCHAT_ECHOLNPAIR_P(STR, VAL) NOOP
+  #define CHITCHAT_EOL()                  NOOP
 #endif
 
 #if ENABLED(EEPROM_SETTINGS)
@@ -431,7 +417,7 @@ void MarlinSettings::postprocess() {
   #define EEPROM_WRITE(VAR) persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
   #define EEPROM_READ(VAR) persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating)
   #define EEPROM_READ_ALWAYS(VAR) persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc)
-  #define EEPROM_ASSERT(TST,ERR) do{ if (!(TST)) { SERIAL_ERROR_MSG_P(port, ERR); eeprom_error = true; } }while(0)
+  #define EEPROM_ASSERT(TST,ERR) do{ if (!(TST)) { SERIAL_ERROR_MSG_P(ERR); eeprom_error = true; } }while(0)
 
   #if ENABLED(DEBUG_EEPROM_READWRITE)
     #define _FIELD_TEST(FIELD) \
@@ -447,9 +433,9 @@ void MarlinSettings::postprocess() {
 
   bool MarlinSettings::eeprom_error, MarlinSettings::validating;
 
-  bool MarlinSettings::size_error(const uint16_t size PORTARG_AFTER) {
+  bool MarlinSettings::size_error(const uint16_t size) {
     if (size != datasize()) {
-      CHITCHAT_ERROR_MSG_P(port, "EEPROM datasize error.");
+      CHITCHAT_ERROR_MSG_P("EEPROM datasize error.");
       return true;
     }
     return false;
@@ -458,7 +444,7 @@ void MarlinSettings::postprocess() {
   /**
    * M500 - Store Configuration
    */
-  bool MarlinSettings::save(PORTARG_SOLO) {
+  bool MarlinSettings::save() {
     float dummy = 0;
     char ver[4] = "ERR";
 
@@ -1125,10 +1111,10 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(final_crc);
 
       // Report storage size
-      CHITCHAT_ECHO_START_P(port);
-      CHITCHAT_ECHOPAIR_P(port, "Settings Stored (", eeprom_size);
-      CHITCHAT_ECHOPAIR_P(port, " bytes; crc ", (uint32_t)final_crc);
-      CHITCHAT_ECHOLNPGM_P(port, ")");
+      CHITCHAT_ECHO_START_P();
+      CHITCHAT_ECHOPAIR_P("Settings Stored (", eeprom_size);
+      CHITCHAT_ECHOPAIR_P(" bytes; crc ", (uint32_t)final_crc);
+      CHITCHAT_ECHOLNPGM_P(")");
 
       eeprom_error |= size_error(eeprom_size);
     }
@@ -1148,7 +1134,7 @@ void MarlinSettings::postprocess() {
   /**
    * M501 - Retrieve Configuration
    */
-  bool MarlinSettings::_load(PORTARG_SOLO) {
+  bool MarlinSettings::_load() {
     uint16_t working_crc = 0;
 
     EEPROM_START();
@@ -1165,10 +1151,10 @@ void MarlinSettings::postprocess() {
         stored_ver[0] = '?';
         stored_ver[1] = '\0';
       }
-      CHITCHAT_ECHO_START_P(port);
-      CHITCHAT_ECHOPGM_P(port, "EEPROM version mismatch ");
-      CHITCHAT_ECHOPAIR_P(port, "(EEPROM=", stored_ver);
-      CHITCHAT_ECHOLNPGM_P(port, " Marlin=" EEPROM_VERSION ")");
+      CHITCHAT_ECHO_START_P();
+      CHITCHAT_ECHOPGM_P("EEPROM version mismatch ");
+      CHITCHAT_ECHOPAIR_P("(EEPROM=", stored_ver);
+      CHITCHAT_ECHOLNPGM_P(" Marlin=" EEPROM_VERSION ")");
       eeprom_error = true;
     }
     else {
@@ -1833,25 +1819,25 @@ void MarlinSettings::postprocess() {
 
       eeprom_error = size_error(eeprom_index - (EEPROM_OFFSET));
       if (eeprom_error) {
-        CHITCHAT_ECHO_START_P(port);
-        CHITCHAT_ECHOPAIR_P(port, "Index: ", int(eeprom_index - (EEPROM_OFFSET)));
-        CHITCHAT_ECHOLNPAIR_P(port, " Size: ", datasize());
+        CHITCHAT_ECHO_START_P();
+        CHITCHAT_ECHOPAIR_P("Index: ", int(eeprom_index - (EEPROM_OFFSET)));
+        CHITCHAT_ECHOLNPAIR_P(" Size: ", datasize());
       }
       else if (working_crc != stored_crc) {
         eeprom_error = true;
-        CHITCHAT_ERROR_START_P(port);
-        CHITCHAT_ECHOPGM_P(port, "EEPROM CRC mismatch - (stored) ");
-        CHITCHAT_ECHO_P(port, stored_crc);
-        CHITCHAT_ECHOPGM_P(port, " != ");
-        CHITCHAT_ECHO_P(port, working_crc);
-        CHITCHAT_ECHOLNPGM_P(port, " (calculated)!");
+        CHITCHAT_ERROR_START_P();
+        CHITCHAT_ECHOPGM_P("EEPROM CRC mismatch - (stored) ");
+        CHITCHAT_ECHO_P(stored_crc);
+        CHITCHAT_ECHOPGM_P(" != ");
+        CHITCHAT_ECHO_P(working_crc);
+        CHITCHAT_ECHOLNPGM_P(" (calculated)!");
       }
       else if (!validating) {
-        CHITCHAT_ECHO_START_P(port);
-        CHITCHAT_ECHO_P(port, version);
-        CHITCHAT_ECHOPAIR_P(port, " stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
-        CHITCHAT_ECHOPAIR_P(port, " bytes; crc ", (uint32_t)working_crc);
-        CHITCHAT_ECHOLNPGM_P(port, ")");
+        CHITCHAT_ECHO_START_P();
+        CHITCHAT_ECHO_P(version);
+        CHITCHAT_ECHOPAIR_P(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
+        CHITCHAT_ECHOPAIR_P(" bytes; crc ", (uint32_t)working_crc);
+        CHITCHAT_ECHOLNPGM_P(")");
       }
 
       if (!validating && !eeprom_error) postprocess();
@@ -1861,52 +1847,52 @@ void MarlinSettings::postprocess() {
           ubl.report_state();
 
           if (!ubl.sanity_check()) {
-            SERIAL_EOL_P(port);
+            SERIAL_EOL_P();
             #if ENABLED(EEPROM_CHITCHAT)
               ubl.echo_name();
-              CHITCHAT_ECHOLNPGM_P(port, " initialized.\n");
+              CHITCHAT_ECHOLNPGM_P(" initialized.\n");
             #endif
           }
           else {
             eeprom_error = true;
             #if ENABLED(EEPROM_CHITCHAT)
-              CHITCHAT_ECHOPGM_P(port, "?Can't enable ");
+              CHITCHAT_ECHOPGM_P("?Can't enable ");
               ubl.echo_name();
-              CHITCHAT_ECHOLNPGM_P(port, ".");
+              CHITCHAT_ECHOLNPGM_P(".");
             #endif
             ubl.reset();
           }
 
           if (ubl.storage_slot >= 0) {
             load_mesh(ubl.storage_slot);
-            CHITCHAT_ECHOPAIR_P(port, "Mesh ", ubl.storage_slot);
-            CHITCHAT_ECHOLNPGM_P(port, " loaded from storage.");
+            CHITCHAT_ECHOPAIR_P("Mesh ", ubl.storage_slot);
+            CHITCHAT_ECHOLNPGM_P(" loaded from storage.");
           }
           else {
             ubl.reset();
-            CHITCHAT_ECHOLNPGM_P(port, "UBL System reset()");
+            CHITCHAT_ECHOLNPGM_P("UBL System reset()");
           }
         }
       #endif
     }
 
     #if ENABLED(EEPROM_CHITCHAT) && DISABLED(DISABLE_M503)
-      if (!validating) report(PORTVAR_SOLO);
+      if (!validating) report();
     #endif
     EEPROM_FINISH();
 
     return !eeprom_error;
   }
 
-  bool MarlinSettings::validate(PORTARG_SOLO) {
+  bool MarlinSettings::validate() {
     validating = true;
-    const bool success = _load(PORTVAR_SOLO);
+    const bool success = _load();
     validating = false;
     return success;
   }
 
-  bool MarlinSettings::load(PORTARG_SOLO) {
-    if (validate(PORTVAR_SOLO)) return _load(PORTVAR_SOLO);
+  bool MarlinSettings::load() {
+    if (validate()) return _load();
     reset();
     return true;
   }
@@ -2009,8 +1995,8 @@ void MarlinSettings::postprocess() {
 
 #else // !EEPROM_SETTINGS
 
-  bool MarlinSettings::save(PORTARG_SOLO) {
-    CHITCHAT_ERROR_MSG_P(port, "EEPROM disabled");
+  bool MarlinSettings::save() {
+    CHITCHAT_ERROR_MSG_P("EEPROM disabled");
     return false;
   }
 
@@ -2019,7 +2005,7 @@ void MarlinSettings::postprocess() {
 /**
  * M502 - Reset Configuration
  */
-void MarlinSettings::reset(PORTARG_SOLO) {
+void MarlinSettings::reset() {
   static const float tmp1[] PROGMEM = DEFAULT_AXIS_STEPS_PER_UNIT, tmp2[] PROGMEM = DEFAULT_MAX_FEEDRATE;
   static const uint32_t tmp3[] PROGMEM = DEFAULT_MAX_ACCELERATION;
   LOOP_XYZE_N(i) {
@@ -2325,91 +2311,72 @@ void MarlinSettings::reset(PORTARG_SOLO) {
 
   postprocess();
 
-  CHITCHAT_ECHO_START_P(port);
-  CHITCHAT_ECHOLNPGM_P(port, "Hardcoded Default Settings Loaded");
+  CHITCHAT_ECHO_START_P();
+  CHITCHAT_ECHOLNPGM_P("Hardcoded Default Settings Loaded");
 }
 
 #if DISABLED(DISABLE_M503)
 
-  #define CONFIG_ECHO_START()       do{ if (!forReplay) SERIAL_ECHO_START_P(port); }while(0)
-  #define CONFIG_ECHO_MSG(STR)      do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(port, STR); }while(0)
-  #define CONFIG_ECHO_HEADING(STR)  do{ if (!forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(port, STR); } }while(0)
+  #define CONFIG_ECHO_START()       do{ if (!forReplay) SERIAL_ECHO_START_P(); }while(0)
+  #define CONFIG_ECHO_MSG(STR)      do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(STR); }while(0)
+  #define CONFIG_ECHO_HEADING(STR)  do{ if (!forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(STR); } }while(0)
 
   #if HAS_TRINAMIC
-    void say_M906(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M906"); }
+    void say_M906() { SERIAL_ECHOPGM_P("  M906"); }
     #if HAS_STEALTHCHOP
-      void say_M569(PORTARG_BEFORE const char * const etc=NULL) {
-        SERIAL_ECHOPGM_P(port, "  M569 S1");
+      void say_M569(const char * const etc=NULL) {
+        SERIAL_ECHOPGM_P("  M569 S1");
         if (etc) {
-          SERIAL_CHAR_P(port, ' ');
-          serialprintPGM_P(port, etc);
-          SERIAL_EOL_P(port);
+          SERIAL_CHAR_P(' ');
+          serialprintPGM_P(etc);
+          SERIAL_EOL_P();
         }
       }
     #endif
     #if ENABLED(HYBRID_THRESHOLD)
-      void say_M913(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M913"); }
+      void say_M913() { SERIAL_ECHOPGM_P("  M913"); }
     #endif
     #if USE_SENSORLESS
-      void say_M914(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M914"); }
+      void say_M914() { SERIAL_ECHOPGM_P("  M914"); }
     #endif
   #endif
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
-    void say_M603(PORTARG_SOLO) { SERIAL_ECHOPGM_P(port, "  M603 "); }
+    void say_M603() { SERIAL_ECHOPGM_P("  M603 "); }
   #endif
 
-  inline void say_units(
-    #if NUM_SERIAL > 1
-      const int8_t port,
-    #endif
-    const bool colon
-  ) {
-    serialprintPGM_P(port,
+  inline void say_units(const bool colon) {
+    serialprintPGM_P(
       #if ENABLED(INCH_MODE_SUPPORT)
         parser.linear_unit_factor != 1.0 ? PSTR(" (in)") :
       #endif
       PSTR(" (mm)")
     );
-    if (colon) SERIAL_ECHOLNPGM_P(port, ":");
+    if (colon) SERIAL_ECHOLNPGM_P(":");
   }
-  #if NUM_SERIAL > 1
-    #define SAY_UNITS_P(PORT, COLON) say_units(PORT, COLON)
-  #else
-    #define SAY_UNITS_P(PORT, COLON) say_units(COLON)
-  #endif
 
-  void report_M92(
-    #if NUM_SERIAL > 1
-      const int8_t port,
-    #endif
-    const bool echo=true, const int8_t e=-1
-  );
+  void report_M92(const bool echo=true, const int8_t e=-1);
 
   /**
    * M503 - Report current settings in RAM
    *
    * Unless specifically disabled, M503 is available even without EEPROM
    */
-  void MarlinSettings::report(const bool forReplay
-    #if NUM_SERIAL > 1
-      , const int8_t port/*=-1*/
-    #endif
-  ) {
+  void MarlinSettings::report(const bool forReplay) {
     /**
      * Announce current units, in case inches are being displayed
      */
     CONFIG_ECHO_START();
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHOPGM_P(port, "  G2");
-      SERIAL_CHAR_P(port, parser.linear_unit_factor == 1.0 ? '1' : '0');
-      SERIAL_ECHOPGM_P(port, " ;");
-      SAY_UNITS_P(port, false);
+      SERIAL_ECHOPGM_P("  G2");
+      SERIAL_CHAR_P(parser.linear_unit_factor == 1.0 ? '1' : '0');
+      SERIAL_ECHOPGM_P(" ;");
+      say_units(false);
     #else
-      SERIAL_ECHOPGM_P(port, "  G21    ; Units in mm");
-      SAY_UNITS_P(port, false);
+      SERIAL_ECHOPGM_P("  G21    ; Units in mm");
+      say_units(false);
     #endif
-    SERIAL_EOL_P(port);
+    SERIAL_EOL_P();
 
     #if HAS_LCD_MENU
 
@@ -2417,17 +2384,17 @@ void MarlinSettings::reset(PORTARG_SOLO) {
 
       CONFIG_ECHO_START();
       #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
-        SERIAL_ECHOPGM_P(port, "  M149 ");
-        SERIAL_CHAR_P(port, parser.temp_units_code());
-        SERIAL_ECHOPGM_P(port, " ; Units in ");
-        serialprintPGM_P(port, parser.temp_units_name());
+        SERIAL_ECHOPGM_P("  M149 ");
+        SERIAL_CHAR_P(parser.temp_units_code());
+        SERIAL_ECHOPGM_P(" ; Units in ");
+        serialprintPGM_P(parser.temp_units_name());
       #else
-        SERIAL_ECHOLNPGM_P(port, "  M149 C ; Units in Celsius");
+        SERIAL_ECHOLNPGM_P("  M149 C ; Units in Celsius");
       #endif
 
     #endif
 
-    SERIAL_EOL_P(port);
+    SERIAL_EOL_P();
 
     #if DISABLED(NO_VOLUMETRICS)
 
@@ -2436,36 +2403,36 @@ void MarlinSettings::reset(PORTARG_SOLO) {
        */
       if (!forReplay) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPGM_P(port, "Filament settings:");
+        SERIAL_ECHOPGM_P("Filament settings:");
         if (parser.volumetric_enabled)
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
         else
-          SERIAL_ECHOLNPGM_P(port, " Disabled");
+          SERIAL_ECHOLNPGM_P(" Disabled");
       }
 
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M200 D", LINEAR_UNIT(planner.filament_size[0]));
-      SERIAL_EOL_P(port);
+      SERIAL_ECHOPAIR_P("  M200 D", LINEAR_UNIT(planner.filament_size[0]));
+      SERIAL_EOL_P();
       #if EXTRUDERS > 1
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P(port, "  M200 T1 D", LINEAR_UNIT(planner.filament_size[1]));
-        SERIAL_EOL_P(port);
+        SERIAL_ECHOPAIR_P("  M200 T1 D", LINEAR_UNIT(planner.filament_size[1]));
+        SERIAL_EOL_P();
         #if EXTRUDERS > 2
           CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR_P(port, "  M200 T2 D", LINEAR_UNIT(planner.filament_size[2]));
-          SERIAL_EOL_P(port);
+          SERIAL_ECHOPAIR_P("  M200 T2 D", LINEAR_UNIT(planner.filament_size[2]));
+          SERIAL_EOL_P();
           #if EXTRUDERS > 3
             CONFIG_ECHO_START();
-            SERIAL_ECHOPAIR_P(port, "  M200 T3 D", LINEAR_UNIT(planner.filament_size[3]));
-            SERIAL_EOL_P(port);
+            SERIAL_ECHOPAIR_P("  M200 T3 D", LINEAR_UNIT(planner.filament_size[3]));
+            SERIAL_EOL_P();
             #if EXTRUDERS > 4
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P(port, "  M200 T4 D", LINEAR_UNIT(planner.filament_size[4]));
-              SERIAL_EOL_P(port);
+              SERIAL_ECHOPAIR_P("  M200 T4 D", LINEAR_UNIT(planner.filament_size[4]));
+              SERIAL_EOL_P();
               #if EXTRUDERS > 5
                 CONFIG_ECHO_START();
-                SERIAL_ECHOPAIR_P(port, "  M200 T5 D", LINEAR_UNIT(planner.filament_size[5]));
-                SERIAL_EOL_P(port);
+                SERIAL_ECHOPAIR_P("  M200 T5 D", LINEAR_UNIT(planner.filament_size[5]));
+                SERIAL_EOL_P();
               #endif // EXTRUDERS > 5
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3
@@ -2478,102 +2445,97 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #endif // !NO_VOLUMETRICS
 
     CONFIG_ECHO_HEADING("Steps per unit:");
-    report_M92(
-      #if NUM_SERIAL > 1
-        port,
-      #endif
-      !forReplay
-    );
+    report_M92(!forReplay);
 
     CONFIG_ECHO_HEADING("Maximum feedrates (units/s):");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P(port, "  M203 X", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]));
-    SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]));
-    SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]));
+    SERIAL_ECHOPAIR_P("  M203 X", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]));
+    SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]));
+    SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]));
     #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS]));
+      SERIAL_ECHOPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS]));
     #endif
-    SERIAL_EOL_P(port);
+    SERIAL_EOL_P();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START();
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR_P(port, "  M203 T", (int)i);
-        SERIAL_ECHOLNPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)]));
+        SERIAL_ECHOPAIR_P("  M203 T", (int)i);
+        SERIAL_ECHOLNPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)]));
       }
     #endif
 
     CONFIG_ECHO_HEADING("Maximum Acceleration (units/s2):");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P(port, "  M201 X", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]));
-    SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]));
-    SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]));
+    SERIAL_ECHOPAIR_P("  M201 X", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]));
+    SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]));
+    SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]));
     #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS]));
+      SERIAL_ECHOPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS]));
     #endif
-    SERIAL_EOL_P(port);
+    SERIAL_EOL_P();
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START();
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR_P(port, "  M201 T", (int)i);
-        SERIAL_ECHOLNPAIR_P(port, " E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)]));
+        SERIAL_ECHOPAIR_P("  M201 T", (int)i);
+        SERIAL_ECHOLNPAIR_P(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)]));
       }
     #endif
 
     CONFIG_ECHO_HEADING("Acceleration (units/s2): P<print_accel> R<retract_accel> T<travel_accel>");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P(port, "  M204 P", LINEAR_UNIT(planner.settings.acceleration));
-    SERIAL_ECHOPAIR_P(port, " R", LINEAR_UNIT(planner.settings.retract_acceleration));
-    SERIAL_ECHOLNPAIR_P(port, " T", LINEAR_UNIT(planner.settings.travel_acceleration));
+    SERIAL_ECHOPAIR_P("  M204 P", LINEAR_UNIT(planner.settings.acceleration));
+    SERIAL_ECHOPAIR_P(" R", LINEAR_UNIT(planner.settings.retract_acceleration));
+    SERIAL_ECHOLNPAIR_P(" T", LINEAR_UNIT(planner.settings.travel_acceleration));
 
     if (!forReplay) {
       CONFIG_ECHO_START();
-      SERIAL_ECHOPGM_P(port, "Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>");
+      SERIAL_ECHOPGM_P("Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>");
       #if ENABLED(JUNCTION_DEVIATION)
-        SERIAL_ECHOPGM_P(port, " J<junc_dev>");
+        SERIAL_ECHOPGM_P(" J<junc_dev>");
       #endif
       #if HAS_CLASSIC_JERK
-        SERIAL_ECHOPGM_P(port, " X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk>");
+        SERIAL_ECHOPGM_P(" X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk>");
         #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
-          SERIAL_ECHOPGM_P(port, " E<max_e_jerk>");
+          SERIAL_ECHOPGM_P(" E<max_e_jerk>");
         #endif
       #endif
-      SERIAL_EOL_P(port);
+      SERIAL_EOL_P();
     }
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR_P(port, "  M205 B", LINEAR_UNIT(planner.settings.min_segment_time_us));
-    SERIAL_ECHOPAIR_P(port, " S", LINEAR_UNIT(planner.settings.min_feedrate_mm_s));
-    SERIAL_ECHOPAIR_P(port, " T", LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s));
+    SERIAL_ECHOPAIR_P("  M205 B", LINEAR_UNIT(planner.settings.min_segment_time_us));
+    SERIAL_ECHOPAIR_P(" S", LINEAR_UNIT(planner.settings.min_feedrate_mm_s));
+    SERIAL_ECHOPAIR_P(" T", LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s));
 
     #if ENABLED(JUNCTION_DEVIATION)
-      SERIAL_ECHOPAIR_P(port, " J", LINEAR_UNIT(planner.junction_deviation_mm));
+      SERIAL_ECHOPAIR_P(" J", LINEAR_UNIT(planner.junction_deviation_mm));
     #endif
     #if HAS_CLASSIC_JERK
-      SERIAL_ECHOPAIR_P(port, " X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
-      SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
-      SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));
+      SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
+      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
+      SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));
       #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
-        SERIAL_ECHOPAIR_P(port, " E", LINEAR_UNIT(planner.max_jerk[E_AXIS]));
+        SERIAL_ECHOPAIR_P(" E", LINEAR_UNIT(planner.max_jerk[E_AXIS]));
       #endif
     #endif
 
-    SERIAL_EOL_P(port);
+    SERIAL_EOL_P();
 
     #if HAS_M206_COMMAND
       CONFIG_ECHO_HEADING("Home offset:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M206 X", LINEAR_UNIT(home_offset[X_AXIS]));
-      SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(home_offset[Y_AXIS]));
-      SERIAL_ECHOLNPAIR_P(port, " Z", LINEAR_UNIT(home_offset[Z_AXIS]));
+      SERIAL_ECHOPAIR_P("  M206 X", LINEAR_UNIT(home_offset[X_AXIS]));
+      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(home_offset[Y_AXIS]));
+      SERIAL_ECHOLNPAIR_P(" Z", LINEAR_UNIT(home_offset[Z_AXIS]));
     #endif
 
     #if HAS_HOTEND_OFFSET
       CONFIG_ECHO_HEADING("Hotend offsets:");
       CONFIG_ECHO_START();
       for (uint8_t e = 1; e < HOTENDS; e++) {
-        SERIAL_ECHOPAIR_P(port, "  M218 T", (int)e);
-        SERIAL_ECHOPAIR_P(port, " X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
-        SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
-        SERIAL_ECHOLNPAIR_F_P(port, " Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]), 3);
+        SERIAL_ECHOPAIR_P("  M218 T", (int)e);
+        SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
+        SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
+        SERIAL_ECHOLNPAIR_F_P(" Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]), 3);
       }
     #endif
 
@@ -2591,7 +2553,7 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         if (!forReplay) {
           CONFIG_ECHO_START();
           ubl.echo_name();
-          SERIAL_ECHOLNPGM_P(port, ":");
+          SERIAL_ECHOLNPGM_P(":");
         }
 
       #elif HAS_ABL
@@ -2601,11 +2563,11 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       #endif
 
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M420 S", planner.leveling_active ? 1 : 0);
+      SERIAL_ECHOPAIR_P("  M420 S", planner.leveling_active ? 1 : 0);
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-        SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(planner.z_fade_height));
+        SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(planner.z_fade_height));
       #endif
-      SERIAL_EOL_P(port);
+      SERIAL_EOL_P();
 
       #if ENABLED(MESH_BED_LEVELING)
 
@@ -2613,9 +2575,9 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P(port, "  G29 S3 X", (int)px + 1);
-              SERIAL_ECHOPAIR_P(port, " Y", (int)py + 1);
-              SERIAL_ECHOLNPAIR_F_P(port, " Z", LINEAR_UNIT(mbl.z_values[px][py]), 5);
+              SERIAL_ECHOPAIR_P("  G29 S3 X", (int)px + 1);
+              SERIAL_ECHOPAIR_P(" Y", (int)py + 1);
+              SERIAL_ECHOLNPAIR_F_P(" Z", LINEAR_UNIT(mbl.z_values[px][py]), 5);
             }
           }
         }
@@ -2623,14 +2585,14 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
 
         if (!forReplay) {
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
           ubl.report_state();
-          SERIAL_ECHOLNPAIR_P(port, "\nActive Mesh Slot: ", ubl.storage_slot);
-          SERIAL_ECHOPAIR_P(port, "EEPROM can hold ", calc_num_meshes());
-          SERIAL_ECHOLNPGM_P(port, " meshes.\n");
+          SERIAL_ECHOLNPAIR_P("\nActive Mesh Slot: ", ubl.storage_slot);
+          SERIAL_ECHOPAIR_P("EEPROM can hold ", calc_num_meshes());
+          SERIAL_ECHOLNPGM_P(" meshes.\n");
         }
 
-       //ubl.report_current_mesh(PORTVAR_SOLO);   // This is too verbose for large meshes. A better (more terse)
+       //ubl.report_current_mesh();   // This is too verbose for large meshes. A better (more terse)
                                                   // solution needs to be found.
       #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
@@ -2638,9 +2600,9 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P(port, "  G29 W I", (int)px);
-              SERIAL_ECHOPAIR_P(port, " J", (int)py);
-              SERIAL_ECHOLNPAIR_F_P(port, " Z", LINEAR_UNIT(z_values[px][py]), 5);
+              SERIAL_ECHOPAIR_P("  G29 W I", (int)px);
+              SERIAL_ECHOPAIR_P(" J", (int)py);
+              SERIAL_ECHOLNPAIR_F_P(" Z", LINEAR_UNIT(z_values[px][py]), 5);
             }
           }
         }
@@ -2665,10 +2627,10 @@ void MarlinSettings::reset(PORTARG_SOLO) {
             case Z_PROBE_SERVO_NR:
           #endif
             CONFIG_ECHO_START();
-            SERIAL_ECHOPAIR_P(port, "  M281 P", int(i));
-            SERIAL_ECHOPAIR_P(port, " L", servo_angles[i][0]);
-            SERIAL_ECHOPAIR_P(port, " U", servo_angles[i][1]);
-            SERIAL_EOL_P(port);
+            SERIAL_ECHOPAIR_P("  M281 P", int(i));
+            SERIAL_ECHOPAIR_P(" L", servo_angles[i][0]);
+            SERIAL_ECHOPAIR_P(" U", servo_angles[i][1]);
+            SERIAL_EOL_P();
           default: break;
         }
       }
@@ -2679,51 +2641,51 @@ void MarlinSettings::reset(PORTARG_SOLO) {
 
       CONFIG_ECHO_HEADING("SCARA settings: S<seg-per-sec> P<theta-psi-offset> T<theta-offset>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M665 S", delta_segments_per_second);
-      SERIAL_ECHOPAIR_P(port, " P", scara_home_offset[A_AXIS]);
-      SERIAL_ECHOPAIR_P(port, " T", scara_home_offset[B_AXIS]);
-      SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(scara_home_offset[Z_AXIS]));
-      SERIAL_EOL_P(port);
+      SERIAL_ECHOPAIR_P("  M665 S", delta_segments_per_second);
+      SERIAL_ECHOPAIR_P(" P", scara_home_offset[A_AXIS]);
+      SERIAL_ECHOPAIR_P(" T", scara_home_offset[B_AXIS]);
+      SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(scara_home_offset[Z_AXIS]));
+      SERIAL_EOL_P();
 
     #elif ENABLED(DELTA)
 
       CONFIG_ECHO_HEADING("Endstop adjustment:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M666 X", LINEAR_UNIT(delta_endstop_adj[X_AXIS]));
-      SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(delta_endstop_adj[Y_AXIS]));
-      SERIAL_ECHOLNPAIR_P(port, " Z", LINEAR_UNIT(delta_endstop_adj[Z_AXIS]));
+      SERIAL_ECHOPAIR_P("  M666 X", LINEAR_UNIT(delta_endstop_adj[X_AXIS]));
+      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(delta_endstop_adj[Y_AXIS]));
+      SERIAL_ECHOLNPAIR_P(" Z", LINEAR_UNIT(delta_endstop_adj[Z_AXIS]));
 
       CONFIG_ECHO_HEADING("Delta settings: L<diagonal_rod> R<radius> H<height> S<segments_per_s> B<calibration radius> XYZ<tower angle corrections>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M665 L", LINEAR_UNIT(delta_diagonal_rod));
-      SERIAL_ECHOPAIR_P(port, " R", LINEAR_UNIT(delta_radius));
-      SERIAL_ECHOPAIR_P(port, " H", LINEAR_UNIT(delta_height));
-      SERIAL_ECHOPAIR_P(port, " S", delta_segments_per_second);
-      SERIAL_ECHOPAIR_P(port, " B", LINEAR_UNIT(delta_calibration_radius));
-      SERIAL_ECHOPAIR_P(port, " X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
-      SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
-      SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS]));
-      SERIAL_EOL_P(port);
+      SERIAL_ECHOPAIR_P("  M665 L", LINEAR_UNIT(delta_diagonal_rod));
+      SERIAL_ECHOPAIR_P(" R", LINEAR_UNIT(delta_radius));
+      SERIAL_ECHOPAIR_P(" H", LINEAR_UNIT(delta_height));
+      SERIAL_ECHOPAIR_P(" S", delta_segments_per_second);
+      SERIAL_ECHOPAIR_P(" B", LINEAR_UNIT(delta_calibration_radius));
+      SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
+      SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
+      SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS]));
+      SERIAL_EOL_P();
 
     #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
 
       CONFIG_ECHO_HEADING("Endstop adjustment:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPGM_P(port, "  M666");
+      SERIAL_ECHOPGM_P("  M666");
       #if ENABLED(X_DUAL_ENDSTOPS)
-        SERIAL_ECHOPAIR_P(port, " X", LINEAR_UNIT(endstops.x2_endstop_adj));
+        SERIAL_ECHOPAIR_P(" X", LINEAR_UNIT(endstops.x2_endstop_adj));
       #endif
       #if ENABLED(Y_DUAL_ENDSTOPS)
-        SERIAL_ECHOPAIR_P(port, " Y", LINEAR_UNIT(endstops.y2_endstop_adj));
+        SERIAL_ECHOPAIR_P(" Y", LINEAR_UNIT(endstops.y2_endstop_adj));
       #endif
       #if ENABLED(Z_TRIPLE_ENDSTOPS)
-        SERIAL_ECHOLNPAIR_P(port, "S1 Z", LINEAR_UNIT(endstops.z2_endstop_adj));
+        SERIAL_ECHOLNPAIR_P("S1 Z", LINEAR_UNIT(endstops.z2_endstop_adj));
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P(port, "  M666 S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
+        SERIAL_ECHOPAIR_P("  M666 S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
       #elif ENABLED(Z_DUAL_ENDSTOPS)
-        SERIAL_ECHOPAIR_P(port, " Z", LINEAR_UNIT(endstops.z2_endstop_adj));
+        SERIAL_ECHOPAIR_P(" Z", LINEAR_UNIT(endstops.z2_endstop_adj));
       #endif
-      SERIAL_EOL_P(port);
+      SERIAL_EOL_P();
 
     #endif // [XYZ]_DUAL_ENDSTOPS
 
@@ -2732,10 +2694,10 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       CONFIG_ECHO_HEADING("Material heatup parameters:");
       for (uint8_t i = 0; i < COUNT(ui.preheat_hotend_temp); i++) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P(port, "  M145 S", (int)i);
-        SERIAL_ECHOPAIR_P(port, " H", TEMP_UNIT(ui.preheat_hotend_temp[i]));
-        SERIAL_ECHOPAIR_P(port, " B", TEMP_UNIT(ui.preheat_bed_temp[i]));
-        SERIAL_ECHOLNPAIR_P(port, " F", int(ui.preheat_fan_speed[i]));
+        SERIAL_ECHOPAIR_P("  M145 S", (int)i);
+        SERIAL_ECHOPAIR_P(" H", TEMP_UNIT(ui.preheat_hotend_temp[i]));
+        SERIAL_ECHOPAIR_P(" B", TEMP_UNIT(ui.preheat_bed_temp[i]));
+        SERIAL_ECHOLNPAIR_P(" F", int(ui.preheat_fan_speed[i]));
       }
 
     #endif
@@ -2748,15 +2710,15 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           if (forReplay) {
             HOTEND_LOOP() {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P(port, "  M301 E", e);
-              SERIAL_ECHOPAIR_P(port, " P", PID_PARAM(Kp, e));
-              SERIAL_ECHOPAIR_P(port, " I", unscalePID_i(PID_PARAM(Ki, e)));
-              SERIAL_ECHOPAIR_P(port, " D", unscalePID_d(PID_PARAM(Kd, e)));
+              SERIAL_ECHOPAIR_P("  M301 E", e);
+              SERIAL_ECHOPAIR_P(" P", PID_PARAM(Kp, e));
+              SERIAL_ECHOPAIR_P(" I", unscalePID_i(PID_PARAM(Ki, e)));
+              SERIAL_ECHOPAIR_P(" D", unscalePID_d(PID_PARAM(Kd, e)));
               #if ENABLED(PID_EXTRUSION_SCALING)
-                SERIAL_ECHOPAIR_P(port, " C", PID_PARAM(Kc, e));
-                if (e == 0) SERIAL_ECHOPAIR_P(port, " L", thermalManager.lpq_len);
+                SERIAL_ECHOPAIR_P(" C", PID_PARAM(Kc, e));
+                if (e == 0) SERIAL_ECHOPAIR_P(" L", thermalManager.lpq_len);
               #endif
-              SERIAL_EOL_P(port);
+              SERIAL_EOL_P();
             }
           }
           else
@@ -2764,23 +2726,23 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         // !forReplay || HOTENDS == 1
         {
           CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR_P(port, "  M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echo values for E0
-          SERIAL_ECHOPAIR_P(port, " I", unscalePID_i(PID_PARAM(Ki, 0)));
-          SERIAL_ECHOPAIR_P(port, " D", unscalePID_d(PID_PARAM(Kd, 0)));
+          SERIAL_ECHOPAIR_P("  M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echo values for E0
+          SERIAL_ECHOPAIR_P(" I", unscalePID_i(PID_PARAM(Ki, 0)));
+          SERIAL_ECHOPAIR_P(" D", unscalePID_d(PID_PARAM(Kd, 0)));
           #if ENABLED(PID_EXTRUSION_SCALING)
-            SERIAL_ECHOPAIR_P(port, " C", PID_PARAM(Kc, 0));
-            SERIAL_ECHOPAIR_P(port, " L", thermalManager.lpq_len);
+            SERIAL_ECHOPAIR_P(" C", PID_PARAM(Kc, 0));
+            SERIAL_ECHOPAIR_P(" L", thermalManager.lpq_len);
           #endif
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
         }
       #endif // PIDTEMP
 
       #if ENABLED(PIDTEMPBED)
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR_P(port, "  M304 P", thermalManager.bed_pid.Kp);
-        SERIAL_ECHOPAIR_P(port, " I", unscalePID_i(thermalManager.bed_pid.Ki));
-        SERIAL_ECHOPAIR_P(port, " D", unscalePID_d(thermalManager.bed_pid.Kd));
-        SERIAL_EOL_P(port);
+        SERIAL_ECHOPAIR_P("  M304 P", thermalManager.bed_pid.Kp);
+        SERIAL_ECHOPAIR_P(" I", unscalePID_i(thermalManager.bed_pid.Ki));
+        SERIAL_ECHOPAIR_P(" D", unscalePID_d(thermalManager.bed_pid.Kd));
+        SERIAL_EOL_P();
       #endif
 
     #endif // PIDTEMP || PIDTEMPBED
@@ -2788,35 +2750,35 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #if HAS_LCD_CONTRAST
       CONFIG_ECHO_HEADING("LCD Contrast:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(port, "  M250 C", ui.contrast);
+      SERIAL_ECHOLNPAIR_P("  M250 C", ui.contrast);
     #endif
 
     #if ENABLED(POWER_LOSS_RECOVERY)
       CONFIG_ECHO_HEADING("Power-Loss Recovery:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(port, "  M413 S", int(recovery.enabled));
+      SERIAL_ECHOLNPAIR_P("  M413 S", int(recovery.enabled));
     #endif
 
     #if ENABLED(FWRETRACT)
 
       CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M207 S", LINEAR_UNIT(fwretract.settings.retract_length));
-      SERIAL_ECHOPAIR_P(port, " W", LINEAR_UNIT(fwretract.settings.swap_retract_length));
-      SERIAL_ECHOPAIR_P(port, " F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_feedrate_mm_s)));
-      SERIAL_ECHOLNPAIR_P(port, " Z", LINEAR_UNIT(fwretract.settings.retract_zraise));
+      SERIAL_ECHOPAIR_P("  M207 S", LINEAR_UNIT(fwretract.settings.retract_length));
+      SERIAL_ECHOPAIR_P(" W", LINEAR_UNIT(fwretract.settings.swap_retract_length));
+      SERIAL_ECHOPAIR_P(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_feedrate_mm_s)));
+      SERIAL_ECHOLNPAIR_P(" Z", LINEAR_UNIT(fwretract.settings.retract_zraise));
 
       CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length));
-      SERIAL_ECHOPAIR_P(port, " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length));
-      SERIAL_ECHOLNPAIR_P(port, " F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s)));
+      SERIAL_ECHOPAIR_P("  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length));
+      SERIAL_ECHOPAIR_P(" W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length));
+      SERIAL_ECHOLNPAIR_P(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s)));
 
       #if ENABLED(FWRETRACT_AUTORETRACT)
 
         CONFIG_ECHO_HEADING("Auto-Retract: S=0 to disable, 1 to interpret E-only moves as retract/recover");
         CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR_P(port, "  M209 S", fwretract.autoretract_enabled ? 1 : 0);
+        SERIAL_ECHOLNPAIR_P("  M209 S", fwretract.autoretract_enabled ? 1 : 0);
 
       #endif // FWRETRACT_AUTORETRACT
 
@@ -2828,11 +2790,11 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #if HAS_BED_PROBE
       if (!forReplay) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPGM_P(port, "Z-Probe Offset");
-        SAY_UNITS_P(port, true);
+        SERIAL_ECHOPGM_P("Z-Probe Offset");
+        say_units(true);
       }
       CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(port, "  M851 Z", LINEAR_UNIT(zprobe_zoffset));
+      SERIAL_ECHOLNPAIR_P("  M851 Z", LINEAR_UNIT(zprobe_zoffset));
     #endif
 
     /**
@@ -2842,11 +2804,11 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       CONFIG_ECHO_HEADING("Skew Factor: ");
       CONFIG_ECHO_START();
       #if ENABLED(SKEW_CORRECTION_FOR_Z)
-        SERIAL_ECHOPAIR_F_P(port, "  M852 I", LINEAR_UNIT(planner.skew_factor.xy), 6);
-        SERIAL_ECHOPAIR_F_P(port, " J", LINEAR_UNIT(planner.skew_factor.xz), 6);
-        SERIAL_ECHOLNPAIR_F_P(port, " K", LINEAR_UNIT(planner.skew_factor.yz), 6);
+        SERIAL_ECHOPAIR_F_P("  M852 I", LINEAR_UNIT(planner.skew_factor.xy), 6);
+        SERIAL_ECHOPAIR_F_P(" J", LINEAR_UNIT(planner.skew_factor.xz), 6);
+        SERIAL_ECHOLNPAIR_F_P(" K", LINEAR_UNIT(planner.skew_factor.yz), 6);
       #else
-        SERIAL_ECHOLNPAIR_F_P(port, "  M852 S", LINEAR_UNIT(planner.skew_factor.xy), 6);
+        SERIAL_ECHOLNPAIR_F_P("  M852 S", LINEAR_UNIT(planner.skew_factor.xy), 6);
       #endif
     #endif
 
@@ -2858,68 +2820,68 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       CONFIG_ECHO_HEADING("Stepper driver current:");
       CONFIG_ECHO_START();
       #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
-        say_M906(PORTVAR_SOLO);
+        say_M906();
       #endif
       #if AXIS_IS_TMC(X)
-        SERIAL_ECHOPAIR_P(port, " X", stepperX.getMilliamps());
+        SERIAL_ECHOPAIR_P(" X", stepperX.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Y)
-        SERIAL_ECHOPAIR_P(port, " Y", stepperY.getMilliamps());
+        SERIAL_ECHOPAIR_P(" Y", stepperY.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Z)
-        SERIAL_ECHOPAIR_P(port, " Z", stepperZ.getMilliamps());
+        SERIAL_ECHOPAIR_P(" Z", stepperZ.getMilliamps());
       #endif
       #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
-        SERIAL_EOL_P(port);
+        SERIAL_EOL_P();
       #endif
 
       #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOPGM_P(port, " I1");
+        say_M906();
+        SERIAL_ECHOPGM_P(" I1");
       #endif
       #if AXIS_IS_TMC(X2)
-        SERIAL_ECHOPAIR_P(port, " X", stepperX2.getMilliamps());
+        SERIAL_ECHOPAIR_P(" X", stepperX2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Y2)
-        SERIAL_ECHOPAIR_P(port, " Y", stepperY2.getMilliamps());
+        SERIAL_ECHOPAIR_P(" Y", stepperY2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(Z2)
-        SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.getMilliamps());
+        SERIAL_ECHOPAIR_P(" Z", stepperZ2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
-        SERIAL_EOL_P(port);
+        SERIAL_EOL_P();
       #endif
 
       #if AXIS_IS_TMC(Z3)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " I2 Z", stepperZ3.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" I2 Z", stepperZ3.getMilliamps());
       #endif
 
       #if AXIS_IS_TMC(E0)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " T0 E", stepperE0.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" T0 E", stepperE0.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E1)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " T1 E", stepperE1.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" T1 E", stepperE1.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E2)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " T2 E", stepperE2.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" T2 E", stepperE2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E3)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " T3 E", stepperE3.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" T3 E", stepperE3.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E4)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " T4 E", stepperE4.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" T4 E", stepperE4.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E5)
-        say_M906(PORTVAR_SOLO);
-        SERIAL_ECHOLNPAIR_P(port, " T5 E", stepperE5.getMilliamps());
+        say_M906();
+        SERIAL_ECHOLNPAIR_P(" T5 E", stepperE5.getMilliamps());
       #endif
-      SERIAL_EOL_P(port);
+      SERIAL_EOL_P();
 
       /**
        * TMC Hybrid Threshold
@@ -2928,69 +2890,69 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         CONFIG_ECHO_HEADING("Hybrid Threshold:");
         CONFIG_ECHO_START();
         #if AXIS_HAS_STEALTHCHOP(X) || AXIS_HAS_STEALTHCHOP(Y) || AXIS_HAS_STEALTHCHOP(Z)
-          say_M913(PORTVAR_SOLO);
+          say_M913();
         #endif
         #if AXIS_HAS_STEALTHCHOP(X)
-          SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X));
+          SERIAL_ECHOPAIR_P(" X", TMC_GET_PWMTHRS(X, X));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y)
-          SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y));
+          SERIAL_ECHOPAIR_P(" Y", TMC_GET_PWMTHRS(Y, Y));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z)
-          SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z));
+          SERIAL_ECHOPAIR_P(" Z", TMC_GET_PWMTHRS(Z, Z));
         #endif
         #if AXIS_HAS_STEALTHCHOP(X) || AXIS_HAS_STEALTHCHOP(Y) || AXIS_HAS_STEALTHCHOP(Z)
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(X2) || AXIS_HAS_STEALTHCHOP(Y2) || AXIS_HAS_STEALTHCHOP(Z2)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOPGM_P(port, " I1");
+          say_M913();
+          SERIAL_ECHOPGM_P(" I1");
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2)
-          SERIAL_ECHOPAIR_P(port, " X", TMC_GET_PWMTHRS(X, X2));
+          SERIAL_ECHOPAIR_P(" X", TMC_GET_PWMTHRS(X, X2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y2)
-          SERIAL_ECHOPAIR_P(port, " Y", TMC_GET_PWMTHRS(Y, Y2));
+          SERIAL_ECHOPAIR_P(" Y", TMC_GET_PWMTHRS(Y, Y2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z2)
-          SERIAL_ECHOPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z2));
+          SERIAL_ECHOPAIR_P(" Z", TMC_GET_PWMTHRS(Z, Z2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2) || AXIS_HAS_STEALTHCHOP(Y2) || AXIS_HAS_STEALTHCHOP(Z2)
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(Z3)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOPGM_P(port, " I2");
-          SERIAL_ECHOLNPAIR_P(port, " Z", TMC_GET_PWMTHRS(Z, Z3));
+          say_M913();
+          SERIAL_ECHOPGM_P(" I2");
+          SERIAL_ECHOLNPAIR_P(" Z", TMC_GET_PWMTHRS(Z, Z3));
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(E0)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, " T0 E", TMC_GET_PWMTHRS(E, E0));
+          say_M913();
+          SERIAL_ECHOLNPAIR_P(" T0 E", TMC_GET_PWMTHRS(E, E0));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E1)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, " T1 E", TMC_GET_PWMTHRS(E, E1));
+          say_M913();
+          SERIAL_ECHOLNPAIR_P(" T1 E", TMC_GET_PWMTHRS(E, E1));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E2)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, " T2 E", TMC_GET_PWMTHRS(E, E2));
+          say_M913();
+          SERIAL_ECHOLNPAIR_P(" T2 E", TMC_GET_PWMTHRS(E, E2));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E3)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, " T3 E", TMC_GET_PWMTHRS(E, E3));
+          say_M913();
+          SERIAL_ECHOLNPAIR_P(" T3 E", TMC_GET_PWMTHRS(E, E3));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E4)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, " T4 E", TMC_GET_PWMTHRS(E, E4));
+          say_M913();
+          SERIAL_ECHOLNPAIR_P(" T4 E", TMC_GET_PWMTHRS(E, E4));
         #endif
         #if AXIS_HAS_STEALTHCHOP(E5)
-          say_M913(PORTVAR_SOLO);
-          SERIAL_ECHOLNPAIR_P(port, " T5 E", TMC_GET_PWMTHRS(E, E5));
+          say_M913();
+          SERIAL_ECHOLNPAIR_P(" T5 E", TMC_GET_PWMTHRS(E, E5));
         #endif
-        SERIAL_EOL_P(port);
+        SERIAL_EOL_P();
       #endif // HYBRID_THRESHOLD
 
       /**
@@ -3000,17 +2962,17 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         CONFIG_ECHO_HEADING("TMC2130 StallGuard threshold:");
         CONFIG_ECHO_START();
         #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
-          say_M914(PORTVAR_SOLO);
+          say_M914();
           #if X_SENSORLESS
-            SERIAL_ECHOPAIR_P(port, " X", stepperX.sgt());
+            SERIAL_ECHOPAIR_P(" X", stepperX.sgt());
           #endif
           #if Y_SENSORLESS
-            SERIAL_ECHOPAIR_P(port, " Y", stepperY.sgt());
+            SERIAL_ECHOPAIR_P(" Y", stepperY.sgt());
           #endif
           #if Z_SENSORLESS
-            SERIAL_ECHOPAIR_P(port, " Z", stepperZ.sgt());
+            SERIAL_ECHOPAIR_P(" Z", stepperZ.sgt());
           #endif
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
         #endif
 
         #define HAS_X2_SENSORLESS (defined(X_STALL_SENSITIVITY) && AXIS_HAS_STALLGUARD(X2))
@@ -3018,24 +2980,24 @@ void MarlinSettings::reset(PORTARG_SOLO) {
         #define HAS_Z2_SENSORLESS (defined(Z_STALL_SENSITIVITY) && AXIS_HAS_STALLGUARD(Z2))
         #define HAS_Z3_SENSORLESS (defined(Z_STALL_SENSITIVITY) && AXIS_HAS_STALLGUARD(Z3))
         #if HAS_X2_SENSORLESS || HAS_Y2_SENSORLESS || HAS_Z2_SENSORLESS
-          say_M914(PORTVAR_SOLO);
-          SERIAL_ECHOPGM_P(port, " I1");
+          say_M914();
+          SERIAL_ECHOPGM_P(" I1");
           #if HAS_X2_SENSORLESS
-            SERIAL_ECHOPAIR_P(port, " X", stepperX2.sgt());
+            SERIAL_ECHOPAIR_P(" X", stepperX2.sgt());
           #endif
           #if HAS_Y2_SENSORLESS
-            SERIAL_ECHOPAIR_P(port, " Y", stepperY2.sgt());
+            SERIAL_ECHOPAIR_P(" Y", stepperY2.sgt());
           #endif
           #if HAS_Z2_SENSORLESS
-            SERIAL_ECHOPAIR_P(port, " Z", stepperZ2.sgt());
+            SERIAL_ECHOPAIR_P(" Z", stepperZ2.sgt());
           #endif
-          SERIAL_EOL_P(port);
+          SERIAL_EOL_P();
         #endif
 
         #if HAS_Z3_SENSORLESS
-          say_M914(PORTVAR_SOLO);
-          SERIAL_ECHOPGM_P(port, " I2");
-          SERIAL_ECHOLNPAIR_P(port, " Z", stepperZ3.sgt());
+          say_M914();
+          SERIAL_ECHOPGM_P(" I2");
+          SERIAL_ECHOLNPAIR_P(" Z", stepperZ3.sgt());
         #endif
 
       #endif // USE_SENSORLESS
@@ -3062,11 +3024,11 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           constexpr bool chop_z = false;
         #endif
 
-        if (chop_x || chop_y || chop_z) say_M569(PORTVAR_SOLO);
-        if (chop_x) SERIAL_ECHOPGM_P(port, " X");
-        if (chop_y) SERIAL_ECHOPGM_P(port, " Y");
-        if (chop_z) SERIAL_ECHOPGM_P(port, " Z");
-        if (chop_x || chop_y || chop_z) SERIAL_EOL_P(port);
+        if (chop_x || chop_y || chop_z) say_M569();
+        if (chop_x) SERIAL_ECHOPGM_P(" X");
+        if (chop_y) SERIAL_ECHOPGM_P(" Y");
+        if (chop_z) SERIAL_ECHOPGM_P(" Z");
+        if (chop_x || chop_y || chop_z) SERIAL_EOL_P();
 
         #if AXIS_HAS_STEALTHCHOP(X2)
           const bool chop_x2 = stepperX2.get_stealthChop_status();
@@ -3084,33 +3046,33 @@ void MarlinSettings::reset(PORTARG_SOLO) {
           constexpr bool chop_z2 = false;
         #endif
 
-        if (chop_x2 || chop_y2 || chop_z2) say_M569(PORTVAR_BEFORE PSTR("I1"));
-        if (chop_x2) SERIAL_ECHOPGM_P(port, " X");
-        if (chop_y2) SERIAL_ECHOPGM_P(port, " Y");
-        if (chop_z2) SERIAL_ECHOPGM_P(port, " Z");
-        if (chop_x2 || chop_y2 || chop_z2) SERIAL_EOL_P(port);
+        if (chop_x2 || chop_y2 || chop_z2) say_M569(PSTR("I1"));
+        if (chop_x2) SERIAL_ECHOPGM_P(" X");
+        if (chop_y2) SERIAL_ECHOPGM_P(" Y");
+        if (chop_z2) SERIAL_ECHOPGM_P(" Z");
+        if (chop_x2 || chop_y2 || chop_z2) SERIAL_EOL_P();
 
         #if AXIS_HAS_STEALTHCHOP(Z3)
-          if (stepperZ3.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("I2 Z")); }
+          if (stepperZ3.get_stealthChop_status()) { say_M569(PSTR("I2 Z")); }
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(E0)
-          if (stepperE0.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("T0 E")); }
+          if (stepperE0.get_stealthChop_status()) { say_M569(PSTR("T0 E")); }
         #endif
         #if AXIS_HAS_STEALTHCHOP(E1)
-          if (stepperE1.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("T1 E")); }
+          if (stepperE1.get_stealthChop_status()) { say_M569(PSTR("T1 E")); }
         #endif
         #if AXIS_HAS_STEALTHCHOP(E2)
-          if (stepperE2.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("T2 E")); }
+          if (stepperE2.get_stealthChop_status()) { say_M569(PSTR("T2 E")); }
         #endif
         #if AXIS_HAS_STEALTHCHOP(E3)
-          if (stepperE3.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("T3 E")); }
+          if (stepperE3.get_stealthChop_status()) { say_M569(PSTR("T3 E")); }
         #endif
         #if AXIS_HAS_STEALTHCHOP(E4)
-          if (stepperE4.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("T4 E")); }
+          if (stepperE4.get_stealthChop_status()) { say_M569(PSTR("T4 E")); }
         #endif
         #if AXIS_HAS_STEALTHCHOP(E5)
-          if (stepperE5.get_stealthChop_status()) { say_M569(PORTVAR_BEFORE PSTR("T5 E")); }
+          if (stepperE5.get_stealthChop_status()) { say_M569(PSTR("T5 E")); }
         #endif
 
       #endif // HAS_STEALTHCHOP
@@ -3124,11 +3086,11 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       CONFIG_ECHO_HEADING("Linear Advance:");
       CONFIG_ECHO_START();
       #if EXTRUDERS < 2
-        SERIAL_ECHOLNPAIR_P(port, "  M900 K", planner.extruder_advance_K[0]);
+        SERIAL_ECHOLNPAIR_P("  M900 K", planner.extruder_advance_K[0]);
       #else
         LOOP_L_N(i, EXTRUDERS) {
-          SERIAL_ECHOPAIR_P(port, "  M900 T", int(i));
-          SERIAL_ECHOLNPAIR_P(port, " K", planner.extruder_advance_K[i]);
+          SERIAL_ECHOPAIR_P("  M900 T", int(i));
+          SERIAL_ECHOLNPAIR_P(" K", planner.extruder_advance_K[i]);
         }
       #endif
     #endif
@@ -3136,10 +3098,10 @@ void MarlinSettings::reset(PORTARG_SOLO) {
     #if HAS_MOTOR_CURRENT_PWM
       CONFIG_ECHO_HEADING("Stepper motor currents:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR_P(port, "  M907 X", stepper.motor_current_setting[0]);
-      SERIAL_ECHOPAIR_P(port, " Z", stepper.motor_current_setting[1]);
-      SERIAL_ECHOPAIR_P(port, " E", stepper.motor_current_setting[2]);
-      SERIAL_EOL_P(port);
+      SERIAL_ECHOPAIR_P("  M907 X", stepper.motor_current_setting[0]);
+      SERIAL_ECHOPAIR_P(" Z", stepper.motor_current_setting[1]);
+      SERIAL_ECHOPAIR_P(" E", stepper.motor_current_setting[2]);
+      SERIAL_EOL_P();
     #endif
 
     /**
@@ -3149,37 +3111,37 @@ void MarlinSettings::reset(PORTARG_SOLO) {
       CONFIG_ECHO_HEADING("Filament load/unload lengths:");
       CONFIG_ECHO_START();
       #if EXTRUDERS == 1
-        say_M603(PORTVAR_SOLO);
-        SERIAL_ECHOPAIR_P(port, "L", LINEAR_UNIT(fc_settings[0].load_length));
-        SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[0].unload_length));
+        say_M603();
+        SERIAL_ECHOPAIR_P("L", LINEAR_UNIT(fc_settings[0].load_length));
+        SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[0].unload_length));
       #else
-        say_M603(PORTVAR_SOLO);
-        SERIAL_ECHOPAIR_P(port, "T0 L", LINEAR_UNIT(fc_settings[0].load_length));
-        SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[0].unload_length));
+        say_M603();
+        SERIAL_ECHOPAIR_P("T0 L", LINEAR_UNIT(fc_settings[0].load_length));
+        SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[0].unload_length));
         CONFIG_ECHO_START();
-        say_M603(PORTVAR_SOLO);
-        SERIAL_ECHOPAIR_P(port, "T1 L", LINEAR_UNIT(fc_settings[1].load_length));
-        SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[1].unload_length));
+        say_M603();
+        SERIAL_ECHOPAIR_P("T1 L", LINEAR_UNIT(fc_settings[1].load_length));
+        SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[1].unload_length));
         #if EXTRUDERS > 2
           CONFIG_ECHO_START();
-          say_M603(PORTVAR_SOLO);
-          SERIAL_ECHOPAIR_P(port, "T2 L", LINEAR_UNIT(fc_settings[2].load_length));
-          SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[2].unload_length));
+          say_M603();
+          SERIAL_ECHOPAIR_P("T2 L", LINEAR_UNIT(fc_settings[2].load_length));
+          SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[2].unload_length));
           #if EXTRUDERS > 3
             CONFIG_ECHO_START();
-            say_M603(PORTVAR_SOLO);
-            SERIAL_ECHOPAIR_P(port, "T3 L", LINEAR_UNIT(fc_settings[3].load_length));
-            SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[3].unload_length));
+            say_M603();
+            SERIAL_ECHOPAIR_P("T3 L", LINEAR_UNIT(fc_settings[3].load_length));
+            SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[3].unload_length));
             #if EXTRUDERS > 4
               CONFIG_ECHO_START();
-              say_M603(PORTVAR_SOLO);
-              SERIAL_ECHOPAIR_P(port, "T4 L", LINEAR_UNIT(fc_settings[4].load_length));
-              SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[4].unload_length));
+              say_M603();
+              SERIAL_ECHOPAIR_P("T4 L", LINEAR_UNIT(fc_settings[4].load_length));
+              SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[4].unload_length));
               #if EXTRUDERS > 5
                 CONFIG_ECHO_START();
-                say_M603(PORTVAR_SOLO);
-                SERIAL_ECHOPAIR_P(port, "T5 L", LINEAR_UNIT(fc_settings[5].load_length));
-                SERIAL_ECHOLNPAIR_P(port, " U", LINEAR_UNIT(fc_settings[5].unload_length));
+                say_M603();
+                SERIAL_ECHOPAIR_P("T5 L", LINEAR_UNIT(fc_settings[5].load_length));
+                SERIAL_ECHOLNPAIR_P(" U", LINEAR_UNIT(fc_settings[5].unload_length));
               #endif // EXTRUDERS > 5
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -27,24 +27,14 @@
   #include "../HAL/shared/persistent_store_api.h"
 #endif
 
-#define ADD_PORT_ARG ENABLED(EEPROM_CHITCHAT) && NUM_SERIAL > 1
-
-#if ADD_PORT_ARG
-  #define PORTINIT_SOLO    const int8_t port=-1
-  #define PORTINIT_AFTER  ,const int8_t port=-1
-#else
-  #define PORTINIT_SOLO
-  #define PORTINIT_AFTER
-#endif
-
 class MarlinSettings {
   public:
     MarlinSettings() { }
 
     static uint16_t datasize();
 
-    static void reset(PORTINIT_SOLO);
-    static bool save(PORTINIT_SOLO);    // Return 'true' if data was saved
+    static void reset();
+    static bool save();    // Return 'true' if data was saved
 
     FORCE_INLINE static bool init_eeprom() {
       reset();
@@ -65,8 +55,8 @@ class MarlinSettings {
     #endif
 
     #if ENABLED(EEPROM_SETTINGS)
-      static bool load(PORTINIT_SOLO);      // Return 'true' if data was loaded ok
-      static bool validate(PORTINIT_SOLO);  // Return 'true' if EEPROM data is ok
+      static bool load();      // Return 'true' if data was loaded ok
+      static bool validate();  // Return 'true' if EEPROM data is ok
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
@@ -86,11 +76,7 @@ class MarlinSettings {
     #endif
 
     #if DISABLED(DISABLE_M503)
-      static void report(const bool forReplay=false
-        #if NUM_SERIAL > 1
-          , const int8_t port=-1
-        #endif
-      );
+      static void report(const bool forReplay=false);
     #else
       FORCE_INLINE
       static void report(const bool forReplay=false) { UNUSED(forReplay); }
@@ -109,12 +95,9 @@ class MarlinSettings {
                                           // live at the very end of the eeprom
       #endif
 
-      static bool _load(PORTINIT_SOLO);
-      static bool size_error(const uint16_t size PORTINIT_AFTER);
+      static bool _load();
+      static bool size_error(const uint16_t size);
     #endif
 };
 
 extern MarlinSettings settings;
-
-#undef PORTINIT_SOLO
-#undef PORTINIT_AFTER

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2506,8 +2506,8 @@ void Temperature::isr() {
       UNUSED(e);
     #endif
 
-    SERIAL_CHAR_P(' ');
-    SERIAL_CHAR_P(
+    SERIAL_CHAR(' ');
+    SERIAL_CHAR(
       #if HAS_TEMP_CHAMBER && HAS_HEATED_BED && HAS_TEMP_HOTEND
         e == -2 ? 'C' : e == -1 ? 'B' : 'T'
       #elif HAS_HEATED_BED && HAS_TEMP_HOTEND
@@ -2519,14 +2519,14 @@ void Temperature::isr() {
       #endif
     );
     #if HOTENDS > 1
-      if (e >= 0) SERIAL_CHAR_P('0' + e);
+      if (e >= 0) SERIAL_CHAR('0' + e);
     #endif
-    SERIAL_CHAR_P(':');
-    SERIAL_ECHO_P(c);
-    SERIAL_ECHOPAIR_P(" /" , t);
+    SERIAL_CHAR(':');
+    SERIAL_ECHO(c);
+    SERIAL_ECHOPAIR(" /" , t);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      SERIAL_ECHOPAIR_P(" (", r / OVERSAMPLENR);
-      SERIAL_CHAR_P(')');
+      SERIAL_ECHOPAIR(" (", r / OVERSAMPLENR);
+      SERIAL_CHAR(')');
     #endif
     delay(2);
   }
@@ -2572,17 +2572,17 @@ void Temperature::isr() {
         , e
       );
     #endif
-    SERIAL_ECHOPGM_P(" @:");
-    SERIAL_ECHO_P(getHeaterPower(target_extruder));
+    SERIAL_ECHOPGM(" @:");
+    SERIAL_ECHO(getHeaterPower(target_extruder));
     #if HAS_HEATED_BED
-      SERIAL_ECHOPGM_P(" B@:");
-      SERIAL_ECHO_P(getHeaterPower(-1));
+      SERIAL_ECHOPGM(" B@:");
+      SERIAL_ECHO(getHeaterPower(-1));
     #endif
     #if HOTENDS > 1
       HOTEND_LOOP() {
-        SERIAL_ECHOPAIR_P(" @", e);
-        SERIAL_CHAR_P(':');
-        SERIAL_ECHO_P(getHeaterPower(e));
+        SERIAL_ECHOPAIR(" @", e);
+        SERIAL_CHAR(':');
+        SERIAL_ECHO(getHeaterPower(e));
       }
     #endif
   }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2500,17 +2500,14 @@ void Temperature::isr() {
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       , const float r
     #endif
-    #if NUM_SERIAL > 1
-      , const int8_t port=-1
-    #endif
     , const int8_t e=-3
   ) {
     #if !(HAS_HEATED_BED && HAS_TEMP_HOTEND && HAS_TEMP_CHAMBER) && HOTENDS <= 1
       UNUSED(e);
     #endif
 
-    SERIAL_CHAR_P(port, ' ');
-    SERIAL_CHAR_P(port,
+    SERIAL_CHAR_P(' ');
+    SERIAL_CHAR_P(
       #if HAS_TEMP_CHAMBER && HAS_HEATED_BED && HAS_TEMP_HOTEND
         e == -2 ? 'C' : e == -1 ? 'B' : 'T'
       #elif HAS_HEATED_BED && HAS_TEMP_HOTEND
@@ -2522,23 +2519,19 @@ void Temperature::isr() {
       #endif
     );
     #if HOTENDS > 1
-      if (e >= 0) SERIAL_CHAR_P(port, '0' + e);
+      if (e >= 0) SERIAL_CHAR_P('0' + e);
     #endif
-    SERIAL_CHAR_P(port, ':');
-    SERIAL_ECHO_P(port, c);
-    SERIAL_ECHOPAIR_P(port, " /" , t);
+    SERIAL_CHAR_P(':');
+    SERIAL_ECHO_P(c);
+    SERIAL_ECHOPAIR_P(" /" , t);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      SERIAL_ECHOPAIR_P(port, " (", r / OVERSAMPLENR);
-      SERIAL_CHAR_P(port, ')');
+      SERIAL_ECHOPAIR_P(" (", r / OVERSAMPLENR);
+      SERIAL_CHAR_P(')');
     #endif
     delay(2);
   }
 
-  void Temperature::print_heater_states(const uint8_t target_extruder
-    #if NUM_SERIAL > 1
-      , const int8_t port
-    #endif
-  ) {
+  void Temperature::print_heater_states(const uint8_t target_extruder) {
     #if HAS_TEMP_HOTEND
       print_heater_state(degHotend(target_extruder), degTargetHotend(target_extruder)
         #if ENABLED(SHOW_TEMP_ADC_VALUES)
@@ -2579,17 +2572,17 @@ void Temperature::isr() {
         , e
       );
     #endif
-    SERIAL_ECHOPGM_P(port, " @:");
-    SERIAL_ECHO_P(port, getHeaterPower(target_extruder));
+    SERIAL_ECHOPGM_P(" @:");
+    SERIAL_ECHO_P(getHeaterPower(target_extruder));
     #if HAS_HEATED_BED
-      SERIAL_ECHOPGM_P(port, " B@:");
-      SERIAL_ECHO_P(port, getHeaterPower(-1));
+      SERIAL_ECHOPGM_P(" B@:");
+      SERIAL_ECHO_P(getHeaterPower(-1));
     #endif
     #if HOTENDS > 1
       HOTEND_LOOP() {
-        SERIAL_ECHOPAIR_P(port, " @", e);
-        SERIAL_CHAR_P(port, ':');
-        SERIAL_ECHO_P(port, getHeaterPower(e));
+        SERIAL_ECHOPAIR_P(" @", e);
+        SERIAL_CHAR_P(':');
+        SERIAL_ECHO_P(getHeaterPower(e));
       }
     #endif
   }

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -672,11 +672,7 @@ class Temperature {
     #endif // HEATER_IDLE_HANDLER
 
     #if HAS_TEMP_SENSOR
-      static void print_heater_states(const uint8_t target_extruder
-        #if NUM_SERIAL > 1
-          , const int8_t port = -1
-        #endif
-      );
+      static void print_heater_states(const uint8_t target_extruder);
       #if ENABLED(AUTO_REPORT_TEMPERATURES)
         static uint8_t auto_report_temp_interval;
         static millis_t next_temp_report_ms;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -191,9 +191,9 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
       SdFile dir;
       if (!dir.open(&parent, dosFilename, O_READ)) {
         if (lsAction == LS_SerialPrint) {
-          SERIAL_ECHO_START_P();
-          SERIAL_ECHOPGM_P(MSG_SD_CANT_OPEN_SUBDIR);
-          SERIAL_ECHOLN_P(dosFilename);
+          SERIAL_ECHO_START();
+          SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
+          SERIAL_ECHOLN(dosFilename);
         }
       }
       lsDive(path, dir);
@@ -218,10 +218,10 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
         case LS_SerialPrint:
           createFilename(filename, p);
-          if (prepend) SERIAL_ECHO_P(prepend);
-          SERIAL_ECHO_P(filename);
-          SERIAL_CHAR_P(' ');
-          SERIAL_ECHOLN_P(p.fileSize);
+          if (prepend) SERIAL_ECHO(prepend);
+          SERIAL_ECHO(filename);
+          SERIAL_CHAR(' ');
+          SERIAL_ECHOLN(p.fileSize);
           break;
 
         case LS_GetFilename:
@@ -254,7 +254,7 @@ void CardReader::ls() {
 
     int i, pathLen = strlen(path);
 
-    // SERIAL_ECHOPGM_P("Full Path: "); SERIAL_ECHOLN_P(path);
+    // SERIAL_ECHOPGM("Full Path: "); SERIAL_ECHOLN(path);
 
     // Zero out slashes to make segments
     for (i = 0; i < pathLen; i++) if (path[i] == '/') path[i] = '\0';
@@ -272,28 +272,28 @@ void CardReader::ls() {
       // Go to the next segment
       while (path[++i]) { }
 
-      // SERIAL_ECHOPGM_P("Looking for segment: "); SERIAL_ECHOLN_P(segment);
+      // SERIAL_ECHOPGM("Looking for segment: "); SERIAL_ECHOLN(segment);
 
       // Find the item, setting the long filename
       diveDir.rewind();
       lsDive(NULL, diveDir, segment);
 
       // Print /LongNamePart to serial output
-      SERIAL_CHAR_P('/');
-      SERIAL_ECHO_P(longFilename[0] ? longFilename : "???");
+      SERIAL_CHAR('/');
+      SERIAL_ECHO(longFilename[0] ? longFilename : "???");
 
       // If the filename was printed then that's it
       if (!flag.filenameIsDir) break;
 
-      // SERIAL_ECHOPGM_P("Opening dir: "); SERIAL_ECHOLN_P(segment);
+      // SERIAL_ECHOPGM("Opening dir: "); SERIAL_ECHOLN(segment);
 
       // Open the sub-item as the new dive parent
       SdFile dir;
       if (!dir.open(&diveDir, segment, O_READ)) {
-        SERIAL_EOL_P();
-        SERIAL_ECHO_START_P();
-        SERIAL_ECHOPGM_P(MSG_SD_CANT_OPEN_SUBDIR);
-        SERIAL_ECHO_P(segment);
+        SERIAL_EOL();
+        SERIAL_ECHO_START();
+        SERIAL_ECHOPGM(MSG_SD_CANT_OPEN_SUBDIR);
+        SERIAL_ECHO(segment);
         break;
       }
 
@@ -302,7 +302,7 @@ void CardReader::ls() {
 
     } // while i<pathLen
 
-    SERIAL_EOL_P();
+    SERIAL_EOL();
   }
 
 #endif // LONG_FILENAME_HOST_SUPPORT
@@ -314,19 +314,19 @@ void CardReader::printFilename() {
   if (file.isOpen()) {
     char dosFilename[FILENAME_LENGTH];
     file.getFilename(dosFilename);
-    SERIAL_ECHO_P(dosFilename);
+    SERIAL_ECHO(dosFilename);
     #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
       getfilename(0, dosFilename);
       if (longFilename[0]) {
-        SERIAL_ECHO_P(' ');
-        SERIAL_ECHO_P(longFilename);
+        SERIAL_ECHO(' ');
+        SERIAL_ECHO(longFilename);
       }
     #endif
   }
   else
-    SERIAL_ECHOPGM_P("(no file)");
+    SERIAL_ECHOPGM("(no file)");
 
-  SERIAL_EOL_P();
+  SERIAL_EOL();
 }
 
 void CardReader::initsd() {
@@ -528,13 +528,13 @@ void CardReader::removeFile(const char * const name) {
 
 void CardReader::report_status() {
   if (isPrinting()) {
-    SERIAL_ECHOPGM_P(MSG_SD_PRINTING_BYTE);
-    SERIAL_ECHO_P(sdpos);
-    SERIAL_CHAR_P('/');
-    SERIAL_ECHOLN_P(filesize);
+    SERIAL_ECHOPGM(MSG_SD_PRINTING_BYTE);
+    SERIAL_ECHO(sdpos);
+    SERIAL_CHAR('/');
+    SERIAL_ECHOLN(filesize);
   }
   else
-    SERIAL_ECHOLNPGM_P(MSG_SD_NOT_PRINTING);
+    SERIAL_ECHOLNPGM(MSG_SD_NOT_PRINTING);
 }
 
 void CardReader::write_command(char *buf) {

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -51,10 +51,8 @@ card_flags_t CardReader::flag;
 char CardReader::filename[FILENAME_LENGTH], CardReader::longFilename[LONG_FILENAME_LENGTH];
 int8_t CardReader::autostart_index;
 
-#if ENABLED(FAST_FILE_TRANSFER)
-  #if NUM_SERIAL > 1
-    uint8_t CardReader::transfer_port;
-  #endif
+#if ENABLED(FAST_FILE_TRANSFER) && NUM_SERIAL > 1
+  int8_t CardReader::transfer_port;
 #endif
 
 // private:
@@ -160,11 +158,7 @@ char *createFilename(char *buffer, const dir_t &p) {
 
 uint16_t nrFile_index;
 
-void CardReader::lsDive(const char *prepend, SdFile parent, const char * const match/*=NULL*/
-  #if NUM_SERIAL > 1
-    , const int8_t port/*= -1*/
-  #endif
-) {
+void CardReader::lsDive(const char *prepend, SdFile parent, const char * const match/*=NULL*/) {
   dir_t p;
   uint8_t cnt = 0;
 
@@ -197,16 +191,12 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
       SdFile dir;
       if (!dir.open(&parent, dosFilename, O_READ)) {
         if (lsAction == LS_SerialPrint) {
-          SERIAL_ECHO_START_P(port);
-          SERIAL_ECHOPGM_P(port, MSG_SD_CANT_OPEN_SUBDIR);
-          SERIAL_ECHOLN_P(port, dosFilename);
+          SERIAL_ECHO_START_P();
+          SERIAL_ECHOPGM_P(MSG_SD_CANT_OPEN_SUBDIR);
+          SERIAL_ECHOLN_P(dosFilename);
         }
       }
-      lsDive(path, dir
-        #if NUM_SERIAL > 1
-          , NULL, port
-        #endif
-      );
+      lsDive(path, dir);
       // close() is done automatically by destructor of SdFile
     }
     else {
@@ -228,10 +218,10 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
         case LS_SerialPrint:
           createFilename(filename, p);
-          if (prepend) SERIAL_ECHO_P(port, prepend);
-          SERIAL_ECHO_P(port, filename);
-          SERIAL_CHAR_P(port, ' ');
-          SERIAL_ECHOLN_P(port, p.fileSize);
+          if (prepend) SERIAL_ECHO_P(prepend);
+          SERIAL_ECHO_P(filename);
+          SERIAL_CHAR_P(' ');
+          SERIAL_ECHOLN_P(p.fileSize);
           break;
 
         case LS_GetFilename:
@@ -248,18 +238,10 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
   } // while readDir
 }
 
-void CardReader::ls(
-  #if NUM_SERIAL > 1
-    const int8_t port
-  #endif
-) {
+void CardReader::ls() {
   lsAction = LS_SerialPrint;
   root.rewind();
-  lsDive(NULL, root
-    #if NUM_SERIAL > 1
-      , NULL, port
-    #endif
-  );
+  lsDive(NULL, root);
 }
 
 #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
@@ -267,16 +249,12 @@ void CardReader::ls(
   /**
    * Get a long pretty path based on a DOS 8.3 path
    */
-  void CardReader::printLongPath(char *path
-    #if NUM_SERIAL > 1
-      , const int8_t port/*= -1*/
-    #endif
-  ) {
+  void CardReader::printLongPath(char *path) {
     lsAction = LS_GetFilename;
 
     int i, pathLen = strlen(path);
 
-    // SERIAL_ECHOPGM_P(port, "Full Path: "); SERIAL_ECHOLN_P(port, path);
+    // SERIAL_ECHOPGM_P("Full Path: "); SERIAL_ECHOLN_P(path);
 
     // Zero out slashes to make segments
     for (i = 0; i < pathLen; i++) if (path[i] == '/') path[i] = '\0';
@@ -294,32 +272,28 @@ void CardReader::ls(
       // Go to the next segment
       while (path[++i]) { }
 
-      // SERIAL_ECHOPGM_P(port, "Looking for segment: "); SERIAL_ECHOLN_P(port, segment);
+      // SERIAL_ECHOPGM_P("Looking for segment: "); SERIAL_ECHOLN_P(segment);
 
       // Find the item, setting the long filename
       diveDir.rewind();
-      lsDive(NULL, diveDir, segment
-        #if NUM_SERIAL > 1
-          , port
-        #endif
-      );
+      lsDive(NULL, diveDir, segment);
 
       // Print /LongNamePart to serial output
-      SERIAL_CHAR_P(port, '/');
-      SERIAL_ECHO_P(port, longFilename[0] ? longFilename : "???");
+      SERIAL_CHAR_P('/');
+      SERIAL_ECHO_P(longFilename[0] ? longFilename : "???");
 
       // If the filename was printed then that's it
       if (!flag.filenameIsDir) break;
 
-      // SERIAL_ECHOPGM_P(port, "Opening dir: "); SERIAL_ECHOLN_P(port, segment);
+      // SERIAL_ECHOPGM_P("Opening dir: "); SERIAL_ECHOLN_P(segment);
 
       // Open the sub-item as the new dive parent
       SdFile dir;
       if (!dir.open(&diveDir, segment, O_READ)) {
-        SERIAL_EOL_P(port);
-        SERIAL_ECHO_START_P(port);
-        SERIAL_ECHOPGM_P(port, MSG_SD_CANT_OPEN_SUBDIR);
-        SERIAL_ECHO_P(port, segment);
+        SERIAL_EOL_P();
+        SERIAL_ECHO_START_P();
+        SERIAL_ECHOPGM_P(MSG_SD_CANT_OPEN_SUBDIR);
+        SERIAL_ECHO_P(segment);
         break;
       }
 
@@ -328,7 +302,7 @@ void CardReader::ls(
 
     } // while i<pathLen
 
-    SERIAL_EOL_P(port);
+    SERIAL_EOL_P();
   }
 
 #endif // LONG_FILENAME_HOST_SUPPORT
@@ -336,27 +310,23 @@ void CardReader::ls(
 /**
  * Echo the DOS 8.3 filename (and long filename, if any)
  */
-void CardReader::printFilename(
-  #if NUM_SERIAL > 1
-    const int8_t port/*= -1*/
-  #endif
-) {
+void CardReader::printFilename() {
   if (file.isOpen()) {
     char dosFilename[FILENAME_LENGTH];
     file.getFilename(dosFilename);
-    SERIAL_ECHO_P(port, dosFilename);
+    SERIAL_ECHO_P(dosFilename);
     #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
       getfilename(0, dosFilename);
       if (longFilename[0]) {
-        SERIAL_ECHO_P(port, ' ');
-        SERIAL_ECHO_P(port, longFilename);
+        SERIAL_ECHO_P(' ');
+        SERIAL_ECHO_P(longFilename);
       }
     #endif
   }
   else
-    SERIAL_ECHOPGM_P(port, "(no file)");
+    SERIAL_ECHOPGM_P("(no file)");
 
-  SERIAL_EOL_P(port);
+  SERIAL_EOL_P();
 }
 
 void CardReader::initsd() {
@@ -556,19 +526,15 @@ void CardReader::removeFile(const char * const name) {
   }
 }
 
-void CardReader::report_status(
-  #if NUM_SERIAL > 1
-    const int8_t port/*= -1*/
-  #endif
-) {
+void CardReader::report_status() {
   if (isPrinting()) {
-    SERIAL_ECHOPGM_P(port, MSG_SD_PRINTING_BYTE);
-    SERIAL_ECHO_P(port, sdpos);
-    SERIAL_CHAR_P(port, '/');
-    SERIAL_ECHOLN_P(port, filesize);
+    SERIAL_ECHOPGM_P(MSG_SD_PRINTING_BYTE);
+    SERIAL_ECHO_P(sdpos);
+    SERIAL_CHAR_P('/');
+    SERIAL_ECHOLN_P(filesize);
   }
   else
-    SERIAL_ECHOLNPGM_P(port, MSG_SD_NOT_PRINTING);
+    SERIAL_ECHOLNPGM_P(MSG_SD_NOT_PRINTING);
 }
 
 void CardReader::write_command(char *buf) {
@@ -1038,18 +1004,15 @@ void CardReader::printingHasFinished() {
   uint8_t CardReader::auto_report_sd_interval = 0;
   millis_t CardReader::next_sd_report_ms;
   #if NUM_SERIAL > 1
-    int8_t CardReader::serialport;
+    int8_t CardReader::auto_report_port;
   #endif
 
   void CardReader::auto_report_sd_status() {
     millis_t current_ms = millis();
     if (auto_report_sd_interval && ELAPSED(current_ms, next_sd_report_ms)) {
       next_sd_report_ms = current_ms + 1000UL * auto_report_sd_interval;
-      report_status(
-        #if NUM_SERIAL > 1
-          serialport
-        #endif
-      );
+      PORT_REDIRECT(auto_report_port);
+      report_status();
     }
   }
 #endif // AUTO_REPORT_SD_STATUS

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -70,24 +70,12 @@ public:
       const bool re_sort=false
     #endif
   );
-  static void report_status(
-    #if NUM_SERIAL > 1
-      const int8_t port = -1
-    #endif
-  );
+  static void report_status();
   static void printingHasFinished();
-  static void printFilename(
-    #if NUM_SERIAL > 1
-      const int8_t port = -1
-    #endif
-  );
+  static void printFilename();
 
   #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
-    static void printLongPath(char *path
-      #if NUM_SERIAL > 1
-        , const int8_t port = -1
-      #endif
-    );
+    static void printLongPath(char *path);
   #endif
 
   static void getfilename(uint16_t nr, const char* const match=NULL);
@@ -95,11 +83,7 @@ public:
 
   static void getAbsFilename(char *t);
 
-  static void ls(
-    #if NUM_SERIAL > 1
-      const int8_t port = -1
-    #endif
-  );
+  static void ls();
   static void chdir(const char *relpath);
   static int8_t updir();
   static void setroot();
@@ -144,13 +128,9 @@ public:
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)
     static void auto_report_sd_status(void);
-    static inline void set_auto_report_interval(uint8_t v
+    static inline void set_auto_report_interval(const uint8_t v) {
       #if NUM_SERIAL > 1
-        , int8_t port
-      #endif
-    ) {
-      #if NUM_SERIAL > 1
-        serialport = port;
+        auto_report_port = serial_port_index;
       #endif
       NOMORE(v, 60);
       auto_report_sd_interval = v;
@@ -167,9 +147,9 @@ public:
 
   #if ENABLED(FAST_FILE_TRANSFER)
     #if NUM_SERIAL > 1
-      static uint8_t transfer_port;
+      static int8_t transfer_port;
     #else
-      static constexpr uint8_t transfer_port = 0;
+      static constexpr int8_t transfer_port = SERIAL_PORT;
     #endif
   #endif
 
@@ -244,11 +224,7 @@ private:
   static LsAction lsAction; //stored for recursion.
   static uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
   static char *diveDirName;
-  static void lsDive(const char *prepend, SdFile parent, const char * const match=NULL
-    #if NUM_SERIAL > 1
-      , const int8_t port = -1
-    #endif
-  );
+  static void lsDive(const char *prepend, SdFile parent, const char * const match=NULL);
 
   #if ENABLED(SDCARD_SORT_ALPHA)
     static void flush_presort();
@@ -258,7 +234,7 @@ private:
     static uint8_t auto_report_sd_interval;
     static millis_t next_sd_report_ms;
     #if NUM_SERIAL > 1
-      static int8_t serialport;
+      static int8_t auto_report_port;
     #endif
   #endif
 };


### PR DESCRIPTION
**Background:** The current system of serial port redirection could be better. We currently support the second serial port using an argument passed to the serial output functions, and a `port` argument conditionally added to various functions throughout the codebase. This is unwieldy to maintain and doesn't scale for the kind of output flow control we need.

**Solution:** This PR adds a `serial_port_index` global to the `serial.*` code to indicate which serial port is currently being used for output.

To do serial redirection we now use the `PORT_REDIRECT` macro to remember and set the serial port index. All serial (`_P` variant) output done within the scope of the `PORT_REDIRECT` will go to the selected port.

The previous serial port will be automatically restored as soon as the `PORT_REDIRECT` goes out of scope. Under this scheme, even interrupt code can use `PORT_REDIRECT` — indeed, now it must.

Under this scheme, any serial output that isn't specifically redirected will go to the default serial output. The exception is serial output within a G-code handler. All G-code serial output is redirected to the serial port that invoked the G-code. If the G-code comes from a non-serial port source, its output will go to the default serial output (`SERIAL_PORT`).

After the initial commit passes Travis CI, I propose to unify the serial functions so that all serial output follows the redirect methodology. Currently, only the serial output that uses the `_P` functions is redirected. With the redirect in place, I don't think this is needed any more. If something very much needs to go to the default serial output, `PORT_REDIRECT(SERIAL_PORT)` will do that.

Reference: #13088