### PR TITLE
Allow SERIAL_ECHO(LN)?PAIR to take up to 12 pairs

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -910,8 +910,7 @@ void setup() {
   #endif
 
   SERIAL_ECHO_START();
-  SERIAL_ECHOPAIR(MSG_FREE_MEMORY, freeMemory());
-  SERIAL_ECHOLNPAIR(MSG_PLANNER_BUFFER_BYTES, (int)sizeof(block_t)*BLOCK_BUFFER_SIZE);
+  SERIAL_ECHOLNPAIR(MSG_FREE_MEMORY, freeMemory(), MSG_PLANNER_BUFFER_BYTES, (int)sizeof(block_t) * (BLOCK_BUFFER_SIZE));
 
   queue_setup();
 

--- a/Marlin/src/core/minmax.h
+++ b/Marlin/src/core/minmax.h
@@ -23,6 +23,10 @@
 #undef MIN
 #undef MAX
 
+// Pass NUM_ARGS(__VA_ARGS__) to use the number of arguments
+#define _NUM_ARGS(_0,_24_,_23,_22,_21,_20,_19,_18,_17,_16,_15,_14,_13,_12,_11,_10,_9,_8,_7,_6,_5,_4,_3,_2,_1,N,...) N
+#define NUM_ARGS(...) _NUM_ARGS(0, __VA_ARGS__ ,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0)
+
 #ifdef __cplusplus
 
   #ifndef _MINMAX_H_
@@ -46,26 +50,30 @@
 
 #else
 
-  // NUM_ARGS(...) evaluates to the number of arguments
-  #define _NUM_ARGS(X,X6,X5,X4,X3,X2,X1,N,...) N
-  #define NUM_ARGS(...) _NUM_ARGS(0, __VA_ARGS__ ,6,5,4,3,2,1,0)
-
-  #define MIN_2(a,b)      ({__typeof__(a) _a = (a); __typeof__(b) _b = (b); _a < _b ? _a : _b;})
+  #define MIN_2(a,b)      ((a)<(b)?(a):(b))
   #define MIN_3(a,...)    MIN_2(a,MIN_2(__VA_ARGS__))
   #define MIN_4(a,...)    MIN_2(a,MIN_3(__VA_ARGS__))
   #define MIN_5(a,...)    MIN_2(a,MIN_4(__VA_ARGS__))
   #define MIN_6(a,...)    MIN_2(a,MIN_5(__VA_ARGS__))
-  #define __MIN_N(N, ...) MIN_ ## N(__VA_ARGS__)
-  #define _MIN_N(N, ...)  __MIN_N(N, __VA_ARGS__)
+  #define MIN_7(a,...)    MIN_2(a,MIN_6(__VA_ARGS__))
+  #define MIN_8(a,...)    MIN_2(a,MIN_7(__VA_ARGS__))
+  #define MIN_9(a,...)    MIN_2(a,MIN_8(__VA_ARGS__))
+  #define MIN_10(a,...)   MIN_2(a,MIN_9(__VA_ARGS__))
+  #define __MIN_N(N, ...) MIN_##N(__VA_ARGS__)
+  #define _MIN_N(N, ...)  __MIN_N(N,__VA_ARGS__)
   #define MIN(...)        _MIN_N(NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
 
-  #define MAX_2(a,b)      ({__typeof__(a) _a = (a); __typeof__(b) _b = (b); _a > _b ? _a : _b;})
+  #define MAX_2(a,b)      ((a)>(b)?(a):(b))
   #define MAX_3(a,...)    MAX_2(a,MAX_2(__VA_ARGS__))
   #define MAX_4(a,...)    MAX_2(a,MAX_3(__VA_ARGS__))
   #define MAX_5(a,...)    MAX_2(a,MAX_4(__VA_ARGS__))
   #define MAX_6(a,...)    MAX_2(a,MAX_5(__VA_ARGS__))
-  #define __MAX_N(N, ...) MAX_ ## N(__VA_ARGS__)
-  #define _MAX_N(N, ...)  __MAX_N(N, __VA_ARGS__)
+  #define MAX_7(a,...)    MAX_2(a,MAX_6(__VA_ARGS__))
+  #define MAX_8(a,...)    MAX_2(a,MAX_7(__VA_ARGS__))
+  #define MAX_9(a,...)    MAX_2(a,MAX_8(__VA_ARGS__))
+  #define MAX_10(a,...)   MAX_2(a,MAX_9(__VA_ARGS__))
+  #define __MAX_N(N, ...) MAX_##N(__VA_ARGS__)
+  #define _MAX_N(N, ...)  __MAX_N(N,__VA_ARGS__)
   #define MAX(...)        _MAX_N(NUM_ARGS(__VA_ARGS__), __VA_ARGS__)
 
 #endif

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -69,8 +69,7 @@ void print_bin(const uint16_t val) {
     serialprintPGM(prefix);
     SERIAL_CHAR('(');
     SERIAL_ECHO(x);
-    SERIAL_ECHOPAIR(", ", y);
-    SERIAL_ECHOPAIR(", ", z);
+    SERIAL_ECHOPAIR(", ", y, ", ", z);
     SERIAL_CHAR(')');
     if (suffix) serialprintPGM(suffix); else SERIAL_EOL();
   }

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "../inc/MarlinConfigPre.h"
+#include "../core/minmax.h"
 #include HAL_PATH(../HAL, HAL.h)
 
 /**
@@ -62,7 +63,7 @@ extern uint8_t marlin_debug_flags;
 
 #define SERIAL_CHAR(x)          SERIAL_OUT(write, x)
 #define SERIAL_ECHO(x)          SERIAL_OUT(print, x)
-#define SERIAL_ECHO_F(x,y)      SERIAL_OUT(print, x, y)
+#define SERIAL_ECHO_F(...)      SERIAL_OUT(print, __VA_ARGS__)
 #define SERIAL_ECHOLN(x)        SERIAL_OUT(println, x)
 #define SERIAL_PRINT(x,b)       SERIAL_OUT(print, x, b)
 #define SERIAL_PRINTLN(x,b)     SERIAL_OUT(println, x, b)
@@ -75,22 +76,78 @@ extern uint8_t marlin_debug_flags;
   #define SERIAL_FLUSHTX()
 #endif
 
-#define SERIAL_ECHOPGM(x)                   (serialprintPGM(PSTR(x)))
-#define SERIAL_ECHOLNPGM(x)                 (serialprintPGM(PSTR(x "\n")))
-#define SERIAL_ECHOPAIR(pre, value)         (serial_echopair_PGM(PSTR(pre), value))
-#define SERIAL_ECHOLNPAIR(pre, value)       do{ SERIAL_ECHOPAIR(pre, value); SERIAL_EOL(); }while(0)
+// Print up to 12 pairs of values
+#define __SEP_N(N,...)      _SEP_##N(__VA_ARGS__)
+#define _SEP_N(N,...)       __SEP_N(N,__VA_ARGS__)
+#define _SEP_2(PRE,V)       serial_echopair_PGM(PSTR(PRE),V)
+#define _SEP_3(a,b,ETC)     do{ _SEP_2(a,b); SERIAL_ECHOPGM(ETC); }while(0)
+#define _SEP_4(a,b,...)     do{ _SEP_2(a,b); _SEP_2(__VA_ARGS__); }while(0)
+#define _SEP_5(a,b,...)     do{ _SEP_2(a,b); _SEP_3(__VA_ARGS__); }while(0)
+#define _SEP_6(a,b,...)     do{ _SEP_2(a,b); _SEP_4(__VA_ARGS__); }while(0)
+#define _SEP_7(a,b,...)     do{ _SEP_2(a,b); _SEP_5(__VA_ARGS__); }while(0)
+#define _SEP_8(a,b,...)     do{ _SEP_2(a,b); _SEP_6(__VA_ARGS__); }while(0)
+#define _SEP_9(a,b,...)     do{ _SEP_2(a,b); _SEP_7(__VA_ARGS__); }while(0)
+#define _SEP_10(a,b,...)    do{ _SEP_2(a,b); _SEP_8(__VA_ARGS__); }while(0)
+#define _SEP_11(a,b,...)    do{ _SEP_2(a,b); _SEP_9(__VA_ARGS__); }while(0)
+#define _SEP_12(a,b,...)    do{ _SEP_2(a,b); _SEP_10(__VA_ARGS__); }while(0)
+#define _SEP_13(a,b,...)    do{ _SEP_2(a,b); _SEP_11(__VA_ARGS__); }while(0)
+#define _SEP_14(a,b,...)    do{ _SEP_2(a,b); _SEP_12(__VA_ARGS__); }while(0)
+#define _SEP_15(a,b,...)    do{ _SEP_2(a,b); _SEP_13(__VA_ARGS__); }while(0)
+#define _SEP_16(a,b,...)    do{ _SEP_2(a,b); _SEP_14(__VA_ARGS__); }while(0)
+#define _SEP_17(a,b,...)    do{ _SEP_2(a,b); _SEP_15(__VA_ARGS__); }while(0)
+#define _SEP_18(a,b,...)    do{ _SEP_2(a,b); _SEP_16(__VA_ARGS__); }while(0)
+#define _SEP_19(a,b,...)    do{ _SEP_2(a,b); _SEP_17(__VA_ARGS__); }while(0)
+#define _SEP_20(a,b,...)    do{ _SEP_2(a,b); _SEP_18(__VA_ARGS__); }while(0)
+#define _SEP_21(a,b,...)    do{ _SEP_2(a,b); _SEP_19(__VA_ARGS__); }while(0)
+#define _SEP_22(a,b,...)    do{ _SEP_2(a,b); _SEP_20(__VA_ARGS__); }while(0)
+#define _SEP_23(a,b,...)    do{ _SEP_2(a,b); _SEP_21(__VA_ARGS__); }while(0)
+#define _SEP_24(a,b,...)    do{ _SEP_2(a,b); _SEP_22(__VA_ARGS__); }while(0)
 
-#define SERIAL_ECHOPAIR_F(pre, value, y)    do{ SERIAL_ECHO(pre); SERIAL_ECHO_F(value, y); }while(0)
-#define SERIAL_ECHOLNPAIR_F(pre, value, y)  do{ SERIAL_ECHOPAIR_F(pre, value, y); SERIAL_EOL(); }while(0)
+#define SERIAL_ECHOPAIR(...) _SEP_N(NUM_ARGS(__VA_ARGS__),__VA_ARGS__)
 
-#define SERIAL_ECHO_START()                 serial_echo_start()
-#define SERIAL_ERROR_START()                serial_error_start()
-#define SERIAL_EOL()                        SERIAL_CHAR('\n')
+// Print up to 12 pairs of values followed by newline
+#define __SELP_N(N,...)     _SELP_##N(__VA_ARGS__)
+#define _SELP_N(N,...)      __SELP_N(N,__VA_ARGS__)
+#define _SELP_2(PRE,V)      do{ serial_echopair_PGM(PSTR(PRE),V); SERIAL_EOL(); }while(0)
+#define _SELP_3(PRE,V,ETC)  do{ serial_echopair_PGM(PSTR(PRE),V); SERIAL_ECHOLNPGM(ETC); }while(0)
+#define _SELP_4(a,b,...)    do{ _SELP_2(a,b); _SELP_2(__VA_ARGS__); }while(0)
+#define _SELP_5(a,b,...)    do{ _SELP_2(a,b); _SELP_3(__VA_ARGS__); }while(0)
+#define _SELP_6(a,b,...)    do{ _SELP_2(a,b); _SELP_4(__VA_ARGS__); }while(0)
+#define _SELP_7(a,b,...)    do{ _SELP_2(a,b); _SELP_5(__VA_ARGS__); }while(0)
+#define _SELP_8(a,b,...)    do{ _SELP_2(a,b); _SELP_6(__VA_ARGS__); }while(0)
+#define _SELP_9(a,b,...)    do{ _SELP_2(a,b); _SELP_7(__VA_ARGS__); }while(0)
+#define _SELP_10(a,b,...)   do{ _SELP_2(a,b); _SELP_8(__VA_ARGS__); }while(0)
+#define _SELP_11(a,b,...)   do{ _SELP_2(a,b); _SELP_9(__VA_ARGS__); }while(0)
+#define _SELP_12(a,b,...)   do{ _SELP_2(a,b); _SELP_10(__VA_ARGS__); }while(0)
+#define _SELP_13(a,b,...)   do{ _SELP_2(a,b); _SELP_11(__VA_ARGS__); }while(0)
+#define _SELP_14(a,b,...)   do{ _SELP_2(a,b); _SELP_12(__VA_ARGS__); }while(0)
+#define _SELP_15(a,b,...)   do{ _SELP_2(a,b); _SELP_13(__VA_ARGS__); }while(0)
+#define _SELP_16(a,b,...)   do{ _SELP_2(a,b); _SELP_14(__VA_ARGS__); }while(0)
+#define _SELP_17(a,b,...)   do{ _SELP_2(a,b); _SELP_15(__VA_ARGS__); }while(0)
+#define _SELP_18(a,b,...)   do{ _SELP_2(a,b); _SELP_16(__VA_ARGS__); }while(0)
+#define _SELP_19(a,b,...)   do{ _SELP_2(a,b); _SELP_17(__VA_ARGS__); }while(0)
+#define _SELP_20(a,b,...)   do{ _SELP_2(a,b); _SELP_18(__VA_ARGS__); }while(0)
+#define _SELP_21(a,b,...)   do{ _SELP_2(a,b); _SELP_19(__VA_ARGS__); }while(0)
+#define _SELP_22(a,b,...)   do{ _SELP_2(a,b); _SELP_20(__VA_ARGS__); }while(0)
+#define _SELP_23(a,b,...)   do{ _SELP_2(a,b); _SELP_21(__VA_ARGS__); }while(0)
+#define _SELP_24(a,b,...)   do{ _SELP_2(a,b); _SELP_22(__VA_ARGS__); }while(0)
 
-#define SERIAL_ECHO_MSG(STR)                do{ SERIAL_ECHO_START(); SERIAL_ECHOLNPGM(STR); }while(0)
-#define SERIAL_ERROR_MSG(STR)               do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPGM(STR); }while(0)
+#define SERIAL_ECHOLNPAIR(...) _SELP_N(NUM_ARGS(__VA_ARGS__),__VA_ARGS__)
 
-#define SERIAL_ECHO_SP(C)                   serial_spaces(C)
+#define SERIAL_ECHOPGM(S)           (serialprintPGM(PSTR(S)))
+#define SERIAL_ECHOLNPGM(S)         (serialprintPGM(PSTR(S "\n")))
+
+#define SERIAL_ECHOPAIR_F(pre, ...) do{ SERIAL_ECHO(pre); SERIAL_ECHO_F(__VA_ARGS__); }while(0)
+#define SERIAL_ECHOLNPAIR_F(...)    do{ SERIAL_ECHOPAIR_F(__VA_ARGS__); SERIAL_EOL(); }while(0)
+
+#define SERIAL_ECHO_START()         serial_echo_start()
+#define SERIAL_ERROR_START()        serial_error_start()
+#define SERIAL_EOL()                SERIAL_CHAR('\n')
+
+#define SERIAL_ECHO_MSG(S)          do{ SERIAL_ECHO_START(); SERIAL_ECHOLNPGM(S); }while(0)
+#define SERIAL_ERROR_MSG(S)         do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPGM(S); }while(0)
+
+#define SERIAL_ECHO_SP(C)           serial_spaces(C)
 
 //
 // Functions for serial printing from PROGMEM. (Saves loads of SRAM.)

--- a/Marlin/src/feature/I2CPositionEncoder.cpp
+++ b/Marlin/src/feature/I2CPositionEncoder.cpp
@@ -47,8 +47,7 @@ void I2CPositionEncoder::init(const uint8_t address, const AxisEnum axis) {
 
   initialized++;
 
-  SERIAL_ECHOPAIR("Setting up encoder on ", axis_codes[encoderAxis]);
-  SERIAL_ECHOLNPAIR(" axis, addr = ", address);
+  SERIAL_ECHOLNPAIR("Setting up encoder on ", axis_codes[encoderAxis], " axis, addr = ", address);
 
   position = get_position();
 }
@@ -66,8 +65,7 @@ void I2CPositionEncoder::update() {
     /*
     if (trusted) { //commented out as part of the note below
       trusted = false;
-      SERIAL_ECHOPAIR("Fault detected on ", axis_codes[encoderAxis]);
-      SERIAL_ECHOLNPGM(" axis encoder. Disengaging error correction until module is trusted again.");
+      SERIAL_ECHOLMPAIR("Fault detected on ", axis_codes[encoderAxis], " axis encoder. Disengaging error correction until module is trusted again.");
     }
     */
     return;
@@ -92,8 +90,7 @@ void I2CPositionEncoder::update() {
       if (millis() - lastErrorTime > I2CPE_TIME_TRUSTED) {
         trusted = true;
 
-        SERIAL_ECHOPAIR("Untrusted encoder module on ", axis_codes[encoderAxis]);
-        SERIAL_ECHOLNPGM(" axis has been fault-free for set duration, reinstating error correction.");
+        SERIAL_ECHOLNPAIR("Untrusted encoder module on ", axis_codes[encoderAxis], " axis has been fault-free for set duration, reinstating error correction.");
 
         //the encoder likely lost its place when the error occured, so we'll reset and use the printer's
         //idea of where it the axis is to re-initialize
@@ -172,8 +169,7 @@ void I2CPositionEncoder::update() {
             LOOP_L_N(i, I2CPE_ERR_PRST_ARRAY_SIZE) sumP += errPrst[i];
             const int32_t errorP = int32_t(sumP * (1.0f / (I2CPE_ERR_PRST_ARRAY_SIZE)));
             SERIAL_ECHO(axis_codes[encoderAxis]);
-            SERIAL_ECHOPAIR(" - err detected: ", errorP * planner.steps_to_mm[encoderAxis]);
-            SERIAL_ECHOLNPGM("mm; correcting!");
+            SERIAL_ECHOLNPAIR(" - err detected: ", errorP * planner.steps_to_mm[encoderAxis], "mm; correcting!");
             thermalManager.babystepsTodo[encoderAxis] = -LROUND(errorP);
             errPrstIdx = 0;
           }
@@ -192,9 +188,7 @@ void I2CPositionEncoder::update() {
     if (ABS(error) > I2CPE_ERR_CNT_THRESH * planner.settings.axis_steps_per_mm[encoderAxis]) {
       const millis_t ms = millis();
       if (ELAPSED(ms, nextErrorCountTime)) {
-        SERIAL_ECHOPAIR("Large error on ", axis_codes[encoderAxis]);
-        SERIAL_ECHOPAIR(" axis. error: ", (int)error);
-        SERIAL_ECHOLNPAIR("; diffSum: ", diffSum);
+        SERIAL_ECHOLNPAIR("Large error on ", axis_codes[encoderAxis], " axis. error: ", (int)error, "; diffSum: ", diffSum);
         errorCount++;
         nextErrorCountTime = ms + I2CPE_ERR_CNT_DEBOUNCE_MS;
       }
@@ -215,8 +209,7 @@ void I2CPositionEncoder::set_homed() {
 
     #ifdef I2CPE_DEBUG
       SERIAL_ECHO(axis_codes[encoderAxis]);
-      SERIAL_ECHOPAIR(" axis encoder homed, offset of ", zeroOffset);
-      SERIAL_ECHOLNPGM(" ticks.");
+      SERIAL_ECHOLNPAIR(" axis encoder homed, offset of ", zeroOffset, " ticks.");
     #endif
   }
 }
@@ -261,9 +254,7 @@ float I2CPositionEncoder::get_axis_error_mm(const bool report) {
 
   if (report) {
     SERIAL_ECHO(axis_codes[encoderAxis]);
-    SERIAL_ECHOPAIR(" axis target: ", target);
-    SERIAL_ECHOPAIR(", actual: ", actual);
-    SERIAL_ECHOLNPAIR(", error : ",error);
+    SERIAL_ECHOLNPAIR(" axis target: ", target, ", actual: ", actual, ", error : ",error);
   }
 
   return error;
@@ -296,10 +287,7 @@ int32_t I2CPositionEncoder::get_axis_error_steps(const bool report) {
 
   if (report) {
     SERIAL_ECHO(axis_codes[encoderAxis]);
-    SERIAL_ECHOPAIR(" axis target: ", target);
-    SERIAL_ECHOPAIR(", actual: ", encoderCountInStepperTicksScaled);
-    SERIAL_ECHOLNPAIR(", error : ", error);
-
+    SERIAL_ECHOLNPAIR(" axis target: ", target, ", actual: ", encoderCountInStepperTicksScaled, ", error : ", error);
     if (suppressOutput) SERIAL_ECHOLNPGM("Discontinuity detected, suppressing error.");
   }
 
@@ -436,11 +424,9 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
     travelledDistance = mm_from_count(ABS(stopCount - startCount));
 
-    SERIAL_ECHOPAIR("Attempted travel: ", travelDistance);
-    SERIAL_ECHOLNPGM("mm");
+    SERIAL_ECHOLNPAIR("Attempted travel: ", travelDistance, "mm");
 
-    SERIAL_ECHOPAIR("   Actual travel:  ", travelledDistance);
-    SERIAL_ECHOLNPGM("mm");
+    SERIAL_ECHOLNPAIR("   Actual travel:  ", travelledDistance, "mm");
 
     //Calculate new axis steps per unit
     old_steps_mm = planner.settings.axis_steps_per_mm[encoderAxis];
@@ -705,21 +691,18 @@ void I2CPositionEncodersMgr::change_module_address(const uint8_t oldaddr, const 
   // First check 'new' address is not in use
   Wire.beginTransmission(I2C_ADDRESS(newaddr));
   if (!Wire.endTransmission()) {
-    SERIAL_ECHOPAIR("?There is already a device with that address on the I2C bus! (", newaddr);
-    SERIAL_ECHOLNPGM(")");
+    SERIAL_ECHOLNPAIR("?There is already a device with that address on the I2C bus! (", newaddr, ")");
     return;
   }
 
   // Now check that we can find the module on the oldaddr address
   Wire.beginTransmission(I2C_ADDRESS(oldaddr));
   if (Wire.endTransmission()) {
-    SERIAL_ECHOPAIR("?No module detected at this address! (", oldaddr);
-    SERIAL_ECHOLNPGM(")");
+    SERIAL_ECHOLNPAIR("?No module detected at this address! (", oldaddr, ")");
     return;
   }
 
-  SERIAL_ECHOPAIR("Module found at ", oldaddr);
-  SERIAL_ECHOLNPAIR(", changing address to ", newaddr);
+  SERIAL_ECHOLNPAIR("Module found at ", oldaddr, ", changing address to ", newaddr);
 
   // Change the modules address
   Wire.beginTransmission(I2C_ADDRESS(oldaddr));
@@ -755,13 +738,11 @@ void I2CPositionEncodersMgr::report_module_firmware(const uint8_t address) {
   // First check there is a module
   Wire.beginTransmission(I2C_ADDRESS(address));
   if (Wire.endTransmission()) {
-    SERIAL_ECHOPAIR("?No module detected at this address! (", address);
-    SERIAL_ECHOLNPGM(")");
+    SERIAL_ECHOLNPAIR("?No module detected at this address! (", address, ")");
     return;
   }
 
-  SERIAL_ECHOPAIR("Requesting version info from module at address ", address);
-  SERIAL_ECHOLNPGM(":");
+  SERIAL_ECHOLNPAIR("Requesting version info from module at address ", address, ":");
 
   Wire.beginTransmission(I2C_ADDRESS(address));
   Wire.write(I2CPE_SET_REPORT_MODE);
@@ -808,15 +789,13 @@ int8_t I2CPositionEncodersMgr::parse() {
   else if (parser.seenval('I')) {
 
     if (!parser.has_value()) {
-      SERIAL_ECHOLNPAIR("?I seen, but no index specified! [0-", I2CPE_ENCODER_CNT - 1);
-      SERIAL_ECHOLNPGM("]");
+      SERIAL_ECHOLNPAIR("?I seen, but no index specified! [0-", I2CPE_ENCODER_CNT - 1, "]");
       return I2CPE_PARSE_ERR;
     };
 
     I2CPE_idx = parser.value_byte();
     if (I2CPE_idx >= I2CPE_ENCODER_CNT) {
-      SERIAL_ECHOLNPAIR("?Index out of range. [0-", I2CPE_ENCODER_CNT - 1);
-      SERIAL_ECHOLNPGM("]");
+      SERIAL_ECHOLNPAIR("?Index out of range. [0-", I2CPE_ENCODER_CNT - 1, "]");
       return I2CPE_PARSE_ERR;
     }
 
@@ -995,8 +974,7 @@ void I2CPositionEncodersMgr::M864() {
     else return;
   }
 
-  SERIAL_ECHOPAIR("Changing module at address ", I2CPE_addr);
-  SERIAL_ECHOLNPAIR(" to address ", newAddress);
+  SERIAL_ECHOLNPAIR("Changing module at address ", I2CPE_addr, " to address ", newAddress);
 
   change_module_address(I2CPE_addr, newAddress);
 }

--- a/Marlin/src/feature/I2CPositionEncoder.h
+++ b/Marlin/src/feature/I2CPositionEncoder.h
@@ -238,8 +238,7 @@ class I2CPositionEncodersMgr {
 
     static void report_status(const int8_t idx) {
       CHECK_IDX();
-      SERIAL_ECHOPAIR("Encoder ", idx);
-      SERIAL_ECHOPGM(": ");
+      SERIAL_ECHOLNPAIR("Encoder ", idx, ": ");
       encoders[idx].get_raw_count();
       encoders[idx].passes_test(true);
     }
@@ -264,22 +263,19 @@ class I2CPositionEncodersMgr {
 
     static void report_error_count(const int8_t idx, const AxisEnum axis) {
       CHECK_IDX();
-      SERIAL_ECHOPAIR("Error count on ", axis_codes[axis]);
-      SERIAL_ECHOLNPAIR(" axis is ", encoders[idx].get_error_count());
+      SERIAL_ECHOLNPAIR("Error count on ", axis_codes[axis], " axis is ", encoders[idx].get_error_count());
     }
 
     static void reset_error_count(const int8_t idx, const AxisEnum axis) {
       CHECK_IDX();
       encoders[idx].set_error_count(0);
-      SERIAL_ECHOPAIR("Error count on ", axis_codes[axis]);
-      SERIAL_ECHOLNPGM(" axis has been reset.");
+      SERIAL_ECHOLNPAIR("Error count on ", axis_codes[axis], " axis has been reset.");
     }
 
     static void enable_ec(const int8_t idx, const bool enabled, const AxisEnum axis) {
       CHECK_IDX();
       encoders[idx].set_ec_enabled(enabled);
-      SERIAL_ECHOPAIR("Error correction on ", axis_codes[axis]);
-      SERIAL_ECHOPGM(" axis is ");
+      SERIAL_ECHOPAIR("Error correction on ", axis_codes[axis], " axis is ");
       serialprintPGM(encoders[idx].get_ec_enabled() ? PSTR("en") : PSTR("dis"));
       SERIAL_ECHOLNPGM("abled.");
     }
@@ -287,17 +283,13 @@ class I2CPositionEncodersMgr {
     static void set_ec_threshold(const int8_t idx, const float newThreshold, const AxisEnum axis) {
       CHECK_IDX();
       encoders[idx].set_ec_threshold(newThreshold);
-      SERIAL_ECHOPAIR("Error correct threshold for ", axis_codes[axis]);
-      SERIAL_ECHOPAIR(" axis set to ", FIXFLOAT(newThreshold));
-      SERIAL_ECHOLNPGM("mm.");
+      SERIAL_ECHOLNPAIR("Error correct threshold for ", axis_codes[axis], " axis set to ", FIXFLOAT(newThreshold), "mm.");
     }
 
     static void get_ec_threshold(const int8_t idx, const AxisEnum axis) {
       CHECK_IDX();
       const float threshold = encoders[idx].get_ec_threshold();
-      SERIAL_ECHOPAIR("Error correct threshold for ", axis_codes[axis]);
-      SERIAL_ECHOPAIR(" axis is ", FIXFLOAT(threshold));
-      SERIAL_ECHOLNPGM("mm.");
+      SERIAL_ECHOLNPAIR("Error correct threshold for ", axis_codes[axis], " axis is ", FIXFLOAT(threshold), "mm.");
     }
 
     static int8_t idx_from_axis(const AxisEnum axis) {

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -338,22 +338,11 @@ float bilinear_z_offset(const float raw[XYZ]) {
   /*
   static float last_offset = 0;
   if (ABS(last_offset - offset) > 0.2) {
-    SERIAL_ECHOPGM("Sudden Shift at ");
-    SERIAL_ECHOPAIR("x=", rx);
-    SERIAL_ECHOPAIR(" / ", bilinear_grid_spacing[X_AXIS]);
-    SERIAL_ECHOLNPAIR(" -> gridx=", gridx);
-    SERIAL_ECHOPAIR(" y=", ry);
-    SERIAL_ECHOPAIR(" / ", bilinear_grid_spacing[Y_AXIS]);
-    SERIAL_ECHOLNPAIR(" -> gridy=", gridy);
-    SERIAL_ECHOPAIR(" ratio_x=", ratio_x);
-    SERIAL_ECHOLNPAIR(" ratio_y=", ratio_y);
-    SERIAL_ECHOPAIR(" z1=", z1);
-    SERIAL_ECHOPAIR(" z2=", z2);
-    SERIAL_ECHOPAIR(" z3=", z3);
-    SERIAL_ECHOLNPAIR(" z4=", z4);
-    SERIAL_ECHOPAIR(" L=", L);
-    SERIAL_ECHOPAIR(" R=", R);
-    SERIAL_ECHOLNPAIR(" offset=", offset);
+    SERIAL_ECHOLNPAIR("Sudden Shift at x=", rx, " / ", bilinear_grid_spacing[X_AXIS], " -> gridx=", gridx);
+    SERIAL_ECHOLNPAIR(" y=", ry, " / ", bilinear_grid_spacing[Y_AXIS], " -> gridy=", gridy);
+    SERIAL_ECHOLNPAIR(" ratio_x=", ratio_x, " ratio_y=", ratio_y);
+    SERIAL_ECHOLNPAIR(" z1=", z1, " z2=", z2, " z3=", z3, " z4=", z4);
+    SERIAL_ECHOLNPAIR(" L=", L, " R=", R, " offset=", offset);
   }
   last_offset = offset;
   //*/

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -45,8 +45,7 @@
       for (uint8_t y = 0;  y < GRID_MAX_POINTS_Y; y++)
         if (!isnan(z_values[x][y])) {
           SERIAL_ECHO_START();
-          SERIAL_ECHOPAIR("  M421 I", x);
-          SERIAL_ECHOPAIR(" J", y);
+          SERIAL_ECHOPAIR("  M421 I", x, " J", y);
           SERIAL_ECHOPAIR_F(" Z", z_values[x][y], 2);
           SERIAL_EOL();
           serial_delay(75); // Prevent Printrun from exploding

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -202,11 +202,7 @@ class unified_bed_leveling {
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             serialprintPGM( !WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) ? PSTR("x1_i") : PSTR("yi") );
-            SERIAL_ECHOPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0);
-            SERIAL_ECHOPAIR(",x1_i=", x1_i);
-            SERIAL_ECHOPAIR(",yi=", yi);
-            SERIAL_CHAR(')');
-            SERIAL_EOL();
+            SERIAL_ECHOLNPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0, ",x1_i=", x1_i, ",yi=", yi, ")");
           }
         #endif
 
@@ -235,12 +231,8 @@ class unified_bed_leveling {
       if (!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(y1_i, 0, GRID_MAX_POINTS_Y - 1)) {
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
-            serialprintPGM( !WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) ? PSTR("xi") : PSTR("y1_i") );
-            SERIAL_ECHOPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0);
-            SERIAL_ECHOPAIR(", xi=", xi);
-            SERIAL_ECHOPAIR(", y1_i=", y1_i);
-            SERIAL_CHAR(')');
-            SERIAL_EOL();
+            serialprintPGM(!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) ? PSTR("xi") : PSTR("y1_i"));
+            SERIAL_ECHOLNPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0, ", xi=", xi, ", y1_i=", y1_i, ")");
           }
         #endif
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -598,8 +598,7 @@
       }
 
       if (!WITHIN(g29_storage_slot, 0, a - 1)) {
-        SERIAL_ECHOLNPGM("?Invalid storage slot.");
-        SERIAL_ECHOLNPAIR("?Use 0 to ", a - 1);
+        SERIAL_ECHOLNPAIR("?Invalid storage slot.\n?Use 0 to ", a - 1);
         return;
       }
 
@@ -627,8 +626,7 @@
       }
 
       if (!WITHIN(g29_storage_slot, 0, a - 1)) {
-        SERIAL_ECHOLNPGM("?Invalid storage slot.");
-        SERIAL_ECHOLNPAIR("?Use 0 to ", a - 1);
+        SERIAL_ECHOLNPAIR("?Invalid storage slot.\n?Use 0 to ", a - 1);
         goto LEAVE;
       }
 
@@ -1640,10 +1638,8 @@
 
       if (storage_slot == -1)
         SERIAL_ECHOPGM("No Mesh Loaded.");
-      else {
-        SERIAL_ECHOPAIR("Mesh ", storage_slot);
-        SERIAL_ECHOPGM(" Loaded.");
-      }
+      else
+        SERIAL_ECHOPAIR("Mesh ", storage_slot, " Loaded.");
       SERIAL_EOL();
       serial_delay(50);
 
@@ -1683,19 +1679,16 @@
       SERIAL_EOL();
 
       #if HAS_KILL
-        SERIAL_ECHOPAIR("Kill pin on :", KILL_PIN);
-        SERIAL_ECHOLNPAIR("  state:", READ(KILL_PIN));
+        SERIAL_ECHOLNPAIR("Kill pin on :", int(KILL_PIN), "  state:", READ(KILL_PIN));
       #endif
       SERIAL_EOL();
       serial_delay(50);
 
       #if ENABLED(UBL_DEVEL_DEBUGGING)
-        SERIAL_ECHOLNPAIR("ubl_state_at_invocation :", ubl_state_at_invocation); SERIAL_EOL();
-        SERIAL_ECHOLNPAIR("ubl_state_recursion_chk :", ubl_state_recursion_chk); SERIAL_EOL();
+        SERIAL_ECHOLNPAIR("ubl_state_at_invocation :", ubl_state_at_invocation, "\nubl_state_recursion_chk :", ubl_state_recursion_chk);
         serial_delay(50);
 
-        SERIAL_ECHOPAIR("Meshes go from ", hex_address((void*)settings.meshes_start_index()));
-        SERIAL_ECHOLNPAIR(" to ", hex_address((void*)settings.meshes_end_index()));
+        SERIAL_ECHOLNPAIR("Meshes go from ", hex_address((void*)settings.meshes_start_index()), " to ", hex_address((void*)settings.meshes_end_index()));
         serial_delay(50);
 
         SERIAL_ECHOLNPAIR("sizeof(ubl) :  ", (int)sizeof(ubl));         SERIAL_EOL();
@@ -1705,8 +1698,7 @@
         SERIAL_ECHOLNPAIR("EEPROM free for UBL: ", hex_address((void*)(settings.meshes_end_index() - settings.meshes_start_index())));
         serial_delay(50);
 
-        SERIAL_ECHOPAIR("EEPROM can hold ", settings.calc_num_meshes());
-        SERIAL_ECHOLNPGM(" meshes.\n");
+        SERIAL_ECHOLNPAIR("EEPROM can hold ", settings.calc_num_meshes(), " meshes.\n");
         serial_delay(25);
       #endif // UBL_DEVEL_DEBUGGING
 
@@ -1753,24 +1745,21 @@
       }
 
       if (!parser.has_value()) {
-        SERIAL_ECHOLNPGM("?Storage slot # required.");
-        SERIAL_ECHOLNPAIR("?Use 0 to ", a - 1);
+        SERIAL_ECHOLNPAIR("?Storage slot # required.\n?Use 0 to ", a - 1);
         return;
       }
 
       g29_storage_slot = parser.value_int();
 
       if (!WITHIN(g29_storage_slot, 0, a - 1)) {
-        SERIAL_ECHOLNPGM("?Invalid storage slot.");
-        SERIAL_ECHOLNPAIR("?Use 0 to ", a - 1);
+        SERIAL_ECHOLNPAIR("?Invalid storage slot.\n?Use 0 to ", a - 1);
         return;
       }
 
       float tmp_z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
       settings.load_mesh(g29_storage_slot, &tmp_z_values);
 
-      SERIAL_ECHOPAIR("Subtracting mesh in slot ", g29_storage_slot);
-      SERIAL_ECHOLNPGM(" from current mesh.");
+      SERIAL_ECHOLNPAIR("Subtracting mesh in slot ", g29_storage_slot, " from current mesh.");
 
       for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
         for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++)

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -65,12 +65,13 @@
               cell_dest_yi  = get_cell_index_y(end[Y_AXIS]);
 
     if (g26_debug_flag) {
-      SERIAL_ECHOPAIR(" ubl.line_to_destination_cartesian(xe=", destination[X_AXIS]);
-      SERIAL_ECHOPAIR(", ye=", destination[Y_AXIS]);
-      SERIAL_ECHOPAIR(", ze=", destination[Z_AXIS]);
-      SERIAL_ECHOPAIR(", ee=", destination[E_AXIS]);
-      SERIAL_CHAR(')');
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR(
+        " ubl.line_to_destination_cartesian(xe=", destination[X_AXIS],
+        ", ye=", destination[Y_AXIS],
+        ", ze=", destination[Z_AXIS],
+        ", ee=", destination[E_AXIS],
+        ")"
+      );
       debug_current_and_destination(PSTR("Start of ubl.line_to_destination_cartesian()"));
     }
 

--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -105,15 +105,12 @@ void dac_print_values() {
 
   SERIAL_ECHO_MSG("Stepper current values in % (Amps):");
   SERIAL_ECHO_START();
-  SERIAL_ECHOPAIR(" X:",  dac_perc(X_AXIS));
-  SERIAL_ECHOPAIR(" (",   dac_amps(X_AXIS));
-  SERIAL_ECHOPAIR(") Y:", dac_perc(Y_AXIS));
-  SERIAL_ECHOPAIR(" (",   dac_amps(Y_AXIS));
-  SERIAL_ECHOPAIR(") Z:", dac_perc(Z_AXIS));
-  SERIAL_ECHOPAIR(" (",   dac_amps(Z_AXIS));
-  SERIAL_ECHOPAIR(") E:", dac_perc(E_AXIS));
-  SERIAL_ECHOPAIR(" (",   dac_amps(E_AXIS));
-  SERIAL_ECHOLNPGM(")");
+  SERIAL_ECHOLNPAIR(
+    " X:", dac_perc(X_AXIS), " (", dac_amps(X_AXIS), ")"
+    " Y:", dac_perc(Y_AXIS), " (", dac_amps(Y_AXIS), ")"
+    " Z:", dac_perc(Z_AXIS), " (", dac_amps(Z_AXIS), ")"
+    " E:", dac_perc(E_AXIS), " (", dac_amps(E_AXIS), ")"
+  );
 }
 
 void dac_commit_eeprom() {

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -112,15 +112,15 @@ void FWRetract::retract(const bool retracting
   #endif
 
   /* // debugging
-    SERIAL_ECHOLNPAIR("retracting ", retracting);
-    SERIAL_ECHOLNPAIR("swapping ", swapping);
-    SERIAL_ECHOLNPAIR("active extruder ", active_extruder);
+    SERIAL_ECHOLNPAIR(
+      "retracting ", retracting,
+      "swapping ", swapping
+      "active extruder ", active_extruder
+    );
     for (uint8_t i = 0; i < EXTRUDERS; ++i) {
-      SERIAL_ECHOPAIR("retracted[", i);
-      SERIAL_ECHOLNPAIR("] ", retracted[i]);
+      SERIAL_ECHOLNPAIR("retracted[", i, "] ", retracted[i]);
       #if EXTRUDERS > 1
-        SERIAL_ECHOPAIR("retracted_swap[", i);
-        SERIAL_ECHOLNPAIR("] ", retracted_swap[i]);
+        SERIAL_ECHOLNPAIR("retracted_swap[", i, "] ", retracted_swap[i]);
       #endif
     }
     SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);
@@ -209,11 +209,9 @@ void FWRetract::retract(const bool retracting
     SERIAL_ECHOLNPAIR("swapping ", swapping);
     SERIAL_ECHOLNPAIR("active_extruder ", active_extruder);
     for (uint8_t i = 0; i < EXTRUDERS; ++i) {
-      SERIAL_ECHOPAIR("retracted[", i);
-      SERIAL_ECHOLNPAIR("] ", retracted[i]);
+      SERIAL_ECHOLNPAIR("retracted[", i, "] ", retracted[i]);
       #if EXTRUDERS > 1
-        SERIAL_ECHOPAIR("retracted_swap[", i);
-        SERIAL_ECHOLNPAIR("] ", retracted_swap[i]);
+        SERIAL_ECHOLNPAIR("retracted_swap[", i, "] ", retracted_swap[i]);
       #endif
     }
     SERIAL_ECHOLNPAIR("current_position[z] ", current_position[Z_AXIS]);

--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -139,19 +139,11 @@ void Mixer::refresh_collector(const float proportion/*=1.0*/, const uint8_t t/*=
     cmax = MAX(cmax, v);
     csum += v;
   }
-  //SERIAL_ECHOPAIR("Mixer::refresh_collector(", proportion);
-  //SERIAL_ECHOPAIR(", ", int(t));
-  //SERIAL_ECHOPAIR(") cmax=", cmax);
-  //SERIAL_ECHOPAIR("  csum=", csum);
-  //SERIAL_ECHOPGM("  color");
+  //SERIAL_ECHOPAIR("Mixer::refresh_collector(", proportion, ", ", int(t), ") cmax=", cmax, "  csum=", csum, "  color");
   const float inv_prop = proportion / csum;
   MIXER_STEPPER_LOOP(i) {
     collector[i] = color[t][i] * inv_prop;
-    //SERIAL_ECHOPAIR(" [", int(t));
-    //SERIAL_ECHOPAIR("][", int(i));
-    //SERIAL_ECHOPAIR("] = ", int(color[t][i]));
-    //SERIAL_ECHOPAIR(" (", collector[i]);
-    //SERIAL_ECHOPGM(")  ");
+    //SERIAL_ECHOPAIR(" [", int(t), "][", int(i), "] = ", int(color[t][i]), " (", collector[i], ")  ");
   }
   //SERIAL_EOL();
 }

--- a/Marlin/src/feature/mixing.h
+++ b/Marlin/src/feature/mixing.h
@@ -148,11 +148,7 @@ class Mixer {
       MIXER_STEPPER_LOOP(i) tcolor[i] = mix[i] * scale;
 
       #ifdef MIXER_NORMALIZER_DEBUG
-        SERIAL_ECHOPAIR("Mix [", int(mix[0]));
-        SERIAL_ECHOPAIR(", ", int(mix[1]));
-        SERIAL_ECHOPAIR("] to Color [", int(tcolor[0]));
-        SERIAL_ECHOPAIR(", ", int(tcolor[1]));
-        SERIAL_ECHOLNPGM("]");
+        SERIAL_ECHOLNPAIR("Mix [", int(mix[0]), ", ", int(mix[1]), "] to Color [", int(tcolor[0]), ", ", int(tcolor[1]), "]");
       #endif
     }
 
@@ -163,12 +159,7 @@ class Mixer {
       mix[0] = mixer_perc_t(100.0f * color[j][0] / ctot);
       mix[1] = 100 - mix[0];
       #ifdef MIXER_NORMALIZER_DEBUG
-        SERIAL_ECHOPAIR("V-tool ", int(j));
-        SERIAL_ECHOPAIR(" [", int(color[j][0]));
-        SERIAL_ECHOPAIR(", ", int(color[j][1]));
-        SERIAL_ECHOPAIR("] to Mix [", int(mix[0]));
-        SERIAL_ECHOPAIR(", ", int(mix[1]));
-        SERIAL_ECHOLNPGM("]");
+        SERIAL_ECHOLNPAIR("V-tool ", int(j), " [", int(color[j][0]), ", ", int(color[j][1]), "] to Mix [", int(mix[0]), ", ", int(mix[1]), "]");
       #endif
     }
 
@@ -211,11 +202,7 @@ class Mixer {
       mix[0] = (mixer_perc_t)CEIL(100.0f * gradient.color[0] / ctot);
       mix[1] = 100 - mix[0];
       #ifdef MIXER_NORMALIZER_DEBUG
-        SERIAL_ECHOPAIR("Gradient [", int(gradient.color[0]));
-        SERIAL_ECHOPAIR(", ", int(gradient.color[1]));
-        SERIAL_ECHOPAIR("] to Mix [", int(mix[0]));
-        SERIAL_ECHOPAIR(", ", int(mix[1]));
-        SERIAL_ECHOLNPGM("]");
+        SERIAL_ECHOLNPAIR("Gradient [", int(gradient.color[0]), ", ", int(gradient.color[1]), "] to Mix [", int(mix[0]), ", ", int(mix[1]), "]");
       #endif
     }
 

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -581,11 +581,12 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
  */
 void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_length/*=0*/, const float &purge_length/*=ADVANCED_PAUSE_PURGE_LENGTH*/, const int8_t max_beep_count/*=0*/ DXC_ARGS) {
   /*
-  SERIAL_ECHOLNPGM("start of resume_print()");
-  SERIAL_ECHOPAIR("\ndual_x_carriage_mode:", dual_x_carriage_mode);
-  SERIAL_ECHOPAIR("\nextruder_duplication_enabled:", extruder_duplication_enabled);
-  SERIAL_ECHOPAIR("\nactive_extruder:", active_extruder);
-  SERIAL_ECHOLNPGM("\n");
+  SERIAL_ECHOLNPAIR(
+    "start of resume_print()\ndual_x_carriage_mode:", dual_x_carriage_mode,
+    "\nextruder_duplication_enabled:", extruder_duplication_enabled,
+    "\nactive_extruder:", active_extruder,
+    "\n"
+  );
   //*/
 
   if (!did_pause_print) return;

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -357,8 +357,7 @@ void PrintJobRecovery::resume() {
 
   void PrintJobRecovery::debug(PGM_P const prefix) {
     serialprintPGM(prefix);
-    SERIAL_ECHOPAIR(" Job Recovery Info...\nvalid_head:", int(info.valid_head));
-    SERIAL_ECHOLNPAIR(" valid_foot:", int(info.valid_foot));
+    SERIAL_ECHOLNPAIR(" Job Recovery Info...\nvalid_head:", int(info.valid_head), " valid_foot:", int(info.valid_foot));
     if (info.valid_head) {
       if (info.valid_head == info.valid_foot) {
         SERIAL_ECHOPGM("current_position: ");
@@ -394,8 +393,7 @@ void PrintJobRecovery::resume() {
         #endif
 
         #if HAS_LEVELING
-          SERIAL_ECHOPAIR("leveling: ", int(info.leveling));
-          SERIAL_ECHOLNPAIR(" fade: ", int(info.fade));
+          SERIAL_ECHOLNPAIR("leveling: ", int(info.leveling), "\n fade: ", int(info.fade));
         #endif
         #if ENABLED(FWRETRACT)
           SERIAL_ECHOPGM("retract: ");

--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -174,8 +174,7 @@ void MMU2::mmuLoop() {
         sscanf(rx_buffer, "%uok\n", &version);
 
         #if ENABLED(MMU2_DEBUG)
-          SERIAL_ECHOLNPAIR("MMU => ", version);
-          SERIAL_ECHOLNPGM("MMU <= 'S2'");
+          SERIAL_ECHOLNPAIR("MMU => ", version, "\nMMU <= 'S2'");
         #endif
 
         tx_str_P(PSTR("S2\n")); // read build number
@@ -234,8 +233,7 @@ void MMU2::mmuLoop() {
         sscanf(rx_buffer, "%hhuok\n", &finda);
 
         #if ENABLED(MMU2_DEBUG)
-          SERIAL_ECHOLNPAIR("MMU => ", finda);
-          SERIAL_ECHOLNPGM("MMU - ENABLED");
+          SERIAL_ECHOLNPAIR("MMU => ", finda, "\nMMU - ENABLED");
         #endif
 
         enabled = true;
@@ -309,8 +307,7 @@ void MMU2::mmuLoop() {
           // filament type
           int filament = cmd - MMU_CMD_F0;
           #if ENABLED(MMU2_DEBUG)
-            SERIAL_ECHOPAIR("MMU <= F", filament);
-            SERIAL_ECHOPGM(" ");
+            SERIAL_ECHOPAIR("MMU <= F", filament, " ");
             SERIAL_ECHO_F(cmd_arg, DEC);
             SERIAL_ECHOPGM("\n");
           #endif

--- a/Marlin/src/feature/twibus.cpp
+++ b/Marlin/src/feature/twibus.cpp
@@ -92,9 +92,7 @@ void TWIBus::send() {
 void TWIBus::echoprefix(uint8_t bytes, const char prefix[], uint8_t adr) {
   SERIAL_ECHO_START();
   serialprintPGM(prefix);
-  SERIAL_ECHOPAIR(": from:", adr);
-  SERIAL_ECHOPAIR(" bytes:", bytes);
-  SERIAL_ECHOPGM(" data:");
+  SERIAL_ECHOPAIR(": from:", adr, " bytes:", bytes, " data:");
 }
 
 // static

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -346,12 +346,7 @@ inline bool look_for_lines_to_connect() {
             if (position_is_reachable(sx, sy) && position_is_reachable(ex, ey)) {
 
               if (g26_debug_flag) {
-                SERIAL_ECHOPAIR(" Connecting with horizontal line (sx=", sx);
-                SERIAL_ECHOPAIR(", sy=", sy);
-                SERIAL_ECHOPAIR(") -> (ex=", ex);
-                SERIAL_ECHOPAIR(", ey=", ey);
-                SERIAL_CHAR(')');
-                SERIAL_EOL();
+                SERIAL_ECHOLNPAIR(" Connecting with horizontal line (sx=", sx, ", sy=", sy, ") -> (ex=", ex, ", ey=", ey, ")");
                 //debug_current_and_destination(PSTR("Connecting horizontal line."));
               }
               print_line_from_here_to_there(sx, sy, g26_layer_height, ex, ey, g26_layer_height);

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -272,8 +272,7 @@ void GCodeParser::parse(char *p) {
 
       #if ENABLED(DEBUG_GCODE_PARSER)
         if (debug) {
-          SERIAL_ECHOPAIR("Got letter ", code);
-          SERIAL_ECHOPAIR(" at index ", (int)(p - command_ptr - 1));
+          SERIAL_ECHOPAIR("Got letter ", code, " at index ", (int)(p - command_ptr - 1));
           if (has_num) SERIAL_ECHOPGM(" (has_num)");
         }
       #endif
@@ -329,47 +328,41 @@ void GCodeParser::parse(char *p) {
 
 void GCodeParser::unknown_command_error() {
   SERIAL_ECHO_START();
-  SERIAL_ECHOPAIR(MSG_UNKNOWN_COMMAND, command_ptr);
-  SERIAL_CHAR('"');
-  SERIAL_EOL();
+  SERIAL_ECHOLNPAIR(MSG_UNKNOWN_COMMAND, command_ptr, "\"");
 }
 
 #if ENABLED(DEBUG_GCODE_PARSER)
 
   void GCodeParser::debug() {
-    SERIAL_ECHOPAIR("Command: ", command_ptr);
-    SERIAL_ECHOPAIR(" (", command_letter);
+    SERIAL_ECHOPAIR("Command: ", command_ptr, " (", command_letter);
     SERIAL_ECHO(codenum);
     SERIAL_ECHOLNPGM(")");
     #if ENABLED(FASTER_GCODE_PARSER)
-      SERIAL_ECHOPGM(" args: \"");
-      for (char c = 'A'; c <= 'Z'; ++c)
-        if (seen(c)) { SERIAL_CHAR(c); SERIAL_CHAR(' '); }
+      SERIAL_ECHOPGM(" args: { ");
+      for (char c = 'A'; c <= 'Z'; ++c) if (seen(c)) { SERIAL_CHAR(c); SERIAL_CHAR(' '); }
+      SERIAL_CHAR('}');
     #else
-      SERIAL_ECHOPAIR(" args: \"", command_args);
+      SERIAL_ECHOPAIR(" args: { ", command_args, " }");
     #endif
-    SERIAL_CHAR('"');
-    if (string_arg) {
-      SERIAL_ECHOPGM(" string: \"");
-      SERIAL_ECHO(string_arg);
-      SERIAL_CHAR('"');
-    }
+    if (string_arg) SERIAL_ECHOPAIR(" string: \"", string_arg, "\"");
     SERIAL_ECHOLNPGM("\n");
     for (char c = 'A'; c <= 'Z'; ++c) {
       if (seen(c)) {
         SERIAL_ECHOPAIR("Code '", c); SERIAL_ECHOPGM("':");
         if (has_value()) {
-          SERIAL_ECHOPAIR("\n    float: ", value_float());
-          SERIAL_ECHOPAIR("\n     long: ", value_long());
-          SERIAL_ECHOPAIR("\n    ulong: ", value_ulong());
-          SERIAL_ECHOPAIR("\n   millis: ", value_millis());
-          SERIAL_ECHOPAIR("\n   sec-ms: ", value_millis_from_seconds());
-          SERIAL_ECHOPAIR("\n      int: ", value_int());
-          SERIAL_ECHOPAIR("\n   ushort: ", value_ushort());
-          SERIAL_ECHOPAIR("\n     byte: ", (int)value_byte());
-          SERIAL_ECHOPAIR("\n     bool: ", (int)value_bool());
-          SERIAL_ECHOPAIR("\n   linear: ", value_linear_units());
-          SERIAL_ECHOPAIR("\n  celsius: ", value_celsius());
+          SERIAL_ECHOPAIR(
+            "\n    float: ", value_float(),
+            "\n     long: ", value_long(),
+            "\n    ulong: ", value_ulong(),
+            "\n   millis: ", value_millis(),
+            "\n   sec-ms: ", value_millis_from_seconds(),
+            "\n      int: ", value_int(),
+            "\n   ushort: ", value_ushort(),
+            "\n     byte: ", (int)value_byte(),
+            "\n     bool: ", (int)value_bool(),
+            "\n   linear: ", value_linear_units(),
+            "\n  celsius: ", value_celsius()
+          );
         }
         else
           SERIAL_ECHOPGM(" (no value)");

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -120,8 +120,7 @@ public:
       param[ind] = ptr ? ptr - command_ptr : 0;  // parameter offset or 0
       #if ENABLED(DEBUG_GCODE_PARSER)
         if (codenum == 800) {
-          SERIAL_ECHOPAIR("Set bit ", (int)ind);
-          SERIAL_ECHOPAIR(" of codebits (", hex_address((void*)(codebits >> 16)));
+          SERIAL_ECHOPAIR("Set bit ", (int)ind, " of codebits (", hex_address((void*)(codebits >> 16)));
           print_hex_word((uint16_t)(codebits & 0xFFFF));
           SERIAL_ECHOLNPAIR(") | param = ", (int)param[ind]);
         }

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -150,9 +150,7 @@ bool enqueue_and_echo_command(const char* cmd) {
 
   if (_enqueuecommand(cmd)) {
     SERIAL_ECHO_START();
-    SERIAL_ECHOPAIR(MSG_ENQUEUEING, cmd);
-    SERIAL_CHAR('"');
-    SERIAL_EOL();
+    SERIAL_ECHOLNPAIR(MSG_ENQUEUEING, cmd, "\"");
     return true;
   }
   return false;
@@ -398,9 +396,10 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
               stream_state = StreamState::PACKET_RESET;
               bytes_received = 0;
               time_stream_start = millis();
-              SERIAL_ECHOPAIR("echo: Datastream initialized (", stream_header.filesize);
-              SERIAL_ECHOLNPGM(" bytes expected)");
-              SERIAL_ECHOLNPAIR("so", buffer_size); // confirm active stream and the maximum block size supported
+              // confirm active stream and the maximum block size supported
+              SERIAL_ECHO_START();
+              SERIAL_ECHOLNPAIR("Datastream initialized (", stream_header.filesize, " bytes expected)");
+              SERIAL_ECHOLNPAIR("so", buffer_size);
             }
             else {
               SERIAL_ECHO_MSG("Datastream init error (invalid token)");
@@ -468,8 +467,7 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
             }
             else {
               SERIAL_ECHO_START();
-              SERIAL_ECHOPAIR("Block(", packet.header.id);
-              SERIAL_ECHOLNPGM(") Corrupt");
+              SERIAL_ECHOLNPAIR("Block(", packet.header.id, ") Corrupt");
               stream_state = StreamState::PACKET_FLUSHRX;
             }
             break;
@@ -504,8 +502,7 @@ void gcode_line_error(PGM_P const err, const int8_t port) {
             card.flag.binary_mode = false;
             SERIAL_ECHO_START();
             SERIAL_ECHO(card.filename);
-            SERIAL_ECHOPAIR(" transfer completed @ ", ((bytes_received / (millis() - time_stream_start) * 1000) / 1024));
-            SERIAL_ECHOLNPGM("KiB/s");
+            SERIAL_ECHOLNPAIR(" transfer completed @ ", ((bytes_received / (millis() - time_stream_start) * 1000) / 1024), "KiB/s");
             SERIAL_ECHOLNPGM("sc"); // transmit stream complete token
             card.closefile();
             return;

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -382,8 +382,8 @@ void MarlinSettings::postprocess() {
 #if ENABLED(EEPROM_CHITCHAT)
   #define CHITCHAT_ECHO(V)              SERIAL_ECHO(V)
   #define CHITCHAT_ECHOLNPGM(STR)       SERIAL_ECHOLNPGM(STR)
-  #define CHITCHAT_ECHOPAIR(STR,V)      SERIAL_ECHOPAIR(STR,V)
-  #define CHITCHAT_ECHOLNPAIR(STR,V)    SERIAL_ECHOLNPAIR(STR,V)
+  #define CHITCHAT_ECHOPAIR(...)        SERIAL_ECHOPAIR(__VA_ARGS__)
+  #define CHITCHAT_ECHOLNPAIR(...)      SERIAL_ECHOLNPAIR(__VA_ARGS__)
   #define CHITCHAT_ECHO_START()         SERIAL_ECHO_START()
   #define CHITCHAT_ERROR_START()        SERIAL_ERROR_START()
   #define CHITCHAT_ERROR_MSG(STR)       SERIAL_ERROR_MSG(STR)
@@ -392,8 +392,8 @@ void MarlinSettings::postprocess() {
 #else
   #define CHITCHAT_ECHO(V)              NOOP
   #define CHITCHAT_ECHOLNPGM(STR)       NOOP
-  #define CHITCHAT_ECHOPAIR(STR,V)      NOOP
-  #define CHITCHAT_ECHOLNPAIR(STR,V)    NOOP
+  #define CHITCHAT_ECHOPAIR(...)        NOOP
+  #define CHITCHAT_ECHOLNPAIR(...)      NOOP
   #define CHITCHAT_ECHO_START()         NOOP
   #define CHITCHAT_ERROR_START()        NOOP
   #define CHITCHAT_ERROR_MSG(STR)       NOOP
@@ -1104,9 +1104,7 @@ void MarlinSettings::postprocess() {
 
       // Report storage size
       CHITCHAT_ECHO_START();
-      CHITCHAT_ECHOPAIR("Settings Stored (", eeprom_size);
-      CHITCHAT_ECHOPAIR(" bytes; crc ", (uint32_t)final_crc);
-      CHITCHAT_ECHOLNPGM(")");
+      CHITCHAT_ECHOLNPAIR("Settings Stored (", eeprom_size, " bytes; crc ", (uint32_t)final_crc, ")");
 
       eeprom_error |= size_error(eeprom_size);
     }
@@ -1144,9 +1142,7 @@ void MarlinSettings::postprocess() {
         stored_ver[1] = '\0';
       }
       CHITCHAT_ECHO_START();
-      CHITCHAT_ECHOPGM("EEPROM version mismatch ");
-      CHITCHAT_ECHOPAIR("(EEPROM=", stored_ver);
-      CHITCHAT_ECHOLNPGM(" Marlin=" EEPROM_VERSION ")");
+      CHITCHAT_ECHOLNPAIR("EEPROM version mismatch (EEPROM=", stored_ver, " Marlin=" EEPROM_VERSION ")");
       eeprom_error = true;
     }
     else {
@@ -1812,24 +1808,17 @@ void MarlinSettings::postprocess() {
       eeprom_error = size_error(eeprom_index - (EEPROM_OFFSET));
       if (eeprom_error) {
         CHITCHAT_ECHO_START();
-        CHITCHAT_ECHOPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)));
-        CHITCHAT_ECHOLNPAIR(" Size: ", datasize());
+        CHITCHAT_ECHOLNPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)), " Size: ", datasize());
       }
       else if (working_crc != stored_crc) {
         eeprom_error = true;
         CHITCHAT_ERROR_START();
-        CHITCHAT_ECHOPGM("EEPROM CRC mismatch - (stored) ");
-        CHITCHAT_ECHO(stored_crc);
-        CHITCHAT_ECHOPGM(" != ");
-        CHITCHAT_ECHO(working_crc);
-        CHITCHAT_ECHOLNPGM(" (calculated)!");
+        CHITCHAT_ECHOLNPAIR("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
       }
       else if (!validating) {
         CHITCHAT_ECHO_START();
         CHITCHAT_ECHO(version);
-        CHITCHAT_ECHOPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET));
-        CHITCHAT_ECHOPAIR(" bytes; crc ", (uint32_t)working_crc);
-        CHITCHAT_ECHOLNPGM(")");
+        CHITCHAT_ECHOLNPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET), " bytes; crc ", (uint32_t)working_crc, ")");
       }
 
       if (!validating && !eeprom_error) postprocess();
@@ -1857,8 +1846,7 @@ void MarlinSettings::postprocess() {
 
           if (ubl.storage_slot >= 0) {
             load_mesh(ubl.storage_slot);
-            CHITCHAT_ECHOPAIR("Mesh ", ubl.storage_slot);
-            CHITCHAT_ECHOLNPGM(" loaded from storage.");
+            CHITCHAT_ECHOLNPAIR("Mesh ", ubl.storage_slot, " loaded from storage.");
           }
           else {
             ubl.reset();
@@ -1924,9 +1912,7 @@ void MarlinSettings::postprocess() {
         const int16_t a = calc_num_meshes();
         if (!WITHIN(slot, 0, a - 1)) {
           ubl_invalid_slot(a);
-          CHITCHAT_ECHOPAIR("E2END=", persistentStore.capacity() - 1);
-          CHITCHAT_ECHOPAIR(" meshes_end=", meshes_end);
-          CHITCHAT_ECHOLNPAIR(" slot=", slot);
+          CHITCHAT_ECHOLNPAIR("E2END=", persistentStore.capacity() - 1, " meshes_end=", meshes_end, " slot=", slot);
           CHITCHAT_EOL();
           return;
         }
@@ -2314,7 +2300,7 @@ void MarlinSettings::reset() {
   #define CONFIG_ECHO_HEADING(STR)  do{ if (!forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOLNPGM(STR); } }while(0)
 
   #if HAS_TRINAMIC
-    void say_M906() { SERIAL_ECHOPGM("  M906"); }
+    inline void say_M906(const bool forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOPGM("  M906"); }
     #if HAS_STEALTHCHOP
       void say_M569(const char * const etc=NULL) {
         SERIAL_ECHOPGM("  M569 S1");
@@ -2326,15 +2312,15 @@ void MarlinSettings::reset() {
       }
     #endif
     #if ENABLED(HYBRID_THRESHOLD)
-      void say_M913() { SERIAL_ECHOPGM("  M913"); }
+      inline void say_M913() { SERIAL_ECHOPGM("  M913"); }
     #endif
     #if USE_SENSORLESS
-      void say_M914() { SERIAL_ECHOPGM("  M914"); }
+      inline void say_M914() { SERIAL_ECHOPGM("  M914"); }
     #endif
   #endif
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
-    void say_M603() { SERIAL_ECHOPGM("  M603 "); }
+    inline void say_M603(const bool forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOPGM("  M603 "); }
   #endif
 
   inline void say_units(const bool colon) {
@@ -2403,28 +2389,22 @@ void MarlinSettings::reset() {
       }
 
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M200 D", LINEAR_UNIT(planner.filament_size[0]));
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR("  M200 D", LINEAR_UNIT(planner.filament_size[0]));
       #if EXTRUDERS > 1
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR("  M200 T1 D", LINEAR_UNIT(planner.filament_size[1]));
-        SERIAL_EOL();
+        SERIAL_ECHOLNPAIR("  M200 T1 D", LINEAR_UNIT(planner.filament_size[1]));
         #if EXTRUDERS > 2
           CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR("  M200 T2 D", LINEAR_UNIT(planner.filament_size[2]));
-          SERIAL_EOL();
+          SERIAL_ECHOLNPAIR("  M200 T2 D", LINEAR_UNIT(planner.filament_size[2]));
           #if EXTRUDERS > 3
             CONFIG_ECHO_START();
-            SERIAL_ECHOPAIR("  M200 T3 D", LINEAR_UNIT(planner.filament_size[3]));
-            SERIAL_EOL();
+            SERIAL_ECHOLNPAIR("  M200 T3 D", LINEAR_UNIT(planner.filament_size[3]));
             #if EXTRUDERS > 4
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  M200 T4 D", LINEAR_UNIT(planner.filament_size[4]));
-              SERIAL_EOL();
+              SERIAL_ECHOLNPAIR("  M200 T4 D", LINEAR_UNIT(planner.filament_size[4]));
               #if EXTRUDERS > 5
                 CONFIG_ECHO_START();
-                SERIAL_ECHOPAIR("  M200 T5 D", LINEAR_UNIT(planner.filament_size[5]));
-                SERIAL_EOL();
+                SERIAL_ECHOLNPAIR("  M200 T5 D", LINEAR_UNIT(planner.filament_size[5]));
               #endif // EXTRUDERS > 5
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3
@@ -2441,43 +2421,50 @@ void MarlinSettings::reset() {
 
     CONFIG_ECHO_HEADING("Maximum feedrates (units/s):");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR("  M203 X", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]));
-    SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]));
-    SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]));
-    #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS]));
-    #endif
-    SERIAL_EOL();
+    SERIAL_ECHOLNPAIR(
+        "  M203 X", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS])
+      , " Y", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS])
+      , " Z", LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS])
+      #if DISABLED(DISTINCT_E_FACTORS)
+        , " E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS])
+      #endif
+    );
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START();
       for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR("  M203 T", (int)i);
-        SERIAL_ECHOLNPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)]));
+        SERIAL_ECHOLNPAIR(
+            "  M203 T", (int)i
+          , " E", VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)])
+        );
       }
     #endif
 
     CONFIG_ECHO_HEADING("Maximum Acceleration (units/s2):");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR("  M201 X", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]));
-    SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]));
-    SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]));
-    #if DISABLED(DISTINCT_E_FACTORS)
-      SERIAL_ECHOPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS]));
-    #endif
-    SERIAL_EOL();
+    SERIAL_ECHOLNPAIR(
+        "  M201 X", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS])
+      , " Y", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS])
+      , " Z", LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS])
+      #if DISABLED(DISTINCT_E_FACTORS)
+        , " E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS])
+      #endif
+    );
     #if ENABLED(DISTINCT_E_FACTORS)
       CONFIG_ECHO_START();
