### PR TITLE
Unify debugging output with debug_out.h

### DIFF
--- a/Marlin/src/core/debug_out.h
+++ b/Marlin/src/core/debug_out.h
@@ -1,0 +1,89 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+//
+// Serial aliases for debugging.
+// Include this header after defining DEBUG_OUT
+//  (or not) in a given .cpp file
+//
+
+#undef DEBUG_ECHO_START
+#undef DEBUG_ERROR_START
+#undef DEBUG_CHAR
+#undef DEBUG_ECHO
+#undef DEBUG_ECHO_F
+#undef DEBUG_ECHOLN
+#undef DEBUG_ECHOPGM
+#undef DEBUG_ECHOLNPGM
+#undef DEBUG_ECHOPAIR
+#undef DEBUG_ECHOPAIR_F
+#undef DEBUG_ECHOLNPAIR
+#undef DEBUG_ECHOLNPAIR_F
+#undef DEBUG_ECHO_MSG
+#undef DEBUG_ERROR_MSG
+#undef DEBUG_EOL
+#undef DEBUG_POS
+#undef DEBUG_XYZ
+#undef DEBUG_DELAY
+
+#if DEBUG_OUT
+  #define DEBUG_ECHO_START        SERIAL_ECHO_START
+  #define DEBUG_ERROR_START       SERIAL_ERROR_START
+  #define DEBUG_CHAR              SERIAL_CHAR
+  #define DEBUG_ECHO              SERIAL_ECHO
+  #define DEBUG_ECHO_F            SERIAL_ECHO_F
+  #define DEBUG_ECHOLN            SERIAL_ECHOLN
+  #define DEBUG_ECHOPGM           SERIAL_ECHOPGM
+  #define DEBUG_ECHOLNPGM         SERIAL_ECHOLNPGM
+  #define DEBUG_ECHOPAIR          SERIAL_ECHOPAIR
+  #define DEBUG_ECHOPAIR_F        SERIAL_ECHOPAIR_F
+  #define DEBUG_ECHOLNPAIR        SERIAL_ECHOLNPAIR
+  #define DEBUG_ECHOLNPAIR_F      SERIAL_ECHOLNPAIR_F
+  #define DEBUG_ECHO_MSG          SERIAL_ECHO_MSG
+  #define DEBUG_ERROR_MSG         SERIAL_ERROR_MSG
+  #define DEBUG_EOL               SERIAL_EOL
+  #define DEBUG_POS               SERIAL_POS
+  #define DEBUG_XYZ               SERIAL_XYZ
+  #define DEBUG_DELAY(ms)         serial_delay(ms)
+#else
+  #define DEBUG_ECHO_START()      NOOP
+  #define DEBUG_ERROR_START()     NOOP
+  #define DEBUG_CHAR(...)         NOOP
+  #define DEBUG_ECHO(...)         NOOP
+  #define DEBUG_ECHO_F(...)       NOOP
+  #define DEBUG_ECHOLN(...)       NOOP
+  #define DEBUG_ECHOPGM(...)      NOOP
+  #define DEBUG_ECHOLNPGM(...)    NOOP
+  #define DEBUG_ECHOPAIR(...)     NOOP
+  #define DEBUG_ECHOPAIR_F(...)   NOOP
+  #define DEBUG_ECHOLNPAIR(...)   NOOP
+  #define DEBUG_ECHOLNPAIR_F(...) NOOP
+  #define DEBUG_ECHO_MSG(...)     NOOP
+  #define DEBUG_ERROR_MSG(...)    NOOP
+  #define DEBUG_EOL()             NOOP
+  #define DEBUG_POS(...)          NOOP
+  #define DEBUG_XYZ(...)          NOOP
+  #define DEBUG_DELAY(...)        NOOP
+#endif
+
+#undef DEBUG_OUT

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -35,8 +35,13 @@ enum MarlinDebugFlags : uint8_t {
   MARLIN_DEBUG_ERRORS        = _BV(2), ///< Not implemented
   MARLIN_DEBUG_DRYRUN        = _BV(3), ///< Ignore temperature setting and E movement commands
   MARLIN_DEBUG_COMMUNICATION = _BV(4), ///< Not implemented
-  MARLIN_DEBUG_LEVELING      = _BV(5), ///< Print detailed output for homing and leveling
-  MARLIN_DEBUG_MESH_ADJUST   = _BV(6), ///< UBL bed leveling
+  #if ENABLED(DEBUG_LEVELING_FEATURE)
+    MARLIN_DEBUG_LEVELING    = _BV(5), ///< Print detailed output for homing and leveling
+    MARLIN_DEBUG_MESH_ADJUST = _BV(6), ///< UBL bed leveling
+  #else
+    MARLIN_DEBUG_LEVELING    = 0,
+    MARLIN_DEBUG_MESH_ADJUST = 0,
+  #endif
   MARLIN_DEBUG_ALL           = 0xFF
 };
 
@@ -178,5 +183,9 @@ void print_bin(const uint16_t val);
 #if ENABLED(DEBUG_LEVELING_FEATURE)
   void print_xyz(PGM_P const prefix, PGM_P const suffix, const float x, const float y, const float z);
   void print_xyz(PGM_P const prefix, PGM_P const suffix, const float xyz[]);
-  #define DEBUG_POS(SUFFIX,VAR) do { print_xyz(PSTR("  " STRINGIFY(VAR) "="), PSTR(" : " SUFFIX "\n"), VAR); } while(0)
+  #define SERIAL_POS(SUFFIX,VAR) do { print_xyz(PSTR("  " STRINGIFY(VAR) "="), PSTR(" : " SUFFIX "\n"), VAR); } while(0)
+  #define SERIAL_XYZ(PREFIX,...) do { print_xyz(PSTR(PREFIX), NULL, __VA_ARGS__); } while(0)
+#else
+  #define SERIAL_POS(...) NOOP
+  #define SERIAL_XYZ(...) NOOP
 #endif

--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -321,8 +321,11 @@ void safe_delay(millis_t ms) {
     );
 
     #if HAS_BED_PROBE
-      SERIAL_ECHOPGM("Probe Offset X:" STRINGIFY(X_PROBE_OFFSET_FROM_EXTRUDER) " Y:" STRINGIFY(Y_PROBE_OFFSET_FROM_EXTRUDER));
-      SERIAL_ECHOPAIR(" Z:", zprobe_zoffset);
+      SERIAL_ECHOPAIR(
+        "Probe Offset X:" STRINGIFY(X_PROBE_OFFSET_FROM_EXTRUDER)
+                    " Y:" STRINGIFY(Y_PROBE_OFFSET_FROM_EXTRUDER)
+                    " Z:", zprobe_zoffset
+      );
       if ((X_PROBE_OFFSET_FROM_EXTRUDER) > 0)
         SERIAL_ECHOPGM(" (Right");
       else if ((X_PROBE_OFFSET_FROM_EXTRUDER) < 0)

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -118,6 +118,8 @@ inline void serial_delay(const millis_t ms) {
 
 #if ENABLED(DEBUG_LEVELING_FEATURE)
   void log_machine_info();
+#else
+  #define log_machine_info() NOOP
 #endif
 
 template<typename T>

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -29,6 +29,9 @@
 
 #include "../../../module/motion.h"
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../../core/debug_out.h"
+
 int bilinear_grid_spacing[2], bilinear_start[2];
 float bilinear_grid_factor[2],
       z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
@@ -37,26 +40,21 @@ float bilinear_grid_factor[2],
  * Extrapolate a single point from its neighbors
  */
 static void extrapolate_one_point(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir) {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOPGM("Extrapolate [");
-      if (x < 10) SERIAL_CHAR(' ');
-      SERIAL_ECHO((int)x);
-      SERIAL_CHAR(xdir ? (xdir > 0 ? '+' : '-') : ' ');
-      SERIAL_CHAR(' ');
-      if (y < 10) SERIAL_CHAR(' ');
-      SERIAL_ECHO((int)y);
-      SERIAL_CHAR(ydir ? (ydir > 0 ? '+' : '-') : ' ');
-      SERIAL_CHAR(']');
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_ECHOPGM("Extrapolate [");
+    if (x < 10) DEBUG_CHAR(' ');
+    DEBUG_ECHO((int)x);
+    DEBUG_CHAR(xdir ? (xdir > 0 ? '+' : '-') : ' ');
+    DEBUG_CHAR(' ');
+    if (y < 10) DEBUG_CHAR(' ');
+    DEBUG_ECHO((int)y);
+    DEBUG_CHAR(ydir ? (ydir > 0 ? '+' : '-') : ' ');
+    DEBUG_ECHOLNPGM("]");
+  }
   if (!isnan(z_values[x][y])) {
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM(" (done)");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(" (done)");
     return;  // Don't overwrite good values.
   }
-  SERIAL_EOL();
 
   // Get X neighbors, Y neighbors, and XY neighbors
   const uint8_t x1 = x + xdir, y1 = y + ydir, x2 = x1 + xdir, y2 = y1 + ydir;

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -39,6 +39,9 @@
   #include "../../lcd/ultralcd.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../core/debug_out.h"
+
 #if ENABLED(G26_MESH_VALIDATION)
   bool g26_debug_flag; // = false
 #endif
@@ -122,9 +125,7 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
  * Reset calibration results to zero.
  */
 void reset_bed_level() {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("reset_bed_level");
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("reset_bed_level");
   set_bed_leveling_enabled(false);
   #if ENABLED(MESH_BED_LEVELING)
     mbl.reset();

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -29,6 +29,9 @@
 #include "../../../lcd/ultralcd.h"
 #include "../../../Marlin.h"
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../../core/debug_out.h"
+
 #define UBL_VERSION "1.01"
 #define UBL_OK false
 #define UBL_ERR true
@@ -199,12 +202,11 @@ class unified_bed_leveling {
      */
     static inline float z_correction_for_x_on_horizontal_mesh_line(const float &rx0, const int x1_i, const int yi) {
       if (!WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(yi, 0, GRID_MAX_POINTS_Y - 1)) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            serialprintPGM( !WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) ? PSTR("x1_i") : PSTR("yi") );
-            SERIAL_ECHOLNPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0, ",x1_i=", x1_i, ",yi=", yi, ")");
-          }
-        #endif
+
+        if (DEBUGGING(LEVELING)) {
+          if (WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1)) DEBUG_ECHOPGM("yi"); else DEBUG_ECHOPGM("x1_i");
+          DEBUG_ECHOLNPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0, ",x1_i=", x1_i, ",yi=", yi, ")");
+        }
 
         // The requested location is off the mesh. Return UBL_Z_RAISE_WHEN_OFF_MESH or NAN.
         return (
@@ -229,12 +231,11 @@ class unified_bed_leveling {
     //
     static inline float z_correction_for_y_on_vertical_mesh_line(const float &ry0, const int xi, const int y1_i) {
       if (!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(y1_i, 0, GRID_MAX_POINTS_Y - 1)) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            serialprintPGM(!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) ? PSTR("xi") : PSTR("y1_i"));
-            SERIAL_ECHOLNPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0, ", xi=", xi, ", y1_i=", y1_i, ")");
-          }
-        #endif
+
+        if (DEBUGGING(LEVELING)) {
+          if (WITHIN(xi, 0, GRID_MAX_POINTS_X - 1)) DEBUG_ECHOPGM("y1_i"); else DEBUG_ECHOPGM("xi");
+          DEBUG_ECHOLNPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0, ", xi=", xi, ", y1_i=", y1_i, ")");
+        }
 
         // The requested location is off the mesh. Return UBL_Z_RAISE_WHEN_OFF_MESH or NAN.
         return (
@@ -285,17 +286,12 @@ class unified_bed_leveling {
                          mesh_index_to_ypos(cy), z1,
                          mesh_index_to_ypos(cy + 1), z2);
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(MESH_ADJUST)) {
-          SERIAL_ECHOPAIR(" raw get_z_correction(", rx0);
-          SERIAL_CHAR(','); SERIAL_ECHO(ry0);
-          SERIAL_ECHOPAIR_F(") = ", z0, 6);
-        }
-      #endif
-
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(MESH_ADJUST)) SERIAL_ECHOLNPAIR_F(" >>>---> ", z0, 6);
-      #endif
+      if (DEBUGGING(MESH_ADJUST)) {
+        DEBUG_ECHOPAIR(" raw get_z_correction(", rx0);
+        DEBUG_CHAR(','); DEBUG_ECHO(ry0);
+        DEBUG_ECHOPAIR_F(") = ", z0, 6);
+        DEBUG_ECHOLNPAIR_F(" >>>---> ", z0, 6);
+      }
 
       if (isnan(z0)) { // if part of the Mesh is undefined, it will show up as NAN
         z0 = 0.0;      // in ubl.z_values[][] and propagate through the
@@ -303,15 +299,13 @@ class unified_bed_leveling {
                        // because part of the Mesh is undefined and we don't have the
                        // information we need to complete the height correction.
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(MESH_ADJUST)) {
-            SERIAL_ECHOPAIR("??? Yikes!  NAN in get_z_correction(", rx0);
-            SERIAL_CHAR(',');
-            SERIAL_ECHO(ry0);
-            SERIAL_CHAR(')');
-            SERIAL_EOL();
-          }
-        #endif
+        if (DEBUGGING(MESH_ADJUST)) {
+          DEBUG_ECHOPAIR("??? Yikes!  NAN in get_z_correction(", rx0);
+          DEBUG_CHAR(',');
+          DEBUG_ECHO(ry0);
+          DEBUG_CHAR(')');
+          DEBUG_EOL();
+        }
       }
       return z0;
     }
