### PR TITLE
Disable Control>Motion menu item when it's empty

### DIFF
--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -3332,8 +3332,11 @@ void lcd_quick_feedback(const bool clear_buttons) {
     START_MENU();
     MENU_BACK(MSG_MAIN);
     MENU_ITEM(submenu, MSG_TEMPERATURE, lcd_control_temperature_menu);
-    MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
-
+    
+    #if DISABLED(SLIM_LCD_MENUS) || ENABLED(BABYSTEP_ZPROBE_OFFSET) || HAS_BED_PROBE || ENABLED(ABORT_ON_ENDSTOP_HIT_FEATURE_ENABLED)
+      MENU_ITEM(submenu, MSG_MOTION, lcd_control_motion_menu);
+    #endif
+    
     #if DISABLED(NO_VOLUMETRICS) || ENABLED(ADVANCED_PAUSE_FEATURE)
       MENU_ITEM(submenu, MSG_FILAMENT, lcd_control_filament_menu);
     #elif ENABLED(LIN_ADVANCE)


### PR DESCRIPTION
### Description

As mentioned in title, I disabled Control>Motion menu item, so it won't appear on screen when SLIM_LCD_MENUS is enabled and no option will appear under that submenu

### Benefits

No empty menu entry when enabling SLIM_LCD_MENUS

### Related Issues

I haven't found any related issue, I did it just because it was a bit annoying for me :)