### PR TITLE
LPC176x NeoPixel Support

### DIFF
--- a/buildroot/share/tests/LPC1768-tests
+++ b/buildroot/share/tests/LPC1768-tests
@@ -13,7 +13,10 @@ exec_test $1 $2 "Build Re-ARM Default Configuration"
 restore_configs
 opt_set MOTHERBOARD BOARD_RAMPS_14_RE_ARM_EFB
 opt_enable VIKI2 SDSUPPORT
-exec_test $1 $2 "ReARM EFB VIKI2 and SDSUPPORT"
+opt_enable SERIAL_PORT2
+opt_enable NEOPIXEL_LED
+opt_set NEOPIXEL_PIN P1_16
+exec_test $1 $2 "ReARM EFB VIKI2, SDSUPPORT, 2 Serial ports (USB CDC + UART0), NeoPixel"
 
 restore_configs
 use_example_configs Mks/Sbase

--- a/platformio.ini
+++ b/platformio.ini
@@ -166,6 +166,7 @@ lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMCStepper@<1.0.0
+  Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
 
 [env:LPC1769]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/master.zip
@@ -184,6 +185,7 @@ lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMCStepper@<1.0.0
+  Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
 
 #
 # Melzi and clones (ATmega1284p)


### PR DESCRIPTION
### Description

Adds my LPC176x compatible fork of the Adafruit NeoPixel library to LPC envs in platformio.ini, update tests.