-      for (uint8_t i = 0; i < E_STEPPERS; i++) {
-        SERIAL_ECHOPAIR("  M201 T", (int)i);
-        SERIAL_ECHOLNPAIR(" E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)]));
-      }
+      for (uint8_t i = 0; i < E_STEPPERS; i++)
+        SERIAL_ECHOLNPAIR(
+            "  M201 T", (int)i
+          , " E", VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)])
+        );
     #endif
 
     CONFIG_ECHO_HEADING("Acceleration (units/s2): P<print_accel> R<retract_accel> T<travel_accel>");
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR("  M204 P", LINEAR_UNIT(planner.settings.acceleration));
-    SERIAL_ECHOPAIR(" R", LINEAR_UNIT(planner.settings.retract_acceleration));
-    SERIAL_ECHOLNPAIR(" T", LINEAR_UNIT(planner.settings.travel_acceleration));
+    SERIAL_ECHOLNPAIR(
+        "  M204 P", LINEAR_UNIT(planner.settings.acceleration)
+      , " R", LINEAR_UNIT(planner.settings.retract_acceleration)
+      , " T", LINEAR_UNIT(planner.settings.travel_acceleration)
+    );
 
     if (!forReplay) {
       CONFIG_ECHO_START();
@@ -2494,39 +2481,42 @@ void MarlinSettings::reset() {
       SERIAL_EOL();
     }
     CONFIG_ECHO_START();
-    SERIAL_ECHOPAIR("  M205 B", LINEAR_UNIT(planner.settings.min_segment_time_us));
-    SERIAL_ECHOPAIR(" S", LINEAR_UNIT(planner.settings.min_feedrate_mm_s));
-    SERIAL_ECHOPAIR(" T", LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s));
-
-    #if ENABLED(JUNCTION_DEVIATION)
-      SERIAL_ECHOPAIR(" J", LINEAR_UNIT(planner.junction_deviation_mm));
-    #endif
-    #if HAS_CLASSIC_JERK
-      SERIAL_ECHOPAIR(" X", LINEAR_UNIT(planner.max_jerk[X_AXIS]));
-      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS]));
-      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS]));
-      #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
-        SERIAL_ECHOPAIR(" E", LINEAR_UNIT(planner.max_jerk[E_AXIS]));
+    SERIAL_ECHOLNPAIR(
+        "  M205 B", LINEAR_UNIT(planner.settings.min_segment_time_us)
+      , " S", LINEAR_UNIT(planner.settings.min_feedrate_mm_s)
+      , " T", LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s)
+      #if ENABLED(JUNCTION_DEVIATION)
+        , " J", LINEAR_UNIT(planner.junction_deviation_mm)
       #endif
