### PR TITLE
Fix stepper current init when HAS_MOTOR_CURRENT_PWM is used

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1979,11 +1979,6 @@ bool Stepper::is_block_busy(const block_t* const block) {
 
 void Stepper::init() {
 
-  // Init Digipot Motor Current
-  #if HAS_DIGIPOTSS || HAS_MOTOR_CURRENT_PWM
-    digipot_init();
-  #endif
-
   #if MB(ALLIGATOR)
     const float motor_current[] = MOTOR_CURRENT;
     unsigned int digipot_motor = 0;
@@ -2165,8 +2160,12 @@ void Stepper::init() {
     | (INVERT_Z_DIR ? _BV(Z_AXIS) : 0);
 
   set_directions();
-  #if HAS_MOTOR_CURRENT_PWM
-    initialized = true;
+
+  #if HAS_DIGIPOTSS || HAS_MOTOR_CURRENT_PWM
+    #if HAS_MOTOR_CURRENT_PWM
+      initialized = true;
+    #endif
+    digipot_init();
   #endif
 }
 


### PR DESCRIPTION
The initial stepper is now not being set after pull request #13284 was applied.   This pull request sets the required flag when using HAS_MOTOR_CURRENT_PWM  to allow the stepper initialization function to set the stepper current after all stepper pins have been initialized.
