### PR TITLE
[2.0.x] Soft Endstops - Bad Software Endstop Logic

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -587,25 +587,25 @@ void clamp_to_software_endstops(float target[XYZ]) {
 
   #else
 
-    #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MIN_SOFTWARE_ENDSTOP_X)
+    #if ENABLED(MIN_SOFTWARE_ENDSTOP_X)
       NOLESS(target[X_AXIS], soft_endstop_min[X_AXIS]);
     #endif
-    #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MAX_SOFTWARE_ENDSTOP_X)
+    #if ENABLED(MAX_SOFTWARE_ENDSTOP_X)
       NOMORE(target[X_AXIS], soft_endstop_max[X_AXIS]);
     #endif
-    #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
+    #if ENABLED(MIN_SOFTWARE_ENDSTOP_Y)
       NOLESS(target[Y_AXIS], soft_endstop_min[Y_AXIS]);
     #endif
-    #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
+    #if ENABLED(MAX_SOFTWARE_ENDSTOP_Y)
       NOMORE(target[Y_AXIS], soft_endstop_max[Y_AXIS]);
     #endif
 
   #endif
 
-  #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
+  #if ENABLED(MIN_SOFTWARE_ENDSTOP_Z)
     NOLESS(target[Z_AXIS], soft_endstop_min[Z_AXIS]);
   #endif
-  #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
+  #if ENABLED(MAX_SOFTWARE_ENDSTOP_Z)
     NOMORE(target[Z_AXIS], soft_endstop_max[Z_AXIS]);
   #endif
 }


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

FIX Software Endstop Bad Logic. Currently Software Endstop always enabled.
PR#13378 can disable Software Endstop, but I think this fix is also necessary.

> #if !HAS_SOFTWARE_ENDSTOPS || ENABLED(MIN_SOFTWARE_ENDSTOP_X)

is just not right.

### Benefits

Can Disable Software Endstop.

### Related Issues

This bad Logic was introduced at PR#13334