### PR TITLE
[2.0.x] Fix compilation warning on redefined 'UNUSED' macro

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -56,7 +56,9 @@
 #define NANOSECONDS_PER_CYCLE (1000000000.0 / F_CPU)
 
 // Remove compiler warning on an unused variable
+#if !defined(ARDUINO_ARCH_STM32)
 #define UNUSED(x) ((void)(x))
+#endif
 
 // Macros to make a string from a macro
 #define STRINGIFY_(M) #M

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -56,9 +56,7 @@
 #define NANOSECONDS_PER_CYCLE (1000000000.0 / F_CPU)
 
 // Remove compiler warning on an unused variable
-#if !defined(ARDUINO_ARCH_STM32)
-#define UNUSED(x) ((void)(x))
-#endif
+#define UNUSED(X) (void)X
 
 // Macros to make a string from a macro
 #define STRINGIFY_(M) #M


### PR DESCRIPTION
### Description

STM32 Core has `UNUSED` macro defined as `#define UNUSED(X) (void)X` in files stm32f1xx_hal_def.h, stm32f4xx_hal_def.h and so on
The same macro is defined in Marlin/src/core/macros.h as `#define UNUSED(x) ((void)(x))`

As a result compilation for new HAL_STM32 with STM32 Core libraries produces lots and lots of 'redefined' warnings when the purpose of this macro is to produce _fewer_ warnings.

### Benefits

There will be _fewer_ warnings for compilation of HAL_STM32 code with STM32 Core libraries.