-    #endif
-
-    SERIAL_EOL();
+      #if HAS_CLASSIC_JERK
+        , " X", LINEAR_UNIT(planner.max_jerk[X_AXIS])
+        , " Y", LINEAR_UNIT(planner.max_jerk[Y_AXIS])
+        , " Z", LINEAR_UNIT(planner.max_jerk[Z_AXIS])
+        #if DISABLED(JUNCTION_DEVIATION) || DISABLED(LIN_ADVANCE)
+          , " E", LINEAR_UNIT(planner.max_jerk[E_AXIS])
+        #endif
+      #endif
+    );
 
     #if HAS_M206_COMMAND
       CONFIG_ECHO_HEADING("Home offset:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M206 X", LINEAR_UNIT(home_offset[X_AXIS]));
-      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(home_offset[Y_AXIS]));
-      SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(home_offset[Z_AXIS]));
+      SERIAL_ECHOLNPAIR(
+          "  M206 X", LINEAR_UNIT(home_offset[X_AXIS])
+        , " Y", LINEAR_UNIT(home_offset[Y_AXIS])
+        , " Z", LINEAR_UNIT(home_offset[Z_AXIS])
+      );
     #endif
 
     #if HAS_HOTEND_OFFSET
       CONFIG_ECHO_HEADING("Hotend offsets:");
       CONFIG_ECHO_START();
       for (uint8_t e = 1; e < HOTENDS; e++) {
-        SERIAL_ECHOPAIR("  M218 T", (int)e);
-        SERIAL_ECHOPAIR(" X", LINEAR_UNIT(hotend_offset[X_AXIS][e]));
-        SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e]));
+        SERIAL_ECHOPAIR(
+            "  M218 T", (int)e
+          , " X", LINEAR_UNIT(hotend_offset[X_AXIS][e])
+          , " Y", LINEAR_UNIT(hotend_offset[Y_AXIS][e])
+        );
         SERIAL_ECHOLNPAIR_F(" Z", LINEAR_UNIT(hotend_offset[Z_AXIS][e]), 3);
       }
     #endif
