### PR TITLE
Support DGUS Display with DWIN OS

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -335,7 +335,7 @@
 #endif
 
 // Extensible UI serial touch screens. (See src/lcd/extensible_ui)
-#if ENABLED(MALYAN_LCD)
+#if EITHER(DGUS_LCD, MALYAN_LCD)
   #define EXTENSIBLE_UI
 #endif
 

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
@@ -198,33 +198,33 @@ void DGUSScreenVariableHandler::setstatusmessagePGM(PGM_P const msg) {
   }
 }
 
-// Send a 8 bit or 16 bit value to the display.
-void DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &ref_to_this) {
-  if (ref_to_this.memadr) {
-    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
-    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
-    uint8_t *tmp = (uint8_t *) ref_to_this.memadr;
+// Send an 8 bit or 16 bit value to the display.
+void DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &var) {
+  if (var.memadr) {
+    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
+    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)var.memadr);
+    uint8_t *tmp = (uint8_t *) var.memadr;
     uint16_t data_to_send = (tmp[0] << 8);
-    if (ref_to_this.size >= 1) data_to_send |= tmp[1];
-    dgusdisplay.WriteVariable(ref_to_this.VP, data_to_send);
+    if (var.size >= 1) data_to_send |= tmp[1];
+    dgusdisplay.WriteVariable(var.VP, data_to_send);
   }
 }
 
 // Send an uint8_t between 0 and 255 to the display, but scale to a percentage (0..100)
-void DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &ref_to_this) {
-  if (ref_to_this.memadr) {
-    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
-    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
-    uint16_t tmp = *(uint8_t *) ref_to_this.memadr +1 ; // +1 -> avoid rounding issues for the display.
+void DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &var) {
+  if (var.memadr) {
+    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
+    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)var.memadr);
+    uint16_t tmp = *(uint8_t *) var.memadr +1 ; // +1 -> avoid rounding issues for the display.
     tmp = map(tmp, 0, 255, 0, 100);
     uint16_t data_to_send = swap16(tmp);
-    dgusdisplay.WriteVariable(ref_to_this.VP, data_to_send);
+    dgusdisplay.WriteVariable(var.VP, data_to_send);
   }
 }
 
 // Send the current print time to the display.
 // It is using a hex display for that: It expects BSD coded data in the format xxyyzz
-void DGUSScreenVariableHandler::DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &ref_to_this) {
+void DGUSScreenVariableHandler::DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &var) {
   duration_t elapsed = print_job_timer.duration();
 
   uint8_t days  = elapsed.day(),
@@ -240,41 +240,41 @@ void DGUSScreenVariableHandler::DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable 
   *p++ = seconds / 10 + '0'; *p++ = seconds % 10 + '0'; *p++ = 's';
   *p = '\0';
 
-  dgusdisplay.WriteVariable(VP_PrintTime, buf, ref_to_this.size, true);
+  dgusdisplay.WriteVariable(VP_PrintTime, buf, var.size, true);
 }
 
 
 
 // Send an uint8_t between 0 and 100 to a variable scale to 0..255
