### PR TITLE
resolve #13274: expose SD_AUTO_START

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -706,6 +706,12 @@
 
 #if ENABLED(SDSUPPORT)
 
+  // Make SD card available to the Marlin board after Marlin boot.
+  // On platforms where SD card can be exposed as mass storage device to the host
+  // set this setting to "false", to keep SD disk attached to the host after Marlin boot.
+  // By default we make SD card available to the Marlin board when there is no LCD is configured.
+  #define SD_AUTO_START DISABLED(ULTRA_LCD)
+
   // Some RAMPS and other boards don't detect when an SD card is inserted. You can work
   // around this by connecting a push button or single throw switch to the pin defined
   // as SD_DETECT_PIN in your board's pins definitions.

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1073,7 +1073,7 @@ void setup() {
     init_closedloop();
   #endif
 
-  #if ENABLED(SDSUPPORT) && DISABLED(ULTRA_LCD)
+  #if ENABLED(SD_AUTO_START)
     card.beginautostart();
   #endif
 


### PR DESCRIPTION
### Description

expose for users `SD_AUTO_START` as part of `Configuration_adv.h`

### Benefits

reduce confusion, i.e. #13274, improve configurability.

### Related Issues

See #13274