@@ -342,3 +336,6 @@ class unified_bed_leveling {
 extern unified_bed_leveling ubl;
 
 #define Z_VALUES(X,Y) ubl.z_values[X][Y]
+
+// Prevent debugging propagating to other files
+#include "../../../core/debug_out.h"

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -46,6 +46,9 @@
     #include "../../../module/tool_change.h"
   #endif
 
+  #define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+  #include "../../../core/debug_out.h"
+
   #include <math.h>
 
   #define UBL_G29_P31
@@ -442,7 +445,7 @@
               SERIAL_ECHOLNPGM("Mesh invalidated. Probing mesh.");
             }
             if (g29_verbose_level > 1) {
-              SERIAL_ECHOPAIR("Probing Mesh Points Closest to (", g29_x_pos);
+              SERIAL_ECHOPAIR("Probing around (", g29_x_pos);
               SERIAL_CHAR(',');
               SERIAL_ECHO(g29_y_pos);
               SERIAL_ECHOLNPGM(").\n");
@@ -1463,27 +1466,24 @@
 
               abort_flag = isnan(measured_z);
 
-              #if ENABLED(DEBUG_LEVELING_FEATURE)
-                if (DEBUGGING(LEVELING)) {
-                  SERIAL_CHAR('(');
-                  SERIAL_ECHO_F(rx, 7);
-                  SERIAL_CHAR(',');
-                  SERIAL_ECHO_F(ry, 7);
-                  SERIAL_ECHOPGM(")   logical: ");
-                  SERIAL_CHAR('(');
-                  SERIAL_ECHO_F(LOGICAL_X_POSITION(rx), 7);
-                  SERIAL_CHAR(',');
-                  SERIAL_ECHO_F(LOGICAL_Y_POSITION(ry), 7);
-                  SERIAL_ECHOPAIR_F(")   measured: ", measured_z, 7);
-                  SERIAL_ECHOPAIR_F("   correction: ", get_z_correction(rx, ry), 7);
-                }
-              #endif
+              if (DEBUGGING(LEVELING)) {
+                DEBUG_CHAR('(');
+                DEBUG_ECHO_F(rx, 7);
+                DEBUG_CHAR(',');
+                DEBUG_ECHO_F(ry, 7);
+                DEBUG_ECHOPGM(")   logical: ");
+                DEBUG_CHAR('(');
+                DEBUG_ECHO_F(LOGICAL_X_POSITION(rx), 7);
+                DEBUG_CHAR(',');
+                DEBUG_ECHO_F(LOGICAL_Y_POSITION(ry), 7);
+                DEBUG_ECHOPAIR_F(")   measured: ", measured_z, 7);
+                DEBUG_ECHOPAIR_F("   correction: ", get_z_correction(rx, ry), 7);
+              }
 
               measured_z -= get_z_correction(rx, ry) /* + zprobe_zoffset */ ;
 
-              #if ENABLED(DEBUG_LEVELING_FEATURE)
-                if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR_F("   final >>>---> ", measured_z, 7);
-              #endif
+              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR_F("   final >>>---> ", measured_z, 7);
+
               if (g29_verbose_level > 3) {
                 serial_spaces(16);
                 SERIAL_ECHOLNPAIR("Corrected_Z=", measured_z);
@@ -1524,31 +1524,27 @@
                 y_tmp = mesh_index_to_ypos(j),
                 z_tmp = z_values[i][j];
 
-          #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) {
-              SERIAL_ECHOPAIR_F("before rotation = [", x_tmp, 7);
-              SERIAL_CHAR(',');
-              SERIAL_ECHO_F(y_tmp, 7);
-              SERIAL_CHAR(',');
-              SERIAL_ECHO_F(z_tmp, 7);
-              SERIAL_ECHOPGM("]   ---> ");
-              serial_delay(20);
-            }
-          #endif
+          if (DEBUGGING(LEVELING)) {
+            DEBUG_ECHOPAIR_F("before rotation = [", x_tmp, 7);
+            DEBUG_CHAR(',');
+            DEBUG_ECHO_F(y_tmp, 7);
+            DEBUG_CHAR(',');
+            DEBUG_ECHO_F(z_tmp, 7);
+            DEBUG_ECHOPGM("]   ---> ");
+            DEBUG_DELAY(20);
+          }
 
           apply_rotation_xyz(rotation, x_tmp, y_tmp, z_tmp);
 
-          #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) {
-              SERIAL_ECHOPAIR_F("after rotation = [", x_tmp, 7);
-              SERIAL_CHAR(',');
-              SERIAL_ECHO_F(y_tmp, 7);
-              SERIAL_CHAR(',');
-              SERIAL_ECHO_F(z_tmp, 7);
-              SERIAL_ECHOLNPGM("]");
-              serial_delay(55);
-            }
-          #endif
+          if (DEBUGGING(LEVELING)) {
+            DEBUG_ECHOPAIR_F("after rotation = [", x_tmp, 7);
+            DEBUG_CHAR(',');
+            DEBUG_ECHO_F(y_tmp, 7);
+            DEBUG_CHAR(',');
+            DEBUG_ECHO_F(z_tmp, 7);
+            DEBUG_ECHOLNPGM("]");
+            DEBUG_DELAY(55);
+          }
 
           z_values[i][j] = z_tmp - lsf_results.D;
           #if ENABLED(EXTENSIBLE_UI)
@@ -1557,62 +1553,59 @@
         }
       }
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) {
-          rotation.debug(PSTR("rotation matrix:\n"));
-          SERIAL_ECHOPAIR_F("LSF Results A=", lsf_results.A, 7);
-          SERIAL_ECHOPAIR_F("  B=", lsf_results.B, 7);
-          SERIAL_ECHOLNPAIR_F("  D=", lsf_results.D, 7);
-          serial_delay(55);
+      if (DEBUGGING(LEVELING)) {
+        rotation.debug(PSTR("rotation matrix:\n"));
+        DEBUG_ECHOPAIR_F("LSF Results A=", lsf_results.A, 7);
+        DEBUG_ECHOPAIR_F("  B=", lsf_results.B, 7);
+        DEBUG_ECHOLNPAIR_F("  D=", lsf_results.D, 7);
+        DEBUG_DELAY(55);
 
-          SERIAL_ECHOPAIR_F("bed plane normal = [", normal.x, 7);
-          SERIAL_CHAR(',');
-          SERIAL_ECHO_F(normal.y, 7);
-          SERIAL_CHAR(',');
-          SERIAL_ECHO_F(normal.z, 7);
-          SERIAL_ECHOLNPGM("]");
-          SERIAL_EOL();
+        DEBUG_ECHOPAIR_F("bed plane normal = [", normal.x, 7);
+        DEBUG_CHAR(',');
+        DEBUG_ECHO_F(normal.y, 7);
+        DEBUG_CHAR(',');
+        DEBUG_ECHO_F(normal.z, 7);
+        DEBUG_ECHOLNPGM("]");
+        DEBUG_EOL();
 
-          /**
-           * The following code can be used to check the validity of the mesh tilting algorithm.
-           * When a 3-Point Mesh Tilt is done, the same algorithm is used as the grid based tilting.
-           * The only difference is just 3 points are used in the calculations.   That fact guarantees
-           * each probed point should have an exact match when a get_z_correction() for that location
-           * is calculated.  The Z error between the probed point locations and the get_z_correction()
-           * numbers for those locations should be 0.
-           */
-          #if 0
-          float t, t1, d;
-          t = normal.x * (PROBE_PT_1_X) + normal.y * (PROBE_PT_1_Y);
-          d = t + normal.z * z1;
-          SERIAL_ECHOPAIR_F("D from 1st point: ", d, 6);
-          SERIAL_ECHOLNPAIR_F("   Z error: ", normal.z*z1-get_z_correction(PROBE_PT_1_X, PROBE_PT_1_Y), 6);
+        /**
+         * The following code can be used to check the validity of the mesh tilting algorithm.
+         * When a 3-Point Mesh Tilt is done, the same algorithm is used as the grid based tilting.
+         * The only difference is just 3 points are used in the calculations.   That fact guarantees
+         * each probed point should have an exact match when a get_z_correction() for that location
+         * is calculated.  The Z error between the probed point locations and the get_z_correction()
+         * numbers for those locations should be 0.
+         */
+        #if 0
+        float t, t1, d;
+        t = normal.x * (PROBE_PT_1_X) + normal.y * (PROBE_PT_1_Y);
+        d = t + normal.z * z1;
+        DEBUG_ECHOPAIR_F("D from 1st point: ", d, 6);
+        DEBUG_ECHOLNPAIR_F("   Z error: ", normal.z*z1-get_z_correction(PROBE_PT_1_X, PROBE_PT_1_Y), 6);
 
-          t = normal.x * (PROBE_PT_2_X) + normal.y * (PROBE_PT_2_Y);
-          d = t + normal.z * z2;
-          SERIAL_EOL();
-          SERIAL_ECHOPAIR_F("D from 2nd point: ", d, 6);
-          SERIAL_ECHOLNPAIR_F("   Z error: ", normal.z*z2-get_z_correction(PROBE_PT_2_X, PROBE_PT_2_Y), 6);
+        t = normal.x * (PROBE_PT_2_X) + normal.y * (PROBE_PT_2_Y);
+        d = t + normal.z * z2;
+        DEBUG_EOL();
+        DEBUG_ECHOPAIR_F("D from 2nd point: ", d, 6);
+        DEBUG_ECHOLNPAIR_F("   Z error: ", normal.z*z2-get_z_correction(PROBE_PT_2_X, PROBE_PT_2_Y), 6);
 
-          t = normal.x * (PROBE_PT_3_X) + normal.y * (PROBE_PT_3_Y);
-          d = t + normal.z * z3;
-          SERIAL_ECHOPAIR_F("D from 3rd point: ", d, 6);
-          SERIAL_ECHOLNPAIR_F("   Z error: ", normal.z*z3-get_z_correction(PROBE_PT_3_X, PROBE_PT_3_Y), 6);
+        t = normal.x * (PROBE_PT_3_X) + normal.y * (PROBE_PT_3_Y);
+        d = t + normal.z * z3;
+        DEBUG_ECHOPAIR_F("D from 3rd point: ", d, 6);
+        DEBUG_ECHOLNPAIR_F("   Z error: ", normal.z*z3-get_z_correction(PROBE_PT_3_X, PROBE_PT_3_Y), 6);
 
-          t = normal.x * (Z_SAFE_HOMING_X_POINT) + normal.y * (Z_SAFE_HOMING_Y_POINT);
-          d = t + normal.z * 0;
-          SERIAL_ECHOLNPAIR_F("D from home location with Z=0 : ", d, 6);
+        t = normal.x * (Z_SAFE_HOMING_X_POINT) + normal.y * (Z_SAFE_HOMING_Y_POINT);
+        d = t + normal.z * 0;
+        DEBUG_ECHOLNPAIR_F("D from home location with Z=0 : ", d, 6);
 
-          t = normal.x * (Z_SAFE_HOMING_X_POINT) + normal.y * (Z_SAFE_HOMING_Y_POINT);
-          d = t + get_z_correction(Z_SAFE_HOMING_X_POINT, Z_SAFE_HOMING_Y_POINT); // normal.z * 0;
-          SERIAL_ECHOPAIR_F("D from home location using mesh value for Z: ", d, 6);
+        t = normal.x * (Z_SAFE_HOMING_X_POINT) + normal.y * (Z_SAFE_HOMING_Y_POINT);
+        d = t + get_z_correction(Z_SAFE_HOMING_X_POINT, Z_SAFE_HOMING_Y_POINT); // normal.z * 0;
+        DEBUG_ECHOPAIR_F("D from home location using mesh value for Z: ", d, 6);
 
-          SERIAL_ECHOPAIR("   Z error: (", Z_SAFE_HOMING_X_POINT);
-          SERIAL_ECHOPAIR(",", Z_SAFE_HOMING_Y_POINT);
-          SERIAL_ECHOLNPAIR_F(") = ", get_z_correction(Z_SAFE_HOMING_X_POINT, Z_SAFE_HOMING_Y_POINT), 6);
-          #endif
-        } // DEBUGGING(LEVELING)
-      #endif
+        DEBUG_ECHOPAIR("   Z error: (", Z_SAFE_HOMING_X_POINT, ",", Z_SAFE_HOMING_Y_POINT);
+        DEBUG_ECHOLNPAIR_F(") = ", get_z_correction(Z_SAFE_HOMING_X_POINT, Z_SAFE_HOMING_Y_POINT), 6);
+        #endif
+      } // DEBUGGING(LEVELING)
 
     }
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -48,6 +48,9 @@
   #include "../../../libs/vector_3.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../../core/debug_out.h"
