### PR TITLE
Add capability string CHAMBER_TEMPERATURE

### DIFF
--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -164,5 +164,13 @@ void GcodeSuite::M115() {
       #endif
     );
 
+    // CHAMBER_TEMPERATURE (M141, M191)
+    cap_line(PSTR("CHAMBER_TEMPERATURE")
+      #if HAS_HEATED_CHAMBER
+        , true
+      #endif
+    );
+
+
   #endif // EXTENDED_CAPABILITIES_REPORT
 }


### PR DESCRIPTION
### Description

Adds support for chamber temperature capability string.
```
CHAMBER_TEMPERATURE:1
```

### Benefits

This will enable OctoPrint to support chamber temperature graphs.
foosel/OctoPrint#321 (comment)

### Related Issues

See #13380
