### PR TITLE
Bugfix 2.0.x add BIGTREE SKR V1.3 motherboard pins define

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -191,6 +191,7 @@
 #define BOARD_AZTEEG_X5_MINI_WIFI 1758  // Azteeg X5 Mini (Power outputs: Hotend0, Bed, Fan)
 #define BOARD_BIQU_SKR_V1_1       1759  // BIQU SKR_V1.1 (Power outputs: Hotend0,Hotend1, Fan, Bed)
 #define BOARD_BIQU_B300_V1_0      1760  // BIQU B300_V1.0 (Power outputs: Hotend0, Fan, Bed, SPI Driver)
+#define BOARD_BIGTREE_SKR_V1_3    1761  // BIGTREE SKR_V1.3 (Power outputs: Hotend0, Hotend1, Fan, Bed)
 
 //
 // SAM3X8E ARM Cortex M3

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -334,6 +334,8 @@
   #include "pins_BIQU_SKR_V1.1.h"     // LPC1768                                    env:LPC1768
 #elif MB(BIQU_B300_V1_0)
   #include "pins_BIQU_B300_V1.0.h"    // LPC1768                                    env:LPC1768
+#elif MB(BIGTREE_SKR_V1_3)
+  #include "pins_BIGTREE_SKR_V1.3.h"  // LPC1768                                    env:LPC1768
 
 //
 // Other 32-bit Boards

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -1,0 +1,237 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef TARGET_LPC1768
+  #error "Oops!  Make sure you have the LPC1768 environment selected in your IDE."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "BIGTREE SKR V1.3"
+#endif
+
+//
+// Servos
+//
+#define SERVO0_PIN         P2_00
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          P1_29
+#define X_MAX_PIN          P1_28
+#define Y_MIN_PIN          P1_27
+#define Y_MAX_PIN          P1_26
+#define Z_MIN_PIN          P1_25
+#define Z_MAX_PIN          P1_24
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN  P1_24
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN         P2_02
+#define X_DIR_PIN          P2_06
+#define X_ENABLE_PIN       P2_01
+#ifndef X_CS_PIN
+  #define X_CS_PIN         P1_17
+#endif
+
+#define Y_STEP_PIN         P0_19
+#define Y_DIR_PIN          P0_20
+#define Y_ENABLE_PIN       P2_08
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN         P1_15
+#endif
+
+#define Z_STEP_PIN         P0_22
+#define Z_DIR_PIN          P2_11
+#define Z_ENABLE_PIN       P0_21
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN         P1_10
+#endif
+
+#define E0_STEP_PIN        P2_13
+#define E0_DIR_PIN         P0_11
+#define E0_ENABLE_PIN      P2_12
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN        P1_08
+#endif
+
+#define E1_STEP_PIN        P0_01
+#define E1_DIR_PIN         P0_00
+#define E1_ENABLE_PIN      P0_10
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN        P1_01
+#endif
+
+//
+// Software SPI pins for TMC2130 stepper drivers
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #define TMC_SW_MOSI      P4_28
+  #define TMC_SW_MISO      P0_05
+  #define TMC_SW_SCK       P0_04
+#endif
+
+#if HAS_DRIVER(TMC2208)
+    /**
+   * TMC2208 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial
+  //#define X2_HARDWARE_SERIAL Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Y2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define Z2_HARDWARE_SERIAL Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial1
+  //#define E2_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
+
+  //
+  // Software serial
+  //
+  #define X_SERIAL_TX_PIN  P4_29
+  #define X_SERIAL_RX_PIN  P1_17
+
+  #define Y_SERIAL_TX_PIN  P1_16
+  #define Y_SERIAL_RX_PIN  P1_15
+
+  #define Z_SERIAL_TX_PIN  P1_14
+  #define Z_SERIAL_RX_PIN  P1_10
+  
+
+  #define E0_SERIAL_TX_PIN P1_09
+  #define E0_SERIAL_RX_PIN P1_08
+
+  #define E1_SERIAL_TX_PIN P1_04
+  #define E1_SERIAL_RX_PIN P1_01  
+#endif
+
+//
+// Temperature Sensors
+//  3.3V max when defined as an analog input
+//
+#define TEMP_BED_PIN       0   // A0 (T0) - (67) - TEMP_BED_PIN
+#define TEMP_0_PIN         1   // A1 (T1) - (68) - TEMP_0_PIN
+#define TEMP_1_PIN         2   // A2 (T2) - (69) - TEMP_1_PIN
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       P2_07
+#if HOTENDS == 1
+  #define FAN1_PIN         P2_04
+#else
+  #define HEATER_1_PIN     P2_04
+#endif
+#define FAN_PIN            P2_03
+#define HEATER_BED_PIN     P2_05
+
+//
+// Misc. Functions
+//
+#define SDSS               P0_06   
+
+/*
+|               _____                                             _____
+|           NC | · · | GND                                    5V | · · | GND
+|        RESET | · · | 1.31(SD_DETECT)             (LCD_D7) 1.23 | · · | 1.22 (LCD_D6)
+|   (MOSI)0.18 | · · | 3.25(BTN_EN2)               (LCD_D5) 1.21 | · · | 1.20 (LCD_D4)
+|  (SD_SS)0.16 | · · | 3.26(BTN_EN1)               (LCD_RS) 1.19 | · · | 1.18 (LCD_EN)
+|    (SCK)0.15 | · · | 0.17(MISO)                 (BTN_ENC) 0.28 | · · | 1.30 (BEEPER)
+|               ￣￣                                               ￣￣  
+|               EXP2                                              EXP1  
+*/
+#if ENABLED(ULTRA_LCD)
+
+  #define BEEPER_PIN       P1_30   // (37) not 5V tolerant
+  #define BTN_ENC          P0_28   // (58) open-drain
+  #define LCD_PINS_RS      P1_19
+
+  #define BTN_EN1          P3_26   // (31) J3-2 & AUX-4
+  #define BTN_EN2          P3_25   // (33) J3-4 & AUX-4
+  #define SD_DETECT_PIN    P1_31   // (49) (NOT 5V tolerant)
+  
+  #define LCD_SDSS         P0_16   // (16) J3-7 & AUX-4
+
+  #define LCD_PINS_ENABLE  P1_18  
+  #define LCD_PINS_D4      P1_20  
+
+  #if ENABLED(ULTIPANEL)
+
+    #define LCD_PINS_D5    P1_21
+    #define LCD_PINS_D6    P1_22
+    #define LCD_PINS_D7    P1_23
+
+  #endif
+
+#endif // ULTRA_LCD
+
+//#define USB_SD_DISABLED
+#define USB_SD_ONBOARD        // Provide the onboard SD card to the host as a USB mass storage device
+
+#define LPC_SD_LCD            // Marlin uses the SD drive attached to the LCD
+//#define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board
+
+#if ENABLED(LPC_SD_LCD)
+
+  #define SCK_PIN          P0_15
+  #define MISO_PIN         P0_17
+  #define MOSI_PIN         P0_18
+  #define SS_PIN           P0_16   // Chip select for SD card used by Marlin
+  #define ONBOARD_SD_CS    P0_06   // Chip select for "System" SD card
+
+#elif ENABLED(LPC_SD_ONBOARD)
+
+  #if ENABLED(USB_SD_ONBOARD)
+    // When sharing the SD card with a PC we want the menu options to
+    // mount/unmount the card and refresh it. So we disable card detect.
+    #define SHARED_SD_CARD
+    #undef SD_DETECT_PIN           // redefine detect pin onboard tf card
+    #define SD_DETECT_PIN  P0_27   // (57) open-drain
+  #endif
+
+  #define SCK_PIN          P0_07
+  #define MISO_PIN         P0_08
+  #define MOSI_PIN         P0_09
+  #define SS_PIN           P0_16   // Chip select for SD card used by Marlin
+  #define ONBOARD_SD_CS    P0_06   // Chip select for "System" SD card
+
+#endif
+
+ /**
+  * Special pins
+  *   P1_30  (37) (NOT 5V tolerant)
+  *   P1_31  (49) (NOT 5V tolerant)
+  *   P0_27  (57) (Open collector)
+  *   P0_28  (58) (Open collector)
+  */

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -137,7 +137,7 @@
   #define SCK_PIN          P0_07
   #define MISO_PIN         P0_08
   #define MOSI_PIN         P0_09
-  #define SS_PIN           P0_06   // Chip select for SD card used by Marlin
+  #define SS_PIN           P1_23   // Chip select for SD card used by Marlin
   #define ONBOARD_SD_CS    P0_06   // Chip select for "System" SD card
 
 #endif


### PR DESCRIPTION
- Add SKR v1.3 pins define
- Fix SKR v1.1 `SS_PIN` of SD card CS pin

It can print file from TF card on board, not SD card on LCD.