### PR TITLE
Z auto level for two steppers and negative Z corrections

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -420,8 +420,13 @@
 //#define Z_STEPPER_AUTO_ALIGN
 #if ENABLED(Z_STEPPER_AUTO_ALIGN)
   // Define probe X and Y positions for Z1, Z2 [, Z3]
-  #define Z_STEPPER_ALIGN_X { 10, 150, 290 }
-  #define Z_STEPPER_ALIGN_Y { 290, 10, 290 }
+  #if Z_STEPPER_COUNT > 2
+    #define Z_STEPPER_ALIGN_X { 10, 150, 290 }
+    #define Z_STEPPER_ALIGN_Y { 290, 10, 290 }
+  #else
+    #define Z_STEPPER_ALIGN_X { 290, 10 }
+    #define Z_STEPPER_ALIGN_Y { 150, 150 }
+  #endif
   // Set number of iterations to align
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -420,13 +420,8 @@
 //#define Z_STEPPER_AUTO_ALIGN
 #if ENABLED(Z_STEPPER_AUTO_ALIGN)
   // Define probe X and Y positions for Z1, Z2 [, Z3]
-  #if Z_STEPPER_COUNT > 2
-    #define Z_STEPPER_ALIGN_X { 10, 150, 290 }
-    #define Z_STEPPER_ALIGN_Y { 290, 10, 290 }
-  #else
-    #define Z_STEPPER_ALIGN_X { 290, 10 }
-    #define Z_STEPPER_ALIGN_Y { 150, 150 }
-  #endif
+  #define Z_STEPPER_ALIGN_X { 10, 150, 290 }
+  #define Z_STEPPER_ALIGN_Y { 290, 10, 290 }
   // Set number of iterations to align
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -88,7 +88,7 @@ void GcodeSuite::G34() {
     }
 
     const float z_auto_align_amplification = parser.floatval('A', Z_STEPPER_ALIGN_AMP);
-    if (!WITHIN(z_auto_align_amplification, 0.5f, 2.0f)) {
+    if (!WITHIN(ABS(z_auto_align_amplification), 0.5f, 2.0f)) {
       SERIAL_ECHOLNPGM("?(A)mplification out of bounds (0.5-2.0).");
       break;
     }
@@ -137,7 +137,7 @@ void GcodeSuite::G34() {
       // For each iteration go through all probe positions (one per Z-Stepper)
       for (uint8_t zstepper = 0; zstepper < Z_STEPPER_COUNT; ++zstepper) {
         // Probe a Z height for each stepper
-        z_measured[zstepper] = probe_pt(z_auto_align_xpos[zstepper], z_auto_align_ypos[zstepper], PROBE_PT_RAISE, false);
+        z_measured[zstepper] = probe_pt(z_auto_align_xpos[zstepper], z_auto_align_ypos[zstepper], PROBE_PT_RAISE, 0, false);
 
         // Stop on error
         if (isnan(z_measured[zstepper])) {


### PR DESCRIPTION
Corrected for a COREXY configuration with two stepper drivers.

corrected

Signed-off-by: Bruce Beare <bbeare1@gmail.com>

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The Z_STEPPER_AUTO_ALIGN makes some assumptions about which Z stepper to be compensated. It can choose incorrectly depending on printer design such as a COREXY. The solution is to allow the multiplier to be negative.

Additionally, we fix the configuration file to build correctly for a DUAL_Z setup.

### Benefits

Z_STEPPER_AUTO_ALIGN now work for both DUAL and TRIPLE Z steppers (not tested for Triple) as well as for COREXY configurations.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
