### PR TITLE
Return progress not only from SD Card

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -569,7 +569,7 @@ namespace ExtUI {
   #endif
 
   uint8_t getProgress_percent() {
-    return IFSD(card.percentDone(), 0);
+    return ui.get_progress();
   }
 
   uint32_t getProgress_seconds_elapsed() {


### PR DESCRIPTION
### Description

Currently ExtUI::getProgress() only considers progress from SD card file progress, but ignores e.g progress set by M73.