### PR TITLE
Add support for printers with inverted fan pins

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1169,6 +1169,10 @@
 /**
  * Up to 3 PWM fans
  */
+#ifndef FAN_INVERTING
+  #define FAN_INVERTING false
+#endif
+
 #if HAS_FAN2
   #define FAN_COUNT 3
 #elif HAS_FAN1
@@ -1180,14 +1184,14 @@
 #endif
 
 #if HAS_FAN0
-  #define WRITE_FAN(v) WRITE(FAN_PIN, v)
+  #define WRITE_FAN(v) WRITE(FAN_PIN, (v) ^ FAN_INVERTING)
   #define WRITE_FAN0(v) WRITE_FAN(v)
 #endif
 #if HAS_FAN1
-  #define WRITE_FAN1(v) WRITE(FAN1_PIN, v)
+  #define WRITE_FAN1(v) WRITE(FAN1_PIN, (v) ^ FAN_INVERTING)
 #endif
 #if HAS_FAN2
-  #define WRITE_FAN2(v) WRITE(FAN2_PIN, v)
+  #define WRITE_FAN2(v) WRITE(FAN2_PIN, (v) ^ FAN_INVERTING)
 #endif
 #define WRITE_FAN_N(n, v) WRITE_FAN##n(v)
 


### PR DESCRIPTION
This PR adds support for printer boards with inverted fan pins.
e.g. by adding  #define FAN_INVERTING 1 to configuration_adv.h

An example board this applies to is the JGAurora A5S/A1 STM32F1 board.