@@ -2555,11 +2545,12 @@ void MarlinSettings::reset() {
       #endif
 
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M420 S", planner.leveling_active ? 1 : 0);
-      #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-        SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(planner.z_fade_height));
-      #endif
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR(
+        "  M420 S", planner.leveling_active ? 1 : 0
+        #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+          , " Z", LINEAR_UNIT(planner.z_fade_height)
+        #endif
+      );
 
       #if ENABLED(MESH_BED_LEVELING)
 
@@ -2567,8 +2558,7 @@ void MarlinSettings::reset() {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  G29 S3 X", (int)px + 1);
-              SERIAL_ECHOPAIR(" Y", (int)py + 1);
+              SERIAL_ECHOPAIR("  G29 S3 X", (int)px + 1, " Y", (int)py + 1);
               SERIAL_ECHOLNPAIR_F(" Z", LINEAR_UNIT(mbl.z_values[px][py]), 5);
             }
           }
@@ -2580,8 +2570,7 @@ void MarlinSettings::reset() {
           SERIAL_EOL();
           ubl.report_state();
           SERIAL_ECHOLNPAIR("\nActive Mesh Slot: ", ubl.storage_slot);
-          SERIAL_ECHOPAIR("EEPROM can hold ", calc_num_meshes());
-          SERIAL_ECHOLNPGM(" meshes.\n");
+          SERIAL_ECHOLNPAIR("EEPROM can hold ", calc_num_meshes(), " meshes.\n");
         }
 
        //ubl.report_current_mesh();   // This is too verbose for large meshes. A better (more terse)