+
 #if ABL_GRID
   #if ENABLED(PROBE_Y_FIRST)
     #define PR_OUTER_VAR xCount
@@ -187,12 +190,7 @@ G29_TYPE GcodeSuite::G29() {
   if (axis_unhomed_error()) G29_RETURN(false);
 
   if (!no_action && planner.leveling_active && parser.boolval('O')) { // Auto-level only if needed
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOLNPGM("> Auto-level not needed, skip");
-        SERIAL_ECHOLNPGM("<<< G29");
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> Auto-level not needed, skip\n<<< G29");
     G29_RETURN(false);
   }
 
@@ -470,9 +468,7 @@ G29_TYPE GcodeSuite::G29() {
 
     #if ENABLED(AUTO_BED_LEVELING_3POINT)
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> 3-point Leveling");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> 3-point Leveling");
 
       // Probe at 3 arbitrary points
       points[0].z = points[1].z = points[2].z = 0;
@@ -555,13 +551,7 @@ G29_TYPE GcodeSuite::G29() {
           ExtUI::onMeshUpdate(xCount, yCount, z_values[xCount][yCount]);
         #endif
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOPAIR("Save X", xCount);
-            SERIAL_ECHOPAIR(" Y", yCount);
-            SERIAL_ECHOLNPAIR(" Z", measured_z + zoffset);
-          }
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Save X", xCount, " Y", yCount, " Z", measured_z + zoffset);
 
       #endif
     }
@@ -790,9 +780,7 @@ G29_TYPE GcodeSuite::G29() {
   // return or loop before this point.
   //
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS("> probing complete", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS("> probing complete", current_position);
 
   #if ENABLED(PROBE_MANUALLY)
     g29_in_progress = false;
@@ -929,9 +917,7 @@ G29_TYPE GcodeSuite::G29() {
         // Correct the current XYZ position based on the tilted plane.
         //
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) DEBUG_POS("G29 uncorrected XYZ", current_position);
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_POS("G29 uncorrected XYZ", current_position);
 
         float converted[XYZ];
         COPY(converted, current_position);
@@ -945,46 +931,32 @@ G29_TYPE GcodeSuite::G29() {
           && NEAR(current_position[Y_AXIS], yProbe - (Y_PROBE_OFFSET_FROM_EXTRUDER))
         ) {
           const float simple_z = current_position[Z_AXIS] - measured_z;
-          #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) {
-              SERIAL_ECHOPAIR("Z from Probe:", simple_z);
-              SERIAL_ECHOPAIR("  Matrix:", converted[Z_AXIS]);
-              SERIAL_ECHOLNPAIR("  Discrepancy:", simple_z - converted[Z_AXIS]);
-            }
-          #endif
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Probed Z", simple_z, "  Matrix Z", converted[Z_AXIS], "  Discrepancy ", simple_z - converted[Z_AXIS]);
           converted[Z_AXIS] = simple_z;
         }
 
         // The rotated XY and corrected Z are now current_position
         COPY(current_position, converted);
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) DEBUG_POS("G29 corrected XYZ", current_position);
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_POS("G29 corrected XYZ", current_position);
       }
 
     #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
       if (!dryrun) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("G29 uncorrected Z:", current_position[Z_AXIS]);
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("G29 uncorrected Z:", current_position[Z_AXIS]);
 
         // Unapply the offset because it is going to be immediately applied
         // and cause compensation movement in Z
         current_position[Z_AXIS] -= bilinear_z_offset(current_position);
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR(" corrected Z:", current_position[Z_AXIS]);
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR(" corrected Z:", current_position[Z_AXIS]);
       }
 
     #endif // ABL_PLANAR
 
     #ifdef Z_PROBE_END_SCRIPT
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
       planner.synchronize();
       enqueue_and_echo_commands_P(PSTR(Z_PROBE_END_SCRIPT));
     #endif
@@ -996,9 +968,7 @@ G29_TYPE GcodeSuite::G29() {
   // Restore state after probing
   if (!faux) clean_up_after_endstop_or_probe_move();
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< G29");
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G29");
 
   KEEPALIVE_STATE(IN_HANDLER);
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -49,6 +49,9 @@
   #include "../../libs/L6470/L6470_Marlin.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../core/debug_out.h"
+
 #if ENABLED(QUICK_HOME)
 
   static void quick_home_xy() {
@@ -113,9 +116,7 @@
       return;
     }
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("Z_SAFE_HOMING >>>");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Z_SAFE_HOMING >>>");
 
     sync_plan_position();
 
@@ -133,9 +134,7 @@
 
     if (position_is_reachable(destination[X_AXIS], destination[Y_AXIS])) {
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("Z_SAFE_HOMING", destination);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Z_SAFE_HOMING", destination);
 
       // This causes the carriage on Dual X to unpark
       #if ENABLED(DUAL_X_CARRIAGE)
@@ -154,9 +153,7 @@
       SERIAL_ECHO_MSG(MSG_ZPROBE_OUT);
     }
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< Z_SAFE_HOMING");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< Z_SAFE_HOMING");
   }
 
 #endif // Z_SAFE_HOMING
@@ -182,12 +179,10 @@
  */
 void GcodeSuite::G28(const bool always_home_all) {
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOLNPGM(">>> G28");
-      log_machine_info();
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_ECHOLNPGM(">>> G28");
+    log_machine_info();
+  }
 
   #if ENABLED(DUAL_X_CARRIAGE)
     bool IDEX_saved_duplication_state = extruder_duplication_enabled;
@@ -200,9 +195,7 @@ void GcodeSuite::G28(const bool always_home_all) {
       sync_plan_position();
       SERIAL_ECHOLNPGM("Simulated Homing");
       report_current_position();
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< G28");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G28");
       return;
     }
   #endif
@@ -215,12 +208,7 @@ void GcodeSuite::G28(const bool always_home_all) {
         all_axes_homed()  // homing needed only if never homed
       #endif
     ) {
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) {
-          SERIAL_ECHOLNPGM("> homing not needed, skip");
-          SERIAL_ECHOLNPGM("<<< G28");
-        }
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> homing not needed, skip\n<<< G28");
       return;
     }
   }
@@ -297,12 +285,7 @@ void GcodeSuite::G28(const bool always_home_all) {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
       destination[Z_AXIS] = z_homing_height;
       if (destination[Z_AXIS] > current_position[Z_AXIS]) {
-
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING))
-            SERIAL_ECHOLNPAIR("Raise Z (before homing) to ", destination[Z_AXIS]);
-        #endif
-
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) to ", destination[Z_AXIS]);
         do_blocking_move_to_z(destination[Z_AXIS]);
       }
     }
