### PR TITLE
Send auto temp reports to both serial ports if available

### DIFF
--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -42,11 +42,11 @@ enum MarlinDebugFlags : uint8_t {
 extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (MARLIN_DEBUG_## F))
 
+#define SERIAL_BOTH 0x7F
 #if NUM_SERIAL > 1
   extern int8_t serial_port_index;
   #define _PORT_REDIRECT(n,p)   REMEMBER(n,serial_port_index,p)
   #define _PORT_RESTORE(n)      RESTORE(n)
-  #define SERIAL_BOTH 0x7F
   #define SERIAL_OUT(WHAT, ...) do{ \
     if (!serial_port_index || serial_port_index == SERIAL_BOTH) MYSERIAL0.WHAT(__VA_ARGS__); \
     if ( serial_port_index) MYSERIAL1.WHAT(__VA_ARGS__); \

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2664,6 +2664,7 @@ void Temperature::isr() {
     void Temperature::auto_report_temperatures() {
       if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
         next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
+        PORT_REDIRECT(SERIAL_BOTH);
         print_heater_states(active_extruder);
         SERIAL_EOL();
       }


### PR DESCRIPTION
### Description

Auto temperature reports go to the wrong serial port, they used to go to both serial ports so this PR makes that change but I'm unsure of how @thinkyhead intended the macros to be used.