### PR TITLE
Alternative patch to have the possiblity of a bootscreen when using ExtUI

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1018,7 +1018,7 @@ void setup() {
   ui.init();
   ui.reset_status();
 
-  #if ENABLED(SHOW_BOOTSCREEN)
+  #if ENABLED(SHOW_BOOTSCREEN) && DISABLED(EXTENSIBLE_UI)
     ui.show_bootscreen();
   #endif
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -353,7 +353,7 @@
 #endif
 
 // Boot screens
-#if !HAS_SPI_LCD
+#if !HAS_SPI_LCD && DISABLED(EXTENSIBLE_UI)
   #undef SHOW_BOOTSCREEN
 #elif !defined(BOOTSCREEN_TIMEOUT)
   #define BOOTSCREEN_TIMEOUT 2500


### PR DESCRIPTION
(I could not reopen the old PR #13305, that is why I filed a new one)

This is an alternative patch to enable me having a Bootscren for my DGUS display and honor the user's wish in Configuration.h.