@@ -451,9 +434,7 @@ void GcodeSuite::G28(const bool always_home_all) {
       SERIAL_ECHOLNPGM(MSG_Z_MOVE_COMP);
   #endif
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< G28");
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G28");
 
   #if HAS_DRIVER(L6470)
     // Set L6470 absolute position registers to counts

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -42,6 +42,9 @@
   #include "../../feature/bedlevel/bedlevel.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../core/debug_out.h"
+
 float z_auto_align_xpos[Z_STEPPER_COUNT] = Z_STEPPER_ALIGN_X,
       z_auto_align_ypos[Z_STEPPER_COUNT] = Z_STEPPER_ALIGN_Y;
 
@@ -59,19 +62,15 @@ inline void set_all_z_lock(const bool lock) {
  * Parameters: I<iterations> T<accuracy> A<amplification>
  */
 void GcodeSuite::G34() {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOLNPGM(">>> G34");
-      log_machine_info();
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_ECHOLNPGM(">>> G34");
+    log_machine_info();
+  }
 
   do { // break out on error
 
     if (!TEST(axis_known_position, X_AXIS) || !TEST(axis_known_position, Y_AXIS)) {
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> XY homing required.");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> XY homing required.");
       break;
     }
 
@@ -128,9 +127,7 @@ void GcodeSuite::G34() {
           z_measured[Z_STEPPER_COUNT] = { 0 };
     bool err_break = false;
     for (uint8_t iteration = 0; iteration < z_auto_align_iterations; ++iteration) {
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> probing all positions.");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> probing all positions.");
 
       // Reset minimum value
       float z_measured_min = 100000.0f;
@@ -141,19 +138,12 @@ void GcodeSuite::G34() {
 
         // Stop on error
         if (isnan(z_measured[zstepper])) {
-          #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> PROBING FAILED!");
-          #endif
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> PROBING FAILED!");
           err_break = true;
           break;
         }
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOPAIR("> Z", int(zstepper + 1));
-            SERIAL_ECHOLNPAIR(" measured position is ", z_measured[zstepper]);
-          }
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", int(zstepper + 1), " measured position is ", z_measured[zstepper]);
 
         // Remember the maximum position to calculate the correction
         z_measured_min = MIN(z_measured_min, z_measured[zstepper]);
@@ -178,9 +168,7 @@ void GcodeSuite::G34() {
         // Check for lost accuracy compared to last move
         if (last_z_align_move[zstepper] < z_align_abs - 1.0) {
           // Stop here
-          #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> detected decreasing accuracy.");
-          #endif
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> detected decreasing accuracy.");
           err_break = true;
           break;
         }
@@ -190,12 +178,7 @@ void GcodeSuite::G34() {
         // Only stop early if all measured points achieve accuracy target
         if (z_align_abs > z_auto_align_accuracy) success_break = false;
 
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOPAIR("> Z", int(zstepper + 1));
-            SERIAL_ECHOLNPAIR(" corrected by ", z_align_move);
-          }
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", int(zstepper + 1), " corrected by ", z_align_move);
 
         switch (zstepper) {
           case 0: stepper.set_z_lock(false); break;
@@ -219,9 +202,7 @@ void GcodeSuite::G34() {
       stepper.set_separate_multi_axis(false);
 
       if (success_break) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("> achieved target accuracy.");
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> achieved target accuracy.");
         break;
       }
     }
@@ -252,9 +233,7 @@ void GcodeSuite::G34() {
 
   } while(0);
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< G34");
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G34");
 }
 
 /**

--- a/Marlin/src/gcode/calibrate/M666.cpp
+++ b/Marlin/src/gcode/calibrate/M666.cpp
@@ -31,32 +31,22 @@
   #include "../../module/delta.h"
   #include "../../module/motion.h"
 
+  #define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+  #include "../../core/debug_out.h"
+
   /**
    * M666: Set delta endstop adjustment
    */
   void GcodeSuite::M666() {
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOLNPGM(">>> M666");
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(">>> M666");
     LOOP_XYZ(i) {
       if (parser.seen(axis_codes[i])) {
         const float v = parser.value_linear_units();
         if (v * Z_HOME_DIR <= 0) delta_endstop_adj[i] = v;
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOPAIR("delta_endstop_adj[", axis_codes[i]);
-            SERIAL_ECHOLNPAIR("] = ", delta_endstop_adj[i]);
-          }
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("delta_endstop_adj[", axis_codes[i], "] = ", delta_endstop_adj[i]);
       }
     }
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOLNPGM("<<< M666");
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< M666");
   }
 
 #elif HAS_EXTRA_ENDSTOPS

--- a/Marlin/src/gcode/control/M111.cpp
+++ b/Marlin/src/gcode/control/M111.cpp
@@ -34,14 +34,14 @@ void GcodeSuite::M111() {
                     str_debug_8[] PROGMEM = MSG_DEBUG_DRYRUN,
                     str_debug_16[] PROGMEM = MSG_DEBUG_COMMUNICATION
                     #if ENABLED(DEBUG_LEVELING_FEATURE)
-                      , str_debug_32[] PROGMEM = MSG_DEBUG_LEVELING
+                      , str_debug_lvl[] PROGMEM = MSG_DEBUG_LEVELING
                     #endif
                     ;
 
   static PGM_P const debug_strings[] PROGMEM = {
     str_debug_1, str_debug_2, str_debug_4, str_debug_8, str_debug_16
     #if ENABLED(DEBUG_LEVELING_FEATURE)
-      , str_debug_32
+      , str_debug_lvl
     #endif
   };
 

--- a/Marlin/src/gcode/control/T.cpp
+++ b/Marlin/src/gcode/control/T.cpp
@@ -31,6 +31,9 @@
   #include "../../feature/prusa_MMU2/mmu2.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../../core/debug_out.h"
+
 /**
  * T0-T<n>: Switch tool, usually switching extruders
  *
@@ -45,14 +48,10 @@
  */
 void GcodeSuite::T(const uint8_t tool_index) {
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOPAIR(">>> T(", tool_index);
-      SERIAL_CHAR(')');
-      SERIAL_EOL();
-      DEBUG_POS("BEFORE", current_position);
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_ECHOLNPAIR(">>> T(", tool_index, ")");
+    DEBUG_POS("BEFORE", current_position);
+  }
 
   #if ENABLED(PRUSA_MMU2)
     if (parser.string_arg) {
@@ -75,10 +74,8 @@ void GcodeSuite::T(const uint8_t tool_index) {
 
   #endif
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      DEBUG_POS("AFTER", current_position);
-      SERIAL_ECHOLNPGM("<<< T()");
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_POS("AFTER", current_position);
+    DEBUG_ECHOLNPGM("<<< T()");
+  }
 }

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -29,6 +29,9 @@
 #include "../../../module/stepper_indirection.h"
 #include "../../../module/planner.h"
 
+#define DEBUG_OUT ENABLED(L6470_CHITCHAT)
+#include "../../../core/debug_out.h"
+
 /**
  *
  * M906: report or set KVAL_HOLD which sets the maximum effective voltage provided by the
@@ -93,7 +96,7 @@ void L6470_report_current(L6470 &motor, const uint8_t axis) {
   L6470.say_axis(axis);
   #if ENABLED(L6470_CHITCHAT)
     sprintf_P(temp_buf, PSTR("   status: %4x   "), status);
-    SERIAL_ECHO(temp_buf);
+    DEBUG_ECHO(temp_buf);
     print_bin(status);
   #endif
   sprintf_P(temp_buf, PSTR("\n...OverCurrent Threshold: %2d (%4d mA)"), overcurrent_threshold, (overcurrent_threshold + 1) * 375);
@@ -134,7 +137,7 @@ void L6470_report_current(L6470 &motor, const uint8_t axis) {
 void GcodeSuite::M906() {
   #define L6470_SET_KVAL_HOLD(Q) stepper##Q.SetParam(L6470_KVAL_HOLD, value)
 
-  L6470_ECHOLNPGM("M906");
+  DEBUG_ECHOLNPGM("M906");
 
   bool report_current = true;
 

--- a/Marlin/src/gcode/feature/L6470/M916-918.cpp
+++ b/Marlin/src/gcode/feature/L6470/M916-918.cpp
@@ -29,6 +29,9 @@
 #include "../../../module/planner.h"
 #include "../../../libs/L6470/L6470_Marlin.h"
 
+#define DEBUG_OUT ENABLED(L6470_CHITCHAT)
+#include "../../../core/debug_out.h"
+
 /**
  *
  * M916: increase KVAL_HOLD until get thermal warning
@@ -59,7 +62,7 @@
 
 void GcodeSuite::M916() {
 
-  L6470_ECHOLNPGM("M916");
+  DEBUG_ECHOLNPGM("M916");
 
   // Variables used by L6470_get_user_input function - some may not be used
   char axis_mon[3][3] = { "  ", "  ", "  " };  // list of Axes to be monitored
@@ -80,7 +83,7 @@ void GcodeSuite::M916() {
   if (L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
     return;  // quit if invalid user input
 
-  L6470_ECHOLNPAIR("feedrate = ", final_feedrate);
+  DEBUG_ECHOLNPAIR("feedrate = ", final_feedrate);
 
   planner.synchronize();                             // wait for all current movement commands to complete
 
@@ -92,11 +95,11 @@ void GcodeSuite::M916() {
   char gcode_string[80];
   uint16_t status_composite = 0;
 
-  L6470_ECHOLNPGM(".\n.");
+  DEBUG_ECHOLNPGM(".\n.");
 
   do {
 
-    L6470_ECHOLNPAIR("kval_hold = ", kval_hold);   // set & report KVAL_HOLD for this run
+    DEBUG_ECHOLNPAIR("kval_hold = ", kval_hold);   // set & report KVAL_HOLD for this run
 
     for (j = 0; j < driver_count; j++)
       L6470.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
@@ -119,9 +122,9 @@ void GcodeSuite::M916() {
     }
 
     if (status_composite && (status_composite & STATUS_UVLO)) {
-      L6470_ECHOLNPGM("Test aborted (Undervoltage lockout active)");
+      DEBUG_ECHOLNPGM("Test aborted (Undervoltage lockout active)");
       for (j = 0; j < driver_count; j++) {
-        L6470_ECHOPGM("...");
+        DEBUG_ECHOPGM("...");
         L6470.error_status_decode(axis_status[j], axis_index[j]);
       }
       return;
@@ -133,18 +136,18 @@ void GcodeSuite::M916() {
 
   } while (!(status_composite & (STATUS_TH_WRN | STATUS_TH_SD)) && kval_hold);  // exit when kval_hold == 0 (rolls over)
 
-  L6470_ECHOPGM(".\n.\nThermal warning/shutdown ");
+  DEBUG_ECHOPGM(".\n.\nThermal warning/shutdown ");
   if ((status_composite & (STATUS_TH_WRN | STATUS_TH_SD))) {
-    L6470_ECHOLNPGM("has occurred");
+    DEBUG_ECHOLNPGM("has occurred");
     for (j = 0; j < driver_count; j++) {
-      L6470_ECHOPGM("...");
+      DEBUG_ECHOPGM("...");
       L6470.error_status_decode(axis_status[j], axis_index[j]);
     }
   }
   else
-    L6470_ECHOLNPGM("(Unable to get)");
+    DEBUG_ECHOLNPGM("(Unable to get)");
 
-  L6470_ECHOLNPGM(".");
+  DEBUG_ECHOLNPGM(".");
 }
 
 /**
@@ -176,7 +179,7 @@ void GcodeSuite::M916() {
  */
 void GcodeSuite::M917() {
 
-  L6470_ECHOLNPGM("M917");
+  DEBUG_ECHOLNPGM("M917");
 
   char axis_mon[3][3] = { "  ", "  ", "  " };  // list of axes to be monitored
   uint8_t axis_index[3];
@@ -196,7 +199,7 @@ void GcodeSuite::M917() {
   if (L6470.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, ocd_th_val, stall_th_val, over_current_threshold))
     return;  // quit if invalid user input
 
-  L6470_ECHOLNPAIR("feedrate = ", final_feedrate);
+  DEBUG_ECHOLNPAIR("feedrate = ", final_feedrate);
 
   planner.synchronize();                             // wait for all current movement commands to complete
   for (j = 0; j < driver_count; j++)
@@ -211,16 +214,16 @@ void GcodeSuite::M917() {
         // 2 - OCD finalized - decreasing STALL - exit when STALL warning happens
         // 3 - OCD finalized - increasing STALL - exit when STALL warning stop
         // 4 - all testing completed
-  L6470_ECHOPAIR(".\n.\n.\nover_current threshold : ", (ocd_th_val + 1) * 375);   // first status display
-  L6470_ECHOPAIR("  (OCD_TH:  : ", ocd_th_val);
-  L6470_ECHOPAIR(")   Stall threshold: ", (stall_th_val + 1) * 31.25);
-  L6470_ECHOPAIR("  (STALL_TH: ", stall_th_val);
-  L6470_ECHOLNPGM(")");
+  DEBUG_ECHOPAIR(".\n.\n.\nover_current threshold : ", (ocd_th_val + 1) * 375);   // first status display
+  DEBUG_ECHOPAIR("  (OCD_TH:  : ", ocd_th_val);
+  DEBUG_ECHOPAIR(")   Stall threshold: ", (stall_th_val + 1) * 31.25);
+  DEBUG_ECHOPAIR("  (STALL_TH: ", stall_th_val);
+  DEBUG_ECHOLNPGM(")");
 
   do {
 
-    L6470_ECHOPAIR("STALL threshold : ", (stall_th_val + 1) * 31.25);
-    L6470_ECHOLNPAIR("   OCD threshold : ", (ocd_th_val + 1) * 375);
+    DEBUG_ECHOPAIR("STALL threshold : ", (stall_th_val + 1) * 31.25);
+    DEBUG_ECHOLNPAIR("   OCD threshold : ", (ocd_th_val + 1) * 375);
 
     sprintf_P(gcode_string, PSTR("G0 %s%4.3f  F%4.3f"), temp_axis_string, position_min, final_feedrate);
     gcode.process_subcommands_now_P(gcode_string);
@@ -238,16 +241,16 @@ void GcodeSuite::M917() {
     }
 
     if (status_composite && (status_composite & STATUS_UVLO)) {
-      L6470_ECHOLNPGM("Test aborted (Undervoltage lockout active)");
+      DEBUG_ECHOLNPGM("Test aborted (Undervoltage lockout active)");
       for (j = 0; j < driver_count; j++) {
-        L6470_ECHOPGM("...");
+        DEBUG_ECHOPGM("...");
         L6470.error_status_decode(axis_status[j], axis_index[j]);
       }
       return;
     }
 
     if (status_composite & (STATUS_TH_WRN | STATUS_TH_SD)) {
-      L6470_ECHOLNPGM("thermal problem - waiting for chip(s) to cool down ");
+      DEBUG_ECHOLNPGM("thermal problem - waiting for chip(s) to cool down ");
       uint16_t status_composite_temp = 0;
       uint8_t k = 0;
       do {
@@ -255,11 +258,11 @@ void GcodeSuite::M917() {
         if (!(k % 4)) {
           kval_hold *= 0.95;
           L6470_EOL();
-          L6470_ECHOLNPAIR("Lowering KVAL_HOLD by about 5% to ", kval_hold);
+          DEBUG_ECHOLNPAIR("Lowering KVAL_HOLD by about 5% to ", kval_hold);
           for (j = 0; j < driver_count; j++)
             L6470.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
         }
-        L6470_ECHOLNPGM(".");
+        DEBUG_ECHOLNPGM(".");
         gcode.reset_stepper_timeout(); // reset_stepper_timeout to keep steppers powered
         watchdog_reset();   // beat the dog
         safe_delay(5000);
@@ -281,22 +284,22 @@ void GcodeSuite::M917() {
             if (ocd_th_val >=15) {
               ocd_th_val = 15;           // limit to max
               test_phase = 2;            // at highest value so skip phase 1
-              L6470_ECHOLNPGM("LOGIC E0A OCD at highest - skip to 2");
+              DEBUG_ECHOLNPGM("LOGIC E0A OCD at highest - skip to 2");
             }
             else {
               ocd_th_val++;              // normal exit to next phase
               test_phase = 1;            // setup for first pass of phase 1
-              L6470_ECHOLNPGM("LOGIC E0B - inc OCD  & go to 1");
+              DEBUG_ECHOLNPGM("LOGIC E0B - inc OCD  & go to 1");
             }
           }
           else {  // phase 0 without OCD warning - keep on decrementing if can
             if (ocd_th_val) {
               ocd_th_val--;              // try lower value
-              L6470_ECHOLNPGM("LOGIC E0C - dec OCD");
+              DEBUG_ECHOLNPGM("LOGIC E0C - dec OCD");
             }
             else {
               test_phase = 2;            // at lowest value without warning so skip phase 1
-              L6470_ECHOLNPGM("LOGIC E0D - OCD at latest - go to 2");
+              DEBUG_ECHOLNPGM("LOGIC E0D - OCD at latest - go to 2");
             }
           }
         } break;
@@ -307,16 +310,16 @@ void GcodeSuite::M917() {
             if (ocd_th_val >= 15) {
               ocd_th_val = 15;           // limit to max
               test_phase = 2;            // at highest value so go to next phase
-              L6470_ECHOLNPGM("LOGIC E1A - OCD at max - go to 2");
+              DEBUG_ECHOLNPGM("LOGIC E1A - OCD at max - go to 2");
             }
             else {
               ocd_th_val++;              // try a higher value
-              L6470_ECHOLNPGM("LOGIC E1B - inc OCD");
+              DEBUG_ECHOLNPGM("LOGIC E1B - inc OCD");
             }
           }
           else { // phase 1 without OCD warning - normal exit to phase 2
             test_phase = 2;
-            L6470_ECHOLNPGM("LOGIC E1C - no OCD warning - go to 1");
+            DEBUG_ECHOLNPGM("LOGIC E1C - no OCD warning - go to 1");
           }
         } break;
 
@@ -325,25 +328,25 @@ void GcodeSuite::M917() {
             // phase 2 with stall warning - time to go to next phase
             if (stall_th_val >= 127) {
               stall_th_val = 127;  // limit to max
-              L6470_ECHOLNPGM("LOGIC E2A - STALL warning, STALL at max, quit");
-              L6470_ECHOLNPGM("finished - STALL at maximum value but still have stall warning");
+              DEBUG_ECHOLNPGM("LOGIC E2A - STALL warning, STALL at max, quit");
+              DEBUG_ECHOLNPGM("finished - STALL at maximum value but still have stall warning");
               test_phase = 4;
             }
             else {
               test_phase = 3;              // normal exit to next phase (found failing value of STALL)
               stall_th_val++;              // setup for first pass of phase 3
-              L6470_ECHOLNPGM("LOGIC E2B - INC - STALL warning, inc Stall, go to 3");
+              DEBUG_ECHOLNPGM("LOGIC E2B - INC - STALL warning, inc Stall, go to 3");
             }
           }
           else {  // phase 2 without stall warning - decrement if can
             if (stall_th_val) {
               stall_th_val--;              // try a lower value
-              L6470_ECHOLNPGM("LOGIC E2C - no STALL, dec STALL");
+              DEBUG_ECHOLNPGM("LOGIC E2C - no STALL, dec STALL");
             }
             else {
-              L6470_ECHOLNPGM("finished - STALL at lowest value but still do NOT have stall warning");
+              DEBUG_ECHOLNPGM("finished - STALL at lowest value but still do NOT have stall warning");
               test_phase = 4;
-              L6470_ECHOLNPGM("LOGIC E2D - no STALL, at lowest so quit");
+              DEBUG_ECHOLNPGM("LOGIC E2D - no STALL, at lowest so quit");
             }
           }
         } break;
@@ -353,19 +356,19 @@ void GcodeSuite::M917() {
             // phase 3 with stall warning - increment if can
             if (stall_th_val >= 127) {
               stall_th_val = 127; // limit to max
-              L6470_ECHOLNPGM("finished - STALL at maximum value but still have stall warning");
+              DEBUG_ECHOLNPGM("finished - STALL at maximum value but still have stall warning");
               test_phase = 4;
-              L6470_ECHOLNPGM("LOGIC E3A - STALL, at max so quit");
+              DEBUG_ECHOLNPGM("LOGIC E3A - STALL, at max so quit");
             }
             else {
               stall_th_val++;              // still looking for passing value
-              L6470_ECHOLNPGM("LOGIC E3B - STALL, inc stall");
+              DEBUG_ECHOLNPGM("LOGIC E3B - STALL, inc stall");
             }
           }
           else {  //phase 3 without stall warning  but have OCD warning
-            L6470_ECHOLNPGM("Hardware problem - OCD warning without STALL warning");
+            DEBUG_ECHOLNPGM("Hardware problem - OCD warning without STALL warning");
             test_phase = 4;
-            L6470_ECHOLNPGM("LOGIC E3C - not STALLED, hardware problem (quit)");
+            DEBUG_ECHOLNPGM("LOGIC E3C - not STALLED, hardware problem (quit)");
           }
         } break;
 
@@ -377,30 +380,30 @@ void GcodeSuite::M917() {
         case 0: { // phase 0 without OCD warning - keep on decrementing if can
           if (ocd_th_val) {
             ocd_th_val--;             // try lower value
-            L6470_ECHOLNPGM("LOGIC N0A - DEC OCD");
+            DEBUG_ECHOLNPGM("LOGIC N0A - DEC OCD");
           }
           else {
             test_phase = 2;           // at lowest value without warning so skip phase 1
-            L6470_ECHOLNPGM("LOGIC N0B - OCD at lowest (go to phase 2)");
+            DEBUG_ECHOLNPGM("LOGIC N0B - OCD at lowest (go to phase 2)");
           }
         } break;
 
-        case 1: L6470_ECHOLNPGM("LOGIC N1 (go directly to 2)"); // phase 1 without OCD warning - drop directly to phase 2
+        case 1: DEBUG_ECHOLNPGM("LOGIC N1 (go directly to 2)"); // phase 1 without OCD warning - drop directly to phase 2
 
         case 2: { // phase 2 without stall warning - keep on decrementing if can
           if (stall_th_val) {
             stall_th_val--;              // try a lower value (stay in phase 2)
-            L6470_ECHOLNPGM("LOGIC N2B - dec STALL");
+            DEBUG_ECHOLNPGM("LOGIC N2B - dec STALL");
           }
           else {
-            L6470_ECHOLNPGM("finished - STALL at lowest value but still no stall warning");
+            DEBUG_ECHOLNPGM("finished - STALL at lowest value but still no stall warning");
             test_phase = 4;
-            L6470_ECHOLNPGM("LOGIC N2C - STALL at lowest (quit)");
+            DEBUG_ECHOLNPGM("LOGIC N2C - STALL at lowest (quit)");
           }
         } break;
 
         case 3: { test_phase = 4;
-           L6470_ECHOLNPGM("LOGIC N3 - finished!");
+           DEBUG_ECHOLNPGM("LOGIC N3 - finished!");
         } break;  // phase 3 without any warnings - desired exit
       }  //
     }  // end of status checks
@@ -409,22 +412,22 @@ void GcodeSuite::M917() {
       for (j = 0; j < driver_count; j++) {                       // update threshold(s)
         L6470.set_param(axis_index[j], L6470_OCD_TH, ocd_th_val);
         L6470.set_param(axis_index[j], L6470_STALL_TH, stall_th_val);
-        if (L6470.get_param(axis_index[j], L6470_OCD_TH) != ocd_th_val) L6470_ECHOLNPGM("OCD mismatch");
-        if (L6470.get_param(axis_index[j], L6470_STALL_TH) != stall_th_val) L6470_ECHOLNPGM("STALL mismatch");
+        if (L6470.get_param(axis_index[j], L6470_OCD_TH) != ocd_th_val) DEBUG_ECHOLNPGM("OCD mismatch");
+        if (L6470.get_param(axis_index[j], L6470_STALL_TH) != stall_th_val) DEBUG_ECHOLNPGM("STALL mismatch");
       }
     }
 
   } while (test_phase != 4);
 
   if (status_composite) {
-    L6470_ECHOLNPGM("Completed with errors");
+    DEBUG_ECHOLNPGM("Completed with errors");
     for (j = 0; j < driver_count; j++) {
-      L6470_ECHOPGM("...");
+      DEBUG_ECHOPGM("...");
       L6470.error_status_decode(axis_status[j], axis_index[j]);
     }
   }
   else
-    L6470_ECHOLNPGM("Completed with no errors");
+    DEBUG_ECHOLNPGM("Completed with no errors");
 
 } // M917
 
@@ -448,7 +451,7 @@ void GcodeSuite::M917() {
  */
 void GcodeSuite::M918() {
 
-  L6470_ECHOLNPGM("M918");
+  DEBUG_ECHOLNPGM("M918");
 
   char axis_mon[3][3] = { "  ", "  ", "  " };  // List of axes to monitor
   uint8_t axis_index[3];
@@ -469,7 +472,7 @@ void GcodeSuite::M918() {
 
   uint8_t m_steps = parser.byteval('M');
   LIMIT(m_steps, 0, 128);
-  L6470_ECHOLNPAIR("M = ", m_steps);
+  DEBUG_ECHOLNPAIR("M = ", m_steps);
 
   int8_t m_bits = -1;
        if (m_steps > 85) m_bits = 7;  // 128 (no synch output)
@@ -484,15 +487,15 @@ void GcodeSuite::M918() {
 
   if (m_bits >= 0) {
     const int micros = _BV(m_bits);
-    if (micros < 100) { L6470_CHAR(' '); if (micros < 10) L6470_CHAR(' '); }
-    L6470_ECHO(micros);
-    L6470_ECHOPGM(" uSTEPS");
+    if (micros < 100) { DEBUG_CHAR(' '); if (micros < 10) DEBUG_CHAR(' '); }
+    DEBUG_ECHO(micros);
+    DEBUG_ECHOPGM(" uSTEPS");
   }
 
   for (j = 0; j < driver_count; j++)
     L6470.set_param(axis_index[j], L6470_STEP_MODE, m_bits);   // set microsteps
 
-  L6470_ECHOLNPAIR("target (maximum) feedrate = ",final_feedrate);
+  DEBUG_ECHOLNPAIR("target (maximum) feedrate = ",final_feedrate);
 
   float feedrate_inc = final_feedrate / 10, // start at 1/10 of max & go up by 1/10 per step)
         current_feedrate = 0;
@@ -508,11 +511,11 @@ void GcodeSuite::M918() {
 
   char gcode_string[80];
   uint16_t status_composite = 0;
-  L6470_ECHOLNPGM(".\n.\n.");            // make the feedrate prints easier to see
+  DEBUG_ECHOLNPGM(".\n.\n.");            // make the feedrate prints easier to see
 
   do {
     current_feedrate += feedrate_inc;
-    L6470_ECHOLNPAIR("...feedrate = ", current_feedrate);
+    DEBUG_ECHOLNPAIR("...feedrate = ", current_feedrate);
 
     sprintf_P(gcode_string, PSTR("G0 %s%4.3f F%4.3f"), temp_axis_string, position_min, current_feedrate);
     gcode.process_subcommands_now_P(gcode_string);
@@ -529,15 +532,16 @@ void GcodeSuite::M918() {
     if (status_composite) break;       // quit if any errors flags are raised
   } while (current_feedrate < final_feedrate * 0.99);
 
+  DEBUG_ECHOPGM("Completed with errors");
   if (status_composite) {
-    L6470_ECHOLNPGM("Completed with errors");
+    DEBUG_ECHOLNPGM("errors");
     for (j = 0; j < driver_count; j++) {
-      L6470_ECHOPGM("...");
+      DEBUG_ECHOPGM("...");
       L6470.error_status_decode(axis_status[j], axis_index[j]);
     }
   }
   else
-    L6470_ECHOLNPGM("Completed with no errors");
+    DEBUG_ECHOLNPGM("no errors");
 
 } // M918
 

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -32,6 +32,8 @@
     //C:\Users\bobku\Documents\GitHub\Marlin-Bob-2\Marlin\src\gcode\host\M114.cpp
     //C:\Users\bobku\Documents\GitHub\Marlin-Bob-2\Marlin\src\module\bob_L6470.cpp
     #include "../../module/L6470/L6470_Marlin.h"
+    #define DEBUG_OUT ENABLED(L6470_CHITCHAT)
+    #include "../../core/debug_out.h"
   #endif
 
   void report_xyze(const float pos[], const uint8_t n = 4, const uint8_t precision = 3) {
@@ -95,10 +97,10 @@
           temp = L6470_GETPARAM(L6470_ABS_POS,Q);                   \
           if (temp & ABS_POS_SIGN_MASK) temp |= ABS_POS_SIGN_MASK;  \
           sprintf_P(temp_buf, PSTR(":%8ld   "), temp);              \
-          L6470_ECHO(temp_buf);                                     \
+          DEBUG_ECHO(temp_buf);                                     \
         }while(0)
 
-      L6470_ECHOPGM("\nL6470:");
+      DEBUG_ECHOPGM("\nL6470:");
       #if AXIS_DRIVER_TYPE_X(L6470)
         REPORT_ABSOLUTE_POS(X);
       #endif

--- a/Marlin/src/libs/L6470/L6470_Marlin.cpp
+++ b/Marlin/src/libs/L6470/L6470_Marlin.cpp
@@ -36,6 +36,9 @@ L6470_Marlin L6470;
 #include "../../gcode/gcode.h"
 #include "../planner.h"
 
+#define DEBUG_OUT ENABLED(L6470_CHITCHAT)
+#include "../../core/debug_out.h"
+
 uint8_t L6470_Marlin::dir_commands[MAX_L6470];  // array to hold direction command for each driver
 
 char L6470_Marlin::index_to_axis[MAX_L6470][3] = { "X ", "Y ", "Z ", "X2", "Y2", "Z2", "Z3", "E0", "E1", "E2", "E3", "E4", "E5" };
@@ -286,16 +289,16 @@ void L6470_Marlin::set_param(uint8_t axis, uint8_t param, uint32_t value) {
 }
 
 inline void echo_min_max(const char a, const float &min, const float &max) {
-  L6470_CHAR(' '); L6470_CHAR(a);
-  L6470_ECHOPAIR(" min = ", min);
-  L6470_ECHOLNPAIR("  max = ", max);
+  DEBUG_CHAR(' '); DEBUG_CHAR(a);
+  DEBUG_ECHOPAIR(" min = ", min);
+  DEBUG_ECHOLNPAIR("  max = ", max);
 }
 inline void echo_oct_used(const float &oct, const bool stall) {
-  L6470_ECHOPAIR("over_current_threshold used     : ", oct);
+  DEBUG_ECHOPAIR("over_current_threshold used     : ", oct);
   serialprintPGM(stall ? PSTR("  (Stall") : PSTR("  (OCD"));
-  L6470_ECHOLNPGM(" threshold)");
+  DEBUG_ECHOLNPGM(" threshold)");
 }
-inline void err_out_of_bounds() { L6470_ECHOLNPGM("ERROR - motion out of bounds"); }
+inline void err_out_of_bounds() { DEBUG_ECHOLNPGM("ERROR - motion out of bounds"); }
 
 bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], char axis_mon[3][3],
                           float &position_max, float &position_min, float &final_feedrate, uint8_t &kval_hold,
@@ -307,7 +310,7 @@ bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], 
   uint8_t j;   // general purpose counter
 
   if (!all_axes_homed()) {
-    L6470_ECHOLNPGM("ERROR - home all before running this command");
+    DEBUG_ECHOLNPGM("ERROR - home all before running this command");
     //return true;
   }
 
@@ -424,12 +427,12 @@ bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], 
   }
 
   if (driver_count == 0) {
-    L6470_ECHOLNPGM("ERROR - not a L6470 axis");
+    DEBUG_ECHOLNPGM("ERROR - not a L6470 axis");
     return true;
   }
 
-  L6470_ECHOPGM("Monitoring:");
-  for (j = 0; j < driver_count; j++) L6470_ECHOPAIR("  ", axis_mon[j]);
+  DEBUG_ECHOPGM("Monitoring:");
+  for (j = 0; j < driver_count; j++) DEBUG_ECHOPAIR("  ", axis_mon[j]);
   L6470_EOL();
 
   // now have a list of driver(s) to monitor
@@ -440,14 +443,14 @@ bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], 
 
   kval_hold = parser.byteval('K');
   if (kval_hold) {
-    L6470_ECHOLNPAIR("kval_hold = ", kval_hold);
+    DEBUG_ECHOLNPAIR("kval_hold = ", kval_hold);
     for (j = 0; j < driver_count; j++)
       set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
   }
   else {
     // only print the KVAL_HOLD from one of the drivers
     kval_hold = get_param(axis_index[0], L6470_KVAL_HOLD);
-    L6470_ECHOLNPAIR("KVAL_HOLD = ", kval_hold);
+    DEBUG_ECHOLNPAIR("KVAL_HOLD = ", kval_hold);
   }
 
   //
@@ -474,7 +477,7 @@ bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], 
         OCD_TH_actual = (OCD_TH_val_local + 1) * 375;
       }
 