@@ -2592,8 +2581,7 @@ void MarlinSettings::reset() {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  G29 W I", (int)px);
-              SERIAL_ECHOPAIR(" J", (int)py);
+              SERIAL_ECHOPAIR("  G29 W I", (int)px, " J", (int)py);
               SERIAL_ECHOLNPAIR_F(" Z", LINEAR_UNIT(z_values[px][py]), 5);
             }
           }
@@ -2619,10 +2607,7 @@ void MarlinSettings::reset() {
             case Z_PROBE_SERVO_NR:
           #endif
             CONFIG_ECHO_START();
-            SERIAL_ECHOPAIR("  M281 P", int(i));
-            SERIAL_ECHOPAIR(" L", servo_angles[i][0]);
-            SERIAL_ECHOPAIR(" U", servo_angles[i][1]);
-            SERIAL_EOL();
+            SERIAL_ECHOLNPAIR("  M281 P", int(i), " L", servo_angles[i][0], " U", servo_angles[i][1]);
           default: break;
         }
       }
@@ -2633,33 +2618,37 @@ void MarlinSettings::reset() {
 
       CONFIG_ECHO_HEADING("SCARA settings: S<seg-per-sec> P<theta-psi-offset> T<theta-offset>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M665 S", delta_segments_per_second);
-      SERIAL_ECHOPAIR(" P", scara_home_offset[A_AXIS]);
-      SERIAL_ECHOPAIR(" T", scara_home_offset[B_AXIS]);
-      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(scara_home_offset[Z_AXIS]));
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR(
+          "  M665 S", delta_segments_per_second
+        , " P", scara_home_offset[A_AXIS]
+        , " T", scara_home_offset[B_AXIS]
+        , " Z", LINEAR_UNIT(scara_home_offset[Z_AXIS])
+      );
 
     #elif ENABLED(DELTA)
 
       CONFIG_ECHO_HEADING("Endstop adjustment:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M666 X", LINEAR_UNIT(delta_endstop_adj[X_AXIS]));