-void DGUSScreenVariableHandler::DGUSLCD_PercentageToUint8(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-  if (ref_to_this.memadr) {
-    uint16_t value = swap16(*(uint16_t*)ptr_to_new_value);
-    *(uint8_t*)ref_to_this.memadr = map(constrain(value, 0, 100), 0, 100, 0, 255);
+void DGUSScreenVariableHandler::DGUSLCD_PercentageToUint8(DGUS_VP_Variable &var, void *val_ptr) {
+  if (var.memadr) {
+    uint16_t value = swap16(*(uint16_t*)val_ptr);
+    *(uint8_t*)var.memadr = map(constrain(value, 0, 100), 0, 100, 0, 255);
   }
 }
 
 // Sends a (RAM located) string to the DGUS Display
 // (Note: The DGUS Display does not clear after the \0, you have to
-// overwrite the remainings with spaces.// ref_to_this.size has the display buffer size!
-void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(DGUS_VP_Variable &ref_to_this) {
-  char *tmp = (char*) ref_to_this.memadr;
-  dgusdisplay.WriteVariable(ref_to_this.VP, tmp, ref_to_this.size, true);
+// overwrite the remainings with spaces.// var.size has the display buffer size!
+void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(DGUS_VP_Variable &var) {
+  char *tmp = (char*) var.memadr;
+  dgusdisplay.WriteVariable(var.VP, tmp, var.size, true);
 }
 
 // Sends a (flash located) string to the DGUS Display
 // (Note: The DGUS Display does not clear after the \0, you have to
-// overwrite the remainings with spaces.// ref_to_this.size has the display buffer size!
-void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &ref_to_this) {
-  char *tmp = (char*) ref_to_this.memadr;
-  dgusdisplay.WriteVariablePGM(ref_to_this.VP, tmp, ref_to_this.size, true);
+// overwrite the remainings with spaces.// var.size has the display buffer size!
+void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &var) {
+  char *tmp = (char*) var.memadr;
+  dgusdisplay.WriteVariablePGM(var.VP, tmp, var.size, true);
 }
 
 #if ENABLED(SDSUPPORT)
 
-  void DGUSScreenVariableHandler::ScreenChangeHookIfSD(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  void DGUSScreenVariableHandler::ScreenChangeHookIfSD(DGUS_VP_Variable &var, void *val_ptr) {
     // default action executed when there is a SD card, but not printing
     if (ExtUI::isMediaInserted() && !ExtUI::isPrintingFromMedia()) {
-      ScreenChangeHook(ref_to_this, ptr_to_new_value);
+      ScreenChangeHook(var, val_ptr);
       dgusdisplay.RequestScreen(current_screen);
       return;
     }
@@ -298,9 +298,9 @@ void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable 
     }
   }
 
-  void DGUSScreenVariableHandler::DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable& ref_to_this, void *ptr_to_new_value) {
+  void DGUSScreenVariableHandler::DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable& var, void *val_ptr) {
     auto old_top = top_file;
-    int16_t scroll = (int16_t)swap16(*(uint16_t*)ptr_to_new_value);
+    int16_t scroll = (int16_t)swap16(*(uint16_t*)val_ptr);
     if (scroll == 0) {
       if (!filelist.isAtRootDir()) {
         filelist.upDir();
@@ -326,8 +326,8 @@ void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable 
     if (old_top != top_file) ForceCompleteUpdate();
   }
 
-  void DGUSScreenVariableHandler::DGUSLCD_SD_FileSelected(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-    uint16_t touched_nr = (int16_t)swap16(*(uint16_t*)ptr_to_new_value) + top_file;
+  void DGUSScreenVariableHandler::DGUSLCD_SD_FileSelected(DGUS_VP_Variable &var, void *val_ptr) {
+    uint16_t touched_nr = (int16_t)swap16(*(uint16_t*)val_ptr) + top_file;
     if (touched_nr > filelist.count()) return;
     if (!filelist.seek(touched_nr)) return;
     if (filelist.isDir()) {
@@ -342,15 +342,15 @@ void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable 
     HandleUserConfirmationPopUp(VP_SD_FileSelectConfirm, nullptr, PSTR("Print file"), filelist.filename(), PSTR("from SD Card?"), true, true, false, true);
   }
 
-  void DGUSScreenVariableHandler::DGUSLCD_SD_StartPrint(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  void DGUSScreenVariableHandler::DGUSLCD_SD_StartPrint(DGUS_VP_Variable &var, void *val_ptr) {
     if(!filelist.seek(file_to_print)) return;
     ExtUI::printFile(filelist.filename());
     ScreenHandler.GotoScreen(DGUSLCD_SCREEN_STATUS);
   }
 
-  void DGUSScreenVariableHandler::DGUSLCD_SD_ResumePauseAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  void DGUSScreenVariableHandler::DGUSLCD_SD_ResumePauseAbort(DGUS_VP_Variable &var, void *val_ptr) {
     if (!ExtUI::isPrintingFromMedia()) return; // avoid race condition when user stays in this menu and printer finishes.
-    switch (swap16(*(uint16_t*)ptr_to_new_value)) {
+    switch (swap16(*(uint16_t*)val_ptr)) {
       case 0:  // Resume
         if (ExtUI::isPrintingFromMediaPaused()) ExtUI::resumePrint();
         break;
@@ -363,19 +363,19 @@ void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable 
     }
   }
 
-  void DGUSScreenVariableHandler::DGUSLCD_SD_ReallyAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  void DGUSScreenVariableHandler::DGUSLCD_SD_ReallyAbort(DGUS_VP_Variable &var, void *val_ptr) {
     ExtUI::stopPrint();
     GotoScreen(DGUSLCD_SCREEN_MAIN);
   }
 
-  void DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename(DGUS_VP_Variable& ref_to_this) {
-    uint16_t target_line = (ref_to_this.VP - VP_SD_FileName0) / VP_SD_FileName_LEN;
+  void DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename(DGUS_VP_Variable& var) {
+    uint16_t target_line = (var.VP - VP_SD_FileName0) / VP_SD_FileName_LEN;
     if (target_line > DGUS_SD_FILESPERSCREEN) return;
     char tmpfilename[VP_SD_FileName_LEN + 1] = "";
-    ref_to_this.memadr = (void*)tmpfilename;
+    var.memadr = (void*)tmpfilename;
     if (filelist.seek(top_file + target_line))
       snprintf_P(tmpfilename, VP_SD_FileName_LEN, PSTR("%s%c"), filelist.filename(), filelist.isDir() ? '/' : 0);
-    DGUSLCD_SendStringToDisplay(ref_to_this);
+    DGUSLCD_SendStringToDisplay(var);
   }
 
 
@@ -402,10 +402,10 @@ void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable 
 
 #endif // SDSUPPORT
 
-void DGUSScreenVariableHandler::ScreenConfirmedOK(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+void DGUSScreenVariableHandler::ScreenConfirmedOK(DGUS_VP_Variable &var, void *val_ptr) {
   DGUS_VP_Variable ramcopy;
   if (!populate_VPVar(ConfirmVP, &ramcopy)) return;
-  if (ramcopy.set_by_display_handler) ramcopy.set_by_display_handler(ramcopy, ptr_to_new_value);
+  if (ramcopy.set_by_display_handler) ramcopy.set_by_display_handler(ramcopy, val_ptr);
 }
 
 const uint16_t* DGUSLCD_FindScreenVPMapList(uint8_t screen) {
@@ -431,15 +431,15 @@ const DGUS_VP_Variable* DGUSLCD_FindVPVar(const uint16_t vp) {
   return nullptr;
 }
 
-void DGUSScreenVariableHandler::ScreenChangeHookIfIdle(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+void DGUSScreenVariableHandler::ScreenChangeHookIfIdle(DGUS_VP_Variable &var, void *val_ptr) {
   if (!ExtUI::isPrinting()) {
-    ScreenChangeHook(ref_to_this, ptr_to_new_value);
+    ScreenChangeHook(var, val_ptr);
     dgusdisplay.RequestScreen(current_screen);
   }
 }
 
-void DGUSScreenVariableHandler::ScreenChangeHook(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-  uint8_t *tmp = (uint8_t*) ptr_to_new_value;
+void DGUSScreenVariableHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
+  uint8_t *tmp = (uint8_t*)val_ptr;
 
   // The keycode in target is coded as <from-frame><to-frame>, so 0x0100A means
   // from screen 1 (main) to 10 (temperature). DGUSLCD_SCREEN_POPUP is special,
@@ -460,16 +460,16 @@ void DGUSScreenVariableHandler::ScreenChangeHook(DGUS_VP_Variable &ref_to_this, 
   #endif
 }
 
-void DGUSScreenVariableHandler::HandleAllHeatersOff(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+void DGUSScreenVariableHandler::HandleAllHeatersOff(DGUS_VP_Variable &var, void *val_ptr) {
   thermalManager.disable_all_heaters();
   ScreenHandler.ForceCompleteUpdate(); // hint to send all data.
 }
 
-void DGUSScreenVariableHandler::HandleTemperatureChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-  uint16_t newvalue = swap16(*(uint16_t*) ptr_to_new_value);
+void DGUSScreenVariableHandler::HandleTemperatureChanged(DGUS_VP_Variable &var, void *val_ptr) {
+  uint16_t newvalue = swap16(*(uint16_t*)val_ptr);
   uint16_t acceptedvalue;
 
-  switch (ref_to_this.VP) {
+  switch (var.VP) {
     default: return;
     #if HOTENDS >= 1
       case VP_T_E1_Set:
@@ -492,14 +492,14 @@ void DGUSScreenVariableHandler::HandleTemperatureChanged(DGUS_VP_Variable &ref_t
   }
 
   // reply to display the new value to update the view if the new value was rejected by the Thermal Manager.
-  if (newvalue != acceptedvalue && ref_to_this.send_to_display_handler) ref_to_this.send_to_display_handler(ref_to_this);
-  ScreenHandler.skipVP = ref_to_this.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
+  if (newvalue != acceptedvalue && var.send_to_display_handler) var.send_to_display_handler(var);
+  ScreenHandler.skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
-void DGUSScreenVariableHandler::HandleFlowRateChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-  uint16_t newvalue = swap16(*(uint16_t*) ptr_to_new_value);
+void DGUSScreenVariableHandler::HandleFlowRateChanged(DGUS_VP_Variable &var, void *val_ptr) {
+  uint16_t newvalue = swap16(*(uint16_t*)val_ptr);
   uint8_t target_extruder;
-  switch (ref_to_this.VP) {
+  switch (var.VP) {
     default: return;
     #if (HOTENDS >= 1)
       case VP_Flowrate_E1: target_extruder = 0; break;
@@ -511,17 +511,17 @@ void DGUSScreenVariableHandler::HandleFlowRateChanged(DGUS_VP_Variable &ref_to_t
 
   planner.flow_percentage[target_extruder] = newvalue;
   planner.refresh_e_factor(target_extruder);
-  ScreenHandler.skipVP = ref_to_this.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
+  ScreenHandler.skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
 }
 
-void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &var, void *val_ptr) {
   DEBUG_ECHOLNPGM("HandleManualMove");
 
-  int16_t movevalue = swap16(*(uint16_t*) ptr_to_new_value);
+  int16_t movevalue = swap16(*(uint16_t*)val_ptr);
   float target = movevalue * 0.01f;
   ExtUI::extruder_t target_extruder;
 
-  switch (ref_to_this.VP) {
+  switch (var.VP) {
     #if HOTENDS >=1
       case VP_MOVE_E1: target_extruder = ExtUI::extruder_t::E0; break;
     #endif
@@ -533,17 +533,17 @@ void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &ref_to_thi
 
   target += ExtUI::getAxisPosition_mm(target_extruder);
   ExtUI::setAxisPosition_mm(target, target_extruder);
-  skipVP = ref_to_this.VP;
+  skipVP = var.VP;
 }
 
-void DGUSScreenVariableHandler::HandleManualMove(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+void DGUSScreenVariableHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   DEBUG_ECHOLNPGM("HandleManualMove");
 
-  int16_t movevalue = swap16(*(uint16_t*) ptr_to_new_value);
+  int16_t movevalue = swap16(*(uint16_t*)val_ptr);
   char axiscode;
   unsigned int speed = 1500;  //FIXME: get default feedrate for manual moves, dont hardcode.
 
-  switch (ref_to_this.VP) {
+  switch (var.VP) {
     case VP_MOVE_X:
       axiscode = 'X';
       if (!ExtUI::canMove(ExtUI::axis_t::X)) goto cannotmove;

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
@@ -1,0 +1,1132 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* DGUS implementation written by coldtobi in 2019 for Marlin */
+
+#include "../../../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DGUS_LCD)
+
+#include "DGUSDisplay.h"
+#include "DGUSVPVariable.h"
+#include "DGUSDisplayDefinition.h"
+
+#include "../../ui_api.h"
+
+#include "../../../../Marlin.h"
+#include "../../../../module/temperature.h"
+#include "../../../../module/motion.h"
+#include "../../../../gcode/queue.h"
+#include "../../../../module/planner.h"
+#include "../../../../sd/cardreader.h"
+#include "../../../../libs/duration_t.h"
+#include "../../../../module/printcounter.h"
+
+// Preamble... 2 Bytes, usually 0x5A 0xA5, but configurable
+constexpr uint8_t DGUS_HEADER1 = 0x5A;
+constexpr uint8_t DGUS_HEADER2 = 0xA5;
+
+constexpr uint8_t DGUS_CMD_WRITEVAR = 0x82;
+constexpr uint8_t DGUS_CMD_READVAR = 0x83;
+
+#if ENABLED(DEBUG_DGUSLCD)
+  bool dguslcd_local_debug; // = false;
+#endif
+
+uint16_t DGUSScreenVariableHandler::ConfirmVP;
+
+#if ENABLED(SDSUPPORT)
+  int16_t DGUSScreenVariableHandler::top_file = 0;
+  int16_t DGUSScreenVariableHandler::file_to_print = 0;
+  static ExtUI::FileList filelist;
+#endif
+
+void (*DGUSScreenVariableHandler::confirmaction_cb)() = nullptr;
+
+//DGUSScreenVariableHandler ScreenHandler;
+
+DGUSLCD_Screens DGUSScreenVariableHandler::current_screen;
+DGUSLCD_Screens DGUSScreenVariableHandler::past_screens[NUM_PAST_SCREENS];
+uint8_t DGUSScreenVariableHandler::update_ptr;
+uint16_t DGUSScreenVariableHandler::skipVP;
+bool DGUSScreenVariableHandler::ScreenComplete;
+
+//DGUSDisplay dgusdisplay;
+
+rx_datagram_state_t DGUSDisplay::rx_datagram_state = DGUS_IDLE;
+uint8_t DGUSDisplay::rx_datagram_len = 0;
+bool DGUSDisplay::Initialized = false;
+bool DGUSDisplay::no_reentrance = false;
+
+#if DGUS_RX_BUFFER_SIZE > 256
+  typedef uint16_t r_ring_buffer_pos_t;
+#else
+  typedef uint8_t r_ring_buffer_pos_t;
+#endif
+
+#if DGUS_TX_BUFFER_SIZE > 256
+  typedef uint16_t t_ring_buffer_pos_t;
+#else
+  typedef uint8_t t_ring_buffer_pos_t;
+#endif
+
+class DGUSSerial {
+public:
+  DGUSSerial();
+  ~DGUSSerial();
+
+  r_ring_buffer_pos_t available();
+  t_ring_buffer_pos_t GetTxBufferFree();
+  void write(const uint8_t c);
+
+  int read();
+
+  // ISR for Rx
+  void store_rxd_char();
+  // ISR for Tx (UDRE vector)
+  void tx_udr_empty_irq(void);
+
+  inline volatile bool is_rx_overrun() {
+    return dgus_rx_overrun;
+  }
+
+  inline void reset_rx_overun() {
+    dgus_rx_overrun = false;
+  }
+
+private:
+  r_ring_buffer_pos_t atomic_read_rx_head();
+  void atomic_set_rx_tail(r_ring_buffer_pos_t value);
+  r_ring_buffer_pos_t atomic_read_rx_tail();
+
+  volatile bool dgus_rx_overrun = false;
+
+  struct ring_buffer_r {
+    volatile r_ring_buffer_pos_t head, tail;
+    unsigned char buffer[DGUS_RX_BUFFER_SIZE];
+  } rx_buffer = { 0, 0, { 0 } };
+
+  struct ring_buffer_t {
+    volatile t_ring_buffer_pos_t head, tail;
+    unsigned char buffer[DGUS_TX_BUFFER_SIZE];
+  } tx_buffer = { 0, 0, { 0 } };
+
+  #if DGUS_RX_BUFFER_SIZE > 256
+    volatile bool rx_tail_value_not_stable = false;
+    volatile uint16_t rx_tail_value_backup = 0;
+  #endif
+
+};
+
+static DGUSSerial dgusserial;
+
+// endianess swap
+uint16_t swap16(uint16_t value) {
+  return (value & 0xffU) << 8U | (value >> 8U);
+}
+
+bool populate_VPVar(uint16_t VP, DGUS_VP_Variable *ramcopy) {
+  // DGUS_ECHOPAIR("populate_VPVar ", VP);
+  const DGUS_VP_Variable *pvp = DGUSLCD_FindVPVar(VP);
+  // DGUS_ECHOLNPAIR(" pvp ", (uint16_t )pvp);
+  if (!pvp) return false;
+  memcpy_P(ramcopy, pvp, sizeof(DGUS_VP_Variable));
+  return true;
+}
+
+void DGUSScreenVariableHandler::sendinfoscreen(const char* line1, const char* line2, const char* line3, const char* line4, bool l1inflash, bool l2inflash, bool l3inflash, bool l4inflash) {
+  DGUS_VP_Variable ramcopy;
+  if (populate_VPVar(VP_MSGSTR1, &ramcopy)) {
+    ramcopy.memadr = (void*) line1;
+    l1inflash ? DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(ramcopy) : DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(ramcopy);
+  }
+  if (populate_VPVar(VP_MSGSTR2, &ramcopy)) {
+    ramcopy.memadr = (void*) line2;
+    l2inflash ? DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(ramcopy) : DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(ramcopy);
+  }
+  if (populate_VPVar(VP_MSGSTR3, &ramcopy)) {
+    ramcopy.memadr = (void*) line3;
+    l3inflash ? DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(ramcopy) : DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(ramcopy);
+  }
+  if (populate_VPVar(VP_MSGSTR4, &ramcopy)) {
+    ramcopy.memadr = (void*) line4;
+    l4inflash ? DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(ramcopy) : DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(ramcopy);
+  }
+}
+
+void DGUSScreenVariableHandler::HandleUserConfirmationPopUp(uint16_t VP, const char* line1, const char* line2, const char* line3, const char* line4,
+    bool l1, bool l2, bool l3, bool l4) {
+  if (current_screen == DGUSLCD_SCREEN_CONFIRM) {
+    // Already showing a pop up, so we need to cancel that first.
+    PopToOldScreen();
+  }
+
+  ConfirmVP = VP;
+  sendinfoscreen(line1, line2, line3, line4, l1, l2, l3, l4);
+  ScreenHandler.GotoScreen(DGUSLCD_SCREEN_CONFIRM);
+}
+
+void DGUSScreenVariableHandler::setstatusmessage(const char *msg) {
+  DGUS_VP_Variable ramcopy;
+  if (populate_VPVar(VP_M117, &ramcopy)) {
+    ramcopy.memadr = (void*) msg;
+    DGUSLCD_SendStringToDisplay(ramcopy);
+  }
+}
+
+void DGUSScreenVariableHandler::setstatusmessagePGM(PGM_P const msg) {
+  DGUS_VP_Variable ramcopy;
+  if (populate_VPVar(VP_M117, &ramcopy)) {
+    ramcopy.memadr = (void*) msg;
+    DGUSLCD_SendStringToDisplayPGM(ramcopy);
+  }
+}
+
+// Send a 8 bit or 16 bit value to the display.
+void DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &ref_to_this) {
+  if (ref_to_this.memadr) {
+    //DGUS_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
+    //DGUS_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
+    uint8_t *tmp = (uint8_t *) ref_to_this.memadr;
+    uint16_t data_to_send = (tmp[0] << 8);
+    if (ref_to_this.size >= 1) {
+      data_to_send |= tmp[1];
+    }
+    dgusdisplay.WriteVariable(ref_to_this.VP, data_to_send);
+  }
+}
+
+// Send an uint8_t between 0 and 255 to the display, but scale to a percentage (0..100)
+void DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &ref_to_this) {
+  if (ref_to_this.memadr) {
+    //DGUS_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
+    //DGUS_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
+    uint16_t tmp = *(uint8_t *) ref_to_this.memadr +1 ; // +1 -> avoid rounding issues for the display.
+    tmp = map(tmp, 0, 255, 0, 100);
+    uint16_t data_to_send = swap16(tmp);
+    dgusdisplay.WriteVariable(ref_to_this.VP, data_to_send);
+  }
+}
+
+// Send the current print time to the display.
+// It is using a hex display for that: It expects BSD coded data in the format xxyyzz
+void DGUSScreenVariableHandler::DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &ref_to_this) {
+  duration_t elapsed = print_job_timer.duration();
+
+  uint8_t days  = elapsed.day();
+  uint8_t hours = elapsed.hour() % 24;
+  uint8_t minutes = elapsed.minute() % 60;
+  uint8_t seconds = elapsed.second() % 60;
+
+  char buf[14]; // that two extra bytes saves us some flash...
+  char *p = buf;
+
+  if (days) { *p++ = days/10 + '0'; *p++ = days%10 + '0'; *p++ = 'd'; }
+  *p++ = hours/10 + '0'; *p++ = hours%10 + '0'; *p++ = 'h';
+  *p++ = minutes/10 + '0'; *p++ = minutes%10 + '0'; *p++ = 'm';
+  *p++ = seconds/10 + '0'; *p++ = seconds%10 + '0'; *p++ = 's';
+  *p=0;
+
+  dgusdisplay.WriteVariable(VP_PrintTime, buf, ref_to_this.size, true);
+}
+
+
+
+// Send an uint8_t between 0 and 100 to a variable scale to 0..255
+void DGUSScreenVariableHandler::DGUSLCD_PercentageToUint8(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  if (ref_to_this.memadr) {
+    uint16_t value = swap16(*(uint16_t*)ptr_to_new_value);
+    *(uint8_t*)ref_to_this.memadr = map(constrain(value, 0, 100), 0, 100, 0, 255);
+  }
+}
+
+// Sends a (RAM located) string to the DGUS Display
+// (Note: The DGUS Display does not clear after the \0, you have to
+// overwrite the remainings with spaces.// ref_to_this.size has the display buffer size!
+void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay(DGUS_VP_Variable &ref_to_this) {
+  char *tmp = (char*) ref_to_this.memadr;
+  dgusdisplay.WriteVariable(ref_to_this.VP, tmp, ref_to_this.size, true);
+}
+
+// Sends a (flash located) string to the DGUS Display
+// (Note: The DGUS Display does not clear after the \0, you have to
+// overwrite the remainings with spaces.// ref_to_this.size has the display buffer size!
+void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &ref_to_this) {
+  char *tmp = (char*) ref_to_this.memadr;
+  dgusdisplay.WriteVariablePGM(ref_to_this.VP, tmp, ref_to_this.size, true);
+}
+
+
+#if ENABLED(SDSUPPORT)
+
+  void DGUSScreenVariableHandler::ScreenChangeHookIfSD(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+    // default action executed when there is a SD card, but not printing
+    if (ExtUI::isMediaInserted() && !ExtUI::isPrintingFromMedia()) {
+      ScreenChangeHook(ref_to_this, ptr_to_new_value);
+      dgusdisplay.RequestScreen(current_screen);
+      return;
+    }
+
+    // if we are printing, we jump to two screens after the requested one.
+    // This should host e.g a print pause / print abort / print resume dialog.
+    // This concept allows to recycle this hook for other file
+    if (ExtUI::isPrintingFromMedia() && !card.flag.abort_sd_printing) {
+      GotoScreen(DGUSLCD_SCREEN_SDPRINTMANIPULATION);
+      return;
+    }
+
+    // Don't let the user in the dark why there is no reaction.
+    if (!ExtUI::isMediaInserted()) {
+       setstatusmessagePGM(PSTR("No SD Card"));
+       return;
+    }
+    if (card.flag.abort_sd_printing) {
+       setstatusmessagePGM(PSTR("Aborting..."));
+       return;
+    }
+  }
+
+  void DGUSScreenVariableHandler::DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable& ref_to_this, void *ptr_to_new_value) {
+    auto old_top = top_file;
+    int16_t scroll = (int16_t)swap16(*(uint16_t*)ptr_to_new_value);
+    if (scroll == 0) {
+      if(!filelist.isAtRootDir()) {
+        filelist.upDir();
+        top_file = 0;
+        ForceCompleteUpdate();
+      }
+    }
+    else {
+      top_file += scroll;
+      DGUS_ECHOPAIR("new topfile calculated:", top_file);
+      if (top_file < 0) {
+        top_file = 0;
+        DGUS_ECHOLN("Top of filelist reached");
+      }
+      else {
+        int16_t max_top = filelist.count() -  DGUS_SD_FILESPERSCREEN;
+        max_top = (max_top > 0) ? max_top :0 ;
+        if(top_file > max_top ) top_file = max_top;
+      }
+      DGUS_ECHOPAIR("new topfile adjusted:", top_file);
+    }
+
+    if (old_top != top_file) ForceCompleteUpdate();
+  }
+
+  void DGUSScreenVariableHandler::DGUSLCD_SD_FileSelected(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+    uint16_t touched_nr = (int16_t)swap16(*(uint16_t*)ptr_to_new_value) + top_file;
+    if (touched_nr > filelist.count()) return;
+    if (!filelist.seek(touched_nr)) return;
+    if (filelist.isDir()) {
+      filelist.changeDir(filelist.filename());
+      top_file = 0;
+      ForceCompleteUpdate();
+      return;
+    }
+
+    // Setup Confirmation screen
+    file_to_print = touched_nr;
+    HandleUserConfirmationPopUp(VP_SD_FileSelectConfirm, nullptr, PSTR("Print file"), filelist.filename(), PSTR("from SD Card?"), true, true, false, true);
+  }
+
+  void DGUSScreenVariableHandler::DGUSLCD_SD_StartPrint(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+    if(!filelist.seek(file_to_print)) return;
+    ExtUI::printFile(filelist.filename());
+    ScreenHandler.GotoScreen(DGUSLCD_SCREEN_STATUS);
+  }
+
+  void DGUSScreenVariableHandler::DGUSLCD_SD_ResumePauseAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+    if (!ExtUI::isPrintingFromMedia()) return; // avoid race condition when user stays in this menu and printer finishes.
+    uint16_t value = swap16(*(uint16_t*)ptr_to_new_value);
+    switch(value) {
+    case 0:  // Resume
+      if (ExtUI::isPrintingFromMediaPaused()) ExtUI::resumePrint();
+      break;
+
+    case 1:  // Pause
+      if (!ExtUI::isPrintingFromMediaPaused()) ExtUI::pausePrint();
+      break;
+
+    case 2:  // Abort
+      ScreenHandler.HandleUserConfirmationPopUp(VP_SD_AbortPrintConfirmed, nullptr, PSTR("Abort printing"), filelist.filename(), PSTR("?"), true, true, false, true);
+      break;
+
+    default:
+      return;
+    }
+
+  }
+
+  void DGUSScreenVariableHandler::DGUSLCD_SD_ReallyAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+    ExtUI::stopPrint();
+    GotoScreen(DGUSLCD_SCREEN_MAIN);
+  }
+
+  void DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename(DGUS_VP_Variable& ref_to_this) {
+    uint16_t target_line = (ref_to_this.VP - VP_SD_FileName0) / VP_SD_FileName_LEN;
+    if (target_line > DGUS_SD_FILESPERSCREEN) return;
+    char tmpfilename[VP_SD_FileName_LEN+1] = "";
+    ref_to_this.memadr = (void*)tmpfilename;
+    if (filelist.seek(top_file + target_line)) {
+      snprintf_P(tmpfilename, VP_SD_FileName_LEN, PSTR("%s%c"), filelist.filename(), filelist.isDir() ? '/' : 0);
+    }
+    DGUSLCD_SendStringToDisplay(ref_to_this);
+  }
+
+
+  void DGUSScreenVariableHandler::SDCardInserted() {
+    top_file = 0;
+    auto cs = ScreenHandler.getCurrentScreen();
+    if (cs == DGUSLCD_SCREEN_MAIN || cs == DGUSLCD_SCREEN_STATUS) {
+      ScreenHandler.GotoScreen(DGUSLCD_SCREEN_SDFILELIST);
+    }
+  }
+
+  void DGUSScreenVariableHandler::SDCardRemoved() {
+    if(current_screen == DGUSLCD_SCREEN_SDFILELIST ||
+       (current_screen == DGUSLCD_SCREEN_CONFIRM && (ConfirmVP == VP_SD_AbortPrintConfirmed || ConfirmVP == VP_SD_FileSelectConfirm)) ||
+       current_screen == DGUSLCD_SCREEN_SDPRINTMANIPULATION ) ScreenHandler.GotoScreen(DGUSLCD_SCREEN_MAIN);
+  }
+
+  void DGUSScreenVariableHandler::SDCardError() {
+    DGUSScreenVariableHandler::SDCardRemoved();
+    ScreenHandler.sendinfoscreen(PSTR("NOTICE"), nullptr, PSTR("SD card error"), nullptr, true, true, true, true);
+    ScreenHandler.SetupConfirmAction(nullptr);
+    ScreenHandler.GotoScreen(DGUSLCD_SCREEN_POPUP);
+  }
+
+#endif // SDSUPPORT
+
+void DGUSScreenVariableHandler::ScreenConfirmedOK(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  DGUS_VP_Variable ramcopy;
+  if (!populate_VPVar(ConfirmVP, &ramcopy)) return;
+  if (ramcopy.set_by_display_handler) ramcopy.set_by_display_handler(ramcopy, ptr_to_new_value);
+}
+
+const uint16_t* DGUSLCD_FindScreenVPMapList(uint8_t screen) {
+  const uint16_t* ret;
+  const struct VPMapping* map = VPMap;
+  while (ret = (uint16_t*) pgm_read_word(&(map->VPList))) {
+    if (pgm_read_byte(&(map->screen)) == screen) return ret;
+    map++;
+  }
+  return nullptr;
+}
+
+const DGUS_VP_Variable* DGUSLCD_FindVPVar(uint16_t vp) {
+  const DGUS_VP_Variable *ret = ListOfVP;
+  do {
+    uint16_t vpcheck = pgm_read_word(&(ret->VP));
+    if (vpcheck == 0) break;
+    if (vpcheck == vp) {
+      return ret;
+    }
+    ++ret;
+  } while (1);
+
+  DGUS_ECHOLNPAIR("FindVPVar NOT FOUND ", vp);
+  return nullptr;
+}
+
+void DGUSScreenVariableHandler::ScreenChangeHookIfIdle(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  if (!ExtUI::isPrinting()) {
+    ScreenChangeHook(ref_to_this, ptr_to_new_value);
+    dgusdisplay.RequestScreen(current_screen);
+  }
+}
+
+void DGUSScreenVariableHandler::ScreenChangeHook(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  uint8_t *tmp = (uint8_t*) ptr_to_new_value;
+
+  // The keycode in target is coded as <from-frame><to-frame>, so 0x0100A means
+  // from screen 1 (main) to 10 (temperature). DGUSLCD_SCREEN_POPUP is special,
+  // meaning "return to previous screen"
+  DGUSLCD_Screens target = (DGUSLCD_Screens) tmp[1];
+
+  if (target == DGUSLCD_SCREEN_POPUP) {
+    // special handling for popup is to return to previous menu
+    if (current_screen == DGUSLCD_SCREEN_POPUP && confirmaction_cb) confirmaction_cb();
+    PopToOldScreen();
+    return;
+  }
+
+  UpdateNewScreen(target);
+
+  #ifdef DEBUG_DGUSLCD
+    auto x = DGUSLCD_FindScreenVPMapList(target);
+    if (!x) DGUS_ECHOLNPAIR("WARNING: No screen Mapping found for ", x);
+  #endif
+}
+
+void DGUSScreenVariableHandler::HandleAllHeatersOff(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  thermalManager.disable_all_heaters();
+  ScreenHandler.ForceCompleteUpdate(); // hint to send all data.
+}
+
+void DGUSScreenVariableHandler::HandleTemperatureChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  uint16_t newvalue = swap16(*(uint16_t*) ptr_to_new_value);
+  uint16_t acceptedvalue;
+
+  switch (ref_to_this.VP) {
+#if HOTENDS >= 1
+  case VP_T_E1_Set:
+    thermalManager.setTargetHotend(newvalue, 0);
+    acceptedvalue = thermalManager.temp_hotend[0].target;
+    break;
+#endif
+#if HOTENDS >= 2
+  case VP_T_E2_Set:
+    thermalManager.setTargetHotend(newvalue, 1);
+    acceptedvalue = thermalManager.temp_hotend[1].target;
+  break;
+#endif
+#if HAS_HEATED_BED
+  case VP_T_Bed_Set:
+    thermalManager.setTargetBed(newvalue);
+    acceptedvalue = thermalManager.temp_bed.target;
+    break;
+#endif
+  default:
+    return;
+  }
+
+  // reply to display the new value to update the view if the new value was rejected by the Thermal Manager.
+  if (newvalue != acceptedvalue && ref_to_this.send_to_display_handler) ref_to_this.send_to_display_handler(ref_to_this);
+  ScreenHandler.skipVP = ref_to_this.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
+}
+
+void DGUSScreenVariableHandler::HandleFlowRateChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  uint16_t newvalue = swap16(*(uint16_t*) ptr_to_new_value);
+  uint8_t target_extruder;
+  switch(ref_to_this.VP) {
+  #if (HOTENDS >= 1)
+    case VP_Flowrate_E1:
+      target_extruder = 0;
+      break;
+  #endif
+  #if (HOTENDS >= 2)
+    case VP_Flowrate_E2:
+      target_extruder = 1;
+      break;
+  #endif
+  default:
+    return;
+  }
+
+  planner.flow_percentage[target_extruder] = newvalue;
+  planner.refresh_e_factor(target_extruder);
+  ScreenHandler.skipVP = ref_to_this.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
+}
+
+void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  DGUS_ECHOLNPGM("HandleManualMove");
+
+  int16_t movevalue = swap16(*(uint16_t*) ptr_to_new_value);
+  float target = movevalue * 0.01f;
+  ExtUI::extruder_t target_extruder;
+
+  switch (ref_to_this.VP) {
+#if HOTENDS >=1
+    case VP_MOVE_E1:
+      target_extruder = ExtUI::extruder_t::E0;
+      break;
+#endif
+#if HOTENDS >=2
+    case VP_MOVE_E2:
+      target_extruder = ExtUI::extruder_t::E1;
+      break
+#endif
+    default: return;
+  }
+
+  target += ExtUI::getAxisPosition_mm(target_extruder);
+  ExtUI::setAxisPosition_mm(target, target_extruder);
+  skipVP = ref_to_this.VP;
+}
+
+void DGUSScreenVariableHandler::HandleManualMove(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+  DGUS_ECHOLNPGM("HandleManualMove");
+
+  int16_t movevalue = swap16(*(uint16_t*) ptr_to_new_value);
+  char axiscode;
+  unsigned int speed = 1500;  //FIXME: get default feedrate for manual moves, dont hardcode.
+
+  switch (ref_to_this.VP) {
+    case VP_MOVE_X:
+      axiscode = 'X';
+      if (!ExtUI::canMove(ExtUI::axis_t::X)) goto cannotmove;
+      break;
+
+    case VP_MOVE_Y:
+      axiscode = 'Y';
+      if (!ExtUI::canMove(ExtUI::axis_t::Y)) goto cannotmove;
+      break;
+
+    case VP_MOVE_Z:
+      axiscode = 'Z';
+      speed = 300; // default to 5mm/s
+      if (!ExtUI::canMove(ExtUI::axis_t::Z)) goto cannotmove;
+      break;
+
+    case VP_HOME_ALL: // only used for homing
+      axiscode = '\0';
+      movevalue = 0; // ignore value sent from display, this VP is _ONLY_ for homing.
+      break;
+
+    default: return;
+  }
+
+  if (!movevalue) {
+    // homing
+    DGUS_ECHOPAIR(" homing ", axiscode);
+    char buf[6] = "G28 X";
+    buf[4] = axiscode;
+    //DGUS_ECHOPAIR(" ", buf);
+    while (!enqueue_and_echo_command(buf)) idle();
+    //DGUS_ECHOLN(" ✓");
+    ScreenHandler.ForceCompleteUpdate();
+    return;
+  }
+  else {
+    //movement
+    DGUS_ECHOPAIR(" move ", axiscode);
+    bool old_relative_mode = relative_mode;
+    if (!relative_mode) {
+      //DGUS_ECHO(" G91");
+      while (!enqueue_and_echo_command("G91")) idle();
+      //DGUS_ECHOPGM(" ✓ ");
+    }
+    char buf[32];  // G1 X9999.99 F12345
+    unsigned int backup_speed = MMS_TO_MMM(feedrate_mm_s);
+    char sign[]="\0";
+    int16_t value = movevalue / 100;
+    if (movevalue < 0) { value = -value; sign[0] = '-'; }
+    int16_t fraction = ((movevalue > 0) ? movevalue : -movevalue) % 100;
+    snprintf_P(buf, 32, PSTR("G0 %c%s%d.%02d F%d"), axiscode, sign, value, fraction, speed);
+    //DGUS_ECHOPAIR(" ", buf);
+    while (!enqueue_and_echo_command(buf)) idle();
+    //DGUS_ECHOLN(" ✓ ");
+    if (backup_speed != speed) {
+      snprintf_P(buf, 32, PSTR("G0 F%d"), backup_speed);
+      while (!enqueue_and_echo_command(buf)) idle();
+      //DGUS_ECHOPAIR(" ", buf);
+    }
+    //while (!enqueue_and_echo_command(buf)) idle();
+    //DGUS_ECHOLN(" ✓ ");
+    if (!old_relative_mode) {
+      //DGUS_ECHO("G90");
+      while (!enqueue_and_echo_command("G90")) idle();
+      //DGUS_ECHO(" ✓ ");
+    }
+  }
+
+  ScreenHandler.ForceCompleteUpdate();
+  DGUS_ECHOLNPGM("manmv done.");
+  return;
+
+  cannotmove:
+  DGUS_ECHOLNPAIR(" cannot move ", axiscode);
+  return;
+}
+
+void DGUSScreenVariableHandler::UpdateNewScreen(DGUSLCD_Screens newscreen, bool popup) {
+  DGUS_ECHOLNPAIR("SetNewScreen: ", newscreen);
+
+  if (!popup) {
+    memmove(&past_screens[1], &past_screens[0], sizeof(past_screens) - 1);
+    past_screens[0] = current_screen;
+  }
+
+  current_screen = newscreen;
+  skipVP = 0;
+  ForceCompleteUpdate();
+}
+
+void DGUSScreenVariableHandler::PopToOldScreen() {
+  DGUS_ECHOLNPAIR("PopToOldScreen s=", past_screens[0]);
+  GotoScreen(past_screens[0], true);
+  memmove(&past_screens[0], &past_screens[1], sizeof(past_screens) - 1);
+  past_screens[sizeof(past_screens) - 1] = DGUSLCD_SCREEN_MAIN;
+}
+
+void DGUSScreenVariableHandler::UpdateScreenVPData() {
+  DGUS_ECHOPAIR(" UpdateScreenVPData Screen: ", current_screen);
+
+  const uint16_t *VPList = DGUSLCD_FindScreenVPMapList(current_screen);
+  if (!VPList) {
+    DGUS_ECHOLNPAIR(" NO SCREEN FOR: ", current_screen);
+    ScreenComplete = true;
+    return;  // nothing to do, likely a bug or boring screen.
+  }
+
+  // Round-Robbin updating of all VPs.
+  VPList += update_ptr;
+
+  bool sent_one = false;
+  do {
+    uint16_t VP = pgm_read_word(VPList);
+    DGUS_ECHOPAIR(" VP: ", VP);
+    if (!VP) {
+      update_ptr = 0;
+      DGUS_ECHOLNPGM(" UpdateScreenVPData done");
+      ScreenComplete = true;
+      return;  // Screen completed.
+    }
+
+    if (VP == skipVP) {
+      skipVP = 0;
+      continue;
+    }
+
+    DGUS_VP_Variable rcpy;
+    if (populate_VPVar(VP, &rcpy)) {
+      uint8_t expected_tx = 6 + rcpy.size;  // expected overhead is 6 bytes + payload.
+      // Send the VP to the display, but try to avoid overruning the Tx Buffer.
+      // But send at least one VP, to avoid getting stalled.
+      if (rcpy.send_to_display_handler && (!sent_one || expected_tx <= dgusdisplay.GetFreeTxBuffer())) {
+        //DGUS_ECHOPAIR(" calling handler for ", rcpy.VP);
+        sent_one = true;
+        rcpy.send_to_display_handler(rcpy);
+      }
+      else {
+        //auto x=dgusdisplay.GetFreeTxBuffer();
+        //DGUS_ECHOLNPAIR(" tx almost full: ", x);
+        //DGUS_ECHOPAIR(" update_ptr ", update_ptr);
+        ScreenComplete = false;
+        return;  // please call again!
+      }
+    }
+
+  } while (++update_ptr, ++VPList, true);
+  return;
+}
+
+void DGUSDisplay::loop() {
+  // protection against recursion… ProcessRx() might call indirectly idle() when trying to injecting gcode commands if the queue is full.
+  if (!no_reentrance) {
+    no_reentrance = true;
+    ProcessRx();
+    no_reentrance = false;
+  }
+}
+
+void DGUSDisplay::InitDisplay() {
+  RequestScreen(
+    #if ENABLED(SHOW_BOOTSCREEN)
+      DGUSLCD_SCREEN_BOOT
+    #else
+      DGUSLCD_SCREEN_MAIN
+    #endif
+  );
+}
+
+void DGUSDisplay::WriteVariable(uint16_t adr, const void* values, uint8_t valueslen, bool isstr) {
+  const char* myvalues = static_cast<const char*>(values);
+  bool strend = (myvalues) ? false : true;
+  WriteHeader(adr, DGUS_CMD_WRITEVAR, valueslen);
+  while (valueslen--) {
+    char x;
+    if (!strend) x = *myvalues++;
+    if ((isstr && !x) || strend) {
+      strend = true;
+      x = ' ';
+    }
+    dgusserial.write(x);
+  }
+}
+
+void DGUSDisplay::WriteVariablePGM(uint16_t adr, const void* values, uint8_t valueslen, bool isstr) {
+  const char* myvalues = static_cast<const char*>(values);
+  bool strend = (myvalues) ? false : true;
+  WriteHeader(adr, DGUS_CMD_WRITEVAR, valueslen);
+  while (valueslen--) {
+    char x;
+    if (!strend) x = pgm_read_byte(myvalues++);
+    if ((isstr && !x) || strend) {
+      strend = true;
+      x = ' ';
+    }
+    dgusserial.write(x);
+  }
+}
+
+void DGUSScreenVariableHandler::GotoScreen(DGUSLCD_Screens screen, bool ispopup) {
+  dgusdisplay.RequestScreen(screen);
+  UpdateNewScreen(screen, ispopup);
+}
+
+bool DGUSScreenVariableHandler::loop() {
+  dgusdisplay.loop();
+
+  const millis_t ms = millis();
+  static millis_t next_event_ms = 0;
+
+  if (!IsScreenComplete() || ELAPSED(ms, next_event_ms)) {
+    next_event_ms = ms + DGUS_UPDATE_INTERVAL_MS;
+    UpdateScreenVPData();
+  }
+
+  #if ENABLED(SHOW_BOOTSCREEN)
+    static bool booted = false;
+    if (!booted && ELAPSED(ms, BOOTSCREEN_TIMEOUT)) {
+      booted = true;
+      GotoScreen(DGUSLCD_SCREEN_MAIN);
+    }
+  #endif
+  return IsScreenComplete();
+}
+
+void DGUSDisplay::RequestScreen(DGUSLCD_Screens screen) {
+  DGUS_ECHOLNPAIR("GotoScreen ", screen);
+  const unsigned char gotoscreen[] = { 0x5A, 0x01, (unsigned char) (screen >> 8U), (unsigned char) (screen & 0xFFU) };
+  WriteVariable(0x84, gotoscreen, sizeof(gotoscreen));
+}
+
+void DGUSDisplay::ProcessRx() {
+
+  if (!dgusserial.available() && dgusserial.is_rx_overrun()) {
+    // if we've got an overrun, but reset the flag only when we've emptied the buffer
+    // We want to extract as many as valid datagrams possible...
+    DGUS_ECHOPGM("OVFL");
+    rx_datagram_state = DGUS_IDLE;
+    dgusserial.reset_rx_overun();
+  }
+
+  uint8_t receivedbyte;
+  while (dgusserial.available()) {
+    switch (rx_datagram_state) {
+
+      case DGUS_IDLE:	// Waiting for the first header byte
+        receivedbyte = dgusserial.read();
+        //DGUS_ECHOPAIR("< ",x);
+        if (DGUS_HEADER1 == receivedbyte) rx_datagram_state = DGUS_HEADER1_SEEN;
+        break;
+
+      case DGUS_HEADER1_SEEN: // Waiting for the second header byte
+        receivedbyte = dgusserial.read();
+        //DGUS_ECHOPAIR(" ",x);
+        rx_datagram_state = (DGUS_HEADER2 == receivedbyte) ? DGUS_HEADER2_SEEN : DGUS_IDLE;
+        break;
+
+      case DGUS_HEADER2_SEEN: // Waiting for the length byte
+        rx_datagram_len = dgusserial.read();
+        DGUS_ECHOPAIR(" (", rx_datagram_len);
+        DGUS_ECHOPGM(") ");
+
+        // Telegram min len is 3 (command and one word of payload)
+        rx_datagram_state = WITHIN(rx_datagram_len, 3, DGUS_RX_BUFFER_SIZE) ? DGUS_WAIT_TELEGRAM : DGUS_IDLE;
+        break;
+
+      case DGUS_WAIT_TELEGRAM: // wait for complete datagram to arrive.
+        if (dgusserial.available() < rx_datagram_len) return;
+
+        Initialized = true; // We've talked to it, so we defined it as initialized.
+        uint8_t command = dgusserial.read();
+
+        DGUS_ECHOPAIR("# ", command);
+
+        uint8_t readlen = rx_datagram_len - 1;  // command is part of len.
+        unsigned char tmp[rx_datagram_len - 1];
+        unsigned char *ptmp = tmp;
+        while (readlen--) {
+          receivedbyte = dgusserial.read();
+          DGUS_ECHOPAIR(" ", receivedbyte);
+          *ptmp++ = receivedbyte;
+        }
+        DGUS_ECHOPGM(" # ");
+        // mostly we'll get this: 5A A5 03 82 4F 4B -- ACK on 0x82, so discard it.
+        if (command == DGUS_CMD_WRITEVAR && 'O' == tmp[0] && 'K' == tmp[1]) {
+          DGUS_ECHOLNPGM(">");
+          rx_datagram_state = DGUS_IDLE;
+          break;
+        }
+
+        /* AutoUpload, (and answer to) Command 0x83 :
+        |      tmp[0  1  2  3  4 ... ]
+        | Example 5A A5 06 83 20 01 01 78 01 ……
+        |          / /  |  |   \ /   |  \     \
+        |        Header |  |    |    |   \_____\_ DATA (Words!)
+        |     DatagramLen  /  VPAdr  |
+        |           Command          DataLen (in Words) */
+        if (command == DGUS_CMD_READVAR) {
+          const uint16_t vp = tmp[0] << 8 | tmp[1];
+          const uint8_t dlen = tmp[2] << 1;  // Convert to Bytes. (Display works with words)
+          //DGUS_ECHOPAIR(" vp=", vp);	DGUS_ECHOPAIR(" dlen=", dlen);
+          DGUS_VP_Variable ramcopy;
+          if (populate_VPVar(vp, &ramcopy)) {
+            if (!(dlen == ramcopy.size || (dlen == 2 && ramcopy.size == 1)))
+              DGUS_ECHOLNPGM("SIZE MISMATCH");
+            else if (ramcopy.set_by_display_handler) {
+              ramcopy.set_by_display_handler(ramcopy, &tmp[3]);
+            }
+            else
+              DGUS_ECHOLNPGM(" VPVar found, no handler.");
+          }
+          else
+            DGUS_ECHOLNPAIR(" VPVar not found:", vp);
+
+          rx_datagram_state = DGUS_IDLE;
+          break;
+        }
+
+      // discard what we do not understand.
+      rx_datagram_state = DGUS_IDLE;
+    }
+  }
+}
+
+size_t DGUSDisplay::GetFreeTxBuffer() {
+  return dgusserial.GetTxBufferFree();
+}
+
+
+void DGUSDisplay::WriteHeader(uint16_t adr, uint8_t cmd, uint8_t payloadlen) {
+  dgusserial.write(DGUS_HEADER1);
+  dgusserial.write(DGUS_HEADER2);
+  dgusserial.write(payloadlen + 3);
+  dgusserial.write(cmd);
+  dgusserial.write(adr >> 8);
+  dgusserial.write(adr & 0xFF);
+}
+
+void DGUSDisplay::WritePGM(const char str[], uint8_t len) {
+  while (len--)
+    dgusserial.write(pgm_read_byte(str++));
+}
+
+// Serial implementation stolen from MarlinSerial.cpp -- but functinality reduced to our use case
+// (no XON/XOFF, no Emergency Parser, no error statistics, no support to send from interrupts ...)
+
+// Define all UART registers
+#define _TNAME(X,Y,Z)                X##Y##Z
+#define TNAME(X,Y,Z)                _TNAME(X,Y,Z)
+#define DGUS_SERIAL_RX_VECT          TNAME(USART,DGUS_SER_PORT,_RX_vect)
+#define DGUS_SERIAL_UDRE_VECT        TNAME(USART,DGUS_SER_PORT,_UDRE_vect)
+#define DGUS_UCSRxA                  TNAME(UCSR,DGUS_SER_PORT,A)
+#define DGUS_UCSRxB                  TNAME(UCSR,DGUS_SER_PORT,B)
+#define DGUS_UCSRxC                  TNAME(UCSR,DGUS_SER_PORT,C)
+#define DGUS_UBRRxH                  TNAME(UBRR,DGUS_SER_PORT,H)
+#define DGUS_UBRRxL                  TNAME(UBRR,DGUS_SER_PORT,L)
+#define DGUS_UDRx                    TNAME(UDR,DGUS_SER_PORT,)
+
+#define U2Xx                    TNAME(U2X,DGUS_SER_PORT,)
+#define RXENx                   TNAME(RXEN,DGUS_SER_PORT,)
+#define TXENx                   TNAME(TXEN,DGUS_SER_PORT,)
+#define TXCx                    TNAME(TXC,DGUS_SER_PORT,)
+#define RXCIEx                  TNAME(RXCIE,DGUS_SER_PORT,)
+#define UDRIEx                  TNAME(UDRIE,DGUS_SER_PORT,)
+#define UDREx                   TNAME(UDRE,DGUS_SER_PORT,)
+
+// A SW memory barrier, to ensure GCC does not overoptimize loops
+#define sw_barrier() asm volatile("": : :"memory");
+
+DGUSSerial::DGUSSerial() {
+  // Initialize UART
+  DGUS_UCSRxA = 1 << U2Xx;
+  const uint16_t baud_setting = (F_CPU / 4 / DGUS_BAUDRATE - 1) / 2;
+  DGUS_UBRRxH = baud_setting >> 8;
+  DGUS_UBRRxL = baud_setting;
+  DGUS_UCSRxC = 0x06;
+  DGUS_UCSRxB = 1 << RXCIEx | 1 << TXENx | 1 << RXENx;  // Enable TX,RX and the RX interrupts.
+}
+
+DGUSSerial::~DGUSSerial() {
+  DGUS_UCSRxB = 0;
+}
+
+// "Atomically" read the RX head index value without disabling interrupts:
+// This MUST be called with RX interrupts enabled, and CAN'T be called
+// from the RX ISR itself!
+FORCE_INLINE r_ring_buffer_pos_t DGUSSerial::atomic_read_rx_head() {
+  #if RX_BUFFER_SIZE > 256
+    // Keep reading until 2 consecutive reads return the same value,
+    // meaning there was no update in-between caused by an interrupt.
+    // This works because serial RX interrupts happen at a slower rate
+    // than successive reads of a variable, so 2 consecutive reads with
+    // the same value means no interrupt updated it.
+    r_ring_buffer_pos_t vold, vnew = rx_buffer.head;
+    sw_barrier();
+    do {
+      vold = vnew;
+      vnew = rx_buffer.head;
+      sw_barrier();
+    }while (vold != vnew);
+    return vnew;
+  #else
+    // With an 8bit index, reads are always atomic. No need for special handling
+    return rx_buffer.head;
+  #endif
+}
+
+// Set RX tail index, taking into account the RX ISR could interrupt
+//  the write to this variable in the middle - So a backup strategy
+//  is used to ensure reads of the correct values.
+//    -Must NOT be called from the RX ISR -
+FORCE_INLINE void DGUSSerial::atomic_set_rx_tail(r_ring_buffer_pos_t value) {
+  #if RX_BUFFER_SIZE > 256
+    // Store the new value in the backup
+    rx_tail_value_backup = value;
+    sw_barrier();
+    // Flag we are about to change the true value
+    rx_tail_value_not_stable = true;
+    sw_barrier();
+    // Store the new value
+    rx_buffer.tail = value;
+    sw_barrier();
+    // Signal the new value is completely stored into the value
+    rx_tail_value_not_stable = false;
+    sw_barrier();
+  #else
+    rx_buffer.tail = value;
+  #endif
+}
+
+// Get the RX tail index, taking into account the read could be
+//  interrupting in the middle of the update of that index value
+//    -Called from the RX ISR -
+FORCE_INLINE r_ring_buffer_pos_t DGUSSerial::atomic_read_rx_tail() {
+  #if RX_BUFFER_SIZE > 256
+    // If the true index is being modified, return the backup value
+    if (rx_tail_value_not_stable) return rx_tail_value_backup;
+  #endif
+  // The true index is stable, return it
+  return rx_buffer.tail;
+}
+
+// (called with RX interrupts disabled)
+FORCE_INLINE void DGUSSerial::store_rxd_char() {
+  // Get the tail - Nothing can alter its value while this ISR is executing, but there's
+  // a chance that this ISR interrupted the main process while it was updating the index.
+  // The backup mechanism ensures the correct value is always returned.
+  const r_ring_buffer_pos_t t = atomic_read_rx_tail();
+
+  // Get the head pointer - This ISR is the only one that modifies its value, so it's safe to read here
+  r_ring_buffer_pos_t h = rx_buffer.head;
+
+  // Get the next element
+  r_ring_buffer_pos_t i = (r_ring_buffer_pos_t) (h + 1) & (r_ring_buffer_pos_t) (DGUS_RX_BUFFER_SIZE - 1);
+
+  // Read the character from the USART
+  uint8_t c = DGUS_UDRx;
+
+  // If the character is to be stored at the index just before the tail
+  // (such that the head would advance to the current tail), the RX FIFO is
+  // full, so don't write the character or advance the head.
+  if (i != t) {
+    rx_buffer.buffer[h] = c;
+    h = i;
+  }
+  else {
+    dgus_rx_overrun = true;
+  }
+
+  // Store the new head value - The main loop will retry until the value is stable
+  rx_buffer.head = h;
+}
+
+// (called with TX irqs disabled)
+FORCE_INLINE void DGUSSerial::tx_udr_empty_irq(void) {
+  // Read positions
+  uint8_t t = tx_buffer.tail;
+  const uint8_t h = tx_buffer.head;
+  // If nothing to transmit, just disable TX interrupts. This could
+  // happen as the result of the non atomicity of the disabling of RX
+  // interrupts that could end reenabling TX interrupts as a side effect.
+  if (h == t) {
+    CBI(DGUS_UCSRxB, UDRIEx); // (Non-atomic, could be reenabled by the main program, but eventually this will succeed)
+    return;
+  }
+
+  // There is something to TX, Send the next byte
+  const uint8_t c = tx_buffer.buffer[t];
+  t = (t + 1) & (DGUS_TX_BUFFER_SIZE - 1);
+  DGUS_UDRx = c;
+  tx_buffer.tail = t;
+
+  // Clear the TXC bit (by writing a one to its bit location).
+  // Ensures flush() won't return until the bytes are actually written/
+  SBI(DGUS_UCSRxA, TXCx);
+
+  // Disable interrupts if there is nothing to transmit following this byte
+  if (h == t) CBI(DGUS_UCSRxB, UDRIEx);
+}
+
+r_ring_buffer_pos_t DGUSSerial::available(void) {
+  const r_ring_buffer_pos_t h = atomic_read_rx_head(), t = rx_buffer.tail;
+  return (r_ring_buffer_pos_t) (DGUS_RX_BUFFER_SIZE + h - t) & (DGUS_RX_BUFFER_SIZE - 1);
+}
+
+int DGUSSerial::read() {
+  const r_ring_buffer_pos_t h = atomic_read_rx_head();
+
+  // Read the tail. Main thread owns it, so it is safe to directly read it
+  r_ring_buffer_pos_t t = rx_buffer.tail;
+
+  // If nothing to read, return now
+  if (h == t) return -1;
+
+  // Get the next char
+  const int v = rx_buffer.buffer[t];
+  t = (r_ring_buffer_pos_t) (t + 1) & (DGUS_RX_BUFFER_SIZE - 1);
+
+  // Advance tail - Making sure the RX ISR will always get an stable value, even
+  // if it interrupts the writing of the value of that variable in the middle.
+  atomic_set_rx_tail(t);
+  return v;
+}
+
+void DGUSSerial::write(const uint8_t c) {
+  // are we currently tranmitting? If not, we can just place the byte in UDR.
+  if (!TEST(DGUS_UCSRxB, UDRIEx) && TEST(DGUS_UCSRxA, UDREx)) {
+    DGUS_UDRx = c;
+    SBI(DGUS_UCSRxA, TXCx);
+    return;
+  }
+
+  const uint8_t i = (tx_buffer.head + 1) & (DGUS_TX_BUFFER_SIZE - 1);
+  while (i == tx_buffer.tail) {
+    sw_barrier();
+  }
+  // Store new char. head is always safe to move
+  tx_buffer.buffer[tx_buffer.head] = c;
+  tx_buffer.head = i;
+  SBI(DGUS_UCSRxB, UDRIEx);  // Enable Interrupts to finish off.
+}
+
+t_ring_buffer_pos_t DGUSSerial::GetTxBufferFree() {
+  const t_ring_buffer_pos_t t = tx_buffer.tail;  // next byte to send.
+  const t_ring_buffer_pos_t h = tx_buffer.head;  // next pos for queue.
+  int ret = t - h - 1;
+  if (ret < 0) ret += DGUS_TX_BUFFER_SIZE + 1;
+  return ret;
+}
+
+ISR(DGUS_SERIAL_UDRE_VECT) {
+  dgusserial.tx_udr_empty_irq();
+}
+
+ISR(DGUS_SERIAL_RX_VECT) {
+  dgusserial.store_rxd_char();
+}
+
+#endif // DGUS_LCD

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
@@ -145,9 +145,9 @@ uint16_t swap16(uint16_t value) {
 }
 
 bool populate_VPVar(uint16_t VP, DGUS_VP_Variable *ramcopy) {
-  // DGUS_ECHOPAIR("populate_VPVar ", VP);
+  // DEBUG_ECHOPAIR("populate_VPVar ", VP);
   const DGUS_VP_Variable *pvp = DGUSLCD_FindVPVar(VP);
-  // DGUS_ECHOLNPAIR(" pvp ", (uint16_t )pvp);
+  // DEBUG_ECHOLNPAIR(" pvp ", (uint16_t )pvp);
   if (!pvp) return false;
   memcpy_P(ramcopy, pvp, sizeof(DGUS_VP_Variable));
   return true;
@@ -203,8 +203,8 @@ void DGUSScreenVariableHandler::setstatusmessagePGM(PGM_P const msg) {
 // Send a 8 bit or 16 bit value to the display.
 void DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &ref_to_this) {
   if (ref_to_this.memadr) {
-    //DGUS_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
-    //DGUS_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
+    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
+    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
     uint8_t *tmp = (uint8_t *) ref_to_this.memadr;
     uint16_t data_to_send = (tmp[0] << 8);
     if (ref_to_this.size >= 1) data_to_send |= tmp[1];
@@ -215,8 +215,8 @@ void DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable 
 // Send an uint8_t between 0 and 255 to the display, but scale to a percentage (0..100)
 void DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &ref_to_this) {
   if (ref_to_this.memadr) {
-    //DGUS_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
-    //DGUS_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
+    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", ref_to_this.VP);
+    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)ref_to_this.memadr);
     uint16_t tmp = *(uint8_t *) ref_to_this.memadr +1 ; // +1 -> avoid rounding issues for the display.
     tmp = map(tmp, 0, 255, 0, 100);
     uint16_t data_to_send = swap16(tmp);
@@ -312,17 +312,17 @@ void DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable 
     }
     else {
       top_file += scroll;
-      DGUS_ECHOPAIR("new topfile calculated:", top_file);
+      DEBUG_ECHOPAIR("new topfile calculated:", top_file);
       if (top_file < 0) {
         top_file = 0;
-        DGUS_ECHOLN("Top of filelist reached");
+        DEBUG_ECHOLN("Top of filelist reached");
       }
       else {
         int16_t max_top = filelist.count() -  DGUS_SD_FILESPERSCREEN;
         NOLESS(max_top, 0);
         NOMORE(top_file, max_top);
       }
-      DGUS_ECHOPAIR("new topfile adjusted:", top_file);
+      DEBUG_ECHOPAIR("new topfile adjusted:", top_file);
     }
 
     if (old_top != top_file) ForceCompleteUpdate();
@@ -429,7 +429,7 @@ const DGUS_VP_Variable* DGUSLCD_FindVPVar(uint16_t vp) {
     ++ret;
   } while (1);
 
-  DGUS_ECHOLNPAIR("FindVPVar NOT FOUND ", vp);
+  DEBUG_ECHOLNPAIR("FindVPVar NOT FOUND ", vp);
   return nullptr;
 }
 
@@ -458,7 +458,7 @@ void DGUSScreenVariableHandler::ScreenChangeHook(DGUS_VP_Variable &ref_to_this, 
   UpdateNewScreen(target);
 
   #ifdef DEBUG_DGUSLCD
-    if (!DGUSLCD_FindScreenVPMapList(target)) DGUS_ECHOLNPAIR("WARNING: No screen Mapping found for ", x);
+    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPAIR("WARNING: No screen Mapping found for ", x);
   #endif
 }
 
@@ -521,7 +521,7 @@ void DGUSScreenVariableHandler::HandleFlowRateChanged(DGUS_VP_Variable &ref_to_t
 }
 
 void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-  DGUS_ECHOLNPGM("HandleManualMove");
+  DEBUG_ECHOLNPGM("HandleManualMove");
 
   int16_t movevalue = swap16(*(uint16_t*) ptr_to_new_value);
   float target = movevalue * 0.01f;
@@ -547,7 +547,7 @@ void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &ref_to_thi
 }
 
 void DGUSScreenVariableHandler::HandleManualMove(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-  DGUS_ECHOLNPGM("HandleManualMove");
+  DEBUG_ECHOLNPGM("HandleManualMove");
 
   int16_t movevalue = swap16(*(uint16_t*) ptr_to_new_value);
   char axiscode;
@@ -580,23 +580,23 @@ void DGUSScreenVariableHandler::HandleManualMove(DGUS_VP_Variable &ref_to_this, 
 
   if (!movevalue) {
     // homing
-    DGUS_ECHOPAIR(" homing ", axiscode);
+    DEBUG_ECHOPAIR(" homing ", axiscode);
     char buf[6] = "G28 X";
     buf[4] = axiscode;
-    //DGUS_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPAIR(" ", buf);
     while (!enqueue_and_echo_command(buf)) idle();
-    //DGUS_ECHOLN(" ✓");
+    //DEBUG_ECHOLN(" ✓");
     ScreenHandler.ForceCompleteUpdate();
     return;
   }
   else {
     //movement
-    DGUS_ECHOPAIR(" move ", axiscode);
+    DEBUG_ECHOPAIR(" move ", axiscode);
     bool old_relative_mode = relative_mode;
     if (!relative_mode) {
-      //DGUS_ECHO(" G91");
+      //DEBUG_ECHO(" G91");
       while (!enqueue_and_echo_command("G91")) idle();
-      //DGUS_ECHOPGM(" ✓ ");
+      //DEBUG_ECHOPGM(" ✓ ");
     }
     char buf[32];  // G1 X9999.99 F12345
     unsigned int backup_speed = MMS_TO_MMM(feedrate_mm_s);
@@ -605,34 +605,34 @@ void DGUSScreenVariableHandler::HandleManualMove(DGUS_VP_Variable &ref_to_this, 
     if (movevalue < 0) { value = -value; sign[0] = '-'; }
     int16_t fraction = ABS(movevalue) % 100;
     snprintf_P(buf, 32, PSTR("G0 %c%s%d.%02d F%d"), axiscode, sign, value, fraction, speed);
-    //DGUS_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPAIR(" ", buf);
     while (!enqueue_and_echo_command(buf)) idle();
-    //DGUS_ECHOLN(" ✓ ");
+    //DEBUG_ECHOLN(" ✓ ");
     if (backup_speed != speed) {
       snprintf_P(buf, 32, PSTR("G0 F%d"), backup_speed);
       while (!enqueue_and_echo_command(buf)) idle();
-      //DGUS_ECHOPAIR(" ", buf);
+      //DEBUG_ECHOPAIR(" ", buf);
     }
     //while (!enqueue_and_echo_command(buf)) idle();
-    //DGUS_ECHOLN(" ✓ ");
+    //DEBUG_ECHOLN(" ✓ ");
     if (!old_relative_mode) {
-      //DGUS_ECHO("G90");
+      //DEBUG_ECHO("G90");
       while (!enqueue_and_echo_command("G90")) idle();
-      //DGUS_ECHO(" ✓ ");
+      //DEBUG_ECHO(" ✓ ");
     }
   }
 
   ScreenHandler.ForceCompleteUpdate();
-  DGUS_ECHOLNPGM("manmv done.");
+  DEBUG_ECHOLNPGM("manmv done.");
   return;
 
   cannotmove:
-  DGUS_ECHOLNPAIR(" cannot move ", axiscode);
+  DEBUG_ECHOLNPAIR(" cannot move ", axiscode);
   return;
 }
 
 void DGUSScreenVariableHandler::UpdateNewScreen(DGUSLCD_Screens newscreen, bool popup) {
-  DGUS_ECHOLNPAIR("SetNewScreen: ", newscreen);
+  DEBUG_ECHOLNPAIR("SetNewScreen: ", newscreen);
 
   if (!popup) {
     memmove(&past_screens[1], &past_screens[0], sizeof(past_screens) - 1);
@@ -645,18 +645,18 @@ void DGUSScreenVariableHandler::UpdateNewScreen(DGUSLCD_Screens newscreen, bool 
 }
 
 void DGUSScreenVariableHandler::PopToOldScreen() {
-  DGUS_ECHOLNPAIR("PopToOldScreen s=", past_screens[0]);
+  DEBUG_ECHOLNPAIR("PopToOldScreen s=", past_screens[0]);
   GotoScreen(past_screens[0], true);
   memmove(&past_screens[0], &past_screens[1], sizeof(past_screens) - 1);
   past_screens[sizeof(past_screens) - 1] = DGUSLCD_SCREEN_MAIN;
 }
 
 void DGUSScreenVariableHandler::UpdateScreenVPData() {
-  DGUS_ECHOPAIR(" UpdateScreenVPData Screen: ", current_screen);
+  DEBUG_ECHOPAIR(" UpdateScreenVPData Screen: ", current_screen);
 
   const uint16_t *VPList = DGUSLCD_FindScreenVPMapList(current_screen);
   if (!VPList) {
-    DGUS_ECHOLNPAIR(" NO SCREEN FOR: ", current_screen);
+    DEBUG_ECHOLNPAIR(" NO SCREEN FOR: ", current_screen);
     ScreenComplete = true;
     return;  // nothing to do, likely a bug or boring screen.
   }
@@ -667,10 +667,10 @@ void DGUSScreenVariableHandler::UpdateScreenVPData() {
   bool sent_one = false;
   do {
     uint16_t VP = pgm_read_word(VPList);
-    DGUS_ECHOPAIR(" VP: ", VP);
+    DEBUG_ECHOPAIR(" VP: ", VP);
     if (!VP) {
       update_ptr = 0;
-      DGUS_ECHOLNPGM(" UpdateScreenVPData done");
+      DEBUG_ECHOLNPGM(" UpdateScreenVPData done");
       ScreenComplete = true;
       return;  // Screen completed.
     }
@@ -686,14 +686,14 @@ void DGUSScreenVariableHandler::UpdateScreenVPData() {
       // Send the VP to the display, but try to avoid overruning the Tx Buffer.
       // But send at least one VP, to avoid getting stalled.
       if (rcpy.send_to_display_handler && (!sent_one || expected_tx <= dgusdisplay.GetFreeTxBuffer())) {
-        //DGUS_ECHOPAIR(" calling handler for ", rcpy.VP);
+        //DEBUG_ECHOPAIR(" calling handler for ", rcpy.VP);
         sent_one = true;
         rcpy.send_to_display_handler(rcpy);
       }
       else {
         //auto x=dgusdisplay.GetFreeTxBuffer();
-        //DGUS_ECHOLNPAIR(" tx almost full: ", x);
-        //DGUS_ECHOPAIR(" update_ptr ", update_ptr);
+        //DEBUG_ECHOLNPAIR(" tx almost full: ", x);
+        //DEBUG_ECHOPAIR(" update_ptr ", update_ptr);
         ScreenComplete = false;
         return;  // please call again!
       }
@@ -778,7 +778,7 @@ bool DGUSScreenVariableHandler::loop() {
 }
 
 void DGUSDisplay::RequestScreen(DGUSLCD_Screens screen) {
-  DGUS_ECHOLNPAIR("GotoScreen ", screen);
+  DEBUG_ECHOLNPAIR("GotoScreen ", screen);
   const unsigned char gotoscreen[] = { 0x5A, 0x01, (unsigned char) (screen >> 8U), (unsigned char) (screen & 0xFFU) };
   WriteVariable(0x84, gotoscreen, sizeof(gotoscreen));
 }
@@ -788,7 +788,7 @@ void DGUSDisplay::ProcessRx() {
   if (!dgusserial.available() && dgusserial.is_rx_overrun()) {
     // if we've got an overrun, but reset the flag only when we've emptied the buffer
     // We want to extract as many as valid datagrams possible...
-    DGUS_ECHOPGM("OVFL");
+    DEBUG_ECHOPGM("OVFL");
     rx_datagram_state = DGUS_IDLE;
     dgusserial.reset_rx_overun();
   }
@@ -799,20 +799,20 @@ void DGUSDisplay::ProcessRx() {
 
       case DGUS_IDLE:	// Waiting for the first header byte
         receivedbyte = dgusserial.read();
-        //DGUS_ECHOPAIR("< ",x);
+        //DEBUG_ECHOPAIR("< ",x);
         if (DGUS_HEADER1 == receivedbyte) rx_datagram_state = DGUS_HEADER1_SEEN;
         break;
 
       case DGUS_HEADER1_SEEN: // Waiting for the second header byte
         receivedbyte = dgusserial.read();
-        //DGUS_ECHOPAIR(" ",x);
+        //DEBUG_ECHOPAIR(" ",x);
         rx_datagram_state = (DGUS_HEADER2 == receivedbyte) ? DGUS_HEADER2_SEEN : DGUS_IDLE;
         break;
 
       case DGUS_HEADER2_SEEN: // Waiting for the length byte
         rx_datagram_len = dgusserial.read();
-        DGUS_ECHOPAIR(" (", rx_datagram_len);
-        DGUS_ECHOPGM(") ");
+        DEBUG_ECHOPAIR(" (", rx_datagram_len);
+        DEBUG_ECHOPGM(") ");
 
         // Telegram min len is 3 (command and one word of payload)
         rx_datagram_state = WITHIN(rx_datagram_len, 3, DGUS_RX_BUFFER_SIZE) ? DGUS_WAIT_TELEGRAM : DGUS_IDLE;
@@ -824,20 +824,20 @@ void DGUSDisplay::ProcessRx() {
         Initialized = true; // We've talked to it, so we defined it as initialized.
         uint8_t command = dgusserial.read();
 
-        DGUS_ECHOPAIR("# ", command);
+        DEBUG_ECHOPAIR("# ", command);
 
         uint8_t readlen = rx_datagram_len - 1;  // command is part of len.
         unsigned char tmp[rx_datagram_len - 1];
         unsigned char *ptmp = tmp;
         while (readlen--) {
           receivedbyte = dgusserial.read();
-          DGUS_ECHOPAIR(" ", receivedbyte);
+          DEBUG_ECHOPAIR(" ", receivedbyte);
           *ptmp++ = receivedbyte;
         }
-        DGUS_ECHOPGM(" # ");
+        DEBUG_ECHOPGM(" # ");
         // mostly we'll get this: 5A A5 03 82 4F 4B -- ACK on 0x82, so discard it.
         if (command == DGUS_CMD_WRITEVAR && 'O' == tmp[0] && 'K' == tmp[1]) {
-          DGUS_ECHOLNPGM(">");
+          DEBUG_ECHOLNPGM(">");
           rx_datagram_state = DGUS_IDLE;
           break;
         }
@@ -852,19 +852,19 @@ void DGUSDisplay::ProcessRx() {
         if (command == DGUS_CMD_READVAR) {
           const uint16_t vp = tmp[0] << 8 | tmp[1];
           const uint8_t dlen = tmp[2] << 1;  // Convert to Bytes. (Display works with words)
-          //DGUS_ECHOPAIR(" vp=", vp);	DGUS_ECHOPAIR(" dlen=", dlen);
+          //DEBUG_ECHOPAIR(" vp=", vp);	DEBUG_ECHOPAIR(" dlen=", dlen);
           DGUS_VP_Variable ramcopy;
           if (populate_VPVar(vp, &ramcopy)) {
             if (!(dlen == ramcopy.size || (dlen == 2 && ramcopy.size == 1)))
-              DGUS_ECHOLNPGM("SIZE MISMATCH");
+              DEBUG_ECHOLNPGM("SIZE MISMATCH");
             else if (ramcopy.set_by_display_handler) {
               ramcopy.set_by_display_handler(ramcopy, &tmp[3]);
             }
             else
-              DGUS_ECHOLNPGM(" VPVar found, no handler.");
+              DEBUG_ECHOLNPGM(" VPVar found, no handler.");
           }
           else
-            DGUS_ECHOLNPAIR(" VPVar not found:", vp);
+            DEBUG_ECHOLNPAIR(" VPVar not found:", vp);
 
           rx_datagram_state = DGUS_IDLE;
           break;

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
@@ -139,12 +139,10 @@ private:
 
 static DGUSSerial dgusserial;
 
-// endianess swap
-uint16_t swap16(uint16_t value) {
-  return (value & 0xffU) << 8U | (value >> 8U);
-}
+// endianness swap
+uint16_t swap16(const uint16_t value) { return (value & 0xffU) << 8U | (value >> 8U); }
 
-bool populate_VPVar(uint16_t VP, DGUS_VP_Variable *ramcopy) {
+bool populate_VPVar(const uint16_t VP, DGUS_VP_Variable * const ramcopy) {
   // DEBUG_ECHOPAIR("populate_VPVar ", VP);
   const DGUS_VP_Variable *pvp = DGUSLCD_FindVPVar(VP);
   // DEBUG_ECHOLNPAIR(" pvp ", (uint16_t )pvp);
@@ -420,7 +418,7 @@ const uint16_t* DGUSLCD_FindScreenVPMapList(uint8_t screen) {
   return nullptr;
 }
 
-const DGUS_VP_Variable* DGUSLCD_FindVPVar(uint16_t vp) {
+const DGUS_VP_Variable* DGUSLCD_FindVPVar(const uint16_t vp) {
   const DGUS_VP_Variable *ret = ListOfVP;
   do {
     const uint16_t vpcheck = pgm_read_word(&(ret->VP));
@@ -501,17 +499,13 @@ void DGUSScreenVariableHandler::HandleTemperatureChanged(DGUS_VP_Variable &ref_t
 void DGUSScreenVariableHandler::HandleFlowRateChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
   uint16_t newvalue = swap16(*(uint16_t*) ptr_to_new_value);
   uint8_t target_extruder;
-  switch(ref_to_this.VP) {
+  switch (ref_to_this.VP) {
     default: return;
     #if (HOTENDS >= 1)
-      case VP_Flowrate_E1:
-        target_extruder = 0;
-        break;
+      case VP_Flowrate_E1: target_extruder = 0; break;
     #endif
     #if (HOTENDS >= 2)
-      case VP_Flowrate_E2:
-        target_extruder = 1;
-        break;
+      case VP_Flowrate_E2: target_extruder = 1; break;
     #endif
   }
 
@@ -528,16 +522,12 @@ void DGUSScreenVariableHandler::HandleManualExtrude(DGUS_VP_Variable &ref_to_thi
   ExtUI::extruder_t target_extruder;
 
   switch (ref_to_this.VP) {
-#if HOTENDS >=1
-    case VP_MOVE_E1:
-      target_extruder = ExtUI::extruder_t::E0;
-      break;
-#endif
-#if HOTENDS >=2
-    case VP_MOVE_E2:
-      target_extruder = ExtUI::extruder_t::E1;
-      break
-#endif
+    #if HOTENDS >=1
+      case VP_MOVE_E1: target_extruder = ExtUI::extruder_t::E0; break;
+    #endif
+    #if HOTENDS >=2
+      case VP_MOVE_E2: target_extruder = ExtUI::extruder_t::E1; break
+    #endif
     default: return;
   }
 

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
@@ -1,0 +1,261 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/* DGUS implementation written by coldtobi in 2019 for Marlin */
+
+#include "../../../../inc/MarlinConfigPre.h"
+
+#include "../../../../Marlin.h"
+#include "DGUSVPVariable.h"
+
+enum DGUSLCD_Screens : uint8_t;
+
+#if ENABLED(DEBUG_DGUSLCD)
+  extern bool dguslcd_local_debug;
+  #define DGUS_DEBUG(V) REMEMBER(dgus,dguslcd_local_debug,V)
+#else
+  constexpr bool dguslcd_local_debug = false;
+  #define DGUS_DEBUG(V)
+#endif
+
+#define DGUS_CHAR(x)                 do{if (dguslcd_local_debug) SERIAL_CHAR(x);}while(0)
+#define DGUS_ECHO(x)                 do{if (dguslcd_local_debug) SERIAL_ECHO(x);}while(0)
+#define DGUS_ECHOPGM(x)              do{if (dguslcd_local_debug) SERIAL_ECHOPGM(x);}while(0)
+#define DGUS_ECHOLN(x)               do{if (dguslcd_local_debug) SERIAL_ECHOLN(x);}while(0)
+#define DGUS_ECHOLNPGM(x)            do{if (dguslcd_local_debug) SERIAL_ECHOLNPGM(x);}while(0)
+#define DGUS_ECHOPAIR(pre,value)     do{if (dguslcd_local_debug) SERIAL_ECHOPAIR(pre, value);}while(0)
+#define DGUS_ECHOLNPAIR(pre,value)   do{if (dguslcd_local_debug) SERIAL_ECHOLNPAIR(pre, value);}while(0)
+#define DGUS_ECHO_F(x,y)             do{if (dguslcd_local_debug) SERIAL_ECHO_F(x,y);}while(0)
+
+typedef enum : uint8_t {
+  DGUS_IDLE,           //< waiting for DGUS_HEADER1.
+  DGUS_HEADER1_SEEN,   //< DGUS_HEADER1 received
+  DGUS_HEADER2_SEEN,   //< DGUS_HEADER2 received
+  DGUS_WAIT_TELEGRAM,  //< LEN received, Waiting for to receive all bytes.
+} rx_datagram_state_t;
+
+// Low-Level access to the display.
+class DGUSDisplay {
+public:
+
+  DGUSDisplay() = default;
+
+  static void InitDisplay();
+
+  // Variable access.
+  static void WriteVariable(uint16_t adr, const void* values, uint8_t valueslen, bool isstr=false);
+  static void WriteVariablePGM(uint16_t adr, const void* values, uint8_t valueslen, bool isstr=false);
+  template<typename T>
+  static void WriteVariable(uint16_t adr, T value) {
+    WriteVariable(adr, static_cast<const void*>(&value), sizeof(T));
+  }
+
+  // Until now I did not have the need to actively read from the display. That's why there is no ReadVariable
+  // (I extensively use the auto upload of the display)
+
+  // Force display into another screen.
+  // (And trigger update of containing VPs)
+  // (to implement an pop up message, which may not be nested)
+  static void RequestScreen(DGUSLCD_Screens screen);
+
+  // Periodic tasks, eg. Rx-Queue handling.
+  static void loop();
+
+public:
+  // Helper for users of this class to estimate if an interaction would be blocking.
+  static size_t GetFreeTxBuffer();
+
+  // Checks two things: Can we confirm the presence of the display and has we initiliazed it.
+  // (both boils down that the display answered to our chatting)
+  static inline bool isInitialized() { return Initialized; }
+
+private:
+  static void WriteHeader(uint16_t adr, uint8_t cmd, uint8_t payloadlen);
+  static void WritePGM(const char str[], uint8_t len);
+  static void ProcessRx();
+
+  static rx_datagram_state_t rx_datagram_state;
+  static uint8_t rx_datagram_len;
+  static bool Initialized, no_reentrance;
+};
+
+extern DGUSDisplay dgusdisplay;
+
+// compile-time x^y
+constexpr float cpow(const float x, const int y) { return y == 0 ? 1.0 : x * cpow(x, y-1); }
+
+class DGUSScreenVariableHandler {
+public:
+  DGUSScreenVariableHandler() = default;
+
+  static bool loop();
+
+  /// Send all 4 strings that are displayed on the infoscreen, confirmation screen and kill screen
+  /// The bools specifing whether the strings are in RAM or FLASH.
+  static void sendinfoscreen(const char* line1, const char* line2, const char* line3, const char* line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);
+
+  static void HandleUserConfirmationPopUp(uint16_t ConfirmVP, const char* line1, const char* line2, const char* line3, const char* line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);
+
+  /// "M117" Message -- msg is a RAM ptr.
+  static void setstatusmessage(const char* msg);
+  /// The same for messages from Flash
+  static void setstatusmessagePGM(PGM_P const msg);
+  // Callback for VP "Display wants to change screen on idle printer"
+  static void ScreenChangeHookIfIdle(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  // Callback for VP "Screen has been changed"
+  static void ScreenChangeHook(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  // Callback for VP "All Heaters Off"
+  static void HandleAllHeatersOff(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  // Hook for "Change this temperature"
+  static void HandleTemperatureChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  // Hook for "Change Flowrate"
+  static void HandleFlowRateChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  // Hook for manual move.
+  static void HandleManualMove(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  // Hook for manual extrude.
+  static void HandleManualExtrude(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+
+  #if ENABLED(SDSUPPORT)
+    // Callcack for VP "Display wants to change screen when there is a SD card"
+    static void ScreenChangeHookIfSD(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    /// Scroll buttons on the filelisting screen.
+    static void DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    /// File touched.
+    static void DGUSLCD_SD_FileSelected(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    /// start print after confirmation received.
+    static void DGUSLCD_SD_StartPrint(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    /// User hit the pause, resume or abort button.
+    static void DGUSLCD_SD_ResumePauseAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    /// User confirmed the abort action
+    static void DGUSLCD_SD_ReallyAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    /// Send a single filename to the display.
+    static void DGUSLCD_SD_SendFilename(DGUS_VP_Variable &ref_to_this);
+    /// Marlin informed us that a new SD has been inserted.
+    static void SDCardInserted();
+    /// Marlin informed us that the SD Card has been removed();
+    static void SDCardRemoved();
+    /// Marlin informed us about an bad SD Card.
+    static void SDCardError();
+  #endif
+
+  // OK Button the Confirm screen.
+  static void ScreenConfirmedOK(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+
+  // Update data after went to new screen (by display or by GotoScreen)
+  // remember: store the last displayed screen, so that one can get back
+  // to it. (e.g for pop up messages)
+  static void UpdateNewScreen(DGUSLCD_Screens newscreen, bool popup=false);
+
+  // Recall the remembered screen.
+  static void PopToOldScreen();
+
+  // Make the display display the screen and update all VPs in it.
+  static void GotoScreen(DGUSLCD_Screens screen, bool ispopup = false);
+
+  static void UpdateScreenVPData();
+
+  // Helpers to convert and transfer data to the display.
+  static void DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &ref_to_this);
+  static void DGUSLCD_SendStringToDisplay(DGUS_VP_Variable &ref_to_this);
+  static void DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &ref_to_this);
+  static void DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &ref_to_this);
+  static void DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &ref_to_this);
+
+  /// Send a value from 0..100 to a variable with a range from 0..255
+  static void DGUSLCD_PercentageToUint8(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+
+  template<typename T>
+  static void DGUSLCD_SetValueDirectly(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
+    if (!ref_to_this.memadr) return;
+
+    union {
+      unsigned char tmp[sizeof(T)];
+      T t;
+    } x;
+    unsigned char *ptr = (unsigned char*)ptr_to_new_value;
+    for(uint8_t i=0; i < sizeof(T); i++) {
+       x.tmp[i] = ptr[sizeof(T) - i - 1 ];
+    }
+    *(T*)ref_to_this.memadr = x.t;
+  }
+
+  /// Send a float value to the display.
+  /// Display will get a 4-byte integer scaled to the number of digits:
+  /// Tell the display the number of digits and it cheats by displaying a dot between...
+  template<unsigned int decimals>
+  static void DGUSLCD_SendFloatAsLongValueToDisplay(DGUS_VP_Variable &ref_to_this) {
+    if (ref_to_this.memadr) {
+      float f = *(float *)ref_to_this.memadr;
+      f *= cpow(10,decimals);
+      union {
+        long l;
+        char lb[4];
+      } endian;
+
+      char tmp[4];
+      endian.l = f;
+      tmp[0] = endian.lb[3];
+      tmp[1] = endian.lb[2];
+      tmp[2] = endian.lb[1];
+      tmp[3] = endian.lb[0];
+      dgusdisplay.WriteVariable(ref_to_this.VP, tmp, 4);
+    }
+  }
+
+  /// Force an update of all VP on the current screen.
+  static inline void ForceCompleteUpdate() { update_ptr = 0; ScreenComplete = false; }
+  /// Has all VPs sent to the screen
+  static inline bool IsScreenComplete() { return ScreenComplete; }
+
+  static inline DGUSLCD_Screens getCurrentScreen() { return current_screen; }
+
+  static inline void SetupConfirmAction( void (*f)()) {
+    confirmaction_cb = f;
+  }
+
+private:
+  static DGUSLCD_Screens current_screen;  ///< currently on screen
+  static constexpr uint8_t NUM_PAST_SCREENS = 4;
+  static DGUSLCD_Screens past_screens[NUM_PAST_SCREENS]; ///< LIFO with past screens for the "back" button.
+
+  static uint8_t update_ptr;    ///< Last sent entry in the VPList for the actual screen.
+  static uint16_t skipVP;       ///< When updating the screen data, skip this one, because the user is interacting with it.
+  static bool ScreenComplete;   ///< All VPs sent to screen?
+
+  static uint16_t ConfirmVP;    ///< context for confirm screen (VP that will be emulated-sent on "OK").
+
+  #if ENABLED(SDSUPPORT)
+    static int16_t top_file;    ///< file on top of file chooser
+    static int16_t file_to_print; ///< touched file to be confimed
+  #endif
+
+  static void (*confirmaction_cb)();
+};
+
+extern DGUSScreenVariableHandler ScreenHandler;
+
+/// Find the flash address of a DGUS_VP_Variable for the VP.
+extern const DGUS_VP_Variable* DGUSLCD_FindVPVar(uint16_t vp);
+
+/// Helper to populae a DGUS_VP_Variable for a given VP. returns false if not found.
+extern bool populate_VPVar(uint16_t VP,  DGUS_VP_Variable *ramcopy);

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
@@ -107,35 +107,35 @@ public:
   /// The same for messages from Flash
   static void setstatusmessagePGM(PGM_P const msg);
   // Callback for VP "Display wants to change screen on idle printer"
-  static void ScreenChangeHookIfIdle(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void ScreenChangeHookIfIdle(DGUS_VP_Variable &var, void *val_ptr);
   // Callback for VP "Screen has been changed"
-  static void ScreenChangeHook(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr);
   // Callback for VP "All Heaters Off"
-  static void HandleAllHeatersOff(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void HandleAllHeatersOff(DGUS_VP_Variable &var, void *val_ptr);
   // Hook for "Change this temperature"
-  static void HandleTemperatureChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void HandleTemperatureChanged(DGUS_VP_Variable &var, void *val_ptr);
   // Hook for "Change Flowrate"
-  static void HandleFlowRateChanged(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void HandleFlowRateChanged(DGUS_VP_Variable &var, void *val_ptr);
   // Hook for manual move.
-  static void HandleManualMove(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void HandleManualMove(DGUS_VP_Variable &var, void *val_ptr);
   // Hook for manual extrude.
-  static void HandleManualExtrude(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void HandleManualExtrude(DGUS_VP_Variable &var, void *val_ptr);
 
   #if ENABLED(SDSUPPORT)
     // Callback for VP "Display wants to change screen when there is a SD card"
-    static void ScreenChangeHookIfSD(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    static void ScreenChangeHookIfSD(DGUS_VP_Variable &var, void *val_ptr);
     /// Scroll buttons on the file listing screen.
-    static void DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    static void DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable &var, void *val_ptr);
     /// File touched.
-    static void DGUSLCD_SD_FileSelected(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    static void DGUSLCD_SD_FileSelected(DGUS_VP_Variable &var, void *val_ptr);
     /// start print after confirmation received.
-    static void DGUSLCD_SD_StartPrint(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    static void DGUSLCD_SD_StartPrint(DGUS_VP_Variable &var, void *val_ptr);
     /// User hit the pause, resume or abort button.
-    static void DGUSLCD_SD_ResumePauseAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    static void DGUSLCD_SD_ResumePauseAbort(DGUS_VP_Variable &var, void *val_ptr);
     /// User confirmed the abort action
-    static void DGUSLCD_SD_ReallyAbort(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+    static void DGUSLCD_SD_ReallyAbort(DGUS_VP_Variable &var, void *val_ptr);
     /// Send a single filename to the display.
-    static void DGUSLCD_SD_SendFilename(DGUS_VP_Variable &ref_to_this);
+    static void DGUSLCD_SD_SendFilename(DGUS_VP_Variable &var);
     /// Marlin informed us that a new SD has been inserted.
     static void SDCardInserted();
     /// Marlin informed us that the SD Card has been removed().
@@ -145,7 +145,7 @@ public:
   #endif
 
   // OK Button the Confirm screen.
-  static void ScreenConfirmedOK(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void ScreenConfirmedOK(DGUS_VP_Variable &var, void *val_ptr);
 
   // Update data after went to new screen (by display or by GotoScreen)
   // remember: store the last-displayed screen, so it can get returned to.
@@ -161,31 +161,31 @@ public:
   static void UpdateScreenVPData();
 
   // Helpers to convert and transfer data to the display.
-  static void DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &ref_to_this);
-  static void DGUSLCD_SendStringToDisplay(DGUS_VP_Variable &ref_to_this);
-  static void DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &ref_to_this);
-  static void DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &ref_to_this);
-  static void DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &ref_to_this);
+  static void DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &var);
+  static void DGUSLCD_SendStringToDisplay(DGUS_VP_Variable &var);
+  static void DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &var);
+  static void DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &var);
+  static void DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &var);
 
   /// Send a value from 0..100 to a variable with a range from 0..255
-  static void DGUSLCD_PercentageToUint8(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  static void DGUSLCD_PercentageToUint8(DGUS_VP_Variable &var, void *val_ptr);
 
   template<typename T>
-  static void DGUSLCD_SetValueDirectly(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
-    if (!ref_to_this.memadr) return;
+  static void DGUSLCD_SetValueDirectly(DGUS_VP_Variable &var, void *val_ptr) {
+    if (!var.memadr) return;
     union { unsigned char tmp[sizeof(T)]; T t; } x;
-    unsigned char *ptr = (unsigned char*)ptr_to_new_value;
+    unsigned char *ptr = (unsigned char*)val_ptr;
     for (uint8_t i = 0; i < sizeof(T); i++) x.tmp[i] = ptr[sizeof(T) - i - 1];
-    *(T*)ref_to_this.memadr = x.t;
+    *(T*)var.memadr = x.t;
   }
 
   /// Send a float value to the display.
   /// Display will get a 4-byte integer scaled to the number of digits:
   /// Tell the display the number of digits and it cheats by displaying a dot between...
   template<unsigned int decimals>
-  static void DGUSLCD_SendFloatAsLongValueToDisplay(DGUS_VP_Variable &ref_to_this) {
-    if (ref_to_this.memadr) {
-      float f = *(float *)ref_to_this.memadr;
+  static void DGUSLCD_SendFloatAsLongValueToDisplay(DGUS_VP_Variable &var) {
+    if (var.memadr) {
+      float f = *(float *)var.memadr;
       f *= cpow(10, decimals);
       union { long l; char lb[4]; } endian;
 
@@ -195,7 +195,7 @@ public:
       tmp[1] = endian.lb[2];
       tmp[2] = endian.lb[1];
       tmp[3] = endian.lb[0];
-      dgusdisplay.WriteVariable(ref_to_this.VP, tmp, 4);
+      dgusdisplay.WriteVariable(var.VP, tmp, 4);
     }
   }
 

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
@@ -30,22 +30,8 @@
 
 enum DGUSLCD_Screens : uint8_t;
 
-#if ENABLED(DEBUG_DGUSLCD)
-  extern bool dguslcd_local_debug;
-  #define DGUS_DEBUG(V) REMEMBER(dgus,dguslcd_local_debug,V)
-#else
-  constexpr bool dguslcd_local_debug = false;
-  #define DGUS_DEBUG(V)
-#endif
-
-#define DGUS_CHAR(x)                 do{if (dguslcd_local_debug) SERIAL_CHAR(x);}while(0)
-#define DGUS_ECHO(x)                 do{if (dguslcd_local_debug) SERIAL_ECHO(x);}while(0)
-#define DGUS_ECHOPGM(x)              do{if (dguslcd_local_debug) SERIAL_ECHOPGM(x);}while(0)
-#define DGUS_ECHOLN(x)               do{if (dguslcd_local_debug) SERIAL_ECHOLN(x);}while(0)
-#define DGUS_ECHOLNPGM(x)            do{if (dguslcd_local_debug) SERIAL_ECHOLNPGM(x);}while(0)
-#define DGUS_ECHOPAIR(pre,value)     do{if (dguslcd_local_debug) SERIAL_ECHOPAIR(pre, value);}while(0)
-#define DGUS_ECHOLNPAIR(pre,value)   do{if (dguslcd_local_debug) SERIAL_ECHOLNPAIR(pre, value);}while(0)
-#define DGUS_ECHO_F(x,y)             do{if (dguslcd_local_debug) SERIAL_ECHO_F(x,y);}while(0)
+#define DEBUG_OUT ENABLED(DEBUG_DGUSLCD)
+#include "../../../../core/debug_out.h"
 
 typedef enum : uint8_t {
   DGUS_IDLE,           //< waiting for DGUS_HEADER1.

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
@@ -56,12 +56,12 @@ public:
     WriteVariable(adr, static_cast<const void*>(&value), sizeof(T));
   }
 
-  // Until now I did not have the need to actively read from the display. That's why there is no ReadVariable
+  // Until now I did not need to actively read from the display. That's why there is no ReadVariable
   // (I extensively use the auto upload of the display)
 
   // Force display into another screen.
   // (And trigger update of containing VPs)
-  // (to implement an pop up message, which may not be nested)
+  // (to implement a pop up message, which may not be nested)
   static void RequestScreen(DGUSLCD_Screens screen);
 
   // Periodic tasks, eg. Rx-Queue handling.
@@ -122,9 +122,9 @@ public:
   static void HandleManualExtrude(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
 
   #if ENABLED(SDSUPPORT)
-    // Callcack for VP "Display wants to change screen when there is a SD card"
+    // Callback for VP "Display wants to change screen when there is a SD card"
     static void ScreenChangeHookIfSD(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
-    /// Scroll buttons on the filelisting screen.
+    /// Scroll buttons on the file listing screen.
     static void DGUSLCD_SD_ScrollFilelist(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
     /// File touched.
     static void DGUSLCD_SD_FileSelected(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
@@ -138,9 +138,9 @@ public:
     static void DGUSLCD_SD_SendFilename(DGUS_VP_Variable &ref_to_this);
     /// Marlin informed us that a new SD has been inserted.
     static void SDCardInserted();
-    /// Marlin informed us that the SD Card has been removed();
+    /// Marlin informed us that the SD Card has been removed().
     static void SDCardRemoved();
-    /// Marlin informed us about an bad SD Card.
+    /// Marlin informed us about a bad SD Card.
     static void SDCardError();
   #endif
 
@@ -148,14 +148,14 @@ public:
   static void ScreenConfirmedOK(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
 
   // Update data after went to new screen (by display or by GotoScreen)
-  // remember: store the last displayed screen, so that one can get back
-  // to it. (e.g for pop up messages)
+  // remember: store the last-displayed screen, so it can get returned to.
+  // (e.g for pop up messages)
   static void UpdateNewScreen(DGUSLCD_Screens newscreen, bool popup=false);
 
   // Recall the remembered screen.
   static void PopToOldScreen();
 
-  // Make the display display the screen and update all VPs in it.
+  // Make the display show the screen and update all VPs in it.
   static void GotoScreen(DGUSLCD_Screens screen, bool ispopup = false);
 
   static void UpdateScreenVPData();
@@ -221,7 +221,7 @@ private:
 
   #if ENABLED(SDSUPPORT)
     static int16_t top_file;    ///< file on top of file chooser
-    static int16_t file_to_print; ///< touched file to be confimed
+    static int16_t file_to_print; ///< touched file to be confirmed
   #endif
 
   static void (*confirm_action_cb)();
@@ -232,5 +232,5 @@ extern DGUSScreenVariableHandler ScreenHandler;
 /// Find the flash address of a DGUS_VP_Variable for the VP.
 extern const DGUS_VP_Variable* DGUSLCD_FindVPVar(const uint16_t vp);
 
-/// Helper to populae a DGUS_VP_Variable for a given VP. returns false if not found.
+/// Helper to populate a DGUS_VP_Variable for a given VP. Return false if not found.
 extern bool populate_VPVar(const uint16_t VP, DGUS_VP_Variable * const ramcopy);

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
@@ -88,7 +88,7 @@ private:
 extern DGUSDisplay dgusdisplay;
 
 // compile-time x^y
-constexpr float cpow(const float x, const int y) { return y == 0 ? 1.0 : x * cpow(x, y-1); }
+constexpr float cpow(const float x, const int y) { return y == 0 ? 1.0 : x * cpow(x, y - 1); }
 
 class DGUSScreenVariableHandler {
 public:
@@ -173,15 +173,9 @@ public:
   template<typename T>
   static void DGUSLCD_SetValueDirectly(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value) {
     if (!ref_to_this.memadr) return;
-
-    union {
-      unsigned char tmp[sizeof(T)];
-      T t;
-    } x;
+    union { unsigned char tmp[sizeof(T)]; T t; } x;
     unsigned char *ptr = (unsigned char*)ptr_to_new_value;
-    for(uint8_t i=0; i < sizeof(T); i++) {
-       x.tmp[i] = ptr[sizeof(T) - i - 1 ];
-    }
+    for (uint8_t i = 0; i < sizeof(T); i++) x.tmp[i] = ptr[sizeof(T) - i - 1];
     *(T*)ref_to_this.memadr = x.t;
   }
 
@@ -192,11 +186,8 @@ public:
   static void DGUSLCD_SendFloatAsLongValueToDisplay(DGUS_VP_Variable &ref_to_this) {
     if (ref_to_this.memadr) {
       float f = *(float *)ref_to_this.memadr;
-      f *= cpow(10,decimals);
-      union {
-        long l;
-        char lb[4];
-      } endian;
+      f *= cpow(10, decimals);
+      union { long l; char lb[4]; } endian;
 
       char tmp[4];
       endian.l = f;
@@ -239,7 +230,7 @@ private:
 extern DGUSScreenVariableHandler ScreenHandler;
 
 /// Find the flash address of a DGUS_VP_Variable for the VP.
-extern const DGUS_VP_Variable* DGUSLCD_FindVPVar(uint16_t vp);
+extern const DGUS_VP_Variable* DGUSLCD_FindVPVar(const uint16_t vp);
 
 /// Helper to populae a DGUS_VP_Variable for a given VP. returns false if not found.
-extern bool populate_VPVar(uint16_t VP,  DGUS_VP_Variable *ramcopy);
+extern bool populate_VPVar(const uint16_t VP, DGUS_VP_Variable * const ramcopy);

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.h
@@ -229,9 +229,7 @@ public:
 
   static inline DGUSLCD_Screens getCurrentScreen() { return current_screen; }
 
-  static inline void SetupConfirmAction( void (*f)()) {
-    confirmaction_cb = f;
-  }
+  static inline void SetupConfirmAction( void (*f)()) { confirm_action_cb = f; }
 
 private:
   static DGUSLCD_Screens current_screen;  ///< currently on screen
@@ -249,7 +247,7 @@ private:
     static int16_t file_to_print; ///< touched file to be confimed
   #endif
 
-  static void (*confirmaction_cb)();
+  static void (*confirm_action_cb)();
 };
 
 extern DGUSScreenVariableHandler ScreenHandler;

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.cpp
@@ -142,6 +142,7 @@ const char MarlinVersion[] PROGMEM = SHORT_BUILD_VERSION;
 #define VPHELPER(VPADR, VPADRVAR, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=sizeof(VPADRVAR), \
   .set_by_display_handler = RXFPTR, .send_to_display_handler = TXFPTR }
 
+// Helper to define a DGUS_VP_Variable when the sizeo of the var cannot be determined automaticalyl (eg. a string)
 #define VPHELPER_STR(VPADR, VPADRVAR, STRLEN, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=STRLEN, \
   .set_by_display_handler = RXFPTR, .send_to_display_handler = TXFPTR }
 
@@ -199,7 +200,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
   VPHELPER(VP_ZPos, &current_position[2], nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<2>),
 
   // Print Progress.
-  VPHELPER(VP_PrintProgress_Percentage, &MarlinUI::progress_bar_percent, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay ),
+  VPHELPER(VP_PrintProgress_Percentage, &MarlinUI::progress_bar_percent, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay ),
 
   // Print Time
   VPHELPER_STR(VP_PrintTime, nullptr, VP_PrintTime_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendPrintTimeToDisplay ),

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.cpp
@@ -1,0 +1,230 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* DGUS implementation written by coldtobi in 2019 for Marlin */
+
+#include "../../../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DGUS_LCD)
+
+#include "DGUSDisplayDefinition.h"
+#include "DGUSDisplay.h"
+
+#include "../../../../module/temperature.h"
+#include "../../../../module/motion.h"
+
+#include "../../../ultralcd.h"
+
+const uint16_t VPList_Boot[] PROGMEM = {
+  VP_MARLIN_VERSION,
+  0x0000
+};
+
+const uint16_t VPList_Main[] PROGMEM = {
+  /* VP_M117, for completeness, but it cannot be auto-uploaded.*/
+  0x0000
+};
+
+const uint16_t VPList_Temp[] PROGMEM = {
+  #if HOTENDS >= 1
+    VP_T_E1_Is, VP_T_E1_Set,
+  #endif
+  #if HOTENDS >= 2
+    VP_T_E2_I, VP_T_E2_S,
+  #endif
+  #if HAS_HEATED_BED
+    VP_T_Bed_Is, VP_T_Bed_Set,
+  #endif
+  0x0000
+};
+
+const uint16_t VPList_Status[] PROGMEM = {
+  /* VP_M117, for completeness, but it cannot be auto-uploaded */
+  #if HOTENDS >= 1
+    VP_T_E1_Is, VP_T_E1_Set,
+  #endif
+  #if HOTENDS >= 2
+    VP_T_E2_I, VP_T_E2_S,
+  #endif
+  #if HAS_HEATED_BED
+    VP_T_Bed_Is, VP_T_Bed_Set,
+  #endif
+  #if FAN_COUNT > 0
+    VP_Fan_Percentage,
+  #endif
+  VP_XPos, VP_YPos, VP_ZPos,
+  VP_Fan_Percentage,
+  VP_Feedrate_Percentage,
+  VP_PrintProgress_Percentage,
+  0x0000
+};
+
+const uint16_t VPList_Status2[] PROGMEM = {
+  /* VP_M117, for completeness, but it cannot be auto-uploaded */
+#if HOTENDS >= 1
+    VP_Flowrate_E1,
+#endif
+#if HOTENDS >= 2
+    VP_Flowrate_E2,
+#endif
+  VP_PrintProgress_Percentage,
+  VP_PrintTime,
+  0x0000
+};
+
+const uint16_t VPList_ManualMove[] PROGMEM = {
+  VP_XPos, VP_YPos, VP_ZPos,
+  0x0000
+};
+
+const uint16_t VPList_ManualExtrude[] PROGMEM = {
+  VP_EPos,
+  0x0000
+};
+
+const uint16_t VPList_FanAndFeedrate[] PROGMEM = {
+  VP_Feedrate_Percentage, VP_Fan_Percentage,
+  0x0000
+};
+
+const uint16_t VPList_SD_FlowRates[] PROGMEM = {
+    VP_Flowrate_E1, VP_Flowrate_E2,
+    0x0000
+};
+
+const uint16_t VPList_SDFileList[] PROGMEM = {
+    VP_SD_FileName0, VP_SD_FileName1, VP_SD_FileName2, VP_SD_FileName3, VP_SD_FileName4,
+    0x0000
+};
+
+const uint16_t VPList_SD_PrintManipulation[] PROGMEM = {
+    VP_PrintProgress_Percentage, VP_PrintTime,
+    0x0000
+};
+
+const struct VPMapping VPMap[] PROGMEM = {
+  { DGUSLCD_SCREEN_BOOT, VPList_Boot },
+  { DGUSLCD_SCREEN_MAIN, VPList_Main },
+  { DGUSLCD_SCREEN_TEMPERATURE, VPList_Temp },
+  { DGUSLCD_SCREEN_STATUS, VPList_Status },
+  { DGUSLCD_SCREEN_STATUS2, VPList_Status2 },
+  { DGUSLCD_SCREEN_MANUALMOVE, VPList_ManualMove },
+  { DGUSLCD_SCREEN_MANUALEXTRUDE, VPList_ManualExtrude },
+  { DGUSLCD_SCREEN_FANANDFEEDRATE, VPList_FanAndFeedrate },
+  { DGUSLCD_SCREEN_FLOWRATES, VPList_SD_FlowRates },
+  { DGUSLCD_SCREEN_SDPRINTMANIPULATION, VPList_SD_PrintManipulation },
+  { DGUSLCD_SCREEN_SDFILELIST, VPList_SDFileList },
+  { 0 , nullptr } // List is terminated with an nullptr as table entry.
+};
+
+const char MarlinVersion[] PROGMEM = SHORT_BUILD_VERSION;
+
+// Helper to define a DGUS_VP_Variable for common use cases.
+#define VPHELPER(VPADR, VPADRVAR, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=sizeof(VPADRVAR), \
+  .set_by_display_handler = RXFPTR, .send_to_display_handler = TXFPTR }
+
+#define VPHELPER_STR(VPADR, VPADRVAR, STRLEN, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=STRLEN, \
+  .set_by_display_handler = RXFPTR, .send_to_display_handler = TXFPTR }
+
+const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
+  // Helper to detect touch events
+  VPHELPER(VP_SCREENCHANGE, nullptr, DGUSScreenVariableHandler::ScreenChangeHook, nullptr),
+  VPHELPER(VP_SCREENCHANGE_ASK, nullptr, DGUSScreenVariableHandler::ScreenChangeHookIfIdle, nullptr),
+  VPHELPER(VP_SCREENCHANGE_WHENSD, nullptr, DGUSScreenVariableHandler::ScreenChangeHookIfSD, nullptr),
+  VPHELPER(VP_CONFIRMED, nullptr, DGUSScreenVariableHandler::ScreenConfirmedOK, nullptr),
+
+  VPHELPER(VP_TEMP_ALL_OFF, nullptr, &DGUSScreenVariableHandler::HandleAllHeatersOff, nullptr),
+
+  VPHELPER(VP_MOVE_X, nullptr, &DGUSScreenVariableHandler::HandleManualMove, nullptr),
+  VPHELPER(VP_MOVE_Y, nullptr, &DGUSScreenVariableHandler::HandleManualMove, nullptr),
+  VPHELPER(VP_MOVE_Z, nullptr, &DGUSScreenVariableHandler::HandleManualMove, nullptr),
+  VPHELPER(VP_HOME_ALL, nullptr, &DGUSScreenVariableHandler::HandleManualMove, nullptr),
+
+  { .VP = VP_MARLIN_VERSION, .memadr = (void*)MarlinVersion, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM },
+  // M117 LCD String (We don't need the string in memory but "just" push it to the display on demand, hence the nullptr
+  { .VP = VP_M117, .memadr = nullptr, .size = VP_M117_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplay },
+
+  // Temperature Data
+  #if HOTENDS >= 1
+    VPHELPER(VP_T_E1_Is, &thermalManager.temp_hotend[0].current, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<0>),
+    VPHELPER(VP_T_E1_Set, &thermalManager.temp_hotend[0].target, DGUSScreenVariableHandler::HandleTemperatureChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),
+    VPHELPER(VP_Flowrate_E1, nullptr, DGUSScreenVariableHandler::HandleFlowRateChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),
+    VPHELPER(VP_EPos, &destination[3], nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<2>),
+    VPHELPER(VP_MOVE_E1, nullptr, &DGUSScreenVariableHandler::HandleManualExtrude, nullptr),
+    #endif
+  #if HOTENDS >= 2
+    VPHELPER(VP_T_E2_I, &thermalManager.temp_hotend[1].current, nullptr, DGUSLCD_SendFloatAsLongValueToDisplay<0>),
+    VPHELPER(VP_T_E2_S, &thermalManager.temp_hotend[1].target, DGUSScreenVariableHandler::HandleTemperatureChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),
+    VPHELPER(VP_Flowrate_E2, nullptr, DGUSScreenVariableHandler::HandleFlowRateChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),
+    VPHELPER(VP_MOVE_E2, nullptr, &DGUSScreenVariableHandler::HandleManualExtrude, nullptr),
+  #endif
+  #if HOTENDS >= 3
+    #error More than 2 Hotends currently not implemented on the Display UI design.
+  #endif
+  #if HAS_HEATED_BED
+    VPHELPER(VP_T_Bed_Is, &thermalManager.temp_bed.current, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<0>),
+    VPHELPER(VP_T_Bed_Set, &thermalManager.temp_bed.target, DGUSScreenVariableHandler::HandleTemperatureChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),
+  #endif
+
+  // Fan Data.
+  #if FAN_COUNT > 0
+    VPHELPER(VP_Fan_Percentage, &thermalManager.fan_speed[0], DGUSScreenVariableHandler::DGUSLCD_PercentageToUint8, &DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay),
+  #endif
+
+  // Feedrate.
+  VPHELPER(VP_Feedrate_Percentage, &feedrate_percentage, DGUSScreenVariableHandler::DGUSLCD_SetValueDirectly<int16_t>, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay ),
+
+  // Position Data.
+  VPHELPER(VP_XPos, &current_position[0], nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<2>),
+  VPHELPER(VP_YPos, &current_position[1], nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<2>),
+  VPHELPER(VP_ZPos, &current_position[2], nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<2>),
+
+  // Print Progress.
+  VPHELPER(VP_PrintProgress_Percentage, &MarlinUI::progress_bar_percent, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendPercentageToDisplay ),
+
+  // Print Time
+  VPHELPER_STR(VP_PrintTime, nullptr, VP_PrintTime_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SendPrintTimeToDisplay ),
+
+  // SDCard File listing.
+  #if ENABLED(SDSUPPORT)
+    VPHELPER(VP_SD_ScrollEvent, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_ScrollFilelist, nullptr),
+    VPHELPER(VP_SD_FileSelected, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_FileSelected, nullptr),
+    VPHELPER(VP_SD_FileSelectConfirm, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_StartPrint, nullptr),
+    VPHELPER_STR(VP_SD_FileName0,  nullptr, VP_SD_FileName_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename ),
+    VPHELPER_STR(VP_SD_FileName1,  nullptr, VP_SD_FileName_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename ),
+    VPHELPER_STR(VP_SD_FileName2,  nullptr, VP_SD_FileName_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename ),
+    VPHELPER_STR(VP_SD_FileName3,  nullptr, VP_SD_FileName_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename ),
+    VPHELPER_STR(VP_SD_FileName4,  nullptr, VP_SD_FileName_LEN, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_SendFilename ),
+    VPHELPER(VP_SD_ResumePauseAbort, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_ResumePauseAbort, nullptr),
+    VPHELPER(VP_SD_AbortPrintConfirmed, nullptr, DGUSScreenVariableHandler::DGUSLCD_SD_ReallyAbort, nullptr),
+  #endif
+
+  // Messages for the User, shared by the popup and the kill screen. They cant be autouploaded as we do not buffer content.
+  { .VP = VP_MSGSTR1, .memadr = nullptr, .size = VP_MSGSTR1_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = &DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM },
+  { .VP = VP_MSGSTR2, .memadr = nullptr, .size = VP_MSGSTR2_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = &DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM },
+  { .VP = VP_MSGSTR3, .memadr = nullptr, .size = VP_MSGSTR3_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = &DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM },
+  { .VP = VP_MSGSTR4, .memadr = nullptr, .size = VP_MSGSTR4_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = &DGUSScreenVariableHandler::DGUSLCD_SendStringToDisplayPGM },
+
+  VPHELPER(0, 0, 0, 0)  // must be last entry.
+};
+
+#endif // DGUS_LCD

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.cpp
@@ -40,7 +40,7 @@ const uint16_t VPList_Boot[] PROGMEM = {
 };
 
 const uint16_t VPList_Main[] PROGMEM = {
-  /* VP_M117, for completeness, but it cannot be auto-uploaded.*/
+  /* VP_M117, for completeness, but it cannot be auto-uploaded. */
   0x0000
 };
 
@@ -80,12 +80,12 @@ const uint16_t VPList_Status[] PROGMEM = {
 
 const uint16_t VPList_Status2[] PROGMEM = {
   /* VP_M117, for completeness, but it cannot be auto-uploaded */
-#if HOTENDS >= 1
+  #if HOTENDS >= 1
     VP_Flowrate_E1,
-#endif
-#if HOTENDS >= 2
+  #endif
+  #if HOTENDS >= 2
     VP_Flowrate_E2,
-#endif
+  #endif
   VP_PrintProgress_Percentage,
   VP_PrintTime,
   0x0000
@@ -107,18 +107,18 @@ const uint16_t VPList_FanAndFeedrate[] PROGMEM = {
 };
 
 const uint16_t VPList_SD_FlowRates[] PROGMEM = {
-    VP_Flowrate_E1, VP_Flowrate_E2,
-    0x0000
+  VP_Flowrate_E1, VP_Flowrate_E2,
+  0x0000
 };
 
 const uint16_t VPList_SDFileList[] PROGMEM = {
-    VP_SD_FileName0, VP_SD_FileName1, VP_SD_FileName2, VP_SD_FileName3, VP_SD_FileName4,
-    0x0000
+  VP_SD_FileName0, VP_SD_FileName1, VP_SD_FileName2, VP_SD_FileName3, VP_SD_FileName4,
+  0x0000
 };
 
 const uint16_t VPList_SD_PrintManipulation[] PROGMEM = {
-    VP_PrintProgress_Percentage, VP_PrintTime,
-    0x0000
+  VP_PrintProgress_Percentage, VP_PrintTime,
+  0x0000
 };
 
 const struct VPMapping VPMap[] PROGMEM = {
@@ -170,7 +170,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_Flowrate_E1, nullptr, DGUSScreenVariableHandler::HandleFlowRateChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),
     VPHELPER(VP_EPos, &destination[3], nullptr, DGUSScreenVariableHandler::DGUSLCD_SendFloatAsLongValueToDisplay<2>),
     VPHELPER(VP_MOVE_E1, nullptr, &DGUSScreenVariableHandler::HandleManualExtrude, nullptr),
-    #endif
+  #endif
   #if HOTENDS >= 2
     VPHELPER(VP_T_E2_I, &thermalManager.temp_hotend[1].current, nullptr, DGUSLCD_SendFloatAsLongValueToDisplay<0>),
     VPHELPER(VP_T_E2_S, &thermalManager.temp_hotend[1].target, DGUSScreenVariableHandler::HandleTemperatureChanged, &DGUSScreenVariableHandler::DGUSLCD_SendWordValueToDisplay),

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplayDefinition.h
@@ -1,0 +1,192 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/* DGUS implementation written by coldtobi in 2019 for Marlin */
+
+#include "DGUSVPVariable.h"
+
+// This file defines the interaction between Marlin and the display firmware.
+
+// information on which screen which VP is displayed
+// As this is a sparse table, two arrays are needed:
+// one to list the VPs of one screen and one to map screens to the lists.
+// (Strictly this would not be necessary, but allows to only send data the display needs and reducing load on Marlin)
+struct VPMapping {
+  const uint8_t screen;
+  const uint16_t *VPList;  // The list is null-terminated.
+};
+
+extern const struct VPMapping VPMap[];
+
+enum DGUSLCD_Screens : uint8_t {
+  DGUSLCD_SCREEN_BOOT = 0,
+  DGUSLCD_SCREEN_MAIN = 10,
+  DGUSLCD_SCREEN_TEMPERATURE = 20,
+  DGUSLCD_SCREEN_STATUS = 30,
+  DGUSLCD_SCREEN_STATUS2 = 32,
+  DGUSLCD_SCREEN_MANUALMOVE = 40,
+  DGUSLCD_SCREEN_MANUALEXTRUDE=42,
+  DGUSLCD_SCREEN_FANANDFEEDRATE = 44,
+  DGUSLCD_SCREEN_FLOWRATES = 46,
+  DGUSLCD_SCREEN_SDFILELIST = 50,
+  DGUSLCD_SCREEN_SDPRINTMANIPULATION = 52,
+  DGUSLCD_SCREEN_CONFIRM = 240,
+  DGUSLCD_SCREEN_KILL = 250, ///< Kill Screen. Must always be 250 (to be able to display "Error wrong LCD Version")
+  DGUSLCD_SCREEN_POPUP = 252,  ///< special target, popup screen will also return this code to say "return to previous screen"
+  DGUSLDC_SCREEN_UNUSED = 255
+};
+
+// Display Memory layout used (T5UID)
+// Except system variables this is arbitrary, just to organize stuff....
+
+// 0x0000 .. 0x0FFF  -- System variables and reserved by the display
+// 0x1000 .. 0x1FFF  -- Variables to never change location, regardless of UI Version
+// 0x2000 .. 0x2FFF  -- Controls (VPs that will trigger some action)
+// 0x3000 .. 0x4FFF  -- Marlin Data to be displayed
+// 0x5000 ..         -- SPs (if we want to modify display elements, e.g change color or like) -- currently unused
+
+// As there is plenty of space (at least most displays have >8k RAM), we do not pack them too tight,
+// so that we can keep variables nicely together in the address space.
+
+// UI Version always on 0x1000...0x1002 so that the firmware can check this and bail out.
+constexpr uint16_t VP_UI_VERSION_MAJOR = 0x1000;  // Major -- incremented when incompatible
+constexpr uint16_t VP_UI_VERSION_MINOR = 0x1001;  // Minor -- incremented on new features, but compatible
+constexpr uint16_t VP_UI_VERSION_PATCH = 0x1002;  // Patch -- fixed which do not change functionality.
+constexpr uint16_t VP_UI_FLAVOUR       = 0x1010;  // lets reserve 16 bytes here to determine if UI is suitable for this Marlin. tbd.
+
+// Storage space for the Killscreen messages. 0x1100 - 0x1200 . Reused for the popup.
+constexpr uint16_t VP_MSGSTR1 = 0x1100;
+constexpr uint8_t VP_MSGSTR1_LEN = 0x20;  // might be more place for it...
+constexpr uint16_t VP_MSGSTR2 = 0x1140;
+constexpr uint8_t VP_MSGSTR2_LEN = 0x20;
+constexpr uint16_t VP_MSGSTR3 = 0x1180;
+constexpr uint8_t VP_MSGSTR3_LEN = 0x20;
+constexpr uint16_t VP_MSGSTR4 = 0x11C0;
+constexpr uint8_t VP_MSGSTR4_LEN = 0x20;
+
+// Screenchange request for screens that only make sense when printer is idle.
+// e.g movement is only allowed if printer is not printing.
+// Marlin must confirm by setting the screen manually.
+constexpr uint16_t VP_SCREENCHANGE_ASK = 0x2000;
+constexpr uint16_t VP_SCREENCHANGE = 0x2001;   // Key-Return button to new menu pressed. Data contains target screen in low byte and info in high byte.
+constexpr uint16_t VP_TEMP_ALL_OFF = 0x2002;   // Turn all heaters off. Value arbitrary ;)=
+constexpr uint16_t VP_SCREENCHANGE_WHENSD = 0x2003; // "Print" Button touched -- go only there if there is an SD Card.
+
+constexpr uint16_t VP_CONFIRMED = 0x2010; // OK on confirm screen.
+
+// Buttons on the SD-Card File listing.
+constexpr uint16_t VP_SD_ScrollEvent = 0x2020; // Data: 0 for "up a directory", numbers are the amount to scroll, e.g -1 one up, 1 one down
+constexpr uint16_t VP_SD_FileSelected = 0x2022; // Number of file field selected.
+constexpr uint16_t VP_SD_FileSelectConfirm = 0x2024; // (This is a virtual VP and emulated by the Confirm Screen when a file has been confirmed)
+
+constexpr uint16_t VP_SD_ResumePauseAbort = 0x2026; // Resume(Data=0), Pause(Data=1), Abort(Data=2) SD Card prints
+constexpr uint16_t VP_SD_AbortPrintConfirmed = 0x2028; // Abort print confirmation (virtual, will be injected by the confirm dialog)
+
+// Controls for movement (we can't use the incremental / decremental feature of the display at this feature works only with 16 bit values
+// (which would limit us to 655.35mm, which is likely not a problem for common setups, but i don't want to rule out hangprinters support)
+// A word about the coding: The VP will be per axis and the return code will be an signed 16 bit value in 0.01 mm resolution, telling us
+// the relative travel amount t he user wants to do. So eg. if the display sends us VP=2100 with value 100, the user wants us to move X by +1 mm.
+constexpr uint16_t VP_MOVE_X = 0x2100;
+constexpr uint16_t VP_MOVE_Y = 0x2102;
+constexpr uint16_t VP_MOVE_Z = 0x2104;
+constexpr uint16_t VP_MOVE_E1 = 0x2110;
+constexpr uint16_t VP_MOVE_E2 = 0x2112;
+//constexpr uint16_t VP_MOVE_E3 = 0x2114;
+//constexpr uint16_t VP_MOVE_E4 = 0x2116;
+//constexpr uint16_t VP_MOVE_E5 = 0x2118;
+//constexpr uint16_t VP_MOVE_E6 = 0x211A;
+constexpr uint16_t VP_HOME_ALL = 0x2120;
+
+// Firmware version on the boot screen.
+constexpr uint16_t VP_MARLIN_VERSION = 0x3000;
+constexpr uint8_t VP_MARLIN_VERSION_LEN = 16;   // there is more space on the display, if needed.
+
+// Place for status messages.
+constexpr uint16_t VP_M117 = 0x3020;
+constexpr uint8_t VP_M117_LEN = 0x20;
+
+// Temperatures.
+constexpr uint16_t VP_T_E1_Is = 0x3060;  // 4 Byte Integer
+constexpr uint16_t VP_T_E1_Set = 0x3062; // 2 Byte Integer
+constexpr uint16_t VP_T_E2_Is = 0x3064;  // 4 Byte Integer
+
+// reserved to support up to 6 Extruders:
+//constexpr uint16_t VP_T_E2_Set = 0x3066; // 2 Byte Integer
+//constexpr uint16_t VP_T_E3_Is = 0x3068;  // 4 Byte Integer
+//constexpr uint16_t VP_T_E3_Set = 0x306A; // 2 Byte Integer
+//constexpr uint16_t VP_T_E4_Is = 0x306C;  // 4 Byte Integer
+//constexpr uint16_t VP_T_E4_Set = 0x306E; // 2 Byte Integer
+//constexpr uint16_t VP_T_E5_Is = 0x3070;  // 4 Byte Integer
+//constexpr uint16_t VP_T_E5_Set = 0x3072; // 2 Byte Integer
+//constexpr uint16_t VP_T_E5_Is = 0x3074;  // 4 Byte Integer
+//constexpr uint16_t VP_T_E5_Set = 0x3076; // 2 Byte Integer
+//constexpr uint16_t VP_T_E6_Is = 0x3078;  // 4 Byte Integer
+//constexpr uint16_t VP_T_E6_Set = 0x307A; // 2 Byte Integer
+
+constexpr uint16_t VP_T_Bed_Is = 0x3080;  // 4 Byte Integer
+constexpr uint16_t VP_T_Bed_Set = 0x3082; // 2 Byte Integer
+
+constexpr uint16_t VP_Flowrate_E1 = 0x3090; // 2 Byte Integer
+constexpr uint16_t VP_Flowrate_E2 = 0x3092; // 2 Byte Integer
+
+// reserved for up to 6 Extruders:
+//constexpr uint16_t VP_Flowrate_E3 = 0x3094;
+//constexpr uint16_t VP_Flowrate_E4 = 0x3096;
+//constexpr uint16_t VP_Flowrate_E5 = 0x3098;
+//constexpr uint16_t VP_Flowrate_E6 = 0x309A;
+
+constexpr uint16_t VP_Fan_Percentage = 0x3100;  // 2 Byte Integer (0..100)
+constexpr uint16_t VP_Feedrate_Percentage = 0x3102; // 2 Byte Integer (0..100)
+constexpr uint16_t VP_PrintProgress_Percentage = 0x3104; // 2 Byte Integer (0..100)
+
+constexpr uint16_t VP_PrintTime = 0x3106;
+constexpr uint16_t VP_PrintTime_LEN = 10;
+
+// Actual Position
+constexpr uint16_t VP_XPos = 0x3110;  // 4 Byte Fixed point number; format xxx.yy
+constexpr uint16_t VP_YPos = 0x3112;  // 4 Byte Fixed point number; format xxx.yy
+constexpr uint16_t VP_ZPos = 0x3114;  // 4 Byte Fixed point number; format xxx.yy
+
+constexpr uint16_t VP_EPos = 0x3120;  // 4 Byte Fixed point number; format xxx.yy
+
+// SDCard File Listing
+constexpr uint16_t VP_SD_FileName_LEN = 32; // LEN is shared for all entries.
+constexpr uint16_t DGUS_SD_FILESPERSCREEN = 5; // FIXME move that info to the display and read it from there.
+constexpr uint16_t VP_SD_FileName0 = 0x3200;
+constexpr uint16_t VP_SD_FileName1 = 0x3220;
+constexpr uint16_t VP_SD_FileName2 = 0x3240;
+constexpr uint16_t VP_SD_FileName3 = 0x3260;
+constexpr uint16_t VP_SD_FileName4 = 0x3280;
+
+// SPs for certain variables...
+// located at 0x5000 and up
+// Not used yet!
+// This can be used e.g to make controls / data display invisible
+constexpr uint16_t SP_T_E1_Is = 0x5000;
+constexpr uint16_t SP_T_E1_Set = 0x5010;
+constexpr uint16_t SP_T_E2_Is = 0x5020;
+constexpr uint16_t SP_T_Bed_Is = 0x5030;
+constexpr uint16_t SP_T_Bed_Set = 0x5040;
+
+// List of VPs handled by Marlin / The Display.
+extern const struct DGUS_VP_Variable ListOfVP[];

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSVPVariable.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSVPVariable.h
@@ -1,0 +1,25 @@
+/**
+ * DGUSVPVariable.h
+ *
+ *  Created on: Feb 9, 2019
+ *      Author: tobi
+ */
+#pragma once
+
+struct DGUS_VP_Variable {
+  uint16_t VP;
+  void* memadr;  // when you have a nullptr here, the value cannot be uploaded to the display.
+  uint8_t size;
+
+  // Callback that will be called if the display modified the value.
+  // nullptr makes it readonly for the display.
+  void (*set_by_display_handler)(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
+  void (*send_to_display_handler)(DGUS_VP_Variable &ref_to_this);
+
+  template<typename T>
+  DGUS_VP_Variable& operator =(T &o) {
+    *(T*)memadr = o;  // warning this is not typesafe.
+    // TODO: Call out the display or mark as dirty for the next update.
+    return *this;
+  }
+};

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSVPVariable.h
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSVPVariable.h
@@ -1,20 +1,42 @@
 /**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
  * DGUSVPVariable.h
  *
  *  Created on: Feb 9, 2019
  *      Author: tobi
  */
-#pragma once
 
 struct DGUS_VP_Variable {
   uint16_t VP;
-  void* memadr;  // when you have a nullptr here, the value cannot be uploaded to the display.
-  uint8_t size;
+  void*    memadr;  // If nullptr, the value cannot be uploaded to the display.
+  uint8_t  size;
 
   // Callback that will be called if the display modified the value.
   // nullptr makes it readonly for the display.
-  void (*set_by_display_handler)(DGUS_VP_Variable &ref_to_this, void *ptr_to_new_value);
-  void (*send_to_display_handler)(DGUS_VP_Variable &ref_to_this);
+  void (*set_by_display_handler)(DGUS_VP_Variable &var, void *val_ptr);
+  void (*send_to_display_handler)(DGUS_VP_Variable &var);
 
   template<typename T>
   DGUS_VP_Variable& operator =(T &o) {

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/dgus_display.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/dgus_display.cpp
@@ -33,58 +33,46 @@
 
 namespace ExtUI {
 
-void onStartup() {
+  void onStartup() {
     dgusdisplay.InitDisplay();
     ScreenHandler.UpdateScreenVPData();
   }
 
- void onIdle() {
-   ScreenHandler.loop();
- }
+ void onIdle() { ScreenHandler.loop(); }
 
  void onPrinterKilled(const char* msg) {
    ScreenHandler.sendinfoscreen(PSTR(MSG_HALTED), msg, PSTR(""), PSTR(MSG_PLEASE_RESET), true, true, true, true);
    ScreenHandler.GotoScreen(DGUSLCD_SCREEN_KILL);
-   while(!ScreenHandler.loop());  // Wait if there is something still to be sent to the display.
+   while (!ScreenHandler.loop());  // Wait while anything is left to be sent
  }
 
- void onMediaInserted() {
-   ScreenHandler.SDCardInserted();
- }
+  void onMediaInserted() { ScreenHandler.SDCardInserted(); }
+  void onMediaError()    { ScreenHandler.SDCardError(); }
+  void onMediaRemoved()  { ScreenHandler.SDCardRemoved(); }
 
- void onMediaError() {
-   ScreenHandler.SDCardError();
- }
-
- void onMediaRemoved() {
-   ScreenHandler.SDCardRemoved();
- }
-
- void onPlayTone(const uint16_t frequency, const uint16_t duration) {}
- void onPrintTimerStarted() {}
- void onPrintTimerPaused() {}
- void onPrintTimerStopped() {}
- void onFilamentRunout() {}
+  void onPlayTone(const uint16_t frequency, const uint16_t duration) {}
+  void onPrintTimerStarted() {}
+  void onPrintTimerPaused() {}
+  void onPrintTimerStopped() {}
+  void onFilamentRunout() {}
 
   void onUserConfirmRequired(const char *msg) {
     if (msg) {
       ScreenHandler.sendinfoscreen(PSTR("Please confirm."), nullptr, msg, nullptr, true, true, false, true);
       ScreenHandler.SetupConfirmAction(ExtUI::setUserConfirmed);
       ScreenHandler.GotoScreen(DGUSLCD_SCREEN_POPUP);
-    } else
-    if (ScreenHandler.getCurrentScreen() == DGUSLCD_SCREEN_POPUP ) {
+    }
+    else if (ScreenHandler.getCurrentScreen() == DGUSLCD_SCREEN_POPUP ) {
       ScreenHandler.SetupConfirmAction(nullptr);
       ScreenHandler.PopToOldScreen();
     }
   }
 
-  void onStatusChanged(const char * const msg) {
-     ScreenHandler.setstatusmessage(msg);
-  }
+  void onStatusChanged(const char * const msg) { ScreenHandler.setstatusmessage(msg); }
 
- void onFactoryReset() {}
- void onLoadSettings() {}
- void onStoreSettings() {}
+  void onFactoryReset() {}
+  void onLoadSettings() {}
+  void onStoreSettings() {}
 }
 
 #endif // DGUS_LCD

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/dgus_display.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/dgus_display.cpp
@@ -1,0 +1,90 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/* DGUS implementation written by coldtobi in 2019 for Marlin */
+
+#include "../../../../inc/MarlinConfigPre.h"
+
+#if ENABLED(DGUS_LCD)
+
+#include "../../ui_api.h"
+
+#include "DGUSDisplay.h"
+#include "DGUSDisplayDefinition.h"
+
+namespace ExtUI {
+
+void onStartup() {
+    dgusdisplay.InitDisplay();
+    ScreenHandler.UpdateScreenVPData();
+  }
+
+ void onIdle() {
+   ScreenHandler.loop();
+ }
+
+ void onPrinterKilled(const char* msg) {
+   ScreenHandler.sendinfoscreen(PSTR(MSG_HALTED), msg, PSTR(""), PSTR(MSG_PLEASE_RESET), true, true, true, true);
+   ScreenHandler.GotoScreen(DGUSLCD_SCREEN_KILL);
+   while(!ScreenHandler.loop());  // Wait if there is something still to be sent to the display.
+ }
+
+ void onMediaInserted() {
+   ScreenHandler.SDCardInserted();
+ }
+
+ void onMediaError() {
+   ScreenHandler.SDCardError();
+ }
+
+ void onMediaRemoved() {
+   ScreenHandler.SDCardRemoved();
+ }
+
+ void onPlayTone(const uint16_t frequency, const uint16_t duration) {}
+ void onPrintTimerStarted() {}
+ void onPrintTimerPaused() {}
+ void onPrintTimerStopped() {}
+ void onFilamentRunout() {}
+
+  void onUserConfirmRequired(const char *msg) {
+    if (msg) {
+      ScreenHandler.sendinfoscreen(PSTR("Please confirm."), nullptr, msg, nullptr, true, true, false, true);
+      ScreenHandler.SetupConfirmAction(ExtUI::setUserConfirmed);
+      ScreenHandler.GotoScreen(DGUSLCD_SCREEN_POPUP);
+    } else
+    if (ScreenHandler.getCurrentScreen() == DGUSLCD_SCREEN_POPUP ) {
+      ScreenHandler.SetupConfirmAction(nullptr);
+      ScreenHandler.PopToOldScreen();
+    }
+  }
+
+  void onStatusChanged(const char * const msg) {
+     ScreenHandler.setstatusmessage(msg);
+  }
+
+ void onFactoryReset() {}
+ void onLoadSettings() {}
+ void onStoreSettings() {}
+}
+
+#endif // DGUS_LCD

--- a/Marlin/src/lcd/extui_dgus_lcd.cpp
+++ b/Marlin/src/lcd/extui_dgus_lcd.cpp
@@ -20,16 +20,19 @@
  *
  */
 
-/* DGUS implementation written by coldtobi in 2019 for Marlin */
+/**
+ * extui_dgus_lcd.cpp
+ *
+ * DGUS implementation for Marlin by coldtobi, Feb-May 2019
+ */
 
-#include "../../../../inc/MarlinConfigPre.h"
+#include "../inc/MarlinConfigPre.h"
 
 #if ENABLED(DGUS_LCD)
 
-#include "../../ui_api.h"
-
-#include "DGUSDisplay.h"
-#include "DGUSDisplayDefinition.h"
+#include "extensible_ui/ui_api.h"
+#include "extensible_ui/lib/dgus/DGUSDisplay.h"
+#include "extensible_ui/lib/dgus/DGUSDisplayDefinition.h"
 
 namespace ExtUI {
 

--- a/Marlin/src/lcd/extui_example.cpp
+++ b/Marlin/src/lcd/extui_example.cpp
@@ -1,6 +1,6 @@
-/***************
- * example.cpp *
- ***************/
+/*********************
+ * extui_example.cpp *
+ *********************/
 
 /****************************************************************************
  *   Written By Marcio Teixeira 2018 - Aleph Objects, Inc.                  *
@@ -19,11 +19,11 @@
  *   location: <http://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#include "../../../inc/MarlinConfigPre.h"
+#include "../inc/MarlinConfigPre.h"
 
 #if BOTH(EXTUI_EXAMPLE, EXTENSIBLE_UI)
 
-#include "../ui_api.h"
+#include "extensible_ui/ui_api.h"
 
 // To implement a new UI, complete the functions below and
 // read or update Marlin's state using the methods in the

--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -21,7 +21,7 @@
  */
 
 /**
- * malyanlcd.cpp
+ * extui_malyan_lcd.cpp
  *
  * LCD implementation for Malyan's LCD, a separate ESP8266 MCU running
  * on Serial1 for the M200 board. This module outputs a pseudo-gcode

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -1994,12 +1994,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2015,15 +2026,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1983,12 +1983,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2004,15 +2015,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -1974,12 +1974,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1995,15 +2006,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -1965,12 +1965,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1986,15 +1997,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -1965,12 +1965,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1986,15 +1997,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -2116,12 +2116,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2137,15 +2148,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -1978,12 +1978,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1999,15 +2010,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -1974,12 +1974,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1995,15 +2006,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -1975,12 +1975,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1996,15 +2007,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -1973,12 +1973,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1994,15 +2005,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -1964,12 +1964,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1985,15 +1996,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -1951,12 +1951,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1972,15 +1983,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -1951,12 +1951,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1972,15 +1983,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -1962,12 +1962,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1983,15 +1994,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -1973,12 +1973,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1994,15 +2005,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -1964,12 +1964,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1985,15 +1996,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -1966,12 +1966,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1987,15 +1998,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -1982,12 +1982,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2003,15 +2014,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -1973,12 +1973,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1994,15 +2005,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -1967,12 +1967,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -1967,12 +1967,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -1973,12 +1973,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1994,15 +2005,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -1968,12 +1968,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1989,15 +2000,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -1973,12 +1973,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1999,15 +2010,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -1945,12 +1945,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1966,15 +1977,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -1945,12 +1945,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1966,15 +1977,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -1954,12 +1954,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1975,15 +1986,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -1969,12 +1969,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1990,15 +2001,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -2068,12 +2068,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2089,15 +2100,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -1997,12 +1997,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2018,15 +2029,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -1991,12 +1991,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2012,15 +2023,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -1948,12 +1948,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1969,15 +1980,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -1948,12 +1948,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1969,15 +1980,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -1950,12 +1950,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1971,15 +1982,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -1978,12 +1978,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1999,15 +2010,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -1970,12 +1970,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1991,15 +2002,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1984,12 +1984,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2005,15 +2016,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1983,12 +1983,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2004,15 +2015,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -1967,12 +1967,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/JGAurora/A1/Configuration.h
+++ b/config/examples/JGAurora/A1/Configuration.h
@@ -1966,12 +1966,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1987,15 +1998,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -1975,12 +1975,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1996,15 +2007,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/JGAurora/A5S/Configuration.h
+++ b/config/examples/JGAurora/A5S/Configuration.h
@@ -1966,12 +1966,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -1983,12 +1983,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2004,15 +2015,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -1991,12 +1991,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2012,15 +2023,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -1962,12 +1962,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -1967,12 +1967,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -1967,12 +1967,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -1965,12 +1965,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1986,15 +1997,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -1971,12 +1971,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1992,15 +2003,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -2012,12 +2012,23 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2033,15 +2044,6 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -1976,12 +1976,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1997,15 +2008,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -1965,12 +1965,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1986,15 +1997,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -1965,12 +1965,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1986,15 +1997,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -1994,12 +1994,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2015,15 +2026,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Tevo/Tarantula Pro/Configuration.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration.h
@@ -1968,12 +1968,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1989,15 +2000,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -2019,12 +2019,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2040,15 +2051,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -1967,12 +1967,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1988,15 +1999,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -1984,12 +1984,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2005,15 +2016,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -1974,12 +1974,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1995,15 +2006,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -1972,12 +1972,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1993,15 +2004,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -1998,12 +1998,23 @@
 
 #endif // K8200_VM8201
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2019,15 +2030,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -1982,12 +1982,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2003,15 +2014,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1976,12 +1976,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1997,15 +2008,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -1963,12 +1963,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1984,15 +1995,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -2151,12 +2151,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2172,15 +2183,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -2091,12 +2091,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2112,15 +2123,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -2090,12 +2090,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2111,15 +2122,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -2090,12 +2090,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2111,15 +2122,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -2078,12 +2078,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2099,15 +2110,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -2093,12 +2093,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2114,15 +2125,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -2078,12 +2078,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2099,15 +2110,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -2082,12 +2082,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2103,15 +2114,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -2078,12 +2078,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2099,15 +2110,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -2080,12 +2080,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2101,15 +2112,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -2081,12 +2081,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2102,15 +2113,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -2081,12 +2081,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -2102,15 +2113,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1977,12 +1977,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1998,15 +2009,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -1966,12 +1966,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1987,15 +1998,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -1958,12 +1958,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1979,15 +1990,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -1968,12 +1968,23 @@
 //
 //#define SILVER_GATE_GLCD_CONTROLLER
 
+//=============================================================================
+//========================== Extensible UI Displays ===========================
+//=============================================================================
+
 //
-// Extensible UI
+// DGUS Touch Display with DWIN OS
 //
-// Enable third-party or vendor customized user interfaces that aren't
-// packaged with Marlin. Source code for the user interface will need to
-// be placed in "src/lcd/extensible_ui/lib"
+//#define DGUS_LCD
+
+//
+// Touch-screen LCD for Malyan M200 printers
+//
+//#define MALYAN_LCD
+
+//
+// Third-party or vendor-customized controller interfaces.
+// Sources should be installed in 'src/lcd/extensible_ui'.
 //
 //#define EXTENSIBLE_UI
 
@@ -1989,15 +2000,6 @@
 //=============================================================================
 //============================  Other Controllers  ============================
 //=============================================================================
-
-//
-// CONTROLLER TYPE: Standalone / Serial
-//
-
-//
-// LCD for Malyan M200 printers.
-//
-//#define MALYAN_LCD
 
 //
 // CONTROLLER TYPE: Keypad / Add-on


### PR DESCRIPTION
### Description ### 

I've bought myself one of those displays and as so like to see them officially supported I started to hack on it. however, I'd like to avoid that my design decision collide with the way of things are done in Marlin, I'd like to obtain a bit feedback before making it feature complete. Bear with me, this is my first major contribution to Marlin, so if I missed obvious stuff, please sure to let me know ;-)

As indicated in the title, the state of my implementation is at PoC. It works and I can already perform basics tasks with it, but there is still a lot missing and clearly it is not yet ready to be merged.

#### DGUS Display In A Nutshell ####

DGUS displays are LCDs with touchscreen that are connected using RS232 for the communication. One characteristic of the display is needs to be preprogrammed with images and logic`*` but  allows to off-load significant parts UI work to the display itself.

The display is screen-based  and is able to define areas on the display data and areas which should be sensible to touch. The data-to-be displayed is send to the display using the RS232 interface  and the display stores them in its internal RAM as variables (and they are referenced by their address.) 
It will then automatically display the data on the predefined areas.

When the use touches one of the pre-defined areas, the display will "push" this information over the serial line, using the same concept of variables. It also allows simple operations like decrement or increment done on the display and the result sent back or displaying progress bars depending on the value sent.
Also the display can automatically go to different screens on touching, so the UI navigation can  largely be offloaded to the display.

`*` there is a gratis non-free tool available for designing the UI; the "firmware" is then uploaded to the display with an SD card and stored permanently in the display's flash memory.
For my PoC I designed this graphics: https://github.com/coldtobi/Marlin_DGUS_Resources/tree/master/DWIN_SET

(Some more background information is in issue #12096) 

### Benefits ###

Those displays are quite inexpensive (~25 USD) and the concept of the display to use RAM-like variables allows one to largely decouple the UI design from the UI logic.
Also, as the display is somehow smart, many tasks (like e.g going through the menus) are handled by the display itself.

### Related Issues

#12096

### First Questions  ###

A ton of them, especially I'm wondering whether I'm holding interacting with the Marlin internals correctly.… But as I forgot to make notes :( let me just start with the ones I'm remembering....

- Today I've implemented "Manual Move" and the way I did it was to inject g-code. It works, but I'm not sure if that is OK or has side effects or if that is ok they way I inject it is OK. [Code](https://github.com/coldtobi/Marlin/blob/29b4ecfbe591b10af07e8f95a1af731a4a9238f0/Marlin/src/lcd/dgus/DGUSDisplay.cpp#L277). The code was inspired from ultra_lcd.cpp internas...
A related question if there is a define to say which speed should be used for manual moves...

- I read from internal variables to send it to the display. This allows me to avoid that my code needs to have detailed information about the actual purpose of the data and "just" sends it over to the display using generalized handlers (e.g., I largely do not need to know whether that information is a temperature, position or like) [Code-reference](https://github.com/coldtobi/Marlin/blob/29b4ecfbe591b10af07e8f95a1af731a4a9238f0/Marlin/src/lcd/dgus/DGUSDisplayDefinition.cpp#L102)

### Open Points 

Besise the incompleteness, especially some points needs refactoring/attention:
- ultralcd_dgus.cpp is still a mess and has a lot of dead code.
- I need to port my code to use serial interface to the Marlin 2.0 Serial class.
- Mixing ultralcd and ExtUI should be sorted, I guess

Cheers,
tobi