-      L6470_ECHOLNPAIR("over_current_threshold specified: ", over_current_threshold);
+      DEBUG_ECHOLNPAIR("over_current_threshold specified: ", over_current_threshold);
       echo_oct_used(STALL_TH_actual, true);
       echo_oct_used(OCD_TH_actual, false);
 
@@ -547,13 +550,13 @@ void L6470_Marlin::error_status_decode(const uint16_t status, const uint8_t axis
     char temp_buf[10];
     say_axis(axis);
     sprintf_P(temp_buf, PSTR("  %4x   "), status);
-    L6470_ECHO(temp_buf);
+    DEBUG_ECHO(temp_buf);
     print_bin(status);
-    L6470_ECHOPGM("  THERMAL: ");
+    DEBUG_ECHOPGM("  THERMAL: ");
     serialprintPGM((status & STATUS_TH_SD) ? PSTR("SHUTDOWN") : (status & STATUS_TH_WRN) ? PSTR("WARNING ") : PSTR("OK      "));
-    L6470_ECHOPGM("   OVERCURRENT: ");
+    DEBUG_ECHOPGM("   OVERCURRENT: ");
     echo_yes_no(status & STATUS_OCD);
-    L6470_ECHOPGM("   STALL: ");
+    DEBUG_ECHOPGM("   STALL: ");
     echo_yes_no(status & (STATUS_STEP_LOSS_A | STATUS_STEP_LOSS_B));
     L6470_EOL();
   #else
@@ -642,14 +645,14 @@ void L6470_Marlin::error_status_decode(const uint16_t status, const uint8_t axis
       if (driver_L6470_data[j].com_counter == 0) {      // warn user when it first happens
         driver_L6470_data[j].com_counter++;
         append_stepper_err(p, stepper_index, PSTR(" - communications lost\n"));
-        L6470_ECHO(temp_buf);
+        DEBUG_ECHO(temp_buf);
       }
       else {
         driver_L6470_data[j].com_counter++;
         if (driver_L6470_data[j].com_counter > 240) {  // remind of com problem about every 2 minutes
           driver_L6470_data[j].com_counter = 1;
           append_stepper_err(p, stepper_index, PSTR(" - still no communications\n"));
-          L6470_ECHO(temp_buf);
+          DEBUG_ECHO(temp_buf);
         }
       }
     }
@@ -657,7 +660,7 @@ void L6470_Marlin::error_status_decode(const uint16_t status, const uint8_t axis
       if (driver_L6470_data[j].com_counter) {   // comms re-established
         driver_L6470_data[j].com_counter = 0;
         append_stepper_err(p, stepper_index, PSTR(" - communications re-established\n.. setting all drivers to default values\n"));
-        L6470_ECHO(temp_buf);
+        DEBUG_ECHO(temp_buf);
         init_to_defaults();
       }
       else {
@@ -718,7 +721,7 @@ void L6470_Marlin::error_status_decode(const uint16_t status, const uint8_t axis
             p += sprintf_P(p, PSTR("%c\n"), ' ');
           #endif
 
-          L6470_ECHOLN(temp_buf);  // print the error message
+          DEBUG_ECHOLN(temp_buf);  // print the error message
         }
         else {
           driver_L6470_data[j].is_ot = false;

--- a/Marlin/src/libs/L6470/L6470_Marlin.h
+++ b/Marlin/src/libs/L6470/L6470_Marlin.h
@@ -25,26 +25,6 @@
 
 #include <L6470.h>
 
-#if ENABLED(L6470_CHITCHAT)
-  #define L6470_EOL()           SERIAL_EOL()
-  #define L6470_CHAR(C)         SERIAL_CHAR(C)
-  #define L6470_ECHO(V)         SERIAL_ECHO(V)
-  #define L6470_ECHOLN(V)       SERIAL_ECHOLN(V)
-  #define L6470_ECHOPGM(S)      SERIAL_ECHOPGM(S)
-  #define L6470_ECHOLNPGM(S)    SERIAL_ECHOLNPGM(S)
-  #define L6470_ECHOPAIR(S,V)   SERIAL_ECHOPAIR(S,V)
-  #define L6470_ECHOLNPAIR(S,V) SERIAL_ECHOLNPAIR(S,V)
-#else
-  #define L6470_EOL()           NOOP
-  #define L6470_CHAR(C)         NOOP
-  #define L6470_ECHO(V)         NOOP
-  #define L6470_ECHOLN(V)       NOOP
-  #define L6470_ECHOPGM(S)      NOOP
-  #define L6470_ECHOLNPGM(S)    NOOP
-  #define L6470_ECHOPAIR(S,V)   NOOP
-  #define L6470_ECHOLNPAIR(S,V) NOOP
-#endif
-
 #define L6470_GETPARAM(P,Q) stepper##Q.GetParam(P)
 
 #define MAX_L6470  (7 + MAX_EXTRUDERS) // Maximum number of axes in Marlin

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -379,27 +379,8 @@ void MarlinSettings::postprocess() {
 
 #endif // SD_FIRMWARE_UPDATE
 
-#if ENABLED(EEPROM_CHITCHAT)
-  #define CHITCHAT_ECHO(V)              SERIAL_ECHO(V)
-  #define CHITCHAT_ECHOLNPGM(STR)       SERIAL_ECHOLNPGM(STR)
-  #define CHITCHAT_ECHOPAIR(...)        SERIAL_ECHOPAIR(__VA_ARGS__)
-  #define CHITCHAT_ECHOLNPAIR(...)      SERIAL_ECHOLNPAIR(__VA_ARGS__)
-  #define CHITCHAT_ECHO_START()         SERIAL_ECHO_START()
-  #define CHITCHAT_ERROR_START()        SERIAL_ERROR_START()
-  #define CHITCHAT_ERROR_MSG(STR)       SERIAL_ERROR_MSG(STR)
-  #define CHITCHAT_ECHOPGM(STR)         SERIAL_ECHOPGM(STR)
-  #define CHITCHAT_EOL()                SERIAL_EOL()
-#else
-  #define CHITCHAT_ECHO(V)              NOOP
-  #define CHITCHAT_ECHOLNPGM(STR)       NOOP
-  #define CHITCHAT_ECHOPAIR(...)        NOOP
-  #define CHITCHAT_ECHOLNPAIR(...)      NOOP
-  #define CHITCHAT_ECHO_START()         NOOP
-  #define CHITCHAT_ERROR_START()        NOOP
-  #define CHITCHAT_ERROR_MSG(STR)       NOOP
-  #define CHITCHAT_ECHOPGM(STR)         NOOP
-  #define CHITCHAT_EOL()                NOOP
-#endif
+#define DEBUG_OUT ENABLED(EEPROM_CHITCHAT)
+#include "../core/debug_out.h"
 
 #if ENABLED(EEPROM_SETTINGS)
 
@@ -427,7 +408,7 @@ void MarlinSettings::postprocess() {
 
   bool MarlinSettings::size_error(const uint16_t size) {
     if (size != datasize()) {
-      CHITCHAT_ERROR_MSG("EEPROM datasize error.");
+      DEBUG_ERROR_MSG("EEPROM datasize error.");
       return true;
     }
     return false;
@@ -1103,8 +1084,8 @@ void MarlinSettings::postprocess() {
       EEPROM_WRITE(final_crc);
 
       // Report storage size
-      CHITCHAT_ECHO_START();
-      CHITCHAT_ECHOLNPAIR("Settings Stored (", eeprom_size, " bytes; crc ", (uint32_t)final_crc, ")");
+      DEBUG_ECHO_START();
+      DEBUG_ECHOLNPAIR("Settings Stored (", eeprom_size, " bytes; crc ", (uint32_t)final_crc, ")");
 
       eeprom_error |= size_error(eeprom_size);
     }
@@ -1141,8 +1122,8 @@ void MarlinSettings::postprocess() {
         stored_ver[0] = '?';
         stored_ver[1] = '\0';
       }
-      CHITCHAT_ECHO_START();
-      CHITCHAT_ECHOLNPAIR("EEPROM version mismatch (EEPROM=", stored_ver, " Marlin=" EEPROM_VERSION ")");
+      DEBUG_ECHO_START();
+      DEBUG_ECHOLNPAIR("EEPROM version mismatch (EEPROM=", stored_ver, " Marlin=" EEPROM_VERSION ")");
       eeprom_error = true;
     }
     else {
@@ -1807,18 +1788,18 @@ void MarlinSettings::postprocess() {
 
       eeprom_error = size_error(eeprom_index - (EEPROM_OFFSET));
       if (eeprom_error) {
-        CHITCHAT_ECHO_START();
-        CHITCHAT_ECHOLNPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)), " Size: ", datasize());
+        DEBUG_ECHO_START();
+        DEBUG_ECHOLNPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)), " Size: ", datasize());
       }
       else if (working_crc != stored_crc) {
         eeprom_error = true;
-        CHITCHAT_ERROR_START();
-        CHITCHAT_ECHOLNPAIR("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
+        DEBUG_ERROR_START();
+        DEBUG_ECHOLNPAIR("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
       }
       else if (!validating) {
-        CHITCHAT_ECHO_START();
-        CHITCHAT_ECHO(version);
-        CHITCHAT_ECHOLNPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET), " bytes; crc ", (uint32_t)working_crc, ")");
+        DEBUG_ECHO_START();
+        DEBUG_ECHO(version);
+        DEBUG_ECHOLNPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET), " bytes; crc ", (uint32_t)working_crc, ")");
       }
 
       if (!validating && !eeprom_error) postprocess();