-      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(delta_endstop_adj[Y_AXIS]));
-      SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(delta_endstop_adj[Z_AXIS]));
+      SERIAL_ECHOLNPAIR(
+          "  M666 X", LINEAR_UNIT(delta_endstop_adj[X_AXIS])
+        , " Y", LINEAR_UNIT(delta_endstop_adj[Y_AXIS])
+        , " Z", LINEAR_UNIT(delta_endstop_adj[Z_AXIS])
+      );
 
       CONFIG_ECHO_HEADING("Delta settings: L<diagonal_rod> R<radius> H<height> S<segments_per_s> B<calibration radius> XYZ<tower angle corrections>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M665 L", LINEAR_UNIT(delta_diagonal_rod));
-      SERIAL_ECHOPAIR(" R", LINEAR_UNIT(delta_radius));
-      SERIAL_ECHOPAIR(" H", LINEAR_UNIT(delta_height));
-      SERIAL_ECHOPAIR(" S", delta_segments_per_second);
-      SERIAL_ECHOPAIR(" B", LINEAR_UNIT(delta_calibration_radius));
-      SERIAL_ECHOPAIR(" X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS]));
-      SERIAL_ECHOPAIR(" Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS]));
-      SERIAL_ECHOPAIR(" Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS]));
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR(
+          "  M665 L", LINEAR_UNIT(delta_diagonal_rod)
+        , " R", LINEAR_UNIT(delta_radius)
+        , " H", LINEAR_UNIT(delta_height)
+        , " S", delta_segments_per_second
+        , " B", LINEAR_UNIT(delta_calibration_radius)
+        , " X", LINEAR_UNIT(delta_tower_angle_trim[A_AXIS])
+        , " Y", LINEAR_UNIT(delta_tower_angle_trim[B_AXIS])
+        , " Z", LINEAR_UNIT(delta_tower_angle_trim[C_AXIS])
+      );
 
-    #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || ENABLED(Z_DUAL_ENDSTOPS)
+    #elif ENABLED(X_DUAL_ENDSTOPS) || ENABLED(Y_DUAL_ENDSTOPS) || Z_MULTI_ENDSTOPS
 
       CONFIG_ECHO_HEADING("Endstop adjustment:");
       CONFIG_ECHO_START();
@@ -2686,10 +2675,12 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Material heatup parameters:");
       for (uint8_t i = 0; i < COUNT(ui.preheat_hotend_temp); i++) {
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR("  M145 S", (int)i);
-        SERIAL_ECHOPAIR(" H", TEMP_UNIT(ui.preheat_hotend_temp[i]));
-        SERIAL_ECHOPAIR(" B", TEMP_UNIT(ui.preheat_bed_temp[i]));
-        SERIAL_ECHOLNPAIR(" F", int(ui.preheat_fan_speed[i]));
+        SERIAL_ECHOLNPAIR(
+            "  M145 S", (int)i
+          , " H", TEMP_UNIT(ui.preheat_hotend_temp[i])
+          , " B", TEMP_UNIT(ui.preheat_bed_temp[i])
+          , " F", int(ui.preheat_fan_speed[i])
+        );
       }
 
     #endif
@@ -2702,10 +2693,12 @@ void MarlinSettings::reset() {
           if (forReplay) {
             HOTEND_LOOP() {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  M301 E", e);
-              SERIAL_ECHOPAIR(" P", PID_PARAM(Kp, e));
-              SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, e)));
-              SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, e)));
+              SERIAL_ECHOPAIR(
+                  "  M301 E", e
+                , " P", PID_PARAM(Kp, e)
+                , " I", unscalePID_i(PID_PARAM(Ki, e))
+                , " D", unscalePID_d(PID_PARAM(Kd, e))
+              );
               #if ENABLED(PID_EXTRUSION_SCALING)
                 SERIAL_ECHOPAIR(" C", PID_PARAM(Kc, e));
                 if (e == 0) SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
@@ -2718,23 +2711,25 @@ void MarlinSettings::reset() {
         // !forReplay || HOTENDS == 1
         {
           CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR("  M301 P", PID_PARAM(Kp, 0)); // for compatibility with hosts, only echo values for E0
-          SERIAL_ECHOPAIR(" I", unscalePID_i(PID_PARAM(Ki, 0)));
-          SERIAL_ECHOPAIR(" D", unscalePID_d(PID_PARAM(Kd, 0)));
-          #if ENABLED(PID_EXTRUSION_SCALING)
-            SERIAL_ECHOPAIR(" C", PID_PARAM(Kc, 0));
-            SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
-          #endif
-          SERIAL_EOL();
+          SERIAL_ECHOLNPAIR(
+              "  M301 P", PID_PARAM(Kp, 0) // for compatibility with hosts, only echo values for E0
+            , " I", unscalePID_i(PID_PARAM(Ki, 0))
+            , " D", unscalePID_d(PID_PARAM(Kd, 0))
+            #if ENABLED(PID_EXTRUSION_SCALING)
+              , " C", PID_PARAM(Kc, 0)
+              , " L", thermalManager.lpq_len
+            #endif
+          );
         }
       #endif // PIDTEMP
 
       #if ENABLED(PIDTEMPBED)
         CONFIG_ECHO_START();
-        SERIAL_ECHOPAIR("  M304 P", thermalManager.bed_pid.Kp);
-        SERIAL_ECHOPAIR(" I", unscalePID_i(thermalManager.bed_pid.Ki));
-        SERIAL_ECHOPAIR(" D", unscalePID_d(thermalManager.bed_pid.Kd));
-        SERIAL_EOL();
+        SERIAL_ECHOLNPAIR(
+            "  M304 P", thermalManager.bed_pid.Kp
+          , " I", unscalePID_i(thermalManager.bed_pid.Ki)
+          , " D", unscalePID_d(thermalManager.bed_pid.Kd)
+        );
       #endif
 
     #endif // PIDTEMP || PIDTEMPBED
@@ -2755,16 +2750,20 @@ void MarlinSettings::reset() {
 
       CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M207 S", LINEAR_UNIT(fwretract.settings.retract_length));
-      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(fwretract.settings.swap_retract_length));
-      SERIAL_ECHOPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_feedrate_mm_s)));
-      SERIAL_ECHOLNPAIR(" Z", LINEAR_UNIT(fwretract.settings.retract_zraise));
+      SERIAL_ECHOLNPAIR(
+          "  M207 S", LINEAR_UNIT(fwretract.settings.retract_length)
+        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_length)
+        , " F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_feedrate_mm_s))
+        , " Z", LINEAR_UNIT(fwretract.settings.retract_zraise)
+      );
 
       CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length));
-      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length));
-      SERIAL_ECHOLNPAIR(" F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s)));
+      SERIAL_ECHOLNPAIR(
+          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length)
+        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length)
+        , " F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s))
+      );
 
       #if ENABLED(FWRETRACT_AUTORETRACT)
 
