### PR TITLE
Support bootscreenhandling in ExtUI

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -353,7 +353,7 @@
 #endif
 
 // Boot screens
-#if !HAS_SPI_LCD
+#if !HAS_SPI_LCD && !ENABLED(EXTENSIBLE_UI)
   #undef SHOW_BOOTSCREEN
 #elif !defined(BOOTSCREEN_TIMEOUT)
   #define BOOTSCREEN_TIMEOUT 2500

--- a/Marlin/src/lcd/extensible_ui/lib/example.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/example.cpp
@@ -45,6 +45,8 @@ namespace ExtUI {
      *   READ(pin)
      */
   }
+  void OnShowBootscreen() {};
+  void OnExitBootscreen() {};
   void onIdle() {}
   void onPrinterKilled(const char* msg) {}
   void onMediaInserted() {};

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -781,6 +781,15 @@ void MarlinUI::update() {
       }
     }
   #endif // SDSUPPORT
+
+  #if ENABLED(SHOW_BOOTSCREEN)
+    static bool booted = false;
+    if (!booted && millis() >= BOOTSCREEN_TIMEOUT) {
+      booted = true;
+      ExtUI::OnExitBootscreen();
+    }
+  #endif
+
   ExtUI::_processManualMoveToDestination();
   ExtUI::onIdle();
 }
@@ -791,5 +800,11 @@ void MarlinUI::kill_screen(PGM_P const msg) {
     ExtUI::onPrinterKilled(msg);
   }
 }
+
+  #if ENABLED(SHOW_BOOTSCREEN)
+    void MarlinUI::show_bootscreen() {
+      ExtUI::OnShowBootscreen();
+    }
+  #endif
 
 #endif // EXTENSIBLE_UI

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -234,6 +234,8 @@ namespace ExtUI {
    * Should be declared by EXTENSIBLE_UI and will be called by Marlin
    */
   void onStartup();
+  void OnShowBootscreen();
+  void OnExitBootscreen();
   void onIdle();
   void onMediaInserted();
   void onMediaError();

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -285,6 +285,10 @@ public:
       static constexpr uint8_t get_progress() { return 0; }
     #endif
 
+    #if ENABLED(SHOW_BOOTSCREEN) && (HAS_SPI_LCD || ENABLED(EXTENSIBLE_UI))
+      static void show_bootscreen();
+    #endif
+
     #if HAS_SPI_LCD
 
       static bool detected();
@@ -293,10 +297,6 @@ public:
       static inline bool should_draw() { return bool(lcdDrawUpdate); }
       static inline void refresh(const LCDViewAction type) { lcdDrawUpdate = type; }
       static inline void refresh() { refresh(LCDVIEW_CLEAR_CALL_REDRAW); }
-
-      #if ENABLED(SHOW_BOOTSCREEN)
-        static void show_bootscreen();
-      #endif
 
       #if HAS_GRAPHICAL_LCD
 


### PR DESCRIPTION
This introduces two ExtUI callbacks. Arguably the OnShowBootscreen() could
also be handled in OnStartup(), but I think this makes the API more
consistent.