@@ -1831,26 +1812,26 @@ void MarlinSettings::postprocess() {
             SERIAL_EOL();
             #if ENABLED(EEPROM_CHITCHAT)
               ubl.echo_name();
-              CHITCHAT_ECHOLNPGM(" initialized.\n");
+              DEBUG_ECHOLNPGM(" initialized.\n");
             #endif
           }
           else {
             eeprom_error = true;
             #if ENABLED(EEPROM_CHITCHAT)
-              CHITCHAT_ECHOPGM("?Can't enable ");
+              DEBUG_ECHOPGM("?Can't enable ");
               ubl.echo_name();
-              CHITCHAT_ECHOLNPGM(".");
+              DEBUG_ECHOLNPGM(".");
             #endif
             ubl.reset();
           }
 
           if (ubl.storage_slot >= 0) {
             load_mesh(ubl.storage_slot);
-            CHITCHAT_ECHOLNPAIR("Mesh ", ubl.storage_slot, " loaded from storage.");
+            DEBUG_ECHOLNPAIR("Mesh ", ubl.storage_slot, " loaded from storage.");
           }
           else {
             ubl.reset();
-            CHITCHAT_ECHOLNPGM("UBL System reset()");
+            DEBUG_ECHOLNPGM("UBL System reset()");
           }
         }
       #endif
