### PR TITLE
[Bug] Fix compilation isse due wait_for_user no longer volatile

### DIFF
--- a/Marlin/src/feature/emergency_parser.h
+++ b/Marlin/src/feature/emergency_parser.h
@@ -31,10 +31,7 @@
   #include "host_actions.h"
 #endif
 
-// External references
-extern volatile bool wait_for_user, wait_for_heatup;
-void quickstop_stepper();
-void host_response_handler(const uint8_t response);
+#include "../Marlin.h"
 
 class EmergencyParser {
 


### PR DESCRIPTION
emergency_parser.h redeclares some variables and with commit 60e82e39 the definition has been changed to be non-volatile, breaking the build.

This changes includes Marlin.h instead, to have always the right declaration. Turns out that then the other external referenes are already covered by the include to host_actions and the include to Marlin.h