@@ -2810,67 +2809,65 @@ void MarlinSettings::reset() {
        * TMC stepper driver current
        */
       CONFIG_ECHO_HEADING("Stepper driver current:");
-      CONFIG_ECHO_START();
+
       #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
-        say_M906();
-      #endif
-      #if AXIS_IS_TMC(X)
-        SERIAL_ECHOPAIR(" X", stepperX.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(Y)
-        SERIAL_ECHOPAIR(" Y", stepperY.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(Z)
-        SERIAL_ECHOPAIR(" Z", stepperZ.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
-        SERIAL_EOL();
+        say_M906(forReplay);
+        SERIAL_ECHOLNPAIR(
+          #if AXIS_IS_TMC(X)
+            " X", stepperX.getMilliamps(),
+          #endif
+          #if AXIS_IS_TMC(Y)
+            " Y", stepperY.getMilliamps(),
+          #endif
+          #if AXIS_IS_TMC(Z)
+            " Z", stepperZ.getMilliamps()
+          #endif
+        );
       #endif
 
       #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOPGM(" I1");
-      #endif
-      #if AXIS_IS_TMC(X2)
-        SERIAL_ECHOPAIR(" X", stepperX2.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(Y2)
-        SERIAL_ECHOPAIR(" Y", stepperY2.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(Z2)
-        SERIAL_ECHOPAIR(" Z", stepperZ2.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
-        SERIAL_EOL();
+        SERIAL_ECHOLNPAIR(
+          #if AXIS_IS_TMC(X2)
+            " X", stepperX2.getMilliamps(),
+          #endif
+          #if AXIS_IS_TMC(Y2)
+            " Y", stepperY2.getMilliamps(),
+          #endif
+          #if AXIS_IS_TMC(Z2)
+            " Z", stepperZ2.getMilliamps()
+          #endif
+        );
       #endif
 
       #if AXIS_IS_TMC(Z3)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.getMilliamps());
       #endif
 
       #if AXIS_IS_TMC(E0)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" T0 E", stepperE0.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E1)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" T1 E", stepperE1.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E2)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" T2 E", stepperE2.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E3)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" T3 E", stepperE3.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E4)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" T4 E", stepperE4.getMilliamps());
       #endif
       #if AXIS_IS_TMC(E5)
-        say_M906();
+        say_M906(forReplay);
         SERIAL_ECHOLNPAIR(" T5 E", stepperE5.getMilliamps());
       #endif
       SERIAL_EOL();
@@ -2916,8 +2913,7 @@ void MarlinSettings::reset() {
 
         #if AXIS_HAS_STEALTHCHOP(Z3)
           say_M913();
-          SERIAL_ECHOPGM(" I2");
-          SERIAL_ECHOLNPAIR(" Z", TMC_GET_PWMTHRS(Z, Z3));
+          SERIAL_ECHOLNPAIR(" I2 Z", TMC_GET_PWMTHRS(Z, Z3));
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(E0)
@@ -2988,8 +2984,7 @@ void MarlinSettings::reset() {
 
         #if HAS_Z3_SENSORLESS
           say_M914();
-          SERIAL_ECHOPGM(" I2");
-          SERIAL_ECHOLNPAIR(" Z", stepperZ3.sgt());
+          SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.sgt());
         #endif
 
       #endif // USE_SENSORLESS
@@ -3080,20 +3075,19 @@ void MarlinSettings::reset() {
       #if EXTRUDERS < 2
         SERIAL_ECHOLNPAIR("  M900 K", planner.extruder_advance_K[0]);
       #else
-        LOOP_L_N(i, EXTRUDERS) {
-          SERIAL_ECHOPAIR("  M900 T", int(i));
-          SERIAL_ECHOLNPAIR(" K", planner.extruder_advance_K[i]);
-        }
+        LOOP_L_N(i, EXTRUDERS)
+          SERIAL_ECHOLNPAIR("  M900 T", int(i), " K", planner.extruder_advance_K[i]);
       #endif
     #endif
 
     #if HAS_MOTOR_CURRENT_PWM
       CONFIG_ECHO_HEADING("Stepper motor currents:");
       CONFIG_ECHO_START();
-      SERIAL_ECHOPAIR("  M907 X", stepper.motor_current_setting[0]);
-      SERIAL_ECHOPAIR(" Z", stepper.motor_current_setting[1]);
-      SERIAL_ECHOPAIR(" E", stepper.motor_current_setting[2]);
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR(
+          "  M907 X", stepper.motor_current_setting[0]
+        , " Z", stepper.motor_current_setting[1]
+        , " E", stepper.motor_current_setting[2]
+      );
     #endif
 
     /**
@@ -3101,39 +3095,21 @@ void MarlinSettings::reset() {
      */
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
       CONFIG_ECHO_HEADING("Filament load/unload lengths:");
-      CONFIG_ECHO_START();
       #if EXTRUDERS == 1
-        say_M603();
-        SERIAL_ECHOPAIR("L", LINEAR_UNIT(fc_settings[0].load_length));
-        SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[0].unload_length));
+        say_M603(forReplay);
+        SERIAL_ECHOLNPAIR("L", LINEAR_UNIT(fc_settings[0].load_length), " U", LINEAR_UNIT(fc_settings[0].unload_length));
       #else
-        say_M603();
-        SERIAL_ECHOPAIR("T0 L", LINEAR_UNIT(fc_settings[0].load_length));
-        SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[0].unload_length));
-        CONFIG_ECHO_START();
-        say_M603();
-        SERIAL_ECHOPAIR("T1 L", LINEAR_UNIT(fc_settings[1].load_length));
-        SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[1].unload_length));
+        #define _ECHO_603(N) do{ say_M603(forReplay); SERIAL_ECHOLNPAIR("T" STRINGIFY(N) " L", LINEAR_UNIT(fc_settings[N].load_length), " U", LINEAR_UNIT(fc_settings[N].unload_length)); }while(0)
+        _ECHO_603(0);
+        _ECHO_603(1);
         #if EXTRUDERS > 2
-          CONFIG_ECHO_START();
-          say_M603();
-          SERIAL_ECHOPAIR("T2 L", LINEAR_UNIT(fc_settings[2].load_length));
-          SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[2].unload_length));
+          _ECHO_603(2);
           #if EXTRUDERS > 3
-            CONFIG_ECHO_START();
-            say_M603();
-            SERIAL_ECHOPAIR("T3 L", LINEAR_UNIT(fc_settings[3].load_length));
-            SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[3].unload_length));
+            _ECHO_603(3);
             #if EXTRUDERS > 4
-              CONFIG_ECHO_START();
-              say_M603();
-              SERIAL_ECHOPAIR("T4 L", LINEAR_UNIT(fc_settings[4].load_length));
-              SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[4].unload_length));
+              _ECHO_603(4);
               #if EXTRUDERS > 5
-                CONFIG_ECHO_START();
-                say_M603();
-                SERIAL_ECHOPAIR("T5 L", LINEAR_UNIT(fc_settings[5].load_length));
-                SERIAL_ECHOLNPAIR(" U", LINEAR_UNIT(fc_settings[5].unload_length));
+                _ECHO_603(5);
               #endif // EXTRUDERS > 5
             #endif // EXTRUDERS > 4
           #endif // EXTRUDERS > 3

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -185,51 +185,32 @@ void PrintCounter::showStats() {
   char buffer[21];
 
   SERIAL_ECHOPGM(MSG_STATS);
+  SERIAL_ECHOLNPAIR(
+    "Prints: ", data.totalPrints,
+    ", Finished: ", data.finishedPrints,
+    ", Failed: ", data.totalPrints - data.finishedPrints
+                    - ((isRunning() || isPaused()) ? 1 : 0) // Remove 1 from failures with an active counter
+  );
 
-  SERIAL_ECHOPGM("Prints: ");
-  SERIAL_ECHO(data.totalPrints);
-
-  SERIAL_ECHOPGM(", Finished: ");
-  SERIAL_ECHO(data.finishedPrints);
-
-  SERIAL_ECHOPGM(", Failed: "); // Note: Removes 1 from failures with an active counter
-  SERIAL_ECHO(data.totalPrints - data.finishedPrints
-    - ((isRunning() || isPaused()) ? 1 : 0));
-
-  SERIAL_EOL();
   SERIAL_ECHOPGM(MSG_STATS);
-
   duration_t elapsed = data.printTime;
   elapsed.toString(buffer);
-
-  SERIAL_ECHOPGM("Total time: ");
-  SERIAL_ECHO(buffer);
-
+  SERIAL_ECHOPAIR("Total time: ", buffer);
   #if ENABLED(DEBUG_PRINTCOUNTER)
-    SERIAL_ECHOPGM(" (");
-    SERIAL_ECHO(data.printTime);
+    SERIAL_ECHOPAIR(" (", data.printTime);
     SERIAL_CHAR(')');
   #endif
 
   elapsed = data.longestPrint;
   elapsed.toString(buffer);
-
-  SERIAL_ECHOPGM(", Longest job: ");
-  SERIAL_ECHO(buffer);
-
+  SERIAL_ECHOPAIR(", Longest job: ", buffer);
   #if ENABLED(DEBUG_PRINTCOUNTER)
-    SERIAL_ECHOPGM(" (");
-    SERIAL_ECHO(data.longestPrint);
+    SERIAL_ECHOPAIR(" (", data.longestPrint);
     SERIAL_CHAR(')');
   #endif
 
-  SERIAL_EOL();
-  SERIAL_ECHOPGM(MSG_STATS);
-
-  SERIAL_ECHOPGM("Filament used: ");
-  SERIAL_ECHO(data.filamentUsed / 1000);
+  SERIAL_ECHOPAIR("\n" MSG_STATS "Filament used: ", data.filamentUsed / 1000);
   SERIAL_CHAR('m');
-
   SERIAL_EOL();
 
   #if SERVICE_INTERVAL_1 > 0

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -83,11 +83,7 @@ float zprobe_zoffset; // Initialized by settings.load()
    */
   static void dock_sled(bool stow) {
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("dock_sled(", stow);
-        SERIAL_CHAR(')');
-        SERIAL_EOL();
-      }
+      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("dock_sled(", stow, ")");
     #endif
 
     // Dock sled a bit closer to ensure proper capturing
@@ -317,11 +313,7 @@ float zprobe_zoffset; // Initialized by settings.load()
     bltouch_command(deploy ? BLTOUCH_DEPLOY : BLTOUCH_STOW);
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("set_bltouch_deployed(", deploy);
-        SERIAL_CHAR(')');
-        SERIAL_EOL();
-      }
+      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("set_bltouch_deployed(", deploy, ")");
     #endif
 
     return false;
@@ -334,11 +326,7 @@ float zprobe_zoffset; // Initialized by settings.load()
  */
 inline void do_probe_raise(const float z_raise) {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOPAIR("do_probe_raise(", z_raise);
-      SERIAL_CHAR(')');
-      SERIAL_EOL();
-    }
+    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("do_probe_raise(", z_raise, ")");
   #endif
 
   float z_dest = z_raise;
@@ -707,10 +695,7 @@ static float run_z_probe() {
     const float z2 = current_position[Z_AXIS];
 
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("2nd Probe Z:", z2);
-        SERIAL_ECHOLNPAIR(" Discrepancy:", first_probe_z - z2);
-      }
+      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("2nd Probe Z:", z2, " Discrepancy:", first_probe_z - z2);
     #endif
 
     // Return a weighted average of the fast and slow probes
@@ -742,12 +727,14 @@ static float run_z_probe() {
 float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/*=PROBE_PT_NONE*/, const uint8_t verbose_level/*=0*/, const bool probe_relative/*=true*/) {
   #if ENABLED(DEBUG_LEVELING_FEATURE)
     if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOPAIR(">>> probe_pt(", LOGICAL_X_POSITION(rx));
-      SERIAL_ECHOPAIR(", ", LOGICAL_Y_POSITION(ry));
-      SERIAL_ECHOPAIR(", ", raise_after == PROBE_PT_RAISE ? "raise" : raise_after == PROBE_PT_STOW ? "stow" : "none");
-      SERIAL_ECHOPAIR(", ", int(verbose_level));
-      SERIAL_ECHOPAIR(", ", probe_relative ? "probe" : "nozzle");
-      SERIAL_ECHOLNPGM("_relative)");
+      SERIAL_ECHOLNPAIR(
+        ">>> probe_pt(", LOGICAL_X_POSITION(rx),
+        ", ", LOGICAL_Y_POSITION(ry),
+        ", ", raise_after == PROBE_PT_RAISE ? "raise" : raise_after == PROBE_PT_STOW ? "stow" : "none",
+        ", ", int(verbose_level),
+        ", ", probe_relative ? "probe" : "nozzle",
+        "_relative)"
+      );
       DEBUG_POS("", current_position);
     }
   #endif

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -45,8 +45,7 @@ void scara_set_axis_is_at_home(const AxisEnum axis) {
     float homeposition[XYZ];
     LOOP_XYZ(i) homeposition[i] = base_home_pos((AxisEnum)i);
 
-    // SERIAL_ECHOPAIR("homeposition X:", homeposition[X_AXIS]);
-    // SERIAL_ECHOLNPAIR(" Y:", homeposition[Y_AXIS]);
+    // SERIAL_ECHOLNPAIR("homeposition X:", homeposition[X_AXIS], " Y:", homeposition[Y_AXIS]);
 
     /**
      * Get Home position SCARA arm angles using inverse kinematics,
@@ -55,8 +54,7 @@ void scara_set_axis_is_at_home(const AxisEnum axis) {
     inverse_kinematics(homeposition);
     forward_kinematics_SCARA(delta[A_AXIS], delta[B_AXIS]);
 
-    // SERIAL_ECHOPAIR("Cartesian X:", cartes[X_AXIS]);
-    // SERIAL_ECHOLNPAIR(" Y:", cartes[Y_AXIS]);
+    // SERIAL_ECHOLNPAIR("Cartesian X:", cartes[X_AXIS], " Y:", cartes[Y_AXIS]);
 
     current_position[axis] = cartes[axis];
 
@@ -80,14 +78,15 @@ void forward_kinematics_SCARA(const float &a, const float &b) {
   cartes[Y_AXIS] = a_sin + b_sin + SCARA_OFFSET_Y;  //theta+phi
 
   /*
-    SERIAL_ECHOPAIR("SCARA FK Angle a=", a);
-    SERIAL_ECHOPAIR(" b=", b);
-    SERIAL_ECHOPAIR(" a_sin=", a_sin);
-    SERIAL_ECHOPAIR(" a_cos=", a_cos);
-    SERIAL_ECHOPAIR(" b_sin=", b_sin);
-    SERIAL_ECHOLNPAIR(" b_cos=", b_cos);
-    SERIAL_ECHOPAIR(" cartes[X_AXIS]=", cartes[X_AXIS]);
-    SERIAL_ECHOLNPAIR(" cartes[Y_AXIS]=", cartes[Y_AXIS]);
+    SERIAL_ECHOLNPAIR(
+      "SCARA FK Angle a=", a,
+      " b=", b,
+      " a_sin=", a_sin,
+      " a_cos=", a_cos,
+      " b_sin=", b_sin,
+      " b_cos=", b_cos
+    );
+    SERIAL_ECHOLNPAIR(" cartes (X,Y) = "(cartes[X_AXIS], ", ", cartes[Y_AXIS], ")");
   //*/
 }
 
