### PR TITLE
Revert a part from commit 562f2321d282eb16d538e6098b0155e0d91e7e4a

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -137,7 +137,7 @@ void GcodeSuite::G34() {
       // For each iteration go through all probe positions (one per Z-Stepper)
       for (uint8_t zstepper = 0; zstepper < Z_STEPPER_COUNT; ++zstepper) {
         // Probe a Z height for each stepper
-        z_measured[zstepper] = probe_pt(z_auto_align_xpos[zstepper], z_auto_align_ypos[zstepper], PROBE_PT_RAISE, 0, false);
+        z_measured[zstepper] = probe_pt(z_auto_align_xpos[zstepper], z_auto_align_ypos[zstepper], PROBE_PT_RAISE, false);
 
         // Stop on error
         if (isnan(z_measured[zstepper])) {


### PR DESCRIPTION
 -  When using G34, the nozzle is set in X/Y instead of the Probe.

### Requirements

* Need to have enable these:

Dual Z with dual steppers.

```
  - Z_DUAL_STEPPER_DRIVERS
  - Z_STEPPER_AUTO_ALIGN 
  - Z_STEPPER_ALIGN_X { 10, 175 }
  - Z_STEPPER_ALIGN_Y { 100, 100 }

  - X_PROBE_OFFSET_FROM_EXTRUDER -25  // X offset: -left  +right  [of the nozzle]
     Y_PROBE_OFFSET_FROM_EXTRUDER -37  // Y offset: -front +behind [the nozzle]
     Z_PROBE_OFFSET_FROM_EXTRUDER 0    // Z offset: -below +above  [the nozzle]

```

### Description

Since few days, when I'm using G34, the nozzle take place of the probe on the X position I have set for X. So my probe is out of the bed and G34 fails.

### Benefits

I revert a part of the  commit, to fix the issue :  [#13240](https://github.com/MarlinFirmware/Marlin/pull/13240/commits/85f9d6c4954d13fea670c75c6cfae57197121753) 

### Related Issues

