### PR TITLE
Remove conditional include of printcounter.h to fix compilation issue

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -69,10 +69,8 @@
   #define IFSD(A,B) (B)
 #endif
 
-#if ENABLED(PRINTCOUNTER)
-  #include "../../core/utility.h"
-  #include "../../module/printcounter.h"
-#endif
+#include "../../core/utility.h"
+#include "../../module/printcounter.h"
 
 #if HAS_TRINAMIC && HAS_LCD_MENU
   #include "../../feature/tmc_util.h"

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -51,8 +51,13 @@
 #include "../../module/planner.h"
 #include "../../module/probe.h"
 #include "../../module/temperature.h"
+#include "../../module/printcounter.h"
 #include "../../libs/duration_t.h"
 #include "../../HAL/shared/Delay.h"
+
+#if ENABLED(PRINTCOUNTER)
+  #include "../../core/utility.h"
+#endif
 
 #if DO_SWITCH_EXTRUDER || ENABLED(SWITCHING_NOZZLE) || ENABLED(PARKING_EXTRUDER)
   #include "../../module/tool_change.h"
@@ -68,9 +73,6 @@
 #else
   #define IFSD(A,B) (B)
 #endif
-
-#include "../../core/utility.h"
-#include "../../module/printcounter.h"
 
 #if HAS_TRINAMIC && HAS_LCD_MENU
   #include "../../feature/tmc_util.h"


### PR DESCRIPTION
Fixes this compile error when PRINTCOUNTER is not enabled:

src/lcd/extensible_ui/ui_api.cpp:576:32: error: 'print_job_timer' was not declared in this scope
     const duration_t elapsed = print_job_timer.duration();
