### PR TITLE
[2.0.x] HAL_STM32 - Change include order to make SERIAL_PORT_2 work

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -42,8 +42,6 @@
 #include "fastio_STM32.h"
 #include "watchdog_STM32.h"
 
-#include "HAL_timers_STM32.h"
-
 // --------------------------------------------------------------------------
 // Defines
 // --------------------------------------------------------------------------
@@ -100,6 +98,8 @@
 #else
   #define NUM_SERIAL 1
 #endif
+
+#include "HAL_timers_STM32.h"
 
 /**
  * TODO: review this to return 1 for pins that are not analog input


### PR DESCRIPTION
### Description

The change in PR #12874 breaks the use of two serial ports (USB + UART for example) on HAL_STM32 because `SanityCheck.h` is included before the the `MYSERIAL / NUM_SERIAL` definitions in `STM32\HAL.h`. `SanityCheck.h` is included from `../../inc/MarlinConfig.h` which is included from `HAL_timers_STM32.h` with the change in PR #12874.

This is fixed by changing the include order of `HAL_timers_STM32.h` in `STM32\HAL.h` so that it is included after the `MYSERIAL` and `NUM_SERIAL` definitions.

### Benefits

`SERIAL_PORT_2` now works. 
