### PR TITLE
Add M997 support and an implementation for LPC176x

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
@@ -59,4 +59,8 @@ int16_t PARSED_PIN_INDEX(const char code, const int16_t dval) {
   return ind > -2 ? ind : dval;
 }
 
+void flashFirmware(int16_t value) {
+  NVIC_SystemReset();
+}
+
 #endif // TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.h
@@ -154,3 +154,6 @@ int16_t PARSED_PIN_INDEX(const char code, const int16_t dval);
 
 #define HAL_IDLETASK 1
 void HAL_idletask(void);
+
+#define PLATFORM_M997_SUPPORT
+void flashFirmware(int16_t value);

--- a/Marlin/src/gcode/control/M997.cpp
+++ b/Marlin/src/gcode/control/M997.cpp
@@ -1,0 +1,34 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../gcode.h"
+
+#if ENABLED(PLATFORM_M997_SUPPORT)
+
+/**
+ * M997: Perform in-application firmware update
+ */
+void GcodeSuite::M997() {
+  flashFirmware(parser.intval('S'));
+}
+
+#endif

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -723,6 +723,10 @@ void GcodeSuite::process_parsed_command(
         case 422: M422(); break;                                  // M422: Set Z Stepper automatic alignment position using probe
       #endif
 
+      #if ENABLED(PLATFORM_M997_SUPPORT)
+        case 997: M997(); break;                                  // M997: Perform in-application firmware update
+      #endif
+
       case 999: M999(); break;                                    // M999: Restart after being Stopped
 
       #if ENABLED(POWER_LOSS_RECOVERY)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -254,6 +254,7 @@
  *
  * ************ Custom codes - This can change to suit future G-code regulations
  * M928 - Start SD logging: "M928 filename.gco". Stop with M29. (Requires SDSUPPORT)
+ * M997 - Perform in-application firmware update
  * M999 - Restart after being stopped by error
  *
  * "T" Codes
@@ -856,6 +857,10 @@ private:
 
   #if ENABLED(MAGNETIC_PARKING_EXTRUDER)
     static void M951();
+  #endif
+
+  #if ENABLED(PLATFORM_M997_SUPPORT)
+    static void M997();
   #endif
 
   static void M999();


### PR DESCRIPTION
### Description
Add [M997](https://reprap.org/wiki/G-code#M997:_Perform_in-application_firmware_update) support to the gcode parser and an implementation for the LPC176x platform. All that is required on the LPC176x is a reset and boot-loader takes care of flashing so in effect this is just a reset command.

### Benefits
Allows for remote flashing of the LPC176x after a firmware file is transferred to the sdcard either by the usb mass storage  or serial binary transfer.