### PR TITLE
Looking for STM32F1 Travis CI build error solution…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ cache:
   - "~/.platformio"
 
 env:
-  - TEST_PLATFORM="megaatmega2560"
-  - TEST_PLATFORM="DUE"
-  - TEST_PLATFORM="LPC1768"
-  - TEST_PLATFORM="LPC1769"
-  #- TEST_PLATFORM="STM32F1"
-  - TEST_PLATFORM="teensy35"
-  - TEST_PLATFORM="linux_native"
+  #- TEST_PLATFORM="megaatmega2560"
+  #- TEST_PLATFORM="DUE"
+  #- TEST_PLATFORM="LPC1768"
+  #- TEST_PLATFORM="LPC1769"
+  - TEST_PLATFORM="STM32F1"
+  #- TEST_PLATFORM="teensy35"
+  #- TEST_PLATFORM="linux_native"
 
 addons:
   apt:

--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -42,6 +42,8 @@
 #include "fastio_STM32.h"
 #include "watchdog_STM32.h"
 
+#include "HAL_timers_STM32.h"
+
 // --------------------------------------------------------------------------
 // Defines
 // --------------------------------------------------------------------------
@@ -98,8 +100,6 @@
 #else
   #define NUM_SERIAL 1
 #endif
-
-#include "HAL_timers_STM32.h"
 
 /**
  * TODO: review this to return 1 for pins that are not analog input

--- a/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL_timers_STM32.h
@@ -26,6 +26,7 @@
 // --------------------------------------------------------------------------
 
 #include <stdint.h>
+
 #include "../../inc/MarlinConfig.h"
 
 // --------------------------------------------------------------------------
@@ -49,7 +50,7 @@
     #define TEMP_TIMER 17
   #endif
 
-#elif defined STM32F1xx
+#elif defined(STM32F1xx)
 
   #define HAL_TIMER_RATE (F_CPU) // frequency of timer peripherals
 
@@ -61,7 +62,7 @@
     #define TEMP_TIMER 2
   #endif
 
-#elif defined STM32F4xx
+#elif defined(STM32F4xx)
 
   #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
 
@@ -73,7 +74,7 @@
     #define TEMP_TIMER 7
   #endif
 
-#elif defined STM32F7xx
+#elif defined(STM32F7xx)
 
   #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
 
@@ -95,21 +96,21 @@
   #define TEMP_TIMER_IRQ_PRIO 2
 #endif
 
-#define STEP_TIMER_NUM 0  // index of timer to use for stepper
-#define TEMP_TIMER_NUM 1  // index of timer to use for temperature
+#define STEP_TIMER_NUM 0            // Stepper timer index
+#define TEMP_TIMER_NUM 1            // Temperature timer index
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 
-#define TEMP_TIMER_RATE 72000 // 72 Khz
-#define TEMP_TIMER_PRESCALE ((HAL_TIMER_RATE)/(TEMP_TIMER_RATE))
-#define TEMP_TIMER_FREQUENCY 1000
+#define TEMP_TIMER_RATE             72000 // 72 Khz
+#define TEMP_TIMER_PRESCALE         ((HAL_TIMER_RATE)/(TEMP_TIMER_RATE))
+#define TEMP_TIMER_FREQUENCY        1000
 
-#define STEPPER_TIMER_RATE 2000000 // 2 Mhz
-#define STEPPER_TIMER_PRESCALE ((HAL_TIMER_RATE)/(STEPPER_TIMER_RATE))
-#define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
+#define STEPPER_TIMER_RATE          2000000 // 2 Mhz
+#define STEPPER_TIMER_PRESCALE      ((HAL_TIMER_RATE)/(STEPPER_TIMER_RATE))
+#define STEPPER_TIMER_TICKS_PER_US  ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 
-#define PULSE_TIMER_RATE STEPPER_TIMER_RATE
-#define PULSE_TIMER_PRESCALE STEPPER_TIMER_PRESCALE
-#define PULSE_TIMER_TICKS_PER_US STEPPER_TIMER_TICKS_PER_US
+#define PULSE_TIMER_RATE            STEPPER_TIMER_RATE
+#define PULSE_TIMER_PRESCALE        STEPPER_TIMER_PRESCALE
+#define PULSE_TIMER_TICKS_PER_US    STEPPER_TIMER_TICKS_PER_US
 
 #define __TIMER_DEV(X) TIM##X
 #define _TIMER_DEV(X) __TIMER_DEV(X)


### PR DESCRIPTION
This PR is for testing Travis CI to figure out what is breaking STM32F1 builds.

- Reverting Marlin to earlier points in time doesn't help.
- Restarting any Travis build results in the same error, even one from weeks ago.
- The `arduinoststm32@2.1.180219` version has been ruled out as the cause.
- The `toolchain-gccarmnoneeabi/arm-none-eabi/include/c++/8.2.1` might be involved.
