### PR TITLE
Complete the soft endstops / tool-change patch

### DIFF
--- a/Marlin/src/feature/I2CPositionEncoder.cpp
+++ b/Marlin/src/feature/I2CPositionEncoder.cpp
@@ -329,8 +329,8 @@ bool I2CPositionEncoder::test_axis() {
 
   float startCoord[NUM_AXIS] = { 0 }, endCoord[NUM_AXIS] = { 0 };
 
-  const float startPosition = soft_endstop_min[encoderAxis] + 10,
-              endPosition = soft_endstop_max[encoderAxis] - 10,
+  const float startPosition = axis_limits[encoderAxis].min + 10,
+              endPosition = axis_limits[encoderAxis].max - 10,
               feedrate = FLOOR(MMM_TO_MMS((encoderAxis == Z_AXIS) ? HOMING_FEEDRATE_Z : HOMING_FEEDRATE_XY));
 
   ec = false;
@@ -391,7 +391,7 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
   ec = false;
 
   startDistance = 20;
-  endDistance = soft_endstop_max[encoderAxis] - 20;
+  endDistance = axis_limits[encoderAxis].max - 20;
   travelDistance = endDistance - startDistance;
 
   LOOP_NA(i) {

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -493,9 +493,7 @@ G29_TYPE GcodeSuite::G29() {
     // Abort current G29 procedure, go back to idle state
     if (seenA && g29_in_progress) {
       SERIAL_ECHOLNPGM("Manual G29 aborted");
-      #if HAS_SOFTWARE_ENDSTOPS
-        soft_endstops_enabled = enable_soft_endstops;
-      #endif
+      soft_endstops_enabled = enable_soft_endstops;
       set_bed_leveling_enabled(abl_should_enable);
       g29_in_progress = false;
       #if ENABLED(LCD_BED_LEVELING)
@@ -518,9 +516,7 @@ G29_TYPE GcodeSuite::G29() {
 
     if (abl_probe_index == 0) {
       // For the initial G29 S2 save software endstop state
-      #if HAS_SOFTWARE_ENDSTOPS
-        enable_soft_endstops = soft_endstops_enabled;
-      #endif
+      enable_soft_endstops = soft_endstops_enabled;
       // Move close to the bed before the first point
       do_blocking_move_to_z(0);
     }
@@ -602,11 +598,7 @@ G29_TYPE GcodeSuite::G29() {
       // Is there a next point to move to?
       if (abl_probe_index < abl_points) {
         _manual_goto_xy(xProbe, yProbe); // Can be used here too!
-        #if HAS_SOFTWARE_ENDSTOPS
-          // Disable software endstops to allow manual adjustment
-          // If G29 is not completed, they will not be re-enabled
-          soft_endstops_enabled = false;
-        #endif
+        soft_endstops_enabled = false;
         G29_RETURN(false);
       }
       else {
@@ -616,9 +608,7 @@ G29_TYPE GcodeSuite::G29() {
         SERIAL_ECHOLNPGM("Grid probing done.");
 
         // Re-enable software endstops, if needed
-        #if HAS_SOFTWARE_ENDSTOPS
-          soft_endstops_enabled = enable_soft_endstops;
-        #endif
+        soft_endstops_enabled = enable_soft_endstops;
       }
 
     #elif ENABLED(AUTO_BED_LEVELING_3POINT)
@@ -628,11 +618,7 @@ G29_TYPE GcodeSuite::G29() {
         xProbe = points[abl_probe_index].x;
         yProbe = points[abl_probe_index].y;
         _manual_goto_xy(xProbe, yProbe);
-        #if HAS_SOFTWARE_ENDSTOPS
-          // Disable software endstops to allow manual adjustment
-          // If G29 is not completed, they will not be re-enabled
-          soft_endstops_enabled = false;
-        #endif
+        soft_endstops_enabled = false;
         G29_RETURN(false);
       }
       else {
@@ -640,9 +626,7 @@ G29_TYPE GcodeSuite::G29() {
         SERIAL_ECHOLNPGM("3-point probing done.");
 
         // Re-enable software endstops, if needed
-        #if HAS_SOFTWARE_ENDSTOPS
-          soft_endstops_enabled = enable_soft_endstops;
-        #endif
+        soft_endstops_enabled = enable_soft_endstops;
 
         if (!dryrun) {
           vector_3 planeNormal = vector_3::cross(points[0] - points[1], points[2] - points[1]).get_normal();

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -59,7 +59,7 @@ void GcodeSuite::G29() {
 
   static int mbl_probe_index = -1;
   #if HAS_SOFTWARE_ENDSTOPS
-    static bool enable_soft_endstops;
+    static bool saved_axis_limits_state;
   #endif
 
   MeshLevelingState state = (MeshLevelingState)parser.byteval('S', (int8_t)MeshReport);
@@ -98,20 +98,20 @@ void GcodeSuite::G29() {
       // For each G29 S2...
       if (mbl_probe_index == 0) {
         // For the initial G29 S2 save software endstop state
-        enable_soft_endstops = soft_endstops_enabled;
+        saved_axis_limits_state = axis_limits_enabled;
         // Move close to the bed before the first point
         do_blocking_move_to_z(0);
       }
       else {
         // Save Z for the previous mesh position
         mbl.set_zigzag_z(mbl_probe_index - 1, current_position[Z_AXIS]);
-        soft_endstops_enabled = enable_soft_endstops;
+        axis_limits_enabled = saved_axis_limits_state;
       }
       // If there's another point to sample, move there with optional lift.
       if (mbl_probe_index < GRID_MAX_POINTS) {
         mbl.zigzag(mbl_probe_index++, ix, iy);
         _manual_goto_xy(mbl.index_to_xpos[ix], mbl.index_to_ypos[iy]);
-        soft_endstops_enabled = false;
+        axis_limits_enabled = false;
       }
       else {
         // One last "return to the bed" (as originally coded) at completion

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -97,30 +97,21 @@ void GcodeSuite::G29() {
       }
       // For each G29 S2...
       if (mbl_probe_index == 0) {
-        #if HAS_SOFTWARE_ENDSTOPS
-          // For the initial G29 S2 save software endstop state
-          enable_soft_endstops = soft_endstops_enabled;
-        #endif
+        // For the initial G29 S2 save software endstop state
+        enable_soft_endstops = soft_endstops_enabled;
         // Move close to the bed before the first point
         do_blocking_move_to_z(0);
       }
       else {
         // Save Z for the previous mesh position
         mbl.set_zigzag_z(mbl_probe_index - 1, current_position[Z_AXIS]);
-        #if HAS_SOFTWARE_ENDSTOPS
-          soft_endstops_enabled = enable_soft_endstops;
-        #endif
+        soft_endstops_enabled = enable_soft_endstops;
       }
       // If there's another point to sample, move there with optional lift.
       if (mbl_probe_index < GRID_MAX_POINTS) {
-        #if HAS_SOFTWARE_ENDSTOPS
-          // Disable software endstops to allow manual adjustment
-          // If G29 is not completed, they will not be re-enabled
-          soft_endstops_enabled = false;
-        #endif
-
         mbl.zigzag(mbl_probe_index++, ix, iy);
         _manual_goto_xy(mbl.index_to_xpos[ix], mbl.index_to_ypos[iy]);
+        soft_endstops_enabled = false;
       }
       else {
         // One last "return to the bed" (as originally coded) at completion

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -190,7 +190,7 @@ void GcodeSuite::G28(const bool always_home_all) {
   #endif
 
   #if !HAS_SOFTWARE_ENDSTOPS
-    soft_endstops_enabled = true; // Ensure that safety limits are enabled
+    axis_limits_enabled = true; // Ensure that safety limits are enabled
   #endif
 
   #if ENABLED(DUAL_X_CARRIAGE)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -189,6 +189,10 @@ void GcodeSuite::G28(const bool always_home_all) {
     }
   #endif
 
+  #if !HAS_SOFTWARE_ENDSTOPS
+    soft_endstops_enabled = true; // Ensure that safety limits are enabled
+  #endif
+
   #if ENABLED(DUAL_X_CARRIAGE)
     bool IDEX_saved_duplication_state = extruder_duplication_enabled;
     DualXMode IDEX_saved_mode = dual_x_carriage_mode;

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -75,7 +75,7 @@ struct measurements_t {
 };
 
 #define TEMPORARY_BED_LEVELING_STATE(enable) TemporaryBedLevelingState tbls(enable)
-#define TEMPORARY_SOFT_ENDSTOP_STATE(enable) REMEMBER(tes, soft_endstops_enabled, enable);
+#define TEMPORARY_SOFT_ENDSTOP_STATE(enable) REMEMBER(tes, axis_limits_enabled, enable);
 
 #if ENABLED(BACKLASH_GCODE)
   #define TEMPORARY_BACKLASH_CORRECTION(value) REMEMBER(tbst, backlash_correction, value)

--- a/Marlin/src/gcode/control/M211.cpp
+++ b/Marlin/src/gcode/control/M211.cpp
@@ -35,16 +35,16 @@
 void GcodeSuite::M211() {
   SERIAL_ECHO_START();
   SERIAL_ECHOPGM(MSG_SOFT_ENDSTOPS);
-  if (parser.seen('S')) soft_endstops_enabled = parser.value_bool();
-  serialprint_onoff(soft_endstops_enabled);
+  if (parser.seen('S')) axis_limits_enabled = parser.value_bool();
+  serialprint_onoff(axis_limits_enabled);
   SERIAL_ECHOPGM(MSG_SOFT_MIN);
-  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(soft_endstop_min[X_AXIS]));
-  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_min[Y_AXIS]));
-  SERIAL_ECHOPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_min[Z_AXIS]));
+  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(axis_limits[X_AXIS].min));
+  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(axis_limits[Y_AXIS].min));
+  SERIAL_ECHOPAIR(" " MSG_Z, LOGICAL_Z_POSITION(axis_limits[Z_AXIS].min));
   SERIAL_ECHOPGM(MSG_SOFT_MAX);
-  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(soft_endstop_max[X_AXIS]));
-  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(soft_endstop_max[Y_AXIS]));
-  SERIAL_ECHOLNPAIR(" " MSG_Z, LOGICAL_Z_POSITION(soft_endstop_max[Z_AXIS]));
+  SERIAL_ECHOPAIR(    MSG_X, LOGICAL_X_POSITION(axis_limits[X_AXIS].max));
+  SERIAL_ECHOPAIR(" " MSG_Y, LOGICAL_Y_POSITION(axis_limits[Y_AXIS].max));
+  SERIAL_ECHOLNPAIR(" " MSG_Z, LOGICAL_Z_POSITION(axis_limits[Z_AXIS].max));
 }
 
 #endif

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -127,7 +127,6 @@ void GcodeSuite::M240() {
        parser.seenval('Y') ? RAW_Y_POSITION(parser.value_linear_units()) : photo_position[Y_AXIS],
       (parser.seenval('Z') ? parser.value_linear_units() : photo_position[Z_AXIS]) + current_position[Z_AXIS]
     };
-    clamp_to_software_endstops(raw);
     do_blocking_move_to(raw, fr_mm_s);
 
     #ifdef PHOTO_SWITCH_POSITION

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -190,7 +190,7 @@ void plan_arc(
     #endif
     raw[E_AXIS] += extruder_per_segment;
 
-    clamp_to_software_endstops(raw);
+    apply_axis_limits(raw);
 
     #if HAS_LEVELING && !PLANNER_LEVELING
       planner.apply_leveling(raw);

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -210,29 +210,29 @@ namespace ExtUI {
 
     // Limit to software endstops, if enabled
     #if HAS_SOFTWARE_ENDSTOPS
-      if (soft_endstops_enabled) switch (axis) {
+      if (axis_limits_enabled) switch (axis) {
         case X_AXIS:
           #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
-            min = soft_endstop_min[X_AXIS];
+            min = axis_limits[X_AXIS].min;
           #endif
           #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
-            max = soft_endstop_max[X_AXIS];
+            max = axis_limits[X_AXIS].max;
           #endif
           break;
         case Y_AXIS:
           #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
-            min = soft_endstop_min[Y_AXIS];
+            min = axis_limits[Y_AXIS].min;
           #endif
           #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
-            max = soft_endstop_max[Y_AXIS];
+            max = axis_limits[Y_AXIS].max;
           #endif
           break;
         case Z_AXIS:
           #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
-            min = soft_endstop_min[Z_AXIS];
+            min = axis_limits[Z_AXIS].min;
           #endif
           #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
-            max = soft_endstop_max[Z_AXIS];
+            max = axis_limits[Z_AXIS].max;
           #endif
         default: break;
       }

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -82,29 +82,29 @@ static void _lcd_move_xyz(PGM_P name, AxisEnum axis) {
           max = current_position[axis] + 1000;
 
     // Limit to software endstops, if enabled
-    if (soft_endstops_enabled) switch (axis) {
+    if (axis_limits_enabled) switch (axis) {
       case X_AXIS:
         #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
-          min = soft_endstop_min[X_AXIS];
+          min = axis_limits[X_AXIS].min;
         #endif
         #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
-          max = soft_endstop_max[X_AXIS];
+          max = axis_limits[X_AXIS].max;
         #endif
         break;
       case Y_AXIS:
         #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
-          min = soft_endstop_min[Y_AXIS];
+          min = axis_limits[Y_AXIS].min;
         #endif
         #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
-          max = soft_endstop_max[Y_AXIS];
+          max = axis_limits[Y_AXIS].max;
         #endif
         break;
       case Z_AXIS:
         #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
-          min = soft_endstop_min[Z_AXIS];
+          min = axis_limits[Z_AXIS].min;
         #endif
         #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
-          max = soft_endstop_max[Z_AXIS];
+          max = axis_limits[Z_AXIS].max;
         #endif
       default: break;
     }
@@ -303,7 +303,7 @@ void menu_move() {
   MENU_BACK(MSG_MOTION);
 
   #if HAS_SOFTWARE_ENDSTOPS && ENABLED(SOFT_ENDSTOPS_MENU_ITEM)
-    MENU_ITEM_EDIT(bool, MSG_LCD_SOFT_ENDSTOPS, &soft_endstops_enabled);
+    MENU_ITEM_EDIT(bool, MSG_LCD_SOFT_ENDSTOPS, &axis_limits_enabled);
   #endif
 
   if (

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -82,34 +82,32 @@ static void _lcd_move_xyz(PGM_P name, AxisEnum axis) {
           max = current_position[axis] + 1000;
 
     // Limit to software endstops, if enabled
-    #if HAS_SOFTWARE_ENDSTOPS
-      if (soft_endstops_enabled) switch (axis) {
-        case X_AXIS:
-          #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
-            min = soft_endstop_min[X_AXIS];
-          #endif
-          #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
-            max = soft_endstop_max[X_AXIS];
-          #endif
-          break;
-        case Y_AXIS:
-          #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
-            min = soft_endstop_min[Y_AXIS];
-          #endif
-          #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
-            max = soft_endstop_max[Y_AXIS];
-          #endif
-          break;
-        case Z_AXIS:
-          #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
-            min = soft_endstop_min[Z_AXIS];
-          #endif
-          #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
-            max = soft_endstop_max[Z_AXIS];
-          #endif
-        default: break;
-      }
-    #endif // HAS_SOFTWARE_ENDSTOPS
+    if (soft_endstops_enabled) switch (axis) {
+      case X_AXIS:
+        #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
+          min = soft_endstop_min[X_AXIS];
+        #endif
+        #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
+          max = soft_endstop_max[X_AXIS];
+        #endif
+        break;
+      case Y_AXIS:
+        #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
+          min = soft_endstop_min[Y_AXIS];
+        #endif
+        #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
+          max = soft_endstop_max[Y_AXIS];
+        #endif
+        break;
+      case Z_AXIS:
+        #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
+          min = soft_endstop_min[Z_AXIS];
+        #endif
+        #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
+          max = soft_endstop_max[Z_AXIS];
+        #endif
+      default: break;
+    }
 
     // Delta limits XY based on the current offset from center
     // This assumes the center is 0,0

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -321,7 +321,7 @@ void MarlinSettings::postprocess() {
   // Software endstops depend on home_offset
   LOOP_XYZ(i) {
     update_workspace_offset((AxisEnum)i);
-    update_software_endstops((AxisEnum)i);
+    update_axis_limits((AxisEnum)i);
   }
 
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -77,7 +77,7 @@ void recalc_delta_settings() {
   delta_diagonal_rod_2_tower[A_AXIS] = sq(delta_diagonal_rod + drt[A_AXIS]);
   delta_diagonal_rod_2_tower[B_AXIS] = sq(delta_diagonal_rod + drt[B_AXIS]);
   delta_diagonal_rod_2_tower[C_AXIS] = sq(delta_diagonal_rod + drt[C_AXIS]);
-  update_software_endstops(Z_AXIS);
+  update_axis_limits(Z_AXIS);
   set_all_unhomed();
 }
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -118,22 +118,14 @@ XYZ_DEFS(signed char, home_dir, HOME_DIR);
   constexpr float hotend_offset[XYZ][HOTENDS] = { { 0 }, { 0 }, { 0 } };
 #endif
 
-#if HAS_SOFTWARE_ENDSTOPS
-  extern bool soft_endstops_enabled;
-  extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
-  void update_software_endstops(const AxisEnum axis
-    #if HAS_HOTEND_OFFSET
-      , const uint8_t old_tool_index=0, const uint8_t new_tool_index=0
-    #endif
-  );
-#else
-  constexpr bool soft_endstops_enabled = true;
-  constexpr float soft_endstop_min[XYZ] = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS },
-                  soft_endstop_max[XYZ] = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
-  #define update_software_endstops(...) NOOP
-#endif
-
+extern bool soft_endstops_enabled;
+extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
 void clamp_to_software_endstops(float target[XYZ]);
+void update_software_endstops(const AxisEnum axis
+  #if HAS_HOTEND_OFFSET
+    , const uint8_t old_tool_index=0, const uint8_t new_tool_index=0
+  #endif
+);
 
 void report_current_position();
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -118,10 +118,12 @@ XYZ_DEFS(signed char, home_dir, HOME_DIR);
   constexpr float hotend_offset[XYZ][HOTENDS] = { { 0 }, { 0 }, { 0 } };
 #endif
 
-extern bool soft_endstops_enabled;
-extern float soft_endstop_min[XYZ], soft_endstop_max[XYZ];
-void clamp_to_software_endstops(float target[XYZ]);
-void update_software_endstops(const AxisEnum axis
+typedef struct { float min, max; } axis_limits_t;
+
+extern bool axis_limits_enabled;
+extern axis_limits_t axis_limits[XYZ];
+void apply_axis_limits(float target[XYZ]);
+void update_axis_limits(const AxisEnum axis
   #if HAS_HOTEND_OFFSET
     , const uint8_t old_tool_index=0, const uint8_t new_tool_index=0
   #endif

--- a/Marlin/src/module/planner_bezier.cpp
+++ b/Marlin/src/module/planner_bezier.cpp
@@ -188,7 +188,7 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
     // not linear in the distance.
     bez_target[Z_AXIS] = interp(position[Z_AXIS], target[Z_AXIS], t);
     bez_target[E_AXIS] = interp(position[E_AXIS], target[E_AXIS], t);
-    clamp_to_software_endstops(bez_target);
+    apply_axis_limits(bez_target);
 
     #if HAS_LEVELING && !PLANNER_LEVELING
       float pos[XYZE] = { bez_target[X_AXIS], bez_target[Y_AXIS], bez_target[Z_AXIS], bez_target[E_AXIS] };

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -58,7 +58,7 @@ void scara_set_axis_is_at_home(const AxisEnum axis) {
 
     current_position[axis] = cartes[axis];
 
-    update_software_endstops(axis);
+    update_axis_limits(axis);
   }
 }
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -736,7 +736,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
       feedrate_mm_s = fr_mm_s > 0.0 ? fr_mm_s : XY_PROBE_FEEDRATE_MM_S;
 
       #if HAS_SOFTWARE_ENDSTOPS && ENABLED(DUAL_X_CARRIAGE)
-        update_software_endstops(X_AXIS, active_extruder, tmp_extruder);
+        update_axis_limits(X_AXIS, active_extruder, tmp_extruder);
       #endif
 
       set_destination_from_current();
@@ -750,7 +750,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           #endif
           current_position[Z_AXIS] += toolchange_settings.z_raise;
           #if HAS_SOFTWARE_ENDSTOPS
-            NOMORE(current_position[Z_AXIS], soft_endstop_max[Z_AXIS]);
+            NOMORE(current_position[Z_AXIS], axis_limits[Z_AXIS].max);
           #endif
           planner.buffer_line(current_position, feedrate_mm_s, active_extruder);
         #endif
@@ -782,7 +782,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         // SWITCHING_NOZZLE_TWO_SERVOS, as both nozzles will lift instead.
         current_position[Z_AXIS] += MAX(-zdiff, 0.0) + toolchange_settings.z_raise;
         #if HAS_SOFTWARE_ENDSTOPS
-          NOMORE(current_position[Z_AXIS], soft_endstop_max[Z_AXIS]);
+          NOMORE(current_position[Z_AXIS], axis_limits[Z_AXIS].max);
         #endif
         if (!no_move) fast_line_to_current(Z_AXIS);
         move_nozzle_servo(tmp_extruder);
@@ -805,7 +805,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
       sync_plan_position();
 
       #if ENABLED(DELTA)
-        //LOOP_XYZ(i) update_software_endstops(i); // or modify the constrain function
+        //LOOP_XYZ(i) update_axis_limits(i); // or modify the constrain function
         const bool safe_to_move = current_position[Z_AXIS] < delta_clip_start_height - 1;
       #else
         constexpr bool safe_to_move = true;

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -850,9 +850,6 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
           }
         #endif
 
-        // Prevent a move outside physical bounds
-        clamp_to_software_endstops(destination);
-
         // Move back to the original (or tweaked) position
         do_blocking_move_to(destination);
 


### PR DESCRIPTION
This PR reverts one line in **motion.h** that was changed in PR #13334.

PR #13334 resulted in the soft endstops being enabled when they were disabled in configuration.h.