@@ -132,18 +131,12 @@ void inverse_kinematics(const float (&raw)[XYZ]) {
   /*
     DEBUG_POS("SCARA IK", raw);
     DEBUG_POS("SCARA IK", delta);
-    SERIAL_ECHOPAIR("  SCARA (x,y) ", sx);
-    SERIAL_ECHOPAIR(",", sy);
-    SERIAL_ECHOPAIR(" C2=", C2);
-    SERIAL_ECHOPAIR(" S2=", S2);
-    SERIAL_ECHOPAIR(" Theta=", THETA);
-    SERIAL_ECHOLNPAIR(" Phi=", PHI);
+    SERIAL_ECHOLNPAIR("  SCARA (x,y) ", sx, ",", sy, " C2=", C2, " S2=", S2, " Theta=", THETA, " Phi=", PHI);
   //*/
 }
 
 void scara_report_positions() {
-  SERIAL_ECHOPAIR("SCARA Theta:", planner.get_axis_position_degrees(A_AXIS));
-  SERIAL_ECHOLNPAIR("   Psi+Theta:", planner.get_axis_position_degrees(B_AXIS));
+  SERIAL_ECHOLNPAIR("SCARA Theta:", planner.get_axis_position_degrees(A_AXIS), "  Psi+Theta:", planner.get_axis_position_degrees(B_AXIS));
   SERIAL_EOL();
 }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -456,37 +456,26 @@ uint8_t Temperature::soft_pwm_amount[HOTENDS];
               bias = constrain(bias, 20, max_pow - 20);
               d = (bias > max_pow >> 1) ? max_pow - 1 - bias : bias;
 
-              SERIAL_ECHOPAIR(MSG_BIAS, bias);
-              SERIAL_ECHOPAIR(MSG_D, d);
-              SERIAL_ECHOPAIR(MSG_T_MIN, min);
-              SERIAL_ECHOPAIR(MSG_T_MAX, max);
+              SERIAL_ECHOPAIR(MSG_BIAS, bias, MSG_D, d, MSG_T_MIN, min, MSG_T_MAX, max);
               if (cycles > 2) {
                 float Ku = (4.0f * d) / (float(M_PI) * (max - min) * 0.5f),
                       Tu = ((float)(t_low + t_high) * 0.001f);
-                SERIAL_ECHOPAIR(MSG_KU, Ku);
-                SERIAL_ECHOPAIR(MSG_TU, Tu);
                 tune_pid.Kp = 0.6f * Ku;
                 tune_pid.Ki = 2 * tune_pid.Kp / Tu;
                 tune_pid.Kd = tune_pid.Kp * Tu * 0.125f;
+                SERIAL_ECHOPAIR(MSG_KU, Ku, MSG_TU, Tu);
                 SERIAL_ECHOLNPGM("\n" MSG_CLASSIC_PID);
-                SERIAL_ECHOPAIR(MSG_KP, tune_pid.Kp);
-                SERIAL_ECHOPAIR(MSG_KI, tune_pid.Ki);
-                SERIAL_ECHOLNPAIR(MSG_KD, tune_pid.Kd);
+                SERIAL_ECHOLNPAIR(MSG_KP, tune_pid.Kp, MSG_KI, tune_pid.Ki, MSG_KD, tune_pid.Kd);
                 /**
                 tune_pid.Kp = 0.33*Ku;
                 tune_pid.Ki = tune_pid.Kp/Tu;
                 tune_pid.Kd = tune_pid.Kp*Tu/3;
                 SERIAL_ECHOLNPGM(" Some overshoot");
-                SERIAL_ECHOPAIR(" Kp: ", tune_pid.Kp);
-                SERIAL_ECHOPAIR(" Ki: ", tune_pid.Ki);
-                SERIAL_ECHOPAIR(" Kd: ", tune_pid.Kd);
+                SERIAL_ECHOLNPAIR(" Kp: ", tune_pid.Kp, " Ki: ", tune_pid.Ki, " Kd: ", tune_pid.Kd, " No overshoot");
                 tune_pid.Kp = 0.2*Ku;
                 tune_pid.Ki = 2*tune_pid.Kp/Tu;
                 tune_pid.Kd = tune_pid.Kp*Tu/3;
-                SERIAL_ECHOLNPGM(" No overshoot");
-                SERIAL_ECHOPAIR(" Kp: ", tune_pid.Kp);
-                SERIAL_ECHOPAIR(" Ki: ", tune_pid.Ki);
-                SERIAL_ECHOPAIR(" Kd: ", tune_pid.Kd);
+                SERIAL_ECHOPAIR(" Kp: ", tune_pid.Kp, " Ki: ", tune_pid.Ki, " Kd: ", tune_pid.Kd);
                 */
               }
             }
@@ -807,16 +796,20 @@ float Temperature::get_pid_output(const int8_t e) {
 
     #if ENABLED(PID_DEBUG)
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR(MSG_PID_DEBUG, HOTEND_INDEX);
-      SERIAL_ECHOPAIR(MSG_PID_DEBUG_INPUT, current_temperature[HOTEND_INDEX]);
-      SERIAL_ECHOPAIR(MSG_PID_DEBUG_OUTPUT, pid_output);
+      SERIAL_ECHOPAIR(
+        MSG_PID_DEBUG, HOTEND_INDEX,
+        MSG_PID_DEBUG_INPUT, current_temperature[HOTEND_INDEX],
+        MSG_PID_DEBUG_OUTPUT, pid_output
+      );
       #if DISABLED(PID_OPENLOOP)
-        SERIAL_ECHOPAIR(MSG_PID_DEBUG_PTERM, work_pid[HOTEND_INDEX].Kp);
-        SERIAL_ECHOPAIR(MSG_PID_DEBUG_ITERM, work_pid[HOTEND_INDEX].Ki);
-        SERIAL_ECHOPAIR(MSG_PID_DEBUG_DTERM, work_pid[HOTEND_INDEX].Kd);
-        #if ENABLED(PID_EXTRUSION_SCALING)
-          SERIAL_ECHOPAIR(MSG_PID_DEBUG_CTERM, work_pid[HOTEND_INDEX].Kc);
-        #endif
+        SERIAL_ECHOPAIR(
+          MSG_PID_DEBUG_PTERM, work_pid[HOTEND_INDEX].Kp,
+          MSG_PID_DEBUG_ITERM, work_pid[HOTEND_INDEX].Ki,
+          MSG_PID_DEBUG_DTERM, work_pid[HOTEND_INDEX].Kd
+          #if ENABLED(PID_EXTRUSION_SCALING),
+            MSG_PID_DEBUG_CTERM, work_pid[HOTEND_INDEX].Kc
+          #endif
+        );
       #endif
       SERIAL_EOL();
     #endif // PID_DEBUG
@@ -869,13 +862,14 @@ float Temperature::get_pid_output(const int8_t e) {
 
     #if ENABLED(PID_BED_DEBUG)
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR(" PID_BED_DEBUG : Input ", current_temperature_bed);
-      SERIAL_ECHOPAIR(" Output ", pid_output);
-      #if DISABLED(PID_OPENLOOP)
-        SERIAL_ECHOPAIR(MSG_PID_DEBUG_PTERM, work_pid.Kp);
-        SERIAL_ECHOPAIR(MSG_PID_DEBUG_ITERM, work_pid.Ki);
-        SERIAL_ECHOLNPAIR(MSG_PID_DEBUG_DTERM, work_pid.Kd);
-      #endif
+      SERIAL_ECHOLNPAIR(
+        " PID_BED_DEBUG : Input ", current_temperature_bed, " Output ", pid_output,
+        #if DISABLED(PID_OPENLOOP)
+          MSG_PID_DEBUG_PTERM, work_pid.Kp,
+          MSG_PID_DEBUG_ITERM, work_pid.Ki,
+          MSG_PID_DEBUG_DTERM, work_pid.Kd,
+        #endif
+      );
     #endif
 
     return pid_output;
@@ -1622,10 +1616,7 @@ void Temperature::init() {
         SERIAL_ECHO_START();
         SERIAL_ECHOPGM("Thermal Thermal Runaway Running. Heater ID: ");
         if (heater_id < 0) SERIAL_ECHOPGM("bed"); else SERIAL_ECHO(heater_id);
-        SERIAL_ECHOPAIR(" ;  State:", *state);
-        SERIAL_ECHOPAIR(" ;  Timer:", *timer);
-        SERIAL_ECHOPAIR(" ;  Temperature:", current);
-        SERIAL_ECHOPAIR(" ;  Target Temp:", target);
+        SERIAL_ECHOPAIR(" ;  State:", *state, " ;  Timer:", *timer, " ;  Temperature:", current, " ;  Target Temp:", target);
         if (heater_id >= 0)
           SERIAL_ECHOPAIR(" ;  Idle Timeout:", heater_idle_timeout_exceeded[heater_id]);
         else

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -804,12 +804,8 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
       #endif
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) {
-          SERIAL_ECHOPAIR("Offset Tool XY by { ", xdiff);
-          SERIAL_ECHOPAIR(", ", ydiff);
-          SERIAL_ECHOPAIR(", ", zdiff);
-          SERIAL_ECHOLNPGM(" }");
-        }
+        if (DEBUGGING(LEVELING))
+          SERIAL_ECHOLNPAIR("Offset Tool XY by { ", xdiff, ", ", ydiff, ", ", zdiff, " }");
       #endif
 
       // The newly-selected extruder XY is actually at...

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -438,9 +438,7 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
       filespos[file_subcall_ctr] = sdpos;
 
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR("SUBROUTINE CALL target:\"", path);
-      SERIAL_ECHOPAIR("\" parent:\"", proc_filenames[file_subcall_ctr]);
-      SERIAL_ECHOLNPAIR("\" pos", sdpos);
+      SERIAL_ECHOLNPAIR("SUBROUTINE CALL target:\"", path, "\" parent:\"", proc_filenames[file_subcall_ctr], "\" pos", sdpos);
       file_subcall_ctr++;
     }
     else
@@ -470,8 +468,7 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
     if (file.open(curDir, fname, O_READ)) {
       filesize = file.fileSize();
       sdpos = 0;
-      SERIAL_ECHOPAIR(MSG_SD_FILE_OPENED, fname);
-      SERIAL_ECHOLNPAIR(MSG_SD_SIZE, filesize);
+      SERIAL_ECHOLNPAIR(MSG_SD_FILE_OPENED, fname, MSG_SD_SIZE, filesize);
       SERIAL_ECHOLNPGM(MSG_SD_FILE_SELECTED);
 
       getfilename(0, fname);
@@ -480,18 +477,12 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
       //  SERIAL_ECHOPAIR(MSG_SD_FILE_LONG_NAME, longFilename);
       //}
     }
-    else {
-      SERIAL_ECHOPAIR(MSG_SD_OPEN_FILE_FAIL, fname);
-      SERIAL_CHAR('.');
-      SERIAL_EOL();
-    }
+    else
+      SERIAL_ECHOLNPAIR(MSG_SD_OPEN_FILE_FAIL, fname, ".");
   }
   else { //write
-    if (!file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)) {
-      SERIAL_ECHOPAIR(MSG_SD_OPEN_FILE_FAIL, fname);
-      SERIAL_CHAR('.');
-      SERIAL_EOL();
-    }
+    if (!file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC))
+      SERIAL_ECHOLNPAIR(MSG_SD_OPEN_FILE_FAIL, fname, ".");
     else {
       flag.saving = true;
       getfilename(0, fname);
@@ -520,10 +511,8 @@ void CardReader::removeFile(const char * const name) {
       presort();
     #endif
   }
-  else {
-    SERIAL_ECHOPAIR("Deletion failed, File: ", fname);
-    SERIAL_CHAR('.');
-  }
+  else
+    SERIAL_ECHOLNPAIR("Deletion failed, File: ", fname, ".");
 }
 
 void CardReader::report_status() {
@@ -669,9 +658,7 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     if (echo) SERIAL_ECHOLN(dosSubdirname);
 
     if (!myDir.open(curDir, dosSubdirname, O_READ)) {
-      SERIAL_ECHOPAIR(MSG_SD_OPEN_FILE_FAIL, dosSubdirname);
-      SERIAL_CHAR('.');
-      SERIAL_EOL();
+      SERIAL_ECHOLNPAIR(MSG_SD_OPEN_FILE_FAIL, dosSubdirname, ".");
       return NULL;
     }
     curDir = &myDir;
@@ -1030,11 +1017,8 @@ void CardReader::printingHasFinished() {
   void CardReader::openJobRecoveryFile(const bool read) {
     if (!isDetected()) return;
     if (recovery.file.isOpen()) return;
-    if (!recovery.file.open(&root, job_recovery_file_name, read ? O_READ : O_CREAT | O_WRITE | O_TRUNC | O_SYNC)) {
-      SERIAL_ECHOPAIR(MSG_SD_OPEN_FILE_FAIL, job_recovery_file_name);
-      SERIAL_CHAR('.');
-      SERIAL_EOL();
-    }
+    if (!recovery.file.open(&root, job_recovery_file_name, read ? O_READ : O_CREAT | O_WRITE | O_TRUNC | O_SYNC))
+      SERIAL_ECHOLNPAIR(MSG_SD_OPEN_FILE_FAIL, job_recovery_file_name, ".");
     else if (!read)
       SERIAL_ECHOLNPAIR(MSG_SD_WRITE_TO_FILE, job_recovery_file_name);
   }


### PR DESCRIPTION
Expand the `SERIAL_ECHOPAIR` and `SERIAL_ECHOLNPAIR` macros so they can take up to 12 pairs of label strings and values. If an odd number of arguments is given, the last one goes to `SERIAL_ECHO(LN)?PGM`.

Before:
```cpp
SERIAL_ECHOPAIR("Block(", packet.header.id);
SERIAL_ECHOLNPGM(") Corrupt");

SERIAL_ECHOPAIR("Large error on ", axis_codes[encoderAxis]);
SERIAL_ECHOPAIR(" axis. error: ", (int)error);
SERIAL_ECHOLNPAIR("; diffSum: ", diffSum);
```
After:
```cpp
SERIAL_ECHOLNPAIR("Block(", packet.header.id, ") Corrupt");

SERIAL_ECHOLNPAIR("Large error on ", axis_codes[encoderAxis], " axis. error: ", (int)error, "; diffSum: ", diffSum);
```