### PR TITLE
Avoid "spontaneous heating" with printers with inverted pins on STM32F1

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -30,7 +30,7 @@
 #include <libmaple/gpio.h>
 
 #define READ(IO)              (PIN_MAP[IO].gpio_device->regs->IDR & (1U << PIN_MAP[IO].gpio_bit) ? HIGH : LOW)
-#define WRITE(IO,V)           (PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << (16 * !(bool)V))
+#define WRITE(IO,V)           (PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << (16 * !((bool)V)))
 #define TOGGLE(IO)            (PIN_MAP[IO].gpio_device->regs->ODR = PIN_MAP[IO].gpio_device->regs->ODR ^ (1U << PIN_MAP[IO].gpio_bit))
 #define WRITE_VAR(IO,V)       WRITE(IO,V)
 


### PR DESCRIPTION
Fix for "spontanous heating" problems due to order of operations error after compiler processing for printers with inverted pins. Error occurs at least with ststm32 v5.1.0 in Platformio.

On printers with inverted pins (e.g. JGAurora A1/A5S motherboard) the heater and bed start to heat straight away, even when the inverted pins option is enabled in configuration_adv.h.

The cause is an error in this definition, that this PR fixes.