@@ -1881,9 +1862,9 @@ void MarlinSettings::postprocess() {
 
     inline void ubl_invalid_slot(const int s) {
       #if ENABLED(EEPROM_CHITCHAT)
-        CHITCHAT_ECHOLNPGM("?Invalid slot.");
-        CHITCHAT_ECHO(s);
-        CHITCHAT_ECHOLNPGM(" mesh slots available.");
+        DEBUG_ECHOLNPGM("?Invalid slot.");
+        DEBUG_ECHO(s);
+        DEBUG_ECHOLNPGM(" mesh slots available.");
       #else
         UNUSED(s);
       #endif
@@ -1912,8 +1893,8 @@ void MarlinSettings::postprocess() {
         const int16_t a = calc_num_meshes();
         if (!WITHIN(slot, 0, a - 1)) {
           ubl_invalid_slot(a);
-          CHITCHAT_ECHOLNPAIR("E2END=", persistentStore.capacity() - 1, " meshes_end=", meshes_end, " slot=", slot);
-          CHITCHAT_EOL();
+          DEBUG_ECHOLNPAIR("E2END=", persistentStore.capacity() - 1, " meshes_end=", meshes_end, " slot=", slot);
+          DEBUG_EOL();
           return;
         }
 
@@ -1926,7 +1907,7 @@ void MarlinSettings::postprocess() {
         persistentStore.access_finish();
 
         if (status) SERIAL_ECHOLNPGM("?Unable to save mesh data.");
-        else        CHITCHAT_ECHOLNPAIR("Mesh saved in slot ", slot);
+        else        DEBUG_ECHOLNPAIR("Mesh saved in slot ", slot);
 
       #else
 
@@ -1955,7 +1936,7 @@ void MarlinSettings::postprocess() {
         persistentStore.access_finish();
 
         if (status) SERIAL_ECHOLNPGM("?Unable to load mesh data.");
-        else        CHITCHAT_ECHOLNPAIR("Mesh loaded from slot ", slot);
+        else        DEBUG_ECHOLNPAIR("Mesh loaded from slot ", slot);
 
         EEPROM_FINISH();
 
@@ -1974,7 +1955,7 @@ void MarlinSettings::postprocess() {
 #else // !EEPROM_SETTINGS
 
   bool MarlinSettings::save() {
-    CHITCHAT_ERROR_MSG("EEPROM disabled");
+    DEBUG_ERROR_MSG("EEPROM disabled");
     return false;
   }
 
@@ -2281,8 +2262,8 @@ void MarlinSettings::reset() {
 
   postprocess();
 
-  CHITCHAT_ECHO_START();
-  CHITCHAT_ECHOLNPGM("Hardcoded Default Settings Loaded");
+  DEBUG_ECHO_START();
+  DEBUG_ECHOLNPGM("Hardcoded Default Settings Loaded");
 }
 
 #if DISABLED(DISABLE_M503)

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -46,6 +46,9 @@
   #include "stepper_indirection.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../core/debug_out.h"
+
 // Initialized by settings.load()
 float delta_height,
       delta_endstop_adj[ABC] = { 0 },
@@ -216,9 +219,7 @@ void forward_kinematics_DELTA(const float &z1, const float &z2, const float &z3)
  * This is like quick_home_xy() but for 3 towers.
  */
 void home_delta() {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> home_delta", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS(">>> home_delta", current_position);
   // Init the current position of all carriages to 0,0,0
   ZERO(current_position);
   ZERO(destination);
@@ -264,9 +265,7 @@ void home_delta() {
 
   sync_plan_position();
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< home_delta", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS("<<< home_delta", current_position);
 }
 
 #endif // DELTA

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -69,6 +69,9 @@ float zprobe_zoffset; // Initialized by settings.load()
   #include "stepper_indirection.h"
 #endif
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../core/debug_out.h"
+
 #if ENABLED(Z_PROBE_SLED)
 
   #ifndef SLED_DOCKING_OFFSET
@@ -82,9 +85,7 @@ float zprobe_zoffset; // Initialized by settings.load()
    *              If true, move to MAX_X and release the solenoid
    */
   static void dock_sled(bool stow) {
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("dock_sled(", stow, ")");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("dock_sled(", stow, ")");
 
     // Dock sled a bit closer to ensure proper capturing
     do_blocking_move_to_x(X_MAX_POS + SLED_DOCKING_OFFSET - ((stow) ? 1 : 0));
@@ -312,9 +313,7 @@ float zprobe_zoffset; // Initialized by settings.load()
 
     bltouch_command(deploy ? BLTOUCH_DEPLOY : BLTOUCH_STOW);
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("set_bltouch_deployed(", deploy, ")");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("set_bltouch_deployed(", deploy, ")");
 
     return false;
   }
@@ -325,9 +324,7 @@ float zprobe_zoffset; // Initialized by settings.load()
  * Raise Z to a minimum height to make room for a probe to move
  */
 inline void do_probe_raise(const float z_raise) {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("do_probe_raise(", z_raise, ")");
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("do_probe_raise(", z_raise, ")");
 
   float z_dest = z_raise;
   if (zprobe_zoffset < 0) z_dest -= zprobe_zoffset;
@@ -393,12 +390,10 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
 // returns false for ok and true for failure
 bool set_probe_deployed(const bool deploy) {
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      DEBUG_POS("set_probe_deployed", current_position);
-      SERIAL_ECHOLNPAIR("deploy: ", deploy);
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_POS("set_probe_deployed", current_position);
+    DEBUG_ECHOLNPAIR("deploy: ", deploy);
+  }
 
   if (endstops.z_probe_enabled == deploy) return false;
 
@@ -521,9 +516,7 @@ bool set_probe_deployed(const bool deploy) {
 #endif
 
 static bool do_probe_move(const float z, const float fr_mm_s) {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> do_probe_move", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS(">>> do_probe_move", current_position);
 
   #if HAS_HEATED_BED && ENABLED(WAIT_FOR_BED_HEATER)
     // Wait for bed to heat back up between probing points
@@ -601,9 +594,7 @@ static bool do_probe_move(const float z, const float fr_mm_s) {
   // Tell the planner where we actually are
   sync_plan_position();
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< do_probe_move", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS("<<< do_probe_move", current_position);
 
   return !probe_triggered;
 }
@@ -616,9 +607,7 @@ static bool do_probe_move(const float z, const float fr_mm_s) {
  */
 static float run_z_probe() {
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS(">>> run_z_probe", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS(">>> run_z_probe", current_position);
 
   // Stop the probe before it goes too low to prevent damage.
   // If Z isn't known then probe to -10mm.
@@ -629,20 +618,16 @@ static float run_z_probe() {
 
     // Do a first probe at the fast speed
     if (do_probe_move(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST))) {
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) {
-          SERIAL_ECHOLNPGM("FAST Probe fail!");
-          DEBUG_POS("<<< run_z_probe", current_position);
-        }
-      #endif
+      if (DEBUGGING(LEVELING)) {
+        DEBUG_ECHOLNPGM("FAST Probe fail!");
+        DEBUG_POS("<<< run_z_probe", current_position);
+      }
       return NAN;
     }
 
     float first_probe_z = current_position[Z_AXIS];
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("1st Probe Z:", first_probe_z);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("1st Probe Z:", first_probe_z);
 
     // move up to make clearance for the probe
     do_blocking_move_to_z(current_position[Z_AXIS] + Z_CLEARANCE_MULTI_PROBE, MMM_TO_MMS(Z_PROBE_SPEED_FAST));
@@ -666,12 +651,10 @@ static float run_z_probe() {
 
       // move down slowly to find bed
       if (do_probe_move(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW))) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOLNPGM("SLOW Probe fail!");
-            DEBUG_POS("<<< run_z_probe", current_position);
-          }
-        #endif
+        if (DEBUGGING(LEVELING)) {
+          DEBUG_ECHOLNPGM("SLOW Probe fail!");
+          DEBUG_POS("<<< run_z_probe", current_position);
+        }
         return NAN;
       }
 
@@ -694,9 +677,7 @@ static float run_z_probe() {
 
     const float z2 = current_position[Z_AXIS];
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("2nd Probe Z:", z2, " Discrepancy:", first_probe_z - z2);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("2nd Probe Z:", z2, " Discrepancy:", first_probe_z - z2);
 
     // Return a weighted average of the fast and slow probes
     const float measured_z = (z2 * 3.0 + first_probe_z * 2.0) * 0.2;
@@ -708,9 +689,7 @@ static float run_z_probe() {
 
   #endif
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) DEBUG_POS("<<< run_z_probe", current_position);
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_POS("<<< run_z_probe", current_position);
 
   return measured_z;
 }
@@ -725,19 +704,15 @@ static float run_z_probe() {
  * - Return the probed Z position
  */
 float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/*=PROBE_PT_NONE*/, const uint8_t verbose_level/*=0*/, const bool probe_relative/*=true*/) {
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) {
-      SERIAL_ECHOLNPAIR(
-        ">>> probe_pt(", LOGICAL_X_POSITION(rx),
-        ", ", LOGICAL_Y_POSITION(ry),
-        ", ", raise_after == PROBE_PT_RAISE ? "raise" : raise_after == PROBE_PT_STOW ? "stow" : "none",
-        ", ", int(verbose_level),
-        ", ", probe_relative ? "probe" : "nozzle",
-        "_relative)"
-      );
-      DEBUG_POS("", current_position);
-    }
-  #endif
+  if (DEBUGGING(LEVELING)) {
+    DEBUG_ECHOLNPAIR(
+      ">>> probe_pt(", LOGICAL_X_POSITION(rx), ", ", LOGICAL_Y_POSITION(ry),
+      ", ", raise_after == PROBE_PT_RAISE ? "raise" : raise_after == PROBE_PT_STOW ? "stow" : "none",
+      ", ", int(verbose_level),
+      ", ", probe_relative ? "probe" : "nozzle", "_relative)"
+    );
+    DEBUG_POS("", current_position);
+  }
 
   // TODO: Adapt for SCARA, where the offset rotates
   float nx = rx, ny = ry;
@@ -788,9 +763,7 @@ float probe_pt(const float &rx, const float &ry, const ProbePtRaise raise_after/
     SERIAL_ERROR_MSG(MSG_ERR_PROBING_FAILED);
   }
 
-  #if ENABLED(DEBUG_LEVELING_FEATURE)
-    if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("<<< probe_pt");
-  #endif
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< probe_pt");
 
   return measured_z;
 }

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -31,6 +31,9 @@
 
 #include "../Marlin.h"
 
+#define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
+#include "../core/debug_out.h"
+
 #if EXTRUDERS > 1
   toolchange_settings_t toolchange_settings;  // Initialized by settings.load()
 #endif
@@ -169,12 +172,10 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     current_position[X_AXIS] = mpe_settings.parking_xpos[tmp_extruder] + offsetcompensation;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("(1) Move extruder ", int(tmp_extruder));
-        DEBUG_POS(" to new extruder ParkPos", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR("(1) Move extruder ", int(tmp_extruder));
+      DEBUG_POS(" to new extruder ParkPos", current_position);
+    }
 
     planner.buffer_line(current_position, mpe_settings.fast_feedrate, tmp_extruder);
     planner.synchronize();
@@ -183,12 +184,10 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     current_position[X_AXIS] = grabpos + offsetcompensation;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("(2) Couple extruder ", int(tmp_extruder));
-        DEBUG_POS(" to new extruder GrabPos", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR("(2) Couple extruder ", int(tmp_extruder));
+      DEBUG_POS(" to new extruder GrabPos", current_position);
+    }
 
     planner.buffer_line(current_position, mpe_settings.slow_feedrate, tmp_extruder);
     planner.synchronize();
@@ -199,12 +198,10 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
     // STEP 3
 
     current_position[X_AXIS] = mpe_settings.parking_xpos[tmp_extruder] + offsetcompensation;
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("(3) Move extruder ", int(tmp_extruder));
-        DEBUG_POS(" back to new extruder ParkPos", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR("(3) Move extruder ", int(tmp_extruder));
+      DEBUG_POS(" back to new extruder ParkPos", current_position);
+    }
 
     planner.buffer_line(current_position, mpe_settings.slow_feedrate, tmp_extruder);
     planner.synchronize();
@@ -212,12 +209,10 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
     // STEP 4
 
     current_position[X_AXIS] = mpe_settings.parking_xpos[active_extruder] + (active_extruder == 0 ? MPE_TRAVEL_DISTANCE : -MPE_TRAVEL_DISTANCE) + offsetcompensation;
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("(4) Move extruder ", int(tmp_extruder));
-        DEBUG_POS(" close to old extruder ParkPos", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR("(4) Move extruder ", int(tmp_extruder));
+      DEBUG_POS(" close to old extruder ParkPos", current_position);
+    }
 
     planner.buffer_line(current_position, mpe_settings.fast_feedrate, tmp_extruder);
     planner.synchronize();
@@ -226,12 +221,10 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     current_position[X_AXIS] = mpe_settings.parking_xpos[active_extruder] + offsetcompensation;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("(5) Park extruder ", int(tmp_extruder));
-        DEBUG_POS(" at old extruder ParkPos", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR("(5) Park extruder ", int(tmp_extruder));
+      DEBUG_POS(" at old extruder ParkPos", current_position);
+    }
 
     planner.buffer_line(current_position, mpe_settings.slow_feedrate, tmp_extruder);
     planner.synchronize();
@@ -240,19 +233,15 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     current_position[X_AXIS] = oldx;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPAIR("(6) Move extruder ", int(tmp_extruder));
-        DEBUG_POS(" to starting position", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR("(6) Move extruder ", int(tmp_extruder));
+      DEBUG_POS(" to starting position", current_position);
+    }
 
     planner.buffer_line(current_position, mpe_settings.fast_feedrate, tmp_extruder);
     planner.synchronize();
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("Autopark done.");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Autopark done.");
   }
 
 #elif ENABLED(PARKING_EXTRUDER)
@@ -302,15 +291,11 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
       // STEP 1
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("Start Autopark", current_position);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Start Autopark", current_position);
 
       current_position[Z_AXIS] += toolchange_settings.z_raise;
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current_position);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current_position);
 
       fast_line_to_current(Z_AXIS);
       planner.synchronize();
@@ -319,43 +304,33 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
       current_position[X_AXIS] = parkingposx[active_extruder] + x_offset;
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) {
-          SERIAL_ECHOLNPAIR("(2) Park extruder ", int(active_extruder));
-          DEBUG_POS("Moving ParkPos", current_position);
-        }
-      #endif
+      if (DEBUGGING(LEVELING)) {
+        DEBUG_ECHOLNPAIR("(2) Park extruder ", int(active_extruder));
+        DEBUG_POS("Moving ParkPos", current_position);
+      }
 
       fast_line_to_current(X_AXIS);
       planner.synchronize();
 
       // STEP 3
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(3) Disengage magnet ");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("(3) Disengage magnet ");
 
       pe_deactivate_solenoid(active_extruder);
 
       // STEP 4
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(4) Move to position near new extruder");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("(4) Move to position near new extruder");
 
       current_position[X_AXIS] += active_extruder ? -10 : 10; // move 10mm away from parked extruder
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("Move away from parked extruder", current_position);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_POS("Move away from parked extruder", current_position);
 
       fast_line_to_current(X_AXIS);
       planner.synchronize();
 
       // STEP 5
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(5) Engage magnetic field");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("(5) Engage magnetic field");
 
       #if ENABLED(PARKING_EXTRUDER_SOLENOIDS_INVERT)
         pe_activate_solenoid(active_extruder); //just save power for inverted magnets
@@ -368,9 +343,7 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
       current_position[X_AXIS] = grabpos + (tmp_extruder ? -10 : 10);
       fast_line_to_current(X_AXIS);
       current_position[X_AXIS] = grabpos;
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("(6) Unpark extruder", current_position);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_POS("(6) Unpark extruder", current_position);
       planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS] * 0.5, active_extruder);
       planner.synchronize();
 
@@ -382,16 +355,12 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
         #endif
       ;
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) DEBUG_POS("(7) Move midway between hotends", current_position);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_POS("(7) Move midway between hotends", current_position);
 
       fast_line_to_current(X_AXIS);
       planner.synchronize();
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        SERIAL_ECHOLNPGM("Autopark done.");
-      #endif
+      DEBUG_ECHOLNPGM("Autopark done.");
     }
     else { // nomove == true
       // Only engage magnetic field for new extruder
@@ -405,9 +374,7 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
       current_position[Z_AXIS] += hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
     #endif
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Applying Z-offset", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Applying Z-offset", current_position);
   }
 
 #endif // PARKING_EXTRUDER
@@ -433,15 +400,11 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     // 1. Raise Z to give enough clearance
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Starting Toolhead change", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Starting Toolhead change", current_position);
 
     current_position[Z_AXIS] += toolchange_settings.z_raise;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("(1) Raise Z-Axis", current_position);
 
     fast_line_to_current(Z_AXIS);
     planner.synchronize();
@@ -450,86 +413,66 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     current_position[X_AXIS] = placexpos;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOLNPAIR("(2) Place old tool ", int(active_extruder));
-        DEBUG_POS("Move X SwitchPos", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOLNPAIR("(2) Place old tool ", int(active_extruder));
+      DEBUG_POS("Move X SwitchPos", current_position);
+    }
 
     fast_line_to_current(X_AXIS);
     planner.synchronize();
 
     current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS - SWITCHING_TOOLHEAD_Y_SECURITY;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current_position);
 
     fast_line_to_current(Y_AXIS);
     planner.synchronize();
 
     // 3. Unlock tool and drop it in the dock
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(3) Unlock and Place Toolhead");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("(3) Unlock and Place Toolhead");
 
     MOVE_SERVO(SWITCHING_TOOLHEAD_SERVO_NR, angles[1]);
     safe_delay(500);
 
     current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current_position);
 
     planner.buffer_line(current_position,(planner.settings.max_feedrate_mm_s[Y_AXIS] * 0.5), active_extruder);
     planner.synchronize();
     safe_delay(200);
     current_position[Y_AXIS] -= SWITCHING_TOOLHEAD_Y_CLEAR;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current_position);
 
     fast_line_to_current(Y_AXIS); // move away from docked toolhead
     planner.synchronize();
 
     // 4. Move to the new toolhead
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(4) Move to new toolhead position");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("(4) Move to new toolhead position");
 
     current_position[X_AXIS] = grabxpos;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move to new toolhead X", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move to new toolhead X", current_position);
 
     fast_line_to_current(X_AXIS);
     planner.synchronize();
     current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS - SWITCHING_TOOLHEAD_Y_SECURITY;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos + Security", current_position);
 
     fast_line_to_current(Y_AXIS);
     planner.synchronize();
 
     // 5. Grab and lock the new toolhead
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("(5) Grab and lock new toolhead ");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("(5) Grab and lock new toolhead ");
 
     current_position[Y_AXIS] = SWITCHING_TOOLHEAD_Y_POS;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move Y SwitchPos", current_position);
 
     planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[Y_AXIS] * 0.5, active_extruder);
     planner.synchronize();
@@ -540,16 +483,12 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
 
     current_position[Y_AXIS] -= SWITCHING_TOOLHEAD_Y_CLEAR;
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("Move back Y clear", current_position);
 
     fast_line_to_current(Y_AXIS); // move away from docked toolhead
     planner.synchronize();
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("Toolhead change done.");
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Toolhead change done.");
   }
 
 #endif // SWITCHING_TOOLHEAD
@@ -563,17 +502,15 @@ inline void invalid_extruder_error(const uint8_t e) {
 #if ENABLED(DUAL_X_CARRIAGE)
 
   inline void dualx_tool_change(const uint8_t tmp_extruder, bool &no_move) {
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOPGM("Dual X Carriage Mode ");
-        switch (dual_x_carriage_mode) {
-          case DXC_FULL_CONTROL_MODE: SERIAL_ECHOLNPGM("DXC_FULL_CONTROL_MODE"); break;
-          case DXC_AUTO_PARK_MODE: SERIAL_ECHOLNPGM("DXC_AUTO_PARK_MODE"); break;
-          case DXC_DUPLICATION_MODE: SERIAL_ECHOLNPGM("DXC_DUPLICATION_MODE"); break;
-          case DXC_SCALED_DUPLICATION_MODE: SERIAL_ECHOLNPGM("DXC_SCALED_DUPLICATION_MODE"); break;
-        }
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPGM("Dual X Carriage Mode ");
+      switch (dual_x_carriage_mode) {
+        case DXC_FULL_CONTROL_MODE: DEBUG_ECHOLNPGM("DXC_FULL_CONTROL_MODE"); break;
+        case DXC_AUTO_PARK_MODE: DEBUG_ECHOLNPGM("DXC_AUTO_PARK_MODE"); break;
+        case DXC_DUPLICATION_MODE: DEBUG_ECHOLNPGM("DXC_DUPLICATION_MODE"); break;
+        case DXC_SCALED_DUPLICATION_MODE: DEBUG_ECHOLNPGM("DXC_SCALED_DUPLICATION_MODE"); break;
       }
-    #endif
+    }
 
     const float xhome = x_home_pos(active_extruder);
     if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE
@@ -581,9 +518,8 @@ inline void invalid_extruder_error(const uint8_t e) {
         && (delayed_move_time || current_position[X_AXIS] != xhome) && ! no_move
     ) {
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("MoveX to ", xhome);
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("MoveX to ", xhome);
+
       // Park old head
       planner.buffer_line(xhome, current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS], planner.settings.max_feedrate_mm_s[X_AXIS], active_extruder);
       planner.synchronize();
@@ -599,9 +535,7 @@ inline void invalid_extruder_error(const uint8_t e) {
     // This function resets the max/min values - the current position may be overwritten below.
     set_axis_is_at_home(X_AXIS);
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) DEBUG_POS("New Extruder", current_position);
-    #endif
+    if (DEBUGGING(LEVELING)) DEBUG_POS("New Extruder", current_position);
 
     switch (dual_x_carriage_mode) {
       case DXC_FULL_CONTROL_MODE:
@@ -620,12 +554,10 @@ inline void invalid_extruder_error(const uint8_t e) {
         break;
     }
 
-    #if ENABLED(DEBUG_LEVELING_FEATURE)
-      if (DEBUGGING(LEVELING)) {
-        SERIAL_ECHOLNPAIR("Active extruder parked: ", active_extruder_parked ? "yes" : "no");
-        DEBUG_POS("New extruder (parked)", current_position);
-      }
-    #endif
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOLNPAIR("Active extruder parked: ", active_extruder_parked ? "yes" : "no");
+      DEBUG_POS("New extruder (parked)", current_position);
+    }
   }
 
 #endif // DUAL_X_CARRIAGE
@@ -680,9 +612,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
     if (!no_move && !all_axes_homed()) {
       no_move = true;
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("No move on toolchange");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("No move on toolchange");
     }
 
     #if HAS_LCD_MENU
@@ -777,10 +707,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
         move_nozzle_servo(tmp_extruder);
       #endif
 
-      #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING))
-          SERIAL_ECHOLNPAIR("Offset Tool XY by { ", xdiff, ", ", ydiff, ", ", zdiff, " }");
-      #endif
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Offset Tool XY by { ", xdiff, ", ", ydiff, ", ", zdiff, " }");
 
       // The newly-selected extruder XY is actually at...
       current_position[X_AXIS] += xdiff;
@@ -802,9 +729,7 @@ void tool_change(const uint8_t tmp_extruder, const float fr_mm_s/*=0.0*/, bool n
 
       // Return to position and lower again
       if (safe_to_move && !no_move && IsRunning()) {
-        #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
-        #endif
+        if (DEBUGGING(LEVELING)) DEBUG_POS("Move back", destination);
 
         #if ENABLED(SINGLENOZZLE)
           #if FAN_COUNT > 0


### PR DESCRIPTION
Debugging code has been getting kind of unwieldy. This PR unifies all debugging with a common set of macros, using a `#define`/`#include` trick to bring in debugging from `core/debug_out.h` according to conditions, on a per-source-file basis.

This PR also eliminates the need to use `#if ENABLED(DEBUG_LEVELING_FEATURE) ...` for every instance where leveling debug output is inserted. Now `DEBUGGING(LEVELING)` will always produce `false` when `DEBUG_LEVELING_FEATURE